### PR TITLE
Add tokenizer integration (HuggingFace tokenizers crate)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,10 @@ uuid = { version = "1", features = ["v4", "serde"] }
 # Time
 chrono = { version = "0.4", features = ["serde"] }
 
+# Tokenization
+tokenizers = { version = "0.21", features = ["http"] }
+minijinja = "2"
+
 # Internal crates
 kiln-core = { path = "crates/kiln-core" }
 kiln-model = { path = "crates/kiln-model" }

--- a/crates/kiln-core/Cargo.toml
+++ b/crates/kiln-core/Cargo.toml
@@ -11,3 +11,5 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+tokenizers = { workspace = true }
+minijinja = { workspace = true }

--- a/crates/kiln-core/src/lib.rs
+++ b/crates/kiln-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod request;
 pub mod sampling;
 pub mod token;
+pub mod tokenizer;
 
 pub use block::{BlockManager, BlockTable};
 pub use config::ModelConfig;

--- a/crates/kiln-core/src/tokenizer.rs
+++ b/crates/kiln-core/src/tokenizer.rs
@@ -1,0 +1,246 @@
+use crate::token::TokenId;
+use thiserror::Error;
+use tokenizers::Tokenizer;
+
+#[derive(Debug, Error)]
+pub enum TokenizerError {
+    #[error("failed to load tokenizer: {0}")]
+    Load(String),
+    #[error("failed to encode text: {0}")]
+    Encode(String),
+    #[error("failed to decode tokens: {0}")]
+    Decode(String),
+    #[error("chat template error: {0}")]
+    ChatTemplate(String),
+}
+
+/// A chat message for template formatting.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ChatMessage {
+    pub role: String,
+    pub content: String,
+}
+
+/// Wraps the HuggingFace tokenizers crate for Kiln's tokenization needs.
+pub struct KilnTokenizer {
+    inner: Tokenizer,
+    chat_template: Option<String>,
+}
+
+impl KilnTokenizer {
+    /// Load a tokenizer from the HuggingFace Hub by model ID (e.g. "Qwen/Qwen3-4B").
+    pub fn from_pretrained(model_id: &str) -> Result<Self, TokenizerError> {
+        let inner = Tokenizer::from_pretrained(model_id, None)
+            .map_err(|e| TokenizerError::Load(e.to_string()))?;
+        Ok(Self {
+            inner,
+            chat_template: None,
+        })
+    }
+
+    /// Load a tokenizer from a local tokenizer.json file.
+    pub fn from_file(path: &str) -> Result<Self, TokenizerError> {
+        let inner =
+            Tokenizer::from_file(path).map_err(|e| TokenizerError::Load(e.to_string()))?;
+        Ok(Self {
+            inner,
+            chat_template: None,
+        })
+    }
+
+    /// Set a Jinja2 chat template string explicitly (from tokenizer_config.json).
+    pub fn with_chat_template(mut self, template: String) -> Self {
+        self.chat_template = Some(template);
+        self
+    }
+
+    /// Encode text into token IDs.
+    pub fn encode(&self, text: &str) -> Result<Vec<TokenId>, TokenizerError> {
+        let encoding = self
+            .inner
+            .encode(text, false)
+            .map_err(|e| TokenizerError::Encode(e.to_string()))?;
+        Ok(encoding.get_ids().to_vec())
+    }
+
+    /// Decode token IDs back to text.
+    pub fn decode(&self, ids: &[TokenId]) -> Result<String, TokenizerError> {
+        self.inner
+            .decode(ids, true)
+            .map_err(|e| TokenizerError::Decode(e.to_string()))
+    }
+
+    /// Apply the chat template to format messages into a prompt string.
+    ///
+    /// If a Jinja2 template was set via [`with_chat_template`], renders it with
+    /// minijinja. Otherwise uses Qwen3's ChatML format as the default.
+    pub fn apply_chat_template(&self, messages: &[ChatMessage]) -> Result<String, TokenizerError> {
+        match &self.chat_template {
+            Some(template) => self.render_jinja_template(template, messages),
+            None => Ok(Self::apply_chatml(messages)),
+        }
+    }
+
+    /// Get the EOS token IDs from the tokenizer's added tokens.
+    pub fn eos_token_ids(&self) -> Vec<TokenId> {
+        let mut eos_ids = Vec::new();
+        for (id, token) in self.inner.get_added_tokens_decoder() {
+            let content = token.content.as_str();
+            if token.special
+                && (content == "<|endoftext|>"
+                    || content == "<|im_end|>"
+                    || content == "<|end|>"
+                    || content == "</s>")
+            {
+                eos_ids.push(id);
+            }
+        }
+        eos_ids.sort();
+        eos_ids
+    }
+
+    /// Get the vocabulary size.
+    pub fn vocab_size(&self) -> usize {
+        self.inner.get_vocab_size(true)
+    }
+
+    fn render_jinja_template(
+        &self,
+        template: &str,
+        messages: &[ChatMessage],
+    ) -> Result<String, TokenizerError> {
+        let mut env = minijinja::Environment::new();
+        env.add_template("chat", template)
+            .map_err(|e| TokenizerError::ChatTemplate(e.to_string()))?;
+
+        let tmpl = env
+            .get_template("chat")
+            .map_err(|e| TokenizerError::ChatTemplate(e.to_string()))?;
+
+        tmpl.render(minijinja::context! {
+            messages => messages,
+            add_generation_prompt => true,
+        })
+        .map_err(|e| TokenizerError::ChatTemplate(e.to_string()))
+    }
+
+    /// Format messages using ChatML (the format used by Qwen3 and many other models).
+    fn apply_chatml(messages: &[ChatMessage]) -> String {
+        let mut prompt = String::new();
+        for msg in messages {
+            prompt.push_str("<|im_start|>");
+            prompt.push_str(&msg.role);
+            prompt.push('\n');
+            prompt.push_str(&msg.content);
+            prompt.push_str("<|im_end|>\n");
+        }
+        prompt.push_str("<|im_start|>assistant\n");
+        prompt
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal valid tokenizer JSON for offline tests (BPE with tiny vocab).
+    fn minimal_tokenizer() -> KilnTokenizer {
+        let json = br#"{
+            "version": "1.0",
+            "model": {
+                "type": "BPE",
+                "vocab": {"a": 0, "b": 1},
+                "merges": []
+            }
+        }"#;
+        KilnTokenizer {
+            inner: Tokenizer::from_bytes(json.as_slice()).unwrap(),
+            chat_template: None,
+        }
+    }
+
+    #[test]
+    fn test_chatml_single_message() {
+        let tok = minimal_tokenizer();
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "Hello".to_string(),
+        }];
+        let prompt = tok.apply_chat_template(&messages).unwrap();
+        assert_eq!(
+            prompt,
+            "<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\n"
+        );
+    }
+
+    #[test]
+    fn test_chatml_multi_turn() {
+        let tok = minimal_tokenizer();
+        let messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You are helpful.".to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Hi".to_string(),
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "Hello!".to_string(),
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "How are you?".to_string(),
+            },
+        ];
+        let prompt = tok.apply_chat_template(&messages).unwrap();
+        assert!(prompt.contains("<|im_start|>system\nYou are helpful.<|im_end|>"));
+        assert!(prompt.contains("<|im_start|>user\nHi<|im_end|>"));
+        assert!(prompt.contains("<|im_start|>assistant\nHello!<|im_end|>"));
+        assert!(prompt.ends_with("<|im_start|>assistant\n"));
+    }
+
+    #[test]
+    fn test_encode_decode_minimal() {
+        let tok = minimal_tokenizer();
+        // With our minimal BPE vocab, "ab" encodes to [0, 1]
+        let ids = tok.encode("ab").unwrap();
+        assert_eq!(ids, vec![0, 1]);
+        // Decode roundtrip — BPE may insert spaces between tokens
+        let decoded = tok.decode(&ids).unwrap();
+        assert!(decoded.contains('a') && decoded.contains('b'));
+    }
+
+    #[test]
+    fn test_vocab_size() {
+        let tok = minimal_tokenizer();
+        assert_eq!(tok.vocab_size(), 2);
+    }
+
+    #[test]
+    #[ignore] // Requires network access to HuggingFace Hub
+    fn test_from_pretrained() {
+        let tok = KilnTokenizer::from_pretrained("Qwen/Qwen3-4B").unwrap();
+        assert!(tok.vocab_size() > 100_000);
+    }
+
+    #[test]
+    #[ignore] // Requires network access to HuggingFace Hub
+    fn test_encode_decode_roundtrip_pretrained() {
+        let tok = KilnTokenizer::from_pretrained("Qwen/Qwen3-4B").unwrap();
+        let text = "Hello, world! This is a test of the tokenizer.";
+        let ids = tok.encode(text).unwrap();
+        assert!(!ids.is_empty());
+        let decoded = tok.decode(&ids).unwrap();
+        assert_eq!(decoded, text);
+    }
+
+    #[test]
+    #[ignore] // Requires network access to HuggingFace Hub
+    fn test_eos_token_ids_pretrained() {
+        let tok = KilnTokenizer::from_pretrained("Qwen/Qwen3-4B").unwrap();
+        let eos = tok.eos_token_ids();
+        assert!(!eos.is_empty(), "Should find at least one EOS token");
+    }
+}

--- a/crates/kiln-core/src/tokenizer.rs
+++ b/crates/kiln-core/src/tokenizer.rs
@@ -28,7 +28,7 @@ pub struct KilnTokenizer {
 }
 
 impl KilnTokenizer {
-    /// Load a tokenizer from the HuggingFace Hub by model ID (e.g. "Qwen/Qwen3-4B").
+    /// Load a tokenizer from the HuggingFace Hub by model ID (e.g. "Qwen/Qwen3.5-4B").
     pub fn from_pretrained(model_id: &str) -> Result<Self, TokenizerError> {
         let inner = Tokenizer::from_pretrained(model_id, None)
             .map_err(|e| TokenizerError::Load(e.to_string()))?;
@@ -221,14 +221,14 @@ mod tests {
     #[test]
     #[ignore] // Requires network access to HuggingFace Hub
     fn test_from_pretrained() {
-        let tok = KilnTokenizer::from_pretrained("Qwen/Qwen3-4B").unwrap();
+        let tok = KilnTokenizer::from_pretrained("Qwen/Qwen3.5-4B").unwrap();
         assert!(tok.vocab_size() > 100_000);
     }
 
     #[test]
     #[ignore] // Requires network access to HuggingFace Hub
     fn test_encode_decode_roundtrip_pretrained() {
-        let tok = KilnTokenizer::from_pretrained("Qwen/Qwen3-4B").unwrap();
+        let tok = KilnTokenizer::from_pretrained("Qwen/Qwen3.5-4B").unwrap();
         let text = "Hello, world! This is a test of the tokenizer.";
         let ids = tok.encode(text).unwrap();
         assert!(!ids.is_empty());
@@ -239,7 +239,7 @@ mod tests {
     #[test]
     #[ignore] // Requires network access to HuggingFace Hub
     fn test_eos_token_ids_pretrained() {
-        let tok = KilnTokenizer::from_pretrained("Qwen/Qwen3-4B").unwrap();
+        let tok = KilnTokenizer::from_pretrained("Qwen/Qwen3.5-4B").unwrap();
         let eos = tok.eos_token_ids();
         assert!(!eos.is_empty(), "Should find at least one EOS token");
     }

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
+use kiln_core::tokenizer::ChatMessage;
 
 use crate::state::AppState;
 
@@ -69,15 +70,26 @@ async fn chat_completions(
     State(state): State<AppState>,
     Json(req): Json<ChatCompletionRequest>,
 ) -> Result<Json<ChatCompletionResponse>, (StatusCode, String)> {
-    // TODO: real tokenization. For now, rough estimate: 1 token per 4 chars.
-    let prompt_text: String = req
+    // Convert request messages to ChatMessage for template formatting
+    let chat_messages: Vec<ChatMessage> = req
         .messages
         .iter()
-        .map(|m| format!("{}: {}", m.role, m.content))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let estimated_tokens = prompt_text.len() / 4;
-    let prompt_tokens: Vec<u32> = (0..estimated_tokens as u32).collect();
+        .map(|m| ChatMessage {
+            role: m.role.clone(),
+            content: m.content.clone(),
+        })
+        .collect();
+
+    // Apply chat template and tokenize
+    let prompt_text = state
+        .tokenizer
+        .apply_chat_template(&chat_messages)
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+
+    let prompt_tokens = state
+        .tokenizer
+        .encode(&prompt_text)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let sampling = SamplingParams {
         temperature: req.temperature.unwrap_or(1.0),
@@ -88,7 +100,8 @@ async fn chat_completions(
         ..Default::default()
     };
 
-    let request = Request::new(prompt_tokens.clone(), sampling, req.adapter);
+    let prompt_token_count = prompt_tokens.len();
+    let request = Request::new(prompt_tokens, sampling, req.adapter);
     let request_id = request.id;
 
     // Add to scheduler
@@ -169,8 +182,12 @@ async fn chat_completions(
         }
     }
 
-    // Mock: generate some text from the output tokens
-    let completion_text = format!("[mock response with {} tokens]", output_tokens.len());
+    // Decode output tokens back to text (mock engine produces token ID 42 repeatedly,
+    // which won't decode to meaningful text, but the pipeline is real)
+    let completion_text = state
+        .tokenizer
+        .decode(&output_tokens)
+        .unwrap_or_else(|_| format!("[{} tokens, decode failed]", output_tokens.len()));
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -191,9 +208,9 @@ async fn chat_completions(
             finish_reason: "stop".to_string(),
         }],
         usage: Usage {
-            prompt_tokens: prompt_tokens.len(),
+            prompt_tokens: prompt_token_count,
             completion_tokens: output_tokens.len(),
-            total_tokens: prompt_tokens.len() + output_tokens.len(),
+            total_tokens: prompt_token_count + output_tokens.len(),
         },
     }))
 }

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<()> {
 
     // Load tokenizer: try from_pretrained (HF Hub), fall back to local path, then fail gracefully.
     let model_id =
-        std::env::var("KILN_MODEL_ID").unwrap_or_else(|_| "Qwen/Qwen3-4B".to_string());
+        std::env::var("KILN_MODEL_ID").unwrap_or_else(|_| "Qwen/Qwen3.5-4B".to_string());
     let tokenizer_path = std::env::var("KILN_TOKENIZER_PATH").ok();
 
     let tokenizer = if let Some(path) = tokenizer_path {

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -6,6 +6,7 @@ mod api;
 mod state;
 
 use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
 use kiln_model::engine::MockEngine;
 use kiln_scheduler::{Scheduler, SchedulerConfig};
 use state::AppState;
@@ -41,7 +42,25 @@ async fn main() -> Result<()> {
     let scheduler = Scheduler::new(scheduler_config, num_blocks);
     let engine = MockEngine::new(model_config.clone());
 
-    let state = AppState::new(model_config, scheduler, Arc::new(engine));
+    // Load tokenizer: try from_pretrained (HF Hub), fall back to local path, then fail gracefully.
+    let model_id =
+        std::env::var("KILN_MODEL_ID").unwrap_or_else(|_| "Qwen/Qwen3-4B".to_string());
+    let tokenizer_path = std::env::var("KILN_TOKENIZER_PATH").ok();
+
+    let tokenizer = if let Some(path) = tokenizer_path {
+        tracing::info!("loading tokenizer from {path}");
+        KilnTokenizer::from_file(&path)?
+    } else {
+        tracing::info!("loading tokenizer from HuggingFace Hub: {model_id}");
+        KilnTokenizer::from_pretrained(&model_id)?
+    };
+
+    tracing::info!(
+        vocab_size = tokenizer.vocab_size(),
+        "tokenizer loaded successfully"
+    );
+
+    let state = AppState::new(model_config, scheduler, Arc::new(engine), tokenizer);
 
     let app = api::router(state);
 

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 
 use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
 use kiln_model::engine::Engine;
 use kiln_scheduler::Scheduler;
 
@@ -11,6 +12,7 @@ pub struct AppState {
     pub model_config: ModelConfig,
     pub scheduler: Arc<Mutex<Scheduler>>,
     pub engine: Arc<dyn Engine>,
+    pub tokenizer: Arc<KilnTokenizer>,
 }
 
 impl AppState {
@@ -18,11 +20,13 @@ impl AppState {
         model_config: ModelConfig,
         scheduler: Scheduler,
         engine: Arc<dyn Engine>,
+        tokenizer: KilnTokenizer,
     ) -> Self {
         Self {
             model_config,
             scheduler: Arc::new(Mutex::new(scheduler)),
             engine,
+            tokenizer: Arc::new(tokenizer),
         }
     }
 }


### PR DESCRIPTION
## What
Replace mock tokenization (`prompt_text.len() / 4`) with real HuggingFace tokenizers crate integration.

### Changes
- **kiln-core**: New `KilnTokenizer` wrapping `tokenizers::Tokenizer` with `from_pretrained`, `from_file`, `encode`, `decode`, `apply_chat_template`, `eos_token_ids`, and `vocab_size`
- **kiln-core**: ChatML formatting (Qwen3 default) with optional Jinja2 template override via `minijinja`
- **kiln-server**: `AppState` now holds `Arc<KilnTokenizer>`, loaded at startup from HF Hub or local path
- **kiln-server**: Completions handler uses real tokenization — chat template formatting, encode for prompt tokens, decode for output text
- **Config**: `KILN_MODEL_ID` (default: `Qwen/Qwen3-4B`) and `KILN_TOKENIZER_PATH` env vars

## Why
Next unchecked Phase 1 item. Real tokenization is prerequisite for model loading and correct token counting.

## Tests
- 9 offline tests pass (ChatML formatting, encode/decode, vocab size)
- 3 network-dependent tests (`#[ignore]`) for HF Hub integration
- All existing scheduler and block manager tests continue to pass