### PR TITLE
Add candle forward pass layers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ minijinja = "2"
 safetensors = "0.5"
 memmap2 = "0.9"
 
+# Tensor compute
+candle-core = "0.10"
+candle-nn = "0.10"
+
 # Testing
 tempfile = "3"
 

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -14,6 +14,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 safetensors = { workspace = true }
 memmap2 = { workspace = true }
+candle-core = { workspace = true }
+candle-nn = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1,0 +1,484 @@
+//! Candle-based forward pass layers for Qwen3.5-4B.
+//!
+//! Implements the foundational compute primitives: embedding lookup, RMSNorm,
+//! RoPE (rotary position embeddings), and SwiGLU FFN. These operate on candle
+//! `Tensor` objects and are composed into the full transformer forward pass.
+
+use anyhow::{Context, Result};
+use candle_core::{DType, Device, Tensor};
+
+use crate::weights::{ModelWeights, TensorDType, WeightTensor};
+
+/// GPU-ready tensors organized by layer, converted from raw `ModelWeights` bytes.
+pub struct GpuWeights {
+    /// Token embedding table: [vocab_size, hidden_size]
+    pub embed_tokens: Tensor,
+    /// Per-layer weights
+    pub layers: Vec<GpuLayerWeights>,
+    /// Final RMSNorm weight: [hidden_size]
+    pub final_norm: Tensor,
+}
+
+/// One transformer layer's tensors on device.
+pub struct GpuLayerWeights {
+    pub input_layernorm: Tensor,
+    pub post_attention_layernorm: Tensor,
+    pub attention: GpuAttentionWeights,
+    pub mlp: GpuFfnWeights,
+}
+
+/// Attention weights on device.
+pub enum GpuAttentionWeights {
+    Full(GpuFullAttentionWeights),
+    Linear(GpuLinearAttentionWeights),
+}
+
+pub struct GpuFullAttentionWeights {
+    pub q_proj: Tensor,
+    pub k_proj: Tensor,
+    pub v_proj: Tensor,
+    pub o_proj: Tensor,
+    pub q_norm: Tensor,
+    pub k_norm: Tensor,
+}
+
+pub struct GpuLinearAttentionWeights {
+    pub in_proj_qkv: Tensor,
+    pub in_proj_z: Tensor,
+    pub out_proj: Tensor,
+    pub in_proj_a: Tensor,
+    pub in_proj_b: Tensor,
+    pub conv1d: Tensor,
+    pub norm: Tensor,
+    pub a_log: Tensor,
+    pub dt_bias: Tensor,
+}
+
+pub struct GpuFfnWeights {
+    pub gate_proj: Tensor,
+    pub up_proj: Tensor,
+    pub down_proj: Tensor,
+}
+
+/// Convert a `WeightTensor` (raw bytes + shape + dtype) to a candle `Tensor` on `device`.
+fn weight_to_tensor(w: &WeightTensor, device: &Device) -> Result<Tensor> {
+    let dtype = match w.dtype {
+        TensorDType::F16 => DType::F16,
+        TensorDType::BF16 => DType::BF16,
+        TensorDType::F32 => DType::F32,
+    };
+    let t = Tensor::from_raw_buffer(&w.data, dtype, &w.shape, device)
+        .context("failed to create tensor from raw buffer")?;
+    Ok(t)
+}
+
+impl GpuWeights {
+    /// Convert `ModelWeights` (CPU bytes) into candle tensors on the given device.
+    pub fn from_model_weights(weights: &ModelWeights, device: &Device) -> Result<Self> {
+        let embed_tokens =
+            weight_to_tensor(&weights.embedding.embed_tokens, device).context("embed_tokens")?;
+        let final_norm = weight_to_tensor(&weights.final_norm, device).context("final_norm")?;
+
+        let mut layers = Vec::with_capacity(weights.layers.len());
+        for (i, lw) in weights.layers.iter().enumerate() {
+            let ctx = |name: &str| format!("layer {i} {name}");
+
+            let input_layernorm =
+                weight_to_tensor(&lw.input_layernorm, device).context(ctx("input_layernorm"))?;
+            let post_attention_layernorm = weight_to_tensor(&lw.post_attention_layernorm, device)
+                .context(ctx("post_attention_layernorm"))?;
+
+            let attention = match &lw.attention {
+                crate::weights::AttentionWeights::Full(attn) => {
+                    GpuAttentionWeights::Full(GpuFullAttentionWeights {
+                        q_proj: weight_to_tensor(&attn.q_proj, device).context(ctx("q_proj"))?,
+                        k_proj: weight_to_tensor(&attn.k_proj, device).context(ctx("k_proj"))?,
+                        v_proj: weight_to_tensor(&attn.v_proj, device).context(ctx("v_proj"))?,
+                        o_proj: weight_to_tensor(&attn.o_proj, device).context(ctx("o_proj"))?,
+                        q_norm: weight_to_tensor(&attn.q_norm, device).context(ctx("q_norm"))?,
+                        k_norm: weight_to_tensor(&attn.k_norm, device).context(ctx("k_norm"))?,
+                    })
+                }
+                crate::weights::AttentionWeights::Linear(attn) => {
+                    GpuAttentionWeights::Linear(GpuLinearAttentionWeights {
+                        in_proj_qkv: weight_to_tensor(&attn.in_proj_qkv, device)
+                            .context(ctx("in_proj_qkv"))?,
+                        in_proj_z: weight_to_tensor(&attn.in_proj_z, device)
+                            .context(ctx("in_proj_z"))?,
+                        out_proj: weight_to_tensor(&attn.out_proj, device)
+                            .context(ctx("out_proj"))?,
+                        in_proj_a: weight_to_tensor(&attn.in_proj_a, device)
+                            .context(ctx("in_proj_a"))?,
+                        in_proj_b: weight_to_tensor(&attn.in_proj_b, device)
+                            .context(ctx("in_proj_b"))?,
+                        conv1d: weight_to_tensor(&attn.conv1d, device).context(ctx("conv1d"))?,
+                        norm: weight_to_tensor(&attn.norm, device).context(ctx("gdn_norm"))?,
+                        a_log: weight_to_tensor(&attn.a_log, device).context(ctx("a_log"))?,
+                        dt_bias: weight_to_tensor(&attn.dt_bias, device).context(ctx("dt_bias"))?,
+                    })
+                }
+            };
+
+            let mlp = GpuFfnWeights {
+                gate_proj: weight_to_tensor(&lw.mlp.gate_proj, device).context(ctx("gate_proj"))?,
+                up_proj: weight_to_tensor(&lw.mlp.up_proj, device).context(ctx("up_proj"))?,
+                down_proj: weight_to_tensor(&lw.mlp.down_proj, device).context(ctx("down_proj"))?,
+            };
+
+            layers.push(GpuLayerWeights {
+                input_layernorm,
+                post_attention_layernorm,
+                attention,
+                mlp,
+            });
+        }
+
+        Ok(Self {
+            embed_tokens,
+            layers,
+            final_norm,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Forward pass primitives
+// ---------------------------------------------------------------------------
+
+/// Look up token embeddings from the embedding table.
+///
+/// `token_ids`: 1-D slice of token IDs.
+/// `embed_weights`: [vocab_size, hidden_size] embedding matrix.
+///
+/// Returns: [seq_len, hidden_size] tensor.
+pub fn embedding_lookup(token_ids: &[u32], embed_weights: &Tensor) -> Result<Tensor> {
+    let index = Tensor::new(token_ids, embed_weights.device())?;
+    let out = embed_weights.index_select(&index, 0)?;
+    Ok(out)
+}
+
+/// RMSNorm: x * weight / sqrt(mean(x^2) + eps).
+///
+/// `x`: [..., hidden_size]
+/// `weight`: [hidden_size] (learnable scale)
+/// `eps`: small constant for numerical stability (1e-6 for Qwen3.5-4B)
+///
+/// Returns: same shape as `x`.
+pub fn rms_norm(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
+    let x_f32 = x.to_dtype(DType::F32)?;
+    let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
+    let rms = (variance + eps)?.sqrt()?;
+    let rms_inv = rms.recip()?;
+    let normed = x_f32.broadcast_mul(&rms_inv)?;
+    // Cast back to original dtype, then scale by weight
+    let normed = normed.to_dtype(x.dtype())?;
+    let out = normed.broadcast_mul(weight)?;
+    Ok(out)
+}
+
+/// Apply Rotary Position Embeddings (RoPE) to query and key tensors.
+///
+/// `q`: [batch, seq_len, num_heads, head_dim]
+/// `k`: [batch, seq_len, num_kv_heads, head_dim]
+/// `positions`: position index for each token in the sequence (length = seq_len)
+/// `head_dim`: dimension of each attention head
+/// `rope_theta`: base frequency (10_000_000.0 for Qwen3.5-4B)
+///
+/// Returns: (rotated_q, rotated_k) with same shapes.
+pub fn rotary_embedding(
+    q: &Tensor,
+    k: &Tensor,
+    positions: &[u32],
+    head_dim: usize,
+    rope_theta: f64,
+) -> Result<(Tensor, Tensor)> {
+    let device = q.device();
+    let half_dim = head_dim / 2;
+
+    // Compute frequency table: freq_i = 1.0 / (theta ^ (2i / head_dim)) for i in 0..half_dim
+    let inv_freq: Vec<f32> = (0..half_dim)
+        .map(|i| 1.0 / rope_theta.powf(2.0 * i as f64 / head_dim as f64) as f32)
+        .collect();
+    let inv_freq = Tensor::new(inv_freq.as_slice(), device)?; // [half_dim]
+
+    // Position tensor
+    let pos_f32: Vec<f32> = positions.iter().map(|&p| p as f32).collect();
+    let pos = Tensor::new(pos_f32.as_slice(), device)?.unsqueeze(1)?; // [seq_len, 1]
+
+    // Outer product: [seq_len, half_dim]
+    let freqs = pos.broadcast_mul(&inv_freq.unsqueeze(0)?)?;
+
+    let cos = freqs.cos()?; // [seq_len, half_dim]
+    let sin = freqs.sin()?; // [seq_len, half_dim]
+
+    let rotated_q = apply_rope(q, &cos, &sin, head_dim)?;
+    let rotated_k = apply_rope(k, &cos, &sin, head_dim)?;
+
+    Ok((rotated_q, rotated_k))
+}
+
+/// Apply the rotation to a single tensor.
+/// `x`: [batch, seq_len, num_heads, head_dim]
+/// `cos`, `sin`: [seq_len, half_dim]
+fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor, head_dim: usize) -> Result<Tensor> {
+    let half = head_dim / 2;
+    let x_dtype = x.dtype();
+
+    // Work in f32 for precision
+    let x = x.to_dtype(DType::F32)?;
+
+    // Split head_dim into two halves along the last dimension
+    let x1 = x.narrow(candle_core::D::Minus1, 0, half)?; // [..., :half]
+    let x2 = x.narrow(candle_core::D::Minus1, half, half)?; // [..., half:]
+
+    // cos/sin are [seq_len, half_dim], need to broadcast to [batch, seq_len, num_heads, half_dim]
+    // Reshape to [1, seq_len, 1, half_dim]
+    let cos = cos.to_dtype(DType::F32)?.unsqueeze(0)?.unsqueeze(2)?;
+    let sin = sin.to_dtype(DType::F32)?.unsqueeze(0)?.unsqueeze(2)?;
+
+    // Standard RoPE rotation: [x1*cos - x2*sin, x1*sin + x2*cos]
+    let r1 = (x1.broadcast_mul(&cos)? - x2.broadcast_mul(&sin)?)?;
+    let r2 = (x1.broadcast_mul(&sin)? + x2.broadcast_mul(&cos)?)?;
+
+    let out = Tensor::cat(&[&r1, &r2], candle_core::D::Minus1)?;
+    Ok(out.to_dtype(x_dtype)?)
+}
+
+/// SwiGLU feed-forward network.
+///
+/// Computes: down_proj @ (silu(gate_proj @ x) * (up_proj @ x))
+///
+/// `x`: [batch, seq_len, hidden_size]
+/// `gate_proj`: [intermediate_size, hidden_size]
+/// `up_proj`: [intermediate_size, hidden_size]
+/// `down_proj`: [hidden_size, intermediate_size]
+///
+/// Returns: [batch, seq_len, hidden_size]
+pub fn swiglu_ffn(
+    x: &Tensor,
+    gate_proj: &Tensor,
+    up_proj: &Tensor,
+    down_proj: &Tensor,
+) -> Result<Tensor> {
+    // x @ gate_proj^T -> [batch, seq_len, intermediate_size]
+    let gate = x.broadcast_matmul(&gate_proj.t()?)?;
+    // SiLU activation: x * sigmoid(x)
+    let gate = candle_nn::ops::silu(&gate)?;
+    // x @ up_proj^T -> [batch, seq_len, intermediate_size]
+    let up = x.broadcast_matmul(&up_proj.t()?)?;
+    // Element-wise multiply
+    let hidden = (gate * up)?;
+    // hidden @ down_proj^T -> [batch, seq_len, hidden_size]
+    let out = hidden.broadcast_matmul(&down_proj.t()?)?;
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_embedding_lookup() -> Result<()> {
+        let device = Device::Cpu;
+        // vocab_size=5, hidden_size=3
+        let embed_data: Vec<f32> = vec![
+            0.1, 0.2, 0.3, // token 0
+            0.4, 0.5, 0.6, // token 1
+            0.7, 0.8, 0.9, // token 2
+            1.0, 1.1, 1.2, // token 3
+            1.3, 1.4, 1.5, // token 4
+        ];
+        let embed = Tensor::new(embed_data, &device)?.reshape((5, 3))?;
+
+        let result = embedding_lookup(&[2, 0, 4], &embed)?;
+        assert_eq!(result.dims(), &[3, 3]); // [seq_len=3, hidden_size=3]
+
+        let vals = result.to_vec2::<f32>()?;
+        // Token 2
+        assert!((vals[0][0] - 0.7).abs() < 1e-6);
+        assert!((vals[0][1] - 0.8).abs() < 1e-6);
+        assert!((vals[0][2] - 0.9).abs() < 1e-6);
+        // Token 0
+        assert!((vals[1][0] - 0.1).abs() < 1e-6);
+        // Token 4
+        assert!((vals[2][0] - 1.3).abs() < 1e-6);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rms_norm_known_values() -> Result<()> {
+        let device = Device::Cpu;
+        // x = [1, 2, 3], weight = [1, 1, 1], eps = 0
+        // RMS = sqrt(mean([1,4,9])) = sqrt(14/3) ≈ 2.1602
+        // normed = [1/2.1602, 2/2.1602, 3/2.1602] ≈ [0.4629, 0.9258, 1.3887]
+        let x = Tensor::new(&[1.0_f32, 2.0, 3.0], &device)?.unsqueeze(0)?; // [1, 3]
+        let w = Tensor::new(&[1.0_f32, 1.0, 1.0], &device)?;
+
+        let result = rms_norm(&x, &w, 1e-8)?;
+        let vals = result.to_vec2::<f32>()?;
+
+        let rms = (14.0_f64 / 3.0).sqrt();
+        assert!((vals[0][0] as f64 - 1.0 / rms).abs() < 1e-4);
+        assert!((vals[0][1] as f64 - 2.0 / rms).abs() < 1e-4);
+        assert!((vals[0][2] as f64 - 3.0 / rms).abs() < 1e-4);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rms_norm_with_weight() -> Result<()> {
+        let device = Device::Cpu;
+        let x = Tensor::new(&[2.0_f32, 2.0, 2.0], &device)?.unsqueeze(0)?;
+        let w = Tensor::new(&[0.5_f32, 1.0, 2.0], &device)?;
+
+        let result = rms_norm(&x, &w, 1e-8)?;
+        let vals = result.to_vec2::<f32>()?;
+
+        // RMS of [2,2,2] = 2.0, so normed = [1,1,1]
+        // After weight: [0.5, 1.0, 2.0]
+        assert!((vals[0][0] - 0.5).abs() < 1e-4);
+        assert!((vals[0][1] - 1.0).abs() < 1e-4);
+        assert!((vals[0][2] - 2.0).abs() < 1e-4);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rope_preserves_shape() -> Result<()> {
+        let device = Device::Cpu;
+        let batch = 1;
+        let seq_len = 4;
+        let num_heads = 2;
+        let num_kv_heads = 1;
+        let head_dim = 8;
+
+        let q = Tensor::randn(0.0_f32, 1.0, (batch, seq_len, num_heads, head_dim), &device)?;
+        let k = Tensor::randn(
+            0.0_f32,
+            1.0,
+            (batch, seq_len, num_kv_heads, head_dim),
+            &device,
+        )?;
+        let positions: Vec<u32> = (0..seq_len as u32).collect();
+
+        let (rq, rk) = rotary_embedding(&q, &k, &positions, head_dim, 10_000.0)?;
+
+        assert_eq!(rq.dims(), &[batch, seq_len, num_heads, head_dim]);
+        assert_eq!(rk.dims(), &[batch, seq_len, num_kv_heads, head_dim]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rope_position_zero_is_identity() -> Result<()> {
+        let device = Device::Cpu;
+        // At position 0, cos=1 and sin=0, so rotation should be identity
+        let head_dim = 4;
+        let q_data: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
+        let q = Tensor::new(q_data.as_slice(), &device)?.reshape((1, 1, 1, head_dim))?;
+        let k = q.clone();
+
+        let (rq, _rk) = rotary_embedding(&q, &k, &[0], head_dim, 10_000.0)?;
+        let orig = q.flatten_all()?.to_vec1::<f32>()?;
+        let rotated = rq.flatten_all()?.to_vec1::<f32>()?;
+
+        for i in 0..head_dim {
+            assert!(
+                (orig[i] - rotated[i]).abs() < 1e-5,
+                "Position 0 should be identity, dim {i}: orig={} rotated={}",
+                orig[i],
+                rotated[i]
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_rope_different_positions_differ() -> Result<()> {
+        let device = Device::Cpu;
+        let head_dim = 8;
+        let q = Tensor::ones((1, 2, 1, head_dim), DType::F32, &device)?;
+        let k = q.clone();
+
+        let (rq, _) = rotary_embedding(&q, &k, &[0, 100], head_dim, 10_000.0)?;
+        // rq shape: [1, 2, 1, 8] — extract pos 0 and pos 100
+        let pos0 = rq.narrow(1, 0, 1)?.flatten_all()?.to_vec1::<f32>()?;
+        let pos100 = rq.narrow(1, 1, 1)?.flatten_all()?.to_vec1::<f32>()?;
+
+        let diff: f32 = pos0.iter().zip(&pos100).map(|(a, b)| (a - b).abs()).sum();
+        assert!(
+            diff > 0.01,
+            "Different positions should produce different embeddings"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_swiglu_output_shape() -> Result<()> {
+        let device = Device::Cpu;
+        let batch = 2;
+        let seq_len = 3;
+        let hidden = 4;
+        let intermediate = 8;
+
+        let x = Tensor::randn(0.0_f32, 1.0, (batch, seq_len, hidden), &device)?;
+        let gate = Tensor::randn(0.0_f32, 0.1, (intermediate, hidden), &device)?;
+        let up = Tensor::randn(0.0_f32, 0.1, (intermediate, hidden), &device)?;
+        let down = Tensor::randn(0.0_f32, 0.1, (hidden, intermediate), &device)?;
+
+        let result = swiglu_ffn(&x, &gate, &up, &down)?;
+        assert_eq!(result.dims(), &[batch, seq_len, hidden]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_swiglu_zero_gate_gives_zero() -> Result<()> {
+        let device = Device::Cpu;
+        let hidden = 4;
+        let intermediate = 8;
+
+        let x = Tensor::ones((1, 1, hidden), DType::F32, &device)?;
+        // Gate weights all zero -> silu(0) = 0 -> output is zero regardless of up/down
+        let gate = Tensor::zeros((intermediate, hidden), DType::F32, &device)?;
+        let up = Tensor::ones((intermediate, hidden), DType::F32, &device)?;
+        let down = Tensor::ones((hidden, intermediate), DType::F32, &device)?;
+
+        let result = swiglu_ffn(&x, &gate, &up, &down)?;
+        let vals = result.to_vec3::<f32>()?;
+
+        for v in &vals[0][0] {
+            assert!(
+                v.abs() < 1e-6,
+                "SwiGLU with zero gate should produce zero, got {v}"
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_weight_to_tensor_f32() -> Result<()> {
+        let device = Device::Cpu;
+        let data: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
+        let wt = WeightTensor {
+            data: bytes,
+            shape: vec![2, 3],
+            dtype: TensorDType::F32,
+        };
+
+        let t = weight_to_tensor(&wt, &device)?;
+        assert_eq!(t.dims(), &[2, 3]);
+        assert_eq!(t.dtype(), DType::F32);
+
+        let vals = t.to_vec2::<f32>()?;
+        assert!((vals[0][0] - 1.0).abs() < 1e-6);
+        assert!((vals[1][2] - 6.0).abs() < 1e-6);
+
+        Ok(())
+    }
+}

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod engine;
+pub mod forward;
 pub mod loader;
 pub mod lora;
 pub mod weights;


### PR DESCRIPTION
## What
Implements the foundational candle-based compute layers for the Qwen3.5-4B forward pass:

- **`GpuWeights`** — Converts `ModelWeights` (raw bytes from safetensors loader) into candle `Tensor` objects on a target device, organized by layer
- **`embedding_lookup`** — Token embedding table indexing
- **`rms_norm`** — RMSNorm with f32 accumulation and learnable scale (eps=1e-6 for Qwen3.5)
- **`rotary_embedding`** — RoPE with precomputed cos/sin tables, supports arbitrary positions and configurable theta (10M for Qwen3.5)
- **`swiglu_ffn`** — SwiGLU feed-forward: `down @ (silu(gate @ x) * (up @ x))`

## Why
These are the building blocks for the full transformer forward pass (Phase 1 roadmap). Each layer is independently tested with small CPU tensors — GPU path comes in a later task.

## Tests
8 new unit tests covering:
- Embedding lookup indexing correctness
- RMSNorm against known analytical values
- RMSNorm with non-unit weights
- RoPE shape preservation
- RoPE identity at position 0
- RoPE produces different outputs at different positions
- SwiGLU output shape
- SwiGLU zero-gate produces zero output
- WeightTensor → candle Tensor conversion

All 29 workspace tests pass.

## Dependencies added
- `candle-core = "0.10"` and `candle-nn = "0.10"` (latest stable)