### PR TITLE
Add full model forward pass and basic sampling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,9 @@ memmap2 = "0.9"
 candle-core = "0.10"
 candle-nn = "0.10"
 
+# Random number generation
+rand = "0.8"
+
 # Testing
 tempfile = "3"
 

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -16,6 +16,7 @@ safetensors = { workspace = true }
 memmap2 = { workspace = true }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -449,6 +449,82 @@ pub fn transformer_block(
     Ok(out)
 }
 
+/// Full model forward pass: embedding → N transformer blocks → final norm → LM head → logits.
+///
+/// `token_ids`: 1-D slice of token IDs for the input sequence.
+/// `weights`: pre-loaded GPU tensors for all model parameters.
+/// `config`: model architecture configuration.
+///
+/// Returns logits tensor with shape [1, seq_len, vocab_size].
+///
+/// Notes:
+/// - Qwen3.5-4B uses weight tying: the LM head reuses `embed_tokens` transposed.
+/// - Linear attention (Gated DeltaNet) layers are not yet implemented and will
+///   be skipped with an identity pass-through.
+pub fn model_forward(
+    token_ids: &[u32],
+    weights: &GpuWeights,
+    config: &kiln_core::config::ModelConfig,
+) -> Result<Tensor> {
+    let seq_len = token_ids.len();
+
+    // 1. Embedding lookup: [seq_len, hidden_size]
+    let mut hidden = embedding_lookup(token_ids, &weights.embed_tokens)?;
+
+    // Add batch dimension: [1, seq_len, hidden_size]
+    hidden = hidden.unsqueeze(0)?;
+
+    // Position indices for RoPE
+    let positions: Vec<u32> = (0..seq_len as u32).collect();
+
+    // 2. Loop through all transformer layers
+    for (i, layer) in weights.layers.iter().enumerate() {
+        match &layer.attention {
+            GpuAttentionWeights::Full(_) => {
+                hidden = transformer_block(
+                    &hidden,
+                    layer,
+                    &positions,
+                    config.num_attention_heads,
+                    config.num_kv_heads,
+                    config.head_dim,
+                    config.rope_theta,
+                    config.rms_norm_eps,
+                )
+                .with_context(|| format!("transformer block {i} (full attention)"))?;
+            }
+            GpuAttentionWeights::Linear(_) => {
+                // TODO: Implement Gated DeltaNet linear attention forward pass.
+                // For now, skip with identity (pass-through) — the layer's FFN still runs
+                // so we at least apply the MLP transformation.
+                let normed = rms_norm(&hidden, &layer.input_layernorm, config.rms_norm_eps)?;
+                // Skip attention (identity), just add zero residual
+                // Then apply FFN
+                let normed_post = rms_norm(&hidden, &layer.post_attention_layernorm, config.rms_norm_eps)?;
+                let ffn_out = swiglu_ffn(
+                    &normed_post,
+                    &layer.mlp.gate_proj,
+                    &layer.mlp.up_proj,
+                    &layer.mlp.down_proj,
+                )?;
+                hidden = (hidden + ffn_out)?;
+                // Suppress unused variable warning
+                let _ = normed;
+            }
+        }
+    }
+
+    // 3. Final RMSNorm
+    hidden = rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?;
+
+    // 4. LM head projection (weight-tied: reuse embed_tokens transposed)
+    // hidden: [1, seq_len, hidden_size], embed_tokens: [vocab_size, hidden_size]
+    // logits = hidden @ embed_tokens^T -> [1, seq_len, vocab_size]
+    let logits = hidden.broadcast_matmul(&weights.embed_tokens.t()?)?;
+
+    Ok(logits)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -863,6 +939,149 @@ mod tests {
         let vals = t.to_vec2::<f32>()?;
         assert!((vals[0][0] - 1.0).abs() < 1e-6);
         assert!((vals[1][2] - 6.0).abs() < 1e-6);
+
+        Ok(())
+    }
+
+    /// Helper: build tiny GpuWeights for testing model_forward shape propagation.
+    /// Uses full-attention layers only (no linear attention) with small dimensions.
+    fn make_tiny_gpu_weights(
+        device: &Device,
+        vocab_size: usize,
+        hidden_size: usize,
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        intermediate_size: usize,
+        num_layers: usize,
+    ) -> Result<GpuWeights> {
+        let randn = |shape: &[usize]| -> Result<Tensor> {
+            let n: usize = shape.iter().product();
+            let data: Vec<f32> = (0..n).map(|i| ((i as f32 * 0.01).sin()) * 0.1).collect();
+            Ok(Tensor::new(data, device)?.reshape(shape)?)
+        };
+
+        let embed_tokens = randn(&[vocab_size, hidden_size])?;
+        let final_norm = Tensor::ones(hidden_size, DType::F32, device)?;
+
+        let mut layers = Vec::with_capacity(num_layers);
+        for _ in 0..num_layers {
+            layers.push(GpuLayerWeights {
+                input_layernorm: Tensor::ones(hidden_size, DType::F32, device)?,
+                post_attention_layernorm: Tensor::ones(hidden_size, DType::F32, device)?,
+                attention: GpuAttentionWeights::Full(GpuFullAttentionWeights {
+                    q_proj: randn(&[num_heads * head_dim, hidden_size])?,
+                    k_proj: randn(&[num_kv_heads * head_dim, hidden_size])?,
+                    v_proj: randn(&[num_kv_heads * head_dim, hidden_size])?,
+                    o_proj: randn(&[hidden_size, num_heads * head_dim])?,
+                    q_norm: Tensor::ones(head_dim, DType::F32, device)?,
+                    k_norm: Tensor::ones(head_dim, DType::F32, device)?,
+                }),
+                mlp: GpuFfnWeights {
+                    gate_proj: randn(&[intermediate_size, hidden_size])?,
+                    up_proj: randn(&[intermediate_size, hidden_size])?,
+                    down_proj: randn(&[hidden_size, intermediate_size])?,
+                },
+            });
+        }
+
+        Ok(GpuWeights {
+            embed_tokens,
+            layers,
+            final_norm,
+        })
+    }
+
+    #[test]
+    fn test_model_forward_shape() -> Result<()> {
+        let device = Device::Cpu;
+        let vocab_size = 32;
+        let hidden_size = 16;
+        let num_heads = 4;
+        let num_kv_heads = 2;
+        let head_dim = 4;
+        let intermediate_size = 32;
+        let num_layers = 2;
+
+        let weights = make_tiny_gpu_weights(
+            &device,
+            vocab_size,
+            hidden_size,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size,
+            num_layers,
+        )?;
+
+        let config = kiln_core::config::ModelConfig {
+            hidden_size,
+            num_layers,
+            num_attention_heads: num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size,
+            vocab_size,
+            max_position_embeddings: 1024,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10000.0,
+            dtype: kiln_core::config::DType::FP32,
+            num_full_attention_layers: num_layers,
+            full_attention_interval: 1, // every layer is full attention
+        };
+
+        let token_ids: Vec<u32> = vec![1, 5, 3, 10];
+        let logits = model_forward(&token_ids, &weights, &config)?;
+
+        // Expected shape: [1, seq_len, vocab_size]
+        assert_eq!(logits.dims(), &[1, 4, vocab_size]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_model_forward_single_token() -> Result<()> {
+        let device = Device::Cpu;
+        let vocab_size = 16;
+        let hidden_size = 8;
+        let num_heads = 2;
+        let num_kv_heads = 1;
+        let head_dim = 4;
+        let intermediate_size = 16;
+
+        let weights = make_tiny_gpu_weights(
+            &device,
+            vocab_size,
+            hidden_size,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size,
+            1, // single layer
+        )?;
+
+        let config = kiln_core::config::ModelConfig {
+            hidden_size,
+            num_layers: 1,
+            num_attention_heads: num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size,
+            vocab_size,
+            max_position_embeddings: 1024,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10000.0,
+            dtype: kiln_core::config::DType::FP32,
+            num_full_attention_layers: 1,
+            full_attention_interval: 1,
+        };
+
+        let logits = model_forward(&[7], &weights, &config)?;
+        assert_eq!(logits.dims(), &[1, 1, vocab_size]);
+
+        // Logits should be finite
+        let vals = logits.flatten_all()?.to_vec1::<f32>()?;
+        assert!(vals.iter().all(|v| v.is_finite()), "all logits should be finite");
 
         Ok(())
     }

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -2,6 +2,7 @@ pub mod engine;
 pub mod forward;
 pub mod loader;
 pub mod lora;
+pub mod sampling;
 pub mod weights;
 
 pub use engine::Engine;

--- a/crates/kiln-model/src/sampling.rs
+++ b/crates/kiln-model/src/sampling.rs
@@ -1,0 +1,254 @@
+//! Token sampling strategies for autoregressive generation.
+//!
+//! Provides greedy (argmax) and parameterized (temperature + top-k + top-p) sampling
+//! over logits produced by the model forward pass.
+
+use anyhow::{Context, Result};
+use candle_core::{DType, Tensor};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+/// Greedy sampling: return the token ID with the highest logit for the last position.
+///
+/// `logits`: tensor of shape [..., vocab_size]. Only the last position is sampled.
+///
+/// Returns the token ID (index of the maximum logit).
+pub fn greedy_sample(logits: &Tensor) -> Result<u32> {
+    let dims = logits.dims();
+    let _vocab_size = *dims.last().context("logits must have at least 1 dimension")?;
+
+    // Extract logits for the last position
+    let last_logits = if dims.len() >= 2 {
+        let seq_len = dims[dims.len() - 2];
+        logits
+            .narrow(dims.len() - 2, seq_len - 1, 1)?
+            .squeeze(dims.len() - 2)?
+    } else {
+        logits.clone()
+    };
+
+    // Flatten to 1-D [vocab_size]
+    let flat = last_logits.flatten_all()?;
+    let vals = flat.to_vec1::<f32>().or_else(|_| {
+        flat.to_dtype(DType::F32)?.to_vec1::<f32>()
+    })?;
+
+    let (max_idx, _) = vals
+        .iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
+        .context("empty logits")?;
+
+    Ok(max_idx as u32)
+}
+
+/// Parameterized sampling with temperature, top-k, and top-p (nucleus) filtering.
+///
+/// `logits`: tensor of shape [..., vocab_size]. Only the last position is sampled.
+/// `temperature`: scaling factor for logits (lower = more deterministic). If 0.0, uses greedy.
+/// `top_p`: nucleus sampling threshold in (0, 1]. Only the smallest set of tokens whose
+///          cumulative probability exceeds `top_p` are considered.
+/// `top_k`: if > 0, only the top-k highest-probability tokens are considered.
+/// `seed`: optional RNG seed for reproducibility.
+///
+/// Returns the sampled token ID.
+pub fn sample_with_params(
+    logits: &Tensor,
+    temperature: f32,
+    top_p: f32,
+    top_k: u32,
+    seed: Option<u64>,
+) -> Result<u32> {
+    if temperature == 0.0 {
+        return greedy_sample(logits);
+    }
+
+    let dims = logits.dims();
+
+    // Extract logits for the last position
+    let last_logits = if dims.len() >= 2 {
+        let seq_len = dims[dims.len() - 2];
+        logits
+            .narrow(dims.len() - 2, seq_len - 1, 1)?
+            .squeeze(dims.len() - 2)?
+    } else {
+        logits.clone()
+    };
+
+    // Flatten to 1-D and convert to f32
+    let flat = last_logits.flatten_all()?.to_dtype(DType::F32)?;
+    let mut vals = flat.to_vec1::<f32>()?;
+
+    // Apply temperature
+    for v in vals.iter_mut() {
+        *v /= temperature;
+    }
+
+    // Build (index, logit) pairs
+    let mut indexed: Vec<(u32, f32)> = vals.iter().copied().enumerate().map(|(i, v)| (i as u32, v)).collect();
+
+    // Sort descending by logit
+    indexed.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+    // Top-k filtering
+    if top_k > 0 && (top_k as usize) < indexed.len() {
+        indexed.truncate(top_k as usize);
+    }
+
+    // Softmax over remaining candidates
+    let max_logit = indexed[0].1;
+    let mut probs: Vec<(u32, f32)> = indexed
+        .iter()
+        .map(|&(idx, logit)| (idx, (logit - max_logit).exp()))
+        .collect();
+    let sum: f32 = probs.iter().map(|(_, p)| p).sum();
+    for (_, p) in probs.iter_mut() {
+        *p /= sum;
+    }
+
+    // Top-p (nucleus) filtering
+    if top_p > 0.0 && top_p < 1.0 {
+        let mut cumsum = 0.0_f32;
+        let mut cutoff = probs.len();
+        for (i, (_, p)) in probs.iter().enumerate() {
+            cumsum += p;
+            if cumsum >= top_p {
+                cutoff = i + 1;
+                break;
+            }
+        }
+        probs.truncate(cutoff);
+        // Renormalize
+        let sum: f32 = probs.iter().map(|(_, p)| p).sum();
+        for (_, p) in probs.iter_mut() {
+            *p /= sum;
+        }
+    }
+
+    // Categorical sampling
+    let mut rng: StdRng = match seed {
+        Some(s) => StdRng::seed_from_u64(s),
+        None => StdRng::from_entropy(),
+    };
+
+    let r: f32 = rng.r#gen();
+    let mut cumsum = 0.0_f32;
+    for &(idx, p) in &probs {
+        cumsum += p;
+        if r < cumsum {
+            return Ok(idx);
+        }
+    }
+
+    // Fallback to last candidate (numerical edge case)
+    Ok(probs.last().context("no candidates after filtering")?.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    #[test]
+    fn test_greedy_sample_1d() -> Result<()> {
+        let device = Device::Cpu;
+        let logits = Tensor::new(&[1.0_f32, 5.0, 3.0, 2.0], &device)?;
+        let token = greedy_sample(&logits)?;
+        assert_eq!(token, 1); // index of 5.0
+        Ok(())
+    }
+
+    #[test]
+    fn test_greedy_sample_2d() -> Result<()> {
+        let device = Device::Cpu;
+        // [seq_len=3, vocab_size=4] — should sample from last position
+        let logits = Tensor::new(
+            &[
+                1.0_f32, 2.0, 3.0, 4.0, // position 0
+                5.0, 6.0, 7.0, 8.0,     // position 1
+                0.1, 0.2, 9.0, 0.3,     // position 2 (last) — max at index 2
+            ],
+            &device,
+        )?
+        .reshape((3, 4))?;
+        let token = greedy_sample(&logits)?;
+        assert_eq!(token, 2); // index of 9.0 in last row
+        Ok(())
+    }
+
+    #[test]
+    fn test_greedy_sample_3d() -> Result<()> {
+        let device = Device::Cpu;
+        // [batch=1, seq_len=2, vocab_size=3]
+        let logits = Tensor::new(
+            &[
+                1.0_f32, 2.0, 3.0, // position 0
+                7.0, 5.0, 6.0,     // position 1 (last) — max at index 0
+            ],
+            &device,
+        )?
+        .reshape((1, 2, 3))?;
+        let token = greedy_sample(&logits)?;
+        assert_eq!(token, 0); // index of 7.0 in last row
+        Ok(())
+    }
+
+    #[test]
+    fn test_sample_temperature_zero_is_greedy() -> Result<()> {
+        let device = Device::Cpu;
+        let logits = Tensor::new(&[1.0_f32, 5.0, 3.0, 2.0], &device)?;
+        let token = sample_with_params(&logits, 0.0, 1.0, 0, Some(42))?;
+        assert_eq!(token, 1); // same as greedy
+        Ok(())
+    }
+
+    #[test]
+    fn test_sample_very_low_temperature_is_near_greedy() -> Result<()> {
+        let device = Device::Cpu;
+        // With very low temperature, sampling should consistently pick the max
+        let logits = Tensor::new(&[1.0_f32, 10.0, 3.0, 2.0], &device)?;
+        for seed in 0..20 {
+            let token = sample_with_params(&logits, 0.01, 1.0, 0, Some(seed))?;
+            assert_eq!(token, 1, "with temp=0.01 and seed={seed}, expected greedy result");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_k_filtering() -> Result<()> {
+        let device = Device::Cpu;
+        // With top_k=2, only the 2 highest logits should be candidates
+        let logits = Tensor::new(&[1.0_f32, 10.0, 8.0, 2.0, 0.5], &device)?;
+        for seed in 0..50 {
+            let token = sample_with_params(&logits, 1.0, 1.0, 2, Some(seed))?;
+            assert!(
+                token == 1 || token == 2,
+                "top_k=2 should only produce tokens 1 or 2, got {token} with seed={seed}"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_top_p_filtering() -> Result<()> {
+        let device = Device::Cpu;
+        // Logits designed so that after softmax, token 0 has ~99.5% probability
+        let logits = Tensor::new(&[10.0_f32, 0.0, 0.0, 0.0], &device)?;
+        for seed in 0..20 {
+            let token = sample_with_params(&logits, 1.0, 0.95, 0, Some(seed))?;
+            // With top_p=0.95, token 0 alone exceeds the threshold
+            assert_eq!(token, 0, "top_p=0.95 with dominant logit should pick token 0, got {token}");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_sample_with_seed_is_deterministic() -> Result<()> {
+        let device = Device::Cpu;
+        let logits = Tensor::new(&[1.0_f32, 2.0, 3.0, 2.5], &device)?;
+        let t1 = sample_with_params(&logits, 1.0, 1.0, 0, Some(12345))?;
+        let t2 = sample_with_params(&logits, 1.0, 1.0, 0, Some(12345))?;
+        assert_eq!(t1, t2, "same seed should produce same result");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What
- `model_forward`: wires embedding → N transformer blocks → final norm → LM head (weight-tied) → logits
- Linear attention layers use FFN-only pass-through (GDN attention TODO)
- `sampling.rs`: `greedy_sample` (argmax) + `sample_with_params` (temperature, top-p, top-k, seed)
- Tests for shape propagation (multi-token, single-token) and all sampling strategies

## Phase 1 progress
Tokenizer, weights, all layers, attention, transformer block, full forward pass, and sampling now complete.