### PR TITLE
Wire ModelRunner into HTTP server for real inference

### DIFF
--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -5,6 +5,10 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lib]
+name = "kiln_server"
+path = "src/lib.rs"
+
 [[bin]]
 name = "kiln"
 path = "src/main.rs"
@@ -14,6 +18,7 @@ kiln-core = { workspace = true }
 kiln-model = { workspace = true }
 kiln-scheduler = { workspace = true }
 kiln-train = { workspace = true }
+candle-core = { workspace = true }
 axum = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }
@@ -27,3 +32,9 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 tokio-stream = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+safetensors = { workspace = true }
+candle-core = { workspace = true }
+tower = { workspace = true, features = ["util"] }

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -6,7 +6,7 @@ use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
 use kiln_core::tokenizer::ChatMessage;
 
-use crate::state::AppState;
+use crate::state::{AppState, ModelBackend};
 
 /// OpenAI-compatible chat completion request.
 #[derive(Debug, Deserialize)]
@@ -18,6 +18,8 @@ pub struct ChatCompletionRequest {
     pub temperature: Option<f32>,
     #[serde(default)]
     pub top_p: Option<f32>,
+    #[serde(default)]
+    pub top_k: Option<u32>,
     #[serde(default)]
     pub max_tokens: Option<usize>,
     #[serde(default)]
@@ -86,45 +88,118 @@ async fn chat_completions(
         .apply_chat_template(&chat_messages)
         .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
 
-    let prompt_tokens = state
-        .tokenizer
-        .encode(&prompt_text)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
     let sampling = SamplingParams {
         temperature: req.temperature.unwrap_or(1.0),
         top_p: req.top_p.unwrap_or(1.0),
+        top_k: req.top_k.unwrap_or(0),
         max_tokens: req.max_tokens.unwrap_or(2048),
-        stop: req.stop.unwrap_or_default(),
+        stop: req.stop.clone().unwrap_or_default(),
         seed: req.seed,
         ..Default::default()
     };
 
+    match state.backend.as_ref() {
+        ModelBackend::Real(runner) => {
+            generate_real(&state, runner, &prompt_text, &sampling, &req).await
+        }
+        ModelBackend::Mock { scheduler, engine } => {
+            generate_mock(&state, scheduler, engine, &prompt_text, &sampling, &req).await
+        }
+    }
+}
+
+/// Generate using the real ModelRunner (direct forward pass).
+async fn generate_real(
+    state: &AppState,
+    runner: &std::sync::Arc<kiln_model::ModelRunner>,
+    prompt_text: &str,
+    sampling: &SamplingParams,
+    req: &ChatCompletionRequest,
+) -> Result<Json<ChatCompletionResponse>, (StatusCode, String)> {
+    // Count prompt tokens for usage stats.
+    let prompt_token_count = state
+        .tokenizer
+        .encode(prompt_text)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .len();
+
+    // ModelRunner.generate() is CPU-bound; run on a blocking thread to
+    // avoid starving the tokio runtime.
+    let runner = runner.clone();
+    let prompt = prompt_text.to_owned();
+    let params = sampling.clone();
+
+    let output = tokio::task::spawn_blocking(move || runner.generate(&prompt, &params))
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let finish_reason = match output.finish_reason {
+        kiln_model::FinishReason::Eos => "stop",
+        kiln_model::FinishReason::MaxTokens => "length",
+        kiln_model::FinishReason::StopSequence(_) => "stop",
+    };
+
+    let now = now_epoch();
+
+    Ok(Json(ChatCompletionResponse {
+        id: format!("chatcmpl-{}", Uuid::new_v4()),
+        object: "chat.completion",
+        created: now,
+        model: req.model.clone(),
+        choices: vec![Choice {
+            index: 0,
+            message: Message {
+                role: "assistant".to_string(),
+                content: output.text,
+            },
+            finish_reason: finish_reason.to_string(),
+        }],
+        usage: Usage {
+            prompt_tokens: prompt_token_count,
+            completion_tokens: output.token_ids.len(),
+            total_tokens: prompt_token_count + output.token_ids.len(),
+        },
+    }))
+}
+
+/// Generate using the mock engine + scheduler loop (existing behavior).
+async fn generate_mock(
+    state: &AppState,
+    scheduler: &tokio::sync::Mutex<kiln_scheduler::Scheduler>,
+    engine: &std::sync::Arc<dyn kiln_model::engine::Engine>,
+    prompt_text: &str,
+    sampling: &SamplingParams,
+    req: &ChatCompletionRequest,
+) -> Result<Json<ChatCompletionResponse>, (StatusCode, String)> {
+    let prompt_tokens = state
+        .tokenizer
+        .encode(prompt_text)
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
     let prompt_token_count = prompt_tokens.len();
-    let request = Request::new(prompt_tokens, sampling, req.adapter);
+    let request = Request::new(prompt_tokens, sampling.clone(), req.adapter.clone());
     let request_id = request.id;
 
     // Add to scheduler
     {
-        let mut sched = state.scheduler.lock().await;
+        let mut sched = scheduler.lock().await;
         sched.add_request(request);
     }
 
     // Run scheduler steps until this request completes.
-    // In the real implementation this will be an async loop driven by the engine.
-    // For now with MockEngine, we just step until done.
     let max_steps = 100;
     let mut output_tokens = Vec::new();
 
     for _ in 0..max_steps {
-        let mut sched = state.scheduler.lock().await;
+        let mut sched = scheduler.lock().await;
         let step_output = sched.step();
 
         if step_output.scheduled.is_empty() {
             break;
         }
 
-        // Build batch input (simplified — real impl builds proper ragged batch)
+        // Build batch input
         let batch = kiln_model::engine::BatchInput {
             token_ids: vec![0; step_output.total_tokens],
             seqlens: step_output
@@ -146,8 +221,7 @@ async fn chat_completions(
                 .collect(),
         };
 
-        let engine_output = state
-            .engine
+        let engine_output = engine
             .step(&batch)
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
@@ -182,23 +256,19 @@ async fn chat_completions(
         }
     }
 
-    // Decode output tokens back to text (mock engine produces token ID 42 repeatedly,
-    // which won't decode to meaningful text, but the pipeline is real)
+    // Decode output tokens
     let completion_text = state
         .tokenizer
         .decode(&output_tokens)
         .unwrap_or_else(|_| format!("[{} tokens, decode failed]", output_tokens.len()));
 
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
+    let now = now_epoch();
 
     Ok(Json(ChatCompletionResponse {
         id: format!("chatcmpl-{}", Uuid::new_v4()),
         object: "chat.completion",
         created: now,
-        model: req.model,
+        model: req.model.clone(),
         choices: vec![Choice {
             index: 0,
             message: Message {
@@ -213,6 +283,13 @@ async fn chat_completions(
             total_tokens: prompt_token_count + output_tokens.len(),
         },
     }))
+}
+
+fn now_epoch() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
 }
 
 pub fn routes() -> Router<AppState> {

--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -1,14 +1,15 @@
 use axum::{extract::State, routing::get, Json, Router};
 use serde::Serialize;
 
-use crate::state::AppState;
+use crate::state::{AppState, ModelBackend};
 
 #[derive(Serialize)]
 struct HealthResponse {
     status: &'static str,
     version: &'static str,
     model: String,
-    scheduler: SchedulerStats,
+    backend: &'static str,
+    scheduler: Option<SchedulerStats>,
 }
 
 #[derive(Serialize)]
@@ -21,8 +22,24 @@ struct SchedulerStats {
 }
 
 async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
-    let sched = state.scheduler.lock().await;
-    let bm = sched.block_manager();
+    let (backend_name, scheduler_stats) = match state.backend.as_ref() {
+        ModelBackend::Mock { scheduler, .. } => {
+            let sched = scheduler.lock().await;
+            let bm = sched.block_manager();
+            (
+                "mock",
+                Some(SchedulerStats {
+                    waiting: sched.num_waiting(),
+                    running: sched.num_running(),
+                    blocks_used: bm.num_used(),
+                    blocks_free: bm.num_free(),
+                    blocks_total: bm.num_blocks(),
+                }),
+            )
+        }
+        ModelBackend::Real(_) => ("model", None),
+    };
+
     Json(HealthResponse {
         status: "ok",
         version: env!("CARGO_PKG_VERSION"),
@@ -32,13 +49,8 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
             state.model_config.num_attention_heads,
             state.model_config.num_kv_heads,
         ),
-        scheduler: SchedulerStats {
-            waiting: sched.num_waiting(),
-            running: sched.num_running(),
-            blocks_used: bm.num_used(),
-            blocks_free: bm.num_free(),
-            blocks_total: bm.num_blocks(),
-        },
+        backend: backend_name,
+        scheduler: scheduler_stats,
     })
 }
 

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -1,0 +1,4 @@
+//! Kiln HTTP server — library interface for integration testing.
+
+pub mod api;
+pub mod state;

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -1,13 +1,17 @@
-use anyhow::Result;
+use std::path::Path;
 use std::sync::Arc;
+
+use anyhow::Result;
 use tracing_subscriber::EnvFilter;
 
-mod api;
-mod state;
+use kiln_server::api;
+use kiln_server::state;
 
 use kiln_core::config::ModelConfig;
 use kiln_core::tokenizer::KilnTokenizer;
 use kiln_model::engine::MockEngine;
+use kiln_model::forward::GpuWeights;
+use kiln_model::ModelRunner;
 use kiln_scheduler::{Scheduler, SchedulerConfig};
 use state::AppState;
 
@@ -24,32 +28,26 @@ async fn main() -> Result<()> {
         .unwrap_or(8420);
 
     let model_config = ModelConfig::qwen3_5_4b();
-
-    let scheduler_config = SchedulerConfig {
-        max_batch_tokens: 8192,
-        max_batch_size: 64,
-        block_size: 16,
-    };
-
-    // Calculate number of KV cache blocks based on available memory.
-    // For now, use a fixed number. Real implementation will query GPU memory.
-    // Target: 131072 tokens (full 128K context) = 8192 blocks at block_size=16.
-    // Qwen3.5-4B only needs KV cache for 8 full-attention layers (out of 32 total).
-    // KV at 128K BF16: ~4 GB (32 KB/token * 131072 tokens). This is the hybrid
-    // architecture payoff — 128K context fits comfortably on a 24GB GPU.
-    let num_blocks = 8192; // 131072 tokens of KV cache with block_size=16
-
-    let scheduler = Scheduler::new(scheduler_config, num_blocks);
-    let engine = MockEngine::new(model_config.clone());
+    let model_path = std::env::var("KILN_MODEL_PATH").ok();
 
     // Load tokenizer: try from_pretrained (HF Hub), fall back to local path, then fail gracefully.
     let model_id =
         std::env::var("KILN_MODEL_ID").unwrap_or_else(|_| "Qwen/Qwen3.5-4B".to_string());
     let tokenizer_path = std::env::var("KILN_TOKENIZER_PATH").ok();
 
-    let tokenizer = if let Some(path) = tokenizer_path {
+    let tokenizer = if let Some(path) = &tokenizer_path {
         tracing::info!("loading tokenizer from {path}");
-        KilnTokenizer::from_file(&path)?
+        KilnTokenizer::from_file(path)?
+    } else if let Some(ref mp) = model_path {
+        // Try loading tokenizer from the model directory first
+        let tok_file = Path::new(mp).join("tokenizer.json");
+        if tok_file.exists() {
+            tracing::info!("loading tokenizer from model directory: {}", tok_file.display());
+            KilnTokenizer::from_file(tok_file.to_str().unwrap())?
+        } else {
+            tracing::info!("loading tokenizer from HuggingFace Hub: {model_id}");
+            KilnTokenizer::from_pretrained(&model_id)?
+        }
     } else {
         tracing::info!("loading tokenizer from HuggingFace Hub: {model_id}");
         KilnTokenizer::from_pretrained(&model_id)?
@@ -60,7 +58,41 @@ async fn main() -> Result<()> {
         "tokenizer loaded successfully"
     );
 
-    let state = AppState::new(model_config, scheduler, Arc::new(engine), tokenizer);
+    let state = if let Some(ref mp) = model_path {
+        // Real inference mode: load model weights and create ModelRunner.
+        tracing::info!("loading model weights from {mp}");
+        let model_weights = kiln_model::load_model(Path::new(mp), &model_config)?;
+        let device = candle_core::Device::Cpu; // TODO: CUDA when available
+        let gpu_weights = GpuWeights::from_model_weights(&model_weights, &device)?;
+
+        // ModelRunner takes ownership of a tokenizer, so load a second instance.
+        let runner_tokenizer = if let Some(ref path) = tokenizer_path {
+            KilnTokenizer::from_file(path)?
+        } else {
+            let tok_file = Path::new(mp).join("tokenizer.json");
+            if tok_file.exists() {
+                KilnTokenizer::from_file(tok_file.to_str().unwrap())?
+            } else {
+                KilnTokenizer::from_pretrained(&model_id)?
+            }
+        };
+
+        let runner = ModelRunner::new(gpu_weights, runner_tokenizer, model_config.clone());
+        tracing::info!("model loaded — real inference mode");
+        AppState::new_real(model_config, runner, tokenizer)
+    } else {
+        // Mock mode: use scheduler + mock engine.
+        tracing::info!("no KILN_MODEL_PATH set — running in mock mode");
+        let scheduler_config = SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+        };
+        let num_blocks = 8192;
+        let scheduler = Scheduler::new(scheduler_config, num_blocks);
+        let engine = MockEngine::new(model_config.clone());
+        AppState::new_mock(model_config, scheduler, Arc::new(engine), tokenizer)
+    };
 
     let app = api::router(state);
 

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -4,19 +4,31 @@ use tokio::sync::Mutex;
 use kiln_core::config::ModelConfig;
 use kiln_core::tokenizer::KilnTokenizer;
 use kiln_model::engine::Engine;
+use kiln_model::ModelRunner;
 use kiln_scheduler::Scheduler;
+
+/// Which inference backend the server is using.
+pub enum ModelBackend {
+    /// Mock engine + scheduler for testing without real weights.
+    Mock {
+        scheduler: Arc<Mutex<Scheduler>>,
+        engine: Arc<dyn Engine>,
+    },
+    /// Real model weights loaded via ModelRunner.
+    Real(Arc<ModelRunner>),
+}
 
 /// Shared application state passed to all handlers.
 #[derive(Clone)]
 pub struct AppState {
     pub model_config: ModelConfig,
-    pub scheduler: Arc<Mutex<Scheduler>>,
-    pub engine: Arc<dyn Engine>,
+    pub backend: Arc<ModelBackend>,
     pub tokenizer: Arc<KilnTokenizer>,
 }
 
 impl AppState {
-    pub fn new(
+    /// Create an AppState with the mock engine backend.
+    pub fn new_mock(
         model_config: ModelConfig,
         scheduler: Scheduler,
         engine: Arc<dyn Engine>,
@@ -24,8 +36,23 @@ impl AppState {
     ) -> Self {
         Self {
             model_config,
-            scheduler: Arc::new(Mutex::new(scheduler)),
-            engine,
+            backend: Arc::new(ModelBackend::Mock {
+                scheduler: Arc::new(Mutex::new(scheduler)),
+                engine,
+            }),
+            tokenizer: Arc::new(tokenizer),
+        }
+    }
+
+    /// Create an AppState with a real ModelRunner backend.
+    pub fn new_real(
+        model_config: ModelConfig,
+        runner: ModelRunner,
+        tokenizer: KilnTokenizer,
+    ) -> Self {
+        Self {
+            model_config,
+            backend: Arc::new(ModelBackend::Real(Arc::new(runner))),
             tokenizer: Arc::new(tokenizer),
         }
     }

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -1,0 +1,238 @@
+//! Integration test: wire a tiny random-weight ModelRunner into the HTTP server
+//! and verify /v1/chat/completions returns real generated text.
+
+use std::collections::HashMap;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use candle_core::{DType, Device, Tensor};
+use serde_json::{json, Value};
+use tower::ServiceExt; // for `oneshot`
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::forward::{
+    GpuAttentionWeights, GpuFfnWeights, GpuFullAttentionWeights, GpuLayerWeights, GpuWeights,
+};
+use kiln_model::ModelRunner;
+use kiln_server::api;
+use kiln_server::state::AppState;
+
+/// Create a tiny model config for testing.
+fn tiny_config() -> ModelConfig {
+    ModelConfig {
+        hidden_size: 8,
+        num_layers: 1,
+        num_attention_heads: 2,
+        num_kv_heads: 1,
+        head_dim: 4,
+        intermediate_size: 16,
+        vocab_size: 32,
+        max_position_embeddings: 128,
+        rms_norm_eps: 1e-6,
+        rope_theta: 10_000.0,
+        dtype: kiln_core::config::DType::FP32,
+        num_full_attention_layers: 1,
+        full_attention_interval: 1,
+    }
+}
+
+/// Create random GPU weights matching the tiny config.
+fn tiny_weights(config: &ModelConfig, device: &Device) -> GpuWeights {
+    let h = config.hidden_size;
+    let inter = config.intermediate_size;
+    let vocab = config.vocab_size;
+    let num_heads = config.num_attention_heads;
+    let num_kv_heads = config.num_kv_heads;
+    let head_dim = config.head_dim;
+
+    let embed = Tensor::randn(0.0_f32, 0.02, (vocab, h), device).unwrap();
+    let final_norm = Tensor::ones((h,), DType::F32, device).unwrap();
+
+    let layer = GpuLayerWeights {
+        input_layernorm: Tensor::ones((h,), DType::F32, device).unwrap(),
+        post_attention_layernorm: Tensor::ones((h,), DType::F32, device).unwrap(),
+        attention: GpuAttentionWeights::Full(GpuFullAttentionWeights {
+            q_proj: Tensor::randn(0.0_f32, 0.02, (num_heads * head_dim, h), device).unwrap(),
+            k_proj: Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, h), device).unwrap(),
+            v_proj: Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, h), device).unwrap(),
+            o_proj: Tensor::randn(0.0_f32, 0.02, (h, num_heads * head_dim), device).unwrap(),
+            q_norm: Tensor::ones((head_dim,), DType::F32, device).unwrap(),
+            k_norm: Tensor::ones((head_dim,), DType::F32, device).unwrap(),
+        }),
+        mlp: GpuFfnWeights {
+            gate_proj: Tensor::randn(0.0_f32, 0.02, (inter, h), device).unwrap(),
+            up_proj: Tensor::randn(0.0_f32, 0.02, (inter, h), device).unwrap(),
+            down_proj: Tensor::randn(0.0_f32, 0.02, (h, inter), device).unwrap(),
+        },
+    };
+
+    GpuWeights {
+        embed_tokens: embed,
+        layers: vec![layer],
+        final_norm,
+    }
+}
+
+/// Create a minimal tokenizer for testing.
+///
+/// The vocab includes ChatML special tokens so that `apply_chat_template`
+/// produces a prompt that can be tokenized (each special token maps to its own ID).
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    // Reserve 0-19 for regular tokens
+    for i in 0u32..20 {
+        let c = format!("t{i}");
+        vocab.insert(c, i);
+    }
+    // ChatML-related tokens as regular vocab entries so BPE can emit them
+    vocab.insert("<|im_start|>".to_string(), 20);
+    vocab.insert("<|im_end|>".to_string(), 21);
+    vocab.insert("user".to_string(), 22);
+    vocab.insert("assistant".to_string(), 23);
+    vocab.insert("\n".to_string(), 24);
+    // Pad to vocab_size=32
+    for i in 25u32..32 {
+        vocab.insert(format!("x{i}"), i);
+    }
+
+    let json = json!({
+        "version": "1.0",
+        "model": {
+            "type": "BPE",
+            "vocab": vocab,
+            "merges": []
+        },
+        "added_tokens": [
+            {
+                "id": 0,
+                "content": "<|endoftext|>",
+                "single_word": false,
+                "lstrip": false,
+                "rstrip": false,
+                "normalized": false,
+                "special": true
+            },
+            {
+                "id": 20,
+                "content": "<|im_start|>",
+                "single_word": false,
+                "lstrip": false,
+                "rstrip": false,
+                "normalized": false,
+                "special": true
+            },
+            {
+                "id": 21,
+                "content": "<|im_end|>",
+                "single_word": false,
+                "lstrip": false,
+                "rstrip": false,
+                "normalized": false,
+                "special": true
+            }
+        ]
+    });
+
+    let bytes = serde_json::to_vec(&json).unwrap();
+    KilnTokenizer::from_bytes(&bytes).unwrap()
+}
+
+#[tokio::test]
+async fn test_real_model_chat_completion() {
+    let config = tiny_config();
+    let device = Device::Cpu;
+    let weights = tiny_weights(&config, &device);
+
+    let runner_tokenizer = test_tokenizer();
+    let state_tokenizer = test_tokenizer();
+
+    let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
+    let state = AppState::new_real(config, runner, state_tokenizer);
+
+    let app = api::router(state);
+
+    let body = json!({
+        "messages": [{"role": "user", "content": "t1 t2 t3"}],
+        "max_tokens": 5,
+        "temperature": 0.0
+    });
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    let status = response.status();
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+
+    if status != StatusCode::OK {
+        let body_str = String::from_utf8_lossy(&body_bytes);
+        panic!("Expected 200, got {status}: {body_str}");
+    }
+
+    let resp: Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    // Verify response structure
+    assert_eq!(resp["object"], "chat.completion");
+    assert!(resp["id"].as_str().unwrap().starts_with("chatcmpl-"));
+
+    let choices = resp["choices"].as_array().unwrap();
+    assert_eq!(choices.len(), 1);
+    assert_eq!(choices[0]["message"]["role"], "assistant");
+
+    // The model produces random tokens, but the content should be a string
+    assert!(choices[0]["message"]["content"].is_string());
+
+    // Verify finish_reason is either "stop" or "length"
+    let finish = choices[0]["finish_reason"].as_str().unwrap();
+    assert!(
+        finish == "stop" || finish == "length",
+        "unexpected finish_reason: {finish}"
+    );
+
+    // Usage should have completion_tokens > 0 (model generated something)
+    let usage = &resp["usage"];
+    assert!(usage["completion_tokens"].as_u64().unwrap() > 0);
+    assert!(usage["total_tokens"].as_u64().unwrap() > 0);
+}
+
+#[tokio::test]
+async fn test_health_with_real_backend() {
+    let config = tiny_config();
+    let device = Device::Cpu;
+    let weights = tiny_weights(&config, &device);
+
+    let runner_tokenizer = test_tokenizer();
+    let state_tokenizer = test_tokenizer();
+
+    let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
+    let state = AppState::new_real(config, runner, state_tokenizer);
+
+    let app = api::router(state);
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let resp: Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert_eq!(resp["status"], "ok");
+    assert_eq!(resp["backend"], "model");
+    // scheduler should be null for real backend
+    assert!(resp["scheduler"].is_null());
+}


### PR DESCRIPTION
## What

Wire the real `ModelRunner` (from PR #6) into the HTTP server so `/v1/chat/completions` produces real model output when `KILN_MODEL_PATH` is set.

## Changes

- **`state.rs`**: Add `ModelBackend` enum — `Mock` (scheduler + mock engine) or `Real` (ModelRunner). Replace `scheduler`/`engine` fields with a single `backend: Arc<ModelBackend>`.
- **`main.rs`**: When `KILN_MODEL_PATH` env var is set, load safetensors weights and create a `ModelRunner`. Otherwise keep mock mode. Also tries loading `tokenizer.json` from the model directory.
- **`completions.rs`**: Dispatch to `ModelRunner.generate()` for real backend (runs on `spawn_blocking` to avoid starving tokio). Mock backend keeps existing scheduler loop. Added `top_k` parameter support.
- **`health.rs`**: Reports `backend: "model"` or `"mock"`. Scheduler stats only shown for mock backend.
- **`lib.rs`**: New library crate entry point so integration tests can access `api::router` and `state::AppState`.
- **Integration test**: Creates a tiny random-weight model, wires it into the server, and verifies `/v1/chat/completions` returns a valid OpenAI-compatible response with real generated tokens.

## How to use

```bash
# Mock mode (no GPU/weights needed)
cargo run

# Real inference mode
KILN_MODEL_PATH=/path/to/qwen3.5-4b cargo run
```

## Test plan

- [x] `cargo test --workspace` — all 53 tests pass (including 2 new integration tests)
- [x] Integration test verifies end-to-end: tiny model → HTTP request → real generated text response
- [x] Health endpoint test verifies backend reporting