### PR TITLE
Add SSE streaming for chat completions

### DIFF
--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -4,6 +4,7 @@
 //! a `ModelRunner` that accepts text prompts and produces text output.
 
 use anyhow::{Context, Result};
+use std::sync::mpsc;
 
 use kiln_core::config::ModelConfig;
 use kiln_core::sampling::SamplingParams;
@@ -31,6 +32,33 @@ pub struct GenerationOutput {
     pub token_ids: Vec<TokenId>,
     /// Why generation stopped.
     pub finish_reason: FinishReason,
+}
+
+/// A single token emitted during streaming generation.
+#[derive(Debug, Clone)]
+pub struct StreamToken {
+    /// The generated token ID.
+    pub token_id: TokenId,
+    /// The decoded text for this token.
+    pub text: String,
+}
+
+/// Final event sent when streaming generation completes.
+#[derive(Debug, Clone)]
+pub struct StreamDone {
+    /// Why generation stopped.
+    pub finish_reason: FinishReason,
+    /// Total number of generated tokens.
+    pub completion_tokens: usize,
+}
+
+/// Events emitted during streaming generation.
+#[derive(Debug, Clone)]
+pub enum StreamEvent {
+    /// A new token was generated.
+    Token(StreamToken),
+    /// Generation is complete.
+    Done(StreamDone),
 }
 
 /// Why generation stopped.
@@ -80,6 +108,110 @@ impl ModelRunner {
             token_ids: output.token_ids,
             finish_reason: output.finish_reason,
         })
+    }
+
+    /// Generate text token-by-token, sending each token to a channel as it is produced.
+    ///
+    /// Returns an `mpsc::Receiver<StreamEvent>` that yields `Token` events
+    /// followed by a final `Done` event.  The generation runs synchronously
+    /// on the calling thread (caller should use `spawn_blocking`).
+    pub fn generate_streaming(
+        &self,
+        prompt: &str,
+        params: &SamplingParams,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        let prompt_tokens = self
+            .tokenizer
+            .encode(prompt)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("failed to tokenize prompt")?;
+
+        anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
+
+        let (tx, rx) = mpsc::channel();
+
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
+        let mut all_tokens: Vec<TokenId> = prompt_tokens.to_vec();
+        let mut step_seed = params.seed;
+
+        let mut finish_reason = FinishReason::MaxTokens;
+
+        for _step in 0..params.max_tokens {
+            let logits = model_forward(&all_tokens, &self.weights, &self.config)
+                .context("forward pass failed")?;
+
+            let next_token = if params.temperature == 0.0 {
+                greedy_sample(&logits)?
+            } else {
+                sample_with_params(
+                    &logits,
+                    params.temperature,
+                    params.top_p,
+                    params.top_k,
+                    step_seed,
+                )?
+            };
+
+            if let Some(s) = step_seed.as_mut() {
+                *s = s.wrapping_add(1);
+            }
+
+            // Check for EOS
+            if self.eos_token_ids.contains(&next_token) {
+                finish_reason = FinishReason::Eos;
+                break;
+            }
+
+            generated_tokens.push(next_token);
+            all_tokens.push(next_token);
+
+            // Decode this token's text
+            let token_text = self
+                .tokenizer
+                .decode(&[next_token])
+                .unwrap_or_default();
+
+            // Send token event; if receiver dropped, stop early
+            if tx
+                .send(StreamEvent::Token(StreamToken {
+                    token_id: next_token,
+                    text: token_text,
+                }))
+                .is_err()
+            {
+                return Ok(rx);
+            }
+
+            // Check stop sequences
+            if !params.stop.is_empty() {
+                let decoded_so_far = self
+                    .tokenizer
+                    .decode(&generated_tokens)
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+                    .ok();
+                if let Some(text) = &decoded_so_far {
+                    for stop_seq in &params.stop {
+                        if text.contains(stop_seq.as_str()) {
+                            finish_reason =
+                                FinishReason::StopSequence(stop_seq.clone());
+                            // Send done and return
+                            let _ = tx.send(StreamEvent::Done(StreamDone {
+                                finish_reason,
+                                completion_tokens: generated_tokens.len(),
+                            }));
+                            return Ok(rx);
+                        }
+                    }
+                }
+            }
+        }
+
+        let _ = tx.send(StreamEvent::Done(StreamDone {
+            finish_reason,
+            completion_tokens: generated_tokens.len(),
+        }));
+
+        Ok(rx)
     }
 
     /// Autoregressive generation loop operating on token IDs.

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -7,6 +7,6 @@ pub mod sampling;
 pub mod weights;
 
 pub use engine::Engine;
-pub use generate::{FinishReason, GenerationOutput, ModelRunner};
+pub use generate::{FinishReason, GenerationOutput, ModelRunner, StreamDone, StreamEvent, StreamToken};
 pub use loader::load_model;
 pub use weights::ModelWeights;

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -1,10 +1,18 @@
-use axum::{extract::State, http::StatusCode, routing::post, Json, Router};
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::StreamExt;
 use uuid::Uuid;
 
 use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
 use kiln_core::tokenizer::ChatMessage;
+use kiln_model::StreamEvent;
 
 use crate::state::{AppState, ModelBackend};
 
@@ -68,10 +76,36 @@ pub struct Usage {
     pub total_tokens: usize,
 }
 
+/// OpenAI-compatible streaming chunk.
+#[derive(Debug, Serialize)]
+pub struct ChatCompletionChunk {
+    pub id: String,
+    pub object: &'static str,
+    pub created: u64,
+    pub model: String,
+    pub choices: Vec<ChunkChoice>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ChunkChoice {
+    pub index: usize,
+    pub delta: Delta,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct Delta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
 async fn chat_completions(
     State(state): State<AppState>,
     Json(req): Json<ChatCompletionRequest>,
-) -> Result<Json<ChatCompletionResponse>, (StatusCode, String)> {
+) -> Result<Response, (StatusCode, String)> {
     // Convert request messages to ChatMessage for template formatting
     let chat_messages: Vec<ChatMessage> = req
         .messages
@@ -98,12 +132,28 @@ async fn chat_completions(
         ..Default::default()
     };
 
-    match state.backend.as_ref() {
-        ModelBackend::Real(runner) => {
-            generate_real(&state, runner, &prompt_text, &sampling, &req).await
+    if req.stream {
+        match state.backend.as_ref() {
+            ModelBackend::Real(runner) => {
+                generate_real_streaming(&state, runner, &prompt_text, &sampling, &req).await
+            }
+            ModelBackend::Mock { .. } => Err((
+                StatusCode::NOT_IMPLEMENTED,
+                "streaming not supported with mock backend".to_string(),
+            )),
         }
-        ModelBackend::Mock { scheduler, engine } => {
-            generate_mock(&state, scheduler, engine, &prompt_text, &sampling, &req).await
+    } else {
+        match state.backend.as_ref() {
+            ModelBackend::Real(runner) => {
+                generate_real(&state, runner, &prompt_text, &sampling, &req)
+                    .await
+                    .map(|json| json.into_response())
+            }
+            ModelBackend::Mock { scheduler, engine } => {
+                generate_mock(&state, scheduler, engine, &prompt_text, &sampling, &req)
+                    .await
+                    .map(|json| json.into_response())
+            }
         }
     }
 }
@@ -161,6 +211,140 @@ async fn generate_real(
             total_tokens: prompt_token_count + output.token_ids.len(),
         },
     }))
+}
+
+/// Generate using the real ModelRunner with SSE streaming.
+async fn generate_real_streaming(
+    _state: &AppState,
+    runner: &std::sync::Arc<kiln_model::ModelRunner>,
+    prompt_text: &str,
+    sampling: &SamplingParams,
+    req: &ChatCompletionRequest,
+) -> Result<Response, (StatusCode, String)> {
+    let runner = runner.clone();
+    let prompt = prompt_text.to_owned();
+    let params = sampling.clone();
+    let model = req.model.clone();
+    let completion_id = format!("chatcmpl-{}", Uuid::new_v4());
+    let created = now_epoch();
+
+    // Use a tokio mpsc channel to bridge sync generation -> async SSE stream.
+    let (tx, rx) = tokio::sync::mpsc::channel::<Event>(32);
+
+    // Spawn a task that runs the blocking generation and converts to SSE events.
+    tokio::task::spawn({
+        let id = completion_id.clone();
+        let model = model.clone();
+        async move {
+            // Send initial role chunk
+            let role_chunk = ChatCompletionChunk {
+                id: id.clone(),
+                object: "chat.completion.chunk",
+                created,
+                model: model.clone(),
+                choices: vec![ChunkChoice {
+                    index: 0,
+                    delta: Delta {
+                        role: Some("assistant".to_string()),
+                        content: None,
+                    },
+                    finish_reason: None,
+                }],
+            };
+            if tx
+                .send(Event::default().data(serde_json::to_string(&role_chunk).unwrap()))
+                .await
+                .is_err()
+            {
+                return;
+            }
+
+            // Run blocking generation
+            let sync_rx = match tokio::task::spawn_blocking(move || {
+                runner.generate_streaming(&prompt, &params)
+            })
+            .await
+            {
+                Ok(Ok(rx)) => rx,
+                _ => {
+                    let _ = tx.send(Event::default().data("[DONE]")).await;
+                    return;
+                }
+            };
+
+            // Forward token events as SSE
+            loop {
+                match sync_rx.recv() {
+                    Ok(StreamEvent::Token(token)) => {
+                        let chunk = ChatCompletionChunk {
+                            id: id.clone(),
+                            object: "chat.completion.chunk",
+                            created,
+                            model: model.clone(),
+                            choices: vec![ChunkChoice {
+                                index: 0,
+                                delta: Delta {
+                                    role: None,
+                                    content: Some(token.text),
+                                },
+                                finish_reason: None,
+                            }],
+                        };
+                        if tx
+                            .send(
+                                Event::default()
+                                    .data(serde_json::to_string(&chunk).unwrap()),
+                            )
+                            .await
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                    Ok(StreamEvent::Done(done)) => {
+                        let finish = match done.finish_reason {
+                            kiln_model::FinishReason::Eos => "stop",
+                            kiln_model::FinishReason::MaxTokens => "length",
+                            kiln_model::FinishReason::StopSequence(_) => "stop",
+                        };
+                        let chunk = ChatCompletionChunk {
+                            id: id.clone(),
+                            object: "chat.completion.chunk",
+                            created,
+                            model: model.clone(),
+                            choices: vec![ChunkChoice {
+                                index: 0,
+                                delta: Delta {
+                                    role: None,
+                                    content: None,
+                                },
+                                finish_reason: Some(finish.to_string()),
+                            }],
+                        };
+                        let _ = tx
+                            .send(
+                                Event::default()
+                                    .data(serde_json::to_string(&chunk).unwrap()),
+                            )
+                            .await;
+                        let _ = tx.send(Event::default().data("[DONE]")).await;
+                        return;
+                    }
+                    Err(_) => {
+                        // Channel closed without Done — send [DONE] anyway
+                        let _ = tx.send(Event::default().data("[DONE]")).await;
+                        return;
+                    }
+                }
+            }
+        }
+    });
+
+    let stream = ReceiverStream::new(rx).map(Ok::<_, std::convert::Infallible>);
+
+    Ok(Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response())
 }
 
 /// Generate using the mock engine + scheduler loop (existing behavior).

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -204,6 +204,112 @@ async fn test_real_model_chat_completion() {
 }
 
 #[tokio::test]
+async fn test_real_model_streaming_chat_completion() {
+    let config = tiny_config();
+    let device = Device::Cpu;
+    let weights = tiny_weights(&config, &device);
+
+    let runner_tokenizer = test_tokenizer();
+    let state_tokenizer = test_tokenizer();
+
+    let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
+    let state = AppState::new_real(config, runner, state_tokenizer);
+
+    let app = api::router(state);
+
+    let body = json!({
+        "messages": [{"role": "user", "content": "t1 t2 t3"}],
+        "max_tokens": 5,
+        "temperature": 0.0,
+        "stream": true
+    });
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_string(&body).unwrap()))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+
+    let status = response.status();
+    assert_eq!(status, StatusCode::OK, "expected 200 for streaming request");
+
+    // Verify content-type is text/event-stream
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        content_type.contains("text/event-stream"),
+        "expected text/event-stream, got {content_type}"
+    );
+
+    // Read the full SSE body
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&body_bytes);
+
+    // Parse SSE events: lines starting with "data: "
+    let data_lines: Vec<&str> = body_str
+        .lines()
+        .filter(|line| line.starts_with("data: ") || line.starts_with("data:"))
+        .map(|line| line.strip_prefix("data: ").or_else(|| line.strip_prefix("data:")).unwrap_or(line))
+        .collect();
+
+    assert!(
+        data_lines.len() >= 3,
+        "expected at least 3 data lines (role + tokens + [DONE]), got {}: {:?}",
+        data_lines.len(),
+        data_lines
+    );
+
+    // First chunk should have role: "assistant"
+    let first: Value = serde_json::from_str(data_lines[0])
+        .unwrap_or_else(|e| panic!("failed to parse first chunk: {e}\nraw: {}", data_lines[0]));
+    assert_eq!(first["object"], "chat.completion.chunk");
+    assert_eq!(first["choices"][0]["delta"]["role"], "assistant");
+    assert!(first["choices"][0]["finish_reason"].is_null());
+
+    // Middle chunks should have content
+    let mut saw_content = false;
+    for line in &data_lines[1..data_lines.len() - 1] {
+        if *line == "[DONE]" {
+            continue;
+        }
+        let chunk: Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("failed to parse chunk: {e}\nraw: {line}"));
+        if chunk["choices"][0]["delta"]["content"].is_string() {
+            saw_content = true;
+        }
+    }
+    assert!(saw_content, "expected at least one content chunk");
+
+    // Last line should be [DONE]
+    assert_eq!(
+        *data_lines.last().unwrap(),
+        "[DONE]",
+        "stream should end with [DONE]"
+    );
+
+    // Second-to-last data line (before [DONE]) should have finish_reason
+    let second_to_last = data_lines[data_lines.len() - 2];
+    let finish_chunk: Value = serde_json::from_str(second_to_last)
+        .unwrap_or_else(|e| panic!("failed to parse finish chunk: {e}\nraw: {second_to_last}"));
+    let finish_reason = finish_chunk["choices"][0]["finish_reason"]
+        .as_str()
+        .expect("finish_reason should be a string");
+    assert!(
+        finish_reason == "stop" || finish_reason == "length",
+        "unexpected finish_reason: {finish_reason}"
+    );
+}
+
+#[tokio::test]
 async fn test_health_with_real_backend() {
     let config = tiny_config();
     let device = Device::Cpu;


### PR DESCRIPTION
## What
Add Server-Sent Events streaming support for `/v1/chat/completions` when `stream: true`.

## Why
Streaming is essential for interactive use — users see tokens as they are generated instead of waiting for the full response. This is a core Phase 1 requirement.

## How
- New `generate_streaming()` method on `ModelRunner` that sends `StreamEvent`s (Token/Done) via `std::sync::mpsc` channel as each token is produced
- SSE response path in completions handler using axum `Sse` with a tokio mpsc bridge
- OpenAI-compatible `ChatCompletionChunk` format with role delta, content deltas, finish_reason, and `[DONE]` sentinel
- Integration test verifying SSE format, content chunks, finish_reason, and `[DONE]` termination

## Format
Follows the OpenAI streaming spec:
1. First chunk: `delta.role = "assistant"`
2. Content chunks: `delta.content = "<token text>"`  
3. Final chunk: `finish_reason = "stop"|"length"`
4. Terminator: `data: [DONE]`