### PR TITLE
Add KV cache for efficient autoregressive generation

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -7,6 +7,7 @@
 use anyhow::{Context, Result};
 use candle_core::{DType, Device, Tensor};
 
+use crate::kv_cache::KvCache;
 use crate::weights::{ModelWeights, TensorDType, WeightTensor};
 
 /// GPU-ready tensors organized by layer, converted from raw `ModelWeights` bytes.
@@ -280,12 +281,14 @@ pub fn swiglu_ffn(
 ///
 /// `x`: [batch, seq_len, hidden_size]
 /// `attn_weights`: Q/K/V/O projection weights plus per-head RMSNorm weights
-/// `positions`: position indices for RoPE (length = seq_len)
+/// `positions`: position indices for RoPE (length = seq_len, absolute positions)
 /// `num_heads`: number of query attention heads
 /// `num_kv_heads`: number of key/value attention heads
 /// `head_dim`: dimension per head
 /// `rope_theta`: RoPE base frequency
 /// `rms_norm_eps`: epsilon for Q/K head norms
+/// `kv_cache`: optional KV cache for incremental decoding
+/// `full_attn_layer_idx`: index into the KV cache's layer array (only full-attn layers)
 ///
 /// Returns: [batch, seq_len, hidden_size]
 pub fn gqa_attention(
@@ -297,6 +300,8 @@ pub fn gqa_attention(
     head_dim: usize,
     rope_theta: f64,
     rms_norm_eps: f64,
+    kv_cache: Option<&mut KvCache>,
+    full_attn_layer_idx: usize,
 ) -> Result<Tensor> {
     let (_batch, seq_len, _hidden) = x.dims3()?;
 
@@ -316,7 +321,7 @@ pub fn gqa_attention(
     let q = rms_norm(&q, &attn_weights.q_norm, rms_norm_eps)?;
     let k = rms_norm(&k, &attn_weights.k_norm, rms_norm_eps)?;
 
-    // Apply RoPE
+    // Apply RoPE (positions are absolute, so cached tokens get correct embeddings)
     let (q, k) = rotary_embedding(&q, &k, positions, head_dim, rope_theta)?;
 
     // Transpose to [batch, heads, seq_len, head_dim] for attention
@@ -324,37 +329,51 @@ pub fn gqa_attention(
     let k = k.transpose(1, 2)?.contiguous()?; // [batch, num_kv_heads, seq_len, head_dim]
     let v = v.transpose(1, 2)?.contiguous()?; // [batch, num_kv_heads, seq_len, head_dim]
 
+    // If KV cache is provided, update it and use full cached K/V
+    let (k, v, kv_len) = if let Some(cache) = kv_cache {
+        let (full_k, full_v) = cache
+            .update(full_attn_layer_idx, &k, &v)
+            .context("KV cache update failed")?;
+        let kv_len = full_k.dim(2)?;
+        (full_k, full_v, kv_len)
+    } else {
+        (k, v, seq_len)
+    };
+
     // GQA head expansion: repeat K/V to match Q head count
     let gqa_ratio = num_heads / num_kv_heads;
     let batch = k.dim(0)?;
     let (k, v) = if gqa_ratio > 1 {
-        // Expand [batch, num_kv_heads, seq, head_dim] -> [batch, num_heads, seq, head_dim]
-        // by repeating each KV head `gqa_ratio` times
+        // Expand [batch, num_kv_heads, kv_len, head_dim] -> [batch, num_heads, kv_len, head_dim]
         let k = k
-            .unsqueeze(2)? // [batch, num_kv_heads, 1, seq, head_dim]
-            .expand(&[batch, num_kv_heads, gqa_ratio, seq_len, head_dim])? // broadcast
+            .unsqueeze(2)?
+            .expand(&[batch, num_kv_heads, gqa_ratio, kv_len, head_dim])?
             .contiguous()?
-            .reshape((batch, num_heads, seq_len, head_dim))?;
+            .reshape((batch, num_heads, kv_len, head_dim))?;
         let v = v
             .unsqueeze(2)?
-            .expand(&[batch, num_kv_heads, gqa_ratio, seq_len, head_dim])?
+            .expand(&[batch, num_kv_heads, gqa_ratio, kv_len, head_dim])?
             .contiguous()?
-            .reshape((batch, num_heads, seq_len, head_dim))?;
+            .reshape((batch, num_heads, kv_len, head_dim))?;
         (k, v)
     } else {
         (k.contiguous()?, v.contiguous()?)
     };
 
     // Scaled dot-product attention: softmax(Q @ K^T / sqrt(head_dim)) @ V
+    // Q: [batch, num_heads, seq_len, head_dim]
+    // K: [batch, num_heads, kv_len, head_dim]
+    // scores: [batch, num_heads, seq_len, kv_len]
     let scale = (head_dim as f64).sqrt();
-    let attn_scores = q.broadcast_matmul(&k.t()?)?; // [batch, num_heads, seq, seq]
+    let attn_scores = q.broadcast_matmul(&k.t()?)?;
     let attn_scores = (attn_scores / scale)?;
 
-    // Apply causal mask: mask out future positions
-    let attn_scores = apply_causal_mask(&attn_scores, seq_len)?;
+    // Apply causal mask (handles Q_len != KV_len for cached decoding)
+    let past_len = kv_len - seq_len;
+    let attn_scores = apply_causal_mask_with_offset(&attn_scores, seq_len, kv_len, past_len)?;
 
     let attn_weights_softmax = candle_nn::ops::softmax_last_dim(&attn_scores)?;
-    let attn_output = attn_weights_softmax.broadcast_matmul(&v)?; // [batch, num_heads, seq, head_dim]
+    let attn_output = attn_weights_softmax.broadcast_matmul(&v)?; // [batch, num_heads, seq_len, head_dim]
 
     // Transpose back: [batch, seq_len, num_heads, head_dim] -> [batch, seq_len, hidden]
     let attn_output = attn_output
@@ -370,17 +389,44 @@ pub fn gqa_attention(
 /// Apply a causal (lower-triangular) mask to attention scores.
 /// Sets future positions to -inf so softmax zeroes them out.
 fn apply_causal_mask(scores: &Tensor, seq_len: usize) -> Result<Tensor> {
-    if seq_len <= 1 {
+    apply_causal_mask_with_offset(scores, seq_len, seq_len, 0)
+}
+
+/// Apply a causal mask with support for KV cache offset.
+///
+/// When using a KV cache, Q has `q_len` new positions and K/V has `kv_len` total
+/// positions (past_len cached + q_len new). Each query position `i` (representing
+/// absolute position `past_len + i`) can attend to all KV positions up to and
+/// including itself: positions `0..past_len + i + 1`.
+///
+/// `scores`: [batch, heads, q_len, kv_len]
+/// `q_len`: number of new query positions
+/// `kv_len`: total KV length (past_len + q_len)
+/// `past_len`: number of cached positions before the new tokens
+fn apply_causal_mask_with_offset(
+    scores: &Tensor,
+    q_len: usize,
+    kv_len: usize,
+    past_len: usize,
+) -> Result<Tensor> {
+    if q_len <= 1 && kv_len <= 1 {
+        return Ok(scores.clone());
+    }
+    // During decode (q_len=1), the single new token can attend to all kv_len
+    // positions (all past + itself), so no masking needed.
+    if q_len == 1 {
         return Ok(scores.clone());
     }
     let device = scores.device();
-    // Build a [seq_len, seq_len] mask: 0 for allowed, -inf for masked
-    let mask: Vec<f32> = (0..seq_len)
+    // Build a [q_len, kv_len] mask: 0 for allowed, -inf for masked
+    // Query position i (absolute: past_len + i) can attend to KV positions 0..past_len+i+1
+    let mask: Vec<f32> = (0..q_len)
         .flat_map(|i| {
-            (0..seq_len).map(move |j| if j <= i { 0.0 } else { f32::NEG_INFINITY })
+            let max_kv = past_len + i + 1; // last allowed KV position (exclusive)
+            (0..kv_len).map(move |j| if j < max_kv { 0.0 } else { f32::NEG_INFINITY })
         })
         .collect();
-    let mask = Tensor::new(mask, device)?.reshape((1, 1, seq_len, seq_len))?;
+    let mask = Tensor::new(mask, device)?.reshape((1, 1, q_len, kv_len))?;
     let mask = mask.to_dtype(scores.dtype())?;
     let out = scores.broadcast_add(&mask)?;
     Ok(out)
@@ -390,12 +436,14 @@ fn apply_causal_mask(scores: &Tensor, seq_len: usize) -> Result<Tensor> {
 ///
 /// `x`: [batch, seq_len, hidden_size]
 /// `layer`: weights for this transformer layer
-/// `positions`: position indices for RoPE
+/// `positions`: position indices for RoPE (absolute positions)
 /// `num_heads`: number of query attention heads
 /// `num_kv_heads`: number of key/value attention heads
 /// `head_dim`: dimension per head
 /// `rope_theta`: RoPE base frequency
 /// `rms_norm_eps`: epsilon for RMSNorm
+/// `kv_cache`: optional KV cache for incremental decoding
+/// `full_attn_layer_idx`: index into the KV cache's layer array
 ///
 /// Returns: [batch, seq_len, hidden_size]
 pub fn transformer_block(
@@ -407,6 +455,8 @@ pub fn transformer_block(
     head_dim: usize,
     rope_theta: f64,
     rms_norm_eps: f64,
+    kv_cache: Option<&mut KvCache>,
+    full_attn_layer_idx: usize,
 ) -> Result<Tensor> {
     let attn_weights = match &layer.attention {
         GpuAttentionWeights::Full(w) => w,
@@ -428,6 +478,8 @@ pub fn transformer_block(
         head_dim,
         rope_theta,
         rms_norm_eps,
+        kv_cache,
+        full_attn_layer_idx,
     )?;
 
     // Residual connection
@@ -454,6 +506,9 @@ pub fn transformer_block(
 /// `token_ids`: 1-D slice of token IDs for the input sequence.
 /// `weights`: pre-loaded GPU tensors for all model parameters.
 /// `config`: model architecture configuration.
+/// `kv_cache`: optional KV cache for incremental decoding. When provided, `token_ids`
+///   should contain only the new (not yet cached) tokens, and positions are computed
+///   starting from `kv_cache.seq_len()`.
 ///
 /// Returns logits tensor with shape [1, seq_len, vocab_size].
 ///
@@ -461,10 +516,13 @@ pub fn transformer_block(
 /// - Qwen3.5-4B uses weight tying: the LM head reuses `embed_tokens` transposed.
 /// - Linear attention (Gated DeltaNet) layers are not yet implemented and will
 ///   be skipped with an identity pass-through.
+/// - After this function returns, the caller must call `kv_cache.advance(token_ids.len())`
+///   to update the cached sequence length.
 pub fn model_forward(
     token_ids: &[u32],
     weights: &GpuWeights,
     config: &kiln_core::config::ModelConfig,
+    mut kv_cache: Option<&mut KvCache>,
 ) -> Result<Tensor> {
     let seq_len = token_ids.len();
 
@@ -474,13 +532,18 @@ pub fn model_forward(
     // Add batch dimension: [1, seq_len, hidden_size]
     hidden = hidden.unsqueeze(0)?;
 
-    // Position indices for RoPE
-    let positions: Vec<u32> = (0..seq_len as u32).collect();
+    // Position indices for RoPE — absolute positions accounting for cached tokens
+    let offset = kv_cache.as_ref().map_or(0, |c| c.seq_len());
+    let positions: Vec<u32> = (offset..offset + seq_len).map(|p| p as u32).collect();
 
     // 2. Loop through all transformer layers
+    // Track full-attention layer index (0-based counter of only full-attn layers)
+    let mut full_attn_idx: usize = 0;
     for (i, layer) in weights.layers.iter().enumerate() {
         match &layer.attention {
             GpuAttentionWeights::Full(_) => {
+                // Reborrow the cache for each layer call
+                let cache_ref = kv_cache.as_mut().map(|c| &mut **c);
                 hidden = transformer_block(
                     &hidden,
                     layer,
@@ -490,8 +553,11 @@ pub fn model_forward(
                     config.head_dim,
                     config.rope_theta,
                     config.rms_norm_eps,
+                    cache_ref,
+                    full_attn_idx,
                 )
                 .with_context(|| format!("transformer block {i} (full attention)"))?;
+                full_attn_idx += 1;
             }
             GpuAttentionWeights::Linear(_) => {
                 // TODO: Implement Gated DeltaNet linear attention forward pass.
@@ -743,7 +809,7 @@ mod tests {
         let attn = make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?;
         let positions: Vec<u32> = (0..seq_len as u32).collect();
 
-        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6)?;
+        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0)?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         Ok(())
@@ -764,7 +830,7 @@ mod tests {
         let attn = make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?;
         let positions: Vec<u32> = (0..seq_len as u32).collect();
 
-        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6)?;
+        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0)?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         // Output should be finite and not all zeros
@@ -788,7 +854,7 @@ mod tests {
         let x = Tensor::randn(0.0_f32, 1.0, (1, 1, hidden), &device)?;
         let attn = make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?;
 
-        let out = gqa_attention(&x, &attn, &[0], num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6)?;
+        let out = gqa_attention(&x, &attn, &[0], num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0)?;
         assert_eq!(out.dims(), &[1, 1, hidden]);
 
         Ok(())
@@ -844,7 +910,7 @@ mod tests {
             },
         };
 
-        let out = transformer_block(&x, &layer, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6)?;
+        let out = transformer_block(&x, &layer, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0)?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         Ok(())
@@ -877,7 +943,7 @@ mod tests {
             },
         };
 
-        let out = transformer_block(&x, &layer, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6)?;
+        let out = transformer_block(&x, &layer, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0)?;
 
         // Output should not be zero (residual adds input through)
         let vals = out.flatten_all()?.to_vec1::<f32>()?;
@@ -915,7 +981,7 @@ mod tests {
         };
 
         let x = Tensor::ones((1, 1, hidden), DType::F32, &device)?;
-        let result = transformer_block(&x, &layer, &[0], 2, 1, 4, 10_000.0, 1e-6);
+        let result = transformer_block(&x, &layer, &[0], 2, 1, 4, 10_000.0, 1e-6, None, 0);
         assert!(result.is_err(), "should reject linear attention layers");
 
         Ok(())
@@ -1031,7 +1097,7 @@ mod tests {
         };
 
         let token_ids: Vec<u32> = vec![1, 5, 3, 10];
-        let logits = model_forward(&token_ids, &weights, &config)?;
+        let logits = model_forward(&token_ids, &weights, &config, None)?;
 
         // Expected shape: [1, seq_len, vocab_size]
         assert_eq!(logits.dims(), &[1, 4, vocab_size]);
@@ -1076,12 +1142,188 @@ mod tests {
             full_attention_interval: 1,
         };
 
-        let logits = model_forward(&[7], &weights, &config)?;
+        let logits = model_forward(&[7], &weights, &config, None)?;
         assert_eq!(logits.dims(), &[1, 1, vocab_size]);
 
         // Logits should be finite
         let vals = logits.flatten_all()?.to_vec1::<f32>()?;
         assert!(vals.iter().all(|v| v.is_finite()), "all logits should be finite");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_model_forward_kv_cache_equivalence() -> Result<()> {
+        // Verify that model_forward with KV cache produces the same last-position
+        // logits as without KV cache, for a multi-token sequence processed
+        // incrementally (prefill + decode steps).
+        use crate::kv_cache::KvCache;
+
+        let device = Device::Cpu;
+        let vocab_size = 16;
+        let hidden_size = 8;
+        let num_heads = 2;
+        let num_kv_heads = 1;
+        let head_dim = 4;
+        let intermediate_size = 16;
+        let num_layers = 2;
+
+        let weights = make_tiny_gpu_weights(
+            &device,
+            vocab_size,
+            hidden_size,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size,
+            num_layers,
+        )?;
+
+        let config = kiln_core::config::ModelConfig {
+            hidden_size,
+            num_layers,
+            num_attention_heads: num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size,
+            vocab_size,
+            max_position_embeddings: 1024,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10000.0,
+            dtype: kiln_core::config::DType::FP32,
+            num_full_attention_layers: num_layers,
+            full_attention_interval: 1,
+        };
+
+        let tokens: Vec<u32> = vec![1, 5, 3, 10, 7];
+
+        // Reference: full forward pass without KV cache
+        let logits_ref = model_forward(&tokens, &weights, &config, None)?;
+        // Extract last position logits: [1, 5, vocab] -> last position
+        let last_ref = logits_ref.narrow(1, tokens.len() - 1, 1)?; // [1, 1, vocab]
+        let last_ref_vals = last_ref.flatten_all()?.to_vec1::<f32>()?;
+
+        // With KV cache: prefill first 4 tokens, then decode the 5th
+        let mut kv_cache = KvCache::new(
+            num_layers, num_kv_heads, head_dim, 32, DType::F32, &device,
+        )?;
+
+        // Prefill
+        let _prefill_logits = model_forward(&tokens[..4], &weights, &config, Some(&mut kv_cache))?;
+        kv_cache.advance(4);
+        assert_eq!(kv_cache.seq_len(), 4);
+
+        // Decode the 5th token
+        let decode_logits = model_forward(&tokens[4..], &weights, &config, Some(&mut kv_cache))?;
+        kv_cache.advance(1);
+        assert_eq!(kv_cache.seq_len(), 5);
+
+        let last_cached_vals = decode_logits.narrow(1, 0, 1)?.flatten_all()?.to_vec1::<f32>()?;
+
+        // Compare: should be identical (within floating point tolerance)
+        assert_eq!(last_ref_vals.len(), last_cached_vals.len());
+        for (i, (r, c)) in last_ref_vals.iter().zip(&last_cached_vals).enumerate() {
+            assert!(
+                (r - c).abs() < 1e-4,
+                "logit {i} differs: ref={r}, cached={c}, diff={}",
+                (r - c).abs()
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_model_forward_kv_cache_token_by_token() -> Result<()> {
+        // Verify that processing tokens one-by-one with KV cache matches
+        // processing all at once without cache.
+        use crate::kv_cache::KvCache;
+
+        let device = Device::Cpu;
+        let vocab_size = 16;
+        let hidden_size = 8;
+        let num_heads = 2;
+        let num_kv_heads = 1;
+        let head_dim = 4;
+        let intermediate_size = 16;
+
+        let weights = make_tiny_gpu_weights(
+            &device, vocab_size, hidden_size, num_heads, num_kv_heads,
+            head_dim, intermediate_size, 1,
+        )?;
+
+        let config = kiln_core::config::ModelConfig {
+            hidden_size,
+            num_layers: 1,
+            num_attention_heads: num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size,
+            vocab_size,
+            max_position_embeddings: 1024,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10000.0,
+            dtype: kiln_core::config::DType::FP32,
+            num_full_attention_layers: 1,
+            full_attention_interval: 1,
+        };
+
+        let tokens: Vec<u32> = vec![3, 7, 1];
+
+        // Reference
+        let logits_ref = model_forward(&tokens, &weights, &config, None)?;
+        let last_ref = logits_ref.narrow(1, 2, 1)?.flatten_all()?.to_vec1::<f32>()?;
+
+        // KV cache: process token by token
+        let mut kv_cache = KvCache::new(1, num_kv_heads, head_dim, 16, DType::F32, &device)?;
+
+        // Token 0
+        let _ = model_forward(&[3], &weights, &config, Some(&mut kv_cache))?;
+        kv_cache.advance(1);
+
+        // Token 1
+        let _ = model_forward(&[7], &weights, &config, Some(&mut kv_cache))?;
+        kv_cache.advance(1);
+
+        // Token 2
+        let logits_cached = model_forward(&[1], &weights, &config, Some(&mut kv_cache))?;
+        kv_cache.advance(1);
+
+        let last_cached = logits_cached.narrow(1, 0, 1)?.flatten_all()?.to_vec1::<f32>()?;
+
+        for (i, (r, c)) in last_ref.iter().zip(&last_cached).enumerate() {
+            assert!(
+                (r - c).abs() < 1e-4,
+                "logit {i} differs: ref={r}, cached={c}",
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_causal_mask_with_offset() -> Result<()> {
+        let device = Device::Cpu;
+        // Simulate decode: 1 new query, 4 total KV (3 cached + 1 new)
+        let scores = Tensor::ones((1, 1, 1, 4), DType::F32, &device)?;
+        let masked = apply_causal_mask_with_offset(&scores, 1, 4, 3)?;
+        // Single query should attend to all 4 positions (no masking for q_len=1)
+        let vals = masked.flatten_all()?.to_vec1::<f32>()?;
+        assert!(vals.iter().all(|v| (*v - 1.0).abs() < 1e-6),
+            "single query token should attend to all KV positions");
+
+        // Simulate prefill with offset: 2 new queries, 5 total KV (3 cached + 2 new)
+        let scores = Tensor::ones((1, 1, 2, 5), DType::F32, &device)?;
+        let masked = apply_causal_mask_with_offset(&scores, 2, 5, 3)?;
+        let vals = masked.flatten_all()?.to_vec1::<f32>()?;
+        // Row 0 (abs pos 3): can attend to positions 0..4 (first 4), mask position 4
+        assert!((vals[0] - 1.0).abs() < 1e-6); // pos 0: ok
+        assert!((vals[1] - 1.0).abs() < 1e-6); // pos 1: ok
+        assert!((vals[2] - 1.0).abs() < 1e-6); // pos 2: ok
+        assert!((vals[3] - 1.0).abs() < 1e-6); // pos 3 (self): ok
+        assert!(vals[4].is_infinite() && vals[4] < 0.0); // pos 4: masked
+        // Row 1 (abs pos 4): can attend to all 5 positions
+        assert!(vals[5..10].iter().all(|v| (*v - 1.0).abs() < 1e-6));
 
         Ok(())
     }

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -4,6 +4,7 @@
 //! a `ModelRunner` that accepts text prompts and produces text output.
 
 use anyhow::{Context, Result};
+use candle_core::DType;
 use std::sync::mpsc;
 
 use kiln_core::config::ModelConfig;
@@ -12,6 +13,7 @@ use kiln_core::token::TokenId;
 use kiln_core::tokenizer::KilnTokenizer;
 
 use crate::forward::{model_forward, GpuWeights};
+use crate::kv_cache::KvCache;
 use crate::sampling::{greedy_sample, sample_with_params};
 
 /// Holds loaded model weights and tokenizer, provides text generation.
@@ -110,6 +112,24 @@ impl ModelRunner {
         })
     }
 
+    /// Create a new KV cache sized for this model.
+    fn new_kv_cache(&self, max_seq_len: usize) -> Result<KvCache> {
+        let dtype = match self.config.dtype {
+            kiln_core::config::DType::BF16 => DType::BF16,
+            kiln_core::config::DType::FP16 => DType::F16,
+            kiln_core::config::DType::FP32 => DType::F32,
+        };
+        let device = self.weights.embed_tokens.device();
+        KvCache::new(
+            self.config.num_full_attention_layers,
+            self.config.num_kv_heads,
+            self.config.head_dim,
+            max_seq_len,
+            dtype,
+            device,
+        )
+    }
+
     /// Generate text token-by-token, sending each token to a channel as it is produced.
     ///
     /// Returns an `mpsc::Receiver<StreamEvent>` that yields `Token` events
@@ -130,28 +150,32 @@ impl ModelRunner {
 
         let (tx, rx) = mpsc::channel();
 
-        let mut generated_tokens: Vec<TokenId> = Vec::new();
-        let mut all_tokens: Vec<TokenId> = prompt_tokens.to_vec();
-        let mut step_seed = params.seed;
+        let max_total = prompt_tokens.len() + params.max_tokens;
+        let mut kv_cache = self.new_kv_cache(max_total)?;
 
+        // Prefill: run forward pass on all prompt tokens at once
+        let logits = model_forward(&prompt_tokens, &self.weights, &self.config, Some(&mut kv_cache))
+            .context("prefill forward pass failed")?;
+        kv_cache.advance(prompt_tokens.len());
+
+        // Sample first token from the last position's logits
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
+        let mut step_seed = params.seed;
         let mut finish_reason = FinishReason::MaxTokens;
 
+        let mut next_token = if params.temperature == 0.0 {
+            greedy_sample(&logits)?
+        } else {
+            sample_with_params(
+                &logits,
+                params.temperature,
+                params.top_p,
+                params.top_k,
+                step_seed,
+            )?
+        };
+
         for _step in 0..params.max_tokens {
-            let logits = model_forward(&all_tokens, &self.weights, &self.config)
-                .context("forward pass failed")?;
-
-            let next_token = if params.temperature == 0.0 {
-                greedy_sample(&logits)?
-            } else {
-                sample_with_params(
-                    &logits,
-                    params.temperature,
-                    params.top_p,
-                    params.top_k,
-                    step_seed,
-                )?
-            };
-
             if let Some(s) = step_seed.as_mut() {
                 *s = s.wrapping_add(1);
             }
@@ -163,7 +187,6 @@ impl ModelRunner {
             }
 
             generated_tokens.push(next_token);
-            all_tokens.push(next_token);
 
             // Decode this token's text
             let token_text = self
@@ -194,7 +217,6 @@ impl ModelRunner {
                         if text.contains(stop_seq.as_str()) {
                             finish_reason =
                                 FinishReason::StopSequence(stop_seq.clone());
-                            // Send done and return
                             let _ = tx.send(StreamEvent::Done(StreamDone {
                                 finish_reason,
                                 completion_tokens: generated_tokens.len(),
@@ -204,6 +226,23 @@ impl ModelRunner {
                     }
                 }
             }
+
+            // Decode step: forward pass on just the new token
+            let logits = model_forward(&[next_token], &self.weights, &self.config, Some(&mut kv_cache))
+                .context("decode forward pass failed")?;
+            kv_cache.advance(1);
+
+            next_token = if params.temperature == 0.0 {
+                greedy_sample(&logits)?
+            } else {
+                sample_with_params(
+                    &logits,
+                    params.temperature,
+                    params.top_p,
+                    params.top_k,
+                    step_seed,
+                )?
+            };
         }
 
         let _ = tx.send(StreamEvent::Done(StreamDone {
@@ -217,7 +256,7 @@ impl ModelRunner {
     /// Autoregressive generation loop operating on token IDs.
     ///
     /// 1. Prefill: run forward pass on the full prompt to get first next-token logits.
-    /// 2. Decode: repeatedly sample a token, append it, run forward on just the new token.
+    /// 2. Decode: repeatedly sample a token, run forward on just the new token.
     /// 3. Stop on EOS, max_tokens, or stop sequence.
     pub fn generate_from_tokens(
         &self,
@@ -226,35 +265,31 @@ impl ModelRunner {
     ) -> Result<GenerationOutput> {
         anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
 
-        let mut generated_tokens: Vec<TokenId> = Vec::new();
-        let mut all_tokens: Vec<TokenId> = prompt_tokens.to_vec();
+        let max_total = prompt_tokens.len() + params.max_tokens;
+        let mut kv_cache = self.new_kv_cache(max_total)?;
 
-        // Track the RNG seed: for deterministic generation with temperature > 0,
-        // we increment the seed for each step so the sequence is reproducible
-        // but each step samples differently.
+        // Prefill: run forward pass on all prompt tokens at once
+        let logits = model_forward(prompt_tokens, &self.weights, &self.config, Some(&mut kv_cache))
+            .context("prefill forward pass failed")?;
+        kv_cache.advance(prompt_tokens.len());
+
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut step_seed = params.seed;
 
+        // Sample first token from the last position's logits
+        let mut next_token = if params.temperature == 0.0 {
+            greedy_sample(&logits)?
+        } else {
+            sample_with_params(
+                &logits,
+                params.temperature,
+                params.top_p,
+                params.top_k,
+                step_seed,
+            )?
+        };
+
         for _step in 0..params.max_tokens {
-            // Run forward pass on all tokens so far.
-            // In a production system this would use KV cache to only compute
-            // the new token's attention, but for correctness-first we recompute
-            // the full sequence each step.
-            let logits = model_forward(&all_tokens, &self.weights, &self.config)
-                .context("forward pass failed")?;
-
-            // Sample next token from the last position's logits
-            let next_token = if params.temperature == 0.0 {
-                greedy_sample(&logits)?
-            } else {
-                sample_with_params(
-                    &logits,
-                    params.temperature,
-                    params.top_p,
-                    params.top_k,
-                    step_seed,
-                )?
-            };
-
             // Advance seed for next step
             if let Some(s) = step_seed.as_mut() {
                 *s = s.wrapping_add(1);
@@ -263,14 +298,13 @@ impl ModelRunner {
             // Check for EOS
             if self.eos_token_ids.contains(&next_token) {
                 return Ok(GenerationOutput {
-                    text: String::new(), // caller fills this in
+                    text: String::new(),
                     token_ids: generated_tokens,
                     finish_reason: FinishReason::Eos,
                 });
             }
 
             generated_tokens.push(next_token);
-            all_tokens.push(next_token);
 
             // Check stop sequences against decoded text so far
             if !params.stop.is_empty() {
@@ -291,6 +325,24 @@ impl ModelRunner {
                     }
                 }
             }
+
+            // Decode step: forward pass on just the new token (KV cache has all previous)
+            let logits = model_forward(&[next_token], &self.weights, &self.config, Some(&mut kv_cache))
+                .context("decode forward pass failed")?;
+            kv_cache.advance(1);
+
+            // Sample next token from the new logits
+            next_token = if params.temperature == 0.0 {
+                greedy_sample(&logits)?
+            } else {
+                sample_with_params(
+                    &logits,
+                    params.temperature,
+                    params.top_p,
+                    params.top_k,
+                    step_seed,
+                )?
+            };
         }
 
         Ok(GenerationOutput {

--- a/crates/kiln-model/src/kv_cache.rs
+++ b/crates/kiln-model/src/kv_cache.rs
@@ -1,0 +1,216 @@
+//! Contiguous KV cache for efficient autoregressive generation.
+//!
+//! Stores per-layer K/V tensors for full-attention layers so that each decode
+//! step only computes attention over the new token(s), reading cached K/V for
+//! all previous positions.
+
+use anyhow::{Context, Result};
+use candle_core::{DType, Device, Tensor};
+
+/// Per-layer KV cache for full-attention layers.
+///
+/// Each full-attention layer gets a pair of pre-allocated tensors
+/// `[1, num_kv_heads, max_seq_len, head_dim]` that are progressively filled
+/// as tokens are processed. Only full-attention layers need KV cache;
+/// linear attention (Gated DeltaNet) layers maintain O(1) recurrent state.
+pub struct KvCache {
+    /// Per full-attention layer: (k_cache, v_cache) tensors.
+    /// Indexed by full-attention layer index (0-based counter of only the
+    /// full-attention layers, not absolute layer index).
+    layers: Vec<(Tensor, Tensor)>,
+    /// Current sequence length (number of cached positions).
+    seq_len: usize,
+    /// Maximum sequence length the cache can hold.
+    max_seq_len: usize,
+}
+
+impl KvCache {
+    /// Create a new KV cache with pre-allocated tensors.
+    ///
+    /// - `num_full_attn_layers`: number of full-attention layers that need caching
+    /// - `num_kv_heads`: number of KV heads per layer
+    /// - `head_dim`: dimension per head
+    /// - `max_seq_len`: maximum sequence length to allocate for
+    /// - `dtype`: tensor data type
+    /// - `device`: device to allocate on
+    pub fn new(
+        num_full_attn_layers: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        max_seq_len: usize,
+        dtype: DType,
+        device: &Device,
+    ) -> Result<Self> {
+        let mut layers = Vec::with_capacity(num_full_attn_layers);
+        for i in 0..num_full_attn_layers {
+            let k = Tensor::zeros((1, num_kv_heads, max_seq_len, head_dim), dtype, device)
+                .with_context(|| format!("allocating k_cache for full-attn layer {i}"))?;
+            let v = Tensor::zeros((1, num_kv_heads, max_seq_len, head_dim), dtype, device)
+                .with_context(|| format!("allocating v_cache for full-attn layer {i}"))?;
+            layers.push((k, v));
+        }
+        Ok(Self {
+            layers,
+            seq_len: 0,
+            max_seq_len,
+        })
+    }
+
+    /// Number of positions currently cached.
+    pub fn seq_len(&self) -> usize {
+        self.seq_len
+    }
+
+    /// Append new K/V for a full-attention layer and return the full
+    /// (cached + new) K/V tensors.
+    ///
+    /// - `layer_idx`: 0-based index into full-attention layers only
+    /// - `new_k`: `[1, num_kv_heads, new_len, head_dim]`
+    /// - `new_v`: `[1, num_kv_heads, new_len, head_dim]`
+    ///
+    /// Returns `(full_k, full_v)` each shaped `[1, num_kv_heads, seq_len + new_len, head_dim]`.
+    ///
+    /// Note: `seq_len` is updated only after the *last* layer calls `update` for
+    /// a given step. The caller must call `advance(new_len)` after all layers
+    /// have been updated.
+    pub fn update(
+        &mut self,
+        layer_idx: usize,
+        new_k: &Tensor,
+        new_v: &Tensor,
+    ) -> Result<(Tensor, Tensor)> {
+        let new_len = new_k.dim(2)?;
+        let end = self.seq_len + new_len;
+        anyhow::ensure!(
+            end <= self.max_seq_len,
+            "KV cache overflow: seq_len {} + new {} > max {}",
+            self.seq_len,
+            new_len,
+            self.max_seq_len
+        );
+
+        let (k_cache, v_cache) = &mut self.layers[layer_idx];
+
+        // Write new K/V into the pre-allocated cache at [seq_len..seq_len+new_len]
+        k_cache.slice_set(new_k, 2, self.seq_len)?;
+        v_cache.slice_set(new_v, 2, self.seq_len)?;
+
+        // Return the filled portion: [1, num_kv_heads, 0..end, head_dim]
+        let full_k = k_cache.narrow(2, 0, end)?;
+        let full_v = v_cache.narrow(2, 0, end)?;
+
+        Ok((full_k, full_v))
+    }
+
+    /// Advance the cached sequence length after all layers have been updated
+    /// for a given step.
+    pub fn advance(&mut self, new_len: usize) {
+        self.seq_len += new_len;
+    }
+
+    /// Reset the cache (e.g., for a new sequence).
+    pub fn reset(&mut self) {
+        self.seq_len = 0;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_kv_cache_new() -> Result<()> {
+        let cache = KvCache::new(2, 4, 8, 128, DType::F32, &Device::Cpu)?;
+        assert_eq!(cache.seq_len(), 0);
+        assert_eq!(cache.layers.len(), 2);
+        Ok(())
+    }
+
+    #[test]
+    fn test_kv_cache_update_and_advance() -> Result<()> {
+        let device = Device::Cpu;
+        let mut cache = KvCache::new(1, 2, 4, 32, DType::F32, &device)?;
+
+        // Simulate prefill with 3 tokens
+        let k = Tensor::ones((1, 2, 3, 4), DType::F32, &device)?;
+        let v = Tensor::ones((1, 2, 3, 4), DType::F32, &device)?;
+        let (full_k, full_v) = cache.update(0, &k, &v)?;
+        assert_eq!(full_k.dims(), &[1, 2, 3, 4]);
+        assert_eq!(full_v.dims(), &[1, 2, 3, 4]);
+        cache.advance(3);
+        assert_eq!(cache.seq_len(), 3);
+
+        // Simulate decode with 1 token
+        let k2 = Tensor::ones((1, 2, 1, 4), DType::F32, &device)?;
+        let v2 = Tensor::ones((1, 2, 1, 4), DType::F32, &device)?;
+        let (full_k, full_v) = cache.update(0, &k2, &v2)?;
+        assert_eq!(full_k.dims(), &[1, 2, 4, 4]); // 3 + 1 = 4
+        assert_eq!(full_v.dims(), &[1, 2, 4, 4]);
+        cache.advance(1);
+        assert_eq!(cache.seq_len(), 4);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_kv_cache_overflow() -> Result<()> {
+        let device = Device::Cpu;
+        let mut cache = KvCache::new(1, 1, 4, 4, DType::F32, &device)?;
+
+        let k = Tensor::ones((1, 1, 3, 4), DType::F32, &device)?;
+        let v = Tensor::ones((1, 1, 3, 4), DType::F32, &device)?;
+        cache.update(0, &k, &v)?;
+        cache.advance(3);
+
+        // This should overflow: 3 + 2 > 4
+        let k2 = Tensor::ones((1, 1, 2, 4), DType::F32, &device)?;
+        let v2 = Tensor::ones((1, 1, 2, 4), DType::F32, &device)?;
+        let result = cache.update(0, &k2, &v2);
+        assert!(result.is_err());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_kv_cache_reset() -> Result<()> {
+        let device = Device::Cpu;
+        let mut cache = KvCache::new(1, 1, 4, 16, DType::F32, &device)?;
+
+        let k = Tensor::ones((1, 1, 5, 4), DType::F32, &device)?;
+        let v = Tensor::ones((1, 1, 5, 4), DType::F32, &device)?;
+        cache.update(0, &k, &v)?;
+        cache.advance(5);
+        assert_eq!(cache.seq_len(), 5);
+
+        cache.reset();
+        assert_eq!(cache.seq_len(), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_kv_cache_content_preserved() -> Result<()> {
+        let device = Device::Cpu;
+        let mut cache = KvCache::new(1, 1, 2, 8, DType::F32, &device)?;
+
+        // Write known values for first 2 positions
+        let k1 = Tensor::new(&[[[[1.0_f32, 2.0], [3.0, 4.0]]]], &device)?; // [1,1,2,2]
+        let v1 = Tensor::new(&[[[[5.0_f32, 6.0], [7.0, 8.0]]]], &device)?;
+        cache.update(0, &k1, &v1)?;
+        cache.advance(2);
+
+        // Write 1 more position
+        let k2 = Tensor::new(&[[[[9.0_f32, 10.0]]]], &device)?; // [1,1,1,2]
+        let v2 = Tensor::new(&[[[[11.0_f32, 12.0]]]], &device)?;
+        let (full_k, full_v) = cache.update(0, &k2, &v2)?;
+        cache.advance(1);
+
+        // Verify all 3 positions are correct
+        let k_vals = full_k.flatten_all()?.to_vec1::<f32>()?;
+        assert_eq!(k_vals, vec![1.0, 2.0, 3.0, 4.0, 9.0, 10.0]);
+        let v_vals = full_v.flatten_all()?.to_vec1::<f32>()?;
+        assert_eq!(v_vals, vec![5.0, 6.0, 7.0, 8.0, 11.0, 12.0]);
+
+        Ok(())
+    }
+}

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod engine;
 pub mod forward;
 pub mod generate;
+pub mod kv_cache;
 pub mod loader;
 pub mod lora;
 pub mod sampling;
@@ -8,5 +9,6 @@ pub mod weights;
 
 pub use engine::Engine;
 pub use generate::{FinishReason, GenerationOutput, ModelRunner, StreamDone, StreamEvent, StreamToken};
+pub use kv_cache::KvCache;
 pub use loader::load_model;
 pub use weights::ModelWeights;


### PR DESCRIPTION
## What
Add a contiguous KV cache to the forward pass so autoregressive generation only processes new token(s) each step instead of recomputing all K/V from scratch.

## Why
Without KV cache, generation is O(n²) per step (must recompute attention over all previous tokens). With KV cache, decode steps are O(n) — the single biggest performance win remaining in Phase 1.

## Changes
- **New `kv_cache.rs`**: `KvCache` struct that pre-allocates per-layer K/V tensors and progressively fills them as tokens are processed
- **Modified `gqa_attention`**: accepts optional KV cache + layer index, appends new K/V to cache and uses full cached K/V for attention
- **New `apply_causal_mask_with_offset`**: handles Q_len != KV_len case for cached decode (single-token decode skips masking entirely)
- **Modified `model_forward`**: threads KV cache through layers, computes absolute positions from cache offset, tracks full-attention layer index separately from absolute layer index
- **Modified `ModelRunner`**: generation loops now use prefill+decode pattern — full prompt processed in one forward pass, then each new token is a single-token forward pass with KV cache
- **Tests**: equivalence (cached output matches uncached), token-by-token incremental, causal mask with offset, KV cache unit tests (content preservation, overflow, reset)

All 44 existing + new tests pass.