### PR TITLE
Switch HTTP server to paged KV cache

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -134,8 +134,21 @@ async fn chat_completions(
 
     if req.stream {
         match state.backend.as_ref() {
-            ModelBackend::Real(runner) => {
-                generate_real_streaming(&state, runner, &prompt_text, &sampling, &req).await
+            ModelBackend::Real {
+                runner,
+                block_manager,
+                paged_cache,
+            } => {
+                generate_real_streaming(
+                    &state,
+                    runner,
+                    block_manager,
+                    paged_cache,
+                    &prompt_text,
+                    &sampling,
+                    &req,
+                )
+                .await
             }
             ModelBackend::Mock { .. } => Err((
                 StatusCode::NOT_IMPLEMENTED,
@@ -144,10 +157,22 @@ async fn chat_completions(
         }
     } else {
         match state.backend.as_ref() {
-            ModelBackend::Real(runner) => {
-                generate_real(&state, runner, &prompt_text, &sampling, &req)
-                    .await
-                    .map(|json| json.into_response())
+            ModelBackend::Real {
+                runner,
+                block_manager,
+                paged_cache,
+            } => {
+                generate_real(
+                    &state,
+                    runner,
+                    block_manager,
+                    paged_cache,
+                    &prompt_text,
+                    &sampling,
+                    &req,
+                )
+                .await
+                .map(|json| json.into_response())
             }
             ModelBackend::Mock { scheduler, engine } => {
                 generate_mock(&state, scheduler, engine, &prompt_text, &sampling, &req)
@@ -158,10 +183,12 @@ async fn chat_completions(
     }
 }
 
-/// Generate using the real ModelRunner (direct forward pass).
+/// Generate using the real ModelRunner with paged KV cache.
 async fn generate_real(
     state: &AppState,
     runner: &std::sync::Arc<kiln_model::ModelRunner>,
+    block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
+    paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
     prompt_text: &str,
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
@@ -173,16 +200,22 @@ async fn generate_real(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .len();
 
-    // ModelRunner.generate() is CPU-bound; run on a blocking thread to
+    // ModelRunner.generate_paged() is CPU-bound; run on a blocking thread to
     // avoid starving the tokio runtime.
     let runner = runner.clone();
+    let bm = block_manager.clone();
+    let pc = paged_cache.clone();
     let prompt = prompt_text.to_owned();
     let params = sampling.clone();
 
-    let output = tokio::task::spawn_blocking(move || runner.generate(&prompt, &params))
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let output = tokio::task::spawn_blocking(move || {
+        let mut bm_guard = bm.lock().unwrap();
+        let mut pc_guard = pc.lock().unwrap();
+        runner.generate_paged(&prompt, &params, &mut bm_guard, &mut pc_guard)
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let finish_reason = match output.finish_reason {
         kiln_model::FinishReason::Eos => "stop",
@@ -213,15 +246,19 @@ async fn generate_real(
     }))
 }
 
-/// Generate using the real ModelRunner with SSE streaming.
+/// Generate using the real ModelRunner with SSE streaming and paged KV cache.
 async fn generate_real_streaming(
     _state: &AppState,
     runner: &std::sync::Arc<kiln_model::ModelRunner>,
+    block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
+    paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
     prompt_text: &str,
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
 ) -> Result<Response, (StatusCode, String)> {
     let runner = runner.clone();
+    let bm = block_manager.clone();
+    let pc = paged_cache.clone();
     let prompt = prompt_text.to_owned();
     let params = sampling.clone();
     let model = req.model.clone();
@@ -259,9 +296,11 @@ async fn generate_real_streaming(
                 return;
             }
 
-            // Run blocking generation
+            // Run blocking generation with paged KV cache
             let sync_rx = match tokio::task::spawn_blocking(move || {
-                runner.generate_streaming(&prompt, &params)
+                let mut bm_guard = bm.lock().unwrap();
+                let mut pc_guard = pc.lock().unwrap();
+                runner.generate_streaming_paged(&prompt, &params, &mut bm_guard, &mut pc_guard)
             })
             .await
             {

--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -37,7 +37,7 @@ async fn health(State(state): State<AppState>) -> Json<HealthResponse> {
                 }),
             )
         }
-        ModelBackend::Real(_) => ("model", None),
+        ModelBackend::Real { .. } => ("model", None),
     };
 
     Json(HealthResponse {

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1,10 +1,12 @@
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
+use candle_core::DType;
+use kiln_core::block::BlockManager;
 use kiln_core::config::ModelConfig;
 use kiln_core::tokenizer::KilnTokenizer;
 use kiln_model::engine::Engine;
-use kiln_model::ModelRunner;
+use kiln_model::{ModelRunner, PagedKvCache};
 use kiln_scheduler::Scheduler;
 
 /// Which inference backend the server is using.
@@ -14,8 +16,12 @@ pub enum ModelBackend {
         scheduler: Arc<Mutex<Scheduler>>,
         engine: Arc<dyn Engine>,
     },
-    /// Real model weights loaded via ModelRunner.
-    Real(Arc<ModelRunner>),
+    /// Real model weights loaded via ModelRunner with paged KV cache.
+    Real {
+        runner: Arc<ModelRunner>,
+        block_manager: Arc<std::sync::Mutex<BlockManager>>,
+        paged_cache: Arc<std::sync::Mutex<PagedKvCache>>,
+    },
 }
 
 /// Shared application state passed to all handlers.
@@ -44,15 +50,38 @@ impl AppState {
         }
     }
 
-    /// Create an AppState with a real ModelRunner backend.
+    /// Create an AppState with a real ModelRunner backend and paged KV cache.
+    ///
+    /// Uses `block_size=16` by default. The number of blocks is derived from
+    /// `max_position_embeddings / block_size` with a minimum of 256.
     pub fn new_real(
         model_config: ModelConfig,
         runner: ModelRunner,
         tokenizer: KilnTokenizer,
     ) -> Self {
+        let block_size = 16;
+        let num_blocks = (model_config.max_position_embeddings / block_size).max(256);
+        let device = candle_core::Device::Cpu;
+
+        let block_manager = BlockManager::new(num_blocks, block_size);
+        let paged_cache = PagedKvCache::new(
+            model_config.num_full_attention_layers,
+            num_blocks,
+            block_size,
+            model_config.num_kv_heads,
+            model_config.head_dim,
+            DType::F32,
+            &device,
+        )
+        .expect("failed to create PagedKvCache");
+
         Self {
             model_config,
-            backend: Arc::new(ModelBackend::Real(Arc::new(runner))),
+            backend: Arc::new(ModelBackend::Real {
+                runner: Arc::new(runner),
+                block_manager: Arc::new(std::sync::Mutex::new(block_manager)),
+                paged_cache: Arc::new(std::sync::Mutex::new(paged_cache)),
+            }),
             tokenizer: Arc::new(tokenizer),
         }
     }


### PR DESCRIPTION
Wire /v1/chat/completions to use generate_paged/generate_streaming_paged instead of contiguous KV cache methods.

## Changes
- Add BlockManager and PagedKvCache to ModelBackend::Real variant (wrapped in Arc<Mutex>)
- new_real() creates paged cache with block_size=16, num_blocks derived from max_position_embeddings
- generate_real() now calls runner.generate_paged() with locked block manager and paged cache
- generate_real_streaming() now calls runner.generate_streaming_paged()
- All existing tests pass unchanged