### PR TITLE
Add CUDA device selection and cuda cargo feature

### DIFF
--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -21,6 +21,7 @@ rand = { workspace = true }
 
 [features]
 flash-attn = ["dep:candle-flash-attn"]
+cuda = ["candle-core/cuda", "candle-nn/cuda"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -33,6 +33,10 @@ chrono = { workspace = true }
 futures = { workspace = true }
 tokio-stream = { workspace = true }
 
+[features]
+cuda = ["kiln-model/cuda"]
+flash-attn = ["kiln-model/flash-attn"]
+
 [dev-dependencies]
 tempfile = { workspace = true }
 safetensors = { workspace = true }

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -62,7 +62,13 @@ async fn main() -> Result<()> {
         // Real inference mode: load model weights and create ModelRunner.
         tracing::info!("loading model weights from {mp}");
         let model_weights = kiln_model::load_model(Path::new(mp), &model_config)?;
-        let device = candle_core::Device::Cpu; // TODO: CUDA when available
+        let device = if candle_core::utils::cuda_is_available() {
+            tracing::info!("CUDA available — using GPU device 0");
+            candle_core::Device::new_cuda(0)?
+        } else {
+            tracing::info!("CUDA not available — using CPU");
+            candle_core::Device::Cpu
+        };
         let gpu_weights = GpuWeights::from_model_weights(&model_weights, &device)?;
 
         // ModelRunner takes ownership of a tokenizer, so load a second instance.
@@ -79,7 +85,7 @@ async fn main() -> Result<()> {
 
         let runner = ModelRunner::new(gpu_weights, runner_tokenizer, model_config.clone());
         tracing::info!("model loaded — real inference mode");
-        AppState::new_real(model_config, runner, tokenizer)
+        AppState::new_real(model_config, runner, tokenizer, device)
     } else {
         // Mock mode: use scheduler + mock engine.
         tracing::info!("no KILN_MODEL_PATH set — running in mock mode");

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -58,10 +58,10 @@ impl AppState {
         model_config: ModelConfig,
         runner: ModelRunner,
         tokenizer: KilnTokenizer,
+        device: candle_core::Device,
     ) -> Self {
         let block_size = 16;
         let num_blocks = (model_config.max_position_embeddings / block_size).max(256);
-        let device = candle_core::Device::Cpu;
 
         let block_manager = BlockManager::new(num_blocks, block_size);
         let paged_cache = PagedKvCache::new(

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -148,7 +148,7 @@ async fn test_real_model_chat_completion() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer);
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone());
 
     let app = api::router(state);
 
@@ -213,7 +213,7 @@ async fn test_real_model_streaming_chat_completion() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer);
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone());
 
     let app = api::router(state);
 
@@ -319,7 +319,7 @@ async fn test_health_with_real_backend() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer);
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone());
 
     let app = api::router(state);
 


### PR DESCRIPTION
## What
Add a `cuda` cargo feature. When enabled, the server loads model weights onto GPU device 0 instead of CPU.

## Changes
- `kiln-model`: Added `cuda` feature that enables `candle-core/cuda` and `candle-nn/cuda`
- `kiln-server`: Added `cuda` and `flash-attn` feature flags that forward to `kiln-model`
- `main.rs`: Replaced hardcoded `Device::Cpu` with runtime CUDA detection via `candle_core::utils::cuda_is_available()`
- `state.rs`: `new_real()` now accepts a `Device` parameter instead of hardcoding CPU
- Integration tests updated to pass device through

## Why
Currently hardcoded to CPU. This is required for real inference at usable speeds.

## Build
- `cargo test --workspace` — passes (CPU path, no CUDA needed)
- `cargo build --release` — passes
- `cargo build --release --features cuda` — requires CUDA toolkit (GPU machine)