### PR TITLE
Implement LoRA weight loading and forward-pass application

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -8,6 +8,7 @@ use anyhow::{Context, Result};
 use candle_core::{DType, Device, Tensor};
 
 use crate::kv_cache::KvCache;
+use crate::lora_loader::{linear_with_lora, LoraLayerWeights, LoraWeights};
 use crate::paged_kv_cache::PagedKvCache;
 use crate::weights::{ModelWeights, TensorDType, WeightTensor};
 
@@ -314,17 +315,22 @@ pub fn swiglu_ffn(
     gate_proj: &Tensor,
     up_proj: &Tensor,
     down_proj: &Tensor,
+    lora: Option<(&LoraLayerWeights, f32)>,
 ) -> Result<Tensor> {
+    let (lora_layer, lora_scale) = match lora {
+        Some((l, s)) => (Some(l), s),
+        None => (None, 0.0),
+    };
     // x @ gate_proj^T -> [batch, seq_len, intermediate_size]
-    let gate = x.broadcast_matmul(&gate_proj.t()?)?;
+    let gate = linear_with_lora(x, gate_proj, lora_layer.and_then(|l| l.gate_proj.as_ref()), lora_scale)?;
     // SiLU activation: x * sigmoid(x)
     let gate = candle_nn::ops::silu(&gate)?;
     // x @ up_proj^T -> [batch, seq_len, intermediate_size]
-    let up = x.broadcast_matmul(&up_proj.t()?)?;
+    let up = linear_with_lora(x, up_proj, lora_layer.and_then(|l| l.up_proj.as_ref()), lora_scale)?;
     // Element-wise multiply
     let hidden = (gate * up)?;
     // hidden @ down_proj^T -> [batch, seq_len, hidden_size]
-    let out = hidden.broadcast_matmul(&down_proj.t()?)?;
+    let out = linear_with_lora(&hidden, down_proj, lora_layer.and_then(|l| l.down_proj.as_ref()), lora_scale)?;
     Ok(out)
 }
 
@@ -356,14 +362,18 @@ pub fn gqa_attention(
     rms_norm_eps: f64,
     kv_cache: Option<&mut KvCache>,
     full_attn_layer_idx: usize,
+    lora: Option<(&LoraLayerWeights, f32)>,
 ) -> Result<Tensor> {
     let (_batch, seq_len, _hidden) = x.dims3()?;
 
-    // Project to Q, K, V
-    // q_proj: [num_heads * head_dim, hidden_size], so x @ q_proj^T -> [batch, seq_len, num_heads * head_dim]
-    let q = x.broadcast_matmul(&attn_weights.q_proj.t()?)?;
-    let k = x.broadcast_matmul(&attn_weights.k_proj.t()?)?;
-    let v = x.broadcast_matmul(&attn_weights.v_proj.t()?)?;
+    // Project to Q, K, V (with optional LoRA delta)
+    let (lora_layer, lora_scale) = match lora {
+        Some((l, s)) => (Some(l), s),
+        None => (None, 0.0),
+    };
+    let q = linear_with_lora(x, &attn_weights.q_proj, lora_layer.and_then(|l| l.q_proj.as_ref()), lora_scale)?;
+    let k = linear_with_lora(x, &attn_weights.k_proj, lora_layer.and_then(|l| l.k_proj.as_ref()), lora_scale)?;
+    let v = linear_with_lora(x, &attn_weights.v_proj, lora_layer.and_then(|l| l.v_proj.as_ref()), lora_scale)?;
 
     // Reshape to [batch, seq_len, num_heads, head_dim]
     let q = q.reshape(((), seq_len, num_heads, head_dim))?;
@@ -388,7 +398,7 @@ pub fn gqa_attention(
         let k = k.contiguous()?;
         let v = v.contiguous()?;
         let attn_output = flash_attention_forward(&q, &k, &v, num_heads, num_kv_heads, head_dim)?;
-        let out = attn_output.broadcast_matmul(&attn_weights.o_proj.t()?)?;
+        let out = linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?;
         return Ok(out);
     }
 
@@ -450,7 +460,7 @@ pub fn gqa_attention(
         .reshape(((), seq_len, num_heads * head_dim))?;
 
     // Output projection
-    let out = attn_output.broadcast_matmul(&attn_weights.o_proj.t()?)?;
+    let out = linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?;
     Ok(out)
 }
 
@@ -474,14 +484,19 @@ pub fn gqa_attention_paged(
     paged_cache: &mut PagedKvCache,
     block_table: &BlockTable,
     full_attn_layer_idx: usize,
+    lora: Option<(&LoraLayerWeights, f32)>,
 ) -> Result<Tensor> {
     let (_batch, seq_len, _hidden) = x.dims3()?;
     let start_pos = positions[0] as usize;
 
-    // Project to Q, K, V
-    let q = x.broadcast_matmul(&attn_weights.q_proj.t()?)?;
-    let k = x.broadcast_matmul(&attn_weights.k_proj.t()?)?;
-    let v = x.broadcast_matmul(&attn_weights.v_proj.t()?)?;
+    // Project to Q, K, V (with optional LoRA delta)
+    let (lora_layer, lora_scale) = match lora {
+        Some((l, s)) => (Some(l), s),
+        None => (None, 0.0),
+    };
+    let q = linear_with_lora(x, &attn_weights.q_proj, lora_layer.and_then(|l| l.q_proj.as_ref()), lora_scale)?;
+    let k = linear_with_lora(x, &attn_weights.k_proj, lora_layer.and_then(|l| l.k_proj.as_ref()), lora_scale)?;
+    let v = linear_with_lora(x, &attn_weights.v_proj, lora_layer.and_then(|l| l.v_proj.as_ref()), lora_scale)?;
 
     let q = q.reshape(((), seq_len, num_heads, head_dim))?;
     let k = k.reshape(((), seq_len, num_kv_heads, head_dim))?;
@@ -520,7 +535,7 @@ pub fn gqa_attention_paged(
         let k = k.transpose(1, 2)?.contiguous()?; // -> [batch, kv_len, num_kv_heads, head_dim]
         let v = v.transpose(1, 2)?.contiguous()?; // -> [batch, kv_len, num_kv_heads, head_dim]
         let attn_output = flash_attention_forward(&q, &k, &v, num_heads, num_kv_heads, head_dim)?;
-        let out = attn_output.broadcast_matmul(&attn_weights.o_proj.t()?)?;
+        let out = linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?;
         return Ok(out);
     }
 
@@ -570,7 +585,7 @@ pub fn gqa_attention_paged(
             .contiguous()?
             .reshape((batch, 1, num_heads * head_dim))?;
 
-        let out = attn_output.broadcast_matmul(&attn_weights.o_proj.t()?)?;
+        let out = linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?;
         return Ok(out);
     }
 
@@ -608,7 +623,7 @@ pub fn gqa_attention_paged(
         .contiguous()?
         .reshape(((), seq_len, num_heads * head_dim))?;
 
-    let out = attn_output.broadcast_matmul(&attn_weights.o_proj.t()?)?;
+    let out = linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?;
     Ok(out)
 }
 
@@ -683,6 +698,7 @@ pub fn transformer_block(
     rms_norm_eps: f64,
     kv_cache: Option<&mut KvCache>,
     full_attn_layer_idx: usize,
+    lora: Option<(&LoraLayerWeights, f32)>,
 ) -> Result<Tensor> {
     let attn_weights = match &layer.attention {
         GpuAttentionWeights::Full(w) => w,
@@ -706,6 +722,7 @@ pub fn transformer_block(
         rms_norm_eps,
         kv_cache,
         full_attn_layer_idx,
+        lora,
     )?;
 
     // Residual connection
@@ -720,6 +737,7 @@ pub fn transformer_block(
         &layer.mlp.gate_proj,
         &layer.mlp.up_proj,
         &layer.mlp.down_proj,
+        lora,
     )?;
 
     // Residual connection
@@ -743,6 +761,7 @@ pub fn transformer_block_paged(
     paged_cache: &mut PagedKvCache,
     block_table: &BlockTable,
     full_attn_layer_idx: usize,
+    lora: Option<(&LoraLayerWeights, f32)>,
 ) -> Result<Tensor> {
     let attn_weights = match &layer.attention {
         GpuAttentionWeights::Full(w) => w,
@@ -767,6 +786,7 @@ pub fn transformer_block_paged(
         paged_cache,
         block_table,
         full_attn_layer_idx,
+        lora,
     )?;
 
     // Residual connection
@@ -781,6 +801,7 @@ pub fn transformer_block_paged(
         &layer.mlp.gate_proj,
         &layer.mlp.up_proj,
         &layer.mlp.down_proj,
+        lora,
     )?;
 
     // Residual connection
@@ -810,6 +831,7 @@ pub fn model_forward(
     weights: &GpuWeights,
     config: &kiln_core::config::ModelConfig,
     mut kv_cache: Option<&mut KvCache>,
+    lora: Option<&LoraWeights>,
 ) -> Result<Tensor> {
     let seq_len = token_ids.len();
 
@@ -827,6 +849,10 @@ pub fn model_forward(
     // Track full-attention layer index (0-based counter of only full-attn layers)
     let mut full_attn_idx: usize = 0;
     for (i, layer) in weights.layers.iter().enumerate() {
+        // Get LoRA weights for this layer, if available
+        let layer_lora: Option<(&LoraLayerWeights, f32)> = lora
+            .and_then(|lw| lw.layers.get(i).map(|ll| (ll, lw.scale)));
+
         match &layer.attention {
             GpuAttentionWeights::Full(_) => {
                 // Reborrow the cache for each layer call
@@ -842,6 +868,7 @@ pub fn model_forward(
                     config.rms_norm_eps,
                     cache_ref,
                     full_attn_idx,
+                    layer_lora,
                 )
                 .with_context(|| format!("transformer block {i} (full attention)"))?;
                 full_attn_idx += 1;
@@ -859,6 +886,7 @@ pub fn model_forward(
                     &layer.mlp.gate_proj,
                     &layer.mlp.up_proj,
                     &layer.mlp.down_proj,
+                    layer_lora,
                 )?;
                 hidden = (hidden + ffn_out)?;
                 // Suppress unused variable warning
@@ -892,6 +920,7 @@ pub fn model_forward_paged(
     paged_cache: &mut PagedKvCache,
     block_table: &BlockTable,
     start_pos: usize,
+    lora: Option<&LoraWeights>,
 ) -> Result<Tensor> {
     let seq_len = token_ids.len();
 
@@ -907,6 +936,10 @@ pub fn model_forward_paged(
     // 2. Loop through all transformer layers
     let mut full_attn_idx: usize = 0;
     for (i, layer) in weights.layers.iter().enumerate() {
+        // Get LoRA weights for this layer, if available
+        let layer_lora: Option<(&LoraLayerWeights, f32)> = lora
+            .and_then(|lw| lw.layers.get(i).map(|ll| (ll, lw.scale)));
+
         match &layer.attention {
             GpuAttentionWeights::Full(_) => {
                 hidden = transformer_block_paged(
@@ -921,6 +954,7 @@ pub fn model_forward_paged(
                     paged_cache,
                     block_table,
                     full_attn_idx,
+                    layer_lora,
                 )
                 .with_context(|| format!("transformer block {i} (full attention, paged)"))?;
                 full_attn_idx += 1;
@@ -934,6 +968,7 @@ pub fn model_forward_paged(
                     &layer.mlp.gate_proj,
                     &layer.mlp.up_proj,
                     &layer.mlp.down_proj,
+                    layer_lora,
                 )?;
                 hidden = (hidden + ffn_out)?;
                 let _ = normed;
@@ -1106,7 +1141,7 @@ mod tests {
         let up = Tensor::randn(0.0_f32, 0.1, (intermediate, hidden), &device)?;
         let down = Tensor::randn(0.0_f32, 0.1, (hidden, intermediate), &device)?;
 
-        let result = swiglu_ffn(&x, &gate, &up, &down)?;
+        let result = swiglu_ffn(&x, &gate, &up, &down, None)?;
         assert_eq!(result.dims(), &[batch, seq_len, hidden]);
 
         Ok(())
@@ -1124,7 +1159,7 @@ mod tests {
         let up = Tensor::ones((intermediate, hidden), DType::F32, &device)?;
         let down = Tensor::ones((hidden, intermediate), DType::F32, &device)?;
 
-        let result = swiglu_ffn(&x, &gate, &up, &down)?;
+        let result = swiglu_ffn(&x, &gate, &up, &down, None)?;
         let vals = result.to_vec3::<f32>()?;
 
         for v in &vals[0][0] {
@@ -1168,7 +1203,7 @@ mod tests {
         let attn = make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?;
         let positions: Vec<u32> = (0..seq_len as u32).collect();
 
-        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0)?;
+        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         Ok(())
@@ -1189,7 +1224,7 @@ mod tests {
         let attn = make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?;
         let positions: Vec<u32> = (0..seq_len as u32).collect();
 
-        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0)?;
+        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         // Output should be finite and not all zeros
@@ -1213,7 +1248,7 @@ mod tests {
         let x = Tensor::randn(0.0_f32, 1.0, (1, 1, hidden), &device)?;
         let attn = make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?;
 
-        let out = gqa_attention(&x, &attn, &[0], num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0)?;
+        let out = gqa_attention(&x, &attn, &[0], num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
         assert_eq!(out.dims(), &[1, 1, hidden]);
 
         Ok(())
@@ -1269,7 +1304,7 @@ mod tests {
             },
         };
 
-        let out = transformer_block(&x, &layer, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0)?;
+        let out = transformer_block(&x, &layer, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         Ok(())
@@ -1302,7 +1337,7 @@ mod tests {
             },
         };
 
-        let out = transformer_block(&x, &layer, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0)?;
+        let out = transformer_block(&x, &layer, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
 
         // Output should not be zero (residual adds input through)
         let vals = out.flatten_all()?.to_vec1::<f32>()?;
@@ -1340,7 +1375,7 @@ mod tests {
         };
 
         let x = Tensor::ones((1, 1, hidden), DType::F32, &device)?;
-        let result = transformer_block(&x, &layer, &[0], 2, 1, 4, 10_000.0, 1e-6, None, 0);
+        let result = transformer_block(&x, &layer, &[0], 2, 1, 4, 10_000.0, 1e-6, None, 0, None);
         assert!(result.is_err(), "should reject linear attention layers");
 
         Ok(())
@@ -1456,7 +1491,7 @@ mod tests {
         };
 
         let token_ids: Vec<u32> = vec![1, 5, 3, 10];
-        let logits = model_forward(&token_ids, &weights, &config, None)?;
+        let logits = model_forward(&token_ids, &weights, &config, None, None)?;
 
         // Expected shape: [1, seq_len, vocab_size]
         assert_eq!(logits.dims(), &[1, 4, vocab_size]);
@@ -1501,7 +1536,7 @@ mod tests {
             full_attention_interval: 1,
         };
 
-        let logits = model_forward(&[7], &weights, &config, None)?;
+        let logits = model_forward(&[7], &weights, &config, None, None)?;
         assert_eq!(logits.dims(), &[1, 1, vocab_size]);
 
         // Logits should be finite
@@ -1557,7 +1592,7 @@ mod tests {
         let tokens: Vec<u32> = vec![1, 5, 3, 10, 7];
 
         // Reference: full forward pass without KV cache
-        let logits_ref = model_forward(&tokens, &weights, &config, None)?;
+        let logits_ref = model_forward(&tokens, &weights, &config, None, None)?;
         // Extract last position logits: [1, 5, vocab] -> last position
         let last_ref = logits_ref.narrow(1, tokens.len() - 1, 1)?; // [1, 1, vocab]
         let last_ref_vals = last_ref.flatten_all()?.to_vec1::<f32>()?;
@@ -1568,12 +1603,12 @@ mod tests {
         )?;
 
         // Prefill
-        let _prefill_logits = model_forward(&tokens[..4], &weights, &config, Some(&mut kv_cache))?;
+        let _prefill_logits = model_forward(&tokens[..4], &weights, &config, Some(&mut kv_cache), None)?;
         kv_cache.advance(4);
         assert_eq!(kv_cache.seq_len(), 4);
 
         // Decode the 5th token
-        let decode_logits = model_forward(&tokens[4..], &weights, &config, Some(&mut kv_cache))?;
+        let decode_logits = model_forward(&tokens[4..], &weights, &config, Some(&mut kv_cache), None)?;
         kv_cache.advance(1);
         assert_eq!(kv_cache.seq_len(), 5);
 
@@ -1630,22 +1665,22 @@ mod tests {
         let tokens: Vec<u32> = vec![3, 7, 1];
 
         // Reference
-        let logits_ref = model_forward(&tokens, &weights, &config, None)?;
+        let logits_ref = model_forward(&tokens, &weights, &config, None, None)?;
         let last_ref = logits_ref.narrow(1, 2, 1)?.flatten_all()?.to_vec1::<f32>()?;
 
         // KV cache: process token by token
         let mut kv_cache = KvCache::new(1, num_kv_heads, head_dim, 16, DType::F32, &device)?;
 
         // Token 0
-        let _ = model_forward(&[3], &weights, &config, Some(&mut kv_cache))?;
+        let _ = model_forward(&[3], &weights, &config, Some(&mut kv_cache), None)?;
         kv_cache.advance(1);
 
         // Token 1
-        let _ = model_forward(&[7], &weights, &config, Some(&mut kv_cache))?;
+        let _ = model_forward(&[7], &weights, &config, Some(&mut kv_cache), None)?;
         kv_cache.advance(1);
 
         // Token 2
-        let logits_cached = model_forward(&[1], &weights, &config, Some(&mut kv_cache))?;
+        let logits_cached = model_forward(&[1], &weights, &config, Some(&mut kv_cache), None)?;
         kv_cache.advance(1);
 
         let last_cached = logits_cached.narrow(1, 0, 1)?.flatten_all()?.to_vec1::<f32>()?;

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{Context, Result};
 use candle_core::DType;
+use std::path::Path;
 use std::sync::mpsc;
 
 use kiln_core::config::ModelConfig;
@@ -14,6 +15,7 @@ use kiln_core::tokenizer::KilnTokenizer;
 
 use crate::forward::{model_forward, model_forward_paged, GpuWeights};
 use crate::kv_cache::KvCache;
+use crate::lora_loader::LoraWeights;
 use crate::paged_kv_cache::PagedKvCache;
 use crate::sampling::{greedy_sample, sample_with_params};
 
@@ -26,6 +28,8 @@ pub struct ModelRunner {
     pub config: ModelConfig,
     /// EOS token IDs cached from the tokenizer.
     eos_token_ids: Vec<TokenId>,
+    /// Currently active LoRA adapter weights (None = base model only).
+    active_lora: Option<LoraWeights>,
 }
 
 /// Output from a generation call.
@@ -86,7 +90,31 @@ impl ModelRunner {
             tokenizer,
             config,
             eos_token_ids,
+            active_lora: None,
         }
+    }
+
+    /// Load a LoRA adapter from a PEFT-compatible directory.
+    ///
+    /// The directory must contain `adapter_config.json` and `adapter_model.safetensors`.
+    /// Replaces any previously loaded adapter.
+    pub fn load_adapter(&mut self, path: &Path) -> Result<()> {
+        let device = self.weights.embed_tokens.device().clone();
+        let num_layers = self.config.num_layers;
+        let lora = LoraWeights::load(path, num_layers, &device)
+            .context("failed to load LoRA adapter")?;
+        self.active_lora = Some(lora);
+        Ok(())
+    }
+
+    /// Unload the currently active LoRA adapter, reverting to base model.
+    pub fn unload_adapter(&mut self) {
+        self.active_lora = None;
+    }
+
+    /// Returns a reference to the active LoRA weights, if any.
+    pub fn active_lora(&self) -> Option<&LoraWeights> {
+        self.active_lora.as_ref()
     }
 
     /// Generate text from a prompt string.
@@ -157,7 +185,7 @@ impl ModelRunner {
         let mut kv_cache = self.new_kv_cache(max_total)?;
 
         // Prefill: run forward pass on all prompt tokens at once
-        let logits = model_forward(&prompt_tokens, &self.weights, &self.config, Some(&mut kv_cache))
+        let logits = model_forward(&prompt_tokens, &self.weights, &self.config, Some(&mut kv_cache), self.active_lora.as_ref())
             .context("prefill forward pass failed")?;
         kv_cache.advance(prompt_tokens.len());
 
@@ -231,7 +259,7 @@ impl ModelRunner {
             }
 
             // Decode step: forward pass on just the new token
-            let logits = model_forward(&[next_token], &self.weights, &self.config, Some(&mut kv_cache))
+            let logits = model_forward(&[next_token], &self.weights, &self.config, Some(&mut kv_cache), self.active_lora.as_ref())
                 .context("decode forward pass failed")?;
             kv_cache.advance(1);
 
@@ -272,7 +300,7 @@ impl ModelRunner {
         let mut kv_cache = self.new_kv_cache(max_total)?;
 
         // Prefill: run forward pass on all prompt tokens at once
-        let logits = model_forward(prompt_tokens, &self.weights, &self.config, Some(&mut kv_cache))
+        let logits = model_forward(prompt_tokens, &self.weights, &self.config, Some(&mut kv_cache), self.active_lora.as_ref())
             .context("prefill forward pass failed")?;
         kv_cache.advance(prompt_tokens.len());
 
@@ -330,7 +358,7 @@ impl ModelRunner {
             }
 
             // Decode step: forward pass on just the new token (KV cache has all previous)
-            let logits = model_forward(&[next_token], &self.weights, &self.config, Some(&mut kv_cache))
+            let logits = model_forward(&[next_token], &self.weights, &self.config, Some(&mut kv_cache), self.active_lora.as_ref())
                 .context("decode forward pass failed")?;
             kv_cache.advance(1);
 
@@ -445,6 +473,7 @@ impl ModelRunner {
             paged_cache,
             block_table,
             0,
+            self.active_lora.as_ref(),
         )
         .context("prefill forward pass (paged) failed")?;
 
@@ -509,6 +538,7 @@ impl ModelRunner {
                 paged_cache,
                 block_table,
                 seq_len,
+                self.active_lora.as_ref(),
             )
             .context("decode forward pass (paged) failed")?;
             seq_len += 1;
@@ -575,6 +605,7 @@ impl ModelRunner {
             paged_cache,
             &block_table,
             0,
+            self.active_lora.as_ref(),
         ) {
             Ok(l) => l,
             Err(e) => {
@@ -658,6 +689,7 @@ impl ModelRunner {
                 paged_cache,
                 &block_table,
                 seq_len,
+                self.active_lora.as_ref(),
             ) {
                 Ok(l) => l,
                 Err(e) => {

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -3,8 +3,9 @@ pub mod forward;
 pub mod generate;
 pub mod kv_cache;
 pub mod loader;
-pub mod paged_kv_cache;
 pub mod lora;
+pub mod lora_loader;
+pub mod paged_kv_cache;
 pub mod sampling;
 pub mod weights;
 
@@ -12,5 +13,6 @@ pub use engine::Engine;
 pub use generate::{FinishReason, GenerationOutput, ModelRunner, StreamDone, StreamEvent, StreamToken};
 pub use kv_cache::KvCache;
 pub use loader::load_model;
+pub use lora_loader::LoraWeights;
 pub use paged_kv_cache::PagedKvCache;
 pub use weights::ModelWeights;

--- a/crates/kiln-model/src/lora.rs
+++ b/crates/kiln-model/src/lora.rs
@@ -1,5 +1,8 @@
 use serde::{Deserialize, Serialize};
 
+// Re-export weight types from lora_loader for convenience.
+pub use crate::lora_loader::{LoraLayerWeights, LoraWeights};
+
 /// Metadata for a LoRA adapter.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AdapterInfo {

--- a/crates/kiln-model/src/lora_loader.rs
+++ b/crates/kiln-model/src/lora_loader.rs
@@ -1,0 +1,458 @@
+//! LoRA adapter weight loading from PEFT-compatible safetensors format.
+//!
+//! Loads LoRA A/B matrices from safetensors files and adapter_config.json,
+//! organizing them into per-layer structs for use during forward pass.
+
+use anyhow::{Context, Result};
+use candle_core::{DType, Device, Tensor};
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+/// Configuration from PEFT's adapter_config.json.
+#[derive(Debug, Deserialize)]
+pub struct AdapterConfig {
+    /// LoRA rank (r).
+    pub r: usize,
+    /// LoRA alpha scaling factor.
+    pub lora_alpha: f32,
+    /// Target modules (e.g., ["q_proj", "k_proj", "v_proj", "o_proj", ...]).
+    pub target_modules: Vec<String>,
+    /// Task type (optional, e.g., "CAUSAL_LM").
+    #[serde(default)]
+    pub task_type: Option<String>,
+}
+
+/// LoRA A/B weight pair for a single linear projection.
+pub struct LoraProjectionWeights {
+    /// A matrix: [rank, in_features]
+    pub a: Tensor,
+    /// B matrix: [out_features, rank]
+    pub b: Tensor,
+}
+
+/// LoRA weights for all targeted modules in one transformer layer.
+#[derive(Default)]
+pub struct LoraLayerWeights {
+    pub q_proj: Option<LoraProjectionWeights>,
+    pub k_proj: Option<LoraProjectionWeights>,
+    pub v_proj: Option<LoraProjectionWeights>,
+    pub o_proj: Option<LoraProjectionWeights>,
+    pub gate_proj: Option<LoraProjectionWeights>,
+    pub up_proj: Option<LoraProjectionWeights>,
+    pub down_proj: Option<LoraProjectionWeights>,
+}
+
+/// Complete LoRA adapter weights for all layers.
+pub struct LoraWeights {
+    /// Per-layer LoRA weights, indexed by layer number.
+    pub layers: Vec<LoraLayerWeights>,
+    /// LoRA rank.
+    pub rank: usize,
+    /// LoRA alpha (scaling factor).
+    pub alpha: f32,
+    /// Precomputed scale = alpha / rank.
+    pub scale: f32,
+}
+
+impl LoraWeights {
+    /// Load a PEFT-compatible LoRA adapter from a directory.
+    ///
+    /// The directory must contain:
+    /// - `adapter_config.json`: PEFT configuration with rank, alpha, target_modules
+    /// - `adapter_model.safetensors`: LoRA A/B weight matrices
+    ///
+    /// Weight keys follow the PEFT naming convention:
+    /// `base_model.model.model.layers.{i}.self_attn.{module}.lora_A.weight`
+    /// `base_model.model.model.layers.{i}.self_attn.{module}.lora_B.weight`
+    /// and similarly for MLP modules under `.mlp.{module}.`.
+    pub fn load(adapter_dir: &Path, num_layers: usize, device: &Device) -> Result<Self> {
+        // Load adapter config
+        let config_path = adapter_dir.join("adapter_config.json");
+        let config_str = std::fs::read_to_string(&config_path)
+            .with_context(|| format!("failed to read {}", config_path.display()))?;
+        let config: AdapterConfig = serde_json::from_str(&config_str)
+            .context("failed to parse adapter_config.json")?;
+
+        let rank = config.r;
+        let alpha = config.lora_alpha;
+        let scale = alpha / rank as f32;
+
+        // Load safetensors
+        let st_path = adapter_dir.join("adapter_model.safetensors");
+        let st_data = std::fs::read(&st_path)
+            .with_context(|| format!("failed to read {}", st_path.display()))?;
+        let tensors = safetensors::SafeTensors::deserialize(&st_data)
+            .context("failed to deserialize safetensors")?;
+
+        // Parse all tensor names into a map: (layer_idx, module_name, "A"|"B") -> tensor_name
+        let mut tensor_map: HashMap<(usize, String, String), String> = HashMap::new();
+
+        for name in tensors.names() {
+            if let Some(parsed) = parse_peft_key(name) {
+                tensor_map.insert((parsed.layer, parsed.module, parsed.ab), name.to_string());
+            }
+        }
+
+        // Build per-layer weights
+        let mut layers = Vec::with_capacity(num_layers);
+        for layer_idx in 0..num_layers {
+            let mut layer = LoraLayerWeights::default();
+
+            for module in &config.target_modules {
+                let a_key = tensor_map.get(&(layer_idx, module.clone(), "A".to_string()));
+                let b_key = tensor_map.get(&(layer_idx, module.clone(), "B".to_string()));
+
+                if let (Some(a_name), Some(b_name)) = (a_key, b_key) {
+                    let a_view = tensors.tensor(a_name)
+                        .with_context(|| format!("failed to get tensor {a_name}"))?;
+                    let b_view = tensors.tensor(b_name)
+                        .with_context(|| format!("failed to get tensor {b_name}"))?;
+
+                    let a = safetensor_to_candle(&a_view, device)
+                        .with_context(|| format!("converting {a_name}"))?;
+                    let b = safetensor_to_candle(&b_view, device)
+                        .with_context(|| format!("converting {b_name}"))?;
+
+                    let proj = LoraProjectionWeights { a, b };
+                    match module.as_str() {
+                        "q_proj" => layer.q_proj = Some(proj),
+                        "k_proj" => layer.k_proj = Some(proj),
+                        "v_proj" => layer.v_proj = Some(proj),
+                        "o_proj" => layer.o_proj = Some(proj),
+                        "gate_proj" => layer.gate_proj = Some(proj),
+                        "up_proj" => layer.up_proj = Some(proj),
+                        "down_proj" => layer.down_proj = Some(proj),
+                        _ => {
+                            tracing::warn!("unknown LoRA target module: {module}, skipping");
+                        }
+                    }
+                }
+            }
+
+            layers.push(layer);
+        }
+
+        Ok(Self {
+            layers,
+            rank,
+            alpha,
+            scale,
+        })
+    }
+}
+
+/// Parsed PEFT weight key components.
+struct ParsedKey {
+    layer: usize,
+    module: String,
+    ab: String, // "A" or "B"
+}
+
+/// Parse a PEFT-style safetensors key into layer index, module name, and A/B indicator.
+///
+/// Expected patterns:
+/// - `base_model.model.model.layers.{i}.self_attn.{module}.lora_{A|B}.weight`
+/// - `base_model.model.model.layers.{i}.mlp.{module}.lora_{A|B}.weight`
+fn parse_peft_key(key: &str) -> Option<ParsedKey> {
+    // Look for "layers.{i}." and "lora_{A|B}.weight"
+    let parts: Vec<&str> = key.split('.').collect();
+
+    // Find "layers" followed by a number
+    let layer_pos = parts.iter().position(|&p| p == "layers")?;
+    let layer_idx: usize = parts.get(layer_pos + 1)?.parse().ok()?;
+
+    // Find "lora_A" or "lora_B"
+    let lora_pos = parts.iter().position(|p| *p == "lora_A" || *p == "lora_B")?;
+    let ab = if parts[lora_pos] == "lora_A" {
+        "A".to_string()
+    } else {
+        "B".to_string()
+    };
+
+    // The module name is the part just before "lora_A" or "lora_B"
+    let module = parts.get(lora_pos.checked_sub(1)?)?.to_string();
+
+    Some(ParsedKey {
+        layer: layer_idx,
+        module,
+        ab,
+    })
+}
+
+/// Convert a safetensors tensor view to a candle Tensor.
+fn safetensor_to_candle(
+    view: &safetensors::tensor::TensorView<'_>,
+    device: &Device,
+) -> Result<Tensor> {
+    let shape: Vec<usize> = view.shape().to_vec();
+    let dtype = match view.dtype() {
+        safetensors::Dtype::F16 => DType::F16,
+        safetensors::Dtype::BF16 => DType::BF16,
+        safetensors::Dtype::F32 => DType::F32,
+        other => anyhow::bail!("unsupported safetensors dtype: {:?}", other),
+    };
+    let tensor = Tensor::from_raw_buffer(view.data(), dtype, &shape, device)
+        .context("failed to create tensor from safetensors data")?;
+    Ok(tensor)
+}
+
+/// Apply a LoRA delta to a linear projection output.
+///
+/// Computes: `base_output + (x @ A^T @ B^T) * scale`
+///
+/// - `x`: input tensor [batch, seq_len, in_features] (or [seq_len, in_features])
+/// - `proj`: LoRA A/B weight pair
+/// - `scale`: alpha / rank
+///
+/// Returns: the LoRA delta tensor (same shape as base_output)
+pub fn compute_lora_delta(
+    x: &Tensor,
+    proj: &LoraProjectionWeights,
+    scale: f32,
+) -> Result<Tensor> {
+    // x: [..., in_features]
+    // A: [rank, in_features] -> A^T: [in_features, rank]
+    // B: [out_features, rank] -> B^T: [rank, out_features]
+    // delta = x @ A^T @ B^T * scale
+    let x_f32 = x.to_dtype(DType::F32)?;
+    let a_f32 = proj.a.to_dtype(DType::F32)?;
+    let b_f32 = proj.b.to_dtype(DType::F32)?;
+
+    let hidden = x_f32.broadcast_matmul(&a_f32.t()?)?; // [..., rank]
+    let delta = hidden.broadcast_matmul(&b_f32.t()?)?; // [..., out_features]
+    let delta = (delta * scale as f64)?;
+
+    // Cast back to input dtype
+    let delta = delta.to_dtype(x.dtype())?;
+    Ok(delta)
+}
+
+/// Apply a LoRA-augmented linear projection.
+///
+/// Computes: `(x @ W^T) + (x @ A^T @ B^T) * scale`
+///
+/// If no LoRA weights are provided for this projection, just returns `x @ W^T`.
+pub fn linear_with_lora(
+    x: &Tensor,
+    base_weight: &Tensor,
+    lora: Option<&LoraProjectionWeights>,
+    scale: f32,
+) -> Result<Tensor> {
+    let base_output = x.broadcast_matmul(&base_weight.t()?)?;
+    if let Some(proj) = lora {
+        let delta = compute_lora_delta(x, proj, scale)?;
+        Ok((base_output + delta)?)
+    } else {
+        Ok(base_output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    #[test]
+    fn test_parse_peft_key_self_attn() {
+        let key = "base_model.model.model.layers.5.self_attn.q_proj.lora_A.weight";
+        let parsed = parse_peft_key(key).unwrap();
+        assert_eq!(parsed.layer, 5);
+        assert_eq!(parsed.module, "q_proj");
+        assert_eq!(parsed.ab, "A");
+    }
+
+    #[test]
+    fn test_parse_peft_key_mlp() {
+        let key = "base_model.model.model.layers.12.mlp.gate_proj.lora_B.weight";
+        let parsed = parse_peft_key(key).unwrap();
+        assert_eq!(parsed.layer, 12);
+        assert_eq!(parsed.module, "gate_proj");
+        assert_eq!(parsed.ab, "B");
+    }
+
+    #[test]
+    fn test_parse_peft_key_invalid() {
+        assert!(parse_peft_key("random.key.name").is_none());
+        assert!(parse_peft_key("layers.abc.q_proj.lora_A.weight").is_none());
+    }
+
+    #[test]
+    fn test_compute_lora_delta_known_values() -> Result<()> {
+        let device = Device::Cpu;
+
+        // x: [1, 2, 4] (batch=1, seq_len=2, in_features=4)
+        let x = Tensor::new(
+            &[[1.0_f32, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+            &device,
+        )?
+        .unsqueeze(0)?;
+
+        // A: [2, 4] (rank=2, in_features=4) — identity-like
+        let a = Tensor::new(
+            &[[1.0_f32, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+            &device,
+        )?;
+
+        // B: [3, 2] (out_features=3, rank=2)
+        let b = Tensor::new(
+            &[[1.0_f32, 0.0], [0.0, 1.0], [1.0, 1.0]],
+            &device,
+        )?;
+
+        let proj = LoraProjectionWeights { a, b };
+        let delta = compute_lora_delta(&x, &proj, 2.0)?;
+
+        // x[0] = [1,0,0,0] -> x@A^T = [1,0] -> @B^T = [1,0,1] -> *2 = [2,0,2]
+        // x[1] = [0,1,0,0] -> x@A^T = [0,1] -> @B^T = [0,1,1] -> *2 = [0,2,2]
+        let vals = delta.squeeze(0)?.to_vec2::<f32>()?;
+        assert!((vals[0][0] - 2.0).abs() < 1e-5);
+        assert!((vals[0][1] - 0.0).abs() < 1e-5);
+        assert!((vals[0][2] - 2.0).abs() < 1e-5);
+        assert!((vals[1][0] - 0.0).abs() < 1e-5);
+        assert!((vals[1][1] - 2.0).abs() < 1e-5);
+        assert!((vals[1][2] - 2.0).abs() < 1e-5);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_linear_with_lora_adds_delta() -> Result<()> {
+        let device = Device::Cpu;
+
+        // x: [1, 1, 4]
+        let x = Tensor::new(&[[1.0_f32, 2.0, 3.0, 4.0]], &device)?.unsqueeze(0)?;
+
+        // W: [3, 4] — base weight
+        let w = Tensor::zeros((3, 4), DType::F32, &device)?;
+
+        // A: [2, 4], B: [3, 2]
+        let a = Tensor::new(
+            &[[1.0_f32, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]],
+            &device,
+        )?;
+        let b = Tensor::new(
+            &[[1.0_f32, 0.0], [0.0, 1.0], [0.5, 0.5]],
+            &device,
+        )?;
+
+        let proj = LoraProjectionWeights { a, b };
+
+        // Without LoRA: output should be all zeros (zero weight)
+        let out_base = linear_with_lora(&x, &w, None, 1.0)?;
+        let vals = out_base.squeeze(0)?.to_vec2::<f32>()?;
+        assert!((vals[0][0]).abs() < 1e-5);
+
+        // With LoRA (scale=1.0):
+        // x@A^T = [1,2] (first two elements of x), @B^T = [1, 2, 1.5], *1.0
+        let out_lora = linear_with_lora(&x, &w, Some(&proj), 1.0)?;
+        let vals = out_lora.squeeze(0)?.to_vec2::<f32>()?;
+        assert!((vals[0][0] - 1.0).abs() < 1e-5);
+        assert!((vals[0][1] - 2.0).abs() < 1e-5);
+        assert!((vals[0][2] - 1.5).abs() < 1e-5);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_load_from_directory() -> Result<()> {
+        // Create a temporary directory with mock adapter files
+        let dir = tempfile::tempdir()?;
+        let adapter_dir = dir.path();
+
+        // Write adapter_config.json
+        let config = serde_json::json!({
+            "r": 4,
+            "lora_alpha": 8.0,
+            "target_modules": ["q_proj", "v_proj"],
+            "task_type": "CAUSAL_LM"
+        });
+        std::fs::write(
+            adapter_dir.join("adapter_config.json"),
+            serde_json::to_string_pretty(&config)?,
+        )?;
+
+        // Create minimal safetensors with A/B for layer 0 q_proj and v_proj
+        let rank = 4usize;
+        let in_features = 8usize;
+        let out_features = 8usize;
+
+        let mut tensors: Vec<(String, Vec<u8>, Vec<usize>, safetensors::Dtype)> = Vec::new();
+
+        // Helper: create f32 tensor data
+        let make_data = |rows: usize, cols: usize| -> Vec<u8> {
+            let vals: Vec<f32> = (0..rows * cols).map(|i| (i as f32) * 0.01).collect();
+            vals.iter().flat_map(|v| v.to_le_bytes()).collect()
+        };
+
+        // q_proj A: [rank, in_features]
+        tensors.push((
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight".to_string(),
+            make_data(rank, in_features),
+            vec![rank, in_features],
+            safetensors::Dtype::F32,
+        ));
+        // q_proj B: [out_features, rank]
+        tensors.push((
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight".to_string(),
+            make_data(out_features, rank),
+            vec![out_features, rank],
+            safetensors::Dtype::F32,
+        ));
+        // v_proj A: [rank, in_features]
+        tensors.push((
+            "base_model.model.model.layers.0.self_attn.v_proj.lora_A.weight".to_string(),
+            make_data(rank, in_features),
+            vec![rank, in_features],
+            safetensors::Dtype::F32,
+        ));
+        // v_proj B: [out_features, rank]
+        tensors.push((
+            "base_model.model.model.layers.0.self_attn.v_proj.lora_B.weight".to_string(),
+            make_data(out_features, rank),
+            vec![out_features, rank],
+            safetensors::Dtype::F32,
+        ));
+
+        // Serialize to safetensors format
+        let tensor_views: Vec<(String, safetensors::tensor::TensorView<'_>)> = tensors
+            .iter()
+            .map(|(name, data, shape, dtype)| {
+                (
+                    name.clone(),
+                    safetensors::tensor::TensorView::new(*dtype, shape.clone(), data).unwrap(),
+                )
+            })
+            .collect();
+        let refs: Vec<(&str, safetensors::tensor::TensorView<'_>)> = tensor_views
+            .iter()
+            .map(|(name, view)| (name.as_str(), view.clone()))
+            .collect();
+
+        let serialized = safetensors::tensor::serialize(refs, &None)?;
+        std::fs::write(adapter_dir.join("adapter_model.safetensors"), &serialized)?;
+
+        // Load
+        let device = Device::Cpu;
+        let weights = LoraWeights::load(adapter_dir, 1, &device)?;
+
+        assert_eq!(weights.rank, 4);
+        assert!((weights.alpha - 8.0).abs() < 1e-5);
+        assert!((weights.scale - 2.0).abs() < 1e-5);
+        assert_eq!(weights.layers.len(), 1);
+
+        let layer = &weights.layers[0];
+        assert!(layer.q_proj.is_some());
+        assert!(layer.k_proj.is_none());
+        assert!(layer.v_proj.is_some());
+        assert!(layer.o_proj.is_none());
+
+        // Verify shapes
+        let q_a = &layer.q_proj.as_ref().unwrap().a;
+        assert_eq!(q_a.dims(), &[rank, in_features]);
+        let q_b = &layer.q_proj.as_ref().unwrap().b;
+        assert_eq!(q_b.dims(), &[out_features, rank]);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## What
Phase 2 items 1-2: Load PEFT-compatible LoRA adapters from safetensors and apply deltas during forward pass (unmerged serving).

## Changes
- **New `lora_loader.rs`**: Parse `adapter_config.json` for rank/alpha/target_modules, load A/B matrices from `adapter_model.safetensors` using standard PEFT naming convention
- **Forward pass**: All linear projections (q/k/v/o_proj, gate/up/down_proj) now accept optional LoRA weights via `linear_with_lora()` which computes `base_output + (x @ A^T @ B^T) * (alpha/rank)` on the fly
- **ModelRunner**: Added `load_adapter(path)` and `unload_adapter()` methods for hot-swapping adapters, plus `active_lora()` accessor
- **lora.rs**: Re-exports `LoraWeights` and `LoraLayerWeights` from lora_loader
- **lib.rs**: Exports `LoraWeights` at crate level

## Testing
All 60 kiln-model tests pass (CPU):
- `test_parse_peft_key_*`: PEFT key parsing for self_attn and mlp modules
- `test_compute_lora_delta_known_values`: Verifies exact delta computation with identity-like A matrix
- `test_linear_with_lora_adds_delta`: Confirms base + delta addition works correctly
- `test_load_from_directory`: End-to-end test creating mock safetensors, loading, and verifying shapes
- All existing forward pass and generation tests continue to pass with `lora: None`