### PR TITLE
Fix Qwen3.5-4B weight shapes and KV cache allocation

### DIFF
--- a/crates/kiln-core/src/config.rs
+++ b/crates/kiln-core/src/config.rs
@@ -25,6 +25,35 @@ pub struct ModelConfig {
     /// Full attention is applied every N layers (the rest are linear attention).
     /// For Qwen3.5-4B: every 4th layer (layers 3, 7, 11, 15, 19, 23, 27, 31).
     pub full_attention_interval: usize,
+
+    /// Whether full-attention layers use an output gate on Q projections.
+    /// When true, q_proj output is 2x normal (Q + gate), and the output is
+    /// multiplied by sigmoid(gate) before the o_proj.
+    /// For Qwen3.5-4B: true.
+    pub attn_output_gate: bool,
+
+    // --- Linear attention (Gated DeltaNet) dimensions ---
+    // These differ from full attention heads/dims in the hybrid architecture.
+
+    /// Number of key heads in linear attention layers.
+    /// For Qwen3.5-4B: 16.
+    pub linear_num_key_heads: usize,
+
+    /// Dimension per key head in linear attention layers.
+    /// For Qwen3.5-4B: 128.
+    pub linear_key_head_dim: usize,
+
+    /// Number of value heads in linear attention layers.
+    /// For Qwen3.5-4B: 32.
+    pub linear_num_value_heads: usize,
+
+    /// Dimension per value head in linear attention layers.
+    /// For Qwen3.5-4B: 128.
+    pub linear_value_head_dim: usize,
+
+    /// Conv1d kernel size for linear attention layers.
+    /// For Qwen3.5-4B: 4.
+    pub linear_conv_kernel_dim: usize,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -58,6 +87,12 @@ impl ModelConfig {
             dtype: DType::BF16,
             num_full_attention_layers: 8,
             full_attention_interval: 4,
+            attn_output_gate: true,
+            linear_num_key_heads: 16,
+            linear_key_head_dim: 128,
+            linear_num_value_heads: 32,
+            linear_value_head_dim: 128,
+            linear_conv_kernel_dim: 4,
         }
     }
 
@@ -87,6 +122,27 @@ impl ModelConfig {
     pub fn is_full_attention_layer(&self, layer_idx: usize) -> bool {
         (layer_idx + 1) % self.full_attention_interval == 0
     }
+
+    /// Full attention Q projection output dim (includes gate when attn_output_gate is true).
+    pub fn full_attn_q_proj_dim(&self) -> usize {
+        let base = self.num_attention_heads * self.head_dim;
+        if self.attn_output_gate { base * 2 } else { base }
+    }
+
+    /// Total Q+K dimension for linear attention (Q and K share the same head count/dim).
+    pub fn linear_qk_dim(&self) -> usize {
+        self.linear_num_key_heads * self.linear_key_head_dim
+    }
+
+    /// Total V dimension for linear attention.
+    pub fn linear_v_dim(&self) -> usize {
+        self.linear_num_value_heads * self.linear_value_head_dim
+    }
+
+    /// Total fused QKV dimension for linear attention: Q + K + V.
+    pub fn linear_qkv_dim(&self) -> usize {
+        self.linear_qk_dim() + self.linear_qk_dim() + self.linear_v_dim()
+    }
 }
 
 #[cfg(test)]
@@ -102,6 +158,19 @@ mod tests {
         // Compare: a pure 32-layer transformer would be 4096 * 32 = 131072 (~128 KB)
         assert_eq!(config.kv_cache_bytes_per_token(), 32768);
         assert_eq!(config.gqa_group_size(), 4);
+    }
+
+    #[test]
+    fn qwen3_5_4b_linear_attention_dims() {
+        let config = ModelConfig::qwen3_5_4b();
+        // Q and K: 16 heads * 128 dim = 2048 each
+        assert_eq!(config.linear_qk_dim(), 2048);
+        // V: 32 heads * 128 dim = 4096
+        assert_eq!(config.linear_v_dim(), 4096);
+        // Fused QKV: 2048 + 2048 + 4096 = 8192
+        assert_eq!(config.linear_qkv_dim(), 8192);
+        // Full attention Q proj with gate: 16 * 256 * 2 = 8192
+        assert_eq!(config.full_attn_q_proj_dim(), 8192);
     }
 
     #[test]

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -362,21 +362,39 @@ pub fn gqa_attention(
     rms_norm_eps: f64,
     kv_cache: Option<&mut KvCache>,
     full_attn_layer_idx: usize,
+    attn_output_gate: bool,
     lora: Option<(&LoraLayerWeights, f32)>,
 ) -> Result<Tensor> {
     let (_batch, seq_len, _hidden) = x.dims3()?;
 
     // Project to Q, K, V (with optional LoRA delta)
+    // When attn_output_gate is true, q_proj outputs [Q, gate] fused:
+    //   q_proj: [num_heads * head_dim * 2, hidden_size]
+    //   Split into Q [num_heads, head_dim] and gate [num_heads, head_dim]
     let (lora_layer, lora_scale) = match lora {
         Some((l, s)) => (Some(l), s),
         None => (None, 0.0),
     };
-    let q = linear_with_lora(x, &attn_weights.q_proj, lora_layer.and_then(|l| l.q_proj.as_ref()), lora_scale)?;
+    let q_raw = linear_with_lora(x, &attn_weights.q_proj, lora_layer.and_then(|l| l.q_proj.as_ref()), lora_scale)?;
     let k = linear_with_lora(x, &attn_weights.k_proj, lora_layer.and_then(|l| l.k_proj.as_ref()), lora_scale)?;
     let v = linear_with_lora(x, &attn_weights.v_proj, lora_layer.and_then(|l| l.v_proj.as_ref()), lora_scale)?;
 
-    // Reshape to [batch, seq_len, num_heads, head_dim]
-    let q = q.reshape(((), seq_len, num_heads, head_dim))?;
+    // Split Q and gate if output gate is enabled
+    let (q, gate) = if attn_output_gate {
+        // q_raw: [batch, seq_len, num_heads * head_dim * 2]
+        // Reshape to [batch, seq_len, num_heads, head_dim * 2] then split
+        let q_raw = q_raw.reshape(((), seq_len, num_heads, head_dim * 2))?;
+        let q = q_raw.narrow(3, 0, head_dim)?;
+        let gate = q_raw.narrow(3, head_dim, head_dim)?;
+        // gate needs to be [batch, seq_len, num_heads * head_dim] for later
+        let gate = gate.contiguous()?.reshape(((), seq_len, num_heads * head_dim))?;
+        (q.contiguous()?, Some(gate))
+    } else {
+        let q = q_raw.reshape(((), seq_len, num_heads, head_dim))?;
+        (q, None)
+    };
+
+    // Reshape K, V to [batch, seq_len, num_heads, head_dim]
     let k = k.reshape(((), seq_len, num_kv_heads, head_dim))?;
     let v = v.reshape(((), seq_len, num_kv_heads, head_dim))?;
 
@@ -398,6 +416,13 @@ pub fn gqa_attention(
         let k = k.contiguous()?;
         let v = v.contiguous()?;
         let attn_output = flash_attention_forward(&q, &k, &v, num_heads, num_kv_heads, head_dim)?;
+        // Apply output gate: attn_output * sigmoid(gate)
+        let attn_output = if let Some(ref gate) = gate {
+            let sigmoid_gate = candle_nn::ops::sigmoid(gate)?;
+            (attn_output * sigmoid_gate)?
+        } else {
+            attn_output
+        };
         let out = linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?;
         return Ok(out);
     }
@@ -459,6 +484,14 @@ pub fn gqa_attention(
         .contiguous()?
         .reshape(((), seq_len, num_heads * head_dim))?;
 
+    // Apply output gate: attn_output * sigmoid(gate)
+    let attn_output = if let Some(ref gate) = gate {
+        let sigmoid_gate = candle_nn::ops::sigmoid(gate)?;
+        (attn_output * sigmoid_gate)?
+    } else {
+        attn_output
+    };
+
     // Output projection
     let out = linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?;
     Ok(out)
@@ -484,21 +517,32 @@ pub fn gqa_attention_paged(
     paged_cache: &mut PagedKvCache,
     block_table: &BlockTable,
     full_attn_layer_idx: usize,
+    attn_output_gate: bool,
     lora: Option<(&LoraLayerWeights, f32)>,
 ) -> Result<Tensor> {
     let (_batch, seq_len, _hidden) = x.dims3()?;
     let start_pos = positions[0] as usize;
 
-    // Project to Q, K, V (with optional LoRA delta)
+    // Project to Q, K, V (with optional LoRA delta and output gate split)
     let (lora_layer, lora_scale) = match lora {
         Some((l, s)) => (Some(l), s),
         None => (None, 0.0),
     };
-    let q = linear_with_lora(x, &attn_weights.q_proj, lora_layer.and_then(|l| l.q_proj.as_ref()), lora_scale)?;
+    let q_raw = linear_with_lora(x, &attn_weights.q_proj, lora_layer.and_then(|l| l.q_proj.as_ref()), lora_scale)?;
     let k = linear_with_lora(x, &attn_weights.k_proj, lora_layer.and_then(|l| l.k_proj.as_ref()), lora_scale)?;
     let v = linear_with_lora(x, &attn_weights.v_proj, lora_layer.and_then(|l| l.v_proj.as_ref()), lora_scale)?;
 
-    let q = q.reshape(((), seq_len, num_heads, head_dim))?;
+    let (q, gate) = if attn_output_gate {
+        let q_raw = q_raw.reshape(((), seq_len, num_heads, head_dim * 2))?;
+        let q = q_raw.narrow(3, 0, head_dim)?;
+        let gate = q_raw.narrow(3, head_dim, head_dim)?;
+        let gate = gate.contiguous()?.reshape(((), seq_len, num_heads * head_dim))?;
+        (q.contiguous()?, Some(gate))
+    } else {
+        let q = q_raw.reshape(((), seq_len, num_heads, head_dim))?;
+        (q, None)
+    };
+
     let k = k.reshape(((), seq_len, num_kv_heads, head_dim))?;
     let v = v.reshape(((), seq_len, num_kv_heads, head_dim))?;
 
@@ -535,6 +579,13 @@ pub fn gqa_attention_paged(
         let k = k.transpose(1, 2)?.contiguous()?; // -> [batch, kv_len, num_kv_heads, head_dim]
         let v = v.transpose(1, 2)?.contiguous()?; // -> [batch, kv_len, num_kv_heads, head_dim]
         let attn_output = flash_attention_forward(&q, &k, &v, num_heads, num_kv_heads, head_dim)?;
+        // Apply output gate: attn_output * sigmoid(gate)
+        let attn_output = if let Some(ref gate) = gate {
+            let sigmoid_gate = candle_nn::ops::sigmoid(gate)?;
+            (attn_output * sigmoid_gate)?
+        } else {
+            attn_output
+        };
         let out = linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?;
         return Ok(out);
     }
@@ -585,6 +636,12 @@ pub fn gqa_attention_paged(
             .contiguous()?
             .reshape((batch, 1, num_heads * head_dim))?;
 
+        let attn_output = if let Some(ref gate) = gate {
+            let sigmoid_gate = candle_nn::ops::sigmoid(gate)?;
+            (attn_output * sigmoid_gate)?
+        } else {
+            attn_output
+        };
         let out = linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?;
         return Ok(out);
     }
@@ -622,6 +679,13 @@ pub fn gqa_attention_paged(
         .transpose(1, 2)?
         .contiguous()?
         .reshape(((), seq_len, num_heads * head_dim))?;
+
+    let attn_output = if let Some(ref gate) = gate {
+        let sigmoid_gate = candle_nn::ops::sigmoid(gate)?;
+        (attn_output * sigmoid_gate)?
+    } else {
+        attn_output
+    };
 
     let out = linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?;
     Ok(out)
@@ -690,6 +754,7 @@ fn apply_causal_mask_with_offset(
 pub fn transformer_block(
     x: &Tensor,
     layer: &GpuLayerWeights,
+    config: &kiln_core::config::ModelConfig,
     positions: &[u32],
     num_heads: usize,
     num_kv_heads: usize,
@@ -722,6 +787,7 @@ pub fn transformer_block(
         rms_norm_eps,
         kv_cache,
         full_attn_layer_idx,
+        config.attn_output_gate,
         lora,
     )?;
 
@@ -752,6 +818,7 @@ pub fn transformer_block(
 pub fn transformer_block_paged(
     x: &Tensor,
     layer: &GpuLayerWeights,
+    config: &kiln_core::config::ModelConfig,
     positions: &[u32],
     num_heads: usize,
     num_kv_heads: usize,
@@ -786,6 +853,7 @@ pub fn transformer_block_paged(
         paged_cache,
         block_table,
         full_attn_layer_idx,
+        config.attn_output_gate,
         lora,
     )?;
 
@@ -860,6 +928,7 @@ pub fn model_forward(
                 hidden = transformer_block(
                     &hidden,
                     layer,
+                    config,
                     &positions,
                     config.num_attention_heads,
                     config.num_kv_heads,
@@ -945,6 +1014,7 @@ pub fn model_forward_paged(
                 hidden = transformer_block_paged(
                     &hidden,
                     layer,
+                    config,
                     &positions,
                     config.num_attention_heads,
                     config.num_kv_heads,
@@ -1172,6 +1242,31 @@ mod tests {
         Ok(())
     }
 
+    /// Create a minimal config for tests (no output gate, simple dims).
+    fn make_test_config(num_heads: usize, num_kv_heads: usize, head_dim: usize, hidden: usize) -> kiln_core::config::ModelConfig {
+        kiln_core::config::ModelConfig {
+            hidden_size: hidden,
+            num_layers: 4,
+            num_attention_heads: num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size: hidden * 2,
+            vocab_size: 256,
+            max_position_embeddings: 1024,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10_000.0,
+            dtype: kiln_core::config::DType::BF16,
+            num_full_attention_layers: 1,
+            full_attention_interval: 4,
+            attn_output_gate: false,
+            linear_num_key_heads: num_heads,
+            linear_key_head_dim: head_dim,
+            linear_num_value_heads: num_heads,
+            linear_value_head_dim: head_dim,
+            linear_conv_kernel_dim: 4,
+        }
+    }
+
     fn make_test_attn_weights(
         num_heads: usize,
         num_kv_heads: usize,
@@ -1203,7 +1298,7 @@ mod tests {
         let attn = make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?;
         let positions: Vec<u32> = (0..seq_len as u32).collect();
 
-        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
+        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, false, None)?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         Ok(())
@@ -1224,7 +1319,7 @@ mod tests {
         let attn = make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?;
         let positions: Vec<u32> = (0..seq_len as u32).collect();
 
-        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
+        let out = gqa_attention(&x, &attn, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, false, None)?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         // Output should be finite and not all zeros
@@ -1248,7 +1343,7 @@ mod tests {
         let x = Tensor::randn(0.0_f32, 1.0, (1, 1, hidden), &device)?;
         let attn = make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?;
 
-        let out = gqa_attention(&x, &attn, &[0], num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
+        let out = gqa_attention(&x, &attn, &[0], num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, false, None)?;
         assert_eq!(out.dims(), &[1, 1, hidden]);
 
         Ok(())
@@ -1304,7 +1399,8 @@ mod tests {
             },
         };
 
-        let out = transformer_block(&x, &layer, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
+        let cfg = make_test_config(num_heads, num_kv_heads, head_dim, hidden);
+        let out = transformer_block(&x, &layer, &cfg, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         Ok(())
@@ -1337,7 +1433,8 @@ mod tests {
             },
         };
 
-        let out = transformer_block(&x, &layer, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
+        let cfg = make_test_config(num_heads, num_kv_heads, head_dim, hidden);
+        let out = transformer_block(&x, &layer, &cfg, &positions, num_heads, num_kv_heads, head_dim, 10_000.0, 1e-6, None, 0, None)?;
 
         // Output should not be zero (residual adds input through)
         let vals = out.flatten_all()?.to_vec1::<f32>()?;
@@ -1375,7 +1472,8 @@ mod tests {
         };
 
         let x = Tensor::ones((1, 1, hidden), DType::F32, &device)?;
-        let result = transformer_block(&x, &layer, &[0], 2, 1, 4, 10_000.0, 1e-6, None, 0, None);
+        let cfg = make_test_config(2, 1, 4, 8);
+        let result = transformer_block(&x, &layer, &cfg, &[0], 2, 1, 4, 10_000.0, 1e-6, None, 0, None);
         assert!(result.is_err(), "should reject linear attention layers");
 
         Ok(())
@@ -1488,6 +1586,12 @@ mod tests {
             dtype: kiln_core::config::DType::FP32,
             num_full_attention_layers: num_layers,
             full_attention_interval: 1, // every layer is full attention
+            attn_output_gate: false,
+            linear_num_key_heads: num_heads,
+            linear_key_head_dim: head_dim,
+            linear_num_value_heads: num_heads,
+            linear_value_head_dim: head_dim,
+            linear_conv_kernel_dim: 4,
         };
 
         let token_ids: Vec<u32> = vec![1, 5, 3, 10];
@@ -1534,6 +1638,12 @@ mod tests {
             dtype: kiln_core::config::DType::FP32,
             num_full_attention_layers: 1,
             full_attention_interval: 1,
+            attn_output_gate: false,
+            linear_num_key_heads: num_heads,
+            linear_key_head_dim: head_dim,
+            linear_num_value_heads: num_heads,
+            linear_value_head_dim: head_dim,
+            linear_conv_kernel_dim: 4,
         };
 
         let logits = model_forward(&[7], &weights, &config, None, None)?;
@@ -1587,6 +1697,12 @@ mod tests {
             dtype: kiln_core::config::DType::FP32,
             num_full_attention_layers: num_layers,
             full_attention_interval: 1,
+            attn_output_gate: false,
+            linear_num_key_heads: num_heads,
+            linear_key_head_dim: head_dim,
+            linear_num_value_heads: num_heads,
+            linear_value_head_dim: head_dim,
+            linear_conv_kernel_dim: 4,
         };
 
         let tokens: Vec<u32> = vec![1, 5, 3, 10, 7];
@@ -1660,6 +1776,12 @@ mod tests {
             dtype: kiln_core::config::DType::FP32,
             num_full_attention_layers: 1,
             full_attention_interval: 1,
+            attn_output_gate: false,
+            linear_num_key_heads: num_heads,
+            linear_key_head_dim: head_dim,
+            linear_num_value_heads: num_heads,
+            linear_value_head_dim: head_dim,
+            linear_conv_kernel_dim: 4,
         };
 
         let tokens: Vec<u32> = vec![3, 7, 1];

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -744,6 +744,12 @@ mod tests {
             dtype: kiln_core::config::DType::FP32,
             num_full_attention_layers: 1,
             full_attention_interval: 1, // every layer is full attention
+            attn_output_gate: false,
+            linear_num_key_heads: 0,
+            linear_key_head_dim: 0,
+            linear_num_value_heads: 0,
+            linear_value_head_dim: 0,
+            linear_conv_kernel_dim: 0,
         }
     }
 

--- a/crates/kiln-model/src/loader.rs
+++ b/crates/kiln-model/src/loader.rs
@@ -234,11 +234,12 @@ fn load_full_attention(
     let attn = format!("{prefix}self_attn.");
     let ctx = |name: &str| format!("layer {layer_idx} self_attn.{name}");
 
-    let q_dim = config.num_attention_heads * config.head_dim;
+    let q_proj_dim = config.full_attn_q_proj_dim();
+    let q_out_dim = config.num_attention_heads * config.head_dim;
     let kv_dim = config.num_kv_heads * config.head_dim;
 
     let q_proj = extract_tensor(tensor_map, &format!("{attn}q_proj.weight"))?;
-    validate_shape(&q_proj, &[q_dim, config.hidden_size], &ctx("q_proj"))?;
+    validate_shape(&q_proj, &[q_proj_dim, config.hidden_size], &ctx("q_proj"))?;
 
     let k_proj = extract_tensor(tensor_map, &format!("{attn}k_proj.weight"))?;
     validate_shape(&k_proj, &[kv_dim, config.hidden_size], &ctx("k_proj"))?;
@@ -247,7 +248,7 @@ fn load_full_attention(
     validate_shape(&v_proj, &[kv_dim, config.hidden_size], &ctx("v_proj"))?;
 
     let o_proj = extract_tensor(tensor_map, &format!("{attn}o_proj.weight"))?;
-    validate_shape(&o_proj, &[config.hidden_size, q_dim], &ctx("o_proj"))?;
+    validate_shape(&o_proj, &[config.hidden_size, q_out_dim], &ctx("o_proj"))?;
 
     let q_norm = extract_tensor(tensor_map, &format!("{attn}q_norm.weight"))?;
     validate_shape(&q_norm, &[config.head_dim], &ctx("q_norm"))?;
@@ -275,44 +276,44 @@ fn load_linear_attention(
     let attn = format!("{prefix}linear_attn.");
     let ctx = |name: &str| format!("layer {layer_idx} linear_attn.{name}");
 
-    let qkv_dim = config.num_attention_heads * config.head_dim;
+    // Linear attention uses asymmetric Q/K/V dimensions from config.
+    let fused_qkv_dim = config.linear_qkv_dim(); // Q + K + V total
+    let v_dim = config.linear_v_dim();
+    let num_heads = config.linear_num_value_heads;
 
     let in_proj_qkv = extract_tensor(tensor_map, &format!("{attn}in_proj_qkv.weight"))?;
-    // Fused QKV: [3 * qkv_dim, hidden_size]
-    validate_shape(&in_proj_qkv, &[3 * qkv_dim, config.hidden_size], &ctx("in_proj_qkv"))?;
+    validate_shape(&in_proj_qkv, &[fused_qkv_dim, config.hidden_size], &ctx("in_proj_qkv"))?;
 
     let in_proj_z = extract_tensor(tensor_map, &format!("{attn}in_proj_z.weight"))?;
-    validate_shape(&in_proj_z, &[qkv_dim, config.hidden_size], &ctx("in_proj_z"))?;
+    validate_shape(&in_proj_z, &[v_dim, config.hidden_size], &ctx("in_proj_z"))?;
 
     let out_proj = extract_tensor(tensor_map, &format!("{attn}out_proj.weight"))?;
-    validate_shape(&out_proj, &[config.hidden_size, qkv_dim], &ctx("out_proj"))?;
+    validate_shape(&out_proj, &[config.hidden_size, v_dim], &ctx("out_proj"))?;
 
     let in_proj_a = extract_tensor(tensor_map, &format!("{attn}in_proj_a.weight"))?;
-    validate_shape(&in_proj_a, &[qkv_dim, config.hidden_size], &ctx("in_proj_a"))?;
+    validate_shape(&in_proj_a, &[num_heads, config.hidden_size], &ctx("in_proj_a"))?;
 
     let in_proj_b = extract_tensor(tensor_map, &format!("{attn}in_proj_b.weight"))?;
-    validate_shape(&in_proj_b, &[qkv_dim, config.hidden_size], &ctx("in_proj_b"))?;
+    validate_shape(&in_proj_b, &[num_heads, config.hidden_size], &ctx("in_proj_b"))?;
 
-    // conv1d shape is [channels, 1, kernel_size] — we validate channels but
-    // allow any kernel size since it's architecture-specific.
+    // conv1d shape is [channels, 1, kernel_size] — channels = fused QKV dim.
     let conv1d = extract_tensor(tensor_map, &format!("{attn}conv1d.weight"))?;
-    if conv1d.shape.len() != 3 || conv1d.shape[0] != qkv_dim || conv1d.shape[1] != 1 {
+    if conv1d.shape.len() != 3 || conv1d.shape[0] != fused_qkv_dim || conv1d.shape[1] != 1 {
         bail!(
-            "Shape mismatch for {}: expected [{qkv_dim}, 1, *], got {:?}",
+            "Shape mismatch for {}: expected [{fused_qkv_dim}, 1, *], got {:?}",
             ctx("conv1d"),
             conv1d.shape
         );
     }
 
     let norm = extract_tensor(tensor_map, &format!("{attn}norm.weight"))?;
-    // Group norm — may be [qkv_dim] or [num_heads * head_dim], same thing.
-    validate_shape(&norm, &[qkv_dim], &ctx("norm"))?;
+    // Group norm weight — per-head normalization.
+    validate_shape(&norm, &[config.linear_key_head_dim], &ctx("norm"))?;
 
     let a_log = extract_tensor(tensor_map, &format!("{attn}A_log"))?;
-    // A_log may be [qkv_dim] or [num_heads, head_dim] — validate total elements.
-    if a_log.numel() != qkv_dim {
+    if a_log.numel() != num_heads {
         bail!(
-            "Element count mismatch for {}: expected {qkv_dim}, got {} (shape {:?})",
+            "Element count mismatch for {}: expected {num_heads}, got {} (shape {:?})",
             ctx("A_log"),
             a_log.numel(),
             a_log.shape
@@ -320,9 +321,9 @@ fn load_linear_attention(
     }
 
     let dt_bias = extract_tensor(tensor_map, &format!("{attn}dt_bias"))?;
-    if dt_bias.numel() != qkv_dim {
+    if dt_bias.numel() != num_heads {
         bail!(
-            "Element count mismatch for {}: expected {qkv_dim}, got {} (shape {:?})",
+            "Element count mismatch for {}: expected {num_heads}, got {} (shape {:?})",
             ctx("dt_bias"),
             dt_bias.numel(),
             dt_bias.shape
@@ -453,15 +454,21 @@ mod tests {
 
     /// Build a list of tensor specs for a tiny test model.
     fn tiny_model_tensors(prefix: &str) -> Vec<(String, Vec<usize>, StDtype)> {
-        let hidden = 64;
-        let heads = 4;
-        let kv_heads = 2;
-        let head_dim = 16;
-        let intermediate = 128;
-        let vocab = 256;
-        let qkv_dim = heads * head_dim;
-        let kv_dim = kv_heads * head_dim;
-        let conv_size = 4;
+        let config = tiny_model_config();
+        let hidden = config.hidden_size;
+        let intermediate = config.intermediate_size;
+        let vocab = config.vocab_size;
+
+        // Full attention dims
+        let q_proj_dim = config.full_attn_q_proj_dim();
+        let q_out_dim = config.num_attention_heads * config.head_dim;
+        let kv_dim = config.num_kv_heads * config.head_dim;
+
+        // Linear attention dims
+        let fused_qkv_dim = config.linear_qkv_dim();
+        let v_dim = config.linear_v_dim();
+        let num_linear_heads = config.linear_num_value_heads;
+        let conv_size = config.linear_conv_kernel_dim;
 
         let mut tensors: Vec<(String, Vec<usize>, StDtype)> = Vec::new();
         let bf16 = StDtype::BF16;
@@ -471,7 +478,7 @@ mod tests {
         tensors.push((format!("{prefix}norm.weight"), vec![hidden], bf16));
 
         // 4 layers: layers 0,1,2 are linear, layer 3 is full attention
-        for i in 0..4 {
+        for i in 0..config.num_layers {
             let lp = format!("{prefix}layers.{i}.");
             tensors.push((format!("{lp}input_layernorm.weight"), vec![hidden], bf16));
             tensors.push((format!("{lp}post_attention_layernorm.weight"), vec![hidden], bf16));
@@ -479,25 +486,25 @@ mod tests {
             tensors.push((format!("{lp}mlp.up_proj.weight"), vec![intermediate, hidden], bf16));
             tensors.push((format!("{lp}mlp.down_proj.weight"), vec![hidden, intermediate], bf16));
 
-            if (i + 1) % 4 == 0 {
+            if config.is_full_attention_layer(i) {
                 // Full attention layer
-                tensors.push((format!("{lp}self_attn.q_proj.weight"), vec![qkv_dim, hidden], bf16));
+                tensors.push((format!("{lp}self_attn.q_proj.weight"), vec![q_proj_dim, hidden], bf16));
                 tensors.push((format!("{lp}self_attn.k_proj.weight"), vec![kv_dim, hidden], bf16));
                 tensors.push((format!("{lp}self_attn.v_proj.weight"), vec![kv_dim, hidden], bf16));
-                tensors.push((format!("{lp}self_attn.o_proj.weight"), vec![hidden, qkv_dim], bf16));
-                tensors.push((format!("{lp}self_attn.q_norm.weight"), vec![head_dim], bf16));
-                tensors.push((format!("{lp}self_attn.k_norm.weight"), vec![head_dim], bf16));
+                tensors.push((format!("{lp}self_attn.o_proj.weight"), vec![hidden, q_out_dim], bf16));
+                tensors.push((format!("{lp}self_attn.q_norm.weight"), vec![config.head_dim], bf16));
+                tensors.push((format!("{lp}self_attn.k_norm.weight"), vec![config.head_dim], bf16));
             } else {
                 // Linear attention layer
-                tensors.push((format!("{lp}linear_attn.in_proj_qkv.weight"), vec![3 * qkv_dim, hidden], bf16));
-                tensors.push((format!("{lp}linear_attn.in_proj_z.weight"), vec![qkv_dim, hidden], bf16));
-                tensors.push((format!("{lp}linear_attn.out_proj.weight"), vec![hidden, qkv_dim], bf16));
-                tensors.push((format!("{lp}linear_attn.in_proj_a.weight"), vec![qkv_dim, hidden], bf16));
-                tensors.push((format!("{lp}linear_attn.in_proj_b.weight"), vec![qkv_dim, hidden], bf16));
-                tensors.push((format!("{lp}linear_attn.conv1d.weight"), vec![qkv_dim, 1, conv_size], bf16));
-                tensors.push((format!("{lp}linear_attn.norm.weight"), vec![qkv_dim], bf16));
-                tensors.push((format!("{lp}linear_attn.A_log"), vec![qkv_dim], bf16));
-                tensors.push((format!("{lp}linear_attn.dt_bias"), vec![qkv_dim], bf16));
+                tensors.push((format!("{lp}linear_attn.in_proj_qkv.weight"), vec![fused_qkv_dim, hidden], bf16));
+                tensors.push((format!("{lp}linear_attn.in_proj_z.weight"), vec![v_dim, hidden], bf16));
+                tensors.push((format!("{lp}linear_attn.out_proj.weight"), vec![hidden, v_dim], bf16));
+                tensors.push((format!("{lp}linear_attn.in_proj_a.weight"), vec![num_linear_heads, hidden], bf16));
+                tensors.push((format!("{lp}linear_attn.in_proj_b.weight"), vec![num_linear_heads, hidden], bf16));
+                tensors.push((format!("{lp}linear_attn.conv1d.weight"), vec![fused_qkv_dim, 1, conv_size], bf16));
+                tensors.push((format!("{lp}linear_attn.norm.weight"), vec![config.linear_key_head_dim], bf16));
+                tensors.push((format!("{lp}linear_attn.A_log"), vec![num_linear_heads], bf16));
+                tensors.push((format!("{lp}linear_attn.dt_bias"), vec![num_linear_heads], bf16));
             }
         }
 
@@ -519,6 +526,12 @@ mod tests {
             dtype: kiln_core::config::DType::BF16,
             num_full_attention_layers: 1,
             full_attention_interval: 4,
+            attn_output_gate: true,
+            linear_num_key_heads: 4,
+            linear_key_head_dim: 8,
+            linear_num_value_heads: 8,
+            linear_value_head_dim: 8,
+            linear_conv_kernel_dim: 4,
         }
     }
 

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -52,8 +52,8 @@ impl AppState {
 
     /// Create an AppState with a real ModelRunner backend and paged KV cache.
     ///
-    /// Uses `block_size=16` by default. The number of blocks is derived from
-    /// `max_position_embeddings / block_size` with a minimum of 256.
+    /// Uses `block_size=16` by default. The number of blocks can be overridden
+    /// with `KILN_NUM_BLOCKS`. Otherwise derived from `max_position_embeddings / block_size`.
     pub fn new_real(
         model_config: ModelConfig,
         runner: ModelRunner,
@@ -61,7 +61,18 @@ impl AppState {
         device: candle_core::Device,
     ) -> Self {
         let block_size = 16;
-        let num_blocks = (model_config.max_position_embeddings / block_size).max(256);
+        let num_blocks = std::env::var("KILN_NUM_BLOCKS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .unwrap_or_else(|| (model_config.max_position_embeddings / block_size).max(256));
+
+        let kv_dtype = if candle_core::utils::cuda_is_available() {
+            DType::BF16
+        } else {
+            DType::F32
+        };
+
+        tracing::info!(num_blocks, block_size, ?kv_dtype, "allocating paged KV cache");
 
         let block_manager = BlockManager::new(num_blocks, block_size);
         let paged_cache = PagedKvCache::new(
@@ -70,7 +81,7 @@ impl AppState {
             block_size,
             model_config.num_kv_heads,
             model_config.head_dim,
-            DType::F32,
+            kv_dtype,
             &device,
         )
         .expect("failed to create PagedKvCache");

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -34,6 +34,12 @@ fn tiny_config() -> ModelConfig {
         dtype: kiln_core::config::DType::FP32,
         num_full_attention_layers: 1,
         full_attention_interval: 1,
+        attn_output_gate: false,
+        linear_num_key_heads: 0,
+        linear_key_head_dim: 0,
+        linear_num_value_heads: 0,
+        linear_value_head_dim: 0,
+        linear_conv_kernel_dim: 0,
     }
 }
 


### PR DESCRIPTION
## Summary
- Fix weight shape mismatches for Qwen3.5-4B hybrid architecture (attn_output_gate doubles q_proj, linear attention has different QKV dims)
- Add `KILN_NUM_BLOCKS` env var to override default block count (default of 16384 blocks requires ~137GB KV cache)
- Use BF16 for KV cache on CUDA (halves memory)
- Log KV cache allocation at startup

## Test Results (RTX A4500, 20GB VRAM)
- Kiln builds with `--features cuda` ✅
- Qwen3.5-4B weights load successfully (4206M params, 8022 MB) ✅
- Server starts and responds to health checks ✅
- KV cache allocates with `KILN_NUM_BLOCKS=512` using ~1GB ✅
- GPU memory usage: 9.8 GB / 20.5 GB ✅
- Inference produces output (token sampling works) ✅
- **Output is NOT coherent** — all spaces. Root cause: Gated DeltaNet linear attention layers are not yet implemented (TODO in `model_forward_paged`). 24 of 32 layers skip attention, so the model can't reason.

## What's Needed Next
The linear attention (Gated DeltaNet) forward pass at `forward.rs:996-1008` needs implementation. Without it, Qwen3.5-4B will only use 8/32 attention layers and produce garbage output.

Alternatively, test with **Qwen3-4B** (pure transformer, no hybrid layers) which should work with the existing full-attention-only code path.