### PR TITLE
Fix paged GQA decode broadcast bug (garbled output)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -965,15 +965,22 @@ pub fn gqa_attention_paged(
             .reshape((batch, num_kv_heads, gqa_ratio, 1, head_dim))?
             .reshape((batch * num_kv_heads, gqa_ratio, 1, head_dim))?
             .contiguous()?;
+        // Unsqueeze K/V to [batch*num_kv_heads, 1, kv_len, head_dim] so that
+        // broadcast_matmul pairs each Q group with its own KV head (dim 0),
+        // broadcasting over the gqa_ratio dim (dim 1).  Without the unsqueeze
+        // the 3-D K would be padded to [1, batch*num_kv_heads, ...] and the
+        // gqa_ratio dim would incorrectly index into different KV heads.
         let k_flat = k
             .reshape((batch * num_kv_heads, kv_len, head_dim))?
+            .unsqueeze(1)?
             .contiguous()?;
         let v_flat = v
             .reshape((batch * num_kv_heads, kv_len, head_dim))?
+            .unsqueeze(1)?
             .contiguous()?;
 
         // Attention scores: [batch*num_kv_heads, gqa_ratio, 1, kv_len]
-        let attn_scores = q_grouped.broadcast_matmul(&k_flat.transpose(1, 2)?.contiguous()?)?;
+        let attn_scores = q_grouped.broadcast_matmul(&k_flat.transpose(2, 3)?.contiguous()?)?;
         let attn_scores = (attn_scores / scale)?;
         // No causal mask needed for decode (q_len=1 attends to everything)
         let attn_weights_softmax = candle_nn::ops::softmax_last_dim(&attn_scores)?;


### PR DESCRIPTION
## Summary

- **Root cause**: In `gqa_attention_paged`'s optimized decode path (seq_len==1, gqa_ratio>1), K/V tensors were 3-D while Q was 4-D. `broadcast_matmul` padded K/V to `[1, batch*num_kv_heads, ...]`, causing the gqa_ratio dimension of Q to index into *different* KV heads instead of broadcasting over the *same* KV head.
- For Qwen3.5-4B (num_kv_heads=4, gqa_ratio=4), 12 of 16 attention heads attended to the wrong KV head on every decode step. Prefill was unaffected (uses flash-attn).
- **Fix**: Unsqueeze K/V to 4-D `[batch*num_kv_heads, 1, kv_len, head_dim]` so broadcast correctly pairs each Q group with its corresponding KV head.

## How it was found

Non-paged `generate()` produced coherent output ("What is 2+2?" → "4"), while paged `generate_paged()` produced garbled text. Layer-by-layer comparison showed GDN layers matched HF reference, narrowing it to the paged attention decode path.

## Test plan

- [ ] Verify paged inference produces coherent output on GPU (RunPod)
- [ ] Run `cargo test` to confirm no regressions
- [ ] Compare paged vs non-paged output for identical prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)