### PR TITLE
Wire up LoRA adapter management API (Phase 2 start)

### DIFF
--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -1,22 +1,185 @@
-use axum::{routing::get, Json, Router};
-use serde::Serialize;
+use std::path::Path;
 
-use crate::state::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
 
+use crate::state::{AppState, ModelBackend};
+
+/// Response for GET /v1/adapters.
 #[derive(Serialize)]
 struct AdaptersResponse {
+    /// Name of the currently active adapter, if any.
     active: Option<String>,
-    available: Vec<String>,
+    /// Adapters available on disk in the adapter directory.
+    available: Vec<AdapterDiskEntry>,
 }
 
-async fn list_adapters() -> Json<AdaptersResponse> {
-    // TODO: query engine for real adapter state
-    Json(AdaptersResponse {
-        active: None,
-        available: vec![],
+/// An adapter directory found on disk.
+#[derive(Serialize)]
+struct AdapterDiskEntry {
+    /// Directory name (used as the adapter name).
+    name: String,
+    /// Whether this adapter has adapter_config.json.
+    has_config: bool,
+    /// Whether this adapter has adapter_model.safetensors.
+    has_weights: bool,
+}
+
+/// Request body for POST /v1/adapters/load.
+#[derive(Deserialize)]
+struct LoadAdapterRequest {
+    /// Adapter name (subdirectory under adapter_dir) or absolute path.
+    name: String,
+}
+
+/// Response for POST /v1/adapters/load.
+#[derive(Serialize)]
+struct LoadAdapterResponse {
+    status: &'static str,
+    name: String,
+}
+
+/// Response for POST /v1/adapters/unload.
+#[derive(Serialize)]
+struct UnloadAdapterResponse {
+    status: &'static str,
+}
+
+/// List loaded and available adapters.
+async fn list_adapters(State(state): State<AppState>) -> Json<AdaptersResponse> {
+    // Check active adapter from ModelRunner
+    let active = match state.backend.as_ref() {
+        ModelBackend::Real { runner, .. } => {
+            let guard = runner.lock().unwrap();
+            guard.active_lora().map(|lora| {
+                format!("rank={}, alpha={}", lora.rank, lora.alpha)
+            })
+        }
+        ModelBackend::Mock { .. } => None,
+    };
+
+    // Scan adapter directory for available adapters
+    let available = scan_adapter_dir(&state.adapter_dir);
+
+    Json(AdaptersResponse { active, available })
+}
+
+/// Load a LoRA adapter from disk.
+async fn load_adapter(
+    State(state): State<AppState>,
+    Json(req): Json<LoadAdapterRequest>,
+) -> Result<Json<LoadAdapterResponse>, (StatusCode, String)> {
+    let runner = match state.backend.as_ref() {
+        ModelBackend::Real { runner, .. } => runner,
+        ModelBackend::Mock { .. } => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "adapter loading not supported in mock mode".to_string(),
+            ));
+        }
+    };
+
+    // Resolve adapter path: if name is absolute, use it directly; otherwise look in adapter_dir.
+    let adapter_path = if Path::new(&req.name).is_absolute() {
+        std::path::PathBuf::from(&req.name)
+    } else {
+        state.adapter_dir.join(&req.name)
+    };
+
+    if !adapter_path.exists() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("adapter directory not found: {}", adapter_path.display()),
+        ));
+    }
+
+    // Load adapter (this does I/O + tensor allocation, so run on blocking thread)
+    let runner = runner.clone();
+    let path = adapter_path.clone();
+    let name = req.name.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let mut guard = runner.lock().unwrap();
+        guard.load_adapter(&path)
     })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to load adapter: {e}"),
+        )
+    })?;
+
+    tracing::info!(adapter = %req.name, path = %adapter_path.display(), "loaded LoRA adapter");
+
+    Ok(Json(LoadAdapterResponse {
+        status: "loaded",
+        name,
+    }))
+}
+
+/// Unload the active LoRA adapter, reverting to base model.
+async fn unload_adapter(
+    State(state): State<AppState>,
+) -> Result<Json<UnloadAdapterResponse>, (StatusCode, String)> {
+    let runner = match state.backend.as_ref() {
+        ModelBackend::Real { runner, .. } => runner,
+        ModelBackend::Mock { .. } => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "adapter management not supported in mock mode".to_string(),
+            ));
+        }
+    };
+
+    let runner = runner.clone();
+    tokio::task::spawn_blocking(move || {
+        let mut guard = runner.lock().unwrap();
+        guard.unload_adapter();
+    })
+    .await
+    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?;
+
+    tracing::info!("unloaded LoRA adapter — reverted to base model");
+
+    Ok(Json(UnloadAdapterResponse {
+        status: "unloaded",
+    }))
+}
+
+/// Scan a directory for adapter subdirectories.
+fn scan_adapter_dir(dir: &Path) -> Vec<AdapterDiskEntry> {
+    let mut entries = Vec::new();
+    let read_dir = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(_) => return entries,
+    };
+    for entry in read_dir.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            let has_config = path.join("adapter_config.json").exists();
+            let has_weights = path.join("adapter_model.safetensors").exists();
+            if has_config || has_weights {
+                entries.push(AdapterDiskEntry {
+                    name,
+                    has_config,
+                    has_weights,
+                });
+            }
+        }
+    }
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+    entries
 }
 
 pub fn routes() -> Router<AppState> {
-    Router::new().route("/v1/adapters", get(list_adapters))
+    Router::new()
+        .route("/v1/adapters", get(list_adapters))
+        .route("/v1/adapters/load", post(load_adapter))
+        .route("/v1/adapters/unload", post(unload_adapter))
 }

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -186,7 +186,7 @@ async fn chat_completions(
 /// Generate using the real ModelRunner with paged KV cache.
 async fn generate_real(
     state: &AppState,
-    runner: &std::sync::Arc<kiln_model::ModelRunner>,
+    runner: &std::sync::Arc<std::sync::Mutex<kiln_model::ModelRunner>>,
     block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
     paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
     prompt_text: &str,
@@ -209,9 +209,10 @@ async fn generate_real(
     let params = sampling.clone();
 
     let output = tokio::task::spawn_blocking(move || {
+        let runner_guard = runner.lock().unwrap();
         let mut bm_guard = bm.lock().unwrap();
         let mut pc_guard = pc.lock().unwrap();
-        runner.generate_paged(&prompt, &params, &mut bm_guard, &mut pc_guard)
+        runner_guard.generate_paged(&prompt, &params, &mut bm_guard, &mut pc_guard)
     })
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?
@@ -249,7 +250,7 @@ async fn generate_real(
 /// Generate using the real ModelRunner with SSE streaming and paged KV cache.
 async fn generate_real_streaming(
     _state: &AppState,
-    runner: &std::sync::Arc<kiln_model::ModelRunner>,
+    runner: &std::sync::Arc<std::sync::Mutex<kiln_model::ModelRunner>>,
     block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
     paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
     prompt_text: &str,
@@ -298,9 +299,10 @@ async fn generate_real_streaming(
 
             // Run blocking generation with paged KV cache
             let sync_rx = match tokio::task::spawn_blocking(move || {
+                let runner_guard = runner.lock().unwrap();
                 let mut bm_guard = bm.lock().unwrap();
                 let mut pc_guard = pc.lock().unwrap();
-                runner.generate_streaming_paged(&prompt, &params, &mut bm_guard, &mut pc_guard)
+                runner_guard.generate_streaming_paged(&prompt, &params, &mut bm_guard, &mut pc_guard)
             })
             .await
             {

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -84,8 +84,18 @@ async fn main() -> Result<()> {
         };
 
         let runner = ModelRunner::new(gpu_weights, runner_tokenizer, model_config.clone());
-        tracing::info!("model loaded — real inference mode");
-        AppState::new_real(model_config, runner, tokenizer, device)
+
+        let adapter_dir = std::env::var("KILN_ADAPTER_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(mp).join("adapters"));
+
+        if !adapter_dir.exists() {
+            tracing::info!(path = %adapter_dir.display(), "creating adapter directory");
+            std::fs::create_dir_all(&adapter_dir)?;
+        }
+
+        tracing::info!(adapter_dir = %adapter_dir.display(), "model loaded — real inference mode");
+        AppState::new_real(model_config, runner, tokenizer, device, adapter_dir)
     } else {
         // Mock mode: use scheduler + mock engine.
         tracing::info!("no KILN_MODEL_PATH set — running in mock mode");

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -18,7 +19,7 @@ pub enum ModelBackend {
     },
     /// Real model weights loaded via ModelRunner with paged KV cache.
     Real {
-        runner: Arc<ModelRunner>,
+        runner: Arc<std::sync::Mutex<ModelRunner>>,
         block_manager: Arc<std::sync::Mutex<BlockManager>>,
         paged_cache: Arc<std::sync::Mutex<PagedKvCache>>,
     },
@@ -30,6 +31,8 @@ pub struct AppState {
     pub model_config: ModelConfig,
     pub backend: Arc<ModelBackend>,
     pub tokenizer: Arc<KilnTokenizer>,
+    /// Directory where LoRA adapter weights are stored on disk.
+    pub adapter_dir: PathBuf,
 }
 
 impl AppState {
@@ -47,6 +50,7 @@ impl AppState {
                 engine,
             }),
             tokenizer: Arc::new(tokenizer),
+            adapter_dir: PathBuf::from("adapters"),
         }
     }
 
@@ -59,6 +63,7 @@ impl AppState {
         runner: ModelRunner,
         tokenizer: KilnTokenizer,
         device: candle_core::Device,
+        adapter_dir: PathBuf,
     ) -> Self {
         let block_size = 16;
         let num_blocks = std::env::var("KILN_NUM_BLOCKS")
@@ -89,11 +94,12 @@ impl AppState {
         Self {
             model_config,
             backend: Arc::new(ModelBackend::Real {
-                runner: Arc::new(runner),
+                runner: Arc::new(std::sync::Mutex::new(runner)),
                 block_manager: Arc::new(std::sync::Mutex::new(block_manager)),
                 paged_cache: Arc::new(std::sync::Mutex::new(paged_cache)),
             }),
             tokenizer: Arc::new(tokenizer),
+            adapter_dir,
         }
     }
 }

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -155,7 +155,7 @@ async fn test_real_model_chat_completion() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone());
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"));
 
     let app = api::router(state);
 
@@ -220,7 +220,7 @@ async fn test_real_model_streaming_chat_completion() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone());
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"));
 
     let app = api::router(state);
 
@@ -326,7 +326,7 @@ async fn test_health_with_real_backend() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone());
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"));
 
     let app = api::router(state);
 


### PR DESCRIPTION
## What

Implements real LoRA adapter management endpoints, wiring the existing ModelRunner load/unload/active_lora methods to the HTTP API. This is the first Phase 2 task — LoRA serving.

## Changes

- **state.rs**: Wrap `ModelRunner` in `Arc<std::sync::Mutex<>>` (needed because `load_adapter` takes `&mut self`). Add `adapter_dir: PathBuf` field to `AppState`.
- **adapters.rs**: Replace TODO stub with real endpoints:
  - `GET /v1/adapters` — reports active adapter status and scans `adapter_dir` for available adapters on disk
  - `POST /v1/adapters/load` — loads a PEFT-compatible LoRA adapter by name (relative to adapter_dir) or absolute path
  - `POST /v1/adapters/unload` — unloads active adapter, reverting to base model
- **completions.rs**: Update `generate_real` and `generate_real_streaming` to lock the ModelRunner Mutex before generating.
- **main.rs**: Add `KILN_ADAPTER_DIR` env var (defaults to `<model_path>/adapters/`), auto-creates the directory.
- **tests**: Update integration test callsites with the new `adapter_dir` parameter.

## Testing

- `cargo test --workspace` — all tests pass
- `cargo build --release` — clean build
- GPU integration testing of actual LoRA serving will be a separate follow-up task