### PR TITLE
Non-blocking LoRA hot-swap with RwLock

### DIFF
--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -117,6 +117,15 @@ impl ModelRunner {
         self.active_lora.as_ref()
     }
 
+    /// Atomically swap the active LoRA adapter.
+    ///
+    /// Pass `Some(lora)` to activate pre-loaded weights, or `None` to revert to
+    /// the base model. Designed for use with `RwLock`: load weights outside the
+    /// lock, then take a brief write lock to call this method.
+    pub fn swap_lora(&mut self, lora: Option<LoraWeights>) {
+        self.active_lora = lora;
+    }
+
     /// Generate text from a prompt string.
     ///
     /// Tokenizes the prompt, runs the autoregressive generation loop,

--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -6,6 +6,8 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
+use kiln_model::lora_loader::LoraWeights;
+
 use crate::state::{AppState, ModelBackend};
 
 /// Response for GET /v1/adapters.
@@ -53,7 +55,7 @@ async fn list_adapters(State(state): State<AppState>) -> Json<AdaptersResponse> 
     // Check active adapter from ModelRunner
     let active = match state.backend.as_ref() {
         ModelBackend::Real { runner, .. } => {
-            let guard = runner.lock().unwrap();
+            let guard = runner.read().unwrap();
             guard.active_lora().map(|lora| {
                 format!("rank={}, alpha={}", lora.rank, lora.alpha)
             })
@@ -96,21 +98,32 @@ async fn load_adapter(
         ));
     }
 
-    // Load adapter (this does I/O + tensor allocation, so run on blocking thread)
+    // Two-phase load: read device/num_layers under a brief read lock, then load
+    // weights outside any lock so inference is not blocked during I/O.
+    let (device, num_layers) = {
+        let guard = runner.read().unwrap();
+        (guard.weights.embed_tokens.device().clone(), guard.config.num_layers)
+    };
+
     let runner = runner.clone();
     let path = adapter_path.clone();
     let name = req.name.clone();
 
     tokio::task::spawn_blocking(move || {
-        let mut guard = runner.lock().unwrap();
-        guard.load_adapter(&path)
+        // Load weights outside any lock (I/O + tensor allocation).
+        let lora = LoraWeights::load(&path, num_layers, &device)
+            .map_err(|e| format!("failed to load adapter: {e}"))?;
+        // Brief write lock to swap the adapter in.
+        let mut guard = runner.write().unwrap();
+        guard.swap_lora(Some(lora));
+        Ok::<(), String>(())
     })
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?
     .map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to load adapter: {e}"),
+            e,
         )
     })?;
 
@@ -138,7 +151,7 @@ async fn unload_adapter(
 
     let runner = runner.clone();
     tokio::task::spawn_blocking(move || {
-        let mut guard = runner.lock().unwrap();
+        let mut guard = runner.write().unwrap();
         guard.unload_adapter();
     })
     .await

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -186,7 +186,7 @@ async fn chat_completions(
 /// Generate using the real ModelRunner with paged KV cache.
 async fn generate_real(
     state: &AppState,
-    runner: &std::sync::Arc<std::sync::Mutex<kiln_model::ModelRunner>>,
+    runner: &std::sync::Arc<std::sync::RwLock<kiln_model::ModelRunner>>,
     block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
     paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
     prompt_text: &str,
@@ -209,7 +209,7 @@ async fn generate_real(
     let params = sampling.clone();
 
     let output = tokio::task::spawn_blocking(move || {
-        let runner_guard = runner.lock().unwrap();
+        let runner_guard = runner.read().unwrap();
         let mut bm_guard = bm.lock().unwrap();
         let mut pc_guard = pc.lock().unwrap();
         runner_guard.generate_paged(&prompt, &params, &mut bm_guard, &mut pc_guard)
@@ -250,7 +250,7 @@ async fn generate_real(
 /// Generate using the real ModelRunner with SSE streaming and paged KV cache.
 async fn generate_real_streaming(
     _state: &AppState,
-    runner: &std::sync::Arc<std::sync::Mutex<kiln_model::ModelRunner>>,
+    runner: &std::sync::Arc<std::sync::RwLock<kiln_model::ModelRunner>>,
     block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
     paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
     prompt_text: &str,
@@ -299,7 +299,7 @@ async fn generate_real_streaming(
 
             // Run blocking generation with paged KV cache
             let sync_rx = match tokio::task::spawn_blocking(move || {
-                let runner_guard = runner.lock().unwrap();
+                let runner_guard = runner.read().unwrap();
                 let mut bm_guard = bm.lock().unwrap();
                 let mut pc_guard = pc.lock().unwrap();
                 runner_guard.generate_streaming_paged(&prompt, &params, &mut bm_guard, &mut pc_guard)

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -19,7 +19,7 @@ pub enum ModelBackend {
     },
     /// Real model weights loaded via ModelRunner with paged KV cache.
     Real {
-        runner: Arc<std::sync::Mutex<ModelRunner>>,
+        runner: Arc<std::sync::RwLock<ModelRunner>>,
         block_manager: Arc<std::sync::Mutex<BlockManager>>,
         paged_cache: Arc<std::sync::Mutex<PagedKvCache>>,
     },
@@ -94,7 +94,7 @@ impl AppState {
         Self {
             model_config,
             backend: Arc::new(ModelBackend::Real {
-                runner: Arc::new(std::sync::Mutex::new(runner)),
+                runner: Arc::new(std::sync::RwLock::new(runner)),
                 block_manager: Arc::new(std::sync::Mutex::new(block_manager)),
                 paged_cache: Arc::new(std::sync::Mutex::new(paged_cache)),
             }),


### PR DESCRIPTION
## What
Replace `Mutex<ModelRunner>` with `RwLock<ModelRunner>` so inference requests take read locks (concurrent) and adapter swaps take write locks (exclusive). Adapter loading now happens in two phases: weights are loaded outside any lock, then swapped in under a brief write lock.

## Why
The Mutex approach blocks all inference during adapter loading (I/O + tensor allocation). With RwLock, inference continues unblocked while weights load, and only pauses briefly for the atomic swap.

## Changes
- **state.rs**: `Mutex<ModelRunner>` → `RwLock<ModelRunner>`
- **completions.rs**: `runner.lock()` → `runner.read()` for inference
- **adapters.rs**: Two-phase load — read lock to get device/num_layers, load weights outside lock, write lock to swap
- **generate.rs**: Added `swap_lora()` method for atomic adapter replacement

## Phase 2 checklist
- [x] Hot-swap at iteration boundary (atomic pointer swap)