### PR TITLE
Per-request LoRA adapter selection

### DIFF
--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -52,16 +52,8 @@ struct UnloadAdapterResponse {
 
 /// List loaded and available adapters.
 async fn list_adapters(State(state): State<AppState>) -> Json<AdaptersResponse> {
-    // Check active adapter from ModelRunner
-    let active = match state.backend.as_ref() {
-        ModelBackend::Real { runner, .. } => {
-            let guard = runner.read().unwrap();
-            guard.active_lora().map(|lora| {
-                format!("rank={}, alpha={}", lora.rank, lora.alpha)
-            })
-        }
-        ModelBackend::Mock { .. } => None,
-    };
+    // Read the active adapter name from shared state.
+    let active = state.active_adapter_name.read().unwrap().clone();
 
     // Scan adapter directory for available adapters
     let available = scan_adapter_dir(&state.adapter_dir);
@@ -127,6 +119,9 @@ async fn load_adapter(
         )
     })?;
 
+    // Update the shared active adapter name.
+    *state.active_adapter_name.write().unwrap() = Some(req.name.clone());
+
     tracing::info!(adapter = %req.name, path = %adapter_path.display(), "loaded LoRA adapter");
 
     Ok(Json(LoadAdapterResponse {
@@ -156,6 +151,9 @@ async fn unload_adapter(
     })
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?;
+
+    // Clear the shared active adapter name.
+    *state.active_adapter_name.write().unwrap() = None;
 
     tracing::info!("unloaded LoRA adapter — reverted to base model");
 

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -9,10 +9,13 @@ use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
 use uuid::Uuid;
 
+use std::path::Path;
+
 use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
 use kiln_core::tokenizer::ChatMessage;
-use kiln_model::StreamEvent;
+use kiln_model::lora_loader::LoraWeights;
+use kiln_model::{ModelRunner, StreamEvent};
 
 use crate::state::{AppState, ModelBackend};
 
@@ -132,6 +135,11 @@ async fn chat_completions(
         ..Default::default()
     };
 
+    // Ensure the correct LoRA adapter is active for this request.
+    if let ModelBackend::Real { runner, .. } = state.backend.as_ref() {
+        ensure_adapter(&state, runner, &req.adapter).await?;
+    }
+
     if req.stream {
         match state.backend.as_ref() {
             ModelBackend::Real {
@@ -181,6 +189,76 @@ async fn chat_completions(
             }
         }
     }
+}
+
+/// Ensure the correct LoRA adapter is active for the given request.
+///
+/// Compares `req_adapter` against the currently active adapter name. If they
+/// differ, loads/unloads the adapter using the two-phase RwLock pattern
+/// (read config, load weights outside lock, write-lock to swap).
+async fn ensure_adapter(
+    state: &AppState,
+    runner: &std::sync::Arc<std::sync::RwLock<ModelRunner>>,
+    req_adapter: &Option<String>,
+) -> Result<(), (StatusCode, String)> {
+    let current = state.active_adapter_name.read().unwrap().clone();
+    if *req_adapter == current {
+        return Ok(());
+    }
+
+    match req_adapter {
+        Some(name) => {
+            // Resolve adapter path
+            let adapter_path = if Path::new(name).is_absolute() {
+                std::path::PathBuf::from(name)
+            } else {
+                state.adapter_dir.join(name)
+            };
+            if !adapter_path.exists() {
+                return Err((
+                    StatusCode::NOT_FOUND,
+                    format!("adapter not found: {}", adapter_path.display()),
+                ));
+            }
+
+            // Two-phase load: read device/num_layers, load weights, then swap.
+            let (device, num_layers) = {
+                let guard = runner.read().unwrap();
+                (guard.weights.embed_tokens.device().clone(), guard.config.num_layers)
+            };
+
+            let runner = runner.clone();
+            let adapter_name = name.clone();
+            let active_name = state.active_adapter_name.clone();
+
+            tokio::task::spawn_blocking(move || {
+                let lora = LoraWeights::load(&adapter_path, num_layers, &device)
+                    .map_err(|e| format!("failed to load adapter: {e}"))?;
+                let mut guard = runner.write().unwrap();
+                guard.swap_lora(Some(lora));
+                *active_name.write().unwrap() = Some(adapter_name);
+                Ok::<(), String>(())
+            })
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+        }
+        None => {
+            // Revert to base model.
+            let runner = runner.clone();
+            let active_name = state.active_adapter_name.clone();
+
+            tokio::task::spawn_blocking(move || {
+                let mut guard = runner.write().unwrap();
+                guard.swap_lora(None);
+                *active_name.write().unwrap() = None;
+            })
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?;
+        }
+    }
+
+    Ok(())
 }
 
 /// Generate using the real ModelRunner with paged KV cache.

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -33,6 +33,8 @@ pub struct AppState {
     pub tokenizer: Arc<KilnTokenizer>,
     /// Directory where LoRA adapter weights are stored on disk.
     pub adapter_dir: PathBuf,
+    /// Name of the currently active LoRA adapter (None = base model).
+    pub active_adapter_name: Arc<std::sync::RwLock<Option<String>>>,
 }
 
 impl AppState {
@@ -51,6 +53,7 @@ impl AppState {
             }),
             tokenizer: Arc::new(tokenizer),
             adapter_dir: PathBuf::from("adapters"),
+            active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 
@@ -100,6 +103,7 @@ impl AppState {
             }),
             tokenizer: Arc::new(tokenizer),
             adapter_dir,
+            active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
         }
     }
 }


### PR DESCRIPTION
Wire the adapter field in ChatCompletionRequest to actually swap the active LoRA adapter before generating. Requests can specify `adapter: "name"` to use a specific adapter or omit it / set null for base model.

## Changes
- Add `active_adapter_name: Arc<RwLock<Option<String>>>` to AppState to track which adapter is loaded
- Add `ensure_adapter()` helper in completions.rs that compares request adapter vs active, swaps if needed using the two-phase RwLock pattern
- Update adapters.rs load/unload handlers to maintain active_adapter_name
- Update list_adapters to return the adapter name instead of rank/alpha info