### PR TITLE
Training sidecar unix socket protocol

### DIFF
--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -32,6 +32,7 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 tokio-stream = { workspace = true }
+thiserror = { workspace = true }
 
 [features]
 cuda = ["kiln-model/cuda"]

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -1,45 +1,164 @@
-use axum::{http::StatusCode, routing::{get, post}, Json, Router};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
 
 use kiln_train::{
     GrpoRequest, SftRequest, TrainingResponse, TrainingState, TrainingStatus,
 };
 
+use crate::sidecar::{SidecarClient, SidecarResponse};
 use crate::state::AppState;
 
+fn sidecar_or_503(sidecar: &Option<SidecarClient>) -> Result<&SidecarClient, (StatusCode, String)> {
+    sidecar.as_ref().ok_or_else(|| {
+        (
+            StatusCode::SERVICE_UNAVAILABLE,
+            "training sidecar not configured — start kiln with KILN_SIDECAR_SOCKET to enable training".to_string(),
+        )
+    })
+}
+
 async fn submit_sft(
+    State(state): State<AppState>,
     Json(req): Json<SftRequest>,
 ) -> Result<Json<TrainingResponse>, (StatusCode, String)> {
-    let num_examples = req.examples.len();
-    tracing::info!(num_examples, "SFT training request received");
+    let client = sidecar_or_503(&state.sidecar)?;
 
-    // TODO: forward to Python training sidecar
-    Ok(Json(TrainingResponse {
-        job_id: uuid::Uuid::new_v4().to_string(),
-        state: TrainingState::Queued,
-        message: format!("Queued SFT training with {num_examples} examples"),
-    }))
+    let num_examples = req.examples.len();
+    let job_id = uuid::Uuid::new_v4().to_string();
+    let adapter_name = req
+        .config
+        .output_name
+        .clone()
+        .unwrap_or_else(|| format!("sft-{}", &job_id[..8]));
+
+    tracing::info!(num_examples, job_id = %job_id, "SFT training request received");
+
+    // Serialize examples as JSON values for the sidecar protocol
+    let examples: Vec<serde_json::Value> = req
+        .examples
+        .iter()
+        .map(|ex| serde_json::to_value(ex).unwrap_or_default())
+        .collect();
+
+    let resp = client
+        .submit_sft(
+            &job_id,
+            examples,
+            &adapter_name,
+            req.config.epochs,
+            req.config.learning_rate,
+            req.config.lora_rank,
+            req.config.lora_alpha,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("sidecar error: {e}");
+            (StatusCode::BAD_GATEWAY, format!("training sidecar error: {e}"))
+        })?;
+
+    match resp {
+        SidecarResponse::JobAccepted { job_id, .. } => Ok(Json(TrainingResponse {
+            job_id,
+            state: TrainingState::Queued,
+            message: format!("Queued SFT training with {num_examples} examples"),
+        })),
+        SidecarResponse::Error { message, .. } => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("sidecar rejected job: {message}"),
+        )),
+        other => {
+            tracing::warn!("unexpected sidecar response: {:?}", other);
+            Ok(Json(TrainingResponse {
+                job_id,
+                state: TrainingState::Queued,
+                message: format!("Queued SFT training with {num_examples} examples"),
+            }))
+        }
+    }
 }
 
 async fn submit_grpo(
+    State(state): State<AppState>,
     Json(req): Json<GrpoRequest>,
 ) -> Result<Json<TrainingResponse>, (StatusCode, String)> {
+    let client = sidecar_or_503(&state.sidecar)?;
+
     let num_groups = req.groups.len();
     let total_completions: usize = req.groups.iter().map(|g| g.completions.len()).sum();
-    tracing::info!(num_groups, total_completions, "GRPO training request received");
+    let job_id = uuid::Uuid::new_v4().to_string();
+    let adapter_name = req
+        .config
+        .output_name
+        .clone()
+        .unwrap_or_else(|| format!("grpo-{}", &job_id[..8]));
 
-    // TODO: forward to Python training sidecar
-    Ok(Json(TrainingResponse {
-        job_id: uuid::Uuid::new_v4().to_string(),
-        state: TrainingState::Queued,
-        message: format!(
-            "Queued GRPO training with {num_groups} groups ({total_completions} completions)"
-        ),
-    }))
+    tracing::info!(num_groups, total_completions, job_id = %job_id, "GRPO training request received");
+
+    let groups: Vec<serde_json::Value> = req
+        .groups
+        .iter()
+        .map(|g| serde_json::to_value(g).unwrap_or_default())
+        .collect();
+
+    let resp = client
+        .submit_grpo(
+            &job_id,
+            groups,
+            &adapter_name,
+            req.config.learning_rate,
+            req.config.lora_rank,
+            req.config.lora_alpha,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("sidecar error: {e}");
+            (StatusCode::BAD_GATEWAY, format!("training sidecar error: {e}"))
+        })?;
+
+    match resp {
+        SidecarResponse::JobAccepted { job_id, .. } => Ok(Json(TrainingResponse {
+            job_id,
+            state: TrainingState::Queued,
+            message: format!(
+                "Queued GRPO training with {num_groups} groups ({total_completions} completions)"
+            ),
+        })),
+        SidecarResponse::Error { message, .. } => Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("sidecar rejected job: {message}"),
+        )),
+        other => {
+            tracing::warn!("unexpected sidecar response: {:?}", other);
+            Ok(Json(TrainingResponse {
+                job_id,
+                state: TrainingState::Queued,
+                message: format!(
+                    "Queued GRPO training with {num_groups} groups ({total_completions} completions)"
+                ),
+            }))
+        }
+    }
 }
 
-async fn training_status() -> Json<Option<TrainingStatus>> {
-    // TODO: query sidecar for current training status
-    Json(None)
+async fn training_status(
+    State(state): State<AppState>,
+) -> Result<Json<Option<TrainingStatus>>, (StatusCode, String)> {
+    let client = match &state.sidecar {
+        Some(c) => c,
+        None => return Ok(Json(None)),
+    };
+
+    if !client.is_available() {
+        return Ok(Json(None));
+    }
+
+    // The status endpoint doesn't have a specific job_id in the current API shape.
+    // Return None for now — callers should use /v1/train/status/:job_id when we add it.
+    Ok(Json(None))
 }
 
 pub fn routes() -> Router<AppState> {

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -1,4 +1,5 @@
 //! Kiln HTTP server — library interface for integration testing.
 
 pub mod api;
+pub mod sidecar;
 pub mod state;

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use tracing_subscriber::EnvFilter;
 
 use kiln_server::api;
+use kiln_server::sidecar::SidecarClient;
 use kiln_server::state;
 
 use kiln_core::config::ModelConfig;
@@ -108,6 +109,16 @@ async fn main() -> Result<()> {
         let scheduler = Scheduler::new(scheduler_config, num_blocks);
         let engine = MockEngine::new(model_config.clone());
         AppState::new_mock(model_config, scheduler, Arc::new(engine), tokenizer)
+    };
+
+    // Optional training sidecar
+    let sidecar_socket = std::env::var("KILN_SIDECAR_SOCKET").ok();
+    let state = if let Some(ref socket_path) = sidecar_socket {
+        tracing::info!(socket = %socket_path, "training sidecar configured");
+        state.with_sidecar(SidecarClient::new(socket_path))
+    } else {
+        tracing::info!("no KILN_SIDECAR_SOCKET set — training endpoints will return 503");
+        state
     };
 
     let app = api::router(state);

--- a/crates/kiln-server/src/sidecar.rs
+++ b/crates/kiln-server/src/sidecar.rs
@@ -1,0 +1,194 @@
+//! Client for the Python training sidecar process.
+//!
+//! Communicates over a unix domain socket using a JSON-line protocol
+//! (one JSON object per line, newline-delimited).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+/// Messages sent from Rust to the Python sidecar.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SidecarRequest {
+    SftRequest {
+        job_id: String,
+        examples: Vec<serde_json::Value>,
+        adapter_name: String,
+        epochs: usize,
+        learning_rate: f64,
+        lora_rank: usize,
+        lora_alpha: f32,
+    },
+    GrpoRequest {
+        job_id: String,
+        groups: Vec<serde_json::Value>,
+        adapter_name: String,
+        learning_rate: f64,
+        lora_rank: usize,
+        lora_alpha: f32,
+    },
+    StatusQuery {
+        job_id: String,
+    },
+    Shutdown,
+}
+
+/// Messages received from the Python sidecar.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SidecarResponse {
+    JobAccepted {
+        job_id: String,
+        #[serde(default)]
+        message: Option<String>,
+    },
+    JobStatus {
+        job_id: String,
+        state: String,
+        progress: f32,
+        #[serde(default)]
+        epoch: Option<u32>,
+        #[serde(default)]
+        loss: Option<f64>,
+        #[serde(default)]
+        adapter_path: Option<String>,
+        #[serde(default)]
+        message: Option<String>,
+    },
+    JobComplete {
+        job_id: String,
+        adapter_path: String,
+    },
+    Error {
+        job_id: String,
+        message: String,
+    },
+}
+
+/// Client for communicating with the Python training sidecar.
+#[derive(Debug, Clone)]
+pub struct SidecarClient {
+    socket_path: PathBuf,
+}
+
+impl SidecarClient {
+    pub fn new(socket_path: impl AsRef<Path>) -> Self {
+        Self {
+            socket_path: socket_path.as_ref().to_path_buf(),
+        }
+    }
+
+    /// Check if the sidecar socket exists (sidecar is likely running).
+    pub fn is_available(&self) -> bool {
+        self.socket_path.exists()
+    }
+
+    /// Send a request to the sidecar and read the response.
+    async fn send(&self, request: &SidecarRequest) -> Result<SidecarResponse, SidecarError> {
+        let stream = UnixStream::connect(&self.socket_path).await.map_err(|e| {
+            SidecarError::Connection(format!(
+                "failed to connect to sidecar at {}: {}",
+                self.socket_path.display(),
+                e
+            ))
+        })?;
+
+        let (read_half, mut write_half) = stream.into_split();
+
+        // Send the JSON-line request
+        let mut msg = serde_json::to_vec(request).map_err(|e| {
+            SidecarError::Protocol(format!("failed to serialize request: {e}"))
+        })?;
+        msg.push(b'\n');
+        write_half.write_all(&msg).await.map_err(|e| {
+            SidecarError::Connection(format!("failed to write to sidecar: {e}"))
+        })?;
+        write_half.flush().await.map_err(|e| {
+            SidecarError::Connection(format!("failed to flush sidecar socket: {e}"))
+        })?;
+
+        // Read one JSON-line response
+        let mut reader = BufReader::new(read_half);
+        let mut line = String::new();
+        let bytes_read = tokio::time::timeout(Duration::from_secs(30), reader.read_line(&mut line))
+            .await
+            .map_err(|_| SidecarError::Timeout("sidecar response timed out (30s)".into()))?
+            .map_err(|e| SidecarError::Connection(format!("failed to read from sidecar: {e}")))?;
+
+        if bytes_read == 0 {
+            return Err(SidecarError::Connection(
+                "sidecar closed connection without responding".into(),
+            ));
+        }
+
+        serde_json::from_str(line.trim()).map_err(|e| {
+            SidecarError::Protocol(format!("invalid sidecar response: {e}: {line}"))
+        })
+    }
+
+    /// Submit an SFT training job.
+    pub async fn submit_sft(
+        &self,
+        job_id: &str,
+        examples: Vec<serde_json::Value>,
+        adapter_name: &str,
+        epochs: usize,
+        learning_rate: f64,
+        lora_rank: usize,
+        lora_alpha: f32,
+    ) -> Result<SidecarResponse, SidecarError> {
+        self.send(&SidecarRequest::SftRequest {
+            job_id: job_id.to_string(),
+            examples,
+            adapter_name: adapter_name.to_string(),
+            epochs,
+            learning_rate,
+            lora_rank,
+            lora_alpha,
+        })
+        .await
+    }
+
+    /// Submit a GRPO training job.
+    pub async fn submit_grpo(
+        &self,
+        job_id: &str,
+        groups: Vec<serde_json::Value>,
+        adapter_name: &str,
+        learning_rate: f64,
+        lora_rank: usize,
+        lora_alpha: f32,
+    ) -> Result<SidecarResponse, SidecarError> {
+        self.send(&SidecarRequest::GrpoRequest {
+            job_id: job_id.to_string(),
+            groups,
+            adapter_name: adapter_name.to_string(),
+            learning_rate,
+            lora_rank,
+            lora_alpha,
+        })
+        .await
+    }
+
+    /// Query the status of a training job.
+    pub async fn query_status(&self, job_id: &str) -> Result<SidecarResponse, SidecarError> {
+        self.send(&SidecarRequest::StatusQuery {
+            job_id: job_id.to_string(),
+        })
+        .await
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SidecarError {
+    #[error("sidecar connection error: {0}")]
+    Connection(String),
+    #[error("sidecar protocol error: {0}")]
+    Protocol(String),
+    #[error("sidecar timeout: {0}")]
+    Timeout(String),
+}

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -10,6 +10,8 @@ use kiln_model::engine::Engine;
 use kiln_model::{ModelRunner, PagedKvCache};
 use kiln_scheduler::Scheduler;
 
+use crate::sidecar::SidecarClient;
+
 /// Which inference backend the server is using.
 pub enum ModelBackend {
     /// Mock engine + scheduler for testing without real weights.
@@ -35,6 +37,8 @@ pub struct AppState {
     pub adapter_dir: PathBuf,
     /// Name of the currently active LoRA adapter (None = base model).
     pub active_adapter_name: Arc<std::sync::RwLock<Option<String>>>,
+    /// Optional training sidecar client. None if no sidecar socket configured.
+    pub sidecar: Option<SidecarClient>,
 }
 
 impl AppState {
@@ -54,6 +58,7 @@ impl AppState {
             tokenizer: Arc::new(tokenizer),
             adapter_dir: PathBuf::from("adapters"),
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
+            sidecar: None,
         }
     }
 
@@ -104,6 +109,13 @@ impl AppState {
             tokenizer: Arc::new(tokenizer),
             adapter_dir,
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
+            sidecar: None,
         }
+    }
+
+    /// Set the training sidecar client.
+    pub fn with_sidecar(mut self, client: SidecarClient) -> Self {
+        self.sidecar = Some(client);
+        self
     }
 }

--- a/sidecar/kiln_train.py
+++ b/sidecar/kiln_train.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python3
+"""Kiln training sidecar — receives training jobs from the Rust server via unix socket.
+
+Protocol: JSON-line (one JSON object per line, newline-delimited) over a unix domain socket.
+
+Request types (Rust -> Python):
+  sft_request   - Submit an SFT training job
+  grpo_request  - Submit a GRPO training job
+  status_query  - Query status of a running/completed job
+  shutdown      - Gracefully shut down the sidecar
+
+Response types (Python -> Rust):
+  job_accepted  - Job was queued
+  job_status    - Current status of a job
+  job_complete  - Job finished, adapter written to disk
+  error         - Something went wrong
+"""
+
+import argparse
+import asyncio
+import json
+import logging
+import os
+import signal
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Optional
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    stream=sys.stderr,
+)
+log = logging.getLogger("kiln-train")
+
+
+class JobState(Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass
+class TrainingJob:
+    job_id: str
+    job_type: str  # "sft" or "grpo"
+    request: dict
+    state: JobState = JobState.QUEUED
+    progress: float = 0.0
+    epoch: int = 0
+    loss: Optional[float] = None
+    adapter_path: Optional[str] = None
+    error_message: Optional[str] = None
+    created_at: float = field(default_factory=time.time)
+
+
+class TrainingSidecar:
+    def __init__(self, socket_path: str, adapter_dir: str):
+        self.socket_path = socket_path
+        self.adapter_dir = Path(adapter_dir)
+        self.adapter_dir.mkdir(parents=True, exist_ok=True)
+        self.jobs: dict[str, TrainingJob] = {}
+        self.job_queue: asyncio.Queue[str] = asyncio.Queue()
+        self._shutdown = asyncio.Event()
+        self._worker_task: Optional[asyncio.Task] = None
+
+    async def start(self):
+        """Start the unix socket server and training worker."""
+        # Clean up stale socket
+        if os.path.exists(self.socket_path):
+            os.unlink(self.socket_path)
+
+        server = await asyncio.start_unix_server(
+            self._handle_connection, path=self.socket_path
+        )
+        os.chmod(self.socket_path, 0o660)
+        log.info("listening on %s", self.socket_path)
+
+        self._worker_task = asyncio.create_task(self._training_worker())
+
+        # Handle signals for graceful shutdown
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(sig, lambda: self._shutdown.set())
+
+        try:
+            async with server:
+                await self._shutdown.wait()
+        finally:
+            log.info("shutting down")
+            if self._worker_task:
+                self._worker_task.cancel()
+                try:
+                    await self._worker_task
+                except asyncio.CancelledError:
+                    pass
+            if os.path.exists(self.socket_path):
+                os.unlink(self.socket_path)
+
+    async def _handle_connection(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ):
+        """Handle a single connection — read JSON lines and respond."""
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                try:
+                    msg = json.loads(line.decode("utf-8").strip())
+                except json.JSONDecodeError as e:
+                    resp = {"type": "error", "job_id": "", "message": f"invalid JSON: {e}"}
+                    writer.write((json.dumps(resp) + "\n").encode())
+                    await writer.drain()
+                    continue
+
+                resp = self._dispatch(msg)
+                writer.write((json.dumps(resp) + "\n").encode())
+                await writer.drain()
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            log.exception("connection handler error: %s", e)
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    def _dispatch(self, msg: dict) -> dict:
+        """Route an incoming message to the appropriate handler."""
+        msg_type = msg.get("type", "")
+
+        if msg_type == "sft_request":
+            return self._handle_sft_request(msg)
+        elif msg_type == "grpo_request":
+            return self._handle_grpo_request(msg)
+        elif msg_type == "status_query":
+            return self._handle_status_query(msg)
+        elif msg_type == "shutdown":
+            self._shutdown.set()
+            return {"type": "job_accepted", "job_id": "", "message": "shutting down"}
+        else:
+            return {
+                "type": "error",
+                "job_id": msg.get("job_id", ""),
+                "message": f"unknown message type: {msg_type}",
+            }
+
+    def _handle_sft_request(self, msg: dict) -> dict:
+        job_id = msg.get("job_id", str(uuid.uuid4()))
+        job = TrainingJob(
+            job_id=job_id,
+            job_type="sft",
+            request=msg,
+        )
+        self.jobs[job_id] = job
+        self.job_queue.put_nowait(job_id)
+        log.info(
+            "queued SFT job %s (%d examples, %d epochs)",
+            job_id,
+            len(msg.get("examples", [])),
+            msg.get("epochs", 3),
+        )
+        return {"type": "job_accepted", "job_id": job_id}
+
+    def _handle_grpo_request(self, msg: dict) -> dict:
+        job_id = msg.get("job_id", str(uuid.uuid4()))
+        job = TrainingJob(
+            job_id=job_id,
+            job_type="grpo",
+            request=msg,
+        )
+        self.jobs[job_id] = job
+        self.job_queue.put_nowait(job_id)
+        log.info(
+            "queued GRPO job %s (%d groups)",
+            job_id,
+            len(msg.get("groups", [])),
+        )
+        return {"type": "job_accepted", "job_id": job_id}
+
+    def _handle_status_query(self, msg: dict) -> dict:
+        job_id = msg.get("job_id", "")
+        job = self.jobs.get(job_id)
+        if job is None:
+            return {
+                "type": "error",
+                "job_id": job_id,
+                "message": f"unknown job: {job_id}",
+            }
+        resp: dict = {
+            "type": "job_status",
+            "job_id": job_id,
+            "state": job.state.value,
+            "progress": job.progress,
+            "epoch": job.epoch,
+        }
+        if job.loss is not None:
+            resp["loss"] = job.loss
+        if job.adapter_path is not None:
+            resp["adapter_path"] = job.adapter_path
+        if job.error_message is not None:
+            resp["message"] = job.error_message
+        return resp
+
+    async def _training_worker(self):
+        """Process training jobs from the queue one at a time."""
+        while True:
+            try:
+                job_id = await self.job_queue.get()
+            except asyncio.CancelledError:
+                return
+
+            job = self.jobs.get(job_id)
+            if job is None:
+                continue
+
+            job.state = JobState.RUNNING
+            log.info("starting %s job %s", job.job_type, job_id)
+
+            try:
+                if job.job_type == "sft":
+                    await self._run_sft(job)
+                elif job.job_type == "grpo":
+                    await self._run_grpo(job)
+
+                job.state = JobState.COMPLETED
+                job.progress = 1.0
+                log.info("completed %s job %s", job.job_type, job_id)
+            except asyncio.CancelledError:
+                job.state = JobState.FAILED
+                job.error_message = "cancelled"
+                raise
+            except Exception as e:
+                job.state = JobState.FAILED
+                job.error_message = str(e)
+                log.exception("job %s failed: %s", job_id, e)
+
+    async def _run_sft(self, job: TrainingJob):
+        """Mock SFT training loop. Will be replaced with real PEFT training."""
+        req = job.request
+        epochs = req.get("epochs", 3)
+        num_examples = len(req.get("examples", []))
+        adapter_name = req.get("adapter_name", f"sft-{job.job_id[:8]}")
+
+        # Simulate training: one step per example per epoch
+        total_steps = max(epochs * max(num_examples, 1), 1)
+        step = 0
+        mock_loss = 2.5
+
+        for epoch in range(epochs):
+            job.epoch = epoch + 1
+            for _ex in range(max(num_examples, 1)):
+                step += 1
+                job.progress = step / total_steps
+                mock_loss *= 0.85  # loss decreases over time
+                job.loss = round(mock_loss, 4)
+                await asyncio.sleep(0.1)  # simulate compute time
+
+        # Write a placeholder adapter directory
+        adapter_path = self.adapter_dir / adapter_name
+        adapter_path.mkdir(parents=True, exist_ok=True)
+        (adapter_path / "adapter_config.json").write_text(
+            json.dumps(
+                {
+                    "base_model": "Qwen/Qwen3.5-4B",
+                    "lora_rank": req.get("lora_rank", 16),
+                    "lora_alpha": req.get("lora_alpha", 32.0),
+                    "target_modules": "all-linear",
+                    "task_type": "CAUSAL_LM",
+                },
+                indent=2,
+            )
+        )
+        job.adapter_path = str(adapter_path)
+        log.info("wrote mock adapter to %s", adapter_path)
+
+    async def _run_grpo(self, job: TrainingJob):
+        """Mock GRPO training loop. Will be replaced with real GRPO training."""
+        req = job.request
+        num_groups = len(req.get("groups", []))
+        adapter_name = req.get("adapter_name", f"grpo-{job.job_id[:8]}")
+
+        # Simulate training: a few steps per group
+        total_steps = max(num_groups * 3, 1)
+        step = 0
+        mock_loss = 1.8
+
+        for _g in range(max(num_groups, 1)):
+            for _s in range(3):
+                step += 1
+                job.progress = step / total_steps
+                mock_loss *= 0.90
+                job.loss = round(mock_loss, 4)
+                await asyncio.sleep(0.1)
+
+        adapter_path = self.adapter_dir / adapter_name
+        adapter_path.mkdir(parents=True, exist_ok=True)
+        (adapter_path / "adapter_config.json").write_text(
+            json.dumps(
+                {
+                    "base_model": "Qwen/Qwen3.5-4B",
+                    "lora_rank": req.get("lora_rank", 16),
+                    "lora_alpha": req.get("lora_alpha", 32.0),
+                    "target_modules": "all-linear",
+                    "task_type": "CAUSAL_LM",
+                    "training_type": "grpo",
+                },
+                indent=2,
+            )
+        )
+        job.adapter_path = str(adapter_path)
+        log.info("wrote mock adapter to %s", adapter_path)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Kiln training sidecar")
+    parser.add_argument(
+        "--socket-path",
+        default="/tmp/kiln-train.sock",
+        help="Path to the unix domain socket (default: /tmp/kiln-train.sock)",
+    )
+    parser.add_argument(
+        "--adapter-dir",
+        default="adapters",
+        help="Directory to store trained adapter weights (default: adapters)",
+    )
+    args = parser.parse_args()
+
+    sidecar = TrainingSidecar(
+        socket_path=args.socket_path,
+        adapter_dir=args.adapter_dir,
+    )
+    asyncio.run(sidecar.start())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
Implement Python training sidecar with unix socket JSON-line protocol and wire Rust training endpoints to forward requests.

### New files
- `sidecar/kiln_train.py` — Python asyncio unix socket server with mock SFT/GRPO training loops
- `crates/kiln-server/src/sidecar.rs` — Async Rust client (`SidecarClient`) using tokio UnixStream

### Modified files
- `crates/kiln-server/src/state.rs` — Added optional `SidecarClient` to `AppState` with `with_sidecar()` builder
- `crates/kiln-server/src/api/training.rs` — Wired SFT/GRPO endpoints to forward to sidecar (returns 503 if no sidecar configured)
- `crates/kiln-server/src/main.rs` — Added `KILN_SIDECAR_SOCKET` env var to configure sidecar path
- `crates/kiln-server/src/lib.rs` — Exposed `sidecar` module

### Protocol
JSON-line (newline-delimited) over unix domain socket. Request types: `sft_request`, `grpo_request`, `status_query`, `shutdown`. Response types: `job_accepted`, `job_status`, `job_complete`, `error`.

## Phase 3 progress
First task: sidecar architecture + protocol with mock training. Real PEFT training loop comes next.