### PR TITLE
Training completion auto-loads adapter + per-job status

### DIFF
--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -1,16 +1,14 @@
 use axum::{
-    extract::State,
+    extract::{Path as AxumPath, State},
     http::StatusCode,
     routing::{get, post},
     Json, Router,
 };
 
-use kiln_train::{
-    GrpoRequest, SftRequest, TrainingResponse, TrainingState, TrainingStatus,
-};
+use kiln_train::{GrpoRequest, SftRequest, TrainingResponse, TrainingState, TrainingStatus};
 
 use crate::sidecar::{SidecarClient, SidecarResponse};
-use crate::state::AppState;
+use crate::state::{AppState, TrainingJobInfo, TrainingJobType};
 
 fn sidecar_or_503(sidecar: &Option<SidecarClient>) -> Result<&SidecarClient, (StatusCode, String)> {
     sidecar.as_ref().ok_or_else(|| {
@@ -34,6 +32,7 @@ async fn submit_sft(
         .output_name
         .clone()
         .unwrap_or_else(|| format!("sft-{}", &job_id[..8]));
+    let auto_load = req.config.auto_load;
 
     tracing::info!(num_examples, job_id = %job_id, "SFT training request received");
 
@@ -61,11 +60,32 @@ async fn submit_sft(
         })?;
 
     match resp {
-        SidecarResponse::JobAccepted { job_id, .. } => Ok(Json(TrainingResponse {
-            job_id,
-            state: TrainingState::Queued,
-            message: format!("Queued SFT training with {num_examples} examples"),
-        })),
+        SidecarResponse::JobAccepted { ref job_id, .. } => {
+            // Track the job in shared state.
+            let info = TrainingJobInfo {
+                job_id: job_id.clone(),
+                adapter_name: adapter_name.clone(),
+                job_type: TrainingJobType::Sft,
+                state: TrainingState::Queued,
+                progress: 0.0,
+                loss: None,
+                epoch: None,
+                adapter_path: None,
+                submitted_at: std::time::Instant::now(),
+                auto_load,
+            };
+            state
+                .training_jobs
+                .write()
+                .unwrap()
+                .insert(job_id.clone(), info);
+
+            Ok(Json(TrainingResponse {
+                job_id: job_id.clone(),
+                state: TrainingState::Queued,
+                message: format!("Queued SFT training with {num_examples} examples"),
+            }))
+        }
         SidecarResponse::Error { message, .. } => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("sidecar rejected job: {message}"),
@@ -95,6 +115,7 @@ async fn submit_grpo(
         .output_name
         .clone()
         .unwrap_or_else(|| format!("grpo-{}", &job_id[..8]));
+    let auto_load = req.config.auto_load;
 
     tracing::info!(num_groups, total_completions, job_id = %job_id, "GRPO training request received");
 
@@ -120,13 +141,33 @@ async fn submit_grpo(
         })?;
 
     match resp {
-        SidecarResponse::JobAccepted { job_id, .. } => Ok(Json(TrainingResponse {
-            job_id,
-            state: TrainingState::Queued,
-            message: format!(
-                "Queued GRPO training with {num_groups} groups ({total_completions} completions)"
-            ),
-        })),
+        SidecarResponse::JobAccepted { ref job_id, .. } => {
+            let info = TrainingJobInfo {
+                job_id: job_id.clone(),
+                adapter_name: adapter_name.clone(),
+                job_type: TrainingJobType::Grpo,
+                state: TrainingState::Queued,
+                progress: 0.0,
+                loss: None,
+                epoch: None,
+                adapter_path: None,
+                submitted_at: std::time::Instant::now(),
+                auto_load,
+            };
+            state
+                .training_jobs
+                .write()
+                .unwrap()
+                .insert(job_id.clone(), info);
+
+            Ok(Json(TrainingResponse {
+                job_id: job_id.clone(),
+                state: TrainingState::Queued,
+                message: format!(
+                    "Queued GRPO training with {num_groups} groups ({total_completions} completions)"
+                ),
+            }))
+        }
         SidecarResponse::Error { message, .. } => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             format!("sidecar rejected job: {message}"),
@@ -144,21 +185,113 @@ async fn submit_grpo(
     }
 }
 
+/// GET /v1/train/status — overall training status (list all tracked jobs).
 async fn training_status(
     State(state): State<AppState>,
-) -> Result<Json<Option<TrainingStatus>>, (StatusCode, String)> {
-    let client = match &state.sidecar {
-        Some(c) => c,
-        None => return Ok(Json(None)),
+) -> Json<Vec<TrainingStatus>> {
+    let jobs = state.training_jobs.read().unwrap();
+    let statuses: Vec<TrainingStatus> = jobs
+        .values()
+        .map(|j| TrainingStatus {
+            job_id: j.job_id.clone(),
+            state: j.state,
+            progress: j.progress,
+            current_loss: j.loss,
+            adapter_name: Some(j.adapter_name.clone()),
+            started_at: format!("{}s ago", j.submitted_at.elapsed().as_secs()),
+            elapsed_secs: j.submitted_at.elapsed().as_secs_f64(),
+        })
+        .collect();
+    Json(statuses)
+}
+
+/// GET /v1/train/status/:job_id — per-job status.
+async fn job_status(
+    State(state): State<AppState>,
+    AxumPath(job_id): AxumPath<String>,
+) -> Result<Json<TrainingStatus>, (StatusCode, String)> {
+    // First check cached state.
+    let cached = {
+        let jobs = state.training_jobs.read().unwrap();
+        jobs.get(&job_id).cloned()
     };
 
-    if !client.is_available() {
-        return Ok(Json(None));
+    if let Some(job) = cached {
+        // For completed/failed jobs, return cached state directly.
+        if job.state == TrainingState::Completed || job.state == TrainingState::Failed {
+            return Ok(Json(TrainingStatus {
+                job_id: job.job_id,
+                state: job.state,
+                progress: job.progress,
+                current_loss: job.loss,
+                adapter_name: Some(job.adapter_name),
+                started_at: format!("{}s ago", job.submitted_at.elapsed().as_secs()),
+                elapsed_secs: job.submitted_at.elapsed().as_secs_f64(),
+            }));
+        }
+
+        // For active jobs, try to get live status from sidecar.
+        if let Some(ref client) = state.sidecar {
+            if let Ok(resp) = client.query_status(&job_id).await {
+                match resp {
+                    SidecarResponse::JobStatus {
+                        state: ref sidecar_state,
+                        progress,
+                        epoch,
+                        loss,
+                        adapter_path,
+                        ..
+                    } => {
+                        let live_state = match sidecar_state.as_str() {
+                            "completed" => TrainingState::Completed,
+                            "failed" => TrainingState::Failed,
+                            "running" => TrainingState::Running,
+                            _ => TrainingState::Queued,
+                        };
+
+                        // Update cached state.
+                        {
+                            let mut jobs = state.training_jobs.write().unwrap();
+                            if let Some(j) = jobs.get_mut(&job_id) {
+                                j.state = live_state;
+                                j.progress = progress;
+                                j.epoch = epoch;
+                                j.loss = loss;
+                                j.adapter_path = adapter_path;
+                            }
+                        }
+
+                        return Ok(Json(TrainingStatus {
+                            job_id: job.job_id,
+                            state: live_state,
+                            progress,
+                            current_loss: loss,
+                            adapter_name: Some(job.adapter_name),
+                            started_at: format!("{}s ago", job.submitted_at.elapsed().as_secs()),
+                            elapsed_secs: job.submitted_at.elapsed().as_secs_f64(),
+                        }));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        // Fallback to cached state.
+        return Ok(Json(TrainingStatus {
+            job_id: job.job_id,
+            state: job.state,
+            progress: job.progress,
+            current_loss: job.loss,
+            adapter_name: Some(job.adapter_name),
+            started_at: format!("{}s ago", job.submitted_at.elapsed().as_secs()),
+            elapsed_secs: job.submitted_at.elapsed().as_secs_f64(),
+        }));
     }
 
-    // The status endpoint doesn't have a specific job_id in the current API shape.
-    // Return None for now — callers should use /v1/train/status/:job_id when we add it.
-    Ok(Json(None))
+    Err((
+        StatusCode::NOT_FOUND,
+        format!("training job not found: {job_id}"),
+    ))
 }
 
 pub fn routes() -> Router<AppState> {
@@ -166,4 +299,5 @@ pub fn routes() -> Router<AppState> {
         .route("/v1/train/sft", post(submit_sft))
         .route("/v1/train/grpo", post(submit_grpo))
         .route("/v1/train/status", get(training_status))
+        .route("/v1/train/status/{job_id}", get(job_status))
 }

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -121,6 +121,12 @@ async fn main() -> Result<()> {
         state
     };
 
+    // Spawn training watcher if sidecar is configured.
+    if state.sidecar.is_some() {
+        tracing::info!("spawning training completion watcher");
+        kiln_server::sidecar::spawn_training_watcher(state.clone());
+    }
+
     let app = api::router(state);
 
     let addr = format!("{host}:{port}");

--- a/crates/kiln-server/src/sidecar.rs
+++ b/crates/kiln-server/src/sidecar.rs
@@ -192,3 +192,196 @@ pub enum SidecarError {
     #[error("sidecar timeout: {0}")]
     Timeout(String),
 }
+
+/// Spawn a background task that polls tracked training jobs and auto-loads
+/// completed adapters via the two-phase RwLock hot-swap pattern.
+pub fn spawn_training_watcher(state: crate::state::AppState) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(2));
+        loop {
+            interval.tick().await;
+
+            let client = match &state.sidecar {
+                Some(c) if c.is_available() => c,
+                _ => continue,
+            };
+
+            // Collect job IDs that need polling.
+            let jobs_to_poll: Vec<(String, bool)> = {
+                let jobs = state.training_jobs.read().unwrap();
+                jobs.values()
+                    .filter(|j| {
+                        j.state == kiln_train::TrainingState::Queued
+                            || j.state == kiln_train::TrainingState::Running
+                    })
+                    .map(|j| (j.job_id.clone(), j.auto_load))
+                    .collect()
+            };
+
+            for (job_id, auto_load) in jobs_to_poll {
+                let resp = match client.query_status(&job_id).await {
+                    Ok(r) => r,
+                    Err(e) => {
+                        tracing::debug!(job_id = %job_id, "watcher poll error: {e}");
+                        continue;
+                    }
+                };
+
+                match resp {
+                    SidecarResponse::JobStatus {
+                        job_id,
+                        state: ref sidecar_state,
+                        progress,
+                        epoch,
+                        loss,
+                        adapter_path,
+                        ..
+                    } => {
+                        let new_state = match sidecar_state.as_str() {
+                            "completed" => kiln_train::TrainingState::Completed,
+                            "failed" => kiln_train::TrainingState::Failed,
+                            "running" => kiln_train::TrainingState::Running,
+                            _ => kiln_train::TrainingState::Queued,
+                        };
+
+                        // Update tracked job state.
+                        {
+                            let mut jobs = state.training_jobs.write().unwrap();
+                            if let Some(job) = jobs.get_mut(&job_id) {
+                                job.state = new_state;
+                                job.progress = progress;
+                                job.epoch = epoch;
+                                job.loss = loss;
+                                job.adapter_path = adapter_path.clone();
+                            }
+                        }
+
+                        if new_state == kiln_train::TrainingState::Completed {
+                            if let Some(ref path) = adapter_path {
+                                if auto_load {
+                                    let adapter_name = {
+                                        state
+                                            .training_jobs
+                                            .read()
+                                            .unwrap()
+                                            .get(&job_id)
+                                            .map(|j| j.adapter_name.clone())
+                                            .unwrap_or_default()
+                                    };
+                                    if let Err(e) =
+                                        auto_load_adapter(&state, path, &adapter_name).await
+                                    {
+                                        tracing::error!(
+                                            job_id = %job_id,
+                                            adapter = %adapter_name,
+                                            "auto-load failed: {e}"
+                                        );
+                                    } else {
+                                        tracing::info!(
+                                            "auto-loaded adapter {} from training job {}",
+                                            adapter_name,
+                                            job_id
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    SidecarResponse::JobComplete {
+                        job_id,
+                        adapter_path,
+                    } => {
+                        let (adapter_name, auto_load_flag) = {
+                            let mut jobs = state.training_jobs.write().unwrap();
+                            if let Some(job) = jobs.get_mut(&job_id) {
+                                job.state = kiln_train::TrainingState::Completed;
+                                job.progress = 1.0;
+                                job.adapter_path = Some(adapter_path.clone());
+                                (job.adapter_name.clone(), job.auto_load)
+                            } else {
+                                continue;
+                            }
+                        };
+                        if auto_load_flag {
+                            if let Err(e) =
+                                auto_load_adapter(&state, &adapter_path, &adapter_name).await
+                            {
+                                tracing::error!(
+                                    job_id = %job_id,
+                                    adapter = %adapter_name,
+                                    "auto-load failed: {e}"
+                                );
+                            } else {
+                                tracing::info!(
+                                    "auto-loaded adapter {} from training job {}",
+                                    adapter_name,
+                                    job_id
+                                );
+                            }
+                        }
+                    }
+                    SidecarResponse::Error { job_id, message } => {
+                        let mut jobs = state.training_jobs.write().unwrap();
+                        if let Some(job) = jobs.get_mut(&job_id) {
+                            job.state = kiln_train::TrainingState::Failed;
+                        }
+                        tracing::warn!(job_id = %job_id, "training job failed: {message}");
+                    }
+                    _ => {}
+                }
+            }
+        }
+    });
+}
+
+/// Load a LoRA adapter using the two-phase RwLock pattern (same as adapters.rs).
+async fn auto_load_adapter(
+    state: &crate::state::AppState,
+    adapter_path: &str,
+    adapter_name: &str,
+) -> Result<(), String> {
+    use crate::state::ModelBackend;
+    use kiln_model::lora_loader::LoraWeights;
+
+    let runner = match state.backend.as_ref() {
+        ModelBackend::Real { runner, .. } => runner.clone(),
+        ModelBackend::Mock { .. } => {
+            // In mock mode, just update the active adapter name.
+            *state.active_adapter_name.write().unwrap() = Some(adapter_name.to_string());
+            return Ok(());
+        }
+    };
+
+    let path = std::path::PathBuf::from(adapter_path);
+    if !path.exists() {
+        return Err(format!(
+            "adapter path does not exist: {}",
+            path.display()
+        ));
+    }
+
+    // Phase 1: read device/num_layers under brief read lock.
+    let (device, num_layers) = {
+        let guard = runner.read().unwrap();
+        (
+            guard.weights.embed_tokens.device().clone(),
+            guard.config.num_layers,
+        )
+    };
+
+    // Phase 2: load weights outside any lock.
+    let name = adapter_name.to_string();
+    let active_adapter = state.active_adapter_name.clone();
+    tokio::task::spawn_blocking(move || {
+        let lora =
+            LoraWeights::load(&path, num_layers, &device).map_err(|e| format!("{e}"))?;
+        // Brief write lock to swap.
+        let mut guard = runner.write().unwrap();
+        guard.swap_lora(Some(lora));
+        // Update active adapter name.
+        *active_adapter.write().unwrap() = Some(name);
+        Ok::<(), String>(())
+    })
+    .await
+    .map_err(|e| format!("join error: {e}"))?
+}

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -9,8 +10,37 @@ use kiln_core::tokenizer::KilnTokenizer;
 use kiln_model::engine::Engine;
 use kiln_model::{ModelRunner, PagedKvCache};
 use kiln_scheduler::Scheduler;
+use kiln_train::TrainingState;
+use serde::Serialize;
 
 use crate::sidecar::SidecarClient;
+
+/// Type of training job.
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrainingJobType {
+    Sft,
+    Grpo,
+}
+
+/// Tracked training job info stored in AppState.
+#[derive(Debug, Clone, Serialize)]
+pub struct TrainingJobInfo {
+    pub job_id: String,
+    pub adapter_name: String,
+    pub job_type: TrainingJobType,
+    pub state: TrainingState,
+    pub progress: f32,
+    pub loss: Option<f64>,
+    pub epoch: Option<u32>,
+    pub adapter_path: Option<String>,
+    #[serde(skip)]
+    pub submitted_at: std::time::Instant,
+    pub auto_load: bool,
+}
+
+/// Thread-safe map of tracked training jobs.
+pub type TrainingJobs = Arc<std::sync::RwLock<HashMap<String, TrainingJobInfo>>>;
 
 /// Which inference backend the server is using.
 pub enum ModelBackend {
@@ -39,6 +69,8 @@ pub struct AppState {
     pub active_adapter_name: Arc<std::sync::RwLock<Option<String>>>,
     /// Optional training sidecar client. None if no sidecar socket configured.
     pub sidecar: Option<SidecarClient>,
+    /// Tracked training jobs (job_id → info).
+    pub training_jobs: TrainingJobs,
 }
 
 impl AppState {
@@ -59,6 +91,7 @@ impl AppState {
             adapter_dir: PathBuf::from("adapters"),
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             sidecar: None,
+            training_jobs: Arc::new(std::sync::RwLock::new(HashMap::new())),
         }
     }
 
@@ -110,6 +143,7 @@ impl AppState {
             adapter_dir,
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             sidecar: None,
+            training_jobs: Arc::new(std::sync::RwLock::new(HashMap::new())),
         }
     }
 

--- a/crates/kiln-train/src/lib.rs
+++ b/crates/kiln-train/src/lib.rs
@@ -41,8 +41,12 @@ pub struct SftConfig {
     pub base_adapter: Option<String>,
     /// Name for the output adapter. Auto-generated if not set.
     pub output_name: Option<String>,
+    /// Automatically load the resulting adapter when training completes (default true).
+    #[serde(default = "default_auto_load")]
+    pub auto_load: bool,
 }
 
+fn default_auto_load() -> bool { true }
 fn default_epochs() -> usize { 3 }
 fn default_sft_lr() -> f64 { 1e-4 }
 fn default_rank() -> usize { 16 }
@@ -57,6 +61,7 @@ impl Default for SftConfig {
             lora_alpha: default_alpha(),
             base_adapter: None,
             output_name: None,
+            auto_load: default_auto_load(),
         }
     }
 }
@@ -99,6 +104,9 @@ pub struct GrpoConfig {
     pub lora_alpha: f32,
     pub base_adapter: Option<String>,
     pub output_name: Option<String>,
+    /// Automatically load the resulting adapter when training completes (default true).
+    #[serde(default = "default_auto_load")]
+    pub auto_load: bool,
 }
 
 fn default_grpo_lr() -> f64 { 1e-5 }
@@ -115,6 +123,7 @@ impl Default for GrpoConfig {
             lora_alpha: default_alpha(),
             base_adapter: None,
             output_name: None,
+            auto_load: default_auto_load(),
         }
     }
 }


### PR DESCRIPTION
## What
When a training job completes, the server now automatically loads the resulting LoRA adapter via the existing hot-swap RwLock pattern. No manual /v1/adapters/load needed.

## Changes
- **state.rs**: Added `TrainingJobInfo` struct and `training_jobs` map to `AppState` for tracking active/completed training jobs
- **kiln-train/lib.rs**: Added `auto_load` field (default `true`) to both `SftConfig` and `GrpoConfig`
- **sidecar.rs**: Added `spawn_training_watcher()` — polls tracked jobs every 2s, auto-loads completed adapters using the two-phase RwLock pattern from adapters.rs
- **training.rs**: Submit handlers now track jobs in AppState; new `GET /v1/train/status/:job_id` endpoint for per-job progress; `GET /v1/train/status` now returns all tracked jobs
- **main.rs**: Spawns the training watcher on startup when sidecar is configured

## API
- `POST /v1/train/sft` and `POST /v1/train/grpo` — new `auto_load` config field (default true)
- `GET /v1/train/status` — returns list of all tracked training jobs
- `GET /v1/train/status/:job_id` — returns live status for a specific job (queries sidecar for active jobs)

## Test
All 85 workspace tests pass (`cargo test`).