### PR TITLE
Fix GRPO shape mismatch in minimum/clamp ops

### DIFF
--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -572,12 +572,19 @@ pub fn grpo_train(
             let advantage = advantages[comp_idx];
             let log_ratio = (&policy_log_probs - &ref_log_probs)?;
             let ratio = log_ratio.exp()?;
+            let ratio_shape = ratio.shape().clone();
 
-            let lo = Tensor::new(1.0 - config.clip_epsilon, &device)?.to_dtype(DType::F32)?;
-            let hi = Tensor::new(1.0 + config.clip_epsilon, &device)?.to_dtype(DType::F32)?;
+            // Broadcast scalars to match ratio shape so minimum/clamp work
+            let lo = Tensor::new(1.0 - config.clip_epsilon, &device)?
+                .to_dtype(DType::F32)?
+                .broadcast_as(&ratio_shape)?;
+            let hi = Tensor::new(1.0 + config.clip_epsilon, &device)?
+                .to_dtype(DType::F32)?
+                .broadcast_as(&ratio_shape)?;
             let clipped_ratio = ratio.clamp(&lo, &hi)?;
 
-            let adv_tensor = Tensor::new(advantage as f32, &device)?;
+            let adv_tensor = Tensor::new(advantage as f32, &device)?
+                .broadcast_as(&ratio_shape)?;
             let surr1 = (&ratio * &adv_tensor)?;
             let surr2 = (&clipped_ratio * &adv_tensor)?;
             let surrogate = surr1.minimum(&surr2)?;


### PR DESCRIPTION
## What
Fix runtime shape mismatch error in GRPO training loop.

## Why
candle's `minimum()` and `clamp()` require matching tensor shapes. The GRPO loss computation passed scalar tensors (shape `[]`) where per-token tensors (shape `[N]`) were expected, causing 'shape mismatch in maximum' errors.

## Fix
Broadcast `lo`, `hi`, and `advantage` tensors to match the ratio tensor's shape before minimum/clamp operations.

## Testing
Discovered and verified on RunPod A40 (48GB) — the shape error was the first failure after OOM was resolved by using a larger GPU.