### PR TITLE
Fix GRPO KL penalty scalar multiplication

### DIFF
--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -572,12 +572,19 @@ pub fn grpo_train(
             let advantage = advantages[comp_idx];
             let log_ratio = (&policy_log_probs - &ref_log_probs)?;
             let ratio = log_ratio.exp()?;
+            let ratio_shape = ratio.shape().clone();
 
-            let lo = Tensor::new(1.0 - config.clip_epsilon, &device)?.to_dtype(DType::F32)?;
-            let hi = Tensor::new(1.0 + config.clip_epsilon, &device)?.to_dtype(DType::F32)?;
+            // Broadcast scalars to match ratio shape so minimum/clamp work
+            let lo = Tensor::new(1.0 - config.clip_epsilon, &device)?
+                .to_dtype(DType::F32)?
+                .broadcast_as(&ratio_shape)?;
+            let hi = Tensor::new(1.0 + config.clip_epsilon, &device)?
+                .to_dtype(DType::F32)?
+                .broadcast_as(&ratio_shape)?;
             let clipped_ratio = ratio.clamp(&lo, &hi)?;
 
-            let adv_tensor = Tensor::new(advantage as f32, &device)?;
+            let adv_tensor = Tensor::new(advantage as f32, &device)?
+                .broadcast_as(&ratio_shape)?;
             let surr1 = (&ratio * &adv_tensor)?;
             let surr2 = (&clipped_ratio * &adv_tensor)?;
             let surrogate = surr1.minimum(&surr2)?;

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -592,8 +592,7 @@ pub fn grpo_train(
 
             // KL divergence per token (policy - reference)
             let kl = &log_ratio;
-            let kl_coeff_t = Tensor::new(config.kl_coeff as f32, &device)?;
-            let kl_penalty = (kl * &kl_coeff_t)?;
+            let kl_penalty = kl.affine(config.kl_coeff, 0.0)?;
 
             // Total loss = mean(-surrogate + kl_penalty)
             let per_token_loss = (&neg_surrogate + &kl_penalty)?;


### PR DESCRIPTION
Follow-up to #38. Use affine() instead of tensor mul for KL penalty computation to avoid shape mismatch with autograd-tracked tensors.