### PR TITLE
VRAM-aware auto-configuration for 24GB GPUs

### DIFF
--- a/crates/kiln-core/src/lib.rs
+++ b/crates/kiln-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod request;
 pub mod sampling;
 pub mod token;
 pub mod tokenizer;
+pub mod vram;
 
 pub use block::{BlockManager, BlockTable};
 pub use config::ModelConfig;

--- a/crates/kiln-core/src/vram.rs
+++ b/crates/kiln-core/src/vram.rs
@@ -95,13 +95,15 @@ pub fn recommended_num_blocks(vram: &GpuVramInfo) -> Option<usize> {
         return None; // user override — don't second-guess
     }
 
+    // Use slightly lower thresholds since GPUs report slightly less than marketed
+    // e.g. RTX A5000 "24GB" reports 24564 MiB ≈ 23.99 GiB
     let gb = vram.total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
 
-    Some(if gb >= 48.0 {
+    Some(if gb >= 45.0 {
         512
-    } else if gb >= 24.0 {
+    } else if gb >= 22.0 {
         64 // proven safe for training on 24GB (18.3GB peak with 8 segments)
-    } else if gb >= 16.0 {
+    } else if gb >= 14.0 {
         32
     } else {
         64 // conservative default for unknown VRAM
@@ -121,13 +123,15 @@ pub fn recommended_checkpoint_segments(vram: &GpuVramInfo) -> Option<usize> {
         return None; // user override
     }
 
+    // Use slightly lower thresholds since GPUs report slightly less than marketed
+    // e.g. RTX A5000 "24GB" reports 24564 MiB ≈ 23.99 GiB
     let gb = vram.total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
 
-    Some(if gb >= 48.0 {
+    Some(if gb >= 45.0 {
         4 // fewer segments = faster training, more VRAM headroom
-    } else if gb >= 24.0 {
+    } else if gb >= 22.0 {
         8 // proven safe on 24GB (18.3GB peak)
-    } else if gb >= 16.0 {
+    } else if gb >= 14.0 {
         12 // aggressive checkpointing for tight VRAM
     } else {
         8 // conservative default
@@ -159,6 +163,13 @@ mod tests {
         };
         assert_eq!(recommended_num_blocks(&vram_24gb), Some(64));
 
+        // Test with real A5000 value (24564 MiB = slightly under 24 GiB)
+        let vram_a5000 = GpuVramInfo {
+            total_bytes: 24564 * 1024 * 1024,
+            source: VramSource::NvidiaSmi,
+        };
+        assert_eq!(recommended_num_blocks(&vram_a5000), Some(64));
+
         let vram_16gb = GpuVramInfo {
             total_bytes: 16 * 1024 * 1024 * 1024,
             source: VramSource::NvidiaSmi,
@@ -185,6 +196,13 @@ mod tests {
             source: VramSource::NvidiaSmi,
         };
         assert_eq!(recommended_checkpoint_segments(&vram_24gb), Some(8));
+
+        // Test with real A5000 value (24564 MiB = slightly under 24 GiB)
+        let vram_a5000 = GpuVramInfo {
+            total_bytes: 24564 * 1024 * 1024,
+            source: VramSource::NvidiaSmi,
+        };
+        assert_eq!(recommended_checkpoint_segments(&vram_a5000), Some(8));
 
         let vram_16gb = GpuVramInfo {
             total_bytes: 16 * 1024 * 1024 * 1024,

--- a/crates/kiln-core/src/vram.rs
+++ b/crates/kiln-core/src/vram.rs
@@ -1,0 +1,202 @@
+//! GPU VRAM detection and auto-configuration utilities.
+//!
+//! Detects available GPU memory and provides recommended training parameters
+//! so that SFT and GRPO training "just works" on consumer GPUs without manual tuning.
+
+/// Detected GPU memory information.
+#[derive(Debug, Clone, Copy)]
+pub struct GpuVramInfo {
+    /// Total VRAM in bytes (0 if detection failed or no GPU).
+    pub total_bytes: u64,
+    /// Source of the detection.
+    pub source: VramSource,
+}
+
+/// How the VRAM value was determined.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VramSource {
+    /// Detected via nvidia-smi.
+    NvidiaSmi,
+    /// User-provided via KILN_GPU_MEMORY_GB env var.
+    EnvOverride,
+    /// No GPU detected or detection failed.
+    None,
+}
+
+impl std::fmt::Display for VramSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            VramSource::NvidiaSmi => write!(f, "nvidia-smi"),
+            VramSource::EnvOverride => write!(f, "KILN_GPU_MEMORY_GB"),
+            VramSource::None => write!(f, "none"),
+        }
+    }
+}
+
+/// Detect total GPU VRAM.
+///
+/// Priority:
+/// 1. `KILN_GPU_MEMORY_GB` env var (user override, always respected)
+/// 2. `nvidia-smi` query (auto-detection)
+/// 3. Returns `GpuVramInfo` with `total_bytes=0` and `source=None` if no GPU
+pub fn detect_vram() -> GpuVramInfo {
+    // 1. Check env override first
+    if let Ok(val) = std::env::var("KILN_GPU_MEMORY_GB") {
+        if let Ok(gb) = val.parse::<f64>() {
+            return GpuVramInfo {
+                total_bytes: (gb * 1024.0 * 1024.0 * 1024.0) as u64,
+                source: VramSource::EnvOverride,
+            };
+        }
+    }
+
+    // 2. Try nvidia-smi
+    if let Some(bytes) = query_nvidia_smi() {
+        return GpuVramInfo {
+            total_bytes: bytes,
+            source: VramSource::NvidiaSmi,
+        };
+    }
+
+    // 3. No GPU detected
+    GpuVramInfo {
+        total_bytes: 0,
+        source: VramSource::None,
+    }
+}
+
+/// Query total GPU memory via nvidia-smi.
+///
+/// Runs `nvidia-smi --query-gpu=memory.total --format=csv,noheader,nounits`
+/// which returns total memory in MiB. Returns None if nvidia-smi is not available
+/// or fails.
+fn query_nvidia_smi() -> Option<u64> {
+    let output = std::process::Command::new("nvidia-smi")
+        .args(["--query-gpu=memory.total", "--format=csv,noheader,nounits"])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    // nvidia-smi may list multiple GPUs; take the first line (GPU 0)
+    let mib: u64 = stdout.trim().lines().next()?.trim().parse().ok()?;
+    Some(mib * 1024 * 1024)
+}
+
+/// Recommended number of KV cache blocks based on total VRAM.
+///
+/// Returns `None` if the user set `KILN_NUM_BLOCKS` (should use that instead).
+/// Otherwise picks a conservative value that leaves room for training.
+pub fn recommended_num_blocks(vram: &GpuVramInfo) -> Option<usize> {
+    if std::env::var("KILN_NUM_BLOCKS").ok().and_then(|v| v.parse::<usize>().ok()).is_some() {
+        return None; // user override — don't second-guess
+    }
+
+    let gb = vram.total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+    Some(if gb >= 48.0 {
+        512
+    } else if gb >= 24.0 {
+        64 // proven safe for training on 24GB (18.3GB peak with 8 segments)
+    } else if gb >= 16.0 {
+        32
+    } else {
+        64 // conservative default for unknown VRAM
+    })
+}
+
+/// Recommended gradient checkpoint segments based on total VRAM.
+///
+/// Returns `None` if the user set `KILN_GRAD_CHECKPOINT_SEGMENTS` (should use that instead).
+/// More segments = less VRAM but more compute overhead.
+pub fn recommended_checkpoint_segments(vram: &GpuVramInfo) -> Option<usize> {
+    if std::env::var("KILN_GRAD_CHECKPOINT_SEGMENTS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .is_some()
+    {
+        return None; // user override
+    }
+
+    let gb = vram.total_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+
+    Some(if gb >= 48.0 {
+        4 // fewer segments = faster training, more VRAM headroom
+    } else if gb >= 24.0 {
+        8 // proven safe on 24GB (18.3GB peak)
+    } else if gb >= 16.0 {
+        12 // aggressive checkpointing for tight VRAM
+    } else {
+        8 // conservative default
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_detect_vram_env_override() {
+        // This test relies on KILN_GPU_MEMORY_GB not being set in CI
+        // and nvidia-smi not being available, so it should return None source
+        // unless overridden. We test the logic paths via the recommendation functions.
+    }
+
+    #[test]
+    fn test_recommended_num_blocks() {
+        let vram_48gb = GpuVramInfo {
+            total_bytes: 48 * 1024 * 1024 * 1024,
+            source: VramSource::NvidiaSmi,
+        };
+        assert_eq!(recommended_num_blocks(&vram_48gb), Some(512));
+
+        let vram_24gb = GpuVramInfo {
+            total_bytes: 24 * 1024 * 1024 * 1024,
+            source: VramSource::NvidiaSmi,
+        };
+        assert_eq!(recommended_num_blocks(&vram_24gb), Some(64));
+
+        let vram_16gb = GpuVramInfo {
+            total_bytes: 16 * 1024 * 1024 * 1024,
+            source: VramSource::NvidiaSmi,
+        };
+        assert_eq!(recommended_num_blocks(&vram_16gb), Some(32));
+
+        let vram_none = GpuVramInfo {
+            total_bytes: 0,
+            source: VramSource::None,
+        };
+        assert_eq!(recommended_num_blocks(&vram_none), Some(64));
+    }
+
+    #[test]
+    fn test_recommended_checkpoint_segments() {
+        let vram_48gb = GpuVramInfo {
+            total_bytes: 48 * 1024 * 1024 * 1024,
+            source: VramSource::NvidiaSmi,
+        };
+        assert_eq!(recommended_checkpoint_segments(&vram_48gb), Some(4));
+
+        let vram_24gb = GpuVramInfo {
+            total_bytes: 24 * 1024 * 1024 * 1024,
+            source: VramSource::NvidiaSmi,
+        };
+        assert_eq!(recommended_checkpoint_segments(&vram_24gb), Some(8));
+
+        let vram_16gb = GpuVramInfo {
+            total_bytes: 16 * 1024 * 1024 * 1024,
+            source: VramSource::NvidiaSmi,
+        };
+        assert_eq!(recommended_checkpoint_segments(&vram_16gb), Some(12));
+    }
+
+    #[test]
+    fn test_vram_source_display() {
+        assert_eq!(VramSource::NvidiaSmi.to_string(), "nvidia-smi");
+        assert_eq!(VramSource::EnvOverride.to_string(), "KILN_GPU_MEMORY_GB");
+        assert_eq!(VramSource::None.to_string(), "none");
+    }
+}

--- a/crates/kiln-server/src/api/config.rs
+++ b/crates/kiln-server/src/api/config.rs
@@ -1,7 +1,7 @@
 use axum::{extract::State, routing::get, Json, Router};
 use serde::Serialize;
 
-use crate::state::AppState;
+use crate::state::{AppState, ModelBackend};
 
 #[derive(Serialize)]
 struct ConfigResponse {
@@ -19,7 +19,7 @@ struct VramConfig {
 
 #[derive(Serialize)]
 struct KvCacheConfig {
-    num_blocks: Option<usize>,
+    num_blocks: usize,
     num_blocks_source: &'static str,
 }
 
@@ -42,16 +42,26 @@ struct MemoryBudgetConfig {
 async fn get_config(State(state): State<AppState>) -> Json<ConfigResponse> {
     let vram = &state.vram_info;
 
-    // Determine num_blocks source
-    let (num_blocks, num_blocks_source) = {
-        let explicit = std::env::var("KILN_NUM_BLOCKS")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok());
-        match explicit {
-            Some(n) => (Some(n), "KILN_NUM_BLOCKS"),
-            None => {
-                let recommended = kiln_core::vram::recommended_num_blocks(vram);
-                (recommended, "auto")
+    // Get actual num_blocks from the running backend
+    let (num_blocks, num_blocks_source) = match state.backend.as_ref() {
+        ModelBackend::Real { block_manager, .. } => {
+            let bm = block_manager.lock().unwrap();
+            let source = if std::env::var("KILN_NUM_BLOCKS")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .is_some()
+            {
+                "KILN_NUM_BLOCKS"
+            } else {
+                "auto"
+            };
+            (bm.num_blocks(), source)
+        }
+        ModelBackend::Mock { scheduler, .. } => {
+            let sched = scheduler.try_lock();
+            match sched {
+                Ok(s) => (s.block_manager().num_blocks(), "mock"),
+                Err(_) => (0, "unknown"),
             }
         }
     };

--- a/crates/kiln-server/src/api/config.rs
+++ b/crates/kiln-server/src/api/config.rs
@@ -1,0 +1,101 @@
+use axum::{extract::State, routing::get, Json, Router};
+use serde::Serialize;
+
+use crate::state::AppState;
+
+#[derive(Serialize)]
+struct ConfigResponse {
+    vram: VramConfig,
+    kv_cache: KvCacheConfig,
+    training: TrainingConfig,
+    memory_budget: MemoryBudgetConfig,
+}
+
+#[derive(Serialize)]
+struct VramConfig {
+    detected_gb: f64,
+    source: String,
+}
+
+#[derive(Serialize)]
+struct KvCacheConfig {
+    num_blocks: Option<usize>,
+    num_blocks_source: &'static str,
+}
+
+#[derive(Serialize)]
+struct TrainingConfig {
+    checkpoint_segments: usize,
+    checkpoint_segments_source: &'static str,
+    checkpointing_enabled: bool,
+}
+
+#[derive(Serialize)]
+struct MemoryBudgetConfig {
+    total_vram_gb: f64,
+    model_gb: f64,
+    kv_cache_gb: f64,
+    training_budget_gb: f64,
+    inference_memory_fraction: f64,
+}
+
+async fn get_config(State(state): State<AppState>) -> Json<ConfigResponse> {
+    let vram = &state.vram_info;
+
+    // Determine num_blocks source
+    let (num_blocks, num_blocks_source) = {
+        let explicit = std::env::var("KILN_NUM_BLOCKS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok());
+        match explicit {
+            Some(n) => (Some(n), "KILN_NUM_BLOCKS"),
+            None => {
+                let recommended = kiln_core::vram::recommended_num_blocks(vram);
+                (recommended, "auto")
+            }
+        }
+    };
+
+    // Determine checkpoint segments
+    let ckpt = kiln_train::CheckpointConfig::from_env(state.model_config.num_layers);
+    let segments_source = if std::env::var("KILN_GRAD_CHECKPOINT_SEGMENTS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .is_some()
+    {
+        "KILN_GRAD_CHECKPOINT_SEGMENTS"
+    } else if ckpt.auto_configured {
+        "auto"
+    } else {
+        "default"
+    };
+
+    let b = &state.memory_budget;
+
+    Json(ConfigResponse {
+        vram: VramConfig {
+            detected_gb: vram.total_bytes as f64 / 1e9,
+            source: vram.source.to_string(),
+        },
+        kv_cache: KvCacheConfig {
+            num_blocks,
+            num_blocks_source,
+        },
+        training: TrainingConfig {
+            checkpoint_segments: ckpt.num_segments,
+            checkpoint_segments_source: segments_source,
+            checkpointing_enabled: ckpt.enabled,
+        },
+        memory_budget: MemoryBudgetConfig {
+            total_vram_gb: b.total_vram_bytes as f64 / 1e9,
+            model_gb: b.model_memory_bytes as f64 / 1e9,
+            kv_cache_gb: b.kv_cache_bytes as f64 / 1e9,
+            training_budget_gb: b.training_budget_bytes as f64 / 1e9,
+            inference_memory_fraction: b.inference_memory_fraction,
+        },
+    })
+}
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/v1/config", get(get_config))
+}

--- a/crates/kiln-server/src/api/mod.rs
+++ b/crates/kiln-server/src/api/mod.rs
@@ -9,6 +9,7 @@ mod models;
 mod completions;
 mod adapters;
 mod training;
+mod config;
 
 pub fn router(state: AppState) -> Router {
     Router::new()
@@ -17,6 +18,7 @@ pub fn router(state: AppState) -> Router {
         .merge(completions::routes())
         .merge(adapters::routes())
         .merge(training::routes())
+        .merge(config::routes())
         .with_state(state)
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -173,6 +173,8 @@ pub struct AppState {
     /// FIFO training queue — jobs are enqueued here and executed sequentially
     /// by a background worker.
     pub training_queue: SharedTrainingQueue,
+    /// Detected VRAM info for config/debug reporting.
+    pub vram_info: kiln_core::vram::GpuVramInfo,
 }
 
 impl AppState {
@@ -196,6 +198,10 @@ impl AppState {
             memory_budget: Arc::new(GpuMemoryBudget::compute(0, 0, 0, 1.0)),
             gpu_lock: Arc::new(std::sync::RwLock::new(())),
             training_queue: crate::training_queue::new_shared_queue(),
+            vram_info: kiln_core::vram::GpuVramInfo {
+                total_bytes: 0,
+                source: kiln_core::vram::VramSource::None,
+            },
         }
     }
 
@@ -246,6 +252,9 @@ impl AppState {
             * model_config.head_dim
             * block_size
             * kv_dtype_bytes) as u64;
+
+        // Detect VRAM for auto-configuration
+        let vram_info = kiln_core::vram::detect_vram();
 
         // Determine num_blocks — either from env, or memory-aware auto-calculation
         let num_blocks = if let Some(explicit) = std::env::var("KILN_NUM_BLOCKS")
@@ -322,6 +331,7 @@ impl AppState {
             memory_budget: Arc::new(memory_budget),
             gpu_lock: Arc::new(std::sync::RwLock::new(())),
             training_queue: crate::training_queue::new_shared_queue(),
+            vram_info,
         }
     }
 }
@@ -351,32 +361,27 @@ fn estimate_model_memory_bytes(config: &ModelConfig) -> u64 {
 
 /// Query total GPU memory in bytes. Returns 0 for CPU devices.
 ///
-/// On CUDA devices, uses candle's CUDA bindings to query device memory.
+/// Uses the shared VRAM detection from kiln-core (nvidia-smi + env override).
+/// For CPU devices, still checks KILN_GPU_MEMORY_GB for testing purposes.
 fn query_gpu_total_memory(device: &candle_core::Device) -> u64 {
+    let vram = kiln_core::vram::detect_vram();
     match device {
         #[cfg(feature = "cuda")]
-        candle_core::Device::Cuda(cuda_dev) => {
-            // Use cuMemGetInfo via candle's CUDA device
-            // candle_core doesn't expose total memory directly, so we use
-            // the CUDA ordinal to query via cudarc if available.
-            // For now, fall back to KILN_GPU_MEMORY_GB env var.
-            if let Ok(val) = std::env::var("KILN_GPU_MEMORY_GB") {
-                if let Ok(gb) = val.parse::<f64>() {
-                    return (gb * 1024.0 * 1024.0 * 1024.0) as u64;
-                }
+        candle_core::Device::Cuda(_) => {
+            if vram.total_bytes > 0 {
+                tracing::info!(
+                    total_gb = vram.total_bytes as f64 / 1e9,
+                    source = %vram.source,
+                    "GPU VRAM detected"
+                );
+                vram.total_bytes
+            } else {
+                // CUDA device exists but detection failed — assume 24GB
+                tracing::warn!("CUDA device present but VRAM detection failed; assuming 24GB");
+                24 * 1024 * 1024 * 1024
             }
-            // Default: assume 24GB (common consumer GPU)
-            24 * 1024 * 1024 * 1024
         }
-        _ => {
-            // CPU or Metal — check if KILN_GPU_MEMORY_GB is set for testing
-            if let Ok(val) = std::env::var("KILN_GPU_MEMORY_GB") {
-                if let Ok(gb) = val.parse::<f64>() {
-                    return (gb * 1024.0 * 1024.0 * 1024.0) as u64;
-                }
-            }
-            0
-        }
+        _ => vram.total_bytes, // 0 if no GPU, or env override for testing
     }
 }
 

--- a/crates/kiln-train/src/lib.rs
+++ b/crates/kiln-train/src/lib.rs
@@ -6,6 +6,8 @@
 
 pub mod trainer;
 
+pub use trainer::CheckpointConfig;
+
 use serde::{Deserialize, Serialize};
 
 /// A chat message in a training example.

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -997,28 +997,60 @@ fn sgd_step_from_map(
 
 /// Gradient checkpointing configuration.
 pub struct CheckpointConfig {
-    /// Number of segments to split layers into (default 4 for 32 layers → 8 layers/segment).
+    /// Number of segments to split layers into.
     pub num_segments: usize,
     /// Whether checkpointing is enabled.
     pub enabled: bool,
+    /// Whether num_segments was auto-configured from VRAM detection.
+    pub auto_configured: bool,
 }
 
 impl CheckpointConfig {
-    /// Create config from environment, defaulting to enabled with 4 segments.
+    /// Create config from environment with VRAM-aware defaults.
+    ///
+    /// Priority for num_segments:
+    /// 1. `KILN_GRAD_CHECKPOINT_SEGMENTS` env var (user override)
+    /// 2. Auto-detect from GPU VRAM via `kiln_core::vram`
+    /// 3. Fallback to 4 segments
     pub fn from_env(num_layers: usize) -> Self {
         let enabled = std::env::var("KILN_NO_GRAD_CHECKPOINT")
             .map(|v| v != "1" && v.to_lowercase() != "true")
             .unwrap_or(true);
-        // Default: 4 segments, or fewer if model has very few layers
-        let num_segments = std::env::var("KILN_GRAD_CHECKPOINT_SEGMENTS")
+
+        // Check for explicit env override first
+        if let Some(explicit) = std::env::var("KILN_GRAD_CHECKPOINT_SEGMENTS")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
-            .unwrap_or(4)
+        {
+            return Self {
+                num_segments: explicit.min(num_layers).max(1),
+                enabled,
+                auto_configured: false,
+            };
+        }
+
+        // VRAM-aware auto-configuration
+        let vram = kiln_core::vram::detect_vram();
+        let num_segments = kiln_core::vram::recommended_checkpoint_segments(&vram)
+            .unwrap_or(4) // fallback if env var was set (shouldn't happen here)
             .min(num_layers)
             .max(1);
+
+        let auto_configured = vram.source != kiln_core::vram::VramSource::None;
+
+        if auto_configured {
+            tracing::info!(
+                num_segments,
+                vram_gb = vram.total_bytes as f64 / 1e9,
+                source = %vram.source,
+                "auto-configured gradient checkpoint segments for detected VRAM"
+            );
+        }
+
         Self {
             num_segments,
             enabled,
+            auto_configured,
         }
     }
 }
@@ -1655,13 +1687,15 @@ mod tests {
 
     #[test]
     fn test_checkpoint_config_from_env() {
-        // Default: enabled, 4 segments
+        // Without KILN_GPU_MEMORY_GB or nvidia-smi, falls back to default (4 segments)
+        // or VRAM-aware value if GPU is detected
         let cfg = CheckpointConfig::from_env(32);
         assert!(cfg.enabled);
-        assert_eq!(cfg.num_segments, 4);
+        // num_segments depends on whether GPU is detected; just verify it's reasonable
+        assert!(cfg.num_segments >= 1 && cfg.num_segments <= 32);
 
-        // With very few layers, segments clamped
+        // With very few layers, segments clamped to num_layers
         let cfg = CheckpointConfig::from_env(2);
-        assert_eq!(cfg.num_segments, 2);
+        assert!(cfg.num_segments <= 2);
     }
 }


### PR DESCRIPTION
## What
Auto-detect GPU VRAM and configure num_blocks + gradient checkpoint segments automatically so training "just works" on consumer GPUs without manual env var tuning.

## Why
Phase 3c found that training OOMs on 24GB GPUs with defaults (256 blocks, 4 segments) but succeeds with 64 blocks + 8 segments at 18.3GB peak. Users shouldn't need to know about KILN_NUM_BLOCKS or KILN_GRAD_CHECKPOINT_SEGMENTS to get training working.

## Changes
- **kiln-core: `vram` module** — VRAM detection via nvidia-smi with KILN_GPU_MEMORY_GB env override
- **kiln-core: `recommended_checkpoint_segments()`** — tier-based auto-config (8 for >=22GB, 4 for >=45GB, 12 for >=14GB)
- **kiln-server: `query_gpu_total_memory()`** — now uses shared nvidia-smi detection instead of hardcoded 24GB assumption
- **kiln-train: `CheckpointConfig::from_env()`** — VRAM-aware segment auto-configuration with logging
- **kiln-server: `/v1/config` endpoint** — shows detected VRAM, actual num_blocks, checkpoint segments, and whether each was auto or user-override
- **Threshold fix** — uses 22/45 GiB instead of 24/48 since GPUs report slightly less than marketed (e.g. A5000 "24GB" = 24564 MiB = 23.99 GiB)

## GPU Verification (RTX A5000 24GB)
- VRAM detected: 25.76 GB via nvidia-smi
- num_blocks: 22164 (memory-aware auto-calculation)
- checkpoint_segments: 8 (auto, proven safe)
- training_budget: 4.98 GB
- User overrides (KILN_NUM_BLOCKS, KILN_GRAD_CHECKPOINT_SEGMENTS) still respected
- All local CPU tests pass