### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -17,6 +17,7 @@ use kiln_core::tokenizer::ChatMessage;
 use kiln_model::lora_loader::LoraWeights;
 use kiln_model::{ModelRunner, StreamEvent};
 
+use crate::metrics::RequestStatus;
 use crate::state::{AppState, ModelBackend};
 
 /// OpenAI-compatible chat completion request.
@@ -109,6 +110,33 @@ async fn chat_completions(
     State(state): State<AppState>,
     Json(req): Json<ChatCompletionRequest>,
 ) -> Result<Response, (StatusCode, String)> {
+    let start = std::time::Instant::now();
+    state.metrics.inc_active();
+
+    let result = chat_completions_inner(&state, req).await;
+
+    state.metrics.dec_active();
+    let elapsed = start.elapsed().as_secs_f64();
+    state.metrics.observe_duration(elapsed);
+
+    match &result {
+        Ok(_) => state.metrics.inc_request(RequestStatus::Ok),
+        Err((code, _)) => {
+            if *code == StatusCode::REQUEST_TIMEOUT {
+                state.metrics.inc_request(RequestStatus::Timeout);
+            } else {
+                state.metrics.inc_request(RequestStatus::Error);
+            }
+        }
+    }
+
+    result
+}
+
+async fn chat_completions_inner(
+    state: &AppState,
+    req: ChatCompletionRequest,
+) -> Result<Response, (StatusCode, String)> {
     // Convert request messages to ChatMessage for template formatting
     let chat_messages: Vec<ChatMessage> = req
         .messages
@@ -137,7 +165,7 @@ async fn chat_completions(
 
     // Ensure the correct LoRA adapter is active for this request.
     if let ModelBackend::Real { runner, .. } = state.backend.as_ref() {
-        ensure_adapter(&state, runner, &req.adapter).await?;
+        ensure_adapter(state, runner, &req.adapter).await?;
     }
 
     if req.stream {
@@ -148,7 +176,7 @@ async fn chat_completions(
                 paged_cache,
             } => {
                 generate_real_streaming(
-                    &state,
+                    state,
                     runner,
                     block_manager,
                     paged_cache,
@@ -170,8 +198,8 @@ async fn chat_completions(
                 block_manager,
                 paged_cache,
             } => {
-                generate_real(
-                    &state,
+                let resp = generate_real(
+                    state,
                     runner,
                     block_manager,
                     paged_cache,
@@ -179,13 +207,20 @@ async fn chat_completions(
                     &sampling,
                     &req,
                 )
-                .await
-                .map(|json| json.into_response())
+                .await?;
+                // Count generated tokens for metrics.
+                state
+                    .metrics
+                    .add_tokens(resp.usage.completion_tokens as u64);
+                Ok(Json(resp).into_response())
             }
             ModelBackend::Mock { scheduler, engine } => {
-                generate_mock(&state, scheduler, engine, &prompt_text, &sampling, &req)
-                    .await
-                    .map(|json| json.into_response())
+                let resp =
+                    generate_mock(state, scheduler, engine, &prompt_text, &sampling, &req).await?;
+                state
+                    .metrics
+                    .add_tokens(resp.usage.completion_tokens as u64);
+                Ok(Json(resp).into_response())
             }
         }
     }
@@ -270,7 +305,7 @@ async fn generate_real(
     prompt_text: &str,
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
-) -> Result<Json<ChatCompletionResponse>, (StatusCode, String)> {
+) -> Result<ChatCompletionResponse, (StatusCode, String)> {
     // Count prompt tokens for usage stats.
     let prompt_token_count = state
         .tokenizer
@@ -321,7 +356,7 @@ async fn generate_real(
 
     let now = now_epoch();
 
-    Ok(Json(ChatCompletionResponse {
+    Ok(ChatCompletionResponse {
         id: format!("chatcmpl-{}", Uuid::new_v4()),
         object: "chat.completion",
         created: now,
@@ -339,7 +374,7 @@ async fn generate_real(
             completion_tokens: output.token_ids.len(),
             total_tokens: prompt_token_count + output.token_ids.len(),
         },
-    }))
+    })
 }
 
 /// Generate using the real ModelRunner with SSE streaming and paged KV cache.
@@ -562,7 +597,7 @@ async fn generate_mock(
     prompt_text: &str,
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
-) -> Result<Json<ChatCompletionResponse>, (StatusCode, String)> {
+) -> Result<ChatCompletionResponse, (StatusCode, String)> {
     let prompt_tokens = state
         .tokenizer
         .encode(prompt_text)
@@ -655,7 +690,7 @@ async fn generate_mock(
 
     let now = now_epoch();
 
-    Ok(Json(ChatCompletionResponse {
+    Ok(ChatCompletionResponse {
         id: format!("chatcmpl-{}", Uuid::new_v4()),
         object: "chat.completion",
         created: now,
@@ -673,7 +708,7 @@ async fn generate_mock(
             completion_tokens: output_tokens.len(),
             total_tokens: prompt_token_count + output_tokens.len(),
         },
-    }))
+    })
 }
 
 fn now_epoch() -> u64 {

--- a/crates/kiln-server/src/api/metrics.rs
+++ b/crates/kiln-server/src/api/metrics.rs
@@ -1,0 +1,74 @@
+//! GET /metrics — Prometheus text exposition format.
+
+use axum::{
+    extract::State,
+    http::{header, StatusCode},
+    response::IntoResponse,
+    routing::get,
+    Router,
+};
+
+use crate::metrics::SnapshotGauges;
+use crate::state::{AppState, ModelBackend};
+use kiln_train::TrainingState;
+
+async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
+    // Snapshot scheduler gauges.
+    let (scheduler_waiting, scheduler_running, blocks_used, blocks_total) =
+        match state.backend.as_ref() {
+            ModelBackend::Mock { scheduler, .. } => {
+                let sched = scheduler.lock().await;
+                let bm = sched.block_manager();
+                (
+                    sched.num_waiting(),
+                    sched.num_running(),
+                    bm.num_used(),
+                    bm.num_blocks(),
+                )
+            }
+            ModelBackend::Real { block_manager, .. } => {
+                let bm = block_manager.lock().unwrap();
+                (0, 0, bm.num_used(), bm.num_blocks())
+            }
+        };
+
+    // Training active?
+    let training_active = {
+        let jobs = state.training_jobs.read().unwrap();
+        if jobs.values().any(|j| j.state == TrainingState::Running) {
+            1
+        } else {
+            0
+        }
+    };
+
+    let active_adapter = state.active_adapter_name.read().unwrap().clone();
+
+    let gauges = SnapshotGauges {
+        scheduler_waiting,
+        scheduler_running,
+        blocks_used,
+        blocks_total,
+        vram_total: state.memory_budget.total_vram_bytes,
+        vram_model: state.memory_budget.model_memory_bytes,
+        vram_kv_cache: state.memory_budget.kv_cache_bytes,
+        vram_training_budget: state.memory_budget.training_budget_bytes,
+        training_active,
+        active_adapter,
+    };
+
+    let body = state.metrics.render(&gauges);
+
+    (
+        StatusCode::OK,
+        [(
+            header::CONTENT_TYPE,
+            "text/plain; version=0.0.4; charset=utf-8",
+        )],
+        body,
+    )
+}
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/metrics", get(metrics_handler))
+}

--- a/crates/kiln-server/src/api/mod.rs
+++ b/crates/kiln-server/src/api/mod.rs
@@ -5,6 +5,7 @@ use tower_http::trace::TraceLayer;
 use crate::state::AppState;
 
 mod health;
+mod metrics;
 mod models;
 mod completions;
 mod adapters;
@@ -14,6 +15,7 @@ mod config;
 pub fn router(state: AppState) -> Router {
     Router::new()
         .merge(health::routes())
+        .merge(metrics::routes())
         .merge(models::routes())
         .merge(completions::routes())
         .merge(adapters::routes())

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -15,6 +15,7 @@ use kiln_train::{GrpoRequest, SftRequest, TrainingResponse, TrainingState, Train
 
 use std::sync::atomic::Ordering;
 
+use crate::metrics::{TrainingMetricStatus, TrainingMetricType};
 use crate::state::{AppState, ModelBackend, TrainingJobInfo, TrainingJobType};
 use crate::training_queue::{QueueEntry, QueuedJob};
 
@@ -305,9 +306,20 @@ async fn cancel_queued_job(
 
     if removed {
         // Mark as failed (cancelled) in the tracking map
-        let mut jobs = state.training_jobs.write().unwrap();
-        if let Some(job) = jobs.get_mut(&job_id) {
-            job.state = TrainingState::Failed;
+        let metric_type = {
+            let mut jobs = state.training_jobs.write().unwrap();
+            let jt = jobs.get(&job_id).map(|j| j.job_type);
+            if let Some(job) = jobs.get_mut(&job_id) {
+                job.state = TrainingState::Failed;
+            }
+            jt
+        };
+        if let Some(jt) = metric_type {
+            let mt = match jt {
+                TrainingJobType::Sft => TrainingMetricType::Sft,
+                TrainingJobType::Grpo => TrainingMetricType::Grpo,
+            };
+            state.metrics.inc_training(mt, TrainingMetricStatus::Cancelled);
         }
         Ok(Json(serde_json::json!({
             "job_id": job_id,

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -1,5 +1,6 @@
 //! Kiln HTTP server — library interface for integration testing.
 
 pub mod api;
+pub mod metrics;
 pub mod state;
 pub mod training_queue;

--- a/crates/kiln-server/src/metrics.rs
+++ b/crates/kiln-server/src/metrics.rs
@@ -1,0 +1,309 @@
+//! Prometheus metrics collection for kiln.
+//!
+//! Uses atomic counters and gauges — no external dependencies.
+//! The `/metrics` endpoint renders all metrics in Prometheus text exposition format.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Atomically tracked metrics for the kiln server.
+pub struct Metrics {
+    // Inference counters
+    pub requests_ok: AtomicU64,
+    pub requests_error: AtomicU64,
+    pub requests_timeout: AtomicU64,
+    pub requests_rejected: AtomicU64,
+
+    /// Total tokens generated across all requests.
+    pub tokens_generated: AtomicU64,
+
+    /// Currently in-flight inference requests.
+    pub active_requests: AtomicU64,
+
+    /// Request duration tracking (simple: count + sum in microseconds).
+    pub request_duration_count: AtomicU64,
+    pub request_duration_sum_us: AtomicU64,
+
+    // Training counters
+    pub training_sft_completed: AtomicU64,
+    pub training_sft_failed: AtomicU64,
+    pub training_sft_cancelled: AtomicU64,
+    pub training_grpo_completed: AtomicU64,
+    pub training_grpo_failed: AtomicU64,
+    pub training_grpo_cancelled: AtomicU64,
+}
+
+impl Metrics {
+    pub fn new() -> Self {
+        Self {
+            requests_ok: AtomicU64::new(0),
+            requests_error: AtomicU64::new(0),
+            requests_timeout: AtomicU64::new(0),
+            requests_rejected: AtomicU64::new(0),
+            tokens_generated: AtomicU64::new(0),
+            active_requests: AtomicU64::new(0),
+            request_duration_count: AtomicU64::new(0),
+            request_duration_sum_us: AtomicU64::new(0),
+            training_sft_completed: AtomicU64::new(0),
+            training_sft_failed: AtomicU64::new(0),
+            training_sft_cancelled: AtomicU64::new(0),
+            training_grpo_completed: AtomicU64::new(0),
+            training_grpo_failed: AtomicU64::new(0),
+            training_grpo_cancelled: AtomicU64::new(0),
+        }
+    }
+
+    /// Increment the request counter for the given status.
+    pub fn inc_request(&self, status: RequestStatus) {
+        match status {
+            RequestStatus::Ok => self.requests_ok.fetch_add(1, Ordering::Relaxed),
+            RequestStatus::Error => self.requests_error.fetch_add(1, Ordering::Relaxed),
+            RequestStatus::Timeout => self.requests_timeout.fetch_add(1, Ordering::Relaxed),
+            RequestStatus::Rejected => self.requests_rejected.fetch_add(1, Ordering::Relaxed),
+        };
+    }
+
+    /// Record a completed request duration in seconds.
+    pub fn observe_duration(&self, secs: f64) {
+        self.request_duration_count.fetch_add(1, Ordering::Relaxed);
+        let us = (secs * 1_000_000.0) as u64;
+        self.request_duration_sum_us.fetch_add(us, Ordering::Relaxed);
+    }
+
+    /// Add generated token count.
+    pub fn add_tokens(&self, n: u64) {
+        self.tokens_generated.fetch_add(n, Ordering::Relaxed);
+    }
+
+    /// Increment active requests (call on request entry).
+    pub fn inc_active(&self) {
+        self.active_requests.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Decrement active requests (call on request exit).
+    pub fn dec_active(&self) {
+        self.active_requests.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    /// Record a training job completion.
+    pub fn inc_training(&self, job_type: TrainingMetricType, status: TrainingMetricStatus) {
+        match (job_type, status) {
+            (TrainingMetricType::Sft, TrainingMetricStatus::Completed) => {
+                self.training_sft_completed.fetch_add(1, Ordering::Relaxed);
+            }
+            (TrainingMetricType::Sft, TrainingMetricStatus::Failed) => {
+                self.training_sft_failed.fetch_add(1, Ordering::Relaxed);
+            }
+            (TrainingMetricType::Sft, TrainingMetricStatus::Cancelled) => {
+                self.training_sft_cancelled.fetch_add(1, Ordering::Relaxed);
+            }
+            (TrainingMetricType::Grpo, TrainingMetricStatus::Completed) => {
+                self.training_grpo_completed.fetch_add(1, Ordering::Relaxed);
+            }
+            (TrainingMetricType::Grpo, TrainingMetricStatus::Failed) => {
+                self.training_grpo_failed.fetch_add(1, Ordering::Relaxed);
+            }
+            (TrainingMetricType::Grpo, TrainingMetricStatus::Cancelled) => {
+                self.training_grpo_cancelled.fetch_add(1, Ordering::Relaxed);
+            }
+        };
+    }
+
+    /// Render all metrics in Prometheus text exposition format.
+    ///
+    /// Dynamic gauges (scheduler state, GPU memory, training active, adapter) are
+    /// passed in as `SnapshotGauges` because they come from shared state that the
+    /// metrics struct itself doesn't own.
+    pub fn render(&self, gauges: &SnapshotGauges) -> String {
+        let mut out = String::with_capacity(2048);
+
+        // --- Inference ---
+        out.push_str("# HELP kiln_requests_total Total inference requests.\n");
+        out.push_str("# TYPE kiln_requests_total counter\n");
+        prom_counter(&mut out, "kiln_requests_total", "status", "ok", self.requests_ok.load(Ordering::Relaxed));
+        prom_counter(&mut out, "kiln_requests_total", "status", "error", self.requests_error.load(Ordering::Relaxed));
+        prom_counter(&mut out, "kiln_requests_total", "status", "timeout", self.requests_timeout.load(Ordering::Relaxed));
+        prom_counter(&mut out, "kiln_requests_total", "status", "rejected", self.requests_rejected.load(Ordering::Relaxed));
+
+        out.push_str("# HELP kiln_request_duration_seconds Request latency.\n");
+        out.push_str("# TYPE kiln_request_duration_seconds summary\n");
+        let count = self.request_duration_count.load(Ordering::Relaxed);
+        let sum_us = self.request_duration_sum_us.load(Ordering::Relaxed);
+        push_line(&mut out, &format!("kiln_request_duration_seconds_count {count}"));
+        push_line(&mut out, &format!("kiln_request_duration_seconds_sum {:.6}", sum_us as f64 / 1_000_000.0));
+
+        out.push_str("# HELP kiln_tokens_generated_total Total tokens generated.\n");
+        out.push_str("# TYPE kiln_tokens_generated_total counter\n");
+        push_line(&mut out, &format!("kiln_tokens_generated_total {}", self.tokens_generated.load(Ordering::Relaxed)));
+
+        out.push_str("# HELP kiln_active_requests Currently in-flight requests.\n");
+        out.push_str("# TYPE kiln_active_requests gauge\n");
+        push_line(&mut out, &format!("kiln_active_requests {}", self.active_requests.load(Ordering::Relaxed)));
+
+        // --- Scheduler ---
+        out.push_str("# HELP kiln_scheduler_waiting Requests waiting to be scheduled.\n");
+        out.push_str("# TYPE kiln_scheduler_waiting gauge\n");
+        push_line(&mut out, &format!("kiln_scheduler_waiting {}", gauges.scheduler_waiting));
+
+        out.push_str("# HELP kiln_scheduler_running Requests currently generating.\n");
+        out.push_str("# TYPE kiln_scheduler_running gauge\n");
+        push_line(&mut out, &format!("kiln_scheduler_running {}", gauges.scheduler_running));
+
+        out.push_str("# HELP kiln_blocks_used KV cache blocks in use.\n");
+        out.push_str("# TYPE kiln_blocks_used gauge\n");
+        push_line(&mut out, &format!("kiln_blocks_used {}", gauges.blocks_used));
+
+        out.push_str("# HELP kiln_blocks_total Total KV cache blocks.\n");
+        out.push_str("# TYPE kiln_blocks_total gauge\n");
+        push_line(&mut out, &format!("kiln_blocks_total {}", gauges.blocks_total));
+
+        // --- GPU Memory ---
+        out.push_str("# HELP kiln_vram_total_bytes Total GPU VRAM.\n");
+        out.push_str("# TYPE kiln_vram_total_bytes gauge\n");
+        push_line(&mut out, &format!("kiln_vram_total_bytes {}", gauges.vram_total));
+
+        out.push_str("# HELP kiln_vram_model_bytes Model weight memory.\n");
+        out.push_str("# TYPE kiln_vram_model_bytes gauge\n");
+        push_line(&mut out, &format!("kiln_vram_model_bytes {}", gauges.vram_model));
+
+        out.push_str("# HELP kiln_vram_kv_cache_bytes KV cache memory.\n");
+        out.push_str("# TYPE kiln_vram_kv_cache_bytes gauge\n");
+        push_line(&mut out, &format!("kiln_vram_kv_cache_bytes {}", gauges.vram_kv_cache));
+
+        out.push_str("# HELP kiln_vram_training_budget_bytes Training memory budget.\n");
+        out.push_str("# TYPE kiln_vram_training_budget_bytes gauge\n");
+        push_line(&mut out, &format!("kiln_vram_training_budget_bytes {}", gauges.vram_training_budget));
+
+        // --- Training ---
+        out.push_str("# HELP kiln_training_jobs_total Total training jobs.\n");
+        out.push_str("# TYPE kiln_training_jobs_total counter\n");
+        prom_counter2(&mut out, "kiln_training_jobs_total", "type", "sft", "status", "completed", self.training_sft_completed.load(Ordering::Relaxed));
+        prom_counter2(&mut out, "kiln_training_jobs_total", "type", "sft", "status", "failed", self.training_sft_failed.load(Ordering::Relaxed));
+        prom_counter2(&mut out, "kiln_training_jobs_total", "type", "sft", "status", "cancelled", self.training_sft_cancelled.load(Ordering::Relaxed));
+        prom_counter2(&mut out, "kiln_training_jobs_total", "type", "grpo", "status", "completed", self.training_grpo_completed.load(Ordering::Relaxed));
+        prom_counter2(&mut out, "kiln_training_jobs_total", "type", "grpo", "status", "failed", self.training_grpo_failed.load(Ordering::Relaxed));
+        prom_counter2(&mut out, "kiln_training_jobs_total", "type", "grpo", "status", "cancelled", self.training_grpo_cancelled.load(Ordering::Relaxed));
+
+        out.push_str("# HELP kiln_training_active Currently running training job.\n");
+        out.push_str("# TYPE kiln_training_active gauge\n");
+        push_line(&mut out, &format!("kiln_training_active {}", gauges.training_active));
+
+        // --- Adapter ---
+        out.push_str("# HELP kiln_active_adapter Currently loaded adapter.\n");
+        out.push_str("# TYPE kiln_active_adapter gauge\n");
+        if let Some(ref name) = gauges.active_adapter {
+            push_line(&mut out, &format!("kiln_active_adapter{{name=\"{name}\"}} 1"));
+        } else {
+            push_line(&mut out, "kiln_active_adapter{name=\"base\"} 1");
+        }
+
+        out
+    }
+}
+
+/// Dynamic gauge values snapshotted at render time.
+pub struct SnapshotGauges {
+    pub scheduler_waiting: usize,
+    pub scheduler_running: usize,
+    pub blocks_used: usize,
+    pub blocks_total: usize,
+    pub vram_total: u64,
+    pub vram_model: u64,
+    pub vram_kv_cache: u64,
+    pub vram_training_budget: u64,
+    pub training_active: u8,
+    pub active_adapter: Option<String>,
+}
+
+pub enum RequestStatus {
+    Ok,
+    Error,
+    Timeout,
+    Rejected,
+}
+
+#[derive(Clone, Copy)]
+pub enum TrainingMetricType {
+    Sft,
+    Grpo,
+}
+
+#[derive(Clone, Copy)]
+pub enum TrainingMetricStatus {
+    Completed,
+    Failed,
+    Cancelled,
+}
+
+fn push_line(out: &mut String, line: &str) {
+    out.push_str(line);
+    out.push('\n');
+}
+
+fn prom_counter(out: &mut String, name: &str, label: &str, value: &str, count: u64) {
+    out.push_str(&format!("{name}{{{label}=\"{value}\"}} {count}\n"));
+}
+
+fn prom_counter2(out: &mut String, name: &str, l1: &str, v1: &str, l2: &str, v2: &str, count: u64) {
+    out.push_str(&format!("{name}{{{l1}=\"{v1}\",{l2}=\"{v2}\"}} {count}\n"));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_metrics_render() {
+        let m = Metrics::new();
+        m.inc_request(RequestStatus::Ok);
+        m.inc_request(RequestStatus::Ok);
+        m.inc_request(RequestStatus::Error);
+        m.observe_duration(0.5);
+        m.add_tokens(100);
+        m.inc_active();
+
+        let gauges = SnapshotGauges {
+            scheduler_waiting: 3,
+            scheduler_running: 1,
+            blocks_used: 10,
+            blocks_total: 256,
+            vram_total: 24_000_000_000,
+            vram_model: 8_000_000_000,
+            vram_kv_cache: 2_000_000_000,
+            vram_training_budget: 14_000_000_000,
+            training_active: 0,
+            active_adapter: Some("my-adapter".to_string()),
+        };
+
+        let output = m.render(&gauges);
+
+        assert!(output.contains("kiln_requests_total{status=\"ok\"} 2"));
+        assert!(output.contains("kiln_requests_total{status=\"error\"} 1"));
+        assert!(output.contains("kiln_tokens_generated_total 100"));
+        assert!(output.contains("kiln_active_requests 1"));
+        assert!(output.contains("kiln_scheduler_waiting 3"));
+        assert!(output.contains("kiln_blocks_total 256"));
+        assert!(output.contains("kiln_vram_total_bytes 24000000000"));
+        assert!(output.contains("kiln_active_adapter{name=\"my-adapter\"} 1"));
+        assert!(output.contains("kiln_request_duration_seconds_count 1"));
+        assert!(output.contains("kiln_request_duration_seconds_sum 0.5"));
+    }
+
+    #[test]
+    fn test_base_adapter_rendering() {
+        let m = Metrics::new();
+        let gauges = SnapshotGauges {
+            scheduler_waiting: 0,
+            scheduler_running: 0,
+            blocks_used: 0,
+            blocks_total: 0,
+            vram_total: 0,
+            vram_model: 0,
+            vram_kv_cache: 0,
+            vram_training_budget: 0,
+            training_active: 0,
+            active_adapter: None,
+        };
+        let output = m.render(&gauges);
+        assert!(output.contains("kiln_active_adapter{name=\"base\"} 1"));
+    }
+}

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -13,6 +13,7 @@ use kiln_scheduler::Scheduler;
 use kiln_train::TrainingState;
 use serde::Serialize;
 
+use crate::metrics::Metrics;
 use crate::training_queue::{SharedTrainingQueue, ShutdownFlag};
 
 /// GPU memory budget tracking for coordinating inference and training.
@@ -179,6 +180,8 @@ pub struct AppState {
     pub shutdown: ShutdownFlag,
     /// Per-request timeout duration. Configurable via KILN_REQUEST_TIMEOUT_SECS (default 300).
     pub request_timeout: std::time::Duration,
+    /// Prometheus metrics counters.
+    pub metrics: Arc<Metrics>,
 }
 
 impl AppState {
@@ -208,6 +211,7 @@ impl AppState {
             },
             shutdown: crate::training_queue::new_shutdown_flag(),
             request_timeout: parse_request_timeout(),
+            metrics: Arc::new(Metrics::new()),
         }
     }
 
@@ -340,6 +344,7 @@ impl AppState {
             vram_info,
             shutdown: crate::training_queue::new_shutdown_flag(),
             request_timeout: parse_request_timeout(),
+            metrics: Arc::new(Metrics::new()),
         }
     }
 }

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -12,7 +12,8 @@ use kiln_model::lora_loader::LoraWeights;
 use kiln_train::{GrpoRequest, SftRequest, TrainingState};
 use kiln_train::trainer;
 
-use crate::state::{AppState, ModelBackend};
+use crate::metrics::{TrainingMetricStatus, TrainingMetricType};
+use crate::state::{AppState, ModelBackend, TrainingJobType};
 
 /// A pending training job in the queue.
 pub enum QueuedJob {
@@ -154,11 +155,16 @@ fn execute_job(state: AppState, entry: QueueEntry) {
         (runner_arc.clone(), guard.config.num_layers)
     };
 
-    // Get auto_load and adapter_name from the job info
-    let (auto_load, adapter_name) = {
+    // Get auto_load, adapter_name, and job_type from the job info
+    let (auto_load, adapter_name, job_type) = {
         let jobs = state.training_jobs.read().unwrap();
         let job = jobs.get(&job_id).unwrap();
-        (job.auto_load, job.adapter_name.clone())
+        (job.auto_load, job.adapter_name.clone(), job.job_type)
+    };
+
+    let metric_type = match job_type {
+        TrainingJobType::Sft => TrainingMetricType::Sft,
+        TrainingJobType::Grpo => TrainingMetricType::Grpo,
     };
 
     // Set up progress callback
@@ -220,6 +226,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                     job.adapter_path = Some(path_str);
                 }
             }
+            state.metrics.inc_training(metric_type, TrainingMetricStatus::Completed);
 
             if auto_load {
                 if let Err(e) = auto_load_adapter(
@@ -241,6 +248,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
             if let Some(job) = jobs.get_mut(&job_id) {
                 job.state = TrainingState::Failed;
             }
+            state.metrics.inc_training(metric_type, TrainingMetricStatus::Failed);
         }
     }
 }


### PR DESCRIPTION
## What

Adds GET /metrics endpoint that exposes server metrics in Prometheus text exposition format. No external dependencies — uses atomic counters and manual text rendering.

## Metrics exposed

- **Inference**: kiln_requests_total (by status), kiln_request_duration_seconds, kiln_tokens_generated_total, kiln_active_requests
- **Scheduler**: kiln_scheduler_waiting, kiln_scheduler_running, kiln_blocks_used, kiln_blocks_total
- **GPU Memory**: kiln_vram_total_bytes, kiln_vram_model_bytes, kiln_vram_kv_cache_bytes, kiln_vram_training_budget_bytes
- **Training**: kiln_training_jobs_total (by type and status), kiln_training_active
- **Adapter**: kiln_active_adapter (by name)

## Files changed

- **NEW** `crates/kiln-server/src/metrics.rs` — Metrics struct with atomic counters and Prometheus text renderer
- **NEW** `crates/kiln-server/src/api/metrics.rs` — GET /metrics handler
- **EDIT** `crates/kiln-server/src/state.rs` — Arc<Metrics> added to AppState
- **EDIT** `crates/kiln-server/src/api/mod.rs` — metrics route registered
- **EDIT** `crates/kiln-server/src/api/completions.rs` — request counting, duration, and token tracking
- **EDIT** `crates/kiln-server/src/api/training.rs` — training job cancellation counting
- **EDIT** `crates/kiln-server/src/training_queue.rs` — training job completion/failure counting
- **EDIT** `crates/kiln-server/src/lib.rs` — pub mod metrics

## Testing

- `cargo test --lib -p kiln-server` — all 11 tests pass (2 new metrics tests)
- Full `cargo build --release --features flash-attn` compiles cleanly on RTX PRO 4500 Blackwell