### PR TITLE
Add TOML configuration file with validation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 
 # Logging
 tracing = "0.1"

--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -33,6 +33,7 @@ chrono = { workspace = true }
 futures = { workspace = true }
 tokio-stream = { workspace = true }
 thiserror = { workspace = true }
+toml = { workspace = true }
 
 [features]
 cuda = ["kiln-model/cuda", "flash-attn"]

--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -215,7 +215,7 @@ mod tests {
         let engine = MockEngine::new(config.clone());
         let tokenizer =
             kiln_core::tokenizer::KilnTokenizer::from_pretrained("Qwen/Qwen3.5-4B").unwrap();
-        AppState::new_mock(config, scheduler, Arc::new(engine), tokenizer)
+        AppState::new_mock(config, scheduler, Arc::new(engine), tokenizer, 300)
     }
 
     #[tokio::test]

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -1,0 +1,501 @@
+//! TOML configuration file support with typed validation and env var overrides.
+//!
+//! Configuration is loaded in this priority order (highest wins):
+//! 1. Environment variables (`KILN_*`)
+//! 2. TOML config file
+//! 3. Built-in defaults
+//!
+//! The config file path is resolved as:
+//! 1. Explicit path passed to `KilnConfig::load()`
+//! 2. `KILN_CONFIG` environment variable
+//! 3. `./kiln.toml` in the current working directory (if it exists)
+//! 4. No file — use defaults only
+
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+/// Top-level configuration for kiln.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct KilnConfig {
+    pub server: ServerConfig,
+    pub model: ModelConfig,
+    pub memory: MemoryConfig,
+    pub training: TrainingConfig,
+    pub logging: LoggingConfig,
+}
+
+/// HTTP server settings.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub request_timeout_secs: u64,
+    pub shutdown_timeout_secs: u64,
+}
+
+/// Model and tokenizer paths.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct ModelConfig {
+    pub path: Option<String>,
+    pub model_id: String,
+    pub tokenizer_path: Option<String>,
+    pub adapter_dir: Option<String>,
+}
+
+/// GPU memory allocation settings.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct MemoryConfig {
+    pub num_blocks: Option<usize>,
+    pub gpu_memory_gb: Option<f64>,
+    pub inference_memory_fraction: f64,
+    pub training_memory_gb: Option<f64>,
+}
+
+/// Training-specific settings.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct TrainingConfig {
+    pub grad_checkpoint_segments: Option<usize>,
+    pub no_grad_checkpoint: bool,
+}
+
+/// Logging settings.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct LoggingConfig {
+    pub level: String,
+    pub format: String,
+}
+
+// --- Defaults ---
+
+impl Default for KilnConfig {
+    fn default() -> Self {
+        Self {
+            server: ServerConfig::default(),
+            model: ModelConfig::default(),
+            memory: MemoryConfig::default(),
+            training: TrainingConfig::default(),
+            logging: LoggingConfig::default(),
+        }
+    }
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: "0.0.0.0".into(),
+            port: 8420,
+            request_timeout_secs: 300,
+            shutdown_timeout_secs: 30,
+        }
+    }
+}
+
+impl Default for ModelConfig {
+    fn default() -> Self {
+        Self {
+            path: None,
+            model_id: "Qwen/Qwen3.5-4B".into(),
+            tokenizer_path: None,
+            adapter_dir: None,
+        }
+    }
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            num_blocks: None,
+            gpu_memory_gb: None,
+            inference_memory_fraction: 0.7,
+            training_memory_gb: None,
+        }
+    }
+}
+
+impl Default for TrainingConfig {
+    fn default() -> Self {
+        Self {
+            grad_checkpoint_segments: None,
+            no_grad_checkpoint: false,
+        }
+    }
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: "info".into(),
+            format: "json".into(),
+        }
+    }
+}
+
+// --- Loading and validation ---
+
+impl KilnConfig {
+    /// Load configuration from an optional file path, then apply env var overrides.
+    ///
+    /// Resolution order for the file path:
+    /// 1. `path` argument (if `Some`)
+    /// 2. `KILN_CONFIG` env var
+    /// 3. `./kiln.toml` (only if it exists)
+    /// 4. No file — defaults only
+    pub fn load(path: Option<&str>) -> Result<Self> {
+        let config_path = path
+            .map(String::from)
+            .or_else(|| std::env::var("KILN_CONFIG").ok());
+
+        let mut config = if let Some(ref p) = config_path {
+            let contents = std::fs::read_to_string(p)
+                .with_context(|| format!("failed to read config file: {p}"))?;
+            toml::from_str(&contents)
+                .with_context(|| format!("failed to parse config file: {p}"))?
+        } else if Path::new("kiln.toml").exists() {
+            let contents = std::fs::read_to_string("kiln.toml")
+                .context("failed to read kiln.toml")?;
+            toml::from_str(&contents).context("failed to parse kiln.toml")?
+        } else {
+            Self::default()
+        };
+
+        config.apply_env_overrides();
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Override config values with KILN_* environment variables (if set).
+    fn apply_env_overrides(&mut self) {
+        // Server
+        if let Ok(v) = std::env::var("KILN_HOST") {
+            self.server.host = v;
+        }
+        if let Ok(v) = std::env::var("KILN_PORT") {
+            if let Ok(p) = v.parse() {
+                self.server.port = p;
+            }
+        }
+        if let Ok(v) = std::env::var("KILN_REQUEST_TIMEOUT_SECS") {
+            if let Ok(s) = v.parse() {
+                self.server.request_timeout_secs = s;
+            }
+        }
+        if let Ok(v) = std::env::var("KILN_SHUTDOWN_TIMEOUT_SECS") {
+            if let Ok(s) = v.parse() {
+                self.server.shutdown_timeout_secs = s;
+            }
+        }
+
+        // Model
+        if let Ok(v) = std::env::var("KILN_MODEL_PATH") {
+            self.model.path = Some(v);
+        }
+        if let Ok(v) = std::env::var("KILN_MODEL_ID") {
+            self.model.model_id = v;
+        }
+        if let Ok(v) = std::env::var("KILN_TOKENIZER_PATH") {
+            self.model.tokenizer_path = Some(v);
+        }
+        if let Ok(v) = std::env::var("KILN_ADAPTER_DIR") {
+            self.model.adapter_dir = Some(v);
+        }
+
+        // Memory
+        if let Ok(v) = std::env::var("KILN_NUM_BLOCKS") {
+            if let Ok(n) = v.parse() {
+                self.memory.num_blocks = Some(n);
+            }
+        }
+        if let Ok(v) = std::env::var("KILN_GPU_MEMORY_GB") {
+            if let Ok(g) = v.parse() {
+                self.memory.gpu_memory_gb = Some(g);
+            }
+        }
+        if let Ok(v) = std::env::var("KILN_INFERENCE_MEMORY_FRACTION") {
+            if let Ok(f) = v.parse::<f64>() {
+                self.memory.inference_memory_fraction = f;
+            }
+        }
+        if let Ok(v) = std::env::var("KILN_TRAINING_MEMORY_GB") {
+            if let Ok(g) = v.parse() {
+                self.memory.training_memory_gb = Some(g);
+            }
+        }
+
+        // Training
+        if let Ok(v) = std::env::var("KILN_GRAD_CHECKPOINT_SEGMENTS") {
+            if let Ok(s) = v.parse() {
+                self.training.grad_checkpoint_segments = Some(s);
+            }
+        }
+        if let Ok(v) = std::env::var("KILN_NO_GRAD_CHECKPOINT") {
+            self.training.no_grad_checkpoint = v == "1" || v.eq_ignore_ascii_case("true");
+        }
+
+        // Logging
+        if let Ok(v) = std::env::var("KILN_LOG_LEVEL") {
+            self.logging.level = v;
+        }
+        if let Ok(v) = std::env::var("KILN_LOG_FORMAT") {
+            self.logging.format = v;
+        }
+    }
+
+    /// Validate configuration values. Returns an error describing the first invalid value.
+    fn validate(&self) -> Result<()> {
+        if self.server.port == 0 {
+            anyhow::bail!("server.port must be > 0");
+        }
+        if self.server.request_timeout_secs == 0 {
+            anyhow::bail!("server.request_timeout_secs must be > 0");
+        }
+        if self.server.shutdown_timeout_secs == 0 {
+            anyhow::bail!("server.shutdown_timeout_secs must be > 0");
+        }
+
+        let f = self.memory.inference_memory_fraction;
+        if !(0.0..=1.0).contains(&f) {
+            anyhow::bail!(
+                "memory.inference_memory_fraction must be between 0.0 and 1.0, got {f}"
+            );
+        }
+
+        let valid_levels = ["trace", "debug", "info", "warn", "error"];
+        let level = self.logging.level.to_lowercase();
+        // Allow both simple levels and tracing filter directives (contain '=')
+        if !valid_levels.contains(&level.as_str()) && !level.contains('=') {
+            anyhow::bail!(
+                "logging.level must be one of {valid_levels:?} or a tracing filter directive, got '{}'",
+                self.logging.level
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_defaults() {
+        let config = KilnConfig::default();
+        assert_eq!(config.server.host, "0.0.0.0");
+        assert_eq!(config.server.port, 8420);
+        assert_eq!(config.server.request_timeout_secs, 300);
+        assert_eq!(config.server.shutdown_timeout_secs, 30);
+        assert_eq!(config.model.model_id, "Qwen/Qwen3.5-4B");
+        assert!(config.model.path.is_none());
+        assert!(config.model.tokenizer_path.is_none());
+        assert!(config.model.adapter_dir.is_none());
+        assert!(config.memory.num_blocks.is_none());
+        assert_eq!(config.memory.inference_memory_fraction, 0.7);
+        assert!(!config.training.no_grad_checkpoint);
+        assert_eq!(config.logging.level, "info");
+        assert_eq!(config.logging.format, "json");
+    }
+
+    #[test]
+    fn test_parse_full_toml() {
+        let toml_str = r#"
+[server]
+host = "127.0.0.1"
+port = 9000
+request_timeout_secs = 60
+shutdown_timeout_secs = 10
+
+[model]
+path = "/models/qwen"
+model_id = "custom/model"
+tokenizer_path = "/models/tokenizer.json"
+adapter_dir = "/models/adapters"
+
+[memory]
+num_blocks = 128
+gpu_memory_gb = 24.0
+inference_memory_fraction = 0.5
+training_memory_gb = 6.0
+
+[training]
+grad_checkpoint_segments = 8
+no_grad_checkpoint = false
+
+[logging]
+level = "debug"
+format = "pretty"
+"#;
+        let config: KilnConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.server.host, "127.0.0.1");
+        assert_eq!(config.server.port, 9000);
+        assert_eq!(config.server.request_timeout_secs, 60);
+        assert_eq!(config.model.path.as_deref(), Some("/models/qwen"));
+        assert_eq!(config.model.model_id, "custom/model");
+        assert_eq!(config.memory.num_blocks, Some(128));
+        assert_eq!(config.memory.gpu_memory_gb, Some(24.0));
+        assert_eq!(config.memory.inference_memory_fraction, 0.5);
+        assert_eq!(config.memory.training_memory_gb, Some(6.0));
+        assert_eq!(config.training.grad_checkpoint_segments, Some(8));
+        assert_eq!(config.logging.level, "debug");
+        assert_eq!(config.logging.format, "pretty");
+    }
+
+    #[test]
+    fn test_partial_toml_uses_defaults() {
+        let toml_str = r#"
+[server]
+port = 3000
+"#;
+        let config: KilnConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.server.port, 3000);
+        assert_eq!(config.server.host, "0.0.0.0"); // default
+        assert_eq!(config.server.request_timeout_secs, 300); // default
+        assert_eq!(config.model.model_id, "Qwen/Qwen3.5-4B"); // default
+        assert_eq!(config.memory.inference_memory_fraction, 0.7); // default
+        assert_eq!(config.logging.level, "info"); // default
+    }
+
+    #[test]
+    fn test_validation_rejects_port_zero() {
+        let mut config = KilnConfig::default();
+        config.server.port = 0;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_fraction_above_one() {
+        let mut config = KilnConfig::default();
+        config.memory.inference_memory_fraction = 1.5;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_negative_fraction() {
+        let mut config = KilnConfig::default();
+        config.memory.inference_memory_fraction = -0.1;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_rejects_bad_log_level() {
+        let mut config = KilnConfig::default();
+        config.logging.level = "banana".into();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validation_accepts_filter_directive() {
+        let mut config = KilnConfig::default();
+        config.logging.level = "kiln=trace,tower_http=warn".into();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validation_rejects_zero_timeout() {
+        let mut config = KilnConfig::default();
+        config.server.request_timeout_secs = 0;
+        assert!(config.validate().is_err());
+
+        let mut config2 = KilnConfig::default();
+        config2.server.shutdown_timeout_secs = 0;
+        assert!(config2.validate().is_err());
+    }
+
+    #[test]
+    fn test_env_var_overrides() {
+        // Safety: these tests manipulate env vars which is unsafe in Rust 1.78+.
+        // They are safe because cargo test runs lib tests single-threaded by default.
+        unsafe {
+            std::env::set_var("KILN_HOST", "10.0.0.1");
+            std::env::set_var("KILN_PORT", "7777");
+            std::env::set_var("KILN_MODEL_PATH", "/tmp/model");
+            std::env::set_var("KILN_INFERENCE_MEMORY_FRACTION", "0.9");
+            std::env::set_var("KILN_LOG_LEVEL", "debug");
+            std::env::set_var("KILN_NO_GRAD_CHECKPOINT", "1");
+        }
+
+        let mut config = KilnConfig::default();
+        config.apply_env_overrides();
+
+        assert_eq!(config.server.host, "10.0.0.1");
+        assert_eq!(config.server.port, 7777);
+        assert_eq!(config.model.path.as_deref(), Some("/tmp/model"));
+        assert_eq!(config.memory.inference_memory_fraction, 0.9);
+        assert_eq!(config.logging.level, "debug");
+        assert!(config.training.no_grad_checkpoint);
+
+        // Clean up
+        unsafe {
+            std::env::remove_var("KILN_HOST");
+            std::env::remove_var("KILN_PORT");
+            std::env::remove_var("KILN_MODEL_PATH");
+            std::env::remove_var("KILN_INFERENCE_MEMORY_FRACTION");
+            std::env::remove_var("KILN_LOG_LEVEL");
+            std::env::remove_var("KILN_NO_GRAD_CHECKPOINT");
+        }
+    }
+
+    #[test]
+    fn test_load_missing_file_returns_defaults() {
+        // With no file and no KILN_CONFIG env var, should return defaults
+        unsafe {
+            std::env::remove_var("KILN_CONFIG");
+            // Clear env vars that would override defaults
+            std::env::remove_var("KILN_HOST");
+            std::env::remove_var("KILN_PORT");
+            std::env::remove_var("KILN_MODEL_PATH");
+            std::env::remove_var("KILN_LOG_LEVEL");
+            std::env::remove_var("KILN_LOG_FORMAT");
+            std::env::remove_var("KILN_NO_GRAD_CHECKPOINT");
+        }
+        // Load from a path that doesn't exist via the CWD fallback (kiln.toml won't exist in test dir)
+        let config = KilnConfig::load(None).unwrap();
+        assert_eq!(config.server.port, 8420);
+        assert_eq!(config.model.model_id, "Qwen/Qwen3.5-4B");
+    }
+
+    #[test]
+    fn test_load_explicit_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("test.toml");
+        std::fs::write(
+            &path,
+            r#"
+[server]
+port = 5555
+
+[logging]
+level = "warn"
+"#,
+        )
+        .unwrap();
+
+        unsafe {
+            // Clear env vars so they don't interfere
+            std::env::remove_var("KILN_PORT");
+            std::env::remove_var("KILN_LOG_LEVEL");
+            std::env::remove_var("KILN_LOG_FORMAT");
+            std::env::remove_var("KILN_HOST");
+            std::env::remove_var("KILN_MODEL_PATH");
+            std::env::remove_var("KILN_NO_GRAD_CHECKPOINT");
+        }
+
+        let config = KilnConfig::load(Some(path.to_str().unwrap())).unwrap();
+        assert_eq!(config.server.port, 5555);
+        assert_eq!(config.logging.level, "warn");
+        assert_eq!(config.server.host, "0.0.0.0"); // default
+    }
+
+    #[test]
+    fn test_load_nonexistent_explicit_path_errors() {
+        let result = KilnConfig::load(Some("/no/such/file.toml"));
+        assert!(result.is_err());
+    }
+}

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -1,6 +1,7 @@
 //! Kiln HTTP server — library interface for integration testing.
 
 pub mod api;
+pub mod config;
 pub mod logging;
 pub mod metrics;
 pub mod state;

--- a/crates/kiln-server/src/logging.rs
+++ b/crates/kiln-server/src/logging.rs
@@ -1,6 +1,6 @@
 //! Structured logging initialization.
 //!
-//! Configurable via environment variables:
+//! Configurable via the `[logging]` section of `kiln.toml` or environment variables:
 //! - `KILN_LOG_LEVEL`: verbosity level (`trace`, `debug`, `info`, `warn`, `error`)
 //!   or a full `tracing_subscriber::EnvFilter` directive. Default: `info`.
 //! - `KILN_LOG_FORMAT`: output format — `json` (default) for structured JSON,
@@ -9,12 +9,10 @@
 
 use tracing_subscriber::EnvFilter;
 
-/// Build an `EnvFilter` from `RUST_LOG` (if set) or `KILN_LOG_LEVEL`.
-pub fn build_filter() -> EnvFilter {
-    let level = std::env::var("KILN_LOG_LEVEL").unwrap_or_else(|_| "info".into());
-
+/// Build an `EnvFilter` from `RUST_LOG` (if set) or the provided level string.
+pub fn build_filter(level: &str) -> EnvFilter {
     EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        match level.as_str() {
+        match level {
             "trace" | "debug" | "info" | "warn" | "error" => {
                 format!("kiln={level},kiln_server={level},tower_http={level}")
                     .parse()
@@ -31,13 +29,15 @@ pub fn build_filter() -> EnvFilter {
 
 /// Initialize the global tracing subscriber.
 ///
+/// `level`: log level or tracing filter directive (e.g. `"info"`, `"kiln=trace,tower_http=warn"`).
+/// `format`: output format — `"json"` (default), `"pretty"`, `"text"`, or `"human"`.
+///
 /// Call once at startup. Panics if called twice (tracing's global subscriber
 /// can only be set once per process).
-pub fn init() -> anyhow::Result<()> {
-    let format = std::env::var("KILN_LOG_FORMAT").unwrap_or_else(|_| "json".into());
-    let filter = build_filter();
+pub fn init(level: &str, format: &str) -> anyhow::Result<()> {
+    let filter = build_filter(level);
 
-    match format.as_str() {
+    match format {
         "pretty" | "text" | "human" => {
             tracing_subscriber::fmt()
                 .with_env_filter(filter)
@@ -68,9 +68,8 @@ mod tests {
         // Ensure RUST_LOG is not set for this test
         unsafe {
             std::env::remove_var("RUST_LOG");
-            std::env::remove_var("KILN_LOG_LEVEL");
         }
-        let filter = build_filter();
+        let filter = build_filter("info");
         let s = format!("{filter}");
         assert!(s.contains("info"), "default filter should contain info: {s}");
     }
@@ -79,30 +78,26 @@ mod tests {
     fn test_build_filter_custom_level() {
         unsafe {
             std::env::remove_var("RUST_LOG");
-            std::env::set_var("KILN_LOG_LEVEL", "debug");
         }
-        let filter = build_filter();
+        let filter = build_filter("debug");
         let s = format!("{filter}");
         assert!(
             s.contains("debug"),
             "filter should contain debug: {s}"
         );
-        unsafe { std::env::remove_var("KILN_LOG_LEVEL"); }
     }
 
     #[test]
     fn test_build_filter_custom_directive() {
         unsafe {
             std::env::remove_var("RUST_LOG");
-            std::env::set_var("KILN_LOG_LEVEL", "kiln=trace,tower_http=warn");
         }
-        let filter = build_filter();
+        let filter = build_filter("kiln=trace,tower_http=warn");
         let s = format!("{filter}");
         // Custom directive is parsed as-is (not expanded to the standard triple)
         assert!(
             s.contains("kiln=trace") || s.contains("tower_http=warn"),
             "filter should parse custom directive: {s}"
         );
-        unsafe { std::env::remove_var("KILN_LOG_LEVEL"); }
     }
 }

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use kiln_server::api;
+use kiln_server::config::KilnConfig;
 use kiln_server::state;
 
 use kiln_core::config::ModelConfig;
@@ -16,26 +17,26 @@ use state::AppState;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    kiln_server::logging::init()?;
+    // Parse optional --config <path> argument
+    let config_path = parse_config_arg();
+    let config = KilnConfig::load(config_path.as_deref())?;
 
-    let host = std::env::var("KILN_HOST").unwrap_or_else(|_| "0.0.0.0".into());
-    let port: u16 = std::env::var("KILN_PORT")
-        .ok()
-        .and_then(|p| p.parse().ok())
-        .unwrap_or(8420);
+    kiln_server::logging::init(&config.logging.level, &config.logging.format)?;
+
+    let host = &config.server.host;
+    let port = config.server.port;
 
     let model_config = ModelConfig::qwen3_5_4b();
-    let model_path = std::env::var("KILN_MODEL_PATH").ok();
+    let model_path = config.model.path.as_deref();
 
     // Load tokenizer: try from_pretrained (HF Hub), fall back to local path, then fail gracefully.
-    let model_id =
-        std::env::var("KILN_MODEL_ID").unwrap_or_else(|_| "Qwen/Qwen3.5-4B".to_string());
-    let tokenizer_path = std::env::var("KILN_TOKENIZER_PATH").ok();
+    let model_id = &config.model.model_id;
+    let tokenizer_path = config.model.tokenizer_path.as_deref();
 
-    let tokenizer = if let Some(path) = &tokenizer_path {
+    let tokenizer = if let Some(path) = tokenizer_path {
         tracing::info!("loading tokenizer from {path}");
         KilnTokenizer::from_file(path)?
-    } else if let Some(ref mp) = model_path {
+    } else if let Some(mp) = model_path {
         // Try loading tokenizer from the model directory first
         let tok_file = Path::new(mp).join("tokenizer.json");
         if tok_file.exists() {
@@ -43,11 +44,11 @@ async fn main() -> Result<()> {
             KilnTokenizer::from_file(tok_file.to_str().unwrap())?
         } else {
             tracing::info!("loading tokenizer from HuggingFace Hub: {model_id}");
-            KilnTokenizer::from_pretrained(&model_id)?
+            KilnTokenizer::from_pretrained(model_id)?
         }
     } else {
         tracing::info!("loading tokenizer from HuggingFace Hub: {model_id}");
-        KilnTokenizer::from_pretrained(&model_id)?
+        KilnTokenizer::from_pretrained(model_id)?
     };
 
     tracing::info!(
@@ -55,7 +56,7 @@ async fn main() -> Result<()> {
         "tokenizer loaded successfully"
     );
 
-    let state = if let Some(ref mp) = model_path {
+    let state = if let Some(mp) = model_path {
         // Real inference mode: load model weights and create ModelRunner.
         tracing::info!("loading model weights from {mp}");
         let model_weights = kiln_model::load_model(Path::new(mp), &model_config)?;
@@ -69,22 +70,25 @@ async fn main() -> Result<()> {
         let gpu_weights = GpuWeights::from_model_weights(&model_weights, &device)?;
 
         // ModelRunner takes ownership of a tokenizer, so load a second instance.
-        let runner_tokenizer = if let Some(ref path) = tokenizer_path {
+        let runner_tokenizer = if let Some(path) = tokenizer_path {
             KilnTokenizer::from_file(path)?
         } else {
             let tok_file = Path::new(mp).join("tokenizer.json");
             if tok_file.exists() {
                 KilnTokenizer::from_file(tok_file.to_str().unwrap())?
             } else {
-                KilnTokenizer::from_pretrained(&model_id)?
+                KilnTokenizer::from_pretrained(model_id)?
             }
         };
 
         let runner = ModelRunner::new(gpu_weights, runner_tokenizer, model_config.clone());
 
-        let adapter_dir = std::env::var("KILN_ADAPTER_DIR")
+        let adapter_dir = config
+            .model
+            .adapter_dir
+            .as_ref()
             .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from(mp).join("adapters"));
+            .unwrap_or_else(|| PathBuf::from(mp).join("adapters"));
 
         if !adapter_dir.exists() {
             tracing::info!(path = %adapter_dir.display(), "creating adapter directory");
@@ -93,10 +97,18 @@ async fn main() -> Result<()> {
 
         tracing::info!(adapter_dir = %adapter_dir.display(), "model loaded — real inference mode");
         tracing::info!("training endpoints available — in-process LoRA training (no sidecar needed)");
-        AppState::new_real(model_config, runner, tokenizer, device, adapter_dir)
+        AppState::new_real(
+            model_config,
+            runner,
+            tokenizer,
+            device,
+            adapter_dir,
+            &config.memory,
+            config.server.request_timeout_secs,
+        )
     } else {
         // Mock mode: use scheduler + mock engine.
-        tracing::info!("no KILN_MODEL_PATH set — running in mock mode");
+        tracing::info!("no model path set — running in mock mode");
         tracing::info!("training endpoints will return 503 in mock mode (no real weights)");
         let scheduler_config = SchedulerConfig {
             max_batch_tokens: 8192,
@@ -106,7 +118,13 @@ async fn main() -> Result<()> {
         let num_blocks = 8192;
         let scheduler = Scheduler::new(scheduler_config, num_blocks);
         let engine = MockEngine::new(model_config.clone());
-        AppState::new_mock(model_config, scheduler, Arc::new(engine), tokenizer)
+        AppState::new_mock(
+            model_config,
+            scheduler,
+            Arc::new(engine),
+            tokenizer,
+            config.server.request_timeout_secs,
+        )
     };
 
     // Spawn the background training queue worker
@@ -120,16 +138,13 @@ async fn main() -> Result<()> {
     tracing::info!(
         host = %host,
         port = port,
-        model_path = model_path.as_deref().unwrap_or("none (mock mode)"),
+        model_path = model_path.unwrap_or("none (mock mode)"),
         "kiln listening"
     );
 
     // Graceful shutdown: listen for SIGTERM/SIGINT, drain in-flight requests,
     // then force-exit after a timeout.
-    let shutdown_timeout_secs: u64 = std::env::var("KILN_SHUTDOWN_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(30);
+    let shutdown_timeout_secs = config.server.shutdown_timeout_secs;
 
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(shutdown_flag))
@@ -145,6 +160,17 @@ async fn main() -> Result<()> {
     tracing::warn!("shutdown timeout reached — exiting");
 
     Ok(())
+}
+
+/// Parse an optional `--config <path>` argument from argv.
+fn parse_config_arg() -> Option<String> {
+    let args: Vec<String> = std::env::args().collect();
+    for i in 1..args.len() {
+        if args[i] == "--config" {
+            return args.get(i + 1).cloned();
+        }
+    }
+    None
 }
 
 /// Wait for SIGTERM or SIGINT, then signal shutdown.

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -42,28 +42,28 @@ impl GpuMemoryBudget {
     /// `total_vram_bytes`: Total GPU VRAM (0 for CPU).
     /// `model_memory_bytes`: Estimated model weight size.
     /// `kv_cache_bytes`: Actual KV cache allocation size.
-    /// `inference_fraction`: Fraction of VRAM for inference (from env).
+    /// `inference_fraction`: Fraction of VRAM for inference.
+    /// `training_memory_gb`: Optional explicit training memory budget in GB.
     pub fn compute(
         total_vram_bytes: u64,
         model_memory_bytes: u64,
         kv_cache_bytes: u64,
         inference_fraction: f64,
+        training_memory_gb: Option<f64>,
     ) -> Self {
         let training_budget_bytes = if total_vram_bytes == 0 {
             // CPU mode — no GPU memory budget applies
             0
         } else {
-            // Override via KILN_TRAINING_MEMORY_GB if set
-            if let Ok(val) = std::env::var("KILN_TRAINING_MEMORY_GB") {
-                if let Ok(gb) = val.parse::<f64>() {
-                    return Self {
-                        total_vram_bytes,
-                        model_memory_bytes,
-                        kv_cache_bytes,
-                        training_budget_bytes: (gb * 1024.0 * 1024.0 * 1024.0) as u64,
-                        inference_memory_fraction: inference_fraction,
-                    };
-                }
+            // Explicit override takes precedence
+            if let Some(gb) = training_memory_gb {
+                return Self {
+                    total_vram_bytes,
+                    model_memory_bytes,
+                    kv_cache_bytes,
+                    training_budget_bytes: (gb * 1024.0 * 1024.0 * 1024.0) as u64,
+                    inference_memory_fraction: inference_fraction,
+                };
             }
             // Auto-detect: total - model - kv_cache
             total_vram_bytes
@@ -193,6 +193,7 @@ impl AppState {
         scheduler: Scheduler,
         engine: Arc<dyn Engine>,
         tokenizer: KilnTokenizer,
+        request_timeout_secs: u64,
     ) -> Self {
         Self {
             model_config,
@@ -204,7 +205,7 @@ impl AppState {
             adapter_dir: PathBuf::from("adapters"),
             active_adapter_name: Arc::new(std::sync::RwLock::new(None)),
             training_jobs: Arc::new(std::sync::RwLock::new(HashMap::new())),
-            memory_budget: Arc::new(GpuMemoryBudget::compute(0, 0, 0, 1.0)),
+            memory_budget: Arc::new(GpuMemoryBudget::compute(0, 0, 0, 1.0, None)),
             gpu_lock: Arc::new(std::sync::RwLock::new(())),
             training_queue: crate::training_queue::new_shared_queue(),
             vram_info: kiln_core::vram::GpuVramInfo {
@@ -212,7 +213,7 @@ impl AppState {
                 source: kiln_core::vram::VramSource::None,
             },
             shutdown: crate::training_queue::new_shutdown_flag(),
-            request_timeout: parse_request_timeout(),
+            request_timeout: std::time::Duration::from_secs(request_timeout_secs),
             metrics: Arc::new(Metrics::new()),
             started_at: std::time::Instant::now(),
         }
@@ -221,17 +222,20 @@ impl AppState {
     /// Create an AppState with a real ModelRunner backend and paged KV cache.
     ///
     /// Uses `block_size=16` by default. The number of blocks can be overridden
-    /// with `KILN_NUM_BLOCKS`. Otherwise derived from `max_position_embeddings / block_size`.
+    /// via `memory_cfg.num_blocks`. Otherwise derived from available VRAM or
+    /// `max_position_embeddings / block_size`.
     ///
-    /// GPU memory sharing: When `KILN_INFERENCE_MEMORY_FRACTION` is set (default 0.7),
-    /// KV cache allocation is limited to that fraction of remaining VRAM (after model weights),
-    /// reserving the rest for training. Set to 1.0 to use all available VRAM for inference.
+    /// GPU memory sharing: `memory_cfg.inference_memory_fraction` (default 0.7)
+    /// controls what fraction of remaining VRAM (after model weights) is allocated
+    /// to KV cache, reserving the rest for training. Set to 1.0 for inference-only.
     pub fn new_real(
         model_config: ModelConfig,
         runner: ModelRunner,
         tokenizer: KilnTokenizer,
         device: candle_core::Device,
         adapter_dir: PathBuf,
+        memory_cfg: &crate::config::MemoryConfig,
+        request_timeout_secs: u64,
     ) -> Self {
         let block_size = 16;
 
@@ -246,12 +250,7 @@ impl AppState {
             _ => 4,
         };
 
-        // Read inference memory fraction (default 0.7 = reserve 30% for training)
-        let inference_fraction: f64 = std::env::var("KILN_INFERENCE_MEMORY_FRACTION")
-            .ok()
-            .and_then(|v| v.parse::<f64>().ok())
-            .unwrap_or(0.7)
-            .clamp(0.1, 1.0);
+        let inference_fraction = memory_cfg.inference_memory_fraction.clamp(0.1, 1.0);
 
         // Estimate model weight memory (approximate: params * dtype_bytes)
         // Qwen3.5-4B ≈ 4B params * 2 bytes (bf16) ≈ 8GB
@@ -269,11 +268,8 @@ impl AppState {
         // Detect VRAM for auto-configuration
         let vram_info = kiln_core::vram::detect_vram();
 
-        // Determine num_blocks — either from env, or memory-aware auto-calculation
-        let num_blocks = if let Some(explicit) = std::env::var("KILN_NUM_BLOCKS")
-            .ok()
-            .and_then(|v| v.parse::<usize>().ok())
-        {
+        // Determine num_blocks — either from config, or memory-aware auto-calculation
+        let num_blocks = if let Some(explicit) = memory_cfg.num_blocks {
             explicit
         } else {
             // Try to compute from available VRAM and inference fraction
@@ -319,6 +315,7 @@ impl AppState {
             estimated_model_bytes,
             kv_cache_bytes,
             inference_fraction,
+            memory_cfg.training_memory_gb,
         );
 
         tracing::info!(
@@ -346,20 +343,11 @@ impl AppState {
             training_queue: crate::training_queue::new_shared_queue(),
             vram_info,
             shutdown: crate::training_queue::new_shutdown_flag(),
-            request_timeout: parse_request_timeout(),
+            request_timeout: std::time::Duration::from_secs(request_timeout_secs),
             metrics: Arc::new(Metrics::new()),
             started_at: std::time::Instant::now(),
         }
     }
-}
-
-/// Parse KILN_REQUEST_TIMEOUT_SECS from environment (default: 300 seconds).
-fn parse_request_timeout() -> std::time::Duration {
-    let secs: u64 = std::env::var("KILN_REQUEST_TIMEOUT_SECS")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(300);
-    std::time::Duration::from_secs(secs)
 }
 
 /// Estimate model weight memory in bytes from config.
@@ -417,7 +405,7 @@ mod tests {
 
     #[test]
     fn test_memory_budget_cpu_mode() {
-        let budget = GpuMemoryBudget::compute(0, 0, 0, 0.7);
+        let budget = GpuMemoryBudget::compute(0, 0, 0, 0.7, None);
         assert_eq!(budget.total_vram_bytes, 0);
         assert_eq!(budget.training_budget_bytes, 0);
         // CPU mode: training feasibility check always passes
@@ -429,7 +417,7 @@ mod tests {
         let total: u64 = 24 * 1024 * 1024 * 1024; // 24 GB
         let model: u64 = 8 * 1024 * 1024 * 1024; // 8 GB model
         let kv: u64 = 2 * 1024 * 1024 * 1024; // 2 GB KV cache
-        let budget = GpuMemoryBudget::compute(total, model, kv, 0.7);
+        let budget = GpuMemoryBudget::compute(total, model, kv, 0.7, None);
         assert_eq!(budget.total_vram_bytes, total);
         assert_eq!(budget.model_memory_bytes, model);
         assert_eq!(budget.kv_cache_bytes, kv);
@@ -442,7 +430,7 @@ mod tests {
         let total: u64 = 24 * 1024 * 1024 * 1024;
         let model: u64 = 8 * 1024 * 1024 * 1024;
         let kv: u64 = 12 * 1024 * 1024 * 1024;
-        let budget = GpuMemoryBudget::compute(total, model, kv, 0.7);
+        let budget = GpuMemoryBudget::compute(total, model, kv, 0.7, None);
         // Only 4GB available for training
         assert_eq!(budget.training_budget_bytes, 4 * 1024 * 1024 * 1024);
         // Requesting 8GB should fail
@@ -461,7 +449,7 @@ mod tests {
         let total: u64 = 24 * 1024 * 1024 * 1024;
         let model: u64 = 20 * 1024 * 1024 * 1024;
         let kv: u64 = 10 * 1024 * 1024 * 1024;
-        let budget = GpuMemoryBudget::compute(total, model, kv, 0.7);
+        let budget = GpuMemoryBudget::compute(total, model, kv, 0.7, None);
         // Should not underflow — saturating_sub handles it
         assert_eq!(budget.training_budget_bytes, 0);
     }
@@ -483,11 +471,11 @@ mod tests {
         let kv: u64 = 2 * 1024 * 1024 * 1024;
 
         // fraction = 1.0 means all VRAM for inference, but training budget is still calculated
-        let budget_full = GpuMemoryBudget::compute(total, model, kv, 1.0);
+        let budget_full = GpuMemoryBudget::compute(total, model, kv, 1.0, None);
         assert_eq!(budget_full.training_budget_bytes, 14 * 1024 * 1024 * 1024);
 
         // fraction = 0.5
-        let budget_half = GpuMemoryBudget::compute(total, model, kv, 0.5);
+        let budget_half = GpuMemoryBudget::compute(total, model, kv, 0.5, None);
         assert_eq!(budget_half.training_budget_bytes, 14 * 1024 * 1024 * 1024);
     }
 }

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -155,7 +155,7 @@ async fn test_real_model_chat_completion() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"));
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300);
 
     let app = api::router(state);
 
@@ -220,7 +220,7 @@ async fn test_real_model_streaming_chat_completion() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"));
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300);
 
     let app = api::router(state);
 
@@ -316,15 +316,9 @@ async fn test_real_model_streaming_chat_completion() {
     );
 }
 
-/// Test that request timeout is configurable via environment variable.
+/// Test that request timeout is configurable via config parameter.
 #[tokio::test]
 async fn test_request_timeout_configurable() {
-    // SAFETY: This test runs in isolation; no concurrent threads depend on
-    // KILN_REQUEST_TIMEOUT_SECS at this point.
-    unsafe {
-        std::env::set_var("KILN_REQUEST_TIMEOUT_SECS", "42");
-    }
-
     let config = tiny_config();
     let device = Device::Cpu;
     let weights = tiny_weights(&config, &device);
@@ -339,23 +333,16 @@ async fn test_request_timeout_configurable() {
         state_tokenizer,
         device.clone(),
         std::path::PathBuf::from("/tmp/kiln-test-adapters"),
+        &kiln_server::config::MemoryConfig::default(),
+        42,
     );
 
     assert_eq!(state.request_timeout.as_secs(), 42);
-
-    unsafe {
-        std::env::remove_var("KILN_REQUEST_TIMEOUT_SECS");
-    }
 }
 
-/// Test that default request timeout is 300 seconds when env var is unset.
+/// Test that default request timeout is 300 seconds.
 #[tokio::test]
 async fn test_default_request_timeout() {
-    // SAFETY: same as above — isolated test environment.
-    unsafe {
-        std::env::remove_var("KILN_REQUEST_TIMEOUT_SECS");
-    }
-
     let config = tiny_config();
     let device = Device::Cpu;
     let weights = tiny_weights(&config, &device);
@@ -370,6 +357,8 @@ async fn test_default_request_timeout() {
         state_tokenizer,
         device.clone(),
         std::path::PathBuf::from("/tmp/kiln-test-adapters"),
+        &kiln_server::config::MemoryConfig::default(),
+        300,
     );
 
     assert_eq!(state.request_timeout.as_secs(), 300);
@@ -385,7 +374,7 @@ async fn test_health_with_real_backend() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"));
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300);
 
     let app = api::router(state);
 

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -1,0 +1,34 @@
+# Kiln configuration — all values shown are defaults.
+# Environment variables (KILN_*) override any value set here.
+#
+# Config file resolution order:
+#   1. --config <path> CLI argument
+#   2. KILN_CONFIG environment variable
+#   3. ./kiln.toml in the current working directory
+#   4. No file — built-in defaults
+
+[server]
+host = "0.0.0.0"
+port = 8420
+request_timeout_secs = 300
+shutdown_timeout_secs = 30
+
+[model]
+# path = "/path/to/model"            # Required for real inference (omit for mock mode)
+model_id = "Qwen/Qwen3.5-4B"
+# tokenizer_path = "/path/to/tokenizer.json"
+# adapter_dir = "/path/to/adapters"  # Default: <model_path>/adapters
+
+[memory]
+# num_blocks = 256                   # KV cache blocks (auto-sized from VRAM if omitted)
+# gpu_memory_gb = 24.0               # Override detected VRAM (for testing)
+inference_memory_fraction = 0.7       # Fraction of VRAM for inference (rest for training)
+# training_memory_gb = 4.0           # Override auto-calculated training budget
+
+[training]
+# grad_checkpoint_segments = 4       # Segments for gradient checkpointing
+no_grad_checkpoint = false
+
+[logging]
+level = "info"                        # trace, debug, info, warn, error, or a filter directive
+format = "json"                       # json, pretty, text, human


### PR DESCRIPTION
## What
Centralize all KILN_* env vars into an optional `kiln.toml` config file with typed validation and good defaults. Env vars still override config file values (highest priority).

## Changes
- New `config.rs` module with `KilnConfig` struct: typed TOML parsing, env var overrides, and validation
- Config file resolution: `--config` flag > `KILN_CONFIG` env > `./kiln.toml` > built-in defaults
- Updated `logging::init()` to accept level/format params instead of reading env vars directly
- Updated `AppState::new_real/new_mock` to accept config values as parameters
- `GpuMemoryBudget::compute` now takes `training_memory_gb` as explicit `Option<f64>`
- Added `kiln.example.toml` with all defaults documented
- 12 new unit tests for config loading, parsing, validation, and env var overrides

## Validation rules
- `server.port` must be > 0
- `server.request_timeout_secs` and `shutdown_timeout_secs` must be > 0
- `memory.inference_memory_fraction` must be between 0.0 and 1.0
- `logging.level` must be a valid level or tracing filter directive

## Test results
All 30 kiln-server lib tests pass (build + test on RunPod A6000 with `--features flash-attn`).

Phase 5h of production hardening.