### PR TITLE
Add Dockerfile and systemd unit file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+sidecar/
+*.swp
+*.swo
+*~
+.DS_Store

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,71 @@
+# Multi-stage Dockerfile for kiln inference server
+# Requires NVIDIA Container Toolkit for GPU access at runtime
+
+# ---------------------------------------------------------------------------
+# Builder stage — compile with CUDA dev tools and Rust nightly
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl build-essential pkg-config libssl-dev git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust (nightly required for edition = "2024")
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | sh -s -- -y --default-toolchain nightly
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /build
+
+# Copy manifests first for layer caching
+COPY Cargo.toml Cargo.lock* ./
+COPY crates/kiln-core/Cargo.toml          crates/kiln-core/Cargo.toml
+COPY crates/kiln-flash-attn/Cargo.toml    crates/kiln-flash-attn/Cargo.toml
+COPY crates/kiln-flash-attn/build.rs      crates/kiln-flash-attn/build.rs
+COPY crates/kiln-model/Cargo.toml         crates/kiln-model/Cargo.toml
+COPY crates/kiln-scheduler/Cargo.toml     crates/kiln-scheduler/Cargo.toml
+COPY crates/kiln-server/Cargo.toml        crates/kiln-server/Cargo.toml
+COPY crates/kiln-train/Cargo.toml         crates/kiln-train/Cargo.toml
+
+# Create dummy source files so cargo can resolve the workspace
+RUN for crate in kiln-core kiln-flash-attn kiln-model kiln-scheduler kiln-server kiln-train; do \
+        mkdir -p crates/$crate/src && echo "" > crates/$crate/src/lib.rs; \
+    done
+
+# Pre-build dependencies (this layer is cached unless Cargo.toml changes)
+RUN cargo build --release --features cuda 2>/dev/null || true
+
+# Copy full source and build for real
+COPY . .
+# Touch source files so cargo sees them as newer than the dummy files
+RUN find crates -name "*.rs" -exec touch {} +
+
+RUN cargo build --release --features cuda
+
+# ---------------------------------------------------------------------------
+# Runtime stage — minimal image with CUDA runtime libs only
+# ---------------------------------------------------------------------------
+FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd -r kiln && useradd -r -g kiln -d /var/lib/kiln -s /sbin/nologin kiln
+RUN mkdir -p /var/lib/kiln /etc/kiln && chown kiln:kiln /var/lib/kiln
+
+# Copy binary and example config
+COPY --from=builder /build/target/release/kiln /usr/local/bin/kiln
+COPY kiln.example.toml /etc/kiln/kiln.example.toml
+
+# Default port
+EXPOSE 8420
+
+# Model path must be provided at runtime (via mount or env var)
+ENV KILN_MODEL_PATH=/models
+
+USER kiln
+ENTRYPOINT ["/usr/local/bin/kiln"]

--- a/deploy/kiln.service
+++ b/deploy/kiln.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Kiln inference server with live LoRA training
+Documentation=https://github.com/ericflo/kiln
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=exec
+User=kiln
+Group=kiln
+
+EnvironmentFile=/etc/kiln/env
+ExecStart=/usr/local/bin/kiln --config /etc/kiln/kiln.toml
+
+Restart=on-failure
+RestartSec=5s
+
+# GPU memory pinning
+LimitMEMLOCK=infinity
+
+# Allow enough file descriptors for model mmapping + connections
+LimitNOFILE=65536
+
+# Protect system directories
+ProtectSystem=strict
+ProtectHome=true
+ReadWritePaths=/var/lib/kiln
+
+# Working directory for adapter storage
+WorkingDirectory=/var/lib/kiln
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## What
- Multi-stage Dockerfile (`deploy/Dockerfile`): builder stage with `nvidia/cuda:12.4.1-devel` + Rust nightly, runtime stage with `nvidia/cuda:12.4.1-runtime` containing only the binary and example config. Runs as non-root `kiln` user.
- Systemd unit file (`deploy/kiln.service`): `Type=exec`, restart on failure, `LimitMEMLOCK=infinity` for GPU memory pinning, filesystem hardening via `ProtectSystem=strict`.
- `.dockerignore` to exclude `target/`, `.git/`, `sidecar/` from build context.

## Phase 5 progress
This is the 8th of 10 Phase 5 production hardening items.