### PR TITLE
Add structured, helpful error messages across all API endpoints

### DIFF
--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -1,13 +1,13 @@
 use std::path::Path;
 
 use axum::extract::{State, Path as AxumPath};
-use axum::http::StatusCode;
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
 use kiln_model::lora_loader::LoraWeights;
 
+use crate::error::ApiError;
 use crate::state::{AppState, ModelBackend};
 
 /// Response for GET /v1/adapters.
@@ -78,14 +78,11 @@ async fn list_adapters(State(state): State<AppState>) -> Json<AdaptersResponse> 
 async fn load_adapter(
     State(state): State<AppState>,
     Json(req): Json<LoadAdapterRequest>,
-) -> Result<Json<LoadAdapterResponse>, (StatusCode, String)> {
+) -> Result<Json<LoadAdapterResponse>, ApiError> {
     let runner = match state.backend.as_ref() {
         ModelBackend::Real { runner, .. } => runner,
         ModelBackend::Mock { .. } => {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "adapter loading not supported in mock mode".to_string(),
-            ));
+            return Err(ApiError::mock_mode_no_adapters());
         }
     };
 
@@ -97,10 +94,7 @@ async fn load_adapter(
     };
 
     if !adapter_path.exists() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            format!("adapter directory not found: {}", adapter_path.display()),
-        ));
+        return Err(ApiError::adapter_not_found(&req.name));
     }
 
     // Two-phase load: read device/num_layers under a brief read lock, then load
@@ -117,20 +111,15 @@ async fn load_adapter(
     tokio::task::spawn_blocking(move || {
         // Load weights outside any lock (I/O + tensor allocation).
         let lora = LoraWeights::load(&path, num_layers, &device)
-            .map_err(|e| format!("failed to load adapter: {e}"))?;
+            .map_err(|e| format!("{e}"))?;
         // Brief write lock to swap the adapter in.
         let mut guard = runner.write().unwrap();
         guard.swap_lora(Some(lora));
         Ok::<(), String>(())
     })
     .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?
-    .map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            e,
-        )
-    })?;
+    .map_err(|e| ApiError::internal(format!("join error: {e}")))?
+    .map_err(ApiError::adapter_load_failed)?;
 
     // Update the shared active adapter name.
     *state.active_adapter_name.write().unwrap() = Some(req.name.clone());
@@ -146,14 +135,11 @@ async fn load_adapter(
 /// Unload the active LoRA adapter, reverting to base model.
 async fn unload_adapter(
     State(state): State<AppState>,
-) -> Result<Json<UnloadAdapterResponse>, (StatusCode, String)> {
+) -> Result<Json<UnloadAdapterResponse>, ApiError> {
     let runner = match state.backend.as_ref() {
         ModelBackend::Real { runner, .. } => runner,
         ModelBackend::Mock { .. } => {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                "adapter management not supported in mock mode".to_string(),
-            ));
+            return Err(ApiError::mock_mode_no_adapters());
         }
     };
 
@@ -163,7 +149,7 @@ async fn unload_adapter(
         guard.unload_adapter();
     })
     .await
-    .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?;
+    .map_err(|e| ApiError::internal(format!("join error: {e}")))?;
 
     // Clear the shared active adapter name.
     *state.active_adapter_name.write().unwrap() = None;
@@ -179,31 +165,20 @@ async fn unload_adapter(
 async fn delete_adapter(
     State(state): State<AppState>,
     AxumPath(name): AxumPath<String>,
-) -> Result<Json<DeleteAdapterResponse>, (StatusCode, String)> {
+) -> Result<Json<DeleteAdapterResponse>, ApiError> {
     let adapter_path = state.adapter_dir.join(&name);
 
     if !adapter_path.exists() || !adapter_path.is_dir() {
-        return Err((
-            StatusCode::NOT_FOUND,
-            format!("adapter not found: {name}"),
-        ));
+        return Err(ApiError::adapter_not_found(&name));
     }
 
     // Check if this adapter is currently active.
     let active = state.active_adapter_name.read().unwrap().clone();
     if active.as_deref() == Some(&name) {
-        return Err((
-            StatusCode::CONFLICT,
-            format!("adapter '{name}' is currently active — unload it first"),
-        ));
+        return Err(ApiError::adapter_active(&name));
     }
 
-    std::fs::remove_dir_all(&adapter_path).map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to delete adapter directory: {e}"),
-        )
-    })?;
+    std::fs::remove_dir_all(&adapter_path).map_err(|e| ApiError::adapter_delete_failed(e))?;
 
     tracing::info!(adapter = %name, operation = "delete", "deleted adapter from disk");
 

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -17,6 +17,7 @@ use kiln_core::tokenizer::ChatMessage;
 use kiln_model::lora_loader::LoraWeights;
 use kiln_model::{ModelRunner, StreamEvent};
 
+use crate::error::ApiError;
 use crate::metrics::RequestStatus;
 use crate::state::{AppState, ModelBackend};
 
@@ -109,7 +110,7 @@ pub struct Delta {
 async fn chat_completions(
     State(state): State<AppState>,
     Json(req): Json<ChatCompletionRequest>,
-) -> Result<Response, (StatusCode, String)> {
+) -> Result<Response, ApiError> {
     let start = std::time::Instant::now();
     state.metrics.inc_active();
 
@@ -121,8 +122,8 @@ async fn chat_completions(
 
     match &result {
         Ok(_) => state.metrics.inc_request(RequestStatus::Ok),
-        Err((code, _)) => {
-            if *code == StatusCode::REQUEST_TIMEOUT {
+        Err(e) => {
+            if e.status == StatusCode::REQUEST_TIMEOUT {
                 state.metrics.inc_request(RequestStatus::Timeout);
             } else {
                 state.metrics.inc_request(RequestStatus::Error);
@@ -136,7 +137,7 @@ async fn chat_completions(
 async fn chat_completions_inner(
     state: &AppState,
     req: ChatCompletionRequest,
-) -> Result<Response, (StatusCode, String)> {
+) -> Result<Response, ApiError> {
     // Convert request messages to ChatMessage for template formatting
     let chat_messages: Vec<ChatMessage> = req
         .messages
@@ -151,7 +152,7 @@ async fn chat_completions_inner(
     let prompt_text = state
         .tokenizer
         .apply_chat_template(&chat_messages)
-        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+        .map_err(ApiError::chat_template_failed)?;
 
     let sampling = SamplingParams {
         temperature: req.temperature.unwrap_or(1.0),
@@ -186,10 +187,7 @@ async fn chat_completions_inner(
                 )
                 .await
             }
-            ModelBackend::Mock { .. } => Err((
-                StatusCode::NOT_IMPLEMENTED,
-                "streaming not supported with mock backend".to_string(),
-            )),
+            ModelBackend::Mock { .. } => Err(ApiError::streaming_not_supported_mock()),
         }
     } else {
         match state.backend.as_ref() {
@@ -235,7 +233,7 @@ async fn ensure_adapter(
     state: &AppState,
     runner: &std::sync::Arc<std::sync::RwLock<ModelRunner>>,
     req_adapter: &Option<String>,
-) -> Result<(), (StatusCode, String)> {
+) -> Result<(), ApiError> {
     let current = state.active_adapter_name.read().unwrap().clone();
     if *req_adapter == current {
         return Ok(());
@@ -250,10 +248,7 @@ async fn ensure_adapter(
                 state.adapter_dir.join(name)
             };
             if !adapter_path.exists() {
-                return Err((
-                    StatusCode::NOT_FOUND,
-                    format!("adapter not found: {}", adapter_path.display()),
-                ));
+                return Err(ApiError::adapter_not_found(name));
             }
 
             // Two-phase load: read device/num_layers, load weights, then swap.
@@ -268,15 +263,15 @@ async fn ensure_adapter(
 
             tokio::task::spawn_blocking(move || {
                 let lora = LoraWeights::load(&adapter_path, num_layers, &device)
-                    .map_err(|e| format!("failed to load adapter: {e}"))?;
+                    .map_err(|e| format!("{e}"))?;
                 let mut guard = runner.write().unwrap();
                 guard.swap_lora(Some(lora));
                 *active_name.write().unwrap() = Some(adapter_name);
                 Ok::<(), String>(())
             })
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+            .map_err(|e| ApiError::internal(format!("join error: {e}")))?
+            .map_err(ApiError::adapter_load_failed)?;
         }
         None => {
             // Revert to base model.
@@ -289,7 +284,7 @@ async fn ensure_adapter(
                 *active_name.write().unwrap() = None;
             })
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?;
+            .map_err(|e| ApiError::internal(format!("join error: {e}")))?;
         }
     }
 
@@ -305,12 +300,12 @@ async fn generate_real(
     prompt_text: &str,
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
-) -> Result<ChatCompletionResponse, (StatusCode, String)> {
+) -> Result<ChatCompletionResponse, ApiError> {
     // Count prompt tokens for usage stats.
     let prompt_token_count = state
         .tokenizer
         .encode(prompt_text)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(ApiError::tokenization_failed)?
         .len();
 
     // ModelRunner.generate_paged() is CPU-bound; run on a blocking thread to
@@ -335,16 +330,10 @@ async fn generate_real(
 
     let output = match tokio::time::timeout(timeout, generation).await {
         Ok(join_result) => join_result
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("join error: {e}")))?
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
+            .map_err(|e| ApiError::internal(format!("join error: {e}")))?
+            .map_err(ApiError::generation_failed)?,
         Err(_) => {
-            return Err((
-                StatusCode::REQUEST_TIMEOUT,
-                format!(
-                    "request timed out after {} seconds",
-                    timeout.as_secs()
-                ),
-            ));
+            return Err(ApiError::request_timeout(timeout.as_secs()));
         }
     };
 
@@ -394,7 +383,7 @@ async fn generate_real_streaming(
     prompt_text: &str,
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
-) -> Result<Response, (StatusCode, String)> {
+) -> Result<Response, ApiError> {
     let runner = runner.clone();
     let bm = block_manager.clone();
     let pc = paged_cache.clone();
@@ -597,11 +586,11 @@ async fn generate_mock(
     prompt_text: &str,
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
-) -> Result<ChatCompletionResponse, (StatusCode, String)> {
+) -> Result<ChatCompletionResponse, ApiError> {
     let prompt_tokens = state
         .tokenizer
         .encode(prompt_text)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(ApiError::tokenization_failed)?;
 
     let prompt_token_count = prompt_tokens.len();
     let request = Request::new(prompt_tokens, sampling.clone(), req.adapter.clone());
@@ -649,7 +638,7 @@ async fn generate_mock(
 
         let engine_output = engine
             .step(&batch)
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            .map_err(ApiError::generation_failed)?;
 
         for (rid, token, finished) in &engine_output.results {
             if *rid == request_id {

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -6,7 +6,6 @@
 
 use axum::{
     extract::{Path as AxumPath, State},
-    http::StatusCode,
     routing::{delete, get, post},
     Json, Router,
 };
@@ -15,6 +14,7 @@ use kiln_train::{GrpoRequest, SftRequest, TrainingResponse, TrainingState, Train
 
 use std::sync::atomic::Ordering;
 
+use crate::error::ApiError;
 use crate::metrics::{TrainingMetricStatus, TrainingMetricType};
 use crate::state::{AppState, ModelBackend, TrainingJobInfo, TrainingJobType};
 use crate::training_queue::{QueueEntry, QueuedJob};
@@ -41,13 +41,10 @@ struct QueueStatusEntry {
 async fn submit_sft(
     State(state): State<AppState>,
     Json(req): Json<SftRequest>,
-) -> Result<Json<TrainingResponse>, (StatusCode, String)> {
+) -> Result<Json<TrainingResponse>, ApiError> {
     // Reject new jobs during shutdown
     if state.shutdown.load(Ordering::Relaxed) {
-        return Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            "server is shutting down — not accepting new training jobs".to_string(),
-        ));
+        return Err(ApiError::shutting_down());
     }
 
     let num_examples = req.examples.len();
@@ -63,10 +60,7 @@ async fn submit_sft(
 
     // Verify we have real model weights
     if matches!(state.backend.as_ref(), ModelBackend::Mock { .. }) {
-        return Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            "training requires real model weights (not available in mock mode)".to_string(),
-        ));
+        return Err(ApiError::mock_mode_no_training());
     }
 
     // Register the job in the tracking map
@@ -110,13 +104,10 @@ async fn submit_sft(
 async fn submit_grpo(
     State(state): State<AppState>,
     Json(req): Json<GrpoRequest>,
-) -> Result<Json<TrainingResponse>, (StatusCode, String)> {
+) -> Result<Json<TrainingResponse>, ApiError> {
     // Reject new jobs during shutdown
     if state.shutdown.load(Ordering::Relaxed) {
-        return Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            "server is shutting down — not accepting new training jobs".to_string(),
-        ));
+        return Err(ApiError::shutting_down());
     }
 
     let num_groups = req.groups.len();
@@ -133,10 +124,7 @@ async fn submit_grpo(
 
     // Verify we have real model weights
     if matches!(state.backend.as_ref(), ModelBackend::Mock { .. }) {
-        return Err((
-            StatusCode::SERVICE_UNAVAILABLE,
-            "training requires real model weights (not available in mock mode)".to_string(),
-        ));
+        return Err(ApiError::mock_mode_no_training());
     }
 
     // Register the job in the tracking map
@@ -199,14 +187,11 @@ async fn training_status(State(state): State<AppState>) -> Json<Vec<TrainingStat
 async fn job_status(
     State(state): State<AppState>,
     AxumPath(job_id): AxumPath<String>,
-) -> Result<Json<TrainingStatus>, (StatusCode, String)> {
+) -> Result<Json<TrainingStatus>, ApiError> {
     let jobs = state.training_jobs.read().unwrap();
-    let job = jobs.get(&job_id).ok_or_else(|| {
-        (
-            StatusCode::NOT_FOUND,
-            format!("training job not found: {job_id}"),
-        )
-    })?;
+    let job = jobs
+        .get(&job_id)
+        .ok_or_else(|| ApiError::training_job_not_found(&job_id))?;
 
     Ok(Json(TrainingStatus {
         job_id: job.job_id.clone(),
@@ -277,23 +262,17 @@ async fn list_queue(State(state): State<AppState>) -> Json<QueueResponse> {
 async fn cancel_queued_job(
     State(state): State<AppState>,
     AxumPath(job_id): AxumPath<String>,
-) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+) -> Result<Json<serde_json::Value>, ApiError> {
     // Check if the job exists and is in Queued state
     {
         let jobs = state.training_jobs.read().unwrap();
-        let job = jobs.get(&job_id).ok_or_else(|| {
-            (
-                StatusCode::NOT_FOUND,
-                format!("training job not found: {job_id}"),
-            )
-        })?;
+        let job = jobs
+            .get(&job_id)
+            .ok_or_else(|| ApiError::training_job_not_found(&job_id))?;
         if job.state != TrainingState::Queued {
-            return Err((
-                StatusCode::CONFLICT,
-                format!(
-                    "cannot cancel job {job_id}: state is {:?} (only queued jobs can be cancelled)",
-                    job.state
-                ),
+            return Err(ApiError::training_job_not_cancellable(
+                &job_id,
+                format!("{:?}", job.state),
             ));
         }
     }
@@ -326,10 +305,7 @@ async fn cancel_queued_job(
             "status": "cancelled"
         })))
     } else {
-        Err((
-            StatusCode::CONFLICT,
-            format!("job {job_id} was not found in queue (may have already started)"),
-        ))
+        Err(ApiError::training_job_already_started(&job_id))
     }
 }
 

--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -1,0 +1,216 @@
+//! Structured API error responses.
+//!
+//! Every error returned by the API is a JSON object with a consistent shape:
+//! ```json
+//! {
+//!   "error": {
+//!     "code": "adapter_not_found",
+//!     "message": "Adapter 'foo' does not exist",
+//!     "hint": "List available adapters with GET /v1/adapters"
+//!   }
+//! }
+//! ```
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+
+/// JSON error body shape, matching OpenAI's convention.
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    error: ErrorDetail,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorDetail {
+    code: &'static str,
+    message: String,
+    hint: &'static str,
+}
+
+/// Structured API error with HTTP status, machine-readable code, human message,
+/// and an actionable hint.
+#[derive(Debug)]
+pub struct ApiError {
+    pub status: StatusCode,
+    pub code: &'static str,
+    pub message: String,
+    pub hint: &'static str,
+}
+
+impl ApiError {
+    // ── Chat completions ────────────────────────────────────────────
+
+    pub fn chat_template_failed(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "invalid_messages",
+            message: format!("Failed to apply chat template: {detail}"),
+            hint: "Check that each message has a valid 'role' (system, user, assistant) and non-empty 'content'.",
+        }
+    }
+
+    pub fn tokenization_failed(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "tokenization_error",
+            message: format!("Tokenization failed: {detail}"),
+            hint: "This is a server-side error. If it persists, check that the tokenizer files are not corrupted.",
+        }
+    }
+
+    pub fn generation_failed(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "generation_error",
+            message: format!("Text generation failed: {detail}"),
+            hint: "Retry the request. If the error mentions OOM, try reducing max_tokens or freeing GPU memory.",
+        }
+    }
+
+    pub fn request_timeout(timeout_secs: u64) -> Self {
+        Self {
+            status: StatusCode::REQUEST_TIMEOUT,
+            code: "request_timeout",
+            message: format!("Request timed out after {timeout_secs} seconds"),
+            hint: "Try reducing max_tokens, or increase the server's request_timeout_secs in the config file.",
+        }
+    }
+
+    pub fn streaming_not_supported_mock() -> Self {
+        Self {
+            status: StatusCode::NOT_IMPLEMENTED,
+            code: "streaming_not_supported",
+            message: "Streaming is not supported with the mock backend".to_string(),
+            hint: "Start the server with a real model (set model.path in config) to enable streaming.",
+        }
+    }
+
+    // ── Adapters ────────────────────────────────────────────────────
+
+    pub fn adapter_not_found(name: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: "adapter_not_found",
+            message: format!("Adapter '{name}' does not exist"),
+            hint: "List available adapters with GET /v1/adapters.",
+        }
+    }
+
+    pub fn adapter_load_failed(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "adapter_load_failed",
+            message: format!("Failed to load adapter: {detail}"),
+            hint: "Check that the adapter directory contains adapter_config.json and adapter_model.safetensors.",
+        }
+    }
+
+    pub fn adapter_active(name: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "adapter_active",
+            message: format!("Adapter '{name}' is currently active and cannot be deleted"),
+            hint: "Unload the adapter first with POST /v1/adapters/unload, then retry the delete.",
+        }
+    }
+
+    pub fn adapter_delete_failed(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "adapter_delete_failed",
+            message: format!("Failed to delete adapter directory: {detail}"),
+            hint: "Check file permissions on the adapter directory.",
+        }
+    }
+
+    pub fn mock_mode_no_adapters() -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "mock_mode",
+            message: "Adapter management is not supported in mock mode".to_string(),
+            hint: "Start the server with a real model (set model.path in config) to use adapters.",
+        }
+    }
+
+    // ── Training ────────────────────────────────────────────────────
+
+    pub fn shutting_down() -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "server_shutting_down",
+            message: "Server is shutting down — not accepting new requests".to_string(),
+            hint: "Wait for the server to restart, then retry.",
+        }
+    }
+
+    pub fn mock_mode_no_training() -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "mock_mode",
+            message: "Training requires real model weights (not available in mock mode)".to_string(),
+            hint: "Start the server with a real model (set model.path in config) to use training.",
+        }
+    }
+
+    pub fn training_job_not_found(job_id: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::NOT_FOUND,
+            code: "training_job_not_found",
+            message: format!("Training job '{job_id}' not found"),
+            hint: "List all training jobs with GET /v1/train/status.",
+        }
+    }
+
+    pub fn training_job_not_cancellable(
+        job_id: impl std::fmt::Display,
+        state: impl std::fmt::Display,
+    ) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "training_job_not_cancellable",
+            message: format!("Cannot cancel job '{job_id}': current state is {state}"),
+            hint: "Only jobs in 'queued' state can be cancelled. Running jobs must complete.",
+        }
+    }
+
+    pub fn training_job_already_started(job_id: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "training_job_already_started",
+            message: format!("Job '{job_id}' was not found in the queue (it may have already started)"),
+            hint: "Check job status with GET /v1/train/status/{job_id}.",
+        }
+    }
+
+    // ── Generic ─────────────────────────────────────────────────────
+
+    pub fn internal(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "internal_error",
+            message: format!("Internal error: {detail}"),
+            hint: "This is unexpected. Check server logs for details.",
+        }
+    }
+}
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        let body = ErrorBody {
+            error: ErrorDetail {
+                code: self.code,
+                message: self.message,
+                hint: self.hint,
+            },
+        };
+        (self.status, Json(body)).into_response()
+    }
+}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.code, self.message)
+    }
+}

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod api;
 pub mod config;
+pub mod error;
 pub mod logging;
 pub mod metrics;
 pub mod state;


### PR DESCRIPTION
## What
Replace generic `(StatusCode, String)` error tuples with a structured `ApiError` type that produces consistent JSON error responses.

## Why
Phase 5j: error messages that help. Users should understand what went wrong and what to do about it.

## Changes
- New `crates/kiln-server/src/error.rs` — `ApiError` struct with constructors for each error case and `IntoResponse` impl producing:
  ```json
  {"error": {"code": "adapter_not_found", "message": "Adapter 'foo' does not exist", "hint": "List available adapters with GET /v1/adapters."}}
  ```
- Updated `completions.rs` — all error paths use `ApiError` (chat template, tokenization, generation, timeout, adapter loading)
- Updated `adapters.rs` — adapter not found, load failed, active conflict, delete failed, mock mode
- Updated `training.rs` — shutdown, mock mode, job not found, not cancellable, already started
- Added `pub mod error` to `lib.rs`

## Testing
- All 30 kiln-server lib tests pass
- All 4 non-pre-existing integration tests pass (the 1 failing test `test_health_with_real_backend` fails on main too — pre-existing)
- Built and tested on RunPod RTX 4090