### PR TITLE
Add automatic adapter checkpointing during training

### DIFF
--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -180,6 +180,21 @@ async fn delete_adapter(
 
     std::fs::remove_dir_all(&adapter_path).map_err(|e| ApiError::adapter_delete_failed(e))?;
 
+    // Clean up any checkpoint directories (e.g. "my-adapter-checkpoint-50")
+    let checkpoint_prefix = format!("{name}-checkpoint-");
+    if let Ok(entries) = std::fs::read_dir(&state.adapter_dir) {
+        for entry in entries.flatten() {
+            let entry_name = entry.file_name().to_string_lossy().to_string();
+            if entry_name.starts_with(&checkpoint_prefix) && entry.path().is_dir() {
+                if let Err(e) = std::fs::remove_dir_all(entry.path()) {
+                    tracing::warn!(checkpoint = %entry_name, error = %e, "failed to delete checkpoint directory");
+                } else {
+                    tracing::info!(checkpoint = %entry_name, "deleted checkpoint directory");
+                }
+            }
+        }
+    }
+
     tracing::info!(adapter = %name, operation = "delete", "deleted adapter from disk");
 
     Ok(Json(DeleteAdapterResponse {

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -63,6 +63,9 @@ pub struct MemoryConfig {
 pub struct TrainingConfig {
     pub grad_checkpoint_segments: Option<usize>,
     pub no_grad_checkpoint: bool,
+    /// Save adapter weights every N training steps during a job.
+    /// Per-job config overrides this. None = only save at the end.
+    pub checkpoint_interval: Option<usize>,
 }
 
 /// Logging settings.
@@ -125,6 +128,7 @@ impl Default for TrainingConfig {
         Self {
             grad_checkpoint_segments: None,
             no_grad_checkpoint: false,
+            checkpoint_interval: None,
         }
     }
 }
@@ -238,6 +242,11 @@ impl KilnConfig {
         if let Ok(v) = std::env::var("KILN_NO_GRAD_CHECKPOINT") {
             self.training.no_grad_checkpoint = v == "1" || v.eq_ignore_ascii_case("true");
         }
+        if let Ok(v) = std::env::var("KILN_CHECKPOINT_INTERVAL") {
+            if let Ok(n) = v.parse() {
+                self.training.checkpoint_interval = Some(n);
+            }
+        }
 
         // Logging
         if let Ok(v) = std::env::var("KILN_LOG_LEVEL") {
@@ -299,6 +308,7 @@ mod tests {
         assert!(config.memory.num_blocks.is_none());
         assert_eq!(config.memory.inference_memory_fraction, 0.7);
         assert!(!config.training.no_grad_checkpoint);
+        assert!(config.training.checkpoint_interval.is_none());
         assert_eq!(config.logging.level, "info");
         assert_eq!(config.logging.format, "json");
     }
@@ -327,6 +337,7 @@ training_memory_gb = 6.0
 [training]
 grad_checkpoint_segments = 8
 no_grad_checkpoint = false
+checkpoint_interval = 50
 
 [logging]
 level = "debug"
@@ -343,6 +354,7 @@ format = "pretty"
         assert_eq!(config.memory.inference_memory_fraction, 0.5);
         assert_eq!(config.memory.training_memory_gb, Some(6.0));
         assert_eq!(config.training.grad_checkpoint_segments, Some(8));
+        assert_eq!(config.training.checkpoint_interval, Some(50));
         assert_eq!(config.logging.level, "debug");
         assert_eq!(config.logging.format, "pretty");
     }
@@ -419,6 +431,7 @@ port = 3000
             std::env::set_var("KILN_INFERENCE_MEMORY_FRACTION", "0.9");
             std::env::set_var("KILN_LOG_LEVEL", "debug");
             std::env::set_var("KILN_NO_GRAD_CHECKPOINT", "1");
+            std::env::set_var("KILN_CHECKPOINT_INTERVAL", "25");
         }
 
         let mut config = KilnConfig::default();
@@ -430,6 +443,7 @@ port = 3000
         assert_eq!(config.memory.inference_memory_fraction, 0.9);
         assert_eq!(config.logging.level, "debug");
         assert!(config.training.no_grad_checkpoint);
+        assert_eq!(config.training.checkpoint_interval, Some(25));
 
         // Clean up
         unsafe {
@@ -439,6 +453,7 @@ port = 3000
             std::env::remove_var("KILN_INFERENCE_MEMORY_FRACTION");
             std::env::remove_var("KILN_LOG_LEVEL");
             std::env::remove_var("KILN_NO_GRAD_CHECKPOINT");
+            std::env::remove_var("KILN_CHECKPOINT_INTERVAL");
         }
     }
 

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -56,7 +56,7 @@ async fn main() -> Result<()> {
         "tokenizer loaded successfully"
     );
 
-    let state = if let Some(mp) = model_path {
+    let mut state = if let Some(mp) = model_path {
         // Real inference mode: load model weights and create ModelRunner.
         tracing::info!("loading model weights from {mp}");
         let model_weights = kiln_model::load_model(Path::new(mp), &model_config)?;
@@ -126,6 +126,9 @@ async fn main() -> Result<()> {
             config.server.request_timeout_secs,
         )
     };
+
+    // Apply server-level checkpoint_interval from config
+    state.checkpoint_interval = config.training.checkpoint_interval;
 
     // Spawn the background training queue worker
     let shutdown_flag = state.shutdown.clone();

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -184,6 +184,9 @@ pub struct AppState {
     pub metrics: Arc<Metrics>,
     /// Server startup time — used to compute uptime in health checks.
     pub started_at: std::time::Instant,
+    /// Server-level default for adapter checkpoint interval during training.
+    /// Per-job config overrides this. None = only save at the end.
+    pub checkpoint_interval: Option<usize>,
 }
 
 impl AppState {
@@ -216,6 +219,7 @@ impl AppState {
             request_timeout: std::time::Duration::from_secs(request_timeout_secs),
             metrics: Arc::new(Metrics::new()),
             started_at: std::time::Instant::now(),
+            checkpoint_interval: None,
         }
     }
 
@@ -346,6 +350,7 @@ impl AppState {
             request_timeout: std::time::Duration::from_secs(request_timeout_secs),
             metrics: Arc::new(Metrics::new()),
             started_at: std::time::Instant::now(),
+            checkpoint_interval: None,
         }
     }
 }

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -179,9 +179,15 @@ fn execute_job(state: AppState, entry: QueueEntry) {
         }
     });
 
+    // Apply server-level checkpoint_interval default if not set per-job
+    let server_checkpoint_interval = state.checkpoint_interval;
+
     // Run the actual training under GPU write lock
     let result: Result<PathBuf, String> = match entry.job {
-        QueuedJob::Sft(req) => {
+        QueuedJob::Sft(mut req) => {
+            if req.config.checkpoint_interval.is_none() {
+                req.config.checkpoint_interval = server_checkpoint_interval;
+            }
             let _gpu_guard = state.gpu_lock.write().unwrap();
             let guard = runner_arc.read().unwrap();
             trainer::sft_train(
@@ -196,7 +202,10 @@ fn execute_job(state: AppState, entry: QueueEntry) {
             )
             .map_err(|e| format!("{e:#}"))
         }
-        QueuedJob::Grpo(req) => {
+        QueuedJob::Grpo(mut req) => {
+            if req.config.checkpoint_interval.is_none() {
+                req.config.checkpoint_interval = server_checkpoint_interval;
+            }
             let _gpu_guard = state.gpu_lock.write().unwrap();
             let guard = runner_arc.read().unwrap();
             trainer::grpo_train(

--- a/crates/kiln-train/src/lib.rs
+++ b/crates/kiln-train/src/lib.rs
@@ -48,6 +48,9 @@ pub struct SftConfig {
     /// Automatically load the resulting adapter when training completes (default true).
     #[serde(default = "default_auto_load")]
     pub auto_load: bool,
+    /// Save adapter weights every N training steps. None = only save at the end.
+    #[serde(default)]
+    pub checkpoint_interval: Option<usize>,
 }
 
 fn default_auto_load() -> bool { true }
@@ -66,6 +69,7 @@ impl Default for SftConfig {
             base_adapter: None,
             output_name: None,
             auto_load: default_auto_load(),
+            checkpoint_interval: None,
         }
     }
 }
@@ -111,6 +115,9 @@ pub struct GrpoConfig {
     /// Automatically load the resulting adapter when training completes (default true).
     #[serde(default = "default_auto_load")]
     pub auto_load: bool,
+    /// Save adapter weights every N training steps. None = only save at the end.
+    #[serde(default)]
+    pub checkpoint_interval: Option<usize>,
 }
 
 fn default_grpo_lr() -> f64 { 1e-5 }
@@ -128,6 +135,7 @@ impl Default for GrpoConfig {
             base_adapter: None,
             output_name: None,
             auto_load: default_auto_load(),
+            checkpoint_interval: None,
         }
     }
 }
@@ -159,4 +167,45 @@ pub struct TrainingResponse {
     pub job_id: String,
     pub state: TrainingState,
     pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sft_config_default_checkpoint_interval_is_none() {
+        let config = SftConfig::default();
+        assert!(config.checkpoint_interval.is_none());
+    }
+
+    #[test]
+    fn test_grpo_config_default_checkpoint_interval_is_none() {
+        let config = GrpoConfig::default();
+        assert!(config.checkpoint_interval.is_none());
+    }
+
+    #[test]
+    fn test_sft_config_deserialize_with_checkpoint_interval() {
+        let json = r#"{"checkpoint_interval": 25}"#;
+        let config: SftConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.checkpoint_interval, Some(25));
+        assert_eq!(config.epochs, 3); // default preserved
+    }
+
+    #[test]
+    fn test_sft_config_deserialize_without_checkpoint_interval() {
+        let json = r#"{"epochs": 5}"#;
+        let config: SftConfig = serde_json::from_str(json).unwrap();
+        assert!(config.checkpoint_interval.is_none());
+        assert_eq!(config.epochs, 5);
+    }
+
+    #[test]
+    fn test_grpo_config_deserialize_with_checkpoint_interval() {
+        let json = r#"{"checkpoint_interval": 10}"#;
+        let config: GrpoConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.checkpoint_interval, Some(10));
+        assert_eq!(config.kl_coeff, 0.1); // default preserved
+    }
 }

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -409,6 +409,18 @@ pub fn sft_train(
 
             global_step += 1;
 
+            // Periodic adapter checkpoint
+            if let Some(interval) = config.checkpoint_interval {
+                if interval > 0 && global_step % interval == 0 && global_step < total_steps {
+                    let ckpt_dir = adapter_dir.join(format!("{adapter_name}-checkpoint-{global_step}"));
+                    if let Err(e) = params.save_peft(&ckpt_dir, model_config.num_layers) {
+                        tracing::warn!(step = global_step, error = %e, "failed to save training checkpoint");
+                    } else {
+                        tracing::info!(step = global_step, "saved training checkpoint");
+                    }
+                }
+            }
+
             if let Some(ref cb) = progress_cb {
                 cb(TrainingProgress {
                     epoch: epoch + 1,
@@ -622,6 +634,18 @@ pub fn grpo_train(
         };
         last_loss = avg_group_loss;
         global_step += 1;
+
+        // Periodic adapter checkpoint
+        if let Some(interval) = config.checkpoint_interval {
+            if interval > 0 && global_step % interval == 0 && global_step < total_steps {
+                let ckpt_dir = adapter_dir.join(format!("{adapter_name}-checkpoint-{global_step}"));
+                if let Err(e) = params.save_peft(&ckpt_dir, model_config.num_layers) {
+                    tracing::warn!(step = global_step, error = %e, "failed to save GRPO training checkpoint");
+                } else {
+                    tracing::info!(step = global_step, "saved GRPO training checkpoint");
+                }
+            }
+        }
 
         if let Some(ref cb) = progress_cb {
             cb(TrainingProgress {


### PR DESCRIPTION
## What
Adds periodic adapter checkpointing during training runs so partial progress is preserved if a job crashes or the server restarts mid-training.

## Changes
- **kiln-train/src/lib.rs**: Added `checkpoint_interval: Option<usize>` to `SftConfig` and `GrpoConfig` (serde default, backward-compatible)
- **kiln-train/src/trainer.rs**: After each training step, if `checkpoint_interval` is set and `global_step % interval == 0`, saves adapter to `{name}-checkpoint-{step}/`
- **kiln-server/src/config.rs**: Added `checkpoint_interval` to `TrainingConfig` with `KILN_CHECKPOINT_INTERVAL` env var and TOML support
- **kiln-server/src/state.rs**: Added `checkpoint_interval` field to `AppState` for server-level default
- **kiln-server/src/main.rs**: Wires server config `checkpoint_interval` into `AppState`
- **kiln-server/src/training_queue.rs**: Falls back to server default when per-job `checkpoint_interval` is not set
- **kiln-server/src/api/adapters.rs**: `DELETE /v1/adapters/{name}` now cleans up `{name}-checkpoint-*` directories

## Configuration
- Per-job: `"checkpoint_interval": 50` in SFT/GRPO request JSON
- Server default: `KILN_CHECKPOINT_INTERVAL=50` env var or `checkpoint_interval = 50` under `[training]` in TOML
- Default: None (only final save, matching current behavior)

## Tests
All 42 lib tests pass (30 kiln-server + 12 kiln-train), including 5 new tests for checkpoint_interval serialization and config parsing.