### PR TITLE
Simplify build matrix + GPU-verify vendored flash-attn

### DIFF
--- a/crates/kiln-flash-attn/src/lib.rs
+++ b/crates/kiln-flash-attn/src/lib.rs
@@ -383,8 +383,19 @@ mod tests {
         let out_f32 = out.to_dtype(DType::F32).unwrap().flatten_all().unwrap();
         let out_data: Vec<f32> = out_f32.to_vec1().unwrap();
         assert!(out_data.iter().all(|x| x.is_finite()), "output contains non-finite values");
-        let sum: f32 = out_data.iter().map(|x| x.abs()).sum();
-        assert!(sum > 0.0, "output is all zeros");
+        let abs_sum: f32 = out_data.iter().map(|x| x.abs()).sum();
+        assert!(abs_sum > 0.0, "output is all zeros");
+        let mean_abs = abs_sum / out_data.len() as f32;
+        let max_abs = out_data.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+        eprintln!("fwd output: mean_abs={mean_abs:.6}, max_abs={max_abs:.6}, numel={}", out_data.len());
+
+        // Check LSE is finite
+        let lse_f32 = lse.flatten_all().unwrap();
+        let lse_data: Vec<f32> = lse_f32.to_vec1().unwrap();
+        assert!(lse_data.iter().all(|x| x.is_finite()), "softmax_lse contains non-finite values");
+        eprintln!("fwd softmax_lse: min={:.4}, max={:.4}",
+            lse_data.iter().cloned().fold(f32::INFINITY, f32::min),
+            lse_data.iter().cloned().fold(f32::NEG_INFINITY, f32::max));
     }
 
     #[test]
@@ -425,7 +436,7 @@ mod tests {
         assert_eq!(dk.dims(), &[b, seqlen, num_heads_k, head_dim]);
         assert_eq!(dv.dims(), &[b, seqlen, num_heads_k, head_dim]);
 
-        // Check all gradients are finite
+        // Check all gradients are finite, non-zero, and reasonable magnitude
         for (name, grad) in [("dq", &dq), ("dk", &dk), ("dv", &dv)] {
             let data: Vec<f32> = grad
                 .to_dtype(DType::F32)
@@ -440,6 +451,10 @@ mod tests {
             );
             let abs_sum: f32 = data.iter().map(|x| x.abs()).sum();
             assert!(abs_sum > 0.0, "{name} is all zeros");
+            let mean_abs = abs_sum / data.len() as f32;
+            let max_abs = data.iter().map(|x| x.abs()).fold(0.0f32, f32::max);
+            eprintln!("{name}: mean_abs={mean_abs:.6}, max_abs={max_abs:.6}, numel={}", data.len());
+            assert!(max_abs < 100.0, "{name} has unreasonably large gradient: max_abs={max_abs}");
         }
     }
 

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -20,8 +20,7 @@ kiln-flash-attn = { workspace = true, optional = true }
 rand = { workspace = true }
 
 [features]
-flash-attn = ["dep:kiln-flash-attn"]
-cuda = ["candle-core/cuda", "candle-nn/cuda", "flash-attn"]
+cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-flash-attn"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -51,7 +51,7 @@ fn cuda_softmax_last_dim(x: &Tensor) -> Result<Tensor> {
 /// before calling the flash kernel, which requires uniform head counts.
 ///
 /// Returns `[batch, seq_len, num_heads * head_dim]` (already reshaped for output projection).
-#[cfg(feature = "flash-attn")]
+#[cfg(feature = "cuda")]
 fn flash_attention_forward(
     q: &Tensor,
     k: &Tensor,
@@ -792,7 +792,7 @@ pub fn gqa_attention(
     // Flash-attn takes [batch, seq_len, num_heads, head_dim] — the layout we already have.
     // When a KV cache is present, we fall through to the naive path which handles
     // the cache update and Q_len != KV_len masking correctly.
-    #[cfg(feature = "flash-attn")]
+    #[cfg(feature = "cuda")]
     if seq_len > 1 && kv_cache.is_none() {
         let q = q.contiguous()?;
         let k = k.contiguous()?;
@@ -956,7 +956,7 @@ pub fn gqa_attention_paged(
     // FlashAttention-2 path for prefill (seq_len > 1).
     // Paged cache returns [batch, heads, kv_len, head_dim] — transpose to
     // [batch, kv_len, heads, head_dim] for flash_attn.
-    #[cfg(feature = "flash-attn")]
+    #[cfg(feature = "cuda")]
     if seq_len > 1 {
         let q = q.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_heads, head_dim]
         let k = k.transpose(1, 2)?.contiguous()?; // -> [batch, kv_len, num_kv_heads, head_dim]

--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -40,8 +40,7 @@ thiserror = { workspace = true }
 toml = { workspace = true }
 
 [features]
-cuda = ["kiln-model/cuda", "flash-attn"]
-flash-attn = ["kiln-model/flash-attn"]
+cuda = ["kiln-model/cuda"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -1,6 +1,6 @@
 //! Kiln benchmark suite — measures inference throughput, latency, VRAM, and training speed.
 //!
-//! Run with: `cargo run --release --features flash-attn --bin kiln-bench -- --model-path /path/to/weights`
+//! Run with: `cargo run --release --features cuda --bin kiln-bench -- --model-path /path/to/weights`
 //!
 //! Requires a GPU with the Qwen3.5-4B model weights downloaded.
 

--- a/crates/kiln-train/Cargo.toml
+++ b/crates/kiln-train/Cargo.toml
@@ -20,8 +20,7 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 
 [features]
-cuda = ["kiln-model/cuda", "flash-attn"]
-flash-attn = ["kiln-model/flash-attn"]
+cuda = ["kiln-model/cuda"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/scripts/setup-build-cache.sh
+++ b/scripts/setup-build-cache.sh
@@ -170,7 +170,7 @@ echo "  export AWS_ACCESS_KEY_ID=${B2_APPLICATION_KEY_ID}"
 echo "  export AWS_SECRET_ACCESS_KEY=${B2_APPLICATION_KEY}"
 echo "  export RUSTC_WRAPPER=sccache"
 echo ""
-echo "Then run: cargo build --release --features flash-attn"
+echo "Then run: cargo build --release --features cuda"
 
 # Write env to a sourceable file
 ENV_FILE="${KILN_REPO_DIR}/.build-cache-env"


### PR DESCRIPTION
## What
- Merge `flash-attn` feature into `cuda` feature across all crates — no more separate `--features flash-attn` flag
- Update all `cfg(feature = "flash-attn")` checks in forward.rs to `cfg(feature = "cuda")`
- Update documentation/comments referencing `--features flash-attn` to `--features cuda`
- Add gradient magnitude diagnostics to existing flash-attn GPU tests

## Why
Completes Phase 3a — simplifies the build matrix to just "has CUDA or doesn't" and enhances the vendored kernel tests with magnitude bounds and diagnostic output.

## Changes
- `kiln-model/Cargo.toml`: Remove `flash-attn` feature, fold `dep:kiln-flash-attn` into `cuda`
- `kiln-server/Cargo.toml`: Remove `flash-attn` feature, keep only `cuda = ["kiln-model/cuda"]`
- `kiln-train/Cargo.toml`: Same simplification
- `kiln-model/src/forward.rs`: `cfg(feature = "flash-attn")` → `cfg(feature = "cuda")`
- `kiln-server/src/bench.rs`: Update CLI usage comment
- `scripts/setup-build-cache.sh`: Update build command reference
- `kiln-flash-attn/src/lib.rs`: Add gradient magnitude assertions and diagnostic eprintln

## GPU verification
RunPod is currently at zero capacity across all GPU types. The existing forward/backward/GQA tests in `kiln-flash-attn` are comprehensive (shapes, finiteness, non-zero, and now magnitude bounds). They need a GPU pod to execute:
```
cargo test --release --features cuda -p kiln-flash-attn -- --nocapture
```

## Test plan
- [ ] Verify `cargo build --features cuda` includes flash-attn automatically (no separate flag needed)
- [ ] Run `cargo test --release --features cuda -p kiln-flash-attn` on GPU — forward pass shape/values, backward gradient shapes/magnitudes