### PR TITLE
Fix CUDA graph RoPE positions for actual decode speedup

### DIFF
--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -390,3 +390,11 @@ mod tests {
         assert_eq!(runner.adapter_generation, 3);
     }
 }
+
+// SAFETY: CudaGraphRunner is protected by a Mutex in ModelRunner. The inner
+// CudaGraph/CudaGraphExec are GPU-side recorded command sequences. Launching a
+// graph is thread-safe — the CUDA driver serialises access on the stream.
+// The raw pointers (*mut CUgraph_st, *mut CUgraphExec_st) are opaque handles
+// to driver-managed objects and are not dereferenced on the CPU side.
+unsafe impl Send for CudaGraphRunner {}
+unsafe impl Sync for CudaGraphRunner {}

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -227,7 +227,7 @@ impl CudaGraphRunner {
         // (the stream is serialized). The device pointer and allocation size
         // are valid because the position_buffer tensor is alive.
         unsafe {
-            let (dev_ptr, _guard) = slice.device_ptr(stream);
+            let (dev_ptr, _guard) = slice.device_ptr(&stream);
             candle_core::cuda_backend::cudarc::driver::result::memcpy_htod_async(
                 dev_ptr,
                 &pos_f32,

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -218,7 +218,7 @@ impl CudaGraphRunner {
             _ => anyhow::bail!("position buffer must be CUDA storage"),
         };
 
-        let stream = cuda_storage.device().cuda_stream();
+        let stream = cuda_storage.device.cuda_stream();
         let raw_stream = stream.cu_stream();
         let slice = cuda_storage.as_cuda_slice::<f32>()?;
 

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -15,19 +15,23 @@
 //!    `cuMemAllocAsync` nodes allocate at the same device addresses, so all
 //!    kernel arguments remain valid.
 //!
+//! ## Position buffer for RoPE
+//!
+//! RoPE requires position indices that change every decode step. A pre-allocated
+//! GPU tensor holds the position value; its contents are updated via
+//! `cudaMemcpyHtoDAsync` (outside the graph) before each replay. The captured
+//! graph reads from the same device pointer but sees the updated position,
+//! producing correct rotary embeddings at every step.
+//!
 //! ## Limitations
 //!
 //! - Only applies to single-token decode steps, not variable-length prefill.
 //! - Requires `cuMemAllocAsync` support (Ampere+ / compute capability ≥ 8.0).
-//! - The captured graph embeds position values from the capture step. On replay,
-//!   RoPE will use the original position, which is incorrect for subsequent steps.
-//!   Future work: refactor `rotary_embedding` to accept a pre-allocated GPU
-//!   position tensor that can be updated outside the graph.
 //! - Graph is invalidated on LoRA adapter swap (different weight pointers).
 //! - Falls back gracefully to eager execution if capture fails.
 
 use anyhow::{Context, Result};
-use candle_core::Device;
+use candle_core::{Device, Tensor};
 use tracing;
 
 use kiln_core::config::ModelConfig;
@@ -47,6 +51,10 @@ struct CapturedDecodeGraph {
     output_logits: candle_core::Tensor,
     /// Adapter generation when captured (invalidate on mismatch).
     adapter_gen: u64,
+    /// Pre-allocated position buffer on GPU (f32, shape [1]).
+    /// Updated via cudaMemcpyHtoDAsync before each replay so RoPE sees
+    /// the correct position while reading from the same device pointer.
+    position_buffer: Tensor,
 }
 
 /// Manages CUDA graph lifecycle for decode forward passes.
@@ -138,6 +146,19 @@ impl CudaGraphRunner {
             // Phase 3: replay if we have a valid captured graph
             if let Some(ref captured) = self.captured {
                 if captured.adapter_gen == self.adapter_generation {
+                    // Update position buffer BEFORE graph replay.
+                    // The graph's RoPE kernels read from the same GPU pointer,
+                    // so updating the data here gives them the correct position.
+                    if let Err(e) = Self::update_position_buffer(&captured.position_buffer, seq_len) {
+                        tracing::warn!("Failed to update position buffer: {e}, falling back to eager");
+                        self.captured = None;
+                        self.enabled = false;
+                        return Self::eager_forward(
+                            token_id, weights, config, paged_cache, block_table, seq_len,
+                            linear_state, lora,
+                        );
+                    }
+
                     match captured.graph.launch() {
                         Ok(()) => {
                             return Ok(captured.output_logits.clone());
@@ -180,6 +201,47 @@ impl CudaGraphRunner {
         )
     }
 
+    /// Update the position buffer tensor with a new position value.
+    ///
+    /// Copies a single f32 value into the existing GPU allocation without
+    /// changing the device pointer. This is done outside the CUDA graph so
+    /// replayed RoPE kernels read the correct position.
+    #[cfg(feature = "cuda")]
+    fn update_position_buffer(position_buffer: &Tensor, position: usize) -> Result<()> {
+        let pos_f32 = [position as f32];
+
+        let (storage, _layout) = position_buffer.storage_and_layout();
+        let cuda_storage = match &*storage {
+            candle_core::Storage::Cuda(s) => s,
+            _ => anyhow::bail!("position buffer must be CUDA storage"),
+        };
+
+        let stream = cuda_storage.device().cuda_stream();
+        let raw_stream = stream.cu_stream();
+        let slice = cuda_storage.as_cuda_slice::<f32>()?;
+
+        // SAFETY: We write into the position buffer before graph replay.
+        // No concurrent GPU reads occur between this memcpy and graph launch
+        // (the stream is serialized). The device pointer and allocation size
+        // are valid because the position_buffer tensor is alive.
+        unsafe {
+            let (dev_ptr, _guard) = slice.device_ptr(&stream);
+            candle_core::cuda_backend::cudarc::driver::result::memcpy_htod_async(
+                dev_ptr as u64,
+                &pos_f32,
+                raw_stream,
+            )
+            .map_err(|e| anyhow::anyhow!("memcpy_htod_async for position buffer: {e:?}"))?;
+        }
+
+        // Synchronize to ensure the copy completes before graph replay
+        stream
+            .synchronize()
+            .map_err(|e| anyhow::anyhow!("stream sync after position update: {e}"))?;
+
+        Ok(())
+    }
+
     /// Attempt to capture a CUDA graph during a decode forward pass.
     #[cfg(feature = "cuda")]
     fn try_capture(
@@ -202,6 +264,13 @@ impl CudaGraphRunner {
         };
         let stream = cuda_dev.cuda_stream();
 
+        // Pre-allocate the position buffer on GPU BEFORE capture.
+        // This tensor's device pointer gets baked into the captured graph.
+        // On replay, we update its contents via memcpy (outside the graph)
+        // so the RoPE kernels see the correct position each step.
+        let pos_f32 = seq_len as f32;
+        let position_buffer = Tensor::new(&[pos_f32], device)?;
+
         // Synchronize all pending work before capture
         stream
             .synchronize()
@@ -212,7 +281,9 @@ impl CudaGraphRunner {
             .begin_capture(CU_STREAM_CAPTURE_MODE_RELAXED)
             .map_err(|e| anyhow::anyhow!("begin_capture: {e}"))?;
 
-        // Run the forward pass; all kernels, allocations, and memcpies are captured
+        // Run the forward pass with the pre-allocated position buffer.
+        // All kernels are captured, including RoPE which reads from
+        // position_buffer's stable GPU address.
         let logits_result = model_forward_paged(
             &[token_id],
             weights,
@@ -222,6 +293,7 @@ impl CudaGraphRunner {
             seq_len,
             Some(linear_state),
             lora,
+            Some(&position_buffer),
         );
 
         // End capture — instantiates the graph
@@ -234,14 +306,14 @@ impl CudaGraphRunner {
         match graph_result {
             Ok(Some(graph)) => {
                 tracing::info!(
-                    "CUDA graph captured for decode ({} layers, {} params)",
+                    "CUDA graph captured for decode ({} layers)",
                     config.num_layers,
-                    "ok"
                 );
                 self.captured = Some(CapturedDecodeGraph {
                     graph,
                     output_logits: logits.clone(),
                     adapter_gen: self.adapter_generation,
+                    position_buffer,
                 });
                 Ok(logits)
             }
@@ -274,6 +346,7 @@ impl CudaGraphRunner {
             seq_len,
             Some(linear_state),
             lora,
+            None, // no pre-allocated position buffer — creates one internally
         )
         .context("eager decode forward pass failed")
     }

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -208,6 +208,8 @@ impl CudaGraphRunner {
     /// replayed RoPE kernels read the correct position.
     #[cfg(feature = "cuda")]
     fn update_position_buffer(position_buffer: &Tensor, position: usize) -> Result<()> {
+        use candle_core::cuda_backend::cudarc::driver::DevicePtr;
+
         let pos_f32 = [position as f32];
 
         let (storage, _layout) = position_buffer.storage_and_layout();
@@ -225,9 +227,9 @@ impl CudaGraphRunner {
         // (the stream is serialized). The device pointer and allocation size
         // are valid because the position_buffer tensor is alive.
         unsafe {
-            let (dev_ptr, _guard) = slice.device_ptr(&stream);
+            let (dev_ptr, _guard) = slice.device_ptr(stream);
             candle_core::cuda_backend::cudarc::driver::result::memcpy_htod_async(
-                dev_ptr as u64,
+                dev_ptr,
                 &pos_f32,
                 raw_stream,
             )
@@ -297,7 +299,9 @@ impl CudaGraphRunner {
         );
 
         // End capture — instantiates the graph
-        let graph_result = stream.end_capture(0);
+        let graph_result = stream.end_capture(
+            candle_core::cuda_backend::cudarc::driver::sys::CUgraphInstantiate_flags_enum::CUDA_GRAPH_INSTANTIATE_FLAG_AUTO_FREE_ON_LAUNCH,
+        );
 
         // Check forward pass success first
         let logits = logits_result.context("forward pass failed during graph capture")?;

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -347,6 +347,42 @@ pub fn rotary_embedding(
     Ok((rotated_q, rotated_k))
 }
 
+/// Same as [`rotary_embedding`] but accepts positions as a pre-allocated GPU tensor
+/// instead of a CPU slice. This is critical for CUDA graph compatibility: the tensor's
+/// GPU address stays stable across graph replays, and its contents can be updated via
+/// `cudaMemcpyAsync` outside the captured graph.
+///
+/// `positions_tensor`: f32 tensor on device, shape [seq_len]
+pub fn rotary_embedding_from_tensor(
+    q: &Tensor,
+    k: &Tensor,
+    positions_tensor: &Tensor,
+    head_dim: usize,
+    rotary_dim: usize,
+    rope_theta: f64,
+) -> Result<(Tensor, Tensor)> {
+    let device = q.device();
+    let half_rotary = rotary_dim / 2;
+
+    let inv_freq: Vec<f32> = (0..half_rotary)
+        .map(|i| 1.0 / rope_theta.powf(2.0 * i as f64 / rotary_dim as f64) as f32)
+        .collect();
+    let inv_freq = Tensor::new(inv_freq.as_slice(), device)?;
+
+    // positions_tensor is [seq_len], unsqueeze to [seq_len, 1]
+    let pos = positions_tensor.unsqueeze(1)?;
+
+    let freqs = pos.broadcast_mul(&inv_freq.unsqueeze(0)?)?;
+
+    let cos = freqs.cos()?;
+    let sin = freqs.sin()?;
+
+    let rotated_q = apply_rope(q, &cos, &sin, head_dim, rotary_dim)?;
+    let rotated_k = apply_rope(k, &cos, &sin, head_dim, rotary_dim)?;
+
+    Ok((rotated_q, rotated_k))
+}
+
 /// Apply the rotation to a single tensor, supporting partial rotary embeddings.
 /// `x`: [batch, seq_len, num_heads, head_dim]
 /// `cos`, `sin`: [seq_len, half_rotary]
@@ -890,7 +926,8 @@ pub fn gqa_attention(
 pub fn gqa_attention_paged(
     x: &Tensor,
     attn_weights: &GpuFullAttentionWeights,
-    positions: &[u32],
+    positions: &Tensor,
+    start_pos: usize,
     num_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
@@ -904,7 +941,6 @@ pub fn gqa_attention_paged(
     lora: Option<(&LoraLayerWeights, f32)>,
 ) -> Result<Tensor> {
     let (_batch, seq_len, _hidden) = x.dims3()?;
-    let start_pos = positions[0] as usize;
 
     // Project to Q, K, V (with optional LoRA delta and output gate split)
     let (lora_layer, lora_scale) = match lora {
@@ -934,7 +970,9 @@ pub fn gqa_attention_paged(
     let k = rms_norm(&k, &attn_weights.k_norm, rms_norm_eps)?;
 
     // RoPE — only rotate first rotary_dim dimensions
-    let (q, k) = rotary_embedding(&q, &k, positions, head_dim, rotary_dim, rope_theta)?;
+    // Use the GPU tensor variant so positions remain at a stable GPU address
+    // (critical for CUDA graph replay correctness)
+    let (q, k) = rotary_embedding_from_tensor(&q, &k, positions, head_dim, rotary_dim, rope_theta)?;
 
     // Transpose to [batch, heads, seq_len, head_dim]
     let q = q.transpose(1, 2)?.contiguous()?;
@@ -1212,7 +1250,8 @@ pub fn transformer_block_paged(
     x: &Tensor,
     layer: &GpuLayerWeights,
     config: &kiln_core::config::ModelConfig,
-    positions: &[u32],
+    positions: &Tensor,
+    start_pos: usize,
     num_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
@@ -1239,6 +1278,7 @@ pub fn transformer_block_paged(
         &normed,
         attn_weights,
         positions,
+        start_pos,
         num_heads,
         num_kv_heads,
         head_dim,
@@ -1501,6 +1541,11 @@ pub fn model_forward_head(
 /// for KV storage. The caller provides `start_pos` (the absolute position of
 /// the first token in `token_ids`) instead of relying on `kv_cache.seq_len()`.
 ///
+/// `positions_gpu`: optional pre-allocated f32 tensor on device with shape [seq_len].
+/// When provided, this tensor is used for RoPE instead of creating a new one.
+/// This is required for CUDA graph replay: the tensor's GPU address must remain
+/// stable so the captured graph reads updated position values on replay.
+///
 /// Returns logits tensor with shape [1, seq_len, vocab_size].
 pub fn model_forward_paged(
     token_ids: &[u32],
@@ -1511,8 +1556,10 @@ pub fn model_forward_paged(
     start_pos: usize,
     mut linear_state: Option<&mut LinearAttentionState>,
     lora: Option<&LoraWeights>,
+    positions_gpu: Option<&Tensor>,
 ) -> Result<Tensor> {
     let seq_len = token_ids.len();
+    let device = weights.embed_tokens.device();
 
     // 1. Embedding lookup: [seq_len, hidden_size]
     let mut hidden = embedding_lookup(token_ids, &weights.embed_tokens)?;
@@ -1520,8 +1567,20 @@ pub fn model_forward_paged(
     // Add batch dimension: [1, seq_len, hidden_size]
     hidden = hidden.unsqueeze(0)?;
 
-    // Position indices for RoPE — absolute positions
-    let positions: Vec<u32> = (start_pos..start_pos + seq_len).map(|p| p as u32).collect();
+    // Position tensor for RoPE — use pre-allocated GPU tensor if provided,
+    // otherwise create one from scratch. The pre-allocated path is essential
+    // for CUDA graph replay where the tensor pointer must be stable.
+    let positions_owned;
+    let positions: &Tensor = match positions_gpu {
+        Some(t) => t,
+        None => {
+            let pos_f32: Vec<f32> = (start_pos..start_pos + seq_len)
+                .map(|p| p as f32)
+                .collect();
+            positions_owned = Tensor::new(pos_f32.as_slice(), device)?;
+            &positions_owned
+        }
+    };
 
     // 2. Loop through all transformer layers
     let mut full_attn_idx: usize = 0;
@@ -1537,7 +1596,8 @@ pub fn model_forward_paged(
                     &hidden,
                     layer,
                     config,
-                    &positions,
+                    positions,
+                    start_pos,
                     config.num_attention_heads,
                     config.num_kv_heads,
                     config.head_dim,

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -526,6 +526,7 @@ impl ModelRunner {
             0,
             Some(&mut linear_state),
             self.active_lora.as_ref(),
+            None,
         )
         .context("prefill forward pass (paged) failed")?;
 
@@ -664,6 +665,7 @@ impl ModelRunner {
             0,
             Some(&mut linear_state),
             self.active_lora.as_ref(),
+            None,
         ) {
             Ok(l) => l,
             Err(e) => {


### PR DESCRIPTION
## What
Refactors RoPE to accept pre-allocated position tensors outside CUDA graph capture, so graphs actually replay instead of always falling back to eager mode.

## Changes
- `rotary_embedding()` accepts external position tensor
- `CudaGraphRunner` pre-allocates position buffer, updates via `cudaMemcpyHtoDAsync` before replay
- 3 fix-up commits for cudarc 0.19 API compatibility (DevicePtr trait, CudaStorage field access, Arc<CudaStream> borrows)
- Add `unsafe impl Send + Sync` for `CudaGraphRunner` so it satisfies axum's `State` bounds (CUDA graphs are GPU-side recorded sequences, safe to launch from any thread)

## Testing
- Built and tested on NVIDIA RTX A6000 with `--features cuda`
- All 151 tests pass (19 kiln-core + 86 kiln-scheduler + 4 kiln-model + 30 kiln-server + 12 kiln-train)
- Release build completes successfully including flash-attn CUDA kernel compilation