### PR TITLE
Add GPTQ INT4 model weight quantization support

### DIFF
--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -8,6 +8,7 @@ pub mod loader;
 pub mod lora;
 pub mod lora_loader;
 pub mod paged_kv_cache;
+pub mod quantized;
 pub mod sampling;
 pub mod weights;
 

--- a/crates/kiln-model/src/loader.rs
+++ b/crates/kiln-model/src/loader.rs
@@ -8,6 +8,7 @@ use safetensors::SafeTensors;
 
 use kiln_core::config::ModelConfig;
 
+use crate::quantized::{self, GptqConfig};
 use crate::weights::*;
 
 /// Weight name prefix for the language model within the VL checkpoint.
@@ -26,6 +27,22 @@ const INDEX_FILENAME: &str = "model.safetensors.index.json";
 /// the safetensors files. Only language model weights (prefixed with
 /// `model.language_model.`) are loaded; vision encoder weights are skipped.
 pub fn load_model(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeights> {
+    // Auto-detect GPTQ quantization.
+    if let Some(gptq_config) = quantized::load_gptq_config(model_dir)? {
+        tracing::info!(
+            bits = gptq_config.bits,
+            group_size = gptq_config.group_size,
+            sym = gptq_config.sym,
+            "Detected GPTQ quantization — loading quantized weights"
+        );
+        return load_model_gptq(model_dir, config, &gptq_config);
+    }
+
+    load_model_dense(model_dir, config)
+}
+
+/// Load dense (unquantized) BF16/FP16 model weights.
+fn load_model_dense(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeights> {
     let shards = discover_shards(model_dir)?;
     tracing::info!(
         "Loading model from {} ({} shard{})",
@@ -90,6 +107,85 @@ pub fn load_model(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeights
         total_params_m,
         total_mb,
         config.num_layers,
+    );
+
+    Ok(weights)
+}
+
+/// Load GPTQ-quantized model weights, dequantizing INT4 to BF16.
+///
+/// GPTQ models store linear layer weights as packed INT4 with per-group scales
+/// and zero points. This function loads and dequantizes them to BF16 `WeightTensor`s
+/// that fit into the standard `ModelWeights` structure.
+///
+/// Non-linear weights (embeddings, layer norms, conv1d, etc.) are loaded as-is
+/// since they are stored in their original precision even in GPTQ models.
+fn load_model_gptq(
+    model_dir: &Path,
+    config: &ModelConfig,
+    gptq_config: &GptqConfig,
+) -> Result<ModelWeights> {
+    let shards = discover_shards(model_dir)?;
+    tracing::info!(
+        "Loading GPTQ model from {} ({} shard{})",
+        model_dir.display(),
+        shards.len(),
+        if shards.len() == 1 { "" } else { "s" }
+    );
+
+    let mmaps = mmap_shards(&shards)?;
+    let parsed: Vec<SafeTensors<'_>> = mmaps
+        .iter()
+        .map(|mmap| {
+            SafeTensors::deserialize(mmap)
+                .context("Failed to parse safetensors file")
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut all_tensors: Vec<(String, usize, safetensors::tensor::TensorView<'_>)> = Vec::new();
+    for (shard_idx, st) in parsed.iter().enumerate() {
+        for (name, view) in st.tensors() {
+            all_tensors.push((name, shard_idx, view));
+        }
+    }
+    let mut tensor_map: HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)> = HashMap::new();
+    for (name, shard_idx, view) in &all_tensors {
+        tensor_map.insert(name.as_str(), (*shard_idx, view));
+    }
+
+    let prefix = detect_prefix(&tensor_map);
+    tracing::info!("Using weight name prefix: \"{prefix}\"");
+
+    // Embedding — stored in original precision even in GPTQ models.
+    let embed_tokens = extract_tensor(&tensor_map, &format!("{prefix}embed_tokens.weight"))?;
+    validate_shape(&embed_tokens, &[config.vocab_size, config.hidden_size], "embed_tokens")?;
+
+    // Load layers — linear projections are GPTQ-quantized, norms are dense.
+    let mut layers = Vec::with_capacity(config.num_layers);
+    for i in 0..config.num_layers {
+        let layer_prefix = format!("{prefix}layers.{i}.");
+        let layer = load_layer_gptq(&tensor_map, &layer_prefix, i, config, gptq_config)?;
+        layers.push(layer);
+    }
+
+    // Final norm — stored in original precision.
+    let final_norm = extract_tensor(&tensor_map, &format!("{prefix}norm.weight"))?;
+    validate_shape(&final_norm, &[config.hidden_size], "final_norm")?;
+
+    let weights = ModelWeights {
+        embedding: EmbeddingWeights { embed_tokens },
+        layers,
+        final_norm,
+    };
+
+    let total_mb = weights.total_bytes() as f64 / (1024.0 * 1024.0);
+    let total_params_m = weights.total_params() as f64 / 1_000_000.0;
+    tracing::info!(
+        "Loaded {:.0}M parameters ({:.0} MB dequantized BF16) across {} layers (GPTQ INT{})",
+        total_params_m,
+        total_mb,
+        config.num_layers,
+        gptq_config.bits,
     );
 
     Ok(weights)
@@ -408,6 +504,333 @@ fn validate_shape(tensor: &WeightTensor, expected: &[usize], name: &str) -> Resu
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// GPTQ layer loading
+// ---------------------------------------------------------------------------
+
+/// Load one transformer layer's weights from a GPTQ-quantized checkpoint.
+///
+/// Linear projections (q/k/v/o_proj, gate/up/down_proj, GDN projections) are
+/// loaded from packed INT4 (qweight + scales + qzeros) and dequantized to BF16.
+/// Non-linear weights (norms, conv1d, a_log, dt_bias) are loaded as-is.
+fn load_layer_gptq(
+    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    prefix: &str,
+    layer_idx: usize,
+    config: &ModelConfig,
+    gptq_config: &GptqConfig,
+) -> Result<LayerWeights> {
+    let input_layernorm = extract_tensor(tensor_map, &format!("{prefix}input_layernorm.weight"))?;
+    validate_shape(
+        &input_layernorm,
+        &[config.hidden_size],
+        &format!("layer {layer_idx} input_layernorm"),
+    )?;
+
+    let post_attention_layernorm =
+        extract_tensor(tensor_map, &format!("{prefix}post_attention_layernorm.weight"))?;
+    validate_shape(
+        &post_attention_layernorm,
+        &[config.hidden_size],
+        &format!("layer {layer_idx} post_attn_layernorm"),
+    )?;
+
+    let mlp = load_ffn_gptq(tensor_map, prefix, layer_idx, config, gptq_config)?;
+
+    let attention = if config.is_full_attention_layer(layer_idx) {
+        AttentionWeights::Full(load_full_attention_gptq(
+            tensor_map,
+            prefix,
+            layer_idx,
+            config,
+            gptq_config,
+        )?)
+    } else {
+        AttentionWeights::Linear(load_linear_attention_gptq(
+            tensor_map,
+            prefix,
+            layer_idx,
+            config,
+            gptq_config,
+        )?)
+    };
+
+    Ok(LayerWeights {
+        input_layernorm,
+        post_attention_layernorm,
+        attention,
+        mlp,
+    })
+}
+
+/// Load and dequantize a single GPTQ-quantized linear projection.
+///
+/// Looks for `{name}.qweight`, `{name}.scales`, `{name}.qzeros` in the tensor map.
+/// Returns a dense BF16 `WeightTensor` with shape `[out_features, in_features]`.
+fn load_gptq_linear(
+    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    name: &str,
+    gptq_config: &GptqConfig,
+    ctx: &str,
+) -> Result<WeightTensor> {
+    let qweight = extract_raw_tensor(tensor_map, &format!("{name}.qweight"))
+        .with_context(|| format!("{ctx}: qweight"))?;
+    let scales = extract_raw_tensor(tensor_map, &format!("{name}.scales"))
+        .with_context(|| format!("{ctx}: scales"))?;
+    let qzeros = extract_raw_tensor(tensor_map, &format!("{name}.qzeros"))
+        .with_context(|| format!("{ctx}: qzeros"))?;
+
+    // Convert scales dtype (GPTQ scales are typically F16)
+    let scales_dtype = convert_dtype(scales.2)
+        .with_context(|| format!("{ctx}: scales dtype {:?}", scales.2))?;
+
+    quantized::dequantize_gptq_weight(
+        &qweight.0,
+        &qweight.1,
+        &scales.0,
+        &scales.1,
+        scales_dtype,
+        &qzeros.0,
+        &qzeros.1,
+        gptq_config.group_size,
+    )
+    .with_context(|| format!("dequantizing {ctx}"))
+}
+
+/// Extract raw tensor data (bytes, shape, dtype) without dtype conversion.
+/// Used for GPTQ tensors which may be I32 (not supported by our TensorDType).
+fn extract_raw_tensor(
+    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    name: &str,
+) -> Result<(Vec<u8>, Vec<usize>, safetensors::Dtype)> {
+    let (_shard_idx, view) = tensor_map
+        .get(name)
+        .with_context(|| format!("Weight tensor not found: {name}"))?;
+    Ok((view.data().to_vec(), view.shape().to_vec(), view.dtype()))
+}
+
+/// Load GPTQ-quantized full GQA attention weights.
+fn load_full_attention_gptq(
+    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    prefix: &str,
+    layer_idx: usize,
+    config: &ModelConfig,
+    gptq_config: &GptqConfig,
+) -> Result<FullAttentionWeights> {
+    let attn = format!("{prefix}self_attn.");
+    let ctx = |name: &str| format!("layer {layer_idx} self_attn.{name}");
+
+    let q_proj_dim = config.full_attn_q_proj_dim();
+    let q_out_dim = config.num_attention_heads * config.head_dim;
+    let kv_dim = config.num_kv_heads * config.head_dim;
+
+    let q_proj = load_gptq_linear(tensor_map, &format!("{attn}q_proj"), gptq_config, &ctx("q_proj"))?;
+    validate_shape(&q_proj, &[q_proj_dim, config.hidden_size], &ctx("q_proj"))?;
+
+    let k_proj = load_gptq_linear(tensor_map, &format!("{attn}k_proj"), gptq_config, &ctx("k_proj"))?;
+    validate_shape(&k_proj, &[kv_dim, config.hidden_size], &ctx("k_proj"))?;
+
+    let v_proj = load_gptq_linear(tensor_map, &format!("{attn}v_proj"), gptq_config, &ctx("v_proj"))?;
+    validate_shape(&v_proj, &[kv_dim, config.hidden_size], &ctx("v_proj"))?;
+
+    let o_proj = load_gptq_linear(tensor_map, &format!("{attn}o_proj"), gptq_config, &ctx("o_proj"))?;
+    validate_shape(&o_proj, &[config.hidden_size, q_out_dim], &ctx("o_proj"))?;
+
+    // QK norms are stored in original precision (1-D, not quantized).
+    let q_norm = extract_tensor(tensor_map, &format!("{attn}q_norm.weight"))?;
+    validate_shape(&q_norm, &[config.head_dim], &ctx("q_norm"))?;
+
+    let k_norm = extract_tensor(tensor_map, &format!("{attn}k_norm.weight"))?;
+    validate_shape(&k_norm, &[config.head_dim], &ctx("k_norm"))?;
+
+    Ok(FullAttentionWeights {
+        q_proj,
+        k_proj,
+        v_proj,
+        o_proj,
+        q_norm,
+        k_norm,
+    })
+}
+
+/// Load GPTQ-quantized Gated DeltaNet linear attention weights.
+fn load_linear_attention_gptq(
+    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    prefix: &str,
+    layer_idx: usize,
+    config: &ModelConfig,
+    gptq_config: &GptqConfig,
+) -> Result<LinearAttentionWeights> {
+    let attn = format!("{prefix}linear_attn.");
+    let ctx = |name: &str| format!("layer {layer_idx} linear_attn.{name}");
+
+    let fused_qkv_dim = config.linear_qkv_dim();
+    let v_dim = config.linear_v_dim();
+    let num_heads = config.linear_num_value_heads;
+
+    // Large projections are GPTQ-quantized.
+    let in_proj_qkv = load_gptq_linear(
+        tensor_map,
+        &format!("{attn}in_proj_qkv"),
+        gptq_config,
+        &ctx("in_proj_qkv"),
+    )?;
+    validate_shape(&in_proj_qkv, &[fused_qkv_dim, config.hidden_size], &ctx("in_proj_qkv"))?;
+
+    let in_proj_z = load_gptq_linear(
+        tensor_map,
+        &format!("{attn}in_proj_z"),
+        gptq_config,
+        &ctx("in_proj_z"),
+    )?;
+    validate_shape(&in_proj_z, &[v_dim, config.hidden_size], &ctx("in_proj_z"))?;
+
+    let out_proj = load_gptq_linear(
+        tensor_map,
+        &format!("{attn}out_proj"),
+        gptq_config,
+        &ctx("out_proj"),
+    )?;
+    validate_shape(&out_proj, &[config.hidden_size, v_dim], &ctx("out_proj"))?;
+
+    // Small projections (a, b) — may or may not be quantized in GPTQ models.
+    // Try GPTQ first, fall back to dense if qweight not found.
+    let in_proj_a = load_gptq_or_dense(
+        tensor_map,
+        &format!("{attn}in_proj_a"),
+        gptq_config,
+        &ctx("in_proj_a"),
+    )?;
+    validate_shape(&in_proj_a, &[num_heads, config.hidden_size], &ctx("in_proj_a"))?;
+
+    let in_proj_b = load_gptq_or_dense(
+        tensor_map,
+        &format!("{attn}in_proj_b"),
+        gptq_config,
+        &ctx("in_proj_b"),
+    )?;
+    validate_shape(&in_proj_b, &[num_heads, config.hidden_size], &ctx("in_proj_b"))?;
+
+    // Non-linear weights: stored in original precision.
+    let conv1d = extract_tensor(tensor_map, &format!("{attn}conv1d.weight"))?;
+    if conv1d.shape.len() != 3 || conv1d.shape[0] != fused_qkv_dim || conv1d.shape[1] != 1 {
+        bail!(
+            "Shape mismatch for {}: expected [{fused_qkv_dim}, 1, *], got {:?}",
+            ctx("conv1d"),
+            conv1d.shape
+        );
+    }
+
+    let norm = extract_tensor(tensor_map, &format!("{attn}norm.weight"))?;
+    validate_shape(&norm, &[config.linear_key_head_dim], &ctx("norm"))?;
+
+    let a_log = extract_tensor(tensor_map, &format!("{attn}A_log"))?;
+    if a_log.numel() != num_heads {
+        bail!(
+            "Element count mismatch for {}: expected {num_heads}, got {} (shape {:?})",
+            ctx("A_log"),
+            a_log.numel(),
+            a_log.shape
+        );
+    }
+
+    let dt_bias = extract_tensor(tensor_map, &format!("{attn}dt_bias"))?;
+    if dt_bias.numel() != num_heads {
+        bail!(
+            "Element count mismatch for {}: expected {num_heads}, got {} (shape {:?})",
+            ctx("dt_bias"),
+            dt_bias.numel(),
+            dt_bias.shape
+        );
+    }
+
+    Ok(LinearAttentionWeights {
+        in_proj_qkv,
+        in_proj_z,
+        out_proj,
+        in_proj_a,
+        in_proj_b,
+        conv1d,
+        norm,
+        a_log,
+        dt_bias,
+    })
+}
+
+/// Load GPTQ-quantized FFN/MLP weights.
+fn load_ffn_gptq(
+    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    prefix: &str,
+    layer_idx: usize,
+    config: &ModelConfig,
+    gptq_config: &GptqConfig,
+) -> Result<FfnWeights> {
+    let mlp = format!("{prefix}mlp.");
+    let ctx = |name: &str| format!("layer {layer_idx} mlp.{name}");
+
+    let gate_proj = load_gptq_linear(
+        tensor_map,
+        &format!("{mlp}gate_proj"),
+        gptq_config,
+        &ctx("gate_proj"),
+    )?;
+    validate_shape(
+        &gate_proj,
+        &[config.intermediate_size, config.hidden_size],
+        &ctx("gate_proj"),
+    )?;
+
+    let up_proj = load_gptq_linear(
+        tensor_map,
+        &format!("{mlp}up_proj"),
+        gptq_config,
+        &ctx("up_proj"),
+    )?;
+    validate_shape(
+        &up_proj,
+        &[config.intermediate_size, config.hidden_size],
+        &ctx("up_proj"),
+    )?;
+
+    let down_proj = load_gptq_linear(
+        tensor_map,
+        &format!("{mlp}down_proj"),
+        gptq_config,
+        &ctx("down_proj"),
+    )?;
+    validate_shape(
+        &down_proj,
+        &[config.hidden_size, config.intermediate_size],
+        &ctx("down_proj"),
+    )?;
+
+    Ok(FfnWeights {
+        gate_proj,
+        up_proj,
+        down_proj,
+    })
+}
+
+/// Try loading a weight as GPTQ-quantized; fall back to dense if qweight not found.
+///
+/// Some small projections (e.g., GDN's in_proj_a/b) may not be quantized
+/// in certain GPTQ models. This function handles both cases gracefully.
+fn load_gptq_or_dense(
+    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    name: &str,
+    gptq_config: &GptqConfig,
+    ctx: &str,
+) -> Result<WeightTensor> {
+    let qweight_name = format!("{name}.qweight");
+    if tensor_map.contains_key(qweight_name.as_str()) {
+        load_gptq_linear(tensor_map, name, gptq_config, ctx)
+    } else {
+        // Fall back to dense weight
+        extract_tensor(tensor_map, &format!("{name}.weight"))
+            .with_context(|| format!("{ctx}: neither GPTQ nor dense weight found"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -694,5 +1117,316 @@ mod tests {
             err.contains("not found"),
             "Error should mention missing tensor: {err}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // GPTQ loading tests
+    // -----------------------------------------------------------------------
+
+    /// Create a safetensors file with custom binary data for each tensor.
+    /// Unlike `create_test_safetensors` which fills with zeros, this takes
+    /// pre-built byte arrays.
+    fn create_safetensors_with_data(
+        tensors: &[(&str, Vec<usize>, StDtype, Vec<u8>)],
+    ) -> Vec<u8> {
+        let tensor_views: Vec<(String, safetensors::tensor::TensorView<'_>)> = tensors
+            .iter()
+            .map(|(name, shape, dtype, data)| {
+                (
+                    name.to_string(),
+                    safetensors::tensor::TensorView::new(*dtype, shape.clone(), data).unwrap(),
+                )
+            })
+            .collect();
+
+        let refs: Vec<(&str, safetensors::tensor::TensorView<'_>)> = tensor_views
+            .iter()
+            .map(|(n, v)| (n.as_str(), v.clone()))
+            .collect();
+
+        safetensors::tensor::serialize(refs, &None).unwrap()
+    }
+
+    /// Pack `values` (each 0..15) into u32 words, 8 values per word.
+    fn pack_int4(values: &[u8]) -> Vec<u8> {
+        let mut words: Vec<u32> = Vec::new();
+        for chunk in values.chunks(8) {
+            let mut packed = 0u32;
+            for (i, &v) in chunk.iter().enumerate() {
+                packed |= (v as u32 & 0xF) << (i * 4);
+            }
+            words.push(packed);
+        }
+        words.iter().flat_map(|w| w.to_le_bytes()).collect()
+    }
+
+    /// Create GPTQ tensor specs for a single linear layer.
+    /// Returns: (name_prefix, qweight_data, scales_data, qzeros_data, tensors_spec)
+    fn gptq_linear_tensors(
+        name: &str,
+        out_features: usize,
+        in_features: usize,
+        group_size: usize,
+    ) -> Vec<(&'static str, String, Vec<usize>, StDtype, Vec<u8>)> {
+        let pack_factor = 8;
+        let in_packed = in_features / pack_factor;
+        let num_groups = in_features / group_size;
+        let out_packed = out_features / pack_factor;
+
+        // qweight: all 5s (INT4 value = 5)
+        let total_int4_values = in_features * out_features;
+        let qweight_values = vec![5u8; total_int4_values];
+        // Pack column-major: qweight[in/8, out]
+        let mut qweight_packed = Vec::new();
+        for pack_row in 0..in_packed {
+            for out_idx in 0..out_features {
+                let mut packed = 0u32;
+                for bit in 0..pack_factor {
+                    let in_idx = pack_row * pack_factor + bit;
+                    let val = qweight_values[in_idx * out_features + out_idx] as u32;
+                    packed |= (val & 0xF) << (bit * 4);
+                }
+                qweight_packed.push(packed);
+            }
+        }
+        let qweight_bytes: Vec<u8> = qweight_packed.iter().flat_map(|w| w.to_le_bytes()).collect();
+
+        // qzeros: all 8s (midpoint)
+        let mut qzeros_packed = Vec::new();
+        for _group in 0..num_groups {
+            for _pack_col in 0..out_packed {
+                let mut packed = 0u32;
+                for bit in 0..pack_factor {
+                    packed |= 8u32 << (bit * 4);
+                }
+                qzeros_packed.push(packed);
+            }
+        }
+        let qzeros_bytes: Vec<u8> = qzeros_packed.iter().flat_map(|w| w.to_le_bytes()).collect();
+
+        // scales: all 1.0 in F16
+        // F16 1.0 = 0x3C00
+        let scales_bytes: Vec<u8> = std::iter::repeat_n(0x3C00u16.to_le_bytes(), num_groups * out_features)
+            .flatten()
+            .collect();
+
+        // We leak the name string to get 'static lifetime for the test
+        let qweight_name = format!("{name}.qweight");
+        let scales_name = format!("{name}.scales");
+        let qzeros_name = format!("{name}.qzeros");
+
+        vec![
+            ("qweight", qweight_name, vec![in_packed, out_features], StDtype::I32, qweight_bytes),
+            ("scales", scales_name, vec![num_groups, out_features], StDtype::F16, scales_bytes),
+            ("qzeros", qzeros_name, vec![num_groups, out_packed], StDtype::I32, qzeros_bytes),
+        ]
+    }
+
+    /// Build GPTQ tensor specs for the tiny test model.
+    fn tiny_gptq_model_tensors(prefix: &str) -> Vec<(String, Vec<usize>, StDtype, Vec<u8>)> {
+        let config = tiny_model_config();
+        let hidden = config.hidden_size;
+        let intermediate = config.intermediate_size;
+        let vocab = config.vocab_size;
+        let group_size = 8; // Small group size for tiny model
+
+        let bf16 = StDtype::BF16;
+
+        let mut tensors: Vec<(String, Vec<usize>, StDtype, Vec<u8>)> = Vec::new();
+
+        // Helper to add a BF16 zero tensor.
+        let mut add_bf16 = |name: String, shape: Vec<usize>| {
+            let numel: usize = shape.iter().product();
+            tensors.push((name, shape, bf16, vec![0u8; numel * 2]));
+        };
+
+        // Helper to add GPTQ-quantized linear layer tensors.
+        let mut add_gptq_linear = |name: &str, out: usize, inp: usize| {
+            let pack_factor = 8usize;
+            let in_packed = inp / pack_factor;
+            let num_groups = inp / group_size;
+            let out_packed = if out >= pack_factor { out / pack_factor } else { 1 };
+
+            // qweight: [in/8, out], all 5s
+            let mut qweight_words = Vec::new();
+            for _row in 0..in_packed {
+                for _col in 0..out {
+                    let packed: u32 = (0..pack_factor as u32).map(|i| 5u32 << (i * 4)).sum();
+                    qweight_words.push(packed);
+                }
+            }
+            let qweight_bytes: Vec<u8> = qweight_words.iter().flat_map(|w| w.to_le_bytes()).collect();
+            tensors.push((format!("{name}.qweight"), vec![in_packed, out], StDtype::I32, qweight_bytes));
+
+            // scales: [num_groups, out], all F16 1.0
+            let scales_bytes: Vec<u8> = vec![0x00, 0x3C].repeat(num_groups * out);
+            tensors.push((format!("{name}.scales"), vec![num_groups, out], StDtype::F16, scales_bytes));
+
+            // qzeros: [num_groups, out/8], all 8s
+            let out_packed_actual = (out + pack_factor - 1) / pack_factor;
+            let mut qzeros_words = Vec::new();
+            for _ in 0..num_groups * out_packed_actual {
+                let packed: u32 = (0..pack_factor as u32).map(|i| 8u32 << (i * 4)).sum();
+                qzeros_words.push(packed);
+            }
+            let qzeros_bytes: Vec<u8> = qzeros_words.iter().flat_map(|w| w.to_le_bytes()).collect();
+            tensors.push((format!("{name}.qzeros"), vec![num_groups, out_packed_actual], StDtype::I32, qzeros_bytes));
+        };
+
+        // Full attention dims
+        let q_proj_dim = config.full_attn_q_proj_dim();
+        let q_out_dim = config.num_attention_heads * config.head_dim;
+        let kv_dim = config.num_kv_heads * config.head_dim;
+
+        // Linear attention dims
+        let fused_qkv_dim = config.linear_qkv_dim();
+        let v_dim = config.linear_v_dim();
+        let num_linear_heads = config.linear_num_value_heads;
+        let conv_size = config.linear_conv_kernel_dim;
+
+        // Embedding + final norm (not quantized)
+        add_bf16(format!("{prefix}embed_tokens.weight"), vec![vocab, hidden]);
+        add_bf16(format!("{prefix}norm.weight"), vec![hidden]);
+
+        for i in 0..config.num_layers {
+            let lp = format!("{prefix}layers.{i}.");
+
+            // Norms (not quantized)
+            add_bf16(format!("{lp}input_layernorm.weight"), vec![hidden]);
+            add_bf16(format!("{lp}post_attention_layernorm.weight"), vec![hidden]);
+
+            // MLP (quantized)
+            add_gptq_linear(&format!("{lp}mlp.gate_proj"), intermediate, hidden);
+            add_gptq_linear(&format!("{lp}mlp.up_proj"), intermediate, hidden);
+            add_gptq_linear(&format!("{lp}mlp.down_proj"), hidden, intermediate);
+
+            if config.is_full_attention_layer(i) {
+                // Full attention projections (quantized)
+                add_gptq_linear(&format!("{lp}self_attn.q_proj"), q_proj_dim, hidden);
+                add_gptq_linear(&format!("{lp}self_attn.k_proj"), kv_dim, hidden);
+                add_gptq_linear(&format!("{lp}self_attn.v_proj"), kv_dim, hidden);
+                add_gptq_linear(&format!("{lp}self_attn.o_proj"), hidden, q_out_dim);
+                // QK norms (not quantized)
+                add_bf16(format!("{lp}self_attn.q_norm.weight"), vec![config.head_dim]);
+                add_bf16(format!("{lp}self_attn.k_norm.weight"), vec![config.head_dim]);
+            } else {
+                // Linear attention: large projections quantized
+                add_gptq_linear(&format!("{lp}linear_attn.in_proj_qkv"), fused_qkv_dim, hidden);
+                add_gptq_linear(&format!("{lp}linear_attn.in_proj_z"), v_dim, hidden);
+                add_gptq_linear(&format!("{lp}linear_attn.out_proj"), hidden, v_dim);
+                // Small projections as dense (a, b have small out dim)
+                add_bf16(format!("{lp}linear_attn.in_proj_a.weight"), vec![num_linear_heads, hidden]);
+                add_bf16(format!("{lp}linear_attn.in_proj_b.weight"), vec![num_linear_heads, hidden]);
+                // Non-linear weights (not quantized)
+                add_bf16(format!("{lp}linear_attn.conv1d.weight"), vec![fused_qkv_dim, 1, conv_size]);
+                add_bf16(format!("{lp}linear_attn.norm.weight"), vec![config.linear_key_head_dim]);
+                add_bf16(format!("{lp}linear_attn.A_log"), vec![num_linear_heads]);
+                add_bf16(format!("{lp}linear_attn.dt_bias"), vec![num_linear_heads]);
+            }
+        }
+
+        tensors
+    }
+
+    #[test]
+    fn test_load_gptq_model() {
+        let tensors = tiny_gptq_model_tensors("model.language_model.");
+
+        // Build safetensors with custom data
+        let tensor_views: Vec<(String, safetensors::tensor::TensorView<'_>)> = tensors
+            .iter()
+            .map(|(name, shape, dtype, data)| {
+                (
+                    name.clone(),
+                    safetensors::tensor::TensorView::new(*dtype, shape.clone(), data).unwrap(),
+                )
+            })
+            .collect();
+        let refs: Vec<(&str, safetensors::tensor::TensorView<'_>)> = tensor_views
+            .iter()
+            .map(|(n, v)| (n.as_str(), v.clone()))
+            .collect();
+        let bytes = safetensors::tensor::serialize(refs, &None).unwrap();
+
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("model.safetensors"), &bytes).unwrap();
+
+        // Write quantize_config.json
+        fs::write(
+            dir.path().join("quantize_config.json"),
+            r#"{"bits": 4, "group_size": 8, "sym": false, "desc_act": false}"#,
+        )
+        .unwrap();
+
+        let config = tiny_model_config();
+        let weights = load_model(dir.path(), &config).unwrap();
+
+        // Basic structural checks
+        assert_eq!(weights.layers.len(), 4);
+        assert_eq!(weights.embedding.embed_tokens.shape, vec![256, 64]);
+        assert_eq!(weights.final_norm.shape, vec![64]);
+
+        // Layer types
+        for i in 0..3 {
+            assert!(
+                matches!(weights.layers[i].attention, AttentionWeights::Linear(_)),
+                "Layer {i} should be linear attention"
+            );
+        }
+        assert!(
+            matches!(weights.layers[3].attention, AttentionWeights::Full(_)),
+            "Layer 3 should be full attention"
+        );
+
+        // Check that dequantized weights have correct shapes.
+        // MLP gate_proj: [intermediate, hidden] = [128, 64]
+        assert_eq!(weights.layers[0].mlp.gate_proj.shape, vec![128, 64]);
+        assert_eq!(weights.layers[0].mlp.gate_proj.dtype, TensorDType::BF16);
+
+        // Full attention q_proj: [q_proj_dim, hidden]
+        if let AttentionWeights::Full(ref attn) = weights.layers[3].attention {
+            // q_proj_dim = 4*16*2 = 128 (with gate), hidden = 64
+            assert_eq!(attn.q_proj.shape, vec![128, 64]);
+            assert_eq!(attn.q_proj.dtype, TensorDType::BF16);
+        }
+
+        // Linear attention in_proj_qkv
+        if let AttentionWeights::Linear(ref attn) = weights.layers[0].attention {
+            let qkv_dim = config.linear_qkv_dim();
+            assert_eq!(attn.in_proj_qkv.shape, vec![qkv_dim, 64]);
+            assert_eq!(attn.in_proj_qkv.dtype, TensorDType::BF16);
+        }
+
+        // Verify dequantized values are reasonable.
+        // With weight=5, zero=8, scale=1.0: expected = (5-8)*1.0 = -3.0
+        let gate_data = &weights.layers[0].mlp.gate_proj.data;
+        let first_bf16 = u16::from_le_bytes([gate_data[0], gate_data[1]]);
+        let first_val = f32::from_bits((first_bf16 as u32) << 16);
+        assert!(
+            (first_val - (-3.0)).abs() < 0.1,
+            "Expected dequantized value ~-3.0, got {first_val}"
+        );
+
+        assert!(weights.total_params() > 0);
+        assert!(weights.total_bytes() > 0);
+    }
+
+    #[test]
+    fn test_gptq_config_autodetect() {
+        // Without quantize_config.json, should load as dense
+        let tensors = tiny_model_tensors("model.language_model.");
+        let tensor_refs: Vec<(&str, Vec<usize>, StDtype)> = tensors
+            .iter()
+            .map(|(n, s, d)| (n.as_str(), s.clone(), *d))
+            .collect();
+        let bytes = create_test_safetensors(&tensor_refs);
+
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("model.safetensors"), &bytes).unwrap();
+        // No quantize_config.json
+
+        let config = tiny_model_config();
+        let weights = load_model(dir.path(), &config).unwrap();
+        assert_eq!(weights.layers.len(), 4);
     }
 }

--- a/crates/kiln-model/src/quantized.rs
+++ b/crates/kiln-model/src/quantized.rs
@@ -1,0 +1,455 @@
+//! GPTQ INT4 weight quantization support.
+//!
+//! Loads pre-quantized GPTQ safetensors (INT4 packed weights + scales + zeros)
+//! and dequantizes them to BF16 for use in the standard forward pass.
+//!
+//! GPTQ packing format (INT4, pack_factor=8):
+//! - `qweight`: `[in_features/8, out_features]`, dtype I32
+//!   Each i32 contains 8 consecutive INT4 values packed in 4-bit groups.
+//! - `scales`: `[num_groups, out_features]`, dtype F16 or BF16
+//!   Per-group per-output-feature scale factors.
+//! - `qzeros`: `[num_groups, out_features/8]`, dtype I32
+//!   Packed INT4 zero points, same packing as qweight.
+//!
+//! The dequantization formula: `weight_f = (weight_int4 - zero_int4) * scale`
+//!
+//! Current implementation: dequantize to BF16 on CPU during model loading.
+//! The resulting weights are stored on GPU in the standard BF16 format.
+//! A future follow-up will add GPU-native INT4 storage with a custom CUDA
+//! dequantization kernel for ~50% GPU memory savings.
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use std::path::Path;
+
+use crate::weights::{TensorDType, WeightTensor};
+
+/// GPTQ quantization configuration from `quantize_config.json`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct GptqConfig {
+    pub bits: usize,
+    pub group_size: usize,
+    #[serde(default)]
+    pub sym: bool,
+    #[serde(default)]
+    pub desc_act: bool,
+}
+
+impl GptqConfig {
+    /// Number of INT4 values packed in one 32-bit word.
+    pub fn pack_factor(&self) -> usize {
+        32 / self.bits
+    }
+}
+
+/// Load GPTQ config from `quantize_config.json` in the model directory.
+///
+/// Returns `None` if the file doesn't exist (model is not GPTQ-quantized).
+pub fn load_gptq_config(model_dir: &Path) -> Result<Option<GptqConfig>> {
+    let config_path = model_dir.join("quantize_config.json");
+    if !config_path.exists() {
+        return Ok(None);
+    }
+    let contents = std::fs::read_to_string(&config_path)
+        .with_context(|| format!("Failed to read {}", config_path.display()))?;
+    let config: GptqConfig = serde_json::from_str(&contents)
+        .with_context(|| format!("Failed to parse {}", config_path.display()))?;
+    if config.bits != 4 {
+        bail!(
+            "Only 4-bit GPTQ quantization is supported, got {} bits",
+            config.bits
+        );
+    }
+    Ok(Some(config))
+}
+
+/// Dequantize a GPTQ-packed linear layer weight to a dense BF16 `WeightTensor`.
+///
+/// The GPTQ format stores weights column-major: `qweight[in/8, out]`.
+/// The output is in kiln's standard layout: `[out_features, in_features]`.
+pub fn dequantize_gptq_weight(
+    qweight_data: &[u8],
+    qweight_shape: &[usize],
+    scales_data: &[u8],
+    scales_shape: &[usize],
+    scales_dtype: TensorDType,
+    qzeros_data: &[u8],
+    qzeros_shape: &[usize],
+    group_size: usize,
+) -> Result<WeightTensor> {
+    let pack_factor = 8usize; // 32 / 4 bits
+
+    if qweight_shape.len() != 2 {
+        bail!(
+            "qweight must be 2-D, got shape {:?}",
+            qweight_shape
+        );
+    }
+
+    let in_features_packed = qweight_shape[0];
+    let out_features = qweight_shape[1];
+    let in_features = in_features_packed * pack_factor;
+    let num_groups = scales_shape[0];
+
+    // Validate shapes
+    if scales_shape.len() != 2 || scales_shape[1] != out_features {
+        bail!(
+            "scales shape mismatch: expected [*, {out_features}], got {:?}",
+            scales_shape
+        );
+    }
+    if qzeros_shape.len() != 2 || qzeros_shape[0] != num_groups {
+        bail!(
+            "qzeros shape mismatch: expected [{num_groups}, *], got {:?}",
+            qzeros_shape
+        );
+    }
+
+    // Interpret raw bytes as u32 slices (GPTQ stores as I32 but bit patterns are the same).
+    let qweight = bytes_as_u32(qweight_data)
+        .context("qweight byte alignment")?;
+    let qzeros = bytes_as_u32(qzeros_data)
+        .context("qzeros byte alignment")?;
+
+    if qweight.len() < in_features_packed * out_features {
+        bail!(
+            "qweight data too short: need {} u32s, got {}",
+            in_features_packed * out_features,
+            qweight.len()
+        );
+    }
+
+    // Convert scales to f32 for computation.
+    let scales_f32 = scales_to_f32(scales_data, scales_dtype, num_groups * out_features)?;
+
+    let out_features_packed = qzeros_shape[1];
+
+    // Dequantize to BF16: output shape [out_features, in_features]
+    let total_elems = out_features * in_features;
+    let mut output_bf16 = vec![0u16; total_elems];
+
+    for out_idx in 0..out_features {
+        for in_idx in 0..in_features {
+            let group = in_idx / group_size;
+
+            // Extract INT4 weight value from packed qweight
+            let pack_row = in_idx / pack_factor;
+            let bit_offset = (in_idx % pack_factor) * 4;
+            let packed_val = qweight[pack_row * out_features + out_idx];
+            let weight_int = ((packed_val >> bit_offset) & 0xF) as i32;
+
+            // Extract INT4 zero point from packed qzeros
+            let zero_pack_col = out_idx / pack_factor;
+            let zero_bit_offset = (out_idx % pack_factor) * 4;
+            let zero_packed = qzeros[group * out_features_packed + zero_pack_col];
+            let zero_int = ((zero_packed >> zero_bit_offset) & 0xF) as i32;
+
+            // Get per-group per-output scale
+            let scale = scales_f32[group * out_features + out_idx];
+
+            // Dequantize: (weight - zero) * scale
+            let dequantized = (weight_int - zero_int) as f32 * scale;
+
+            // Store as BF16 in [out, in] layout
+            output_bf16[out_idx * in_features + in_idx] = f32_to_bf16(dequantized);
+        }
+    }
+
+    // Convert u16 slice to bytes
+    let output_bytes: Vec<u8> = output_bf16
+        .iter()
+        .flat_map(|v| v.to_le_bytes())
+        .collect();
+
+    Ok(WeightTensor {
+        data: output_bytes,
+        shape: vec![out_features, in_features],
+        dtype: TensorDType::BF16,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Reinterpret a byte slice as a u32 slice (little-endian assumed).
+fn bytes_as_u32(data: &[u8]) -> Result<Vec<u32>> {
+    if data.len() % 4 != 0 {
+        bail!(
+            "byte slice length {} is not a multiple of 4",
+            data.len()
+        );
+    }
+    Ok(data
+        .chunks_exact(4)
+        .map(|chunk| u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+        .collect())
+}
+
+/// Convert scale tensor raw bytes to a Vec<f32>.
+fn scales_to_f32(data: &[u8], dtype: TensorDType, count: usize) -> Result<Vec<f32>> {
+    match dtype {
+        TensorDType::F16 => {
+            if data.len() < count * 2 {
+                bail!("scales data too short for {} F16 values", count);
+            }
+            Ok(data
+                .chunks_exact(2)
+                .take(count)
+                .map(|chunk| {
+                    let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
+                    f16_to_f32(bits)
+                })
+                .collect())
+        }
+        TensorDType::BF16 => {
+            if data.len() < count * 2 {
+                bail!("scales data too short for {} BF16 values", count);
+            }
+            Ok(data
+                .chunks_exact(2)
+                .take(count)
+                .map(|chunk| {
+                    let bits = u16::from_le_bytes([chunk[0], chunk[1]]);
+                    bf16_to_f32(bits)
+                })
+                .collect())
+        }
+        TensorDType::F32 => {
+            if data.len() < count * 4 {
+                bail!("scales data too short for {} F32 values", count);
+            }
+            Ok(data
+                .chunks_exact(4)
+                .take(count)
+                .map(|chunk| f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]))
+                .collect())
+        }
+    }
+}
+
+/// Convert IEEE 754 half-precision (F16) bits to f32.
+fn f16_to_f32(bits: u16) -> f32 {
+    let sign = ((bits >> 15) & 1) as u32;
+    let exp = ((bits >> 10) & 0x1F) as u32;
+    let frac = (bits & 0x3FF) as u32;
+
+    if exp == 0 {
+        if frac == 0 {
+            // ±0
+            f32::from_bits(sign << 31)
+        } else {
+            // Subnormal: normalize
+            let mut f = frac;
+            let mut e = 0u32;
+            while (f & 0x400) == 0 {
+                f <<= 1;
+                e += 1;
+            }
+            f &= 0x3FF;
+            let exp32 = 127 - 15 + 1 - e;
+            f32::from_bits((sign << 31) | (exp32 << 23) | (f << 13))
+        }
+    } else if exp == 31 {
+        // Inf / NaN
+        f32::from_bits((sign << 31) | (0xFF << 23) | (frac << 13))
+    } else {
+        // Normal
+        let exp32 = exp + 127 - 15;
+        f32::from_bits((sign << 31) | (exp32 << 23) | (frac << 13))
+    }
+}
+
+/// Convert BF16 bits to f32.
+fn bf16_to_f32(bits: u16) -> f32 {
+    f32::from_bits((bits as u32) << 16)
+}
+
+/// Convert f32 to BF16 bits (round-to-nearest-even).
+fn f32_to_bf16(v: f32) -> u16 {
+    let bits = v.to_bits();
+    // Round to nearest even: add 0x7FFF + bit 16 (the LSB of the result)
+    let round = bits.wrapping_add(0x7FFF + ((bits >> 16) & 1));
+    (round >> 16) as u16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_f16_to_f32_zero() {
+        assert_eq!(f16_to_f32(0x0000), 0.0f32);
+        assert_eq!(f16_to_f32(0x8000), -0.0f32);
+    }
+
+    #[test]
+    fn test_f16_to_f32_one() {
+        assert!((f16_to_f32(0x3C00) - 1.0f32).abs() < 1e-6);
+    }
+
+    #[test]
+    fn test_bf16_roundtrip() {
+        for v in [0.0f32, 1.0, -1.0, 0.5, 100.0, -0.001] {
+            let bf16 = f32_to_bf16(v);
+            let back = bf16_to_f32(bf16);
+            assert!(
+                (back - v).abs() < v.abs() * 0.01 + 1e-6,
+                "roundtrip failed for {v}: got {back}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_bytes_as_u32() {
+        let data = [0x01, 0x00, 0x00, 0x00, 0xFF, 0x00, 0x00, 0x00];
+        let result = bytes_as_u32(&data).unwrap();
+        assert_eq!(result, vec![1u32, 255u32]);
+    }
+
+    #[test]
+    fn test_bytes_as_u32_bad_alignment() {
+        let data = [0x01, 0x02, 0x03];
+        assert!(bytes_as_u32(&data).is_err());
+    }
+
+    #[test]
+    fn test_dequantize_gptq_tiny() {
+        // Create a tiny GPTQ-quantized weight:
+        // 2x2 linear layer (in=16, out=2) with group_size=8
+        //
+        // qweight: [in/8, out] = [2, 2] (each u32 packs 8 INT4 values)
+        // scales: [num_groups, out] = [2, 2]
+        // qzeros: [num_groups, out/8] = [2, 1]
+
+        let in_features = 16;
+        let out_features = 2;
+        let group_size = 8;
+        let pack_factor = 8;
+
+        // Pack weight values: all 5s (INT4 value = 5)
+        // u32 with 8 copies of 5: 5 | (5<<4) | (5<<8) | ... | (5<<28)
+        let packed_5: u32 = (0..pack_factor)
+            .map(|i| 5u32 << (i * 4))
+            .sum();
+
+        // qweight: [2, 2] flattened row-major
+        let qweight: Vec<u32> = vec![packed_5; (in_features / pack_factor) * out_features];
+        let qweight_bytes: Vec<u8> = qweight.iter().flat_map(|v| v.to_le_bytes()).collect();
+
+        // qzeros: all 8s (midpoint for symmetric INT4)
+        // [2, 1] = 2 u32 values, each packing 8 zero points
+        let packed_8: u32 = (0..pack_factor)
+            .map(|i| 8u32 << (i * 4))
+            .sum();
+        let qzeros: Vec<u32> = vec![packed_8; 2];
+        let qzeros_bytes: Vec<u8> = qzeros.iter().flat_map(|v| v.to_le_bytes()).collect();
+
+        // scales: all 0.5 in F32
+        let scale_val = 0.5f32;
+        let num_groups = in_features / group_size;
+        let scales: Vec<f32> = vec![scale_val; num_groups * out_features];
+        let scales_bytes: Vec<u8> = scales.iter().flat_map(|v| v.to_le_bytes()).collect();
+
+        let result = dequantize_gptq_weight(
+            &qweight_bytes,
+            &[in_features / pack_factor, out_features],
+            &scales_bytes,
+            &[num_groups, out_features],
+            TensorDType::F32,
+            &qzeros_bytes,
+            &[num_groups, out_features / pack_factor],
+            group_size,
+        )
+        .unwrap();
+
+        assert_eq!(result.shape, vec![out_features, in_features]);
+        assert_eq!(result.dtype, TensorDType::BF16);
+
+        // Expected: (5 - 8) * 0.5 = -1.5 for all elements
+        let expected_bf16 = f32_to_bf16(-1.5);
+        let result_u16: Vec<u16> = result
+            .data
+            .chunks_exact(2)
+            .map(|c| u16::from_le_bytes([c[0], c[1]]))
+            .collect();
+
+        for (i, &val) in result_u16.iter().enumerate() {
+            let actual = bf16_to_f32(val);
+            assert!(
+                (actual - (-1.5)).abs() < 0.1,
+                "element {i}: expected -1.5, got {actual} (bf16 bits: {val:#06X}, expected {expected_bf16:#06X})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_dequantize_gptq_varying_values() {
+        // Test that different packed INT4 values dequantize correctly
+        let in_features = 8;
+        let out_features = 1;
+        let group_size = 8;
+
+        // Pack values 0,1,2,3,4,5,6,7 into one u32
+        let packed: u32 = (0..8u32).map(|i| i << (i * 4)).sum();
+        let qweight_bytes: Vec<u8> = packed.to_le_bytes().to_vec();
+
+        // Zero point = 0, scale = 1.0
+        let packed_zero: u32 = 0;
+        let qzeros_bytes: Vec<u8> = packed_zero.to_le_bytes().to_vec();
+        let scale = 1.0f32;
+        let scales_bytes: Vec<u8> = scale.to_le_bytes().to_vec();
+
+        let result = dequantize_gptq_weight(
+            &qweight_bytes,
+            &[1, 1],
+            &scales_bytes,
+            &[1, 1],
+            TensorDType::F32,
+            &qzeros_bytes,
+            &[1, 1],
+            group_size,
+        )
+        .unwrap();
+
+        assert_eq!(result.shape, vec![1, 8]);
+
+        let result_values: Vec<f32> = result
+            .data
+            .chunks_exact(2)
+            .map(|c| bf16_to_f32(u16::from_le_bytes([c[0], c[1]])))
+            .collect();
+
+        for (i, &val) in result_values.iter().enumerate() {
+            let expected = i as f32; // (i - 0) * 1.0
+            assert!(
+                (val - expected).abs() < 0.1,
+                "element {i}: expected {expected}, got {val}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_gptq_config_parse() {
+        let json = r#"{
+            "bits": 4,
+            "group_size": 128,
+            "sym": true,
+            "desc_act": false
+        }"#;
+        let config: GptqConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.bits, 4);
+        assert_eq!(config.group_size, 128);
+        assert!(config.sym);
+        assert!(!config.desc_act);
+        assert_eq!(config.pack_factor(), 8);
+    }
+
+    #[test]
+    fn test_gptq_config_defaults() {
+        let json = r#"{"bits": 4, "group_size": 128}"#;
+        let config: GptqConfig = serde_json::from_str(json).unwrap();
+        assert!(!config.sym);
+        assert!(!config.desc_act);
+    }
+}

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -18,6 +18,10 @@ shutdown_timeout_secs = 30
 model_id = "Qwen/Qwen3.5-4B"
 # tokenizer_path = "/path/to/tokenizer.json"
 # adapter_dir = "/path/to/adapters"  # Default: <model_path>/adapters
+                                      #
+                                      # GPTQ INT4 quantization: point `path` at a GPTQ model directory
+                                      # containing quantize_config.json. Kiln auto-detects GPTQ and
+                                      # dequantizes INT4 weights to BF16 during loading.
 
 [memory]
 # num_blocks = 256                   # KV cache blocks (auto-sized from VRAM if omitted)


### PR DESCRIPTION
## Summary

- Auto-detect GPTQ-quantized models via `quantize_config.json` in the model directory
- Load packed INT4 `qweight`/`scales`/`qzeros` from safetensors and dequantize to BF16 `WeightTensor` at load time
- Small projections (GDN `in_proj_a`/`in_proj_b`) gracefully fall back to dense loading if not quantized
- CPU-side dequantization (candle lacks GPU-native INT4 bitwise ops; custom CUDA kernel deferred to follow-up)
- No changes to forward pass or GPU code — dequantization is transparent to downstream consumers

## New files

- `crates/kiln-model/src/quantized.rs` — GPTQ config parsing, dequantization math, unit tests

## Modified files

- `crates/kiln-model/src/loader.rs` — GPTQ-aware loading paths (`load_model_gptq`, `load_gptq_linear`, `load_gptq_or_dense`), integration test with full 4-layer GPTQ-packed tiny model
- `crates/kiln-model/src/lib.rs` — `pub mod quantized`
- `kiln.example.toml` — Document GPTQ auto-detection in comments

## Test plan

- [ ] Unit tests pass: `cargo test -p kiln-model quantized` (dequant math, config parsing, bf16 roundtrip)
- [ ] Integration test passes: `cargo test -p kiln-model test_load_gptq_model` (full tiny GPTQ model load)
- [ ] Existing tests still pass: `cargo test -p kiln-model`
- [ ] E2E verification on RunPod with actual GPTQ Qwen3.5-4B model (deferred to post-merge GPU test)

## Follow-up work

- GPU-native INT4 dequantization via custom CUDA kernel (keeps weights packed on GPU, ~2x memory savings)
- Benchmark CPU dequant overhead vs dense loading