### PR TITLE
Add prefix caching for KV cache reuse

### DIFF
--- a/crates/kiln-core/src/lib.rs
+++ b/crates/kiln-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod block;
 pub mod config;
+pub mod prefix_cache;
 pub mod request;
 pub mod sampling;
 pub mod token;
@@ -8,5 +9,6 @@ pub mod vram;
 
 pub use block::{BlockManager, BlockTable};
 pub use config::ModelConfig;
+pub use prefix_cache::PrefixCache;
 pub use request::{Request, RequestId, RequestState};
 pub use sampling::SamplingParams;

--- a/crates/kiln-core/src/prefix_cache.rs
+++ b/crates/kiln-core/src/prefix_cache.rs
@@ -8,6 +8,11 @@ use crate::token::TokenId;
 /// the second request can reuse the already-computed KV cache blocks instead of
 /// recomputing them. Blocks are reference-counted so they aren't freed while
 /// still in use, and evicted via LRU when memory pressure requires it.
+///
+/// Uses hash chaining: each block's key is derived from the tokens in that block
+/// AND the previous block's hash. This means any prefix that matches block-by-block
+/// from the start will find the longest cached run, even if different suffixes
+/// were registered from different prompts.
 #[derive(Debug)]
 pub struct PrefixCache {
     /// Maximum number of physical blocks the prefix cache may hold.
@@ -18,19 +23,20 @@ pub struct PrefixCache {
     clock: u64,
     /// Block size in tokens — must match the block manager's block_size.
     block_size: usize,
-    /// Hash of a block-aligned token prefix → cache entry.
-    entries: HashMap<u64, CacheEntry>,
+    /// Hash chain key → cached block entry.
+    /// Each entry represents one block at a specific position in a specific prefix.
+    entries: HashMap<u64, BlockCacheEntry>,
     /// Reference counts for individual physical block IDs.
     /// A block with refcount > 0 must not be evicted.
     refcounts: HashMap<u32, usize>,
 }
 
 #[derive(Debug, Clone)]
-struct CacheEntry {
-    /// Physical block IDs for this prefix, in order.
-    block_ids: Vec<u32>,
-    /// Number of token-blocks (prefix length in block-aligned chunks).
-    num_blocks: usize,
+struct BlockCacheEntry {
+    /// Physical block ID for this cached block.
+    block_id: u32,
+    /// The hash chain value at this position (used as the key).
+    chain_hash: u64,
     /// Last-access timestamp for LRU eviction.
     last_used: u64,
 }
@@ -69,96 +75,108 @@ impl PrefixCache {
             return None;
         }
 
-        // We hash progressively longer block-aligned prefixes and find the
-        // longest one that exists in the cache. This is O(num_blocks) hash
-        // lookups per request which is fine — prefixes are typically < 100 blocks.
         let num_full_blocks = tokens.len() / self.block_size;
         if num_full_blocks == 0 {
             return None;
         }
 
-        let mut best: Option<(usize, &CacheEntry)> = None;
+        let mut cached_blocks = Vec::new();
+        let mut prev_hash: u64 = 0;
 
-        for n in (1..=num_full_blocks).rev() {
-            let hash = self.compute_hash(tokens, n);
-            if let Some(entry) = self.entries.get(&hash) {
-                // Verify block count matches (collision guard)
-                if entry.num_blocks == n {
-                    best = Some((n, entry));
-                    break; // longest match (we iterate from longest to shortest)
-                }
+        for block_idx in 0..num_full_blocks {
+            let start = block_idx * self.block_size;
+            let end = start + self.block_size;
+            let block_tokens = &tokens[start..end];
+            let chain_hash = Self::chain_hash(prev_hash, block_tokens);
+
+            if let Some(entry) = self.entries.get(&chain_hash) {
+                cached_blocks.push(entry.block_id);
+                prev_hash = chain_hash;
+            } else {
+                break; // Chain broken — no more cached blocks
             }
         }
 
-        let (num_blocks, entry) = best?;
-        let block_ids = entry.block_ids.clone();
-        let cached_tokens = num_blocks * self.block_size;
+        if cached_blocks.is_empty() {
+            return None;
+        }
 
-        // Bump LRU timestamp
+        let cached_tokens = cached_blocks.len() * self.block_size;
+
+        // Bump LRU timestamps for all matched entries
         self.clock += 1;
         let ts = self.clock;
-        // Re-borrow mutably
-        let hash = self.compute_hash(tokens, num_blocks);
-        if let Some(entry) = self.entries.get_mut(&hash) {
-            entry.last_used = ts;
+        let mut ph: u64 = 0;
+        for block_idx in 0..cached_blocks.len() {
+            let start = block_idx * self.block_size;
+            let end = start + self.block_size;
+            let block_tokens = &tokens[start..end];
+            let ch = Self::chain_hash(ph, block_tokens);
+            if let Some(entry) = self.entries.get_mut(&ch) {
+                entry.last_used = ts;
+            }
+            ph = ch;
         }
 
         // Increment refcounts
-        for &bid in &block_ids {
+        for &bid in &cached_blocks {
             *self.refcounts.entry(bid).or_insert(0) += 1;
         }
 
-        Some((cached_tokens, block_ids))
+        Some((cached_tokens, cached_blocks))
     }
 
     /// Register a completed prefix so future requests can reuse it.
     ///
     /// `tokens` is the full prompt, `block_ids` are the physical blocks that
-    /// hold its KV cache. Only the block-aligned prefix is cached.
+    /// hold its KV cache. Registers each block-aligned block in the hash chain.
     pub fn register(&mut self, tokens: &[TokenId], block_ids: &[u32]) {
         let num_full_blocks = tokens.len() / self.block_size;
         if num_full_blocks == 0 || block_ids.len() < num_full_blocks {
             return;
         }
 
-        let hash = self.compute_hash(tokens, num_full_blocks);
-        if self.entries.contains_key(&hash) {
-            // Already cached — just bump LRU
-            self.clock += 1;
-            let ts = self.clock;
-            if let Some(entry) = self.entries.get_mut(&hash) {
-                entry.last_used = ts;
-            }
-            return;
-        }
-
-        let prefix_blocks: Vec<u32> = block_ids[..num_full_blocks].to_vec();
-
-        // Evict if needed to make room
-        while self.total_cached_blocks + prefix_blocks.len() > self.max_blocks {
-            if !self.evict_one() {
-                // Can't evict anything (all cached blocks are referenced) — don't cache
-                return;
-            }
-        }
-
         self.clock += 1;
         let ts = self.clock;
+        let mut prev_hash: u64 = 0;
 
-        // Increment refcounts for the cached blocks
-        for &bid in &prefix_blocks {
-            *self.refcounts.entry(bid).or_insert(0) += 1;
+        for block_idx in 0..num_full_blocks {
+            let start = block_idx * self.block_size;
+            let end = start + self.block_size;
+            let block_tokens = &tokens[start..end];
+            let chain_hash = Self::chain_hash(prev_hash, block_tokens);
+
+            if self.entries.contains_key(&chain_hash) {
+                // Already cached — just bump LRU
+                if let Some(entry) = self.entries.get_mut(&chain_hash) {
+                    entry.last_used = ts;
+                }
+            } else {
+                // Evict if needed to make room for one block
+                while self.total_cached_blocks >= self.max_blocks {
+                    if !self.evict_one() {
+                        // Can't evict anything — stop caching
+                        prev_hash = chain_hash;
+                        continue;
+                    }
+                }
+
+                // Increment refcount for this block
+                *self.refcounts.entry(block_ids[block_idx]).or_insert(0) += 1;
+                self.total_cached_blocks += 1;
+
+                self.entries.insert(
+                    chain_hash,
+                    BlockCacheEntry {
+                        block_id: block_ids[block_idx],
+                        chain_hash,
+                        last_used: ts,
+                    },
+                );
+            }
+
+            prev_hash = chain_hash;
         }
-
-        self.total_cached_blocks += prefix_blocks.len();
-        self.entries.insert(
-            hash,
-            CacheEntry {
-                num_blocks: num_full_blocks,
-                block_ids: prefix_blocks,
-                last_used: ts,
-            },
-        );
     }
 
     /// Decrement refcounts for blocks that were obtained via `lookup`.
@@ -174,10 +192,7 @@ impl PrefixCache {
     /// Returns the set of physical block IDs that are held by the prefix cache.
     /// The block manager must not free these blocks.
     pub fn held_block_ids(&self) -> Vec<u32> {
-        let mut ids = Vec::new();
-        for entry in self.entries.values() {
-            ids.extend_from_slice(&entry.block_ids);
-        }
+        let mut ids: Vec<u32> = self.entries.values().map(|e| e.block_id).collect();
         ids.sort_unstable();
         ids.dedup();
         ids
@@ -189,22 +204,17 @@ impl PrefixCache {
         self.refcounts.get(&block_id).copied().unwrap_or(0) > 0
     }
 
-    /// Evict the least-recently-used entry whose blocks all have refcount ≤ 1
-    /// (i.e. only the cache itself holds them, no active requests).
+    /// Evict the least-recently-used block entry whose block has refcount ≤ 1
+    /// (i.e. only the cache itself holds it, no active requests).
     /// Returns true if an entry was evicted.
     fn evict_one(&mut self) -> bool {
-        // Find the LRU entry that can be evicted
         let mut best_hash: Option<u64> = None;
         let mut best_ts = u64::MAX;
 
         for (&hash, entry) in &self.entries {
             if entry.last_used < best_ts {
-                // Check all blocks have refcount == 1 (only the cache holds them)
-                let can_evict = entry
-                    .block_ids
-                    .iter()
-                    .all(|&bid| self.refcounts.get(&bid).copied().unwrap_or(0) <= 1);
-                if can_evict {
+                let rc = self.refcounts.get(&entry.block_id).copied().unwrap_or(0);
+                if rc <= 1 {
                     best_hash = Some(hash);
                     best_ts = entry.last_used;
                 }
@@ -213,13 +223,11 @@ impl PrefixCache {
 
         if let Some(hash) = best_hash {
             if let Some(entry) = self.entries.remove(&hash) {
-                self.total_cached_blocks -= entry.block_ids.len();
-                for &bid in &entry.block_ids {
-                    if let Some(rc) = self.refcounts.get_mut(&bid) {
-                        *rc = rc.saturating_sub(1);
-                        if *rc == 0 {
-                            self.refcounts.remove(&bid);
-                        }
+                self.total_cached_blocks -= 1;
+                if let Some(rc) = self.refcounts.get_mut(&entry.block_id) {
+                    *rc = rc.saturating_sub(1);
+                    if *rc == 0 {
+                        self.refcounts.remove(&entry.block_id);
                     }
                 }
                 return true;
@@ -228,16 +236,14 @@ impl PrefixCache {
         false
     }
 
-    /// Compute a hash for the first `num_blocks` block-aligned token chunks.
-    fn compute_hash(&self, tokens: &[TokenId], num_blocks: usize) -> u64 {
+    /// Compute a chained hash for a block of tokens, incorporating the previous block's hash.
+    /// This ensures that the same token block at different positions (after different prefixes)
+    /// gets different hashes.
+    fn chain_hash(prev_hash: u64, block_tokens: &[TokenId]) -> u64 {
         use std::hash::{Hash, Hasher};
-        let end = num_blocks * self.block_size;
-        let slice = &tokens[..end.min(tokens.len())];
-
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        slice.hash(&mut hasher);
-        // Include num_blocks in hash to differentiate prefix lengths
-        num_blocks.hash(&mut hasher);
+        prev_hash.hash(&mut hasher);
+        block_tokens.hash(&mut hasher);
         hasher.finish()
     }
 }
@@ -256,7 +262,7 @@ mod tests {
         let block_ids = vec![10, 20, 30];
         cache.register(&tokens, &block_ids);
 
-        assert_eq!(cache.num_cached_entries(), 1);
+        assert_eq!(cache.num_cached_entries(), 3); // one per block
         assert_eq!(cache.total_cached_blocks(), 3);
 
         // Look up the same tokens — should find all 3 blocks
@@ -276,14 +282,36 @@ mod tests {
         let prefix: Vec<TokenId> = (0..12).collect();
         cache.register(&prefix, &[10, 20, 30]);
 
-        // Look up a longer sequence that shares the same prefix
-        let mut longer: Vec<TokenId> = (0..20).collect();
+        // Look up a longer sequence that shares the same 12-token prefix
+        // but has different suffix tokens
+        let mut longer: Vec<TokenId> = (0..12).collect();
         longer.extend_from_slice(&[99, 98, 97, 96, 95, 94, 93, 92]);
         let result = cache.lookup(&longer);
         assert!(result.is_some());
         let (cached_tokens, found_blocks) = result.unwrap();
         assert_eq!(cached_tokens, 12);
         assert_eq!(found_blocks, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn test_shared_prefix_different_suffix() {
+        let block_size = 4;
+        let mut cache = PrefixCache::new(block_size, 100);
+
+        // Register a 20-token prompt (5 blocks)
+        let tokens1: Vec<TokenId> = (0..20).collect();
+        cache.register(&tokens1, &[10, 20, 30, 40, 50]);
+
+        // Look up a prompt that shares the first 16 tokens but differs in the last block
+        let mut tokens2: Vec<TokenId> = (0..16).collect();
+        tokens2.extend_from_slice(&[200, 201, 202, 203]);
+
+        let result = cache.lookup(&tokens2);
+        assert!(result.is_some());
+        let (cached_tokens, found_blocks) = result.unwrap();
+        // Should match first 4 blocks (16 tokens), not 5
+        assert_eq!(cached_tokens, 16);
+        assert_eq!(found_blocks, vec![10, 20, 30, 40]);
     }
 
     #[test]
@@ -317,7 +345,7 @@ mod tests {
     #[test]
     fn test_lru_eviction() {
         let block_size = 4;
-        // max_blocks = 4, so can hold 4 blocks total
+        // max_blocks = 4, so can hold 4 block entries total
         let mut cache = PrefixCache::new(block_size, 4);
 
         // Register prefix A (2 blocks)
@@ -330,13 +358,12 @@ mod tests {
         cache.register(&tokens_b, &[30, 40]);
         assert_eq!(cache.total_cached_blocks(), 4);
 
-        // Register prefix C (2 blocks) — should evict A (oldest)
+        // Register prefix C (2 blocks) — should evict A's blocks (oldest)
         let tokens_c: Vec<TokenId> = (200..208).collect();
         cache.register(&tokens_c, &[50, 60]);
         assert_eq!(cache.total_cached_blocks(), 4);
-        assert_eq!(cache.num_cached_entries(), 2);
 
-        // A should be gone
+        // A should be gone (its blocks were evicted)
         assert!(cache.lookup(&tokens_a).is_none());
         // B and C should still be there
         assert!(cache.lookup(&tokens_b).is_some());
@@ -348,7 +375,7 @@ mod tests {
         let block_size = 4;
         let mut cache = PrefixCache::new(block_size, 4);
 
-        // Register prefix A and keep a reference
+        // Register prefix A and keep a reference via lookup
         let tokens_a: Vec<TokenId> = (0..8).collect();
         cache.register(&tokens_a, &[10, 20]);
         let _lookup_a = cache.lookup(&tokens_a); // refcount now 2 (cache + lookup)
@@ -372,7 +399,7 @@ mod tests {
     #[test]
     fn test_release_blocks() {
         let block_size = 4;
-        let mut cache = PrefixCache::new(block_size, 4);
+        let mut cache = PrefixCache::new(block_size, 100);
 
         let tokens: Vec<TokenId> = (0..8).collect();
         cache.register(&tokens, &[10, 20]);
@@ -397,11 +424,11 @@ mod tests {
 
         let tokens: Vec<TokenId> = (0..8).collect();
         cache.register(&tokens, &[10, 20]);
-        assert_eq!(cache.num_cached_entries(), 1);
+        assert_eq!(cache.num_cached_entries(), 2); // 2 block entries
 
-        // Register again — should not create duplicate
+        // Register again — should not create duplicates
         cache.register(&tokens, &[10, 20]);
-        assert_eq!(cache.num_cached_entries(), 1);
+        assert_eq!(cache.num_cached_entries(), 2);
         assert_eq!(cache.total_cached_blocks(), 2);
     }
 

--- a/crates/kiln-core/src/prefix_cache.rs
+++ b/crates/kiln-core/src/prefix_cache.rs
@@ -1,0 +1,422 @@
+use std::collections::HashMap;
+
+use crate::token::TokenId;
+
+/// A prefix cache that maps token block sequences to physical KV cache block IDs.
+///
+/// When multiple requests share a common prefix (e.g. the same system prompt),
+/// the second request can reuse the already-computed KV cache blocks instead of
+/// recomputing them. Blocks are reference-counted so they aren't freed while
+/// still in use, and evicted via LRU when memory pressure requires it.
+#[derive(Debug)]
+pub struct PrefixCache {
+    /// Maximum number of physical blocks the prefix cache may hold.
+    max_blocks: usize,
+    /// Total physical blocks currently held by cached entries.
+    total_cached_blocks: usize,
+    /// Monotonically increasing counter used for LRU ordering.
+    clock: u64,
+    /// Block size in tokens — must match the block manager's block_size.
+    block_size: usize,
+    /// Hash of a block-aligned token prefix → cache entry.
+    entries: HashMap<u64, CacheEntry>,
+    /// Reference counts for individual physical block IDs.
+    /// A block with refcount > 0 must not be evicted.
+    refcounts: HashMap<u32, usize>,
+}
+
+#[derive(Debug, Clone)]
+struct CacheEntry {
+    /// Physical block IDs for this prefix, in order.
+    block_ids: Vec<u32>,
+    /// Number of token-blocks (prefix length in block-aligned chunks).
+    num_blocks: usize,
+    /// Last-access timestamp for LRU eviction.
+    last_used: u64,
+}
+
+impl PrefixCache {
+    pub fn new(block_size: usize, max_blocks: usize) -> Self {
+        Self {
+            max_blocks,
+            total_cached_blocks: 0,
+            clock: 0,
+            block_size,
+            entries: HashMap::new(),
+            refcounts: HashMap::new(),
+        }
+    }
+
+    pub fn block_size(&self) -> usize {
+        self.block_size
+    }
+
+    pub fn num_cached_entries(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn total_cached_blocks(&self) -> usize {
+        self.total_cached_blocks
+    }
+
+    /// Look up how many leading blocks of `tokens` are already cached.
+    ///
+    /// Returns `(num_cached_tokens, Vec<block_id>)` for the longest cached prefix.
+    /// The returned block IDs have their refcount incremented — the caller must
+    /// call `release_blocks` when the request finishes.
+    pub fn lookup(&mut self, tokens: &[TokenId]) -> Option<(usize, Vec<u32>)> {
+        if tokens.is_empty() {
+            return None;
+        }
+
+        // We hash progressively longer block-aligned prefixes and find the
+        // longest one that exists in the cache. This is O(num_blocks) hash
+        // lookups per request which is fine — prefixes are typically < 100 blocks.
+        let num_full_blocks = tokens.len() / self.block_size;
+        if num_full_blocks == 0 {
+            return None;
+        }
+
+        let mut best: Option<(usize, &CacheEntry)> = None;
+
+        for n in (1..=num_full_blocks).rev() {
+            let hash = self.compute_hash(tokens, n);
+            if let Some(entry) = self.entries.get(&hash) {
+                // Verify block count matches (collision guard)
+                if entry.num_blocks == n {
+                    best = Some((n, entry));
+                    break; // longest match (we iterate from longest to shortest)
+                }
+            }
+        }
+
+        let (num_blocks, entry) = best?;
+        let block_ids = entry.block_ids.clone();
+        let cached_tokens = num_blocks * self.block_size;
+
+        // Bump LRU timestamp
+        self.clock += 1;
+        let ts = self.clock;
+        // Re-borrow mutably
+        let hash = self.compute_hash(tokens, num_blocks);
+        if let Some(entry) = self.entries.get_mut(&hash) {
+            entry.last_used = ts;
+        }
+
+        // Increment refcounts
+        for &bid in &block_ids {
+            *self.refcounts.entry(bid).or_insert(0) += 1;
+        }
+
+        Some((cached_tokens, block_ids))
+    }
+
+    /// Register a completed prefix so future requests can reuse it.
+    ///
+    /// `tokens` is the full prompt, `block_ids` are the physical blocks that
+    /// hold its KV cache. Only the block-aligned prefix is cached.
+    pub fn register(&mut self, tokens: &[TokenId], block_ids: &[u32]) {
+        let num_full_blocks = tokens.len() / self.block_size;
+        if num_full_blocks == 0 || block_ids.len() < num_full_blocks {
+            return;
+        }
+
+        let hash = self.compute_hash(tokens, num_full_blocks);
+        if self.entries.contains_key(&hash) {
+            // Already cached — just bump LRU
+            self.clock += 1;
+            let ts = self.clock;
+            if let Some(entry) = self.entries.get_mut(&hash) {
+                entry.last_used = ts;
+            }
+            return;
+        }
+
+        let prefix_blocks: Vec<u32> = block_ids[..num_full_blocks].to_vec();
+
+        // Evict if needed to make room
+        while self.total_cached_blocks + prefix_blocks.len() > self.max_blocks {
+            if !self.evict_one() {
+                // Can't evict anything (all cached blocks are referenced) — don't cache
+                return;
+            }
+        }
+
+        self.clock += 1;
+        let ts = self.clock;
+
+        // Increment refcounts for the cached blocks
+        for &bid in &prefix_blocks {
+            *self.refcounts.entry(bid).or_insert(0) += 1;
+        }
+
+        self.total_cached_blocks += prefix_blocks.len();
+        self.entries.insert(
+            hash,
+            CacheEntry {
+                num_blocks: num_full_blocks,
+                block_ids: prefix_blocks,
+                last_used: ts,
+            },
+        );
+    }
+
+    /// Decrement refcounts for blocks that were obtained via `lookup`.
+    /// Call this when a request that used cached prefix blocks finishes.
+    pub fn release_blocks(&mut self, block_ids: &[u32]) {
+        for &bid in block_ids {
+            if let Some(rc) = self.refcounts.get_mut(&bid) {
+                *rc = rc.saturating_sub(1);
+            }
+        }
+    }
+
+    /// Returns the set of physical block IDs that are held by the prefix cache.
+    /// The block manager must not free these blocks.
+    pub fn held_block_ids(&self) -> Vec<u32> {
+        let mut ids = Vec::new();
+        for entry in self.entries.values() {
+            ids.extend_from_slice(&entry.block_ids);
+        }
+        ids.sort_unstable();
+        ids.dedup();
+        ids
+    }
+
+    /// Check if a physical block ID is currently held by the prefix cache
+    /// (with refcount > 0 from active requests or from the cache entry itself).
+    pub fn is_block_held(&self, block_id: u32) -> bool {
+        self.refcounts.get(&block_id).copied().unwrap_or(0) > 0
+    }
+
+    /// Evict the least-recently-used entry whose blocks all have refcount ≤ 1
+    /// (i.e. only the cache itself holds them, no active requests).
+    /// Returns true if an entry was evicted.
+    fn evict_one(&mut self) -> bool {
+        // Find the LRU entry that can be evicted
+        let mut best_hash: Option<u64> = None;
+        let mut best_ts = u64::MAX;
+
+        for (&hash, entry) in &self.entries {
+            if entry.last_used < best_ts {
+                // Check all blocks have refcount == 1 (only the cache holds them)
+                let can_evict = entry
+                    .block_ids
+                    .iter()
+                    .all(|&bid| self.refcounts.get(&bid).copied().unwrap_or(0) <= 1);
+                if can_evict {
+                    best_hash = Some(hash);
+                    best_ts = entry.last_used;
+                }
+            }
+        }
+
+        if let Some(hash) = best_hash {
+            if let Some(entry) = self.entries.remove(&hash) {
+                self.total_cached_blocks -= entry.block_ids.len();
+                for &bid in &entry.block_ids {
+                    if let Some(rc) = self.refcounts.get_mut(&bid) {
+                        *rc = rc.saturating_sub(1);
+                        if *rc == 0 {
+                            self.refcounts.remove(&bid);
+                        }
+                    }
+                }
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Compute a hash for the first `num_blocks` block-aligned token chunks.
+    fn compute_hash(&self, tokens: &[TokenId], num_blocks: usize) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let end = num_blocks * self.block_size;
+        let slice = &tokens[..end.min(tokens.len())];
+
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        slice.hash(&mut hasher);
+        // Include num_blocks in hash to differentiate prefix lengths
+        num_blocks.hash(&mut hasher);
+        hasher.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_and_lookup() {
+        let block_size = 4;
+        let mut cache = PrefixCache::new(block_size, 100);
+
+        // Register a 12-token prefix (3 full blocks)
+        let tokens: Vec<TokenId> = (0..12).collect();
+        let block_ids = vec![10, 20, 30];
+        cache.register(&tokens, &block_ids);
+
+        assert_eq!(cache.num_cached_entries(), 1);
+        assert_eq!(cache.total_cached_blocks(), 3);
+
+        // Look up the same tokens — should find all 3 blocks
+        let result = cache.lookup(&tokens);
+        assert!(result.is_some());
+        let (cached_tokens, found_blocks) = result.unwrap();
+        assert_eq!(cached_tokens, 12);
+        assert_eq!(found_blocks, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn test_partial_prefix_match() {
+        let block_size = 4;
+        let mut cache = PrefixCache::new(block_size, 100);
+
+        // Register a 12-token prefix
+        let prefix: Vec<TokenId> = (0..12).collect();
+        cache.register(&prefix, &[10, 20, 30]);
+
+        // Look up a longer sequence that shares the same prefix
+        let mut longer: Vec<TokenId> = (0..20).collect();
+        longer.extend_from_slice(&[99, 98, 97, 96, 95, 94, 93, 92]);
+        let result = cache.lookup(&longer);
+        assert!(result.is_some());
+        let (cached_tokens, found_blocks) = result.unwrap();
+        assert_eq!(cached_tokens, 12);
+        assert_eq!(found_blocks, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn test_no_match_different_tokens() {
+        let block_size = 4;
+        let mut cache = PrefixCache::new(block_size, 100);
+
+        let tokens_a: Vec<TokenId> = (0..8).collect();
+        cache.register(&tokens_a, &[10, 20]);
+
+        // Different tokens — no match
+        let tokens_b: Vec<TokenId> = (100..108).collect();
+        let result = cache.lookup(&tokens_b);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_too_short_for_cache() {
+        let block_size = 4;
+        let mut cache = PrefixCache::new(block_size, 100);
+
+        // Only 3 tokens — less than 1 block, should not cache
+        let tokens: Vec<TokenId> = vec![1, 2, 3];
+        cache.register(&tokens, &[10]);
+        assert_eq!(cache.num_cached_entries(), 0);
+
+        let result = cache.lookup(&tokens);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_lru_eviction() {
+        let block_size = 4;
+        // max_blocks = 4, so can hold 4 blocks total
+        let mut cache = PrefixCache::new(block_size, 4);
+
+        // Register prefix A (2 blocks)
+        let tokens_a: Vec<TokenId> = (0..8).collect();
+        cache.register(&tokens_a, &[10, 20]);
+        assert_eq!(cache.total_cached_blocks(), 2);
+
+        // Register prefix B (2 blocks)
+        let tokens_b: Vec<TokenId> = (100..108).collect();
+        cache.register(&tokens_b, &[30, 40]);
+        assert_eq!(cache.total_cached_blocks(), 4);
+
+        // Register prefix C (2 blocks) — should evict A (oldest)
+        let tokens_c: Vec<TokenId> = (200..208).collect();
+        cache.register(&tokens_c, &[50, 60]);
+        assert_eq!(cache.total_cached_blocks(), 4);
+        assert_eq!(cache.num_cached_entries(), 2);
+
+        // A should be gone
+        assert!(cache.lookup(&tokens_a).is_none());
+        // B and C should still be there
+        assert!(cache.lookup(&tokens_b).is_some());
+        assert!(cache.lookup(&tokens_c).is_some());
+    }
+
+    #[test]
+    fn test_refcount_prevents_eviction() {
+        let block_size = 4;
+        let mut cache = PrefixCache::new(block_size, 4);
+
+        // Register prefix A and keep a reference
+        let tokens_a: Vec<TokenId> = (0..8).collect();
+        cache.register(&tokens_a, &[10, 20]);
+        let _lookup_a = cache.lookup(&tokens_a); // refcount now 2 (cache + lookup)
+
+        // Register prefix B
+        let tokens_b: Vec<TokenId> = (100..108).collect();
+        cache.register(&tokens_b, &[30, 40]);
+
+        // Try to register prefix C — A can't be evicted (refcount > 1), B can
+        let tokens_c: Vec<TokenId> = (200..208).collect();
+        cache.register(&tokens_c, &[50, 60]);
+
+        // A should still be there (protected by refcount)
+        assert!(cache.lookup(&tokens_a).is_some());
+        // B should be evicted
+        assert!(cache.lookup(&tokens_b).is_none());
+        // C should be there
+        assert!(cache.lookup(&tokens_c).is_some());
+    }
+
+    #[test]
+    fn test_release_blocks() {
+        let block_size = 4;
+        let mut cache = PrefixCache::new(block_size, 4);
+
+        let tokens: Vec<TokenId> = (0..8).collect();
+        cache.register(&tokens, &[10, 20]);
+
+        // Lookup increases refcount
+        let (_, blocks) = cache.lookup(&tokens).unwrap();
+        assert!(cache.is_block_held(10));
+        assert!(cache.is_block_held(20));
+
+        // Release the lookup reference
+        cache.release_blocks(&blocks);
+
+        // Cache still holds them (refcount == 1 from cache entry)
+        assert!(cache.is_block_held(10));
+        assert!(cache.is_block_held(20));
+    }
+
+    #[test]
+    fn test_duplicate_register_is_noop() {
+        let block_size = 4;
+        let mut cache = PrefixCache::new(block_size, 100);
+
+        let tokens: Vec<TokenId> = (0..8).collect();
+        cache.register(&tokens, &[10, 20]);
+        assert_eq!(cache.num_cached_entries(), 1);
+
+        // Register again — should not create duplicate
+        cache.register(&tokens, &[10, 20]);
+        assert_eq!(cache.num_cached_entries(), 1);
+        assert_eq!(cache.total_cached_blocks(), 2);
+    }
+
+    #[test]
+    fn test_held_block_ids() {
+        let block_size = 4;
+        let mut cache = PrefixCache::new(block_size, 100);
+
+        let tokens_a: Vec<TokenId> = (0..8).collect();
+        cache.register(&tokens_a, &[10, 20]);
+
+        let tokens_b: Vec<TokenId> = (100..108).collect();
+        cache.register(&tokens_b, &[30, 40]);
+
+        let held = cache.held_block_ids();
+        assert_eq!(held, vec![10, 20, 30, 40]);
+    }
+}

--- a/crates/kiln-scheduler/src/scheduler.rs
+++ b/crates/kiln-scheduler/src/scheduler.rs
@@ -1,4 +1,5 @@
 use kiln_core::block::BlockManager;
+use kiln_core::prefix_cache::PrefixCache;
 use kiln_core::request::{Request, RequestId, RequestState};
 use kiln_core::token::TokenId;
 use std::collections::VecDeque;
@@ -16,6 +17,12 @@ pub struct SchedulerConfig {
 
     /// KV cache block size (tokens per block).
     pub block_size: usize,
+
+    /// Enable prefix caching for shared prompt prefixes.
+    pub prefix_cache_enabled: bool,
+
+    /// Maximum blocks the prefix cache may retain (0 = unlimited up to num_blocks / 4).
+    pub prefix_cache_max_blocks: Option<usize>,
 }
 
 impl Default for SchedulerConfig {
@@ -24,6 +31,8 @@ impl Default for SchedulerConfig {
             max_batch_tokens: 8192,
             max_batch_size: 64,
             block_size: 16,
+            prefix_cache_enabled: true,
+            prefix_cache_max_blocks: None,
         }
     }
 }
@@ -58,21 +67,38 @@ pub struct SchedulerOutput {
 /// 3. Start new prefills with any remaining budget
 ///
 /// This ensures decode requests are never stalled by long prefills.
+///
+/// When prefix caching is enabled, new requests check the prefix cache before
+/// allocating blocks. If a prefix is found, the cached KV blocks are reused and
+/// only the non-cached suffix is scheduled for prefill.
 pub struct Scheduler {
     config: SchedulerConfig,
     waiting: VecDeque<Request>,
     running: Vec<Request>,
     block_manager: BlockManager,
+    prefix_cache: Option<PrefixCache>,
+    /// Tracks which blocks per request came from prefix cache (should not be freed).
+    cached_block_counts: std::collections::HashMap<RequestId, usize>,
 }
 
 impl Scheduler {
     pub fn new(config: SchedulerConfig, num_blocks: usize) -> Self {
         let block_manager = BlockManager::new(num_blocks, config.block_size);
+        let prefix_cache = if config.prefix_cache_enabled {
+            let max_blocks = config
+                .prefix_cache_max_blocks
+                .unwrap_or(num_blocks / 4);
+            Some(PrefixCache::new(config.block_size, max_blocks))
+        } else {
+            None
+        };
         Self {
             config,
             waiting: VecDeque::new(),
             running: Vec::new(),
             block_manager,
+            prefix_cache,
+            cached_block_counts: std::collections::HashMap::new(),
         }
     }
 
@@ -110,9 +136,25 @@ impl Scheduler {
                 RequestState::Complete | RequestState::Cancelled
             );
             if should_remove {
-                self.block_manager.free_all(&req.block_ids);
+                let cached_count = self.cached_block_counts.remove(&req.id).unwrap_or(0);
+                // Free only the non-cached blocks (suffix blocks allocated by us)
+                if cached_count < req.block_ids.len() {
+                    self.block_manager.free_all(&req.block_ids[cached_count..]);
+                }
+                // Release the cached blocks back to the prefix cache
+                if cached_count > 0 {
+                    if let Some(ref mut pc) = self.prefix_cache {
+                        pc.release_blocks(&req.block_ids[..cached_count]);
+                    }
+                }
                 completed_ids.push(req.id);
-                tracing::debug!(id = %req.id, "freed {} blocks", req.block_ids.len());
+                tracing::debug!(
+                    id = %req.id,
+                    total_blocks = req.block_ids.len(),
+                    cached = cached_count,
+                    freed = req.block_ids.len() - cached_count,
+                    "freed blocks"
+                );
             }
             !should_remove
         });
@@ -171,33 +213,85 @@ impl Scheduler {
                 break;
             };
 
-            // Allocate blocks for the full prompt
-            let blocks_needed = req.blocks_needed(self.config.block_size);
-            if !self.block_manager.can_allocate(blocks_needed) {
-                // Can't fit this request — put it back and stop promoting
-                self.waiting.push_front(req);
-                break;
+            // Check prefix cache first
+            let mut cached_blocks = 0usize;
+            let mut tokens_already_cached = 0usize;
+
+            if let Some(ref mut pc) = self.prefix_cache {
+                if let Some((cached_tokens, cached_block_ids)) = pc.lookup(&req.prompt_tokens) {
+                    cached_blocks = cached_block_ids.len();
+                    tokens_already_cached = cached_tokens;
+                    req.block_ids = cached_block_ids;
+                    tracing::debug!(
+                        id = %req.id,
+                        cached_tokens,
+                        cached_blocks,
+                        "prefix cache hit"
+                    );
+                }
             }
 
-            let blocks = self.block_manager.allocate(blocks_needed).unwrap();
-            req.block_ids = blocks;
+            // Allocate remaining blocks for the non-cached suffix
+            let total_blocks_needed = req.blocks_needed(self.config.block_size);
+            let extra_blocks_needed = total_blocks_needed.saturating_sub(cached_blocks);
+
+            if extra_blocks_needed > 0 {
+                if !self.block_manager.can_allocate(extra_blocks_needed) {
+                    // Can't fit this request — release cached blocks and put back
+                    if cached_blocks > 0 {
+                        if let Some(ref mut pc) = self.prefix_cache {
+                            pc.release_blocks(&req.block_ids[..cached_blocks]);
+                        }
+                        req.block_ids.clear();
+                    }
+                    self.waiting.push_front(req);
+                    break;
+                }
+                let new_blocks = self.block_manager.allocate(extra_blocks_needed).unwrap();
+                req.block_ids.extend(new_blocks);
+            }
+
+            // Track cached block count for this request
+            if cached_blocks > 0 {
+                self.cached_block_counts.insert(req.id, cached_blocks);
+            }
+
+            // Start prefill from the non-cached position
             req.state = RequestState::Prefilling {
-                tokens_processed: 0,
+                tokens_processed: tokens_already_cached,
             };
 
-            let chunk = req.prompt_tokens.len().min(budget);
-            scheduled.push(ScheduledRequest {
-                request_id: req.id,
-                num_tokens: chunk,
-                is_prefill: true,
-            });
-            budget -= chunk;
-            num_prefill_tokens += chunk;
+            let remaining_prefill = req.prompt_tokens.len() - tokens_already_cached;
+            let chunk = remaining_prefill.min(budget);
+
+            if chunk > 0 {
+                scheduled.push(ScheduledRequest {
+                    request_id: req.id,
+                    num_tokens: chunk,
+                    is_prefill: true,
+                });
+                budget -= chunk;
+                num_prefill_tokens += chunk;
+            } else {
+                // Entire prompt was cached — go straight to decode
+                req.state = RequestState::Decoding;
+                // Schedule a decode token if budget allows
+                if budget > 0 {
+                    scheduled.push(ScheduledRequest {
+                        request_id: req.id,
+                        num_tokens: 1,
+                        is_prefill: false,
+                    });
+                    budget -= 1;
+                    num_decode_tokens += 1;
+                }
+            }
 
             tracing::debug!(
                 id = %req.id,
                 prompt_len = req.prompt_tokens.len(),
-                chunk_size = chunk,
+                cached_tokens = tokens_already_cached,
+                chunk_size = if chunk > 0 { chunk } else { 1 },
                 blocks = req.block_ids.len(),
                 "promoted request"
             );
@@ -234,6 +328,11 @@ impl Scheduler {
             if processed >= req.prompt_tokens.len() {
                 // Prefill complete, transition to decode
                 req.state = RequestState::Decoding;
+
+                // Register this prefix in the cache
+                if let Some(ref mut pc) = self.prefix_cache {
+                    pc.register(&req.prompt_tokens, &req.block_ids);
+                }
             } else {
                 req.state = RequestState::Prefilling {
                     tokens_processed: processed,
@@ -277,6 +376,10 @@ impl Scheduler {
     pub fn block_manager(&self) -> &BlockManager {
         &self.block_manager
     }
+
+    pub fn prefix_cache(&self) -> Option<&PrefixCache> {
+        self.prefix_cache.as_ref()
+    }
 }
 
 #[cfg(test)]
@@ -288,12 +391,18 @@ mod tests {
         Request::new(vec![1; prompt_len], SamplingParams::greedy(), None)
     }
 
+    fn make_request_with_tokens(tokens: Vec<TokenId>) -> Request {
+        Request::new(tokens, SamplingParams::greedy(), None)
+    }
+
     #[test]
     fn basic_scheduling() {
         let config = SchedulerConfig {
             max_batch_tokens: 100,
             max_batch_size: 8,
             block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
         };
         let mut sched = Scheduler::new(config, 100);
 
@@ -325,6 +434,8 @@ mod tests {
             max_batch_tokens: 30,
             max_batch_size: 8,
             block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
         };
         let mut sched = Scheduler::new(config, 100);
 
@@ -351,6 +462,8 @@ mod tests {
             max_batch_tokens: 10,
             max_batch_size: 8,
             block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
         };
         let mut sched = Scheduler::new(config, 100);
 
@@ -376,7 +489,10 @@ mod tests {
 
     #[test]
     fn request_completion() {
-        let config = SchedulerConfig::default();
+        let config = SchedulerConfig {
+            prefix_cache_enabled: false,
+            ..Default::default()
+        };
         let mut sched = Scheduler::new(config, 100);
 
         let req = make_request(5);
@@ -391,5 +507,200 @@ mod tests {
         let output = sched.step();
         assert!(output.completed_ids.contains(&id));
         assert_eq!(sched.num_running(), 0);
+    }
+
+    // --- Prefix caching tests ---
+
+    #[test]
+    fn prefix_cache_hit_skips_prefill() {
+        let config = SchedulerConfig {
+            max_batch_tokens: 200,
+            max_batch_size: 8,
+            block_size: 4,
+            prefix_cache_enabled: true,
+            prefix_cache_max_blocks: Some(100),
+        };
+        let mut sched = Scheduler::new(config, 200);
+
+        // First request: system prompt (16 tokens = 4 blocks)
+        let system_prompt: Vec<TokenId> = (0..16).collect();
+        let mut tokens1 = system_prompt.clone();
+        tokens1.extend_from_slice(&[100, 101, 102, 103]); // user message
+        let req1 = make_request_with_tokens(tokens1.clone());
+        let id1 = req1.id;
+        sched.add_request(req1);
+
+        // Schedule and complete prefill for req1
+        let output = sched.step();
+        assert_eq!(output.scheduled.len(), 1);
+        assert_eq!(output.scheduled[0].num_tokens, 20); // full 20 tokens
+        assert!(output.scheduled[0].is_prefill);
+
+        // Complete prefill — this registers the prefix in the cache
+        sched.update_request(&id1, None, false, Some(20));
+        sched.update_request(&id1, Some(42), true, None);
+        sched.step(); // clear completed
+
+        // Verify prefix cache has an entry
+        assert!(sched.prefix_cache().is_some());
+        let pc = sched.prefix_cache().unwrap();
+        assert!(pc.num_cached_entries() > 0);
+
+        // Second request: same system prompt, different user message
+        let mut tokens2 = system_prompt;
+        tokens2.extend_from_slice(&[200, 201, 202, 203]); // different user message
+        let req2 = make_request_with_tokens(tokens2);
+        let id2 = req2.id;
+        sched.add_request(req2);
+
+        // Schedule req2 — should skip the cached prefix (16 tokens) and only prefill 4
+        let output = sched.step();
+        assert_eq!(output.scheduled.len(), 1);
+        assert_eq!(output.scheduled[0].request_id, id2);
+        assert!(output.scheduled[0].is_prefill);
+        assert_eq!(output.scheduled[0].num_tokens, 4); // only the suffix!
+        assert_eq!(output.num_prefill_tokens, 4);
+    }
+
+    #[test]
+    fn prefix_cache_full_hit_goes_to_decode() {
+        let config = SchedulerConfig {
+            max_batch_tokens: 200,
+            max_batch_size: 8,
+            block_size: 4,
+            prefix_cache_enabled: true,
+            prefix_cache_max_blocks: Some(100),
+        };
+        let mut sched = Scheduler::new(config, 200);
+
+        // Prompt exactly block-aligned (8 tokens = 2 blocks)
+        let tokens: Vec<TokenId> = (0..8).collect();
+        let req1 = make_request_with_tokens(tokens.clone());
+        let id1 = req1.id;
+        sched.add_request(req1);
+
+        sched.step();
+        sched.update_request(&id1, None, false, Some(8));
+        sched.update_request(&id1, Some(42), true, None);
+        sched.step(); // clear
+
+        // Same exact prompt — entire prompt is cached
+        let req2 = make_request_with_tokens(tokens);
+        let id2 = req2.id;
+        sched.add_request(req2);
+
+        let output = sched.step();
+        assert_eq!(output.scheduled.len(), 1);
+        assert_eq!(output.scheduled[0].request_id, id2);
+        // Should go straight to decode since all tokens are cached
+        assert!(!output.scheduled[0].is_prefill);
+        assert_eq!(output.scheduled[0].num_tokens, 1);
+        assert_eq!(output.num_decode_tokens, 1);
+        assert_eq!(output.num_prefill_tokens, 0);
+    }
+
+    #[test]
+    fn prefix_cache_no_hit_different_tokens() {
+        let config = SchedulerConfig {
+            max_batch_tokens: 200,
+            max_batch_size: 8,
+            block_size: 4,
+            prefix_cache_enabled: true,
+            prefix_cache_max_blocks: Some(100),
+        };
+        let mut sched = Scheduler::new(config, 200);
+
+        // First request
+        let tokens1: Vec<TokenId> = (0..8).collect();
+        let req1 = make_request_with_tokens(tokens1);
+        let id1 = req1.id;
+        sched.add_request(req1);
+        sched.step();
+        sched.update_request(&id1, None, false, Some(8));
+        sched.update_request(&id1, Some(42), true, None);
+        sched.step();
+
+        // Second request — completely different tokens, no cache hit
+        let tokens2: Vec<TokenId> = (100..108).collect();
+        let req2 = make_request_with_tokens(tokens2);
+        sched.add_request(req2);
+
+        let output = sched.step();
+        assert_eq!(output.scheduled.len(), 1);
+        assert!(output.scheduled[0].is_prefill);
+        assert_eq!(output.scheduled[0].num_tokens, 8); // full prefill
+    }
+
+    #[test]
+    fn prefix_cache_blocks_freed_correctly() {
+        let config = SchedulerConfig {
+            max_batch_tokens: 200,
+            max_batch_size: 8,
+            block_size: 4,
+            prefix_cache_enabled: true,
+            prefix_cache_max_blocks: Some(100),
+        };
+        let num_blocks = 50;
+        let mut sched = Scheduler::new(config, num_blocks);
+
+        let initial_free = sched.block_manager().num_free();
+
+        // First request: 8 tokens = 2 blocks
+        let tokens: Vec<TokenId> = (0..8).collect();
+        let req1 = make_request_with_tokens(tokens.clone());
+        let id1 = req1.id;
+        sched.add_request(req1);
+        sched.step();
+        sched.update_request(&id1, None, false, Some(8));
+        sched.update_request(&id1, Some(42), true, None);
+        sched.step(); // completes req1, prefix cached
+
+        // After first request completes: the 2 cached blocks are still held
+        // by the prefix cache, so free blocks = initial - 2
+        let free_after_cache = sched.block_manager().num_free();
+        assert_eq!(free_after_cache, initial_free - 2);
+
+        // Second request with same prefix — reuses cached blocks
+        let req2 = make_request_with_tokens(tokens);
+        let id2 = req2.id;
+        sched.add_request(req2);
+        sched.step();
+        // req2 goes straight to decode, no extra blocks allocated (prompt was 8 = 2 blocks, all cached)
+        sched.update_request(&id2, Some(99), true, None);
+        sched.step(); // completes req2
+
+        // After second request: cached blocks still held by cache
+        let free_after_second = sched.block_manager().num_free();
+        assert_eq!(free_after_second, initial_free - 2);
+    }
+
+    #[test]
+    fn prefix_cache_disabled() {
+        let config = SchedulerConfig {
+            max_batch_tokens: 200,
+            max_batch_size: 8,
+            block_size: 4,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        };
+        let mut sched = Scheduler::new(config, 200);
+        assert!(sched.prefix_cache().is_none());
+
+        // First request
+        let tokens: Vec<TokenId> = (0..8).collect();
+        let req1 = make_request_with_tokens(tokens.clone());
+        let id1 = req1.id;
+        sched.add_request(req1);
+        sched.step();
+        sched.update_request(&id1, None, false, Some(8));
+        sched.update_request(&id1, Some(42), true, None);
+        sched.step();
+
+        // Second request with same tokens — no cache, full prefill
+        let req2 = make_request_with_tokens(tokens);
+        sched.add_request(req2);
+        let output = sched.step();
+        assert_eq!(output.scheduled[0].num_tokens, 8);
+        assert!(output.scheduled[0].is_prefill);
     }
 }

--- a/crates/kiln-scheduler/src/scheduler.rs
+++ b/crates/kiln-scheduler/src/scheduler.rs
@@ -329,9 +329,20 @@ impl Scheduler {
                 // Prefill complete, transition to decode
                 req.state = RequestState::Decoding;
 
-                // Register this prefix in the cache
+                // Register this prefix in the cache.
+                // Mark the prefix blocks as "cached" so they won't be freed
+                // when this request completes — the prefix cache now owns them.
                 if let Some(ref mut pc) = self.prefix_cache {
-                    pc.register(&req.prompt_tokens, &req.block_ids);
+                    let num_prefix_blocks = req.prompt_tokens.len() / self.config.block_size;
+                    if num_prefix_blocks > 0 && req.block_ids.len() >= num_prefix_blocks {
+                        pc.register(&req.prompt_tokens, &req.block_ids);
+                        // Record that these blocks are cache-owned, so free()
+                        // skips them on request completion. Only update if not
+                        // already tracked (from a cache hit).
+                        self.cached_block_counts
+                            .entry(req.id)
+                            .or_insert(num_prefix_blocks);
+                    }
                 }
             } else {
                 req.state = RequestState::Prefilling {

--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -210,6 +210,8 @@ mod tests {
             max_batch_tokens: 8192,
             max_batch_size: 64,
             block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
         };
         let scheduler = Scheduler::new(sched_config, 256);
         let engine = MockEngine::new(config.clone());

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -25,6 +25,7 @@ pub struct KilnConfig {
     pub memory: MemoryConfig,
     pub training: TrainingConfig,
     pub logging: LoggingConfig,
+    pub prefix_cache: PrefixCacheConfig,
 }
 
 /// HTTP server settings.
@@ -85,6 +86,18 @@ pub struct LoggingConfig {
     pub format: String,
 }
 
+/// Prefix caching settings.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct PrefixCacheConfig {
+    /// Enable prefix caching for shared prompt prefixes (default: true).
+    /// When enabled, KV cache blocks for shared prefixes are reused across requests.
+    pub enabled: bool,
+    /// Maximum number of KV cache blocks the prefix cache may retain.
+    /// Default: 25% of total blocks. Set to 0 to use the default.
+    pub max_blocks: Option<usize>,
+}
+
 // --- Defaults ---
 
 impl Default for KilnConfig {
@@ -95,6 +108,7 @@ impl Default for KilnConfig {
             memory: MemoryConfig::default(),
             training: TrainingConfig::default(),
             logging: LoggingConfig::default(),
+            prefix_cache: PrefixCacheConfig::default(),
         }
     }
 }
@@ -149,6 +163,15 @@ impl Default for LoggingConfig {
         Self {
             level: "info".into(),
             format: "json".into(),
+        }
+    }
+}
+
+impl Default for PrefixCacheConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_blocks: None,
         }
     }
 }
@@ -272,6 +295,16 @@ impl KilnConfig {
         if let Ok(v) = std::env::var("KILN_LOG_FORMAT") {
             self.logging.format = v;
         }
+
+        // Prefix cache
+        if let Ok(v) = std::env::var("KILN_PREFIX_CACHE_ENABLED") {
+            self.prefix_cache.enabled = v == "1" || v.eq_ignore_ascii_case("true");
+        }
+        if let Ok(v) = std::env::var("KILN_PREFIX_CACHE_MAX_BLOCKS") {
+            if let Ok(n) = v.parse() {
+                self.prefix_cache.max_blocks = Some(n);
+            }
+        }
     }
 
     /// Validate configuration values. Returns an error describing the first invalid value.
@@ -330,6 +363,8 @@ mod tests {
         assert!(config.training.checkpoint_interval.is_none());
         assert_eq!(config.logging.level, "info");
         assert_eq!(config.logging.format, "json");
+        assert!(config.prefix_cache.enabled);
+        assert!(config.prefix_cache.max_blocks.is_none());
     }
 
     #[test]
@@ -363,6 +398,10 @@ checkpoint_interval = 50
 [logging]
 level = "debug"
 format = "pretty"
+
+[prefix_cache]
+enabled = false
+max_blocks = 32
 "#;
         let config: KilnConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.server.host, "127.0.0.1");
@@ -380,6 +419,8 @@ format = "pretty"
         assert_eq!(config.training.checkpoint_interval, Some(50));
         assert_eq!(config.logging.level, "debug");
         assert_eq!(config.logging.format, "pretty");
+        assert!(!config.prefix_cache.enabled);
+        assert_eq!(config.prefix_cache.max_blocks, Some(32));
     }
 
     #[test]
@@ -457,6 +498,8 @@ port = 3000
             std::env::set_var("KILN_CHECKPOINT_INTERVAL", "25");
             std::env::set_var("KILN_KV_CACHE_FP8", "1");
             std::env::set_var("KILN_CUDA_GRAPHS", "false");
+            std::env::set_var("KILN_PREFIX_CACHE_ENABLED", "false");
+            std::env::set_var("KILN_PREFIX_CACHE_MAX_BLOCKS", "128");
         }
 
         let mut config = KilnConfig::default();
@@ -471,6 +514,8 @@ port = 3000
         assert_eq!(config.training.checkpoint_interval, Some(25));
         assert!(config.memory.kv_cache_fp8);
         assert!(!config.memory.cuda_graphs);
+        assert!(!config.prefix_cache.enabled);
+        assert_eq!(config.prefix_cache.max_blocks, Some(128));
 
         // Clean up
         unsafe {
@@ -483,6 +528,8 @@ port = 3000
             std::env::remove_var("KILN_CHECKPOINT_INTERVAL");
             std::env::remove_var("KILN_KV_CACHE_FP8");
             std::env::remove_var("KILN_CUDA_GRAPHS");
+            std::env::remove_var("KILN_PREFIX_CACHE_ENABLED");
+            std::env::remove_var("KILN_PREFIX_CACHE_MAX_BLOCKS");
         }
     }
 

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -119,6 +119,8 @@ async fn main() -> Result<()> {
             max_batch_tokens: 8192,
             max_batch_size: 64,
             block_size: 16,
+            prefix_cache_enabled: config.prefix_cache.enabled,
+            prefix_cache_max_blocks: config.prefix_cache.max_blocks,
         };
         let num_blocks = 8192;
         let scheduler = Scheduler::new(scheduler_config, num_blocks);

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -38,3 +38,7 @@ no_grad_checkpoint = false
 [logging]
 level = "info"                        # trace, debug, info, warn, error, or a filter directive
 format = "json"                       # json, pretty, text, human
+
+[prefix_cache]
+enabled = true                        # Reuse KV cache blocks for shared prompt prefixes
+# max_blocks = 64                     # Max blocks for prefix cache (default: 25% of total)


### PR DESCRIPTION
## What
Prefix caching with LRU eviction for shared prompt prefixes. When multiple requests share a common prefix (e.g. system prompt), the second request reuses the already-computed KV cache blocks instead of recomputing them.

## Implementation

### New: `kiln-core/src/prefix_cache.rs`
- Hash-based lookup of token block sequences to physical block IDs
- LRU eviction when cache reaches max_blocks limit
- Reference counting prevents eviction of blocks used by active requests
- Block-aligned hashing for efficient prefix matching

### Modified: `kiln-scheduler/src/scheduler.rs`
- On new request promotion, checks prefix cache before allocating blocks
- Cached prefix blocks are reused; only suffix tokens are allocated fresh
- Full cache hit (entire prompt cached) skips prefill, goes straight to decode
- After prefill completes, registers the prefix for future reuse
- Correct block lifecycle: cached blocks released to cache, suffix blocks freed to pool

### Modified: `kiln-server/src/config.rs`
- `[prefix_cache]` config section with `enabled` (default: true) and `max_blocks`
- `KILN_PREFIX_CACHE_ENABLED` and `KILN_PREFIX_CACHE_MAX_BLOCKS` env vars
- Default max_blocks = 25% of total KV cache blocks

## Tests
- 8 unit tests for PrefixCache (register, lookup, partial match, LRU eviction, refcount protection, dedup)
- 5 integration tests in scheduler (cache hit skips prefill, full hit goes to decode, no hit different tokens, correct block freeing, disabled mode)