### PR TITLE
Add beautiful CLI with clap subcommands and progress bars

### DIFF
--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -38,6 +38,10 @@ futures = { workspace = true }
 tokio-stream = { workspace = true }
 thiserror = { workspace = true }
 toml = { workspace = true }
+clap = { version = "4", features = ["derive"] }
+indicatif = "0.17"
+console = "0.15"
+reqwest = { version = "0.12", features = ["json"] }
 
 [features]
 cuda = ["kiln-model/cuda"]

--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -1,0 +1,565 @@
+//! CLI interface for kiln — structured subcommands with clap.
+
+use std::io::Write;
+
+use clap::{Parser, Subcommand};
+use console::style;
+
+/// Kiln — single-model inference server with live online learning
+#[derive(Parser)]
+#[command(
+    name = "kiln",
+    version,
+    about = "Single-model inference server with live online learning",
+    long_about = None,
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+
+    /// Path to TOML config file
+    #[arg(long, short, global = true)]
+    pub config: Option<String>,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Start the inference server (default when no subcommand given)
+    Serve,
+
+    /// Submit training data to a running server
+    #[command(subcommand)]
+    Train(TrainCommands),
+
+    /// Manage LoRA adapters on a running server
+    #[command(subcommand)]
+    Adapters(AdapterCommands),
+
+    /// Check health of a running server
+    Health {
+        /// Server URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        url: String,
+    },
+
+    /// Validate a config file without starting the server
+    #[command(name = "config")]
+    ConfigCheck {
+        /// Path to config file to validate
+        #[arg(long, short)]
+        file: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum TrainCommands {
+    /// Submit SFT training examples
+    Sft {
+        /// Path to JSONL file with training examples
+        #[arg(long, short)]
+        file: String,
+
+        /// Adapter name to train (created if it doesn't exist)
+        #[arg(long, default_value = "default")]
+        adapter: String,
+
+        /// Learning rate
+        #[arg(long, default_value = "1e-4")]
+        lr: f64,
+
+        /// Number of epochs
+        #[arg(long, default_value = "1")]
+        epochs: u32,
+
+        /// Server URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        url: String,
+    },
+    /// Submit GRPO training batch
+    Grpo {
+        /// Path to JSONL file with scored completions
+        #[arg(long, short)]
+        file: String,
+
+        /// Adapter name to train
+        #[arg(long, default_value = "default")]
+        adapter: String,
+
+        /// Server URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        url: String,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum AdapterCommands {
+    /// List all adapters
+    List {
+        /// Server URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        url: String,
+    },
+    /// Load an adapter from disk
+    Load {
+        /// Adapter name
+        name: String,
+        /// Server URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        url: String,
+    },
+    /// Unload an active adapter
+    Unload {
+        /// Adapter name
+        name: String,
+        /// Server URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        url: String,
+    },
+    /// Delete an adapter
+    Delete {
+        /// Adapter name
+        name: String,
+        /// Server URL
+        #[arg(long, default_value = "http://localhost:8420")]
+        url: String,
+    },
+}
+
+/// Print the startup banner with config details.
+pub fn print_banner(host: &str, port: u16, model_path: Option<&str>, config_path: Option<&str>) {
+    let mut stderr = std::io::stderr();
+
+    let _ = writeln!(stderr);
+    let _ = writeln!(
+        stderr,
+        "  {}",
+        style("┌─────────────────────────────────────┐").cyan()
+    );
+    let _ = writeln!(
+        stderr,
+        "  {}",
+        style("│           🔥 K I L N 🔥             │").cyan().bold()
+    );
+    let _ = writeln!(
+        stderr,
+        "  {}",
+        style("│   inference · training · adapters    │").cyan()
+    );
+    let _ = writeln!(
+        stderr,
+        "  {}",
+        style("└─────────────────────────────────────┘").cyan()
+    );
+    let _ = writeln!(stderr);
+
+    let _ = writeln!(
+        stderr,
+        "  {} {}",
+        style("Version:").dim(),
+        style(env!("CARGO_PKG_VERSION")).white().bold()
+    );
+
+    if let Some(cp) = config_path {
+        let _ = writeln!(
+            stderr,
+            "  {} {}",
+            style("Config:").dim(),
+            style(cp).white()
+        );
+    }
+
+    let mode = if model_path.is_some() {
+        style("GPU inference").green().bold()
+    } else {
+        style("mock (no model loaded)").yellow().bold()
+    };
+    let _ = writeln!(stderr, "  {} {}", style("Mode:").dim(), mode);
+
+    if let Some(mp) = model_path {
+        let _ = writeln!(
+            stderr,
+            "  {} {}",
+            style("Model:").dim(),
+            style(mp).white()
+        );
+    }
+
+    let cuda_status = if candle_core::utils::cuda_is_available() {
+        style("available ✓").green()
+    } else {
+        style("not available").yellow()
+    };
+    let _ = writeln!(stderr, "  {} {}", style("CUDA:").dim(), cuda_status);
+
+    let _ = writeln!(
+        stderr,
+        "  {} {}",
+        style("Listen:").dim(),
+        style(format!("http://{host}:{port}")).cyan().bold()
+    );
+
+    let _ = writeln!(stderr);
+    let _ = writeln!(
+        stderr,
+        "  {} /v1/chat/completions, /v1/train/sft, /health, /metrics",
+        style("Endpoints:").dim()
+    );
+    let _ = writeln!(stderr);
+}
+
+/// Run the `health` CLI subcommand: GET /health on the server.
+pub async fn run_health(url: &str) -> anyhow::Result<()> {
+    let resp = reqwest::get(format!("{url}/health")).await?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await?;
+
+    if status.is_success() {
+        println!(
+            "{} Server is healthy",
+            style("✓").green().bold()
+        );
+        println!("{}", serde_json::to_string_pretty(&body)?);
+    } else {
+        eprintln!(
+            "{} Server returned {}",
+            style("✗").red().bold(),
+            style(status).red()
+        );
+        eprintln!("{}", serde_json::to_string_pretty(&body)?);
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Run the `config check` CLI subcommand: validate config without starting.
+pub fn run_config_check(file: Option<&str>) -> anyhow::Result<()> {
+    use crate::config::KilnConfig;
+
+    match KilnConfig::load(file) {
+        Ok(config) => {
+            println!(
+                "{} Configuration is valid",
+                style("✓").green().bold()
+            );
+            println!();
+            println!(
+                "  {} {}:{}",
+                style("Server:").dim(),
+                config.server.host,
+                config.server.port
+            );
+            println!(
+                "  {} {}",
+                style("Model ID:").dim(),
+                config.model.model_id
+            );
+            if let Some(ref p) = config.model.path {
+                println!("  {} {}", style("Model path:").dim(), p);
+            }
+            println!(
+                "  {} {}",
+                style("Log level:").dim(),
+                config.logging.level
+            );
+            println!(
+                "  {} {}",
+                style("Log format:").dim(),
+                config.logging.format
+            );
+            println!(
+                "  {} {}",
+                style("KV cache FP8:").dim(),
+                config.memory.kv_cache_fp8
+            );
+            println!(
+                "  {} {}",
+                style("CUDA graphs:").dim(),
+                config.memory.cuda_graphs
+            );
+            println!(
+                "  {} {}",
+                style("Prefix cache:").dim(),
+                config.prefix_cache.enabled
+            );
+            println!(
+                "  {} {}",
+                style("Speculative:").dim(),
+                config.speculative.enabled
+            );
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!(
+                "{} Configuration error: {e}",
+                style("✗").red().bold()
+            );
+            std::process::exit(1);
+        }
+    }
+}
+
+/// Run the `adapters list` CLI subcommand.
+pub async fn run_adapters_list(url: &str) -> anyhow::Result<()> {
+    let resp = reqwest::get(format!("{url}/v1/adapters")).await?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await?;
+
+    if status.is_success() {
+        let adapters = body.get("adapters").and_then(|a| a.as_array());
+        match adapters {
+            Some(list) if list.is_empty() => {
+                println!("{}", style("No adapters loaded").dim());
+            }
+            Some(list) => {
+                println!(
+                    "{} {} adapter(s):",
+                    style("✓").green().bold(),
+                    list.len()
+                );
+                for a in list {
+                    let name = a.get("name").and_then(|n| n.as_str()).unwrap_or("?");
+                    let active = a
+                        .get("active")
+                        .and_then(|v| v.as_bool())
+                        .unwrap_or(false);
+                    let status_str = if active {
+                        style("active").green()
+                    } else {
+                        style("loaded").dim()
+                    };
+                    println!("  {} [{}]", style(name).white().bold(), status_str);
+                }
+            }
+            None => {
+                println!("{}", serde_json::to_string_pretty(&body)?);
+            }
+        }
+    } else {
+        eprintln!(
+            "{} Server returned {}",
+            style("✗").red().bold(),
+            style(status).red()
+        );
+        eprintln!("{}", serde_json::to_string_pretty(&body)?);
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Run the `adapters load` CLI subcommand.
+pub async fn run_adapters_load(url: &str, name: &str) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{url}/v1/adapters/{name}/load"))
+        .send()
+        .await?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await?;
+
+    if status.is_success() {
+        println!(
+            "{} Adapter '{}' loaded",
+            style("✓").green().bold(),
+            style(name).white().bold()
+        );
+    } else {
+        eprintln!(
+            "{} Failed to load adapter '{}': {}",
+            style("✗").red().bold(),
+            name,
+            body.get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or(&status.to_string())
+        );
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Run the `adapters unload` CLI subcommand.
+pub async fn run_adapters_unload(url: &str, name: &str) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{url}/v1/adapters/{name}/unload"))
+        .send()
+        .await?;
+    let status = resp.status();
+    let body: serde_json::Value = resp.json().await?;
+
+    if status.is_success() {
+        println!(
+            "{} Adapter '{}' unloaded",
+            style("✓").green().bold(),
+            style(name).white().bold()
+        );
+    } else {
+        eprintln!(
+            "{} Failed to unload adapter '{}': {}",
+            style("✗").red().bold(),
+            name,
+            body.get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or(&status.to_string())
+        );
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Run the `adapters delete` CLI subcommand.
+pub async fn run_adapters_delete(url: &str, name: &str) -> anyhow::Result<()> {
+    let client = reqwest::Client::new();
+    let resp = client
+        .delete(format!("{url}/v1/adapters/{name}"))
+        .send()
+        .await?;
+    let status = resp.status();
+
+    if status.is_success() {
+        println!(
+            "{} Adapter '{}' deleted",
+            style("✓").green().bold(),
+            style(name).white().bold()
+        );
+    } else {
+        let body: serde_json::Value = resp.json().await?;
+        eprintln!(
+            "{} Failed to delete adapter '{}': {}",
+            style("✗").red().bold(),
+            name,
+            body.get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or(&status.to_string())
+        );
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Run the `train sft` CLI subcommand.
+pub async fn run_train_sft(
+    url: &str,
+    file: &str,
+    adapter: &str,
+    lr: f64,
+    epochs: u32,
+) -> anyhow::Result<()> {
+    let content = std::fs::read_to_string(file)
+        .map_err(|e| anyhow::anyhow!("Failed to read {file}: {e}"))?;
+
+    let mut examples = Vec::new();
+    for (i, line) in content.lines().enumerate() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let val: serde_json::Value = serde_json::from_str(line)
+            .map_err(|e| anyhow::anyhow!("Invalid JSON on line {}: {e}", i + 1))?;
+        examples.push(val);
+    }
+
+    println!(
+        "{} Submitting {} example(s) for SFT training on adapter '{}'",
+        style("→").cyan().bold(),
+        style(examples.len()).white().bold(),
+        style(adapter).white().bold()
+    );
+
+    let body = serde_json::json!({
+        "adapter_name": adapter,
+        "examples": examples,
+        "learning_rate": lr,
+        "num_epochs": epochs,
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{url}/v1/train/sft"))
+        .json(&body)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    let resp_body: serde_json::Value = resp.json().await?;
+
+    if status.is_success() {
+        println!(
+            "{} Training job submitted",
+            style("✓").green().bold()
+        );
+        if let Some(job_id) = resp_body.get("job_id").and_then(|j| j.as_str()) {
+            println!("  {} {}", style("Job ID:").dim(), job_id);
+        }
+        println!(
+            "  {} kiln health --url {url}",
+            style("Check status:").dim()
+        );
+    } else {
+        eprintln!(
+            "{} Training submission failed: {}",
+            style("✗").red().bold(),
+            resp_body
+                .get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or(&status.to_string())
+        );
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+/// Run the `train grpo` CLI subcommand.
+pub async fn run_train_grpo(url: &str, file: &str, adapter: &str) -> anyhow::Result<()> {
+    let content = std::fs::read_to_string(file)
+        .map_err(|e| anyhow::anyhow!("Failed to read {file}: {e}"))?;
+
+    let body: serde_json::Value = serde_json::from_str(&content)
+        .map_err(|e| anyhow::anyhow!("Invalid JSON in {file}: {e}"))?;
+
+    // Wrap with adapter name if not already present
+    let body = if body.get("adapter_name").is_some() {
+        body
+    } else {
+        let mut obj = body;
+        obj.as_object_mut()
+            .map(|m| m.insert("adapter_name".into(), serde_json::json!(adapter)));
+        obj
+    };
+
+    println!(
+        "{} Submitting GRPO training batch on adapter '{}'",
+        style("→").cyan().bold(),
+        style(adapter).white().bold()
+    );
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{url}/v1/train/grpo"))
+        .json(&body)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    let resp_body: serde_json::Value = resp.json().await?;
+
+    if status.is_success() {
+        println!(
+            "{} GRPO training job submitted",
+            style("✓").green().bold()
+        );
+        if let Some(job_id) = resp_body.get("job_id").and_then(|j| j.as_str()) {
+            println!("  {} {}", style("Job ID:").dim(), job_id);
+        }
+    } else {
+        eprintln!(
+            "{} GRPO submission failed: {}",
+            style("✗").red().bold(),
+            resp_body
+                .get("error")
+                .and_then(|e| e.as_str())
+                .unwrap_or(&status.to_string())
+        );
+        std::process::exit(1);
+    }
+    Ok(())
+}

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -1,6 +1,7 @@
 //! Kiln HTTP server — library interface for integration testing.
 
 pub mod api;
+pub mod cli;
 pub mod config;
 pub mod error;
 pub mod logging;

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -2,8 +2,12 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::Result;
+use clap::Parser;
 
 use kiln_server::api;
+use kiln_server::cli::{
+    self, AdapterCommands, Cli, Commands, TrainCommands,
+};
 use kiln_server::config::KilnConfig;
 use kiln_server::state;
 
@@ -17,9 +21,50 @@ use state::AppState;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Parse optional --config <path> argument
-    let config_path = parse_config_arg();
-    let config = KilnConfig::load(config_path.as_deref())?;
+    let args = Cli::parse();
+
+    match args.command {
+        // Client-side commands (talk to a running server)
+        Some(Commands::Health { ref url }) => {
+            return cli::run_health(url).await;
+        }
+        Some(Commands::ConfigCheck { ref file }) => {
+            return cli::run_config_check(file.as_deref().or(args.config.as_deref()));
+        }
+        Some(Commands::Train(ref train)) => match train {
+            TrainCommands::Sft {
+                file,
+                adapter,
+                lr,
+                epochs,
+                url,
+            } => {
+                return cli::run_train_sft(url, file, adapter, *lr, *epochs).await;
+            }
+            TrainCommands::Grpo { file, adapter, url } => {
+                return cli::run_train_grpo(url, file, adapter).await;
+            }
+        },
+        Some(Commands::Adapters(ref adapter_cmd)) => match adapter_cmd {
+            AdapterCommands::List { url } => {
+                return cli::run_adapters_list(url).await;
+            }
+            AdapterCommands::Load { name, url } => {
+                return cli::run_adapters_load(url, name).await;
+            }
+            AdapterCommands::Unload { name, url } => {
+                return cli::run_adapters_unload(url, name).await;
+            }
+            AdapterCommands::Delete { name, url } => {
+                return cli::run_adapters_delete(url, name).await;
+            }
+        },
+        // Serve mode (default)
+        Some(Commands::Serve) | None => {}
+    }
+
+    // --- Server startup ---
+    let config = KilnConfig::load(args.config.as_deref())?;
 
     kiln_server::logging::init(&config.logging.level, &config.logging.format)?;
 
@@ -28,6 +73,9 @@ async fn main() -> Result<()> {
 
     let model_config = ModelConfig::qwen3_5_4b();
     let model_path = config.model.path.as_deref();
+
+    // Print startup banner to stderr (doesn't interfere with structured logs)
+    cli::print_banner(host, port, model_path, args.config.as_deref());
 
     // Load tokenizer: try from_pretrained (HF Hub), fall back to local path, then fail gracefully.
     let model_id = &config.model.model_id;
@@ -170,17 +218,6 @@ async fn main() -> Result<()> {
     tracing::warn!("shutdown timeout reached — exiting");
 
     Ok(())
-}
-
-/// Parse an optional `--config <path>` argument from argv.
-fn parse_config_arg() -> Option<String> {
-    let args: Vec<String> = std::env::args().collect();
-    for i in 1..args.len() {
-        if args[i] == "--config" {
-            return args.get(i + 1).cloned();
-        }
-    }
-    None
 }
 
 /// Wait for SIGTERM or SIGINT, then signal shutdown.


### PR DESCRIPTION
## Phase 7: Developer Experience — Beautiful CLI

Adds a structured CLI experience to kiln using clap, console, and reqwest.

### Subcommands

- `kiln serve` — Start the inference server (default when no subcommand given)
- `kiln train sft --file examples.jsonl` — Submit SFT training via HTTP
- `kiln train grpo --file scored.jsonl` — Submit GRPO training
- `kiln adapters list|load|unload|delete` — Adapter management via HTTP
- `kiln health` — Check server health
- `kiln config --file config.toml` — Validate config without starting

### Features

- Startup banner with model info, CUDA status, config path, and endpoint list
- Colored output via `console` crate (green ✓ for success, red ✗ for errors)
- Global `--config` flag available to all subcommands
- Client commands talk to a running server via HTTP (reqwest)
- Default (no subcommand) = `kiln serve` for backwards compatibility

### Dependencies added

- `clap` 4 (derive) — CLI argument parsing
- `console` 0.15 — Colored terminal output
- `indicatif` 0.17 — Progress bars (for future model loading progress)
- `reqwest` 0.12 (json) — HTTP client for CLI commands

### Note

RunPod was completely unavailable (all GPU types) during this task, so build verification was not possible. The changes are confined to kiln-server and add no CUDA-specific code — they should compile cleanly.