### PR TITLE
Add linear-interpolation adapter merging

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -313,10 +313,35 @@ Applied to: q_proj, k_proj, v_proj, o_proj (attention), gate_proj, up_proj, down
 GET    /v1/adapters              List active + available adapters
 POST   /v1/adapters/load         Load adapter from disk
 POST   /v1/adapters/unload       Revert to base model
+POST   /v1/adapters/merge        Merge multiple adapters via weighted average
 DELETE /v1/adapters/{name}       Delete adapter from disk
 ```
 
 See `crates/kiln-server/src/api/adapters.rs`.
+
+### Adapter Merging
+
+Multiple PEFT adapters that share the same base model, rank, and target modules can be combined via linear interpolation:
+
+```
+merged = Σᵢ wᵢ · adapter_i        # element-wise on every (A, B) tensor
+```
+
+Request:
+
+```json
+POST /v1/adapters/merge
+{
+  "mode": "weighted_average",
+  "sources": [
+    {"name": "code-fix",   "weight": 0.6},
+    {"name": "doc-style",  "weight": 0.4}
+  ],
+  "output_name": "code-fix-doc-style"
+}
+```
+
+Sources must share `r`, `target_modules`, `base_model_name_or_path`, and per-tensor shapes. The merged adapter is written to disk in the same PEFT format (`adapter_config.json` + `adapter_model.safetensors`, f32) and can immediately be loaded via `POST /v1/adapters/load`. Merging happens off the async runtime via `spawn_blocking` and the helper lives at `crates/kiln-model/src/adapter_merge.rs::merge_linear`. TIES and concatenation merging are deferred to follow-up phases.
 
 ## Training Pipeline
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Qwen3.5-4B's hybrid architecture is the key. Only 8 of 32 layers need KV cache, 
 | GET | `/v1/adapters` | List loaded LoRA adapters |
 | POST | `/v1/adapters/load` | Load adapter from disk |
 | POST | `/v1/adapters/unload` | Unload active adapter |
+| POST | `/v1/adapters/merge` | Merge adapters via weighted average |
 | GET | `/v1/models` | List available models |
 | GET | `/health` | Server health and diagnostics |
 | GET | `/metrics` | Prometheus metrics |

--- a/crates/kiln-model/src/adapter_merge.rs
+++ b/crates/kiln-model/src/adapter_merge.rs
@@ -1,0 +1,676 @@
+//! Adapter merging via weighted (linear-interpolation) averaging.
+//!
+//! Given a set of `(adapter, weight)` pairs that share the same rank,
+//! target modules, and tensor layout, produces a new PEFT-compatible
+//! LoRA adapter whose A/B matrices are the weighted sum of the inputs:
+//!
+//! ```text
+//! merged_A = Σᵢ wᵢ · Aᵢ
+//! merged_B = Σᵢ wᵢ · Bᵢ
+//! ```
+//!
+//! This is the "weighted average" / linear-interpolation merge mode.
+//! TIES and concatenation merging are deferred to follow-up PRs.
+//!
+//! All merging is performed in `f32` on CPU using raw safetensors I/O,
+//! so it does not depend on candle / CUDA and can be unit-tested without
+//! a GPU.
+
+use anyhow::{Context, Result, anyhow, bail};
+use safetensors::Dtype;
+use serde_json::Value;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// On-disk PEFT LoRA adapter loaded into memory as raw `f32` tensors.
+///
+/// `config` is the parsed `adapter_config.json` as a `serde_json::Value`,
+/// preserving every field (including ones Kiln does not interpret) so the
+/// merged output stays compatible with downstream PEFT consumers.
+///
+/// `tensors` is keyed by the safetensors weight name (e.g.
+/// `base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight`) and
+/// holds row-major `f32` data plus the original shape. We use a
+/// `BTreeMap` so saved safetensors files are deterministic.
+#[derive(Debug)]
+pub struct PeftLora {
+    pub config: Value,
+    pub tensors: BTreeMap<String, MergeTensor>,
+}
+
+/// Raw `f32` tensor data plus shape, used for merge arithmetic.
+#[derive(Clone, Debug)]
+pub struct MergeTensor {
+    pub shape: Vec<usize>,
+    pub data: Vec<f32>,
+}
+
+impl MergeTensor {
+    pub fn numel(&self) -> usize {
+        self.shape.iter().product::<usize>()
+    }
+}
+
+impl PeftLora {
+    /// Load a PEFT adapter directory into memory for merging.
+    ///
+    /// Reads `adapter_config.json` (preserved verbatim) and decodes every
+    /// tensor in `adapter_model.safetensors` to `f32`.
+    pub fn load(adapter_dir: &Path) -> Result<Self> {
+        let config_path = adapter_dir.join("adapter_config.json");
+        let config_str = std::fs::read_to_string(&config_path)
+            .with_context(|| format!("failed to read {}", config_path.display()))?;
+        let config: Value = serde_json::from_str(&config_str)
+            .with_context(|| format!("failed to parse {}", config_path.display()))?;
+
+        let st_path = adapter_dir.join("adapter_model.safetensors");
+        let st_data = std::fs::read(&st_path)
+            .with_context(|| format!("failed to read {}", st_path.display()))?;
+        let tensors = safetensors::SafeTensors::deserialize(&st_data)
+            .with_context(|| format!("failed to deserialize {}", st_path.display()))?;
+
+        let mut out: BTreeMap<String, MergeTensor> = BTreeMap::new();
+        for name in tensors.names() {
+            let view = tensors
+                .tensor(name)
+                .with_context(|| format!("missing tensor view for {name}"))?;
+            let shape = view.shape().to_vec();
+            let data = decode_tensor_to_f32(view.dtype(), view.data())
+                .with_context(|| format!("decoding tensor {name}"))?;
+            let expected = shape.iter().product::<usize>();
+            if data.len() != expected {
+                bail!(
+                    "tensor {name} has shape {:?} ({expected} elements) but decoded {} values",
+                    shape,
+                    data.len()
+                );
+            }
+            out.insert(name.to_string(), MergeTensor { shape, data });
+        }
+
+        Ok(Self {
+            config,
+            tensors: out,
+        })
+    }
+
+    /// Save this adapter to `adapter_dir` in PEFT-compatible format.
+    ///
+    /// Writes `adapter_config.json` (pretty-printed) and
+    /// `adapter_model.safetensors`. All tensors are stored as `f32`.
+    pub fn save(&self, adapter_dir: &Path) -> Result<()> {
+        std::fs::create_dir_all(adapter_dir)
+            .with_context(|| format!("creating adapter dir {}", adapter_dir.display()))?;
+
+        let config_path = adapter_dir.join("adapter_config.json");
+        let config_str = serde_json::to_string_pretty(&self.config)?;
+        std::fs::write(&config_path, config_str)
+            .with_context(|| format!("writing {}", config_path.display()))?;
+
+        // Encode each tensor as little-endian f32 bytes for safetensors.
+        let mut byte_storage: Vec<(String, Vec<usize>, Vec<u8>)> =
+            Vec::with_capacity(self.tensors.len());
+        for (name, t) in &self.tensors {
+            let mut bytes = Vec::with_capacity(t.data.len() * 4);
+            for v in &t.data {
+                bytes.extend_from_slice(&v.to_le_bytes());
+            }
+            byte_storage.push((name.clone(), t.shape.clone(), bytes));
+        }
+
+        let views: Vec<(String, safetensors::tensor::TensorView<'_>)> = byte_storage
+            .iter()
+            .map(|(name, shape, bytes)| {
+                let view = safetensors::tensor::TensorView::new(Dtype::F32, shape.clone(), bytes)
+                    .map_err(|e| anyhow!("building safetensors view for {name}: {e}"))?;
+                Ok::<_, anyhow::Error>((name.clone(), view))
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let refs: Vec<(&str, safetensors::tensor::TensorView<'_>)> = views
+            .iter()
+            .map(|(name, view)| (name.as_str(), view.clone()))
+            .collect();
+
+        let serialized = safetensors::tensor::serialize(refs, &None)
+            .context("serializing merged safetensors")?;
+        let st_path = adapter_dir.join("adapter_model.safetensors");
+        std::fs::write(&st_path, serialized)
+            .with_context(|| format!("writing {}", st_path.display()))?;
+
+        Ok(())
+    }
+
+    /// Convenience accessor for `r` from the parsed config.
+    pub fn rank(&self) -> Option<u64> {
+        self.config.get("r")?.as_u64()
+    }
+
+    /// Convenience accessor for `target_modules` (array of strings) from
+    /// the parsed config.
+    pub fn target_modules(&self) -> Vec<String> {
+        self.config
+            .get("target_modules")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    /// Convenience accessor for `base_model_name_or_path` from the parsed
+    /// config (PEFT's canonical field name).
+    pub fn base_model(&self) -> Option<String> {
+        self.config
+            .get("base_model_name_or_path")
+            .and_then(|v| v.as_str())
+            .map(String::from)
+    }
+}
+
+/// Linearly interpolate (weighted-average) a set of LoRA adapters.
+///
+/// Each input is a `(&PeftLora, weight)` pair. The output adapter has:
+/// - the same `adapter_config.json` as `adapters[0]` (preserving fields
+///   PEFT cares about that Kiln does not interpret);
+/// - tensors equal to the elementwise weighted sum of the inputs:
+///   `out[k] = Σᵢ wᵢ · adapters[i].tensors[k]`.
+///
+/// Validation (returns `Err` with an actionable message):
+/// - at least one adapter is supplied;
+/// - all adapters share the same `r` (rank) — required for v1 merge;
+/// - all adapters share the same set of `target_modules`;
+/// - all adapters share the same `base_model_name_or_path` (when present
+///   on more than one input);
+/// - all adapters have identical tensor key sets and matching shapes.
+pub fn merge_linear(adapters: &[(&PeftLora, f32)]) -> Result<PeftLora> {
+    if adapters.is_empty() {
+        bail!("merge_linear requires at least one source adapter");
+    }
+
+    let (first, _) = adapters[0];
+    let first_rank = first.rank();
+    let first_targets = first.target_modules();
+    let first_base = first.base_model();
+
+    let mut keys: Vec<&String> = first.tensors.keys().collect();
+    keys.sort();
+
+    // Validate every adapter against the first.
+    for (idx, (adapter, _)) in adapters.iter().enumerate().skip(1) {
+        if adapter.rank() != first_rank {
+            bail!(
+                "adapter rank mismatch: source[0] has r={:?}, source[{idx}] has r={:?} \
+                 (linear interpolation merge requires identical rank)",
+                first_rank,
+                adapter.rank()
+            );
+        }
+        let targets = adapter.target_modules();
+        if !same_string_set(&first_targets, &targets) {
+            bail!(
+                "adapter target_modules mismatch: source[0] has {:?}, source[{idx}] has {:?}",
+                first_targets,
+                targets
+            );
+        }
+        if let (Some(a), Some(b)) = (&first_base, &adapter.base_model()) {
+            if a != b {
+                bail!(
+                    "adapter base_model_name_or_path mismatch: source[0] is {a:?}, \
+                     source[{idx}] is {b:?}"
+                );
+            }
+        }
+
+        // Tensor key sets must match exactly.
+        let other_keys: Vec<&String> = adapter.tensors.keys().collect();
+        if first.tensors.len() != adapter.tensors.len() {
+            bail!(
+                "adapter tensor count mismatch: source[0] has {} tensors, source[{idx}] has {}",
+                first.tensors.len(),
+                adapter.tensors.len()
+            );
+        }
+        for key in &other_keys {
+            if !first.tensors.contains_key(key.as_str()) {
+                bail!(
+                    "adapter tensor key mismatch: source[{idx}] has tensor {:?} not present in source[0]",
+                    key
+                );
+            }
+        }
+
+        // Shape match per tensor.
+        for key in &keys {
+            let a = &first.tensors[key.as_str()];
+            let b = adapter.tensors.get(key.as_str()).ok_or_else(|| {
+                anyhow!("adapter tensor key mismatch: source[{idx}] missing tensor {:?}", key)
+            })?;
+            if a.shape != b.shape {
+                bail!(
+                    "tensor shape mismatch for {key:?}: source[0] is {:?}, source[{idx}] is {:?}",
+                    a.shape,
+                    b.shape
+                );
+            }
+        }
+    }
+
+    // Compute weighted sum per tensor.
+    let mut merged: BTreeMap<String, MergeTensor> = BTreeMap::new();
+    for key in &keys {
+        let key_str = key.as_str();
+        let template = &first.tensors[key_str];
+        let n = template.numel();
+        let mut acc = vec![0.0_f32; n];
+        for (adapter, weight) in adapters {
+            let t = &adapter.tensors[key_str];
+            // Defensive: shape was validated above, but recheck length.
+            if t.data.len() != n {
+                bail!(
+                    "internal error: tensor {key:?} has {} elements, expected {n}",
+                    t.data.len()
+                );
+            }
+            let w = *weight;
+            for (i, v) in t.data.iter().enumerate() {
+                acc[i] += w * v;
+            }
+        }
+        merged.insert(
+            key_str.to_string(),
+            MergeTensor {
+                shape: template.shape.clone(),
+                data: acc,
+            },
+        );
+    }
+
+    Ok(PeftLora {
+        config: first.config.clone(),
+        tensors: merged,
+    })
+}
+
+fn same_string_set(a: &[String], b: &[String]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut a_sorted = a.to_vec();
+    let mut b_sorted = b.to_vec();
+    a_sorted.sort();
+    b_sorted.sort();
+    a_sorted == b_sorted
+}
+
+fn decode_tensor_to_f32(dtype: Dtype, bytes: &[u8]) -> Result<Vec<f32>> {
+    match dtype {
+        Dtype::F32 => {
+            if bytes.len() % 4 != 0 {
+                bail!("F32 tensor byte length {} is not a multiple of 4", bytes.len());
+            }
+            let mut out = Vec::with_capacity(bytes.len() / 4);
+            for chunk in bytes.chunks_exact(4) {
+                let arr: [u8; 4] = chunk.try_into().expect("chunk size 4");
+                out.push(f32::from_le_bytes(arr));
+            }
+            Ok(out)
+        }
+        Dtype::F16 => {
+            if bytes.len() % 2 != 0 {
+                bail!("F16 tensor byte length {} is not a multiple of 2", bytes.len());
+            }
+            let mut out = Vec::with_capacity(bytes.len() / 2);
+            for chunk in bytes.chunks_exact(2) {
+                let arr: [u8; 2] = chunk.try_into().expect("chunk size 2");
+                out.push(f16_le_bytes_to_f32(arr));
+            }
+            Ok(out)
+        }
+        Dtype::BF16 => {
+            if bytes.len() % 2 != 0 {
+                bail!("BF16 tensor byte length {} is not a multiple of 2", bytes.len());
+            }
+            let mut out = Vec::with_capacity(bytes.len() / 2);
+            for chunk in bytes.chunks_exact(2) {
+                let arr: [u8; 2] = chunk.try_into().expect("chunk size 2");
+                out.push(bf16_le_bytes_to_f32(arr));
+            }
+            Ok(out)
+        }
+        other => bail!("unsupported safetensors dtype for adapter merge: {other:?}"),
+    }
+}
+
+fn f16_le_bytes_to_f32(bytes: [u8; 2]) -> f32 {
+    let bits = u16::from_le_bytes(bytes);
+    let sign = ((bits >> 15) & 0x1) as u32;
+    let exp = ((bits >> 10) & 0x1f) as u32;
+    let mant = (bits & 0x3ff) as u32;
+    let f32_bits = if exp == 0 {
+        if mant == 0 {
+            sign << 31
+        } else {
+            // Subnormal: normalize.
+            let mut m = mant;
+            let mut e: i32 = 1;
+            while (m & 0x400) == 0 {
+                m <<= 1;
+                e -= 1;
+            }
+            m &= 0x3ff;
+            let exp32 = (127 - 15 + e) as u32;
+            (sign << 31) | (exp32 << 23) | (m << 13)
+        }
+    } else if exp == 0x1f {
+        // Inf or NaN.
+        (sign << 31) | (0xff << 23) | (mant << 13)
+    } else {
+        let exp32 = exp + (127 - 15);
+        (sign << 31) | (exp32 << 23) | (mant << 13)
+    };
+    f32::from_bits(f32_bits)
+}
+
+fn bf16_le_bytes_to_f32(bytes: [u8; 2]) -> f32 {
+    // bf16 occupies the upper 16 bits of an f32; lower 16 bits are zero.
+    let bits = (u16::from_le_bytes(bytes) as u32) << 16;
+    f32::from_bits(bits)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    fn make_adapter(
+        rank: usize,
+        a_data: Vec<f32>,
+        b_data: Vec<f32>,
+    ) -> PeftLora {
+        // Single layer, single target module (q_proj), in_features=4, out_features=3.
+        // A: [rank, 4], B: [3, rank]
+        let mut tensors = BTreeMap::new();
+        tensors.insert(
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight".to_string(),
+            MergeTensor {
+                shape: vec![rank, 4],
+                data: a_data,
+            },
+        );
+        tensors.insert(
+            "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight".to_string(),
+            MergeTensor {
+                shape: vec![3, rank],
+                data: b_data,
+            },
+        );
+
+        let config = json!({
+            "r": rank,
+            "lora_alpha": (rank * 2) as f32,
+            "target_modules": ["q_proj"],
+            "task_type": "CAUSAL_LM",
+            "peft_type": "LORA",
+            "base_model_name_or_path": "Qwen/Qwen3.5-4B"
+        });
+
+        PeftLora { config, tensors }
+    }
+
+    #[test]
+    fn test_merge_linear_weighted_average() -> Result<()> {
+        // rank 2: A is [2,4]=8 elements, B is [3,2]=6 elements.
+        let a1 = vec![1.0_f32; 8];
+        let b1 = vec![2.0_f32; 6];
+
+        let a2 = vec![3.0_f32; 8];
+        let b2 = vec![4.0_f32; 6];
+
+        let adapter1 = make_adapter(2, a1, b1);
+        let adapter2 = make_adapter(2, a2, b2);
+
+        let merged = merge_linear(&[(&adapter1, 0.5), (&adapter2, 0.5)])?;
+
+        // Check config preserved (same rank).
+        assert_eq!(merged.rank(), Some(2));
+        assert_eq!(merged.target_modules(), vec!["q_proj".to_string()]);
+
+        let merged_a = &merged.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"];
+        let merged_b = &merged.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"];
+
+        // 0.5*1 + 0.5*3 = 2 for A
+        for v in &merged_a.data {
+            assert!((*v - 2.0).abs() < 1e-6, "expected 2.0, got {v}");
+        }
+        // 0.5*2 + 0.5*4 = 3 for B
+        for v in &merged_b.data {
+            assert!((*v - 3.0).abs() < 1e-6, "expected 3.0, got {v}");
+        }
+
+        // Shapes preserved.
+        assert_eq!(merged_a.shape, vec![2, 4]);
+        assert_eq!(merged_b.shape, vec![3, 2]);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_linear_uneven_weights() -> Result<()> {
+        let a1 = vec![1.0_f32; 8];
+        let b1 = vec![10.0_f32; 6];
+        let a2 = vec![5.0_f32; 8];
+        let b2 = vec![20.0_f32; 6];
+
+        let adapter1 = make_adapter(2, a1, b1);
+        let adapter2 = make_adapter(2, a2, b2);
+
+        // 0.25 * a1 + 0.75 * a2 = 0.25 + 3.75 = 4.0
+        // 0.25 * b1 + 0.75 * b2 = 2.5 + 15.0 = 17.5
+        let merged = merge_linear(&[(&adapter1, 0.25), (&adapter2, 0.75)])?;
+
+        let merged_a = &merged.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"];
+        let merged_b = &merged.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"];
+
+        for v in &merged_a.data {
+            assert!((*v - 4.0).abs() < 1e-6, "expected 4.0, got {v}");
+        }
+        for v in &merged_b.data {
+            assert!((*v - 17.5).abs() < 1e-6, "expected 17.5, got {v}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_linear_three_adapters_uniform() -> Result<()> {
+        let adapter1 = make_adapter(2, vec![3.0_f32; 8], vec![6.0_f32; 6]);
+        let adapter2 = make_adapter(2, vec![6.0_f32; 8], vec![9.0_f32; 6]);
+        let adapter3 = make_adapter(2, vec![9.0_f32; 8], vec![12.0_f32; 6]);
+
+        let third = 1.0 / 3.0;
+        let merged = merge_linear(&[
+            (&adapter1, third),
+            (&adapter2, third),
+            (&adapter3, third),
+        ])?;
+
+        let merged_a = &merged.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"];
+        // (3+6+9)/3 = 6
+        for v in &merged_a.data {
+            assert!((*v - 6.0).abs() < 1e-5, "expected 6.0, got {v}");
+        }
+        let merged_b = &merged.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"];
+        // (6+9+12)/3 = 9
+        for v in &merged_b.data {
+            assert!((*v - 9.0).abs() < 1e-5, "expected 9.0, got {v}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_linear_rank_mismatch_errors() {
+        let a1 = make_adapter(2, vec![1.0_f32; 8], vec![1.0_f32; 6]);
+        // rank 4: A is [4,4]=16, B is [3,4]=12
+        let a2 = make_adapter(4, vec![1.0_f32; 16], vec![1.0_f32; 12]);
+
+        let err = merge_linear(&[(&a1, 0.5), (&a2, 0.5)]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("rank mismatch"),
+            "expected rank mismatch error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_merge_linear_target_modules_mismatch_errors() {
+        let a1 = make_adapter(2, vec![1.0_f32; 8], vec![1.0_f32; 6]);
+        let mut a2 = make_adapter(2, vec![1.0_f32; 8], vec![1.0_f32; 6]);
+        // Mutate config to change target_modules.
+        a2.config["target_modules"] = json!(["k_proj"]);
+
+        let err = merge_linear(&[(&a1, 0.5), (&a2, 0.5)]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("target_modules mismatch"),
+            "expected target_modules mismatch error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_merge_linear_base_model_mismatch_errors() {
+        let a1 = make_adapter(2, vec![1.0_f32; 8], vec![1.0_f32; 6]);
+        let mut a2 = make_adapter(2, vec![1.0_f32; 8], vec![1.0_f32; 6]);
+        a2.config["base_model_name_or_path"] = json!("meta-llama/Llama-3-8B");
+
+        let err = merge_linear(&[(&a1, 0.5), (&a2, 0.5)]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("base_model_name_or_path mismatch"),
+            "expected base model mismatch error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_merge_linear_empty_errors() {
+        let err = merge_linear(&[]).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("at least one source adapter"),
+            "expected empty error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_merge_linear_single_source_passthrough() -> Result<()> {
+        let adapter = make_adapter(2, vec![7.0_f32; 8], vec![11.0_f32; 6]);
+        let merged = merge_linear(&[(&adapter, 1.0)])?;
+        let merged_a = &merged.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"];
+        for v in &merged_a.data {
+            assert!((*v - 7.0).abs() < 1e-6);
+        }
+        let merged_b = &merged.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"];
+        for v in &merged_b.data {
+            assert!((*v - 11.0).abs() < 1e-6);
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn test_save_and_load_roundtrip() -> Result<()> {
+        let dir = tempdir()?;
+        let adapter_dir = dir.path();
+
+        let adapter = make_adapter(2, (0..8).map(|i| i as f32 * 0.5).collect(), vec![3.0_f32; 6]);
+        adapter.save(adapter_dir)?;
+
+        // Files written.
+        assert!(adapter_dir.join("adapter_config.json").exists());
+        assert!(adapter_dir.join("adapter_model.safetensors").exists());
+
+        // Round-trip.
+        let loaded = PeftLora::load(adapter_dir)?;
+        assert_eq!(loaded.rank(), Some(2));
+        assert_eq!(loaded.target_modules(), vec!["q_proj".to_string()]);
+        assert_eq!(loaded.base_model().as_deref(), Some("Qwen/Qwen3.5-4B"));
+        assert_eq!(loaded.tensors.len(), 2);
+
+        let a = &loaded.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"];
+        assert_eq!(a.shape, vec![2, 4]);
+        for (i, v) in a.data.iter().enumerate() {
+            assert!((*v - (i as f32 * 0.5)).abs() < 1e-6);
+        }
+        let b = &loaded.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"];
+        assert_eq!(b.shape, vec![3, 2]);
+        for v in &b.data {
+            assert!((*v - 3.0).abs() < 1e-6);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_then_save_and_load() -> Result<()> {
+        let dir = tempdir()?;
+        let merged_dir = dir.path().join("merged");
+
+        let adapter1 = make_adapter(2, vec![1.0_f32; 8], vec![2.0_f32; 6]);
+        let adapter2 = make_adapter(2, vec![3.0_f32; 8], vec![4.0_f32; 6]);
+
+        let merged = merge_linear(&[(&adapter1, 0.5), (&adapter2, 0.5)])?;
+        merged.save(&merged_dir)?;
+
+        let loaded = PeftLora::load(&merged_dir)?;
+        let a = &loaded.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"];
+        for v in &a.data {
+            assert!((*v - 2.0).abs() < 1e-6);
+        }
+        let b = &loaded.tensors
+            ["base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"];
+        for v in &b.data {
+            assert!((*v - 3.0).abs() < 1e-6);
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merged_loadable_by_lora_weights() -> Result<()> {
+        // The merged adapter should be loadable by the existing
+        // LoraWeights::load() pipeline (which is what production code
+        // uses to apply adapters during inference). This guards against
+        // accidental format drift.
+        use crate::lora_loader::LoraWeights;
+        use candle_core::Device;
+
+        let dir = tempdir()?;
+        let merged_dir = dir.path().join("merged");
+
+        let a1 = make_adapter(2, vec![1.0_f32; 8], vec![1.0_f32; 6]);
+        let a2 = make_adapter(2, vec![3.0_f32; 8], vec![3.0_f32; 6]);
+        let merged = merge_linear(&[(&a1, 0.5), (&a2, 0.5)])?;
+        merged.save(&merged_dir)?;
+
+        let device = Device::Cpu;
+        let loaded = LoraWeights::load(&merged_dir, 1, &device)?;
+        assert_eq!(loaded.rank, 2);
+        assert!(loaded.layers[0].q_proj.is_some());
+
+        Ok(())
+    }
+}

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod adapter_merge;
 pub mod cuda_graph;
 pub mod engine;
 pub mod forward;

--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -5,6 +5,7 @@ use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
+use kiln_model::adapter_merge::{merge_linear, PeftLora};
 use kiln_model::lora_loader::LoraWeights;
 
 use crate::error::ApiError;
@@ -268,6 +269,180 @@ fn scan_adapter_dir(dir: &Path) -> Vec<AdapterDiskEntry> {
     entries
 }
 
+/// Source adapter to include in a merge.
+#[derive(Deserialize)]
+struct MergeSource {
+    /// Adapter name (subdirectory under adapter_dir).
+    name: String,
+    /// Weight applied to this adapter's tensors in the linear interpolation.
+    weight: f32,
+}
+
+/// Request body for POST /v1/adapters/merge.
+#[derive(Deserialize)]
+struct MergeAdapterRequest {
+    /// Source adapters and their interpolation weights. Must contain at least
+    /// two entries to be a true merge (a single source is allowed and behaves
+    /// as a copy with optional rescaling).
+    sources: Vec<MergeSource>,
+    /// Name of the output adapter (subdirectory created under adapter_dir).
+    output_name: String,
+    /// Merge mode. Currently only "weighted_average" (the default) is
+    /// supported. TIES and concatenation will arrive in follow-up PRs.
+    #[serde(default)]
+    mode: Option<String>,
+}
+
+/// Source summary echoed back in the merge response.
+#[derive(Serialize)]
+struct MergeSourceInfo {
+    name: String,
+    weight: f32,
+}
+
+/// Response body for POST /v1/adapters/merge.
+#[derive(Serialize)]
+struct MergeAdapterResponse {
+    status: &'static str,
+    output_name: String,
+    mode: &'static str,
+    sources: Vec<MergeSourceInfo>,
+    /// Number of tensors in the merged adapter.
+    num_tensors: usize,
+}
+
+/// Merge multiple LoRA adapters via linear interpolation.
+///
+/// For each tensor key shared across the input adapters, computes the
+/// weighted sum `Σᵢ wᵢ · tensor_i` and writes the result to a new adapter
+/// directory in `adapter_dir`. Source adapters must have identical rank,
+/// target_modules, base model, and tensor shapes.
+async fn merge_adapters(
+    State(state): State<AppState>,
+    Json(req): Json<MergeAdapterRequest>,
+) -> Result<Json<MergeAdapterResponse>, ApiError> {
+    // Validate mode (default = weighted_average).
+    let mode = req.mode.as_deref().unwrap_or("weighted_average");
+    if mode != "weighted_average" {
+        return Err(ApiError::adapter_merge_invalid(format!(
+            "unsupported merge mode '{mode}' — only 'weighted_average' is supported in v1"
+        )));
+    }
+
+    // Need at least one source.
+    if req.sources.is_empty() {
+        return Err(ApiError::adapter_merge_invalid(
+            "sources must contain at least one entry",
+        ));
+    }
+
+    // Validate output_name: no path separators, not "." or "..", non-empty.
+    let output_name = req.output_name.trim().to_string();
+    if output_name.is_empty()
+        || output_name == "."
+        || output_name == ".."
+        || output_name.contains('/')
+        || output_name.contains('\\')
+    {
+        return Err(ApiError::adapter_merge_bad_name(&output_name));
+    }
+
+    // Resolve and confirm all source adapter directories exist before
+    // doing any I/O work.
+    let mut source_paths: Vec<(String, f32, std::path::PathBuf)> =
+        Vec::with_capacity(req.sources.len());
+    for src in &req.sources {
+        let path = state.adapter_dir.join(&src.name);
+        if !path.exists() || !path.is_dir() {
+            return Err(ApiError::adapter_not_found(&src.name));
+        }
+        source_paths.push((src.name.clone(), src.weight, path));
+    }
+
+    // Refuse to overwrite an existing output adapter.
+    let output_path = state.adapter_dir.join(&output_name);
+    if output_path.exists() {
+        return Err(ApiError::adapter_merge_output_exists(&output_name));
+    }
+
+    let sources_info: Vec<MergeSourceInfo> = req
+        .sources
+        .iter()
+        .map(|s| MergeSourceInfo {
+            name: s.name.clone(),
+            weight: s.weight,
+        })
+        .collect();
+
+    // Run the (potentially slow, CPU-bound) merge work on a blocking thread.
+    let output_name_for_task = output_name.clone();
+    let output_path_for_task = output_path.clone();
+    let merge_result = tokio::task::spawn_blocking(move || -> Result<usize, MergeError> {
+        // Load each source adapter from disk.
+        let mut loaded: Vec<(PeftLora, f32)> = Vec::with_capacity(source_paths.len());
+        for (name, weight, path) in source_paths {
+            let adapter = PeftLora::load(&path).map_err(|e| MergeError::Failed(format!(
+                "loading source adapter '{name}' from {}: {e}",
+                path.display()
+            )))?;
+            loaded.push((adapter, weight));
+        }
+
+        let refs: Vec<(&PeftLora, f32)> =
+            loaded.iter().map(|(a, w)| (a, *w)).collect();
+
+        let merged = merge_linear(&refs).map_err(|e| MergeError::Invalid(format!("{e}")))?;
+        let num_tensors = merged.tensors.len();
+        merged
+            .save(&output_path_for_task)
+            .map_err(|e| MergeError::Failed(format!(
+                "saving merged adapter to {}: {e}",
+                output_path_for_task.display()
+            )))?;
+        let _ = output_name_for_task;
+        Ok(num_tensors)
+    })
+    .await
+    .map_err(|e| ApiError::internal(format!("join error: {e}")))?;
+
+    let num_tensors = match merge_result {
+        Ok(n) => n,
+        Err(MergeError::Invalid(msg)) => {
+            // Best-effort cleanup if we partially wrote anything.
+            let _ = std::fs::remove_dir_all(&output_path);
+            return Err(ApiError::adapter_merge_invalid(msg));
+        }
+        Err(MergeError::Failed(msg)) => {
+            let _ = std::fs::remove_dir_all(&output_path);
+            return Err(ApiError::adapter_merge_failed(msg));
+        }
+    };
+
+    tracing::info!(
+        output = %output_name,
+        num_sources = req.sources.len(),
+        num_tensors,
+        mode,
+        operation = "merge",
+        "merged LoRA adapters"
+    );
+
+    Ok(Json(MergeAdapterResponse {
+        status: "merged",
+        output_name,
+        mode: "weighted_average",
+        sources: sources_info,
+        num_tensors,
+    }))
+}
+
+/// Internal error type for the blocking merge task — distinguishes user
+/// validation failures (400) from internal I/O failures (500).
+enum MergeError {
+    Invalid(String),
+    Failed(String),
+}
+
 /// Convert days since Unix epoch to (year, month, day).
 fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
     // Civil calendar algorithm from Howard Hinnant.
@@ -289,5 +464,6 @@ pub fn routes() -> Router<AppState> {
         .route("/v1/adapters", get(list_adapters))
         .route("/v1/adapters/load", post(load_adapter))
         .route("/v1/adapters/unload", post(unload_adapter))
+        .route("/v1/adapters/merge", post(merge_adapters))
         .route("/v1/adapters/{name}", delete(delete_adapter))
 }

--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -125,6 +125,42 @@ impl ApiError {
         }
     }
 
+    pub fn adapter_merge_invalid(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "adapter_merge_invalid",
+            message: format!("Cannot merge adapters: {detail}"),
+            hint: "All sources must share the same rank, target_modules, base_model, and tensor shapes. Linear interpolation requires identical adapter layouts.",
+        }
+    }
+
+    pub fn adapter_merge_failed(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "adapter_merge_failed",
+            message: format!("Adapter merge failed: {detail}"),
+            hint: "Check server logs for the underlying I/O or serialization error.",
+        }
+    }
+
+    pub fn adapter_merge_output_exists(name: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "adapter_merge_output_exists",
+            message: format!("Output adapter '{name}' already exists"),
+            hint: "Choose a different output_name, or delete the existing adapter first with DELETE /v1/adapters/{name}.",
+        }
+    }
+
+    pub fn adapter_merge_bad_name(name: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "adapter_merge_bad_name",
+            message: format!("Invalid output_name '{name}'"),
+            hint: "output_name must be non-empty, contain no path separators, and not be '.' or '..'.",
+        }
+    }
+
     pub fn mock_mode_no_adapters() -> Self {
         Self {
             status: StatusCode::BAD_REQUEST,


### PR DESCRIPTION
## What

Implements Phase 8 adapter merging via weighted average.

- `merge_linear` helper in `kiln-model::adapter_merge` loads two or more PEFT adapters, validates that `r`, `target_modules`, `base_model_name_or_path`, and per-tensor shapes match, then computes `merged = Σᵢ wᵢ · adapterᵢ` element-wise on every (A, B) tensor and writes the result back as PEFT (`adapter_config.json` + `adapter_model.safetensors`, f32).
- `POST /v1/adapters/merge` endpoint accepting:
  ```json
  {
    "mode": "weighted_average",
    "sources": [{"name": "code-fix", "weight": 0.6}, {"name": "doc-style", "weight": 0.4}],
    "output_name": "code-fix-doc-style"
  }
  ```
  Runs the merge off the async runtime via `spawn_blocking`. Sanitizes `output_name`, refuses to overwrite an existing adapter, and best-effort cleans up partial output on failure.
- New `ApiError` variants: `adapter_merge_invalid` (400), `adapter_merge_failed` (500), `adapter_merge_output_exists` (409), `adapter_merge_bad_name` (400).
- 11 CPU-only unit tests with rank-2 dim-4 tensors: weighted average correctness, uneven weights, three-adapter uniform mix, rank / target_modules / base_model mismatch errors, empty sources, single-source passthrough, save/load roundtrip, and PEFT loadability via `LoraWeights::from_path`.
- README and ARCHITECTURE updated with the new endpoint and a brief example.

## Why

Operators want to combine specialized adapters (e.g. a code-fix LoRA and a doc-style LoRA) without a separate Python/PEFT toolchain. Linear interpolation is the simplest, fastest baseline and unblocks the API surface for richer modes later.

## Tests

`cargo test -p kiln-model adapter_merge` — 11 passed.

The endpoint and `kiln-model::adapter_merge` are CPU-compilable; the broader `kiln-server` workspace requires CUDA/openssl that is not available in the build sandbox here.

## Follow-ups

- TIES merging
- Concatenation merging (rank-additive)