### PR TITLE
GDN: run recurrence in bf16, eliminate redundant state clone (PROFILING #2 first step)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -707,6 +707,12 @@ pub fn gated_deltanet_forward(
         *recurrent_state = recurrent_state.to_dtype(input_dtype)?;
     }
 
+    // Cast v back to input_dtype so the loop stays in bf16. After the causal
+    // conv1d + SiLU step above, mixed_qkv (and hence v) is F32; without this
+    // cast the subtract `(v_t - kv_mem)` below hits a dtype mismatch on bf16
+    // GPU runs, because kv_mem inherits the (now bf16) state dtype.
+    let v = v.to_dtype(input_dtype)?;
+
     // Transpose to [B, nv, T, dim] for per-head processing
     let q = q.transpose(1, 2)?; // [B, nv, T, dk]
     let k = k.transpose(1, 2)?; // [B, nv, T, dk]

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -669,16 +669,22 @@ pub fn gated_deltanet_forward(
     };
 
     // --- Step 5: L2 normalize Q, K; scale Q by 1/sqrt(dk) ---
+    // Normalize in F32 for numerical stability (sqrt/div), then cast back to
+    // the input dtype so the recurrent loop below runs in bf16 (see Step 7).
     let q = l2_normalize(&q)?; // F32
     let k = l2_normalize(&k)?; // F32
     let scale = 1.0 / (dk as f64).sqrt();
-    let q = (q * scale)?;
+    let q = (q * scale)?.to_dtype(input_dtype)?;
+    let k = k.to_dtype(input_dtype)?;
 
     // --- Step 6: Compute gates ---
-    // beta = sigmoid(b) — write gate, in (0, 1)
-    let beta = cuda_sigmoid(&b)?.to_dtype(DType::F32)?; // [B, T, nv]
+    // beta = sigmoid(b) — write gate, in (0, 1). sigmoid output is bounded so
+    // bf16 has enough precision; no F32 upcast needed.
+    let beta = cuda_sigmoid(&b)?; // [B, T, nv], bf16
 
-    // g = -exp(A_log) * softplus(a + dt_bias) — decay (negative log-space)
+    // g = -exp(A_log) * softplus(a + dt_bias) — decay (negative log-space).
+    // The softplus/exp pipeline is computed in F32 for stability (it involves
+    // exp and log near 0), then cast to the input dtype for the bf16 loop.
     let a_f32 = a.to_dtype(DType::F32)?;
     let a_log_f32 = weights.a_log.to_dtype(DType::F32)?;
     let dt_bias_f32 = weights.dt_bias.to_dtype(DType::F32)?;
@@ -687,10 +693,19 @@ pub fn gated_deltanet_forward(
         let sp = softplus(&a_biased)?;
         let neg_decay = a_log_f32.exp()?.neg()?; // -exp(A_log)
         sp.broadcast_mul(&neg_decay)?
-    }; // [B, T, nv], negative values → exp(g) ∈ (0, 1)
+    }
+    .to_dtype(input_dtype)?; // [B, T, nv], negative values → exp(g) ∈ (0, 1)
 
-    // --- Step 7: Sequential recurrence (all F32) ---
-    let v = v.to_dtype(DType::F32)?;
+    // --- Step 7: Sequential recurrence ---
+    // The recurrent state is stored in F32 externally (across layers/steps)
+    // for accumulator stability, but we run the loop in bf16 to reclaim the
+    // ~66% of prefill GPU time previously spent in bmul_f32 / fast_sum_f32 /
+    // badd_f32 (see PROFILING.md recommendation #2). State is cast bf16 at
+    // entry and restored to F32 at exit so the external invariant holds.
+    let state_external_dtype = recurrent_state.dtype();
+    if state_external_dtype != input_dtype {
+        *recurrent_state = recurrent_state.to_dtype(input_dtype)?;
+    }
 
     // Transpose to [B, nv, T, dim] for per-head processing
     let q = q.transpose(1, 2)?; // [B, nv, T, dk]
@@ -719,16 +734,24 @@ pub fn gated_deltanet_forward(
         // 3. Delta rule: delta = (v_t - kv_mem) * beta_t
         let delta: Tensor = (v_t - kv_mem)?.broadcast_mul(&beta_t.unsqueeze(2)?)?; // [B, nv, dv]
 
-        // 4. Update: S += outer(k_t, delta)
-        let outer = k_t
-            .unsqueeze(3)?
-            .broadcast_mul(&delta.unsqueeze(2)?)?; // [B, nv, dk, dv]
-        *recurrent_state = (recurrent_state.clone() + outer)?;
+        // 4. Update: S += outer(k_t, delta) — reference add, no explicit clone.
+        // The `Tensor::add` op takes references and allocates a new tensor for
+        // the result regardless of how `lhs` is passed, so clone() was pure
+        // Arc churn with no effect on storage allocation.
+        let outer = k_t.unsqueeze(3)?.broadcast_mul(&delta.unsqueeze(2)?)?; // [B, nv, dk, dv]
+        let new_state = (&*recurrent_state + &outer)?;
+        *recurrent_state = new_state;
 
         // 5. Output: out_t = einsum('bhkv,bhk->bhv', S, q_t)
         let q_expanded = q_t.unsqueeze(3)?; // [B, nv, dk, 1]
         let out_t = recurrent_state.broadcast_mul(&q_expanded)?.sum(2)?; // [B, nv, dv]
         outputs.push(out_t.unsqueeze(2)?); // [B, nv, 1, dv]
+    }
+
+    // Restore state to its original dtype so the caller's F32 invariant holds
+    // across layer calls and across prefill/decode steps.
+    if state_external_dtype != input_dtype {
+        *recurrent_state = recurrent_state.to_dtype(state_external_dtype)?;
     }
 
     // Collect: [B, nv, T, dv]


### PR DESCRIPTION
## What

Phase 6 optimization for the Gated DeltaNet (GDN) recurrence loop (24 of 32 layers in Qwen3.5-4B). Targets the top profiling hotspot from `PROFILING.md`: `bmul_f32` (45.1%) + `fast_sum_f32` (16.7%) + `badd_f32` (4.4%) ≈ 66% of prefill GPU time on sm_86.

Two changes in `crates/kiln-model/src/forward.rs::gated_deltanet_forward`:

1. **Run the per-timestep recurrence in bf16 instead of F32.** Previously `v` was blanket-upcast to F32 at the start of the loop. Now `q`, `k`, `v`, `beta`, `g`, and the `broadcast_mul` / `sum` / `add` ops stay in `input_dtype` (bf16). The caller-visible `recurrent_state` remains F32 externally for numerical stability; we cast it to bf16 on entry and restore it to F32 on exit via a guarded pair.
2. **Eliminate `recurrent_state.clone()` inside the loop.** `Tensor::add` always allocates a fresh output, so the clone was pure Arc churn. Replaced with `let new_state = (&*recurrent_state + &outer)?; *recurrent_state = new_state;`.

Commit `1f16f8f` adds a small bf16 discipline fix discovered during GPU validation: `cuda_silu` upcasts `mixed_qkv` to F32 internally for numerical stability, which propagates F32 to `v` even when `input_dtype` is bf16. A single `let v = v.to_dtype(input_dtype)?;` before the transpose keeps the subtract `(v_t - kv_mem)` dtype-consistent.

## Why

F32 bmul/sum/add dominate prefill. Staying in bf16 cuts the work in half for the heaviest kernels (the weights themselves are bf16). The caller invariant (F32 external state) is preserved.

## Numbers

**A40 sm_86 Ampere** (A6000 unavailable on RunPod; A40 is architecturally equivalent: same compute cap 8.6, same 48GB VRAM, same CUDA 12.8 / Ubuntu 24.04). Qwen3.5-4B bf16, prompt 512, 1 decode token, `--skip-training`.

| Build | Run | Prefill (ms) | Prefill (tok/s) |
|-------|-----|-------------:|----------------:|
| main  (`97b0909`) | 1 | 2105.5 | 240 |
| main  (`97b0909`) | 2 | 2104.5 | 240 |
| **branch (`1f16f8f`)** | 1 | **2061.4** | **245** |
| **branch (`1f16f8f`)** | 2 | **2055.5** | **246** |

**~2.3% prefill speedup** on A40. Decode ITL is unchanged (~258ms) because decode uses seq_len=1 so the per-token GDN loop runs only once — the win is proportional to prefill sequence length.

## Coherence / sanity

Branch with 16-token prompt, 64 decode tokens (GPU): Prefill 436.8ms / 32 tok/s, Decode 65 tokens at stable ITL ~247.9ms, no crash and no NaN.

CPU tests: **122 / 122 pass** on both commits (cast is a no-op when `input_dtype == F32`).

## Commits

- `52274c7` GDN: run recurrence in bf16, eliminate redundant state clone
- `1f16f8f` GDN: cast v back to input_dtype before bf16 loop