### PR TITLE
Add kiln-runpod image (preinstalled CUDA 12.4 + nsys + Rust + sccache + PyTorch)

### DIFF
--- a/.github/workflows/runpod-image.yml
+++ b/.github/workflows/runpod-image.yml
@@ -1,0 +1,54 @@
+name: Build kiln-runpod image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/runpod/**'
+      - '.github/workflows/runpod-image.yml'
+  workflow_dispatch:
+  schedule:
+    # Weekly rebuild for security patches
+    - cron: '0 8 * * 1'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ericflo/kiln-runpod
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: deploy/runpod
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/deploy/runpod/Dockerfile
+++ b/deploy/runpod/Dockerfile
@@ -1,0 +1,88 @@
+# kiln-runpod: Pre-baked GPU dev/profiling/training image for RunPod.
+#
+# Eliminates the per-pod setup tax: CUDA 12.4 toolkit, nsight-systems,
+# Rust + sccache, b2 CLI, hf-transfer, PyTorch cu124 — all preinstalled.
+#
+# Built and pushed by .github/workflows/runpod-image.yml on changes to
+# deploy/runpod/. Published as ghcr.io/ericflo/kiln-runpod:latest.
+
+FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH=/usr/local/cuda/bin:/usr/local/cargo/bin:/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin \
+    CUDA_HOME=/usr/local/cuda \
+    HF_HUB_ENABLE_HF_TRANSFER=1 \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PYTHONUNBUFFERED=1
+
+# --- Base apt packages ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        build-essential pkg-config libssl-dev \
+        git curl ca-certificates wget jq vim less gnupg2 \
+        python3.11 python3.11-dev python3-pip \
+        openssh-server software-properties-common \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+    && update-alternatives --install /usr/bin/python  python  /usr/bin/python3.11 1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- nsight-systems (nsys) for profiling ---
+# cuda-nsight-systems-12-4 lands binaries under /opt/nvidia/nsight-systems-*/bin
+# OR /usr/local/cuda-12.4/nsight-systems-*/bin depending on package version.
+# Symlink whichever exists into /usr/local/bin.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cuda-nsight-systems-12-4 \
+    && rm -rf /var/lib/apt/lists/* \
+    && (NSYS_BIN="$(find /opt/nvidia /usr/local/cuda-12.4 -name nsys -type f 2>/dev/null | head -1)"; \
+        if [ -n "$NSYS_BIN" ]; then ln -sf "$NSYS_BIN" /usr/local/bin/nsys; \
+        else echo "ERROR: nsys not found after install" && find / -name nsys -type f 2>/dev/null && exit 1; fi) \
+    && nsys --version
+
+# --- GitHub CLI ---
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod 644 /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Rust stable (system-wide so any user can use it) ---
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+        | sh -s -- -y --default-toolchain stable --profile minimal --no-modify-path \
+    && chmod -R a+rwX /usr/local/rustup /usr/local/cargo \
+    && rustc --version && cargo --version
+
+# --- sccache (matches scripts/setup-build-cache.sh default) ---
+ARG SCCACHE_VERSION=v0.9.1
+RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_VERSION}/sccache-${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+        | tar xz -C /tmp \
+    && mv /tmp/sccache-*/sccache /usr/local/bin/sccache \
+    && chmod +x /usr/local/bin/sccache \
+    && rm -rf /tmp/sccache-* \
+    && sccache --version
+
+# --- Python tooling ---
+# PyTorch cu124 + huggingface stack + b2 CLI + safetensors/numpy.
+# --break-system-packages is needed on Ubuntu 22.04 PEP 668 setups.
+RUN pip install --no-cache-dir --break-system-packages \
+        --index-url https://download.pytorch.org/whl/cu124 \
+        torch==2.4.1 \
+    && pip install --no-cache-dir --break-system-packages \
+        'b2[full]' huggingface-hub hf-transfer safetensors numpy
+
+# --- SSH server config (RunPod injects $PUBLIC_KEY at pod boot) ---
+RUN mkdir -p /var/run/sshd /root/.ssh \
+    && chmod 700 /root/.ssh \
+    && sed -i 's/#\?PermitRootLogin.*/PermitRootLogin prohibit-password/' /etc/ssh/sshd_config \
+    && sed -i 's/#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /workspace
+
+EXPOSE 22
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD ["/usr/sbin/sshd", "-D", "-e"]

--- a/deploy/runpod/README.md
+++ b/deploy/runpod/README.md
@@ -1,0 +1,61 @@
+# kiln-runpod image
+
+Pre-baked GPU dev/profiling/training image for RunPod pods.
+
+Eliminates the per-pod setup tax kiln tasks were paying every launch:
+CUDA 12.4.1 toolkit, nsight-systems (`nsys`), Rust stable + `sccache` 0.9.1,
+PyTorch 2.4.1 (cu124), `b2[full]`, `huggingface-hub` + `hf-transfer`, and `gh` —
+all baked in.
+
+## Usage
+
+```python
+from runpod_api import RunPod
+rp = RunPod()
+pod = rp.launch(
+    gpu_id="NVIDIA RTX A6000",
+    name="kiln-bench",
+    image="ghcr.io/ericflo/kiln-runpod:latest",
+)
+```
+
+## What's inside
+
+- Ubuntu 22.04, CUDA 12.4.1 toolkit (`nvcc`), cuDNN dev
+- `nsys` (nsight-systems) for profiling
+- Rust stable + `cargo` + `sccache` 0.9.1
+- Python 3.11 + PyTorch 2.4.1 (cu124)
+- `b2[full]`, `huggingface-hub`, `hf-transfer`, `safetensors`, `numpy`
+- `git`, `gh`, `jq`, `vim`, `less`, `wget`, `curl`
+- OpenSSH with RunPod `PUBLIC_KEY` env injection
+
+## Build & publish
+
+Built by `.github/workflows/runpod-image.yml` on changes to `deploy/runpod/**`.
+
+Tags:
+- `ghcr.io/ericflo/kiln-runpod:latest` — main branch
+- `ghcr.io/ericflo/kiln-runpod:sha-<short>` — per-commit
+- Weekly rebuild (Mon 08:00 UTC)
+
+## Local sanity check
+
+```bash
+docker build -t kiln-runpod-test deploy/runpod/
+docker run --rm kiln-runpod-test bash -c \
+    'nvcc --version && rustc --version && nsys --version | head -1 \
+     && which sccache b2 hf gh \
+     && python3 -c "import torch; print(torch.__version__)"'
+```
+
+## After first push: make package public
+
+GHCR packages default to private. After the first successful push, mark
+the package public so RunPod can pull without registry auth:
+
+```bash
+gh api -X PATCH /user/packages/container/kiln-runpod/visibility \
+    -f visibility=public
+```
+
+(One-time. Subsequent pushes inherit the public visibility.)

--- a/deploy/runpod/entrypoint.sh
+++ b/deploy/runpod/entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# entrypoint.sh — install RunPod $PUBLIC_KEY, start sshd.
+set -euo pipefail
+
+if [ -n "${PUBLIC_KEY:-}" ]; then
+    mkdir -p /root/.ssh
+    chmod 700 /root/.ssh
+    echo "${PUBLIC_KEY}" >> /root/.ssh/authorized_keys
+    chmod 600 /root/.ssh/authorized_keys
+fi
+
+# Generate host keys on first boot
+if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
+    ssh-keygen -A
+fi
+
+exec "$@"


### PR DESCRIPTION
## What

Adds a pre-baked GPU dev/profiling/training image at `deploy/runpod/`, plus a GitHub Actions workflow that publishes it to `ghcr.io/ericflo/kiln-runpod:latest` on every push to `main` that touches `deploy/runpod/`.

## Why

Every RunPod-backed kiln task today spends ~15-30 minutes of pod time installing nsight-systems, Rust, sccache, b2 CLI, and hf-transfer, and frequently has to terminate the first pod after discovering a CUDA-version mismatch. Phase 6 (task 7562e7a202257eb15f6d00f7) is a fresh example. This image bakes all of that in.

## What's inside

- CUDA 12.4.1 toolkit (`nvcc`) + cuDNN dev — matches kiln's required CUDA version
- `nsys` (cuda-nsight-systems-12-4) — for profiling
- Rust stable + `sccache` 0.9.1 — Cargo + B2-backed compile cache work out of the box
- PyTorch 2.4.1 cu124 — for any torch-based scripts (trajectory-trainer reuse)
- `b2[full]`, `huggingface-hub`, `hf-transfer`, `safetensors`, `numpy`
- `gh`, `jq`, `git`, `vim`, `less`, `wget`, `curl`
- OpenSSH with RunPod `PUBLIC_KEY` env injection (drop-in replacement for default RunPod images)

## Follow-up

After this lands and the workflow's first run succeeds, the GHCR package needs to be flipped public (one-time, see `deploy/runpod/README.md`). A subsequent task will update `runpod_api.py` defaults / kiln task templates to point at `ghcr.io/ericflo/kiln-runpod:latest`.