### PR TITLE
Fix runpod image build: drop --break-system-packages

### DIFF
--- a/deploy/runpod/Dockerfile
+++ b/deploy/runpod/Dockerfile
@@ -64,11 +64,13 @@ RUN curl -fsSL "https://github.com/mozilla/sccache/releases/download/${SCCACHE_V
 
 # --- Python tooling ---
 # PyTorch cu124 + huggingface stack + b2 CLI + safetensors/numpy.
-# --break-system-packages is needed on Ubuntu 22.04 PEP 668 setups.
-RUN pip install --no-cache-dir --break-system-packages \
+# Ubuntu 22.04 ships pip 22.0.2 which predates --break-system-packages
+# (added in pip 23.0.1) and does not enforce PEP 668, so the flag is
+# neither available nor needed here.
+RUN pip install --no-cache-dir \
         --index-url https://download.pytorch.org/whl/cu124 \
         torch==2.4.1 \
-    && pip install --no-cache-dir --break-system-packages \
+    && pip install --no-cache-dir \
         'b2[full]' huggingface-hub hf-transfer safetensors numpy
 
 # --- SSH server config (RunPod injects $PUBLIC_KEY at pod boot) ---


### PR DESCRIPTION
## What
Drop the `--break-system-packages` pip flag from `deploy/runpod/Dockerfile`.

## Why
The first build of the new `kiln-runpod` image (workflow run [24541288798](https://github.com/ericflo/kiln/actions/runs/24541288798/job/71747454011)) failed with:

```
no such option: --break-system-packages
ERROR: process "/bin/sh -c pip install --no-cache-dir --break-system-packages ..." did not complete successfully: exit code: 2
```

The base image is `nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04`. Ubuntu 22.04 ships pip 22.0.2, which:
- Does **not** recognize `--break-system-packages` (the flag was added in pip 23.0.1)
- Does **not** enforce PEP 668 (no `EXTERNALLY-MANAGED` marker)

So the flag was both unrecognized and unnecessary. Removing it lets the pip install run cleanly.

## Test plan
- [ ] Re-run `runpod-image.yml` workflow on this branch and confirm the image builds and pushes.