### PR TITLE
Free disk space on runner before runpod image build

### DIFF
--- a/.github/workflows/runpod-image.yml
+++ b/.github/workflows/runpod-image.yml
@@ -22,6 +22,21 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Free disk space
+        # The CUDA dev base image (~10 GB) plus nsight-systems, Rust, and the
+        # PyTorch cu124 wheel (~2.5 GB) overflow the default ~14 GB free space
+        # on ubuntu-latest runners. Reclaim ~30 GB by removing preinstalled
+        # tooling we don't need (Android SDK, .NET, Haskell, CodeQL, etc.).
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
       - uses: actions/checkout@v4
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## What
Add `jlumbroso/free-disk-space` as the first step of `runpod-image.yml` to reclaim ~30 GB on the runner before the Docker build starts.

## Why
After PR #78 fixed the `--break-system-packages` issue, the next build on `main` ([run 24542124881](https://github.com/ericflo/kiln/actions/runs/24542124881)) failed during the pip install with:

```
ERROR: Could not install packages due to an OSError: [Errno 28] No space left on device
```

`ubuntu-latest` runners come with ~14 GB free. The CUDA 12.4 dev base image (~10 GB) plus nsight-systems, Rust, and the PyTorch cu124 wheel (~2.5 GB) overflow that. Removing the preinstalled Android SDK, .NET, Haskell, CodeQL caches, and swap frees ~30 GB and lets the build complete.

Kept `large-packages: false` and `docker-images: false` to keep the cleanup step fast — those passes are slow and we don't need that much headroom.

## Test plan
- [ ] Merge and confirm the runpod-image workflow on main succeeds end-to-end.