### PR TITLE
CE: Fix runpod-image buildx to emit Docker v2 manifest list

### DIFF
--- a/.github/workflows/runpod-image.yml
+++ b/.github/workflows/runpod-image.yml
@@ -67,3 +67,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: false


### PR DESCRIPTION
## Summary
Adds `provenance: false` to the buildx step so the pushed image includes a Docker v2 manifest list in addition to the OCI image index. Without this, RunPod's Docker daemon fails to pull `ghcr.io/ericflo/kiln-runpod:latest` anonymously with `denied: denied` even though the package is public — anonymous OCI pulls work fine, but Docker daemons older than buildx only understand Docker v2 manifest lists.

## Why
Observed in production 2026-04-17: pod launches failed with `error creating container: Error response from daemon: Head "https://ghcr.io/v2/ericflo/kiln-runpod/manifests/latest": denied: denied`. Worked around by creating a RunPod containerRegistryAuth with a GitHub token, but that's a per-launch burden. This fix makes the image pullable anonymously from any Docker daemon.

## Verification
After this PR merges and the workflow runs, verify Docker v2 manifest list is present:
```
curl -sI -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
  -H "Authorization: Bearer $(curl -s https://ghcr.io/token?scope=repository:ericflo/kiln-runpod:pull | jq -r .token)" \
  https://ghcr.io/v2/ericflo/kiln-runpod/manifests/latest
```
Should return 200 (currently returns 404).