### PR TITLE
desktop: system tray with status icon and menu

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -14,7 +14,7 @@ license = "MIT"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["tray-icon"] }
+tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,11 +1,12 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 mod supervisor;
+mod tray;
 
 use std::sync::Arc;
 
 use supervisor::{ServerState, Supervisor, SupervisorConfig};
-use tauri::State;
+use tauri::{Manager, State};
 
 #[tauri::command]
 async fn start_server(sup: State<'_, Arc<Supervisor>>) -> Result<(), String> {
@@ -33,6 +34,11 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .manage(supervisor)
+        .setup(|app| {
+            let sup: State<'_, Arc<Supervisor>> = app.state();
+            tray::build_tray(app.handle(), sup.inner().clone())?;
+            Ok(())
+        })
         .invoke_handler(tauri::generate_handler![
             start_server,
             stop_server,

--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -1,0 +1,189 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tauri::menu::{MenuBuilder, MenuItem, MenuItemBuilder};
+use tauri::tray::TrayIconBuilder;
+use tauri::{AppHandle, Emitter, Manager};
+
+use crate::supervisor::{ServerState, Supervisor};
+
+const TRAY_ID: &str = "kiln-main";
+const ITEM_DASHBOARD: &str = "open_dashboard";
+const ITEM_SETTINGS: &str = "open_settings";
+const ITEM_START: &str = "start_server";
+const ITEM_STOP: &str = "stop_server";
+const ITEM_LOGS: &str = "view_logs";
+const ITEM_QUIT: &str = "quit";
+
+const ICON_BYTES: &[u8] = include_bytes!("../icons/32x32.png");
+
+pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result<()> {
+    let dashboard = MenuItemBuilder::with_id(ITEM_DASHBOARD, "Open Dashboard").build(app)?;
+    let settings = MenuItemBuilder::with_id(ITEM_SETTINGS, "Settings…").build(app)?;
+    let start = MenuItemBuilder::with_id(ITEM_START, "Start Server").build(app)?;
+    let stop = MenuItemBuilder::with_id(ITEM_STOP, "Stop Server")
+        .enabled(false)
+        .build(app)?;
+    let logs = MenuItemBuilder::with_id(ITEM_LOGS, "View Logs").build(app)?;
+    let quit = MenuItemBuilder::with_id(ITEM_QUIT, "Quit").build(app)?;
+
+    let menu = MenuBuilder::new(app)
+        .items(&[&dashboard, &settings])
+        .separator()
+        .items(&[&start, &stop, &logs])
+        .separator()
+        .item(&quit)
+        .build()?;
+
+    let icon = tauri::image::Image::from_bytes(ICON_BYTES)?;
+
+    let supervisor_for_events = Arc::clone(&supervisor);
+    // TODO: per-state tray icons in a later PR. Single icon for all states today.
+    let _tray = TrayIconBuilder::with_id(TRAY_ID)
+        .icon(icon)
+        .tooltip("kiln: Stopped")
+        .menu(&menu)
+        .on_menu_event(move |app, event| {
+            let app_handle = app.clone();
+            let supervisor = Arc::clone(&supervisor_for_events);
+            match event.id().as_ref() {
+                ITEM_START => {
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(e) = supervisor.start().await {
+                            eprintln!("[tray] start_server failed: {}", e);
+                        }
+                    });
+                }
+                ITEM_STOP => {
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(e) = supervisor.stop().await {
+                            eprintln!("[tray] stop_server failed: {}", e);
+                        }
+                    });
+                }
+                ITEM_QUIT => {
+                    app_handle.exit(0);
+                }
+                ITEM_DASHBOARD => {
+                    let _ = app_handle.emit("menu://open-dashboard", ());
+                }
+                ITEM_SETTINGS => {
+                    let _ = app_handle.emit("menu://open-settings", ());
+                }
+                ITEM_LOGS => {
+                    let _ = app_handle.emit("menu://view-logs", ());
+                }
+                _ => {}
+            }
+        })
+        .build(app)?;
+
+    spawn_state_watcher(app.clone(), supervisor, start, stop);
+    Ok(())
+}
+
+fn spawn_state_watcher(
+    app: AppHandle,
+    supervisor: Arc<Supervisor>,
+    start_item: MenuItem<tauri::Wry>,
+    stop_item: MenuItem<tauri::Wry>,
+) {
+    tauri::async_runtime::spawn(async move {
+        let mut last_kind: Option<&'static str> = None;
+        loop {
+            let state = supervisor.state().await;
+            let kind = state_kind(&state);
+            if last_kind != Some(kind) {
+                last_kind = Some(kind);
+                let tooltip = format!("kiln: {}", state_label(&state));
+                if let Some(tray) = app.tray_by_id(TRAY_ID) {
+                    let _ = tray.set_tooltip(Some(tooltip.as_str()));
+                }
+                let _ = start_item.set_enabled(start_enabled(&state));
+                let _ = stop_item.set_enabled(stop_enabled(&state));
+            }
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+    });
+}
+
+fn state_kind(state: &ServerState) -> &'static str {
+    match state {
+        ServerState::Stopped => "stopped",
+        ServerState::Starting => "starting",
+        ServerState::Running => "running",
+        ServerState::TrainingActive => "training",
+        ServerState::Error(_) => "error",
+    }
+}
+
+pub fn state_label(state: &ServerState) -> String {
+    match state {
+        ServerState::Stopped => "Stopped".to_string(),
+        ServerState::Starting => "Starting…".to_string(),
+        ServerState::Running => "Running".to_string(),
+        ServerState::TrainingActive => "Training".to_string(),
+        ServerState::Error(msg) => format!("Error: {}", msg),
+    }
+}
+
+pub fn start_enabled(state: &ServerState) -> bool {
+    matches!(state, ServerState::Stopped | ServerState::Error(_))
+}
+
+pub fn stop_enabled(state: &ServerState) -> bool {
+    matches!(
+        state,
+        ServerState::Starting | ServerState::Running | ServerState::TrainingActive
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn labels_cover_all_variants() {
+        assert_eq!(state_label(&ServerState::Stopped), "Stopped");
+        assert_eq!(state_label(&ServerState::Starting), "Starting…");
+        assert_eq!(state_label(&ServerState::Running), "Running");
+        assert_eq!(state_label(&ServerState::TrainingActive), "Training");
+        assert_eq!(
+            state_label(&ServerState::Error("boom".into())),
+            "Error: boom"
+        );
+    }
+
+    #[test]
+    fn kinds_are_distinct() {
+        let kinds = [
+            state_kind(&ServerState::Stopped),
+            state_kind(&ServerState::Starting),
+            state_kind(&ServerState::Running),
+            state_kind(&ServerState::TrainingActive),
+            state_kind(&ServerState::Error("x".into())),
+        ];
+        let mut sorted = kinds.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), kinds.len(), "kinds must be unique");
+    }
+
+    #[test]
+    fn start_button_enabled_when_idle() {
+        assert!(start_enabled(&ServerState::Stopped));
+        assert!(start_enabled(&ServerState::Error("x".into())));
+        assert!(!start_enabled(&ServerState::Starting));
+        assert!(!start_enabled(&ServerState::Running));
+        assert!(!start_enabled(&ServerState::TrainingActive));
+    }
+
+    #[test]
+    fn stop_button_enabled_when_active() {
+        assert!(stop_enabled(&ServerState::Starting));
+        assert!(stop_enabled(&ServerState::Running));
+        assert!(stop_enabled(&ServerState::TrainingActive));
+        assert!(!stop_enabled(&ServerState::Stopped));
+        assert!(!stop_enabled(&ServerState::Error("x".into())));
+    }
+}


### PR DESCRIPTION
## What

Adds the kiln-desktop system tray icon backed by the existing Supervisor.

- New `desktop/src/tray.rs` builds a `TrayIconBuilder` with a right-click menu (Open Dashboard, Settings, Start Server, Stop Server, View Logs, Quit) and a stable tray id (`kiln-main`).
- `main.rs` wires the tray into Tauri's `setup` callback, sharing the supervisor `Arc<Supervisor>` already in app state.
- A background `tauri::async_runtime` task polls `supervisor.state()` once per second and updates:
  - tooltip (`kiln: Stopped` / `Starting…` / `Running` / `Training` / `Error: …`)
  - the Start/Stop menu items' enabled state (Start enabled when Stopped/Error, Stop enabled when Starting/Running/TrainingActive)
- Menu actions:
  - Start/Stop spawn `supervisor.start()/stop()` via `tauri::async_runtime::spawn` and log failures via `eprintln!`.
  - Quit calls `app.exit(0)`.
  - Open Dashboard / Settings / View Logs emit Tauri events (`menu://open-dashboard`, `menu://open-settings`, `menu://view-logs`) so the still-to-be-built windows can subscribe.
- `image-png` feature added to the `tauri` dep so `Image::from_bytes` can decode the bundled `desktop/icons/32x32.png` used as the tray icon.
- TODO left in place to swap in per-state tray icons in a later PR — single icon for all states today.

## Why

Goal #3 of the Kiln Desktop project: visible status icon and right-click menu. Foundation for the dashboard / settings / logs windows that follow.

## Validation

`cargo check` cannot run end-to-end in the Cloud Eric build environment (missing GTK / glib / gio system libs — same constraint documented for previous desktop PRs).

What was validated:

- `cargo metadata --format-version 1 --manifest-path desktop/Cargo.toml` parses cleanly.
- The pure helpers in `tray.rs` (`state_label`, `state_kind`, `start_enabled`, `stop_enabled`) were extracted into a standalone scratch `cargo` lib and the four unit tests pass:
  - `labels_cover_all_variants`
  - `kinds_are_distinct`
  - `start_button_enabled_when_idle`
  - `stop_button_enabled_when_active`
- All Tauri 2.10.3 APIs used (`MenuItemBuilder`, `MenuBuilder::items/separator/item/build`, `TrayIconBuilder::with_id/icon/tooltip/menu/on_menu_event/build`, `Manager::tray_by_id`, `MenuItem::set_enabled`, `TrayIcon::set_tooltip`, `Image::from_bytes`, `Emitter::emit`, `tauri::async_runtime::spawn`) were verified against the cached `tauri-2.10.3` crate source under `/data/cache/cargo-home/registry/src/`.

The same `tray.rs` unit tests are also embedded in the file under `#[cfg(test)]` so they will run wherever `cargo test --package kiln-desktop --lib tray` can be invoked (i.e. on a machine with GTK installed, or in CI once it's wired up).

## Out of scope (queued for follow-up tasks)

- Real Dashboard / Settings / Logs windows (events are wired but no listener yet).
- Per-state tray icons.
- Polling `/v1/train/status` to flip the tray into the Training state automatically.
- Launch-at-login.