### PR TITLE
desktop: settings window with persistence and Supervisor wiring

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -19,6 +19,7 @@ tauri-plugin-shell = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "sync", "time", "io-util"] }
+dirs = "5"
 
 [features]
 default = ["custom-protocol"]

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,12 +1,17 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod settings;
 mod supervisor;
 mod tray;
 
 use std::sync::Arc;
 
+use settings::{apply_to_supervisor_config, Settings};
 use supervisor::{ServerState, Supervisor, SupervisorConfig};
 use tauri::{Manager, State};
+use tokio::sync::RwLock;
+
+type SettingsState = Arc<RwLock<Settings>>;
 
 #[tauri::command]
 async fn start_server(sup: State<'_, Arc<Supervisor>>) -> Result<(), String> {
@@ -28,22 +33,66 @@ async fn server_logs(sup: State<'_, Arc<Supervisor>>) -> Result<Vec<String>, Str
     Ok(sup.logs().await)
 }
 
-fn main() {
-    let supervisor = Arc::new(Supervisor::new(SupervisorConfig::default()));
+#[tauri::command]
+async fn get_settings(state: State<'_, SettingsState>) -> Result<Settings, String> {
+    Ok(state.read().await.clone())
+}
 
+/// Persist the supplied settings to disk and rebuild the supervisor's
+/// `SupervisorConfig`. A currently-running server is NOT restarted; the new
+/// args take effect on the next `start_server` call.
+#[tauri::command]
+async fn set_settings(
+    new: Settings,
+    app: tauri::AppHandle,
+    state: State<'_, SettingsState>,
+    sup: State<'_, Arc<Supervisor>>,
+) -> Result<(), String> {
+    new.save(&app)?;
+    {
+        let mut guard = state.write().await;
+        *guard = new.clone();
+    }
+    let mut cfg = SupervisorConfig::default();
+    apply_to_supervisor_config(&new, &mut cfg);
+    sup.update_config(cfg).await;
+    Ok(())
+}
+
+fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
-        .manage(supervisor)
         .setup(|app| {
-            let sup: State<'_, Arc<Supervisor>> = app.state();
-            tray::build_tray(app.handle(), sup.inner().clone())?;
+            let handle = app.handle().clone();
+            let settings = Settings::load(&handle);
+
+            let mut cfg = SupervisorConfig::default();
+            apply_to_supervisor_config(&settings, &mut cfg);
+            let supervisor = Arc::new(Supervisor::new(cfg));
+            let settings_state: SettingsState = Arc::new(RwLock::new(settings.clone()));
+
+            app.manage(Arc::clone(&supervisor));
+            app.manage(Arc::clone(&settings_state));
+
+            tray::build_tray(app.handle(), Arc::clone(&supervisor))?;
+
+            if settings.auto_start {
+                let sup = Arc::clone(&supervisor);
+                tauri::async_runtime::spawn(async move {
+                    if let Err(e) = sup.start().await {
+                        eprintln!("[main] auto_start failed: {}", e);
+                    }
+                });
+            }
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             start_server,
             stop_server,
             server_state,
-            server_logs
+            server_logs,
+            get_settings,
+            set_settings
         ])
         .run(tauri::generate_context!())
         .expect("error while running kiln-desktop");

--- a/desktop/src/settings.rs
+++ b/desktop/src/settings.rs
@@ -1,0 +1,177 @@
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Manager};
+
+use crate::supervisor::SupervisorConfig;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Settings {
+    pub model_path: Option<PathBuf>,
+    pub host: String,
+    pub port: u16,
+    pub inference_fraction: f32,
+    pub fp8_kv_cache: bool,
+    pub cuda_graphs: bool,
+    pub prefix_cache: bool,
+    pub speculative_decoding: bool,
+    pub adapter_dir: Option<PathBuf>,
+    pub auto_start: bool,
+    pub auto_restart: bool,
+    pub launch_at_login: bool,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            model_path: None,
+            host: "127.0.0.1".to_string(),
+            port: 8000,
+            inference_fraction: 0.9,
+            fp8_kv_cache: false,
+            cuda_graphs: true,
+            prefix_cache: true,
+            speculative_decoding: false,
+            adapter_dir: None,
+            auto_start: true,
+            auto_restart: true,
+            launch_at_login: false,
+        }
+    }
+}
+
+impl Settings {
+    pub fn path(app: &AppHandle) -> Result<PathBuf, String> {
+        let dir = app
+            .path()
+            .app_config_dir()
+            .map_err(|e| format!("app_config_dir unavailable: {}", e))?;
+        Ok(dir.join("settings.json"))
+    }
+
+    pub fn load(app: &AppHandle) -> Self {
+        let path = match Self::path(app) {
+            Ok(p) => p,
+            Err(_) => return Self::default(),
+        };
+        let Ok(data) = std::fs::read_to_string(&path) else {
+            return Self::default();
+        };
+        serde_json::from_str(&data).unwrap_or_default()
+    }
+
+    pub fn save(&self, app: &AppHandle) -> Result<(), String> {
+        let path = Self::path(app)?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("create settings dir: {}", e))?;
+        }
+        let body =
+            serde_json::to_string_pretty(self).map_err(|e| format!("serialize: {}", e))?;
+        std::fs::write(&path, body).map_err(|e| format!("write settings.json: {}", e))
+    }
+}
+
+pub fn apply_to_supervisor_config(s: &Settings, cfg: &mut SupervisorConfig) {
+    let mut args: Vec<String> = Vec::new();
+    args.push("--host".to_string());
+    args.push(s.host.clone());
+    args.push("--port".to_string());
+    args.push(s.port.to_string());
+    args.push("--inference-fraction".to_string());
+    args.push(format!("{}", s.inference_fraction));
+
+    if s.fp8_kv_cache {
+        args.push("--fp8-kv-cache".to_string());
+    }
+    if s.cuda_graphs {
+        args.push("--cuda-graphs".to_string());
+    }
+    if s.prefix_cache {
+        args.push("--prefix-cache".to_string());
+    }
+    if s.speculative_decoding {
+        args.push("--speculative-decoding".to_string());
+    }
+    if let Some(dir) = &s.adapter_dir {
+        args.push("--adapter-dir".to_string());
+        args.push(dir.display().to_string());
+    }
+    if let Some(model) = &s.model_path {
+        args.push("--model".to_string());
+        args.push(model.display().to_string());
+    }
+
+    cfg.args = args;
+    cfg.auto_restart = s.auto_restart;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values_are_sane() {
+        let s = Settings::default();
+        assert_eq!(s.host, "127.0.0.1");
+        assert_eq!(s.port, 8000);
+        assert!((s.inference_fraction - 0.9).abs() < f32::EPSILON);
+        assert!(!s.fp8_kv_cache);
+        assert!(s.cuda_graphs);
+        assert!(s.prefix_cache);
+        assert!(!s.speculative_decoding);
+        assert!(s.auto_start);
+        assert!(s.auto_restart);
+        assert!(!s.launch_at_login);
+    }
+
+    #[test]
+    fn apply_builds_args_with_expected_flags() {
+        let mut s = Settings::default();
+        s.port = 9000;
+        s.host = "0.0.0.0".to_string();
+        s.fp8_kv_cache = true;
+        s.model_path = Some(PathBuf::from("/models/foo"));
+        s.adapter_dir = Some(PathBuf::from("/adapters"));
+        s.auto_restart = false;
+
+        let mut cfg = SupervisorConfig::default();
+        apply_to_supervisor_config(&s, &mut cfg);
+
+        // Flags should contain the structured args in order.
+        assert!(cfg.args.windows(2).any(|w| w == ["--host", "0.0.0.0"]));
+        assert!(cfg.args.windows(2).any(|w| w == ["--port", "9000"]));
+        assert!(cfg.args.iter().any(|a| a == "--fp8-kv-cache"));
+        assert!(cfg.args.iter().any(|a| a == "--cuda-graphs"));
+        assert!(cfg.args.iter().any(|a| a == "--prefix-cache"));
+        assert!(!cfg.args.iter().any(|a| a == "--speculative-decoding"));
+        assert!(cfg
+            .args
+            .windows(2)
+            .any(|w| w == ["--model", "/models/foo"]));
+        assert!(cfg
+            .args
+            .windows(2)
+            .any(|w| w == ["--adapter-dir", "/adapters"]));
+        assert!(!cfg.auto_restart);
+    }
+
+    #[test]
+    fn roundtrip_json() {
+        let s = Settings::default();
+        let json = serde_json::to_string(&s).unwrap();
+        let back: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.port, s.port);
+        assert_eq!(back.host, s.host);
+    }
+
+    #[test]
+    fn missing_fields_fall_back_to_defaults() {
+        let partial = r#"{ "port": 9001 }"#;
+        let s: Settings = serde_json::from_str(partial).unwrap();
+        assert_eq!(s.port, 9001);
+        assert_eq!(s.host, "127.0.0.1");
+        assert!(s.cuda_graphs);
+    }
+}

--- a/desktop/src/supervisor.rs
+++ b/desktop/src/supervisor.rs
@@ -78,7 +78,7 @@ impl RingBuffer {
 }
 
 pub struct Supervisor {
-    config: SupervisorConfig,
+    config: Arc<Mutex<SupervisorConfig>>,
     state: Arc<Mutex<ServerState>>,
     logs: Arc<Mutex<RingBuffer>>,
     task: Arc<Mutex<Option<JoinHandle<()>>>>,
@@ -89,12 +89,18 @@ impl Supervisor {
     pub fn new(config: SupervisorConfig) -> Self {
         let cap = config.log_buffer_bytes;
         Self {
-            config,
+            config: Arc::new(Mutex::new(config)),
             state: Arc::new(Mutex::new(ServerState::Stopped)),
             logs: Arc::new(Mutex::new(RingBuffer::new(cap))),
             task: Arc::new(Mutex::new(None)),
             shutdown_tx: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Replace the supervisor config. Does NOT restart a running child.
+    /// The new config takes effect on the next successful `start()`.
+    pub async fn update_config(&self, new_cfg: SupervisorConfig) {
+        *self.config.lock().await = new_cfg;
     }
 
     pub async fn start(&self) -> Result<(), String> {
@@ -110,7 +116,7 @@ impl Supervisor {
         *self.shutdown_tx.lock().await = Some(tx);
         *self.state.lock().await = ServerState::Starting;
 
-        let config = self.config.clone();
+        let config = self.config.lock().await.clone();
         let state = Arc::clone(&self.state);
         let logs = Arc::clone(&self.logs);
 

--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use tauri::menu::{MenuBuilder, MenuItem, MenuItemBuilder};
 use tauri::tray::TrayIconBuilder;
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
 use crate::supervisor::{ServerState, Supervisor};
 
@@ -68,6 +68,9 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                     let _ = app_handle.emit("menu://open-dashboard", ());
                 }
                 ITEM_SETTINGS => {
+                    if let Err(e) = open_settings_window(&app_handle) {
+                        eprintln!("[tray] open_settings_window failed: {}", e);
+                    }
                     let _ = app_handle.emit("menu://open-settings", ());
                 }
                 ITEM_LOGS => {
@@ -79,6 +82,22 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
         .build(app)?;
 
     spawn_state_watcher(app.clone(), supervisor, start, stop);
+    Ok(())
+}
+
+fn open_settings_window(app: &AppHandle) -> tauri::Result<()> {
+    if let Some(win) = app.get_webview_window("settings") {
+        win.show()?;
+        win.set_focus()?;
+        return Ok(());
+    }
+    let win = WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("settings.html".into()))
+        .title("Kiln Settings")
+        .inner_size(520.0, 640.0)
+        .resizable(true)
+        .visible(true)
+        .build()?;
+    win.set_focus()?;
     Ok(())
 }
 

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -17,6 +17,15 @@
         "height": 640,
         "resizable": true,
         "visible": false
+      },
+      {
+        "label": "settings",
+        "url": "settings.html",
+        "title": "Kiln Settings",
+        "width": 520,
+        "height": 640,
+        "resizable": true,
+        "visible": false
       }
     ],
     "security": {

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kiln Settings</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        background: #0f1115;
+        color: #e6e6e6;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      }
+      .wrap { padding: 24px; max-width: 520px; box-sizing: border-box; }
+      h1 { font-size: 18px; margin: 0 0 16px 0; font-weight: 600; }
+      fieldset {
+        border: 1px solid #2a2f3a;
+        border-radius: 6px;
+        padding: 12px 16px 16px 16px;
+        margin: 0 0 16px 0;
+      }
+      legend { padding: 0 6px; color: #a8aeb8; font-size: 12px; text-transform: uppercase; letter-spacing: 0.06em; }
+      label.row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 6px 0;
+        font-size: 13px;
+      }
+      label.row > span.name { color: #cfd3da; }
+      label.row > input[type="text"],
+      label.row > input[type="number"] {
+        background: #181b21;
+        color: #e6e6e6;
+        border: 1px solid #2a2f3a;
+        border-radius: 4px;
+        padding: 4px 8px;
+        font-size: 13px;
+        width: 260px;
+        box-sizing: border-box;
+      }
+      label.row > input[type="number"].small { width: 100px; }
+      .actions {
+        display: flex;
+        gap: 8px;
+        justify-content: flex-end;
+        margin-top: 8px;
+      }
+      button {
+        background: #2f66f0;
+        color: #fff;
+        border: 0;
+        border-radius: 4px;
+        padding: 8px 14px;
+        font-size: 13px;
+        cursor: pointer;
+      }
+      button.secondary { background: #2a2f3a; }
+      button:disabled { opacity: 0.5; cursor: default; }
+      .status { margin-top: 8px; font-size: 12px; color: #7fbf7f; min-height: 16px; }
+      .status.error { color: #f08080; }
+      .todo { color: #a8aeb8; font-size: 11px; margin-top: 4px; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Kiln Settings</h1>
+
+      <fieldset>
+        <legend>Server</legend>
+        <!-- TODO: replace with native file picker via tauri-plugin-dialog -->
+        <label class="row"><span class="name">Model path</span>
+          <input type="text" id="model_path" placeholder="/path/to/model" />
+        </label>
+        <label class="row"><span class="name">Host</span>
+          <input type="text" id="host" />
+        </label>
+        <label class="row"><span class="name">Port</span>
+          <input type="number" class="small" id="port" min="1" max="65535" />
+        </label>
+        <label class="row"><span class="name">Adapter directory</span>
+          <input type="text" id="adapter_dir" placeholder="/path/to/adapters" />
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Memory &amp; performance</legend>
+        <label class="row"><span class="name">Inference fraction (0..1)</span>
+          <input type="number" class="small" id="inference_fraction" min="0" max="1" step="0.05" />
+        </label>
+        <label class="row"><span class="name">FP8 KV cache</span>
+          <input type="checkbox" id="fp8_kv_cache" />
+        </label>
+        <label class="row"><span class="name">CUDA graphs</span>
+          <input type="checkbox" id="cuda_graphs" />
+        </label>
+        <label class="row"><span class="name">Prefix cache</span>
+          <input type="checkbox" id="prefix_cache" />
+        </label>
+        <label class="row"><span class="name">Speculative decoding</span>
+          <input type="checkbox" id="speculative_decoding" />
+        </label>
+      </fieldset>
+
+      <fieldset>
+        <legend>Startup</legend>
+        <label class="row"><span class="name">Auto-start kiln on app launch</span>
+          <input type="checkbox" id="auto_start" />
+        </label>
+        <label class="row"><span class="name">Auto-restart on crash</span>
+          <input type="checkbox" id="auto_restart" />
+        </label>
+        <label class="row"><span class="name">Launch at login</span>
+          <input type="checkbox" id="launch_at_login" />
+        </label>
+        <div class="todo">TODO: launch_at_login is persisted only; OS autostart integration is a follow-up.</div>
+      </fieldset>
+
+      <div class="actions">
+        <button class="secondary" id="reload">Reload</button>
+        <button id="save">Save</button>
+      </div>
+      <div class="status" id="status"></div>
+    </div>
+
+    <script>
+      const invoke = window.__TAURI__.core.invoke;
+      const statusEl = document.getElementById("status");
+
+      const fields = [
+        "model_path", "host", "port",
+        "inference_fraction", "fp8_kv_cache", "cuda_graphs",
+        "prefix_cache", "speculative_decoding", "adapter_dir",
+        "auto_start", "auto_restart", "launch_at_login",
+      ];
+
+      function readForm() {
+        const n = (id) => document.getElementById(id);
+        const strOrNull = (id) => {
+          const v = n(id).value.trim();
+          return v.length ? v : null;
+        };
+        return {
+          model_path: strOrNull("model_path"),
+          host: n("host").value.trim() || "127.0.0.1",
+          port: parseInt(n("port").value, 10) || 8000,
+          inference_fraction: parseFloat(n("inference_fraction").value) || 0.9,
+          fp8_kv_cache: n("fp8_kv_cache").checked,
+          cuda_graphs: n("cuda_graphs").checked,
+          prefix_cache: n("prefix_cache").checked,
+          speculative_decoding: n("speculative_decoding").checked,
+          adapter_dir: strOrNull("adapter_dir"),
+          auto_start: n("auto_start").checked,
+          auto_restart: n("auto_restart").checked,
+          launch_at_login: n("launch_at_login").checked,
+        };
+      }
+
+      function writeForm(s) {
+        const n = (id) => document.getElementById(id);
+        n("model_path").value = s.model_path || "";
+        n("host").value = s.host || "";
+        n("port").value = s.port ?? 8000;
+        n("inference_fraction").value = s.inference_fraction ?? 0.9;
+        n("fp8_kv_cache").checked = !!s.fp8_kv_cache;
+        n("cuda_graphs").checked = !!s.cuda_graphs;
+        n("prefix_cache").checked = !!s.prefix_cache;
+        n("speculative_decoding").checked = !!s.speculative_decoding;
+        n("adapter_dir").value = s.adapter_dir || "";
+        n("auto_start").checked = !!s.auto_start;
+        n("auto_restart").checked = !!s.auto_restart;
+        n("launch_at_login").checked = !!s.launch_at_login;
+      }
+
+      function setStatus(msg, err) {
+        statusEl.textContent = msg;
+        statusEl.className = err ? "status error" : "status";
+      }
+
+      async function load() {
+        try {
+          const s = await invoke("get_settings");
+          writeForm(s);
+          setStatus("Loaded.");
+        } catch (e) {
+          setStatus("Failed to load: " + e, true);
+        }
+      }
+
+      async function save() {
+        try {
+          await invoke("set_settings", { new: readForm() });
+          setStatus("Saved. New settings apply on next Start.");
+        } catch (e) {
+          setStatus("Save failed: " + e, true);
+        }
+      }
+
+      document.getElementById("reload").addEventListener("click", load);
+      document.getElementById("save").addEventListener("click", save);
+      load();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What
Adds a persisted Settings struct (model path, host, port, inference fraction, FP8 KV cache, CUDA graphs, prefix cache, speculative decoding, adapter dir, auto-start, auto-restart, launch-at-login) that feeds SupervisorConfig, plus a minimal settings.html window reachable from the tray.

## Why
So \`Start server\` uses the user's chosen model/port/flags instead of hard-coded defaults. Next goals (dashboard, auto-start on app launch, launch-at-login OS integration) layer on top.

## Notes
- \`set_settings\` persists immediately and updates the Supervisor's in-memory config; a running server is NOT restarted (takes effect on next start). Documented on the Tauri command.
- \`launch_at_login\` is persisted only; OS autostart integration is a follow-up task.
- Model/adapter paths use plain text inputs for MVP; native file picker via tauri-plugin-dialog is TODO.
- \`cargo check\` is not runnable in Cloud Eric (no GTK/webkit). Settings logic was validated in a scratch cargo project (default values, arg building, JSON roundtrip); CI will verify the full Tauri build.