### PR TITLE
desktop: dashboard window embedding kiln /ui

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -38,6 +38,25 @@ async fn get_settings(state: State<'_, SettingsState>) -> Result<Settings, Strin
     Ok(state.read().await.clone())
 }
 
+/// Return the kiln server's /ui URL based on the current settings, but only
+/// when the supervisor reports a state that should have the HTTP server up.
+/// Returns an empty string when the server is Stopped or in Error, so the
+/// dashboard UI can distinguish "server not running" from a real URL.
+#[tauri::command]
+async fn get_kiln_url(
+    state: State<'_, SettingsState>,
+    sup: State<'_, Arc<Supervisor>>,
+) -> Result<String, String> {
+    let server_state = sup.state().await;
+    match server_state {
+        ServerState::Stopped | ServerState::Error(_) => Ok(String::new()),
+        ServerState::Starting | ServerState::Running | ServerState::TrainingActive => {
+            let s = state.read().await;
+            Ok(format!("http://{}:{}/ui", s.host, s.port))
+        }
+    }
+}
+
 /// Persist the supplied settings to disk and rebuild the supervisor's
 /// `SupervisorConfig`. A currently-running server is NOT restarted; the new
 /// args take effect on the next `start_server` call.
@@ -92,7 +111,8 @@ fn main() {
             server_state,
             server_logs,
             get_settings,
-            set_settings
+            set_settings,
+            get_kiln_url
         ])
         .run(tauri::generate_context!())
         .expect("error while running kiln-desktop");

--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -65,6 +65,9 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                     app_handle.exit(0);
                 }
                 ITEM_DASHBOARD => {
+                    if let Err(e) = open_dashboard_window(&app_handle) {
+                        eprintln!("[tray] open_dashboard_window failed: {}", e);
+                    }
                     let _ = app_handle.emit("menu://open-dashboard", ());
                 }
                 ITEM_SETTINGS => {
@@ -94,6 +97,22 @@ fn open_settings_window(app: &AppHandle) -> tauri::Result<()> {
     let win = WebviewWindowBuilder::new(app, "settings", WebviewUrl::App("settings.html".into()))
         .title("Kiln Settings")
         .inner_size(520.0, 640.0)
+        .resizable(true)
+        .visible(true)
+        .build()?;
+    win.set_focus()?;
+    Ok(())
+}
+
+fn open_dashboard_window(app: &AppHandle) -> tauri::Result<()> {
+    if let Some(win) = app.get_webview_window("dashboard") {
+        win.show()?;
+        win.set_focus()?;
+        return Ok(());
+    }
+    let win = WebviewWindowBuilder::new(app, "dashboard", WebviewUrl::App("dashboard.html".into()))
+        .title("Kiln Dashboard")
+        .inner_size(1024.0, 768.0)
         .resizable(true)
         .visible(true)
         .build()?;

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -26,6 +26,15 @@
         "height": 640,
         "resizable": true,
         "visible": false
+      },
+      {
+        "label": "dashboard",
+        "url": "dashboard.html",
+        "title": "Kiln Dashboard",
+        "width": 1024,
+        "height": 768,
+        "resizable": true,
+        "visible": false
       }
     ],
     "security": {

--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kiln Dashboard</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+        background: #0f1115;
+        color: #e6e6e6;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        overflow: hidden;
+      }
+      #frame {
+        display: block;
+        width: 100vw;
+        height: 100vh;
+        border: 0;
+        background: #0f1115;
+      }
+      #status {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        padding: 32px;
+        box-sizing: border-box;
+        text-align: center;
+        background: #0f1115;
+      }
+      #status h1 {
+        font-size: 18px;
+        margin: 0 0 8px 0;
+        font-weight: 600;
+      }
+      #status p {
+        margin: 4px 0;
+        color: #a8aeb8;
+        font-size: 14px;
+        max-width: 440px;
+      }
+      #status code {
+        background: #1b1e24;
+        padding: 2px 6px;
+        border-radius: 4px;
+        font-size: 13px;
+      }
+      button {
+        margin-top: 16px;
+        background: #2a6df4;
+        color: #fff;
+        border: 0;
+        border-radius: 6px;
+        padding: 8px 14px;
+        font-size: 13px;
+        cursor: pointer;
+      }
+      button:hover { background: #3b7af5; }
+      button:disabled { background: #2a2f3a; cursor: default; }
+      .hidden { display: none !important; }
+    </style>
+  </head>
+  <body>
+    <iframe id="frame" class="hidden" title="Kiln UI"></iframe>
+    <div id="status">
+      <h1 id="status-title">Connecting to Kiln server…</h1>
+      <p id="status-detail">Looking up the server URL from your settings.</p>
+      <button id="retry" class="hidden">Retry</button>
+    </div>
+    <script>
+      const invoke = (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
+        || (window.__TAURI__ && window.__TAURI__.invoke);
+
+      const frame = document.getElementById("frame");
+      const status = document.getElementById("status");
+      const title = document.getElementById("status-title");
+      const detail = document.getElementById("status-detail");
+      const retry = document.getElementById("retry");
+
+      function showStatus(titleText, detailText, showRetry) {
+        frame.classList.add("hidden");
+        frame.src = "about:blank";
+        status.classList.remove("hidden");
+        title.textContent = titleText;
+        detail.textContent = detailText;
+        retry.classList.toggle("hidden", !showRetry);
+      }
+
+      function showFrame(url) {
+        frame.src = url;
+        frame.classList.remove("hidden");
+        status.classList.add("hidden");
+      }
+
+      async function load() {
+        showStatus("Connecting to Kiln server…", "Looking up the server URL from your settings.", false);
+        if (!invoke) {
+          showStatus(
+            "Tauri bridge unavailable",
+            "This page must run inside Kiln Desktop.",
+            false
+          );
+          return;
+        }
+        try {
+          const url = await invoke("get_kiln_url");
+          if (!url) {
+            showStatus(
+              "Kiln server not running.",
+              "Start it from the tray menu, then retry.",
+              true
+            );
+            return;
+          }
+          showFrame(url);
+        } catch (err) {
+          showStatus(
+            "Could not reach Kiln server.",
+            String(err || "Unknown error"),
+            true
+          );
+        }
+      }
+
+      retry.addEventListener("click", load);
+      window.addEventListener("DOMContentLoaded", load);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What
- New `dashboard` window entry in `desktop/tauri.conf.json` (1024x768, hidden by default, loads `dashboard.html`).
- New `desktop/ui/dashboard.html` — a minimal shell that invokes the Tauri `get_kiln_url` command and iframes the returned URL. If the server isn't running, shows "Kiln server not running. Start it from the tray menu." with a Retry button that re-invokes the command.
- New `get_kiln_url` Tauri command in `desktop/src/main.rs` that reads the current `Settings` (host, port) and returns `http://{host}:{port}/ui`. Returns an empty string when the supervisor state is `Stopped` or `Error`, so the HTML can differentiate "not running" from a real URL.
- `tray.rs` "Open Dashboard" menu item now shows/focuses the dashboard window (creates it if it hasn't been built yet), mirroring the settings window handler. The existing `menu://open-dashboard` event is still emitted for any listeners.

## Why
MVP dashboard per project plan — embed the kiln server's existing `/ui` page via webview rather than building a richer native dashboard. A native UI is later polish. Keeping the shell around (iframe inside a container) lets us reload or swap the URL without tearing down the window.

## Validation
- `cargo check` / `cargo build` are not runnable in Cloud Eric due to missing GTK/webkit2gtk system libs — expected for Tauri v2 desktop crates. CI will build for Windows + Linux.
- Manual review:
  - iframe loads `http://{host}:{port}/ui` on window open
  - `get_kiln_url` returns URL from current settings when server is running; empty string when stopped
  - Tray "Open Dashboard" shows and focuses the window
  - Retry button re-invokes `get_kiln_url` after the user starts the server from the tray