### PR TITLE
desktop: wire launch-at-login via tauri-plugin-autostart

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -16,6 +16,7 @@ tauri-build = { version = "2", features = [] }
 [dependencies]
 tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "sync", "time", "io-util"] }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -8,8 +8,32 @@ use std::sync::Arc;
 
 use settings::{apply_to_supervisor_config, Settings};
 use supervisor::{ServerState, Supervisor, SupervisorConfig};
-use tauri::{Manager, State};
+use tauri::{AppHandle, Manager, State};
+use tauri_plugin_autostart::{ManagerExt, MacosLauncher};
 use tokio::sync::RwLock;
+
+/// Reconcile the OS autostart registration with the desired `launch_at_login`
+/// setting. Errors are logged but never propagated — a broken autostart
+/// registration must not crash the app or block settings persistence.
+fn reconcile_autolaunch(app: &AppHandle, desired: bool) {
+    let manager = app.autolaunch();
+    let enabled = match manager.is_enabled() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[main] autolaunch is_enabled failed: {}", e);
+            return;
+        }
+    };
+    if desired && !enabled {
+        if let Err(e) = manager.enable() {
+            eprintln!("[main] autolaunch enable failed: {}", e);
+        }
+    } else if !desired && enabled {
+        if let Err(e) = manager.disable() {
+            eprintln!("[main] autolaunch disable failed: {}", e);
+        }
+    }
+}
 
 type SettingsState = Arc<RwLock<Settings>>;
 
@@ -75,12 +99,17 @@ async fn set_settings(
     let mut cfg = SupervisorConfig::default();
     apply_to_supervisor_config(&new, &mut cfg);
     sup.update_config(cfg).await;
+    reconcile_autolaunch(&app, new.launch_at_login);
     Ok(())
 }
 
 fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_autostart::init(
+            MacosLauncher::LaunchAgent,
+            None,
+        ))
         .setup(|app| {
             let handle = app.handle().clone();
             let settings = Settings::load(&handle);
@@ -94,6 +123,8 @@ fn main() {
             app.manage(Arc::clone(&settings_state));
 
             tray::build_tray(app.handle(), Arc::clone(&supervisor))?;
+
+            reconcile_autolaunch(&handle, settings.launch_at_login);
 
             if settings.auto_start {
                 let sup = Arc::clone(&supervisor);

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -115,7 +115,6 @@
         <label class="row"><span class="name">Launch at login</span>
           <input type="checkbox" id="launch_at_login" />
         </label>
-        <div class="todo">TODO: launch_at_login is persisted only; OS autostart integration is a follow-up.</div>
       </fieldset>
 
       <div class="actions">


### PR DESCRIPTION
## What

Wire the existing `launch_at_login` setting into the OS so toggling it in Settings registers/unregisters kiln-desktop with the user's login session.

### Changes

- `desktop/Cargo.toml` — add `tauri-plugin-autostart = "2"`.
- `desktop/src/main.rs`:
  - Register the autostart plugin in the builder (`MacosLauncher::LaunchAgent`, args `None`) alongside `tauri_plugin_shell`. The macOS launcher enum is required by the plugin API even though we ship Windows/Linux only.
  - New `reconcile_autolaunch(&AppHandle, desired: bool)` helper that reads the current OS state via `app.autolaunch().is_enabled()` and calls `enable()` / `disable()` only when the state diverges from `desired`. All errors are logged via `eprintln!("[main] autolaunch … failed: {}", e)` and never propagated, so a broken registration cannot crash setup or block settings saves.
  - In `setup(...)`: call `reconcile_autolaunch(&handle, settings.launch_at_login)` after the tray is built and before the `auto_start` spawn, so the initial state matches the persisted setting every launch.
  - In `set_settings`: call `reconcile_autolaunch(&app, new.launch_at_login)` after settings are persisted and the supervisor config is updated, so flipping the checkbox in Settings takes effect immediately without restarting the server.
- `desktop/ui/settings.html` — remove the `TODO: launch_at_login is persisted only; OS autostart integration is a follow-up.` note since the setting is now wired. The existing checkbox (bound to `get_settings` / `set_settings`) is left untouched.

No changes to `tray.rs`, `supervisor.rs`, or the frontend's get/set wiring.

## Validation

`cd desktop && cargo check` in the Cloud Eric sandbox fails as expected — `glib-sys` / `gobject-sys` require GTK system libraries that are not installed in this environment. This is documented in the `tauri-desktop-validation-without-gtk` and `tauri-ci-gotchas` notes and affects every Tauri PR from this environment. The crate dependency graph resolves cleanly (Cargo.lock pulls `tauri-plugin-autostart 2.5.1`); the failure is purely a missing-system-lib issue in transitive GTK deps. Relying on CI and/or a local Windows/Linux box for full compilation and manual verification.

## Manual verification plan

On a real Windows or Linux workstation:
1. Build and launch kiln-desktop.
2. Open Settings, toggle **Launch at login** on, click Save.
3. Confirm autostart is registered: on Linux check `~/.config/autostart/kiln-desktop.desktop`; on Windows check `HKCU\Software\Microsoft\Windows\CurrentVersion\Run`.
4. Toggle it off, Save, and confirm the entry is removed.
5. Quit and relaunch with the setting on → app should reconcile and leave the OS entry in place without toggling it (no duplicate registration).

## Scope boundary

Goal 6 (launch-at-login half) only. Does not add any new UI, does not touch auto-start-kiln-on-app-launch (already wired separately via `settings.auto_start`), and does not modify macOS-specific behavior since macOS is out of scope.