### PR TITLE
desktop: HTTP health + training polling drives tray state

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -20,6 +20,7 @@ tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "sync", "time", "io-util"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 dirs = "5"
 
 [features]

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod poller;
 mod settings;
 mod supervisor;
 mod tray;

--- a/desktop/src/poller.rs
+++ b/desktop/src/poller.rs
@@ -1,0 +1,261 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::{watch, Mutex};
+use tokio::task::JoinHandle;
+
+use crate::supervisor::ServerState;
+
+const POLL_INTERVAL_SECS: u64 = 2;
+const REQUEST_TIMEOUT_SECS: u64 = 1;
+const MAX_CONSECUTIVE_FAILURES: u32 = 3;
+
+/// Spawn a background task that polls `/v1/health` and `/v1/train/status` on
+/// the managed kiln server every `POLL_INTERVAL_SECS` seconds and drives
+/// `state` transitions accordingly. Exits when `shutdown` changes or when the
+/// observed state is `Stopped`.
+pub fn spawn_health_poller(
+    state: Arc<Mutex<ServerState>>,
+    host: String,
+    port: u16,
+    mut shutdown: watch::Receiver<bool>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let client = match reqwest::Client::builder()
+            .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+        {
+            Ok(c) => c,
+            Err(_) => return,
+        };
+
+        let mut interval = tokio::time::interval(Duration::from_secs(POLL_INTERVAL_SECS));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut consecutive_failures: u32 = 0;
+
+        loop {
+            tokio::select! {
+                _ = shutdown.changed() => {
+                    return;
+                }
+                _ = interval.tick() => {
+                    {
+                        let s = state.lock().await;
+                        if matches!(*s, ServerState::Stopped) {
+                            return;
+                        }
+                    }
+
+                    let health_url = format!("http://{}:{}/v1/health", host, port);
+                    let health_ok = match client.get(&health_url).send().await {
+                        Ok(resp) => resp.status().is_success(),
+                        Err(_) => false,
+                    };
+
+                    if health_ok {
+                        consecutive_failures = 0;
+                    } else {
+                        consecutive_failures = consecutive_failures.saturating_add(1);
+                    }
+
+                    let train_status = if health_ok {
+                        let train_url =
+                            format!("http://{}:{}/v1/train/status", host, port);
+                        match client.get(&train_url).send().await {
+                            Ok(resp) if resp.status().is_success() => {
+                                resp.json::<serde_json::Value>().await.ok()
+                            }
+                            _ => None,
+                        }
+                    } else {
+                        None
+                    };
+
+                    let mut s = state.lock().await;
+                    let new_state = derive_state(
+                        health_ok,
+                        consecutive_failures,
+                        train_status.as_ref(),
+                        &s,
+                    );
+                    *s = new_state;
+                }
+            }
+        }
+    })
+}
+
+/// Pure, testable decision function that derives the next `ServerState`
+/// from the latest poll outcome.
+///
+/// Rules:
+/// - `Stopped` is terminal from the poller's perspective — never overwrite it.
+/// - `Starting` is only exited by a successful health check; health failures
+///   keep us in `Starting` to accommodate slow server boot.
+/// - Otherwise, after `MAX_CONSECUTIVE_FAILURES` consecutive health failures,
+///   transition to `Error`. Before that, preserve the prior state.
+/// - On health success, transition to `TrainingActive` if any entry in
+///   `train_status` reports `state == "Running"` (case-sensitive, matching
+///   the `TrainingState` enum serialized by the kiln server). Otherwise,
+///   transition to `Running`.
+pub fn derive_state(
+    health_ok: bool,
+    consecutive_failures: u32,
+    train_status: Option<&serde_json::Value>,
+    prior: &ServerState,
+) -> ServerState {
+    if matches!(prior, ServerState::Stopped) {
+        return ServerState::Stopped;
+    }
+
+    if matches!(prior, ServerState::Starting) && !health_ok {
+        return ServerState::Starting;
+    }
+
+    if !health_ok {
+        if consecutive_failures >= MAX_CONSECUTIVE_FAILURES {
+            return ServerState::Error("health check failed".into());
+        }
+        return prior.clone();
+    }
+
+    if let Some(status) = train_status {
+        if has_running_job(status) {
+            return ServerState::TrainingActive;
+        }
+    }
+    ServerState::Running
+}
+
+fn has_running_job(status: &serde_json::Value) -> bool {
+    let Some(arr) = status.as_array() else {
+        return false;
+    };
+    arr.iter()
+        .any(|item| item.get("state").and_then(|v| v.as_str()) == Some("Running"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn starting_plus_health_ok_transitions_to_running() {
+        let got = derive_state(true, 0, None, &ServerState::Starting);
+        assert!(matches!(got, ServerState::Running), "got {:?}", got);
+    }
+
+    #[test]
+    fn starting_plus_health_fail_stays_starting_even_after_many_failures() {
+        // Starting must never be overwritten by health failures — only a
+        // successful health check can transition Starting into Running.
+        let got = derive_state(false, 10, None, &ServerState::Starting);
+        assert!(matches!(got, ServerState::Starting), "got {:?}", got);
+    }
+
+    #[test]
+    fn running_plus_two_failures_stays_running() {
+        let got = derive_state(false, 2, None, &ServerState::Running);
+        assert!(matches!(got, ServerState::Running), "got {:?}", got);
+    }
+
+    #[test]
+    fn running_plus_three_failures_transitions_to_error() {
+        let got = derive_state(false, 3, None, &ServerState::Running);
+        assert!(matches!(got, ServerState::Error(_)), "got {:?}", got);
+    }
+
+    #[test]
+    fn running_plus_training_job_transitions_to_training_active() {
+        let train = json!([{"state": "Running", "loss": 0.42}]);
+        let got = derive_state(true, 0, Some(&train), &ServerState::Running);
+        assert!(matches!(got, ServerState::TrainingActive), "got {:?}", got);
+    }
+
+    #[test]
+    fn training_active_plus_no_running_job_returns_to_running() {
+        let train = json!([{"state": "Completed"}, {"state": "Queued"}]);
+        let got = derive_state(true, 0, Some(&train), &ServerState::TrainingActive);
+        assert!(matches!(got, ServerState::Running), "got {:?}", got);
+    }
+
+    #[test]
+    fn training_active_plus_empty_array_returns_to_running() {
+        let train = json!([]);
+        let got = derive_state(true, 0, Some(&train), &ServerState::TrainingActive);
+        assert!(matches!(got, ServerState::Running), "got {:?}", got);
+    }
+
+    #[test]
+    fn training_active_plus_no_train_status_returns_to_running() {
+        // If the train endpoint didn't return a parseable response but health
+        // is OK, we can't confirm an active job — go back to Running.
+        let got = derive_state(true, 0, None, &ServerState::TrainingActive);
+        assert!(matches!(got, ServerState::Running), "got {:?}", got);
+    }
+
+    #[test]
+    fn stopped_stays_stopped_regardless_of_inputs() {
+        let train = json!([{"state": "Running"}]);
+        let got = derive_state(true, 0, Some(&train), &ServerState::Stopped);
+        assert!(matches!(got, ServerState::Stopped), "got {:?}", got);
+        let got = derive_state(false, 10, None, &ServerState::Stopped);
+        assert!(matches!(got, ServerState::Stopped), "got {:?}", got);
+    }
+
+    #[test]
+    fn error_plus_health_ok_recovers_to_running() {
+        let prior = ServerState::Error("health check failed".into());
+        let got = derive_state(true, 0, None, &prior);
+        assert!(matches!(got, ServerState::Running), "got {:?}", got);
+    }
+
+    #[test]
+    fn error_plus_health_ok_with_training_job_goes_to_training_active() {
+        let prior = ServerState::Error("health check failed".into());
+        let train = json!([{"state": "Running"}]);
+        let got = derive_state(true, 0, Some(&train), &prior);
+        assert!(matches!(got, ServerState::TrainingActive), "got {:?}", got);
+    }
+
+    #[test]
+    fn running_job_match_is_case_sensitive() {
+        // Lowercase "running" must not match — the kiln server serializes the
+        // `TrainingState::Running` variant as "Running" via default serde.
+        let train = json!([{"state": "running"}]);
+        let got = derive_state(true, 0, Some(&train), &ServerState::Running);
+        assert!(matches!(got, ServerState::Running), "got {:?}", got);
+        let train = json!([{"state": "RUNNING"}]);
+        let got = derive_state(true, 0, Some(&train), &ServerState::Running);
+        assert!(matches!(got, ServerState::Running), "got {:?}", got);
+    }
+
+    #[test]
+    fn training_array_with_one_running_among_many_triggers_training_active() {
+        let train = json!([
+            {"state": "Completed"},
+            {"state": "Running", "loss": 0.1},
+            {"state": "Queued"},
+        ]);
+        let got = derive_state(true, 0, Some(&train), &ServerState::Running);
+        assert!(matches!(got, ServerState::TrainingActive), "got {:?}", got);
+    }
+
+    #[test]
+    fn non_array_train_status_is_ignored() {
+        // If the kiln server ever returns an object instead of an array, we
+        // should not crash — just treat it as "no active job".
+        let train = json!({"state": "Running"});
+        let got = derive_state(true, 0, Some(&train), &ServerState::Running);
+        assert!(matches!(got, ServerState::Running), "got {:?}", got);
+    }
+
+    #[test]
+    fn healthy_poll_resets_error_state_via_recovery_path() {
+        // Simulate: Error -> one healthy poll -> Running.
+        let prior = ServerState::Error("health check failed".into());
+        let got = derive_state(true, 0, None, &prior);
+        assert!(matches!(got, ServerState::Running), "got {:?}", got);
+    }
+}

--- a/desktop/src/settings.rs
+++ b/desktop/src/settings.rs
@@ -105,6 +105,8 @@ pub fn apply_to_supervisor_config(s: &Settings, cfg: &mut SupervisorConfig) {
 
     cfg.args = args;
     cfg.auto_restart = s.auto_restart;
+    cfg.host = s.host.clone();
+    cfg.port = s.port;
 }
 
 #[cfg(test)]
@@ -142,6 +144,9 @@ mod tests {
         // Flags should contain the structured args in order.
         assert!(cfg.args.windows(2).any(|w| w == ["--host", "0.0.0.0"]));
         assert!(cfg.args.windows(2).any(|w| w == ["--port", "9000"]));
+        // Host/port are also propagated as structured fields for the poller.
+        assert_eq!(cfg.host, "0.0.0.0");
+        assert_eq!(cfg.port, 9000);
         assert!(cfg.args.iter().any(|a| a == "--fp8-kv-cache"));
         assert!(cfg.args.iter().any(|a| a == "--cuda-graphs"));
         assert!(cfg.args.iter().any(|a| a == "--prefix-cache"));

--- a/desktop/src/supervisor.rs
+++ b/desktop/src/supervisor.rs
@@ -29,6 +29,11 @@ pub struct SupervisorConfig {
     pub max_restarts: u32,
     pub restart_backoff_ms: u64,
     pub log_buffer_bytes: usize,
+    /// Host the kiln server binds to — used by the health poller to build
+    /// `/v1/health` and `/v1/train/status` URLs.
+    pub host: String,
+    /// Port the kiln server binds to — used by the health poller.
+    pub port: u16,
 }
 
 impl Default for SupervisorConfig {
@@ -40,6 +45,8 @@ impl Default for SupervisorConfig {
             max_restarts: 5,
             restart_backoff_ms: 500,
             log_buffer_bytes: 4 * 1024 * 1024,
+            host: "127.0.0.1".to_string(),
+            port: 8000,
         }
     }
 }
@@ -113,12 +120,24 @@ impl Supervisor {
         *task_guard = None;
 
         let (tx, rx) = watch::channel(false);
+        let poller_shutdown = rx.clone();
         *self.shutdown_tx.lock().await = Some(tx);
         *self.state.lock().await = ServerState::Starting;
 
         let config = self.config.lock().await.clone();
         let state = Arc::clone(&self.state);
         let logs = Arc::clone(&self.logs);
+
+        // Spawn the HTTP health poller alongside the run loop. It shares the
+        // same shutdown receiver so `stop()` terminates both. The handle is
+        // detached — the poller also exits on its own when state flips to
+        // `Stopped`.
+        let _ = crate::poller::spawn_health_poller(
+            Arc::clone(&self.state),
+            config.host.clone(),
+            config.port,
+            poller_shutdown,
+        );
 
         let handle = tokio::spawn(async move {
             run_loop(config, state, logs, rx).await;
@@ -270,6 +289,8 @@ mod tests {
             max_restarts: 0,
             restart_backoff_ms: 100,
             log_buffer_bytes: 1024,
+            host: "127.0.0.1".to_string(),
+            port: 8000,
         };
         let sup = Supervisor::new(config);
         sup.start().await.expect("start");
@@ -300,6 +321,8 @@ mod tests {
             max_restarts: 0,
             restart_backoff_ms: 100,
             log_buffer_bytes: 1024,
+            host: "127.0.0.1".to_string(),
+            port: 8000,
         };
         let sup = Supervisor::new(config);
         sup.start().await.expect("start");
@@ -326,6 +349,8 @@ mod tests {
             max_restarts: 0,
             restart_backoff_ms: 10,
             log_buffer_bytes: 1024,
+            host: "127.0.0.1".to_string(),
+            port: 8000,
         };
         let sup = Supervisor::new(config);
         sup.start().await.expect("start");


### PR DESCRIPTION
## What

Adds a background HTTP poller that hits \`/v1/health\` and \`/v1/train/status\` on the managed kiln server every 2 seconds and drives \`ServerState\` transitions, so the tray icon reflects real server health and training activity rather than just subprocess lifecycle.

- \`desktop/src/poller.rs\` — new module.
  - \`spawn_health_poller(state, host, port, shutdown) -> JoinHandle<()>\` — \`tokio::select!\` loop on a 2s interval with a 1s reqwest timeout. Exits when the shared shutdown watch fires or when observed state is \`Stopped\`.
  - \`derive_state(health_ok, consecutive_failures, train_status, prior) -> ServerState\` — pure, testable decision function.
- \`desktop/src/supervisor.rs\` — adds \`host: String\` and \`port: u16\` fields on \`SupervisorConfig\`, clones the shutdown \`watch::Receiver\` before handing it to \`run_loop\`, and spawns the poller with it in \`start()\`. Existing tests updated to include host/port.
- \`desktop/src/settings.rs\` — \`apply_to_supervisor_config\` now propagates \`host\`/\`port\` as structured fields on the config (in addition to the existing \`--host\`/\`--port\` CLI args for the kiln binary). Adds a test assertion.
- \`desktop/src/main.rs\` — registers \`mod poller;\`.
- \`desktop/Cargo.toml\` — adds \`reqwest = { version = \"0.12\", default-features = false, features = [\"json\", \"rustls-tls\"] }\`. \`default-features = false\` avoids pulling native-tls onto Linux/Windows bundles.

## Why

Project goal 7: *Health and training status polling that drives tray icon state changes.* Before this PR, the tray only reflected the subprocess lifecycle — a wedged kiln server still appeared \"Running\", and an active training job was never surfaced as \`TrainingActive\`.

## Decision rules (see \`derive_state\`)

- \`Stopped\` is terminal from the poller's perspective — never overwritten.
- \`Starting\` is only exited by a *successful* health check, so slow kiln boots don't flip into \`Error\` before the server is listening.
- On health failure: after 3 consecutive failures, transition to \`Error(\"health check failed\")\`; before that, preserve the prior state.
- On health success: if any entry in the \`/v1/train/status\` JSON array has \`\"state\": \"Running\"\` (case-sensitive, matching how the server's \`TrainingState\` enum serializes by default), transition to \`TrainingActive\`. Otherwise transition to \`Running\`.

## Validation

Cloud Eric cannot \`cargo check\` this Tauri crate — \`glib-sys\` needs GTK/webkit2gtk system libs that aren't installable in this environment (see repo note \`tauri-cargo-check-gtk-missing\`). Instead, the pure poller logic was validated in a scratch cargo project that mirrors just \`ServerState\` + the poller module against \`tokio\` + \`reqwest\` + \`serde_json\`:

\`\`\`
running 15 tests
test poller::tests::error_plus_health_ok_recovers_to_running ... ok
test poller::tests::error_plus_health_ok_with_training_job_goes_to_training_active ... ok
test poller::tests::healthy_poll_resets_error_state_via_recovery_path ... ok
test poller::tests::non_array_train_status_is_ignored ... ok
test poller::tests::running_job_match_is_case_sensitive ... ok
test poller::tests::running_plus_three_failures_transitions_to_error ... ok
test poller::tests::running_plus_training_job_transitions_to_training_active ... ok
test poller::tests::running_plus_two_failures_stays_running ... ok
test poller::tests::starting_plus_health_fail_stays_starting_even_after_many_failures ... ok
test poller::tests::starting_plus_health_ok_transitions_to_running ... ok
test poller::tests::stopped_stays_stopped_regardless_of_inputs ... ok
test poller::tests::training_active_plus_empty_array_returns_to_running ... ok
test poller::tests::training_active_plus_no_running_job_returns_to_running ... ok
test poller::tests::training_active_plus_no_train_status_returns_to_running ... ok
test poller::tests::training_array_with_one_running_among_many_triggers_training_active ... ok

test result: ok. 15 passed; 0 failed
\`\`\`

The full Tauri build and integration test (does the tray actually flip when a real kiln server is up / wedged / training) requires a dev machine with GTK or CI — expected and documented.

\`rustfmt --edition 2021 --check\` on the new and edited lines is clean; the only remaining diffs in the desktop/ tree are in pre-existing code that was already unformatted and is out of scope for this PR.

## Non-goals

- No change to the \`run_loop\` subprocess state transitions — the poller sits alongside them. A future refactor can remove the \`state = Running\` set in \`run_loop\` and let the poller be the sole authority.
- No UI surfacing of per-state tray icons or training-step readouts — that's downstream work.