### PR TITLE
desktop: log viewer window tailing supervisor stdout/stderr

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -77,6 +77,9 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                     let _ = app_handle.emit("menu://open-settings", ());
                 }
                 ITEM_LOGS => {
+                    if let Err(e) = open_logs_window(&app_handle) {
+                        eprintln!("[tray] open_logs_window failed: {}", e);
+                    }
                     let _ = app_handle.emit("menu://view-logs", ());
                 }
                 _ => {}
@@ -113,6 +116,22 @@ fn open_dashboard_window(app: &AppHandle) -> tauri::Result<()> {
     let win = WebviewWindowBuilder::new(app, "dashboard", WebviewUrl::App("dashboard.html".into()))
         .title("Kiln Dashboard")
         .inner_size(1024.0, 768.0)
+        .resizable(true)
+        .visible(true)
+        .build()?;
+    win.set_focus()?;
+    Ok(())
+}
+
+fn open_logs_window(app: &AppHandle) -> tauri::Result<()> {
+    if let Some(win) = app.get_webview_window("logs") {
+        win.show()?;
+        win.set_focus()?;
+        return Ok(());
+    }
+    let win = WebviewWindowBuilder::new(app, "logs", WebviewUrl::App("logs.html".into()))
+        .title("Kiln Logs")
+        .inner_size(900.0, 600.0)
         .resizable(true)
         .visible(true)
         .build()?;

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -35,6 +35,15 @@
         "height": 768,
         "resizable": true,
         "visible": false
+      },
+      {
+        "label": "logs",
+        "url": "logs.html",
+        "title": "Kiln Logs",
+        "width": 900,
+        "height": 600,
+        "resizable": true,
+        "visible": false
       }
     ],
     "security": {

--- a/desktop/ui/logs.html
+++ b/desktop/ui/logs.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Kiln Logs</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+        background: #0f1115;
+        color: #e6e6e6;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        overflow: hidden;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 10px 14px;
+        background: #161922;
+        border-bottom: 1px solid #232733;
+        flex: 0 0 auto;
+      }
+      header h1 {
+        font-size: 13px;
+        font-weight: 600;
+        margin: 0;
+        flex: 1 1 auto;
+        color: #cfd3dc;
+      }
+      header label {
+        font-size: 12px;
+        color: #a8aeb8;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        cursor: pointer;
+        user-select: none;
+      }
+      header input[type="checkbox"] {
+        accent-color: #2a6df4;
+        margin: 0;
+      }
+      button {
+        background: #2a6df4;
+        color: #fff;
+        border: 0;
+        border-radius: 6px;
+        padding: 6px 12px;
+        font-size: 12px;
+        cursor: pointer;
+      }
+      button:hover { background: #3b7af5; }
+      #log {
+        flex: 1 1 auto;
+        margin: 0;
+        padding: 12px 14px;
+        background: #0f1115;
+        color: #d6dae3;
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        line-height: 1.45;
+        white-space: pre-wrap;
+        word-break: break-word;
+        overflow-y: auto;
+        overflow-x: hidden;
+      }
+      #log.empty {
+        color: #6c7280;
+        font-style: italic;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Kiln server logs</h1>
+      <label><input type="checkbox" id="autoscroll" checked /> Auto-scroll</label>
+      <button id="clear" type="button">Clear view</button>
+    </header>
+    <div id="log" class="empty">(no log lines yet)</div>
+    <script defer>
+      const invoke = (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
+        || (window.__TAURI__ && window.__TAURI__.invoke);
+
+      const logEl = document.getElementById("log");
+      const autoscrollEl = document.getElementById("autoscroll");
+      const clearEl = document.getElementById("clear");
+
+      // Lines beyond `baseline` are shown. "Clear view" sets baseline to the
+      // current line count so the user sees only new lines from then on. The
+      // supervisor ring buffer itself is never modified.
+      let baseline = 0;
+
+      function render(lines) {
+        const visible = lines.slice(baseline);
+        if (visible.length === 0) {
+          logEl.textContent = lines.length === 0
+            ? "(no log lines yet)"
+            : "(view cleared — new lines will appear here)";
+          logEl.classList.add("empty");
+          return;
+        }
+        logEl.classList.remove("empty");
+        logEl.textContent = visible.join("\n");
+        if (autoscrollEl.checked) {
+          logEl.scrollTop = logEl.scrollHeight;
+        }
+      }
+
+      async function refresh() {
+        if (!invoke) {
+          logEl.textContent = "Tauri bridge unavailable. This page must run inside Kiln Desktop.";
+          logEl.classList.remove("empty");
+          return;
+        }
+        try {
+          const lines = await invoke("server_logs");
+          const arr = Array.isArray(lines) ? lines : [];
+          // If the ring buffer rotated and dropped lines below our baseline,
+          // clamp so we don't end up with a negative offset.
+          if (baseline > arr.length) {
+            baseline = arr.length;
+          }
+          render(arr);
+        } catch (err) {
+          logEl.textContent = "Failed to read logs: " + String(err || "unknown error");
+          logEl.classList.remove("empty");
+        }
+      }
+
+      clearEl.addEventListener("click", async () => {
+        try {
+          const lines = invoke ? await invoke("server_logs") : [];
+          baseline = Array.isArray(lines) ? lines.length : 0;
+        } catch {
+          // If we can't read, fall back to clearing what we have on screen.
+          baseline = 0;
+        }
+        render([]);
+      });
+
+      refresh();
+      setInterval(refresh, 1000);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What
Add a Kiln Logs window that tails the supervisor stdout/stderr ring buffer via the existing `server_logs` invoke command, and wire the tray "View Logs" item to actually open it.

- New `logs` webview window in `desktop/tauri.conf.json` (900x600, hidden by default).
- New `desktop/ui/logs.html` — vanilla HTML, dark theme matching `dashboard.html`, polls `server_logs` every 1s, with an Auto-scroll toggle (default on) and a Clear view button. Clear sets a baseline against the supervisor's current line count so subsequent ticks only show new lines; the supervisor ring buffer itself is never modified.
- `desktop/src/tray.rs` gains an `open_logs_window` helper (mirroring `open_dashboard_window`) and the `ITEM_LOGS` branch now opens/focuses the window before emitting the existing `menu://view-logs` event.

## Why
The ring buffer and `server_logs` command have existed since the supervisor PR (#83), but "View Logs" only emitted an event with nothing to receive it. This closes goal #8 of the desktop project (Log viewer window that tails captured stdout/stderr).

## Notes
- Cloud Eric cannot `cargo check` Tauri v2 crates (GTK/webkit2gtk system libs unavailable). Validated locally with `cargo metadata --format-version 1 --manifest-path Cargo.toml`, `python3 -m json.tool desktop/tauri.conf.json`, and `html.parser` on `logs.html`. CI / a real OS will validate the full build.
- Empty-state handling: page shows `(no log lines yet)` when the ring buffer is empty and `(view cleared - new lines will appear here)` when the user has cleared and no new lines have arrived yet.
- Baseline self-heals if the supervisor ring buffer rotates and drops lines below the user's baseline (clamped to current length).