### PR TITLE
desktop: CI building Windows MSI/NSIS and Linux deb/AppImage

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,0 +1,78 @@
+name: Build kiln-desktop
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'desktop/**'
+      - '.github/workflows/desktop-build.yml'
+    tags:
+      - 'desktop-v*'
+  pull_request:
+    paths:
+      - 'desktop/**'
+      - '.github/workflows/desktop-build.yml'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: 'ubuntu-22.04'
+            args: ''
+          - platform: 'windows-latest'
+            args: ''
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            libxdo-dev \
+            libssl-dev \
+            build-essential \
+            curl \
+            wget \
+            file
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './desktop -> target'
+
+      - name: Build (tauri-action)
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: desktop
+          tagName: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && github.ref_name || '' }}
+          releaseName: 'Kiln Desktop ${{ startsWith(github.ref, ''refs/tags/desktop-v'') && github.ref_name || '''' }}'
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}
+
+      - name: Upload artifacts (non-tag)
+        if: "!startsWith(github.ref, 'refs/tags/desktop-v')"
+        uses: actions/upload-artifact@v4
+        with:
+          name: kiln-desktop-${{ matrix.platform }}
+          path: |
+            desktop/target/release/bundle/deb/*.deb
+            desktop/target/release/bundle/appimage/*.AppImage
+            desktop/target/release/bundle/msi/*.msi
+            desktop/target/release/bundle/nsis/*.exe
+          if-no-files-found: ignore
+          retention-days: 14


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that builds kiln-desktop installers on Windows (MSI + NSIS) and Linux (.deb + .AppImage). Uses the official tauri-apps/tauri-action@v0.

- Trigger: push to main on desktop paths, PRs on desktop paths, tag pushes matching desktop-v*, and workflow_dispatch.
- Non-tag runs upload installers as workflow artifacts (14-day retention).
- Tag pushes (desktop-v*) create a draft GitHub Release with all bundles attached.
- Linux: ubuntu-22.04 with webkit2gtk-4.1 and libayatana-appindicator deps.
- Windows: windows-latest, no extra system setup needed.
- Tauri wrapper does NOT depend on CUDA, so this CI stays GPU-free.

## Follow-up

Next task pushes the first desktop-v0.1.0 tag to trigger the release.