### PR TITLE
desktop: grant contents:write to CI so tauri-action can create releases

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -14,6 +14,9 @@ on:
       - '.github/workflows/desktop-build.yml'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
## What

Add top-level `permissions: contents: write` to .github/workflows/desktop-build.yml.

## Why

The tag build for `desktop-v0.1.0` failed with `Resource not accessible by integration` because the default GITHUB_TOKEN is read-only for contents. tauri-action needs contents:write to create the GitHub Release on tag pushes.

## Test plan

- YAML validates
- After merge, delete and re-push the desktop-v0.1.0 tag to retrigger the release build