### PR TITLE
Phase 6: Wire kiln-flash-attn into paged decode path (fused single-query GQA)

### DIFF
--- a/crates/kiln-flash-attn/csrc/flash_attn/flash_api_c.cu
+++ b/crates/kiln-flash-attn/csrc/flash_attn/flash_api_c.cu
@@ -175,6 +175,145 @@ extern "C" kiln_flash_status_t kiln_flash_attn_fwd(
     return 0;
 }
 
+extern "C" kiln_flash_status_t kiln_flash_attn_fwd_paged_decode(
+    const void *q,
+    const void *k_pool,
+    const void *v_pool,
+    const int  *block_table,
+    void *out,
+    void *softmax_lse_out,
+    int batch_size,
+    int num_heads,
+    int num_heads_k,
+    int head_dim,
+    int max_seqlen_k,
+    int max_blocks_per_seq,
+    int page_block_size,
+    float softmax_scale,
+    int is_causal,
+    void *stream)
+{
+    if (head_dim != 128 && head_dim != 256) {
+        fprintf(stderr, "kiln_flash_attn_fwd_paged_decode: only head_dim=128,256 supported, got %d\n", head_dim);
+        return -1;
+    }
+    if (num_heads % num_heads_k != 0) {
+        fprintf(stderr, "kiln_flash_attn_fwd_paged_decode: num_heads (%d) must be divisible by num_heads_k (%d)\n",
+                num_heads, num_heads_k);
+        return -2;
+    }
+    // The splitkv hdim128/hdim256 instantiations use kBlockN = 128. Within a
+    // single 128-token chunk, the kernel reads a contiguous run of physical
+    // tokens using a single block_table entry; therefore physical pages within
+    // each 128-token chunk must be contiguous in the pool. The kernel handles
+    // page_block_size <= kBlockN by computing per-chunk block_table indices,
+    // but kBlockN must be evenly divisible by page_block_size.
+    constexpr int kBlockN = 128;
+    if (page_block_size <= 0 || (kBlockN % page_block_size) != 0) {
+        fprintf(stderr, "kiln_flash_attn_fwd_paged_decode: page_block_size (%d) must divide kBlockN (%d)\n",
+                page_block_size, kBlockN);
+        return -3;
+    }
+
+    FLASH_NAMESPACE::Flash_fwd_params params;
+    memset(&params, 0, sizeof(params));
+
+    params.is_bf16 = true;
+
+    // Pointers
+    params.q_ptr = const_cast<void *>(q);
+    params.k_ptr = const_cast<void *>(k_pool);
+    params.v_ptr = const_cast<void *>(v_pool);
+    params.o_ptr = out;
+    params.softmax_lse_ptr = softmax_lse_out;
+
+    // Q layout: [batch, 1, num_heads, head_dim]
+    params.q_row_stride   = num_heads * head_dim;
+    params.q_head_stride  = head_dim;
+    params.q_batch_stride = num_heads * head_dim;  // seqlen_q = 1
+
+    // K/V pool layout: each logical block is [page_block_size, num_heads_k, head_dim]
+    // The kernel computes the base of a block via:
+    //   row_offset_k = block_table[idx] * params.k_batch_stride + offset_in_block * params.k_row_stride + (kv_head) * params.k_head_stride
+    // So k_batch_stride is the stride between adjacent logical pages.
+    params.k_row_stride   = num_heads_k * head_dim;
+    params.v_row_stride   = num_heads_k * head_dim;
+    params.k_head_stride  = head_dim;
+    params.v_head_stride  = head_dim;
+    params.k_batch_stride = (int64_t)page_block_size * num_heads_k * head_dim;
+    params.v_batch_stride = (int64_t)page_block_size * num_heads_k * head_dim;
+
+    // Output: [batch, 1, num_heads, head_dim]
+    params.o_row_stride   = num_heads * head_dim;
+    params.o_head_stride  = head_dim;
+    params.o_batch_stride = num_heads * head_dim;
+
+    // Dimensions
+    params.b      = batch_size;
+    params.h      = num_heads;
+    params.h_k    = num_heads_k;
+    params.h_h_k_ratio = num_heads / num_heads_k;
+    params.seqlen_q = 1;
+    params.seqlen_k = max_seqlen_k;
+    params.d        = head_dim;
+    params.d_rounded = round_up(head_dim, 32);
+    params.seqlen_q_rounded = round_up(1, 128);
+    params.seqlen_k_rounded = round_up(max_seqlen_k, 128);
+
+    // Scale
+    params.scale_softmax = softmax_scale;
+    params.scale_softmax_log2 = softmax_scale * float(M_LOG2E);
+
+    // Dropout disabled
+    params.p_dropout = 1.0f;
+    params.p_dropout_in_uint8_t = 255;
+    params.rp_dropout = 1.0f;
+    params.scale_softmax_rp_dropout = params.scale_softmax;
+
+    // Causal mask
+    params.is_causal = is_causal != 0;
+    params.window_size_left = -1;
+    params.window_size_right = (is_causal != 0) ? 0 : -1;
+
+    // Paged KV
+    params.block_table = const_cast<int *>(block_table);
+    params.block_table_batch_stride = max_blocks_per_seq;
+    params.page_block_size = page_block_size;
+
+    // Unused
+    params.cu_seqlens_q = nullptr;
+    params.cu_seqlens_k = nullptr;
+    params.leftpad_k = nullptr;
+    params.seqused_k = nullptr;
+    params.p_ptr = nullptr;
+    params.softmax_lseaccum_ptr = nullptr;
+    params.oaccum_ptr = nullptr;
+    params.knew_ptr = nullptr;
+    params.vnew_ptr = nullptr;
+    params.rotary_cos_ptr = nullptr;
+    params.rotary_sin_ptr = nullptr;
+    params.cache_batch_idx = nullptr;
+    params.blockmask = nullptr;
+    params.alibi_slopes_ptr = nullptr;
+    params.rng_state = nullptr;
+
+    params.is_seqlens_k_cumulative = true;
+    params.is_rotary_interleaved = false;
+    params.num_splits = 1;  // no split-KV; avoids needing accum scratch
+    params.softcap = 0.0f;
+    params.unpadded_lse = false;
+    params.seqlenq_ngroups_swapped = false;
+
+    cudaStream_t cuda_stream = static_cast<cudaStream_t>(stream);
+    if (head_dim == 128) {
+        FLASH_NAMESPACE::run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 128, true>(params, cuda_stream);
+    } else {
+        FLASH_NAMESPACE::run_mha_fwd_splitkv_dispatch<cutlass::bfloat16_t, 256, true>(params, cuda_stream);
+    }
+
+    return 0;
+}
+
 extern "C" kiln_flash_status_t kiln_flash_attn_bwd(
     const void *dout,
     const void *q, const void *k, const void *v,

--- a/crates/kiln-flash-attn/csrc/flash_attn/flash_api_c.h
+++ b/crates/kiln-flash-attn/csrc/flash_attn/flash_api_c.h
@@ -43,6 +43,47 @@ kiln_flash_status_t kiln_flash_attn_fwd(
     void *stream
 );
 
+// Flash Attention Forward Pass — Paged Decode (single-query GQA)
+//
+// All pointer arguments must be CUDA device pointers.
+// Specialized for the decode step: query length = 1, K/V are gathered from a
+// paged pool indexed by `block_table`.
+//
+// Layouts:
+//   q       : [batch, 1, num_heads, head_dim] bf16
+//   k_pool  : [total_slots, num_heads_k, head_dim] bf16
+//   v_pool  : [total_slots, num_heads_k, head_dim] bf16
+//   block_table : [batch, max_blocks_per_seq] int32 (host-allocated, device-resident)
+//   out     : [batch, 1, num_heads, head_dim] bf16
+//   softmax_lse_out : [batch, num_heads, 1] float32
+//
+// The kernel reads `kBlockN` (= 128 for hdim128) consecutive K/V tokens per chunk
+// using a single block_table entry, so `page_block_size` must be >= 128 and
+// physical pages within a chunk must be contiguous. Callers using a smaller
+// logical page size (e.g. 16) must construct an equivalent block_table that
+// indexes 128-token-aligned super-blocks.
+//
+// max_seqlen_k is the current K/V length (number of cached tokens incl. the
+// freshly-written current step).
+kiln_flash_status_t kiln_flash_attn_fwd_paged_decode(
+    const void *q,
+    const void *k_pool,
+    const void *v_pool,
+    const int  *block_table,
+    void *out,
+    void *softmax_lse_out,
+    int batch_size,
+    int num_heads,
+    int num_heads_k,
+    int head_dim,
+    int max_seqlen_k,
+    int max_blocks_per_seq,
+    int page_block_size,
+    float softmax_scale,
+    int is_causal,
+    void *stream
+);
+
 // Flash Attention Backward Pass
 //
 // All pointer arguments must be CUDA device pointers.

--- a/crates/kiln-flash-attn/src/lib.rs
+++ b/crates/kiln-flash-attn/src/lib.rs
@@ -32,6 +32,25 @@ unsafe extern "C" {
         stream: *mut core::ffi::c_void,
     ) -> i32;
 
+    fn kiln_flash_attn_fwd_paged_decode(
+        q: *const core::ffi::c_void,
+        k_pool: *const core::ffi::c_void,
+        v_pool: *const core::ffi::c_void,
+        block_table: *const i32,
+        out: *mut core::ffi::c_void,
+        softmax_lse_out: *mut core::ffi::c_void,
+        batch_size: i32,
+        num_heads: i32,
+        num_heads_k: i32,
+        head_dim: i32,
+        max_seqlen_k: i32,
+        max_blocks_per_seq: i32,
+        page_block_size: i32,
+        softmax_scale: f32,
+        is_causal: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
     fn kiln_flash_attn_bwd(
         dout: *const core::ffi::c_void,
         q: *const core::ffi::c_void,
@@ -169,6 +188,178 @@ pub fn flash_attn_fwd(
     }
 
     Ok((out, softmax_lse))
+}
+
+/// Flash-attention v2 forward pass — paged decode (single-query GQA).
+///
+/// Specialized for the decode step:
+///   - `q`            : `[batch, 1, num_heads, head_dim]` bf16 (contiguous)
+///   - `k_pool`       : `[total_slots, num_heads_k, head_dim]` bf16 (contiguous)
+///   - `v_pool`       : `[total_slots, num_heads_k, head_dim]` bf16 (contiguous)
+///   - `block_table`  : `[batch, max_blocks_per_seq]` i32 (CUDA tensor)
+///   - `seqlen_k`     : current K/V length per sequence (single value, applies to all batch entries)
+///   - `page_block_size`: tokens per logical page in `block_table`. Must be a multiple of 128
+///                      (the kernel reads kBlockN=128 contiguous tokens per chunk).
+///
+/// Returns the attention output `[batch, 1, num_heads, head_dim]` bf16.
+pub fn flash_attn_paged_decode(
+    q: &Tensor,
+    k_pool: &Tensor,
+    v_pool: &Tensor,
+    block_table: &Tensor,
+    seqlen_k: usize,
+    page_block_size: usize,
+    softmax_scale: f32,
+    causal: bool,
+) -> Result<Tensor> {
+    let device = q.device();
+    let (b, q_len, num_heads, head_dim) = q.dims4()?;
+    if q_len != 1 {
+        candle_core::bail!(
+            "flash_attn_paged_decode requires query_len==1, got {q_len}"
+        );
+    }
+    let (_total_slots, num_heads_k, hd_k) = k_pool.dims3()?;
+    if hd_k != head_dim {
+        candle_core::bail!(
+            "k_pool head_dim ({hd_k}) does not match q head_dim ({head_dim})"
+        );
+    }
+    if v_pool.dims3()?.2 != head_dim {
+        candle_core::bail!("v_pool head_dim mismatch");
+    }
+    if num_heads % num_heads_k != 0 {
+        candle_core::bail!(
+            "num_heads ({num_heads}) must be divisible by num_heads_k ({num_heads_k})"
+        );
+    }
+    if q.dtype() != DType::BF16
+        || k_pool.dtype() != DType::BF16
+        || v_pool.dtype() != DType::BF16
+    {
+        candle_core::bail!("flash_attn_paged_decode requires bf16 q/k/v");
+    }
+    if head_dim != 128 && head_dim != 256 {
+        candle_core::bail!(
+            "flash_attn_paged_decode only supports head_dim=128,256, got {head_dim}"
+        );
+    }
+    // kBlockN = 128 for hdim128/hdim256 splitkv. Page size must divide kBlockN.
+    if page_block_size == 0 || 128 % page_block_size != 0 {
+        candle_core::bail!(
+            "flash_attn_paged_decode requires page_block_size to divide 128 (kBlockN), got {page_block_size}"
+        );
+    }
+    if block_table.dtype() != DType::U32 {
+        candle_core::bail!(
+            "flash_attn_paged_decode requires block_table dtype=u32, got {:?}",
+            block_table.dtype()
+        );
+    }
+
+    let (bt_batch, max_blocks_per_seq) = block_table.dims2()?;
+    if bt_batch != b {
+        candle_core::bail!(
+            "block_table batch dim ({bt_batch}) must match q batch ({b})"
+        );
+    }
+
+    // Ensure contiguous
+    let q = q.contiguous()?;
+    let k_pool = k_pool.contiguous()?;
+    let v_pool = v_pool.contiguous()?;
+    let block_table = block_table.contiguous()?;
+
+    // Allocate output and softmax LSE
+    let out = Tensor::zeros((b, 1, num_heads, head_dim), DType::BF16, device)?;
+    let softmax_lse = Tensor::zeros((b, num_heads, 1), DType::F32, device)?;
+
+    {
+        let (q_storage, q_layout) = q.storage_and_layout();
+        let (k_storage, k_layout) = k_pool.storage_and_layout();
+        let (v_storage, v_layout) = v_pool.storage_and_layout();
+        let (bt_storage, bt_layout) = block_table.storage_and_layout();
+        let (out_storage, out_layout) = out.storage_and_layout();
+        let (lse_storage, lse_layout) = softmax_lse.storage_and_layout();
+
+        macro_rules! cuda {
+            ($s:expr, $name:expr) => {
+                match &*$s {
+                    candle_core::Storage::Cuda(c) => c,
+                    _ => candle_core::bail!(concat!($name, " must be a CUDA tensor")),
+                }
+            };
+        }
+
+        let q_cuda = cuda!(q_storage, "q");
+        let k_cuda = cuda!(k_storage, "k_pool");
+        let v_cuda = cuda!(v_storage, "v_pool");
+        let bt_cuda = cuda!(bt_storage, "block_table");
+        let out_cuda = cuda!(out_storage, "out");
+        let lse_cuda = cuda!(lse_storage, "softmax_lse");
+
+        let stream = q_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let q_slice = q_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(q_layout.start_offset()..);
+        let k_slice = k_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(k_layout.start_offset()..);
+        let v_slice = v_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(v_layout.start_offset()..);
+        let out_slice = out_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(out_layout.start_offset()..);
+        let lse_slice = lse_cuda
+            .as_cuda_slice::<f32>()?
+            .slice(lse_layout.start_offset()..);
+
+        // The block_table tensor is u32 in candle; the FFI expects int32. They
+        // are bit-identical for non-negative IDs, so we can reinterpret the
+        // pointer.
+        let bt_slice = bt_cuda
+            .as_cuda_slice::<u32>()?
+            .slice(bt_layout.start_offset()..);
+
+        unsafe {
+            let (q_ptr, _g1) = q_slice.device_ptr(&stream);
+            let (k_ptr, _g2) = k_slice.device_ptr(&stream);
+            let (v_ptr, _g3) = v_slice.device_ptr(&stream);
+            let (bt_ptr, _g4) = bt_slice.device_ptr(&stream);
+            let (out_ptr, _g5) = out_slice.device_ptr(&stream);
+            let (lse_ptr, _g6) = lse_slice.device_ptr(&stream);
+
+            let status = kiln_flash_attn_fwd_paged_decode(
+                q_ptr as *const _,
+                k_ptr as *const _,
+                v_ptr as *const _,
+                bt_ptr as *const i32,
+                out_ptr as *mut _,
+                lse_ptr as *mut _,
+                b as i32,
+                num_heads as i32,
+                num_heads_k as i32,
+                head_dim as i32,
+                seqlen_k as i32,
+                max_blocks_per_seq as i32,
+                page_block_size as i32,
+                softmax_scale,
+                if causal { 1 } else { 0 },
+                raw_stream,
+            );
+
+            if status != 0 {
+                candle_core::bail!(
+                    "kiln_flash_attn_fwd_paged_decode failed with status {status}"
+                );
+            }
+        }
+    }
+
+    Ok(out)
 }
 
 /// Flash-attention v2 backward pass.

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1325,6 +1325,154 @@ pub fn gqa_attention(
     Ok(out)
 }
 
+/// Try the fused paged-decode flash-attention kernel.
+///
+/// Returns `Ok(Some(output))` on success and `Ok(None)` when the kernel
+/// preconditions cannot be satisfied (forcing the caller to fall back to the
+/// materializing slow path).
+///
+/// ### Preconditions checked here
+///   * `block_size` divides `kBlockN = 128`
+///   * Within each `kBlockN`-wide chunk of the block table, the underlying
+///     physical pages are contiguous in the pool. The FA2 splitkv paged kernel
+///     reads only one block-table entry per kBlockN chunk and assumes the next
+///     `kBlockN / block_size` pages are physically contiguous (see
+///     `flash_fwd_kernel.h` lines 587-596 and 770-779).
+///
+/// ### Output
+/// `[batch, 1, num_heads * head_dim]` after o_proj (matches the slow path).
+#[cfg(feature = "cuda")]
+#[allow(clippy::too_many_arguments)]
+fn try_flash_attn_paged_decode(
+    q: &Tensor,
+    paged_cache: &PagedKvCache,
+    block_table: &BlockTable,
+    full_attn_layer_idx: usize,
+    total_seq_len: usize,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    gate: Option<&Tensor>,
+    attn_weights: &GpuFullAttentionWeights,
+    lora_layer: Option<&LoraLayerWeights>,
+    lora_scale: f32,
+) -> Result<Option<Tensor>> {
+    const K_BLOCK_N: usize = 128;
+
+    let block_size = paged_cache.block_size();
+    if block_size == 0 || K_BLOCK_N % block_size != 0 {
+        return Ok(None);
+    }
+    let pages_per_chunk = K_BLOCK_N / block_size;
+
+    // q here is [batch, num_heads, 1, head_dim] after the transpose at the
+    // call site. Flash-attn wants [batch, 1, num_heads, head_dim].
+    let (batch, q_heads, q_len, q_hd) = q.dims4()?;
+    if q_len != 1 || q_heads != num_heads || q_hd != head_dim {
+        return Ok(None);
+    }
+    if batch != 1 {
+        // Multi-sequence dispatch needs a per-sequence block_table tensor.
+        // Defer to the slow path until the scheduler exercises it.
+        return Ok(None);
+    }
+
+    // Verify intra-chunk contiguity. The kernel reads block_table[c * 8] only
+    // (for block_size=16) and assumes pages [c*8 .. c*8+7] are physically
+    // contiguous in the pool. kiln's `BlockManager` allocates blocks
+    // sequentially from a free list, so a single freshly-allocated sequence
+    // satisfies this trivially. After eviction or interleaved allocation the
+    // condition may not hold, in which case we fall back.
+    let n_chunks = total_seq_len.div_ceil(K_BLOCK_N);
+    let blocks = &block_table.blocks;
+    let allocated = blocks.len();
+    if allocated < n_chunks * pages_per_chunk
+        && allocated < total_seq_len.div_ceil(block_size)
+    {
+        // Block table too short for the requested seqlen.
+        return Ok(None);
+    }
+    for c in 0..n_chunks {
+        let base_idx = c * pages_per_chunk;
+        if base_idx >= allocated {
+            break;
+        }
+        let base_phys = blocks[base_idx];
+        for i in 1..pages_per_chunk {
+            let idx = base_idx + i;
+            if idx >= allocated {
+                break;
+            }
+            if blocks[idx] != base_phys + i as u32 {
+                return Ok(None);
+            }
+        }
+    }
+
+    // Build a padded block_table tensor sized [1, n_chunks * pages_per_chunk].
+    // Only the entries at indices c * pages_per_chunk are read by the kernel,
+    // but we copy the full kiln block table verbatim and pad the tail by
+    // continuing the contiguous run from the last valid block (so any
+    // stray reads stay within the cache pool).
+    let max_blocks_per_seq = n_chunks * pages_per_chunk;
+    let mut padded: Vec<u32> = Vec::with_capacity(max_blocks_per_seq);
+    padded.extend_from_slice(blocks);
+    if padded.is_empty() {
+        return Ok(None);
+    }
+    while padded.len() < max_blocks_per_seq {
+        let next = padded.last().copied().unwrap_or(0).wrapping_add(1);
+        padded.push(next);
+    }
+
+    let device = q.device();
+    let bt_tensor = Tensor::new(padded.as_slice(), device)?
+        .reshape((1usize, max_blocks_per_seq))?;
+
+    // Reshape Q for the flash-attn API: [batch, num_heads, 1, head_dim]
+    // -> [batch, 1, num_heads, head_dim].
+    let q_fa = q.transpose(1, 2)?.contiguous()?;
+
+    let (k_pool, v_pool) = match paged_cache.pool_tensors(full_attn_layer_idx) {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+
+    let softmax_scale = 1.0f32 / (head_dim as f32).sqrt();
+
+    let attn_out = kiln_flash_attn::flash_attn_paged_decode(
+        &q_fa,
+        k_pool,
+        v_pool,
+        &bt_tensor,
+        total_seq_len,
+        block_size,
+        softmax_scale,
+        true,
+    )
+    .context("flash_attn_paged_decode kernel failed")?;
+
+    // attn_out is [batch, 1, num_heads, head_dim] bf16. Reshape to
+    // [batch, 1, num_heads * head_dim] for the gate / o_proj path.
+    let _ = num_kv_heads; // unused — kept in signature for symmetry / future use
+    let attn_output = attn_out.reshape((batch, 1usize, num_heads * head_dim))?;
+
+    let attn_output = if let Some(gate) = gate {
+        let sigmoid_gate = cuda_sigmoid(gate)?;
+        (attn_output * sigmoid_gate)?
+    } else {
+        attn_output
+    };
+
+    let out = linear_with_lora(
+        &attn_output,
+        &attn_weights.o_proj,
+        lora_layer.and_then(|l| l.o_proj.as_ref()),
+        lora_scale,
+    )?;
+    Ok(Some(out))
+}
+
 /// Grouped-query attention using a paged KV cache.
 ///
 /// Same computation as [`gqa_attention`] but reads/writes K/V through a
@@ -1394,8 +1542,43 @@ pub fn gqa_attention_paged(
         .write(full_attn_layer_idx, block_table, start_pos, &k, &v)
         .context("paged KV cache write failed")?;
 
-    // Read full K/V from paged cache (all positions 0..start_pos+seq_len)
     let total_seq_len = start_pos + seq_len;
+
+    // Fast path: fused paged-decode flash-attention kernel.
+    // Eliminates the materializing `paged_cache.read()` (an `index_select` /
+    // u8→bf16 dequant) on the decode hot path. Limited to:
+    //   * CUDA + bf16 (the only kernel we compile)
+    //   * Decode steps (seq_len == 1)
+    //   * Non-FP8 caches (the kernel reads bf16 pool slots directly)
+    //   * Page sizes that divide kBlockN=128 (block_size=16 satisfies this)
+    //   * Single sequence with physically contiguous block allocation
+    //     (kiln's BlockManager allocates blocks in order from a free list, so
+    //     a freshly-allocated single sequence is always contiguous)
+    #[cfg(feature = "cuda")]
+    if seq_len == 1
+        && q.dtype() == candle_core::DType::BF16
+        && !paged_cache.is_fp8()
+        && (num_heads / num_kv_heads) > 1
+    {
+        if let Some(out) = try_flash_attn_paged_decode(
+            &q,
+            paged_cache,
+            block_table,
+            full_attn_layer_idx,
+            total_seq_len,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            gate.as_ref(),
+            attn_weights,
+            lora_layer,
+            lora_scale,
+        )? {
+            return Ok(out);
+        }
+    }
+
+    // Read full K/V from paged cache (all positions 0..start_pos+seq_len)
     let (k, v) = paged_cache
         .read(full_attn_layer_idx, block_table, total_seq_len)
         .context("paged KV cache read failed")?;

--- a/crates/kiln-model/src/paged_kv_cache.rs
+++ b/crates/kiln-model/src/paged_kv_cache.rs
@@ -233,6 +233,22 @@ impl PagedKvCache {
     pub fn is_fp8(&self) -> bool {
         self.fp8
     }
+
+    /// Borrow the raw `(k_pool, v_pool)` tensors for `layer_idx`.
+    ///
+    /// Each pool has shape `[total_slots, num_kv_heads, head_dim]` where
+    /// `total_slots = num_blocks * block_size`. Returns `None` if `layer_idx`
+    /// is out of range.
+    ///
+    /// Intended for fused attention kernels (e.g. flash-attention paged decode)
+    /// that index into the pool directly via a precomputed block_table tensor.
+    /// For FP8 caches the returned tensors are still U8-encoded — callers must
+    /// either dequantize first or use a kernel that supports FP8 inputs.
+    pub fn pool_tensors(&self, layer_idx: usize) -> Option<(&Tensor, &Tensor)> {
+        self.layers
+            .get(layer_idx)
+            .map(|(k, v)| (k, v))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Wires the vendored `kiln-flash-attn` kernel into the paged decode path. New entry point `kiln_flash_attn_fwd_paged_decode` (single-query GQA, bf16, head_dim=128, causal) gathers K/V from the paged pool via a block-table tensor, eliminating the materializing `index_select` / dequant on the decode hot path.

PROFILING.md (PR #97) identified this as the top decode hotspot in the paged production path.

## Changes

- `kiln_flash_attn_fwd_paged_decode` C entry — routes to the FA2 splitkv paged kernel. `page_block_size` may be any divisor of `kBlockN=128`, which covers kiln's default `block_size=16` directly (no synthetic super-blocks needed — see `flash_fwd_kernel.h:587-596,770-779`).
- `flash_attn_paged_decode` Rust wrapper — validates shapes/dtypes, allocates output + softmax LSE, reinterprets the u32 block-table pointer as i32 for the kernel.
- `PagedKvCache::pool_tensors(layer_idx)` — borrows raw bf16 K/V pools.
- `gqa_attention_paged` — dispatches to `try_flash_attn_paged_decode` when `seq_len==1`, q is bf16, cache is non-FP8, and `gqa_ratio>1`. Helper verifies intra-chunk page contiguity, pads block-table to multiple of `kBlockN/page_block_size`, and falls back to the materializing slow path on any precondition miss.

Slow path (candle-DSL) is preserved unchanged; remains the fallback for CPU, FP8 caches, multi-batch decode, and non-GQA layers.

## Validation status

- Host `cargo check` is clean.
- GPU validation pending — needs RTX A6000 (sm_86) bench run comparing paged-decode latency vs main. Two prior attempts (tasks 0c27c75 and 74a6951) timed out during the `cargo test` compile phase on RunPod.
- Opening this PR so it is reviewable + CI-visible. A follow-up task will run the bench validation on a fresh pod and append the speedup numbers.

## Risk

- Low: every dispatch precondition is checked; any miss falls back to the existing slow path.
- The new C entry only affects the paged decode hot path when all preconditions are met.