### PR TITLE
desktop: Copy OpenAI base URL (tray + dashboard)

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -18,6 +18,7 @@ tauri = { version = "2", features = ["tray-icon", "image-png"] }
 tauri-plugin-shell = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2"
+tauri-plugin-clipboard-manager = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "sync", "time", "io-util"] }

--- a/desktop/capabilities/default.json
+++ b/desktop/capabilities/default.json
@@ -5,6 +5,7 @@
   "windows": ["*"],
   "permissions": [
     "core:default",
-    "dialog:default"
+    "dialog:default",
+    "clipboard-manager:allow-write-text"
   ]
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -63,6 +63,12 @@ async fn get_settings(state: State<'_, SettingsState>) -> Result<Settings, Strin
     Ok(state.read().await.clone())
 }
 
+/// Build the OpenAI-compatible base URL for a given host/port. Kept as a pure
+/// helper so it can be unit-tested without a Tauri runtime.
+pub fn openai_base_url(host: &str, port: u16) -> String {
+    format!("http://{}:{}/v1", host, port)
+}
+
 /// Return the kiln server's /ui URL based on the current settings, but only
 /// when the supervisor reports a state that should have the HTTP server up.
 /// Returns an empty string when the server is Stopped or in Error, so the
@@ -78,6 +84,26 @@ async fn get_kiln_url(
         ServerState::Starting | ServerState::Running | ServerState::TrainingActive => {
             let s = state.read().await;
             Ok(format!("http://{}:{}/ui", s.host, s.port))
+        }
+    }
+}
+
+/// Return the OpenAI-compatible base URL (`http://<host>:<port>/v1`) based on
+/// current settings, but only when the supervisor reports a state that should
+/// have the HTTP server up. Returns an empty string when the server is
+/// Stopped or in Error, so the UI can distinguish "server not running" from a
+/// real URL.
+#[tauri::command]
+async fn get_openai_base_url(
+    state: State<'_, SettingsState>,
+    sup: State<'_, Arc<Supervisor>>,
+) -> Result<String, String> {
+    let server_state = sup.state().await;
+    match server_state {
+        ServerState::Stopped | ServerState::Error(_) => Ok(String::new()),
+        ServerState::Starting | ServerState::Running | ServerState::TrainingActive => {
+            let s = state.read().await;
+            Ok(openai_base_url(&s.host, s.port))
         }
     }
 }
@@ -108,6 +134,7 @@ fn main() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
+        .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,
             None,
@@ -145,8 +172,25 @@ fn main() {
             server_logs,
             get_settings,
             set_settings,
-            get_kiln_url
+            get_kiln_url,
+            get_openai_base_url
         ])
         .run(tauri::generate_context!())
         .expect("error while running kiln-desktop");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::openai_base_url;
+
+    #[test]
+    fn default_loopback() {
+        assert_eq!(openai_base_url("127.0.0.1", 8000), "http://127.0.0.1:8000/v1");
+    }
+
+    #[test]
+    fn alternate_host_and_port() {
+        assert_eq!(openai_base_url("0.0.0.0", 9001), "http://0.0.0.0:9001/v1");
+        assert_eq!(openai_base_url("localhost", 80), "http://localhost:80/v1");
+    }
 }

--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -4,7 +4,10 @@ use std::time::Duration;
 use tauri::menu::{MenuBuilder, MenuItem, MenuItemBuilder};
 use tauri::tray::TrayIconBuilder;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
+use tauri_plugin_clipboard_manager::ClipboardExt;
+use tokio::sync::RwLock;
 
+use crate::settings::Settings;
 use crate::supervisor::{ServerState, Supervisor};
 
 const TRAY_ID: &str = "kiln-main";
@@ -13,6 +16,7 @@ const ITEM_SETTINGS: &str = "open_settings";
 const ITEM_START: &str = "start_server";
 const ITEM_STOP: &str = "stop_server";
 const ITEM_LOGS: &str = "view_logs";
+const ITEM_COPY_URL: &str = "copy_openai_url";
 const ITEM_QUIT: &str = "quit";
 
 const ICON_STOPPED: &[u8] = include_bytes!("../icons/tray/stopped.png");
@@ -34,6 +38,8 @@ fn state_icon_bytes(state: &ServerState) -> &'static [u8] {
 pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result<()> {
     let dashboard = MenuItemBuilder::with_id(ITEM_DASHBOARD, "Open Dashboard").build(app)?;
     let settings = MenuItemBuilder::with_id(ITEM_SETTINGS, "Settings…").build(app)?;
+    let copy_url =
+        MenuItemBuilder::with_id(ITEM_COPY_URL, "Copy OpenAI Base URL").build(app)?;
     let start = MenuItemBuilder::with_id(ITEM_START, "Start Server").build(app)?;
     let stop = MenuItemBuilder::with_id(ITEM_STOP, "Stop Server")
         .enabled(false)
@@ -43,6 +49,8 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
 
     let menu = MenuBuilder::new(app)
         .items(&[&dashboard, &settings])
+        .separator()
+        .item(&copy_url)
         .separator()
         .items(&[&start, &stop, &logs])
         .separator()
@@ -95,6 +103,12 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                     }
                     let _ = app_handle.emit("menu://view-logs", ());
                 }
+                ITEM_COPY_URL => {
+                    let supervisor = Arc::clone(&supervisor);
+                    tauri::async_runtime::spawn(async move {
+                        copy_openai_base_url_to_clipboard(&app_handle, supervisor).await;
+                    });
+                }
                 _ => {}
             }
         })
@@ -134,6 +148,29 @@ fn open_dashboard_window(app: &AppHandle) -> tauri::Result<()> {
         .build()?;
     win.set_focus()?;
     Ok(())
+}
+
+async fn copy_openai_base_url_to_clipboard(app: &AppHandle, supervisor: Arc<Supervisor>) {
+    let state = supervisor.state().await;
+    if !matches!(
+        state,
+        ServerState::Starting | ServerState::Running | ServerState::TrainingActive
+    ) {
+        eprintln!(
+            "[tray] copy OpenAI base URL skipped — server not running (state: {})",
+            state_label(&state)
+        );
+        return;
+    }
+    let (host, port) = {
+        let settings_state = app.state::<Arc<RwLock<Settings>>>();
+        let s = settings_state.read().await;
+        (s.host.clone(), s.port)
+    };
+    let url = crate::openai_base_url(&host, port);
+    if let Err(e) = app.clipboard().write_text(url) {
+        eprintln!("[tray] clipboard write_text failed: {}", e);
+    }
 }
 
 fn open_logs_window(app: &AppHandle) -> tauri::Result<()> {

--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -64,9 +64,31 @@
       button:hover { background: #3b7af5; }
       button:disabled { background: #2a2f3a; cursor: default; }
       .hidden { display: none !important; }
+      #toolbar {
+        position: absolute;
+        top: 8px;
+        right: 12px;
+        display: flex;
+        gap: 8px;
+        z-index: 10;
+      }
+      #toolbar button {
+        margin-top: 0;
+        background: #1b1e24;
+        color: #d8dbe2;
+        border: 1px solid #2a2f3a;
+        padding: 6px 10px;
+        font-size: 12px;
+      }
+      #toolbar button:hover { background: #232831; }
+      #copy-url.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
+      #copy-url.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
     </style>
   </head>
   <body>
+    <div id="toolbar">
+      <button id="copy-url" title="Copy the OpenAI-compatible base URL for this server">Copy OpenAI base URL</button>
+    </div>
     <iframe id="frame" class="hidden" title="Kiln UI"></iframe>
     <div id="status">
       <h1 id="status-title">Connecting to Kiln server…</h1>
@@ -129,6 +151,52 @@
       }
 
       retry.addEventListener("click", load);
+
+      const copyBtn = document.getElementById("copy-url");
+      const COPY_LABEL = "Copy OpenAI base URL";
+      let copyResetTimer = null;
+
+      function flashCopyBtn(label, cls) {
+        if (copyResetTimer) {
+          clearTimeout(copyResetTimer);
+          copyResetTimer = null;
+        }
+        copyBtn.textContent = label;
+        copyBtn.classList.remove("flash", "flash-warn");
+        if (cls) copyBtn.classList.add(cls);
+        copyResetTimer = setTimeout(() => {
+          copyBtn.textContent = COPY_LABEL;
+          copyBtn.classList.remove("flash", "flash-warn");
+          copyResetTimer = null;
+        }, 1500);
+      }
+
+      async function copyOpenAiBaseUrl() {
+        if (!invoke) {
+          flashCopyBtn("Tauri bridge unavailable", "flash-warn");
+          return;
+        }
+        try {
+          const url = await invoke("get_openai_base_url");
+          if (!url) {
+            flashCopyBtn("Server not running", "flash-warn");
+            return;
+          }
+          try {
+            await navigator.clipboard.writeText(url);
+            flashCopyBtn("Copied!", "flash");
+          } catch (err) {
+            flashCopyBtn("Copy failed", "flash-warn");
+            console.error("clipboard.writeText failed", err);
+          }
+        } catch (err) {
+          flashCopyBtn("Copy failed", "flash-warn");
+          console.error("get_openai_base_url failed", err);
+        }
+      }
+
+      copyBtn.addEventListener("click", copyOpenAiBaseUrl);
+
       window.addEventListener("DOMContentLoaded", load);
     </script>
   </body>


### PR DESCRIPTION
## What

- New Tauri command `get_openai_base_url` that returns `http://<host>:<port>/v1` when the supervisor reports `Starting|Running|TrainingActive`, and an empty string when the server is `Stopped` or `Error(_)`.
- New tray menu item **Copy OpenAI Base URL** (its own separator group between the dashboard/settings items and the start/stop group). Uses `tauri-plugin-clipboard-manager` to write the URL. When the server is not running, it logs to stderr and no-ops instead of handing the user a dead URL.
- New **Copy OpenAI base URL** button in the dashboard header toolbar. On click, invokes `get_openai_base_url` and writes via `navigator.clipboard.writeText(...)`, flashing "Copied!" for ~1.5s on success, "Server not running" when empty, or "Copy failed" on error.
- Pure helper `openai_base_url(host: &str, port: u16) -> String` in `main.rs`, unit-tested with two cases (default loopback and alternate host/port). Both the Tauri command and the tray handler go through this helper, so the format is covered by a single test.
- `tauri-plugin-clipboard-manager = "2"` added to `Cargo.toml` and `clipboard-manager:allow-write-text` added to `capabilities/default.json`.

## Why

Fills the last MVP UX bullet ("Copy OpenAI base URL") from the project description. Lets users point OpenAI-compatible clients at the local server without touching a terminal or building the URL by hand.

## Validation

- Pure helper validated in a scratch cargo project: `cargo test` green for `openai_base_url("127.0.0.1", 8000) -> "http://127.0.0.1:8000/v1"` and the alternate-host/port case.
- `cd desktop && cargo check` fails in this environment at the gobject-sys step: `Package 'gobject-2.0', required by 'virtual:world', not found`. This is expected — Cloud Eric sandboxes can't compile Tauri crates because GTK/webkit2gtk system libs aren't installed. CI validates the full Tauri build on real OS runners.
- `desktop/capabilities/default.json` parses as valid JSON.

## Scope

Desktop-only. No kiln-server edits, no macOS work, no workspace Cargo.toml changes. Diff is 5 files, ~150 lines, confined to `desktop/`.