### PR TITLE
desktop: Start Server button on dashboard not-running state

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -64,6 +64,11 @@
       button:hover { background: #3b7af5; }
       button:disabled { background: #2a2f3a; cursor: default; }
       .hidden { display: none !important; }
+      #status-actions {
+        display: flex;
+        gap: 8px;
+        justify-content: center;
+      }
       #toolbar {
         position: absolute;
         top: 8px;
@@ -93,7 +98,10 @@
     <div id="status">
       <h1 id="status-title">Connecting to Kiln server…</h1>
       <p id="status-detail">Looking up the server URL from your settings.</p>
-      <button id="retry" class="hidden">Retry</button>
+      <div id="status-actions">
+        <button id="start-server" class="hidden">Start Server</button>
+        <button id="retry" class="hidden">Retry</button>
+      </div>
     </div>
     <script>
       const invoke = (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
@@ -104,14 +112,19 @@
       const title = document.getElementById("status-title");
       const detail = document.getElementById("status-detail");
       const retry = document.getElementById("retry");
+      const startBtn = document.getElementById("start-server");
+      const START_LABEL = "Start Server";
 
-      function showStatus(titleText, detailText, showRetry) {
+      function showStatus(titleText, detailText, showRetry, showStart) {
         frame.classList.add("hidden");
         frame.src = "about:blank";
         status.classList.remove("hidden");
         title.textContent = titleText;
         detail.textContent = detailText;
         retry.classList.toggle("hidden", !showRetry);
+        startBtn.classList.toggle("hidden", !showStart);
+        startBtn.disabled = false;
+        startBtn.textContent = START_LABEL;
       }
 
       function showFrame(url) {
@@ -121,11 +134,12 @@
       }
 
       async function load() {
-        showStatus("Connecting to Kiln server…", "Looking up the server URL from your settings.", false);
+        showStatus("Connecting to Kiln server…", "Looking up the server URL from your settings.", false, false);
         if (!invoke) {
           showStatus(
             "Tauri bridge unavailable",
             "This page must run inside Kiln Desktop.",
+            false,
             false
           );
           return;
@@ -135,7 +149,8 @@
           if (!url) {
             showStatus(
               "Kiln server not running.",
-              "Start it from the tray menu, then retry.",
+              "Click Start Server to launch it, or start it from the tray menu.",
+              true,
               true
             );
             return;
@@ -145,12 +160,51 @@
           showStatus(
             "Could not reach Kiln server.",
             String(err || "Unknown error"),
-            true
+            true,
+            false
           );
         }
       }
 
       retry.addEventListener("click", load);
+
+      async function startServerInline() {
+        if (!invoke) {
+          detail.textContent = "Tauri bridge unavailable.";
+          return;
+        }
+        startBtn.disabled = true;
+        startBtn.textContent = "Starting…";
+        retry.classList.add("hidden");
+        try {
+          await invoke("start_server");
+        } catch (err) {
+          detail.textContent = String(err || "Failed to start server.");
+          startBtn.disabled = false;
+          startBtn.textContent = START_LABEL;
+          retry.classList.remove("hidden");
+          return;
+        }
+        const deadline = Date.now() + 10000;
+        while (Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, 500));
+          try {
+            const url = await invoke("get_kiln_url");
+            if (url) {
+              showFrame(url);
+              return;
+            }
+          } catch (_) {
+            // keep polling
+          }
+        }
+        detail.textContent = "Server did not come up in time. Check the log viewer.";
+        startBtn.disabled = false;
+        startBtn.textContent = START_LABEL;
+        retry.classList.remove("hidden");
+      }
+
+      startBtn.addEventListener("click", startServerInline);
 
       const copyBtn = document.getElementById("copy-url");
       const COPY_LABEL = "Copy OpenAI base URL";


### PR DESCRIPTION
## What

When the kiln server isn't running, the dashboard status panel now shows a **Start Server** button alongside Retry. Clicking it calls `invoke(\"start_server\")`, polls `get_kiln_url` every 500ms up to 10s, and loads the iframe once the URL becomes available. On failure or timeout it surfaces the error in the status detail and restores the button.

## Why

The previous state told users to go find the tray icon, start the server, come back to the dashboard, and click Retry. That's three windows of context switching for a one-click action. The server state is already known to this window (it just called `get_kiln_url`), and `start_server` is already a registered Tauri command — the button is a thin wiring of the two.

## Files

- `desktop/ui/dashboard.html` — added `#start-server` button, extended `showStatus()` with a 4th `showStart` arg, added `startServerInline()` handler, wrapped the action buttons in `#status-actions` for consistent spacing.

No Rust changes — `start_server` (desktop/src/main.rs:42) and `get_kiln_url` (desktop/src/main.rs:77) are already `invoke_handler`-registered.

## Validation

Manual review of the HTML/JS change. `cd desktop && cargo check` cannot run in the Cloud Eric sandbox — it fails at `glib-sys` because GTK/webkit2gtk system libs aren't installed and installing system packages is forbidden:

```
The system library \`glib-2.0\` required by crate \`glib-sys\` was not found.
The file \`glib-2.0.pc\` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
```

CI on a real OS will compile. This PR only touches the frontend HTML/JS; Rust code is unchanged.

## UX

Not-running state now reads:

> **Kiln server not running.**
> Click Start Server to launch it, or start it from the tray menu.
> [ Start Server ] [ Retry ]

While starting: button text flips to "Starting…" and disables. On success: iframe loads. On error or 10s timeout: detail text shows the reason, button re-enables, Retry reappears.