### PR TITLE
desktop: status indicator row at top of tray menu

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -11,6 +11,7 @@ use crate::settings::Settings;
 use crate::supervisor::{ServerState, Supervisor};
 
 const TRAY_ID: &str = "kiln-main";
+const ITEM_STATUS: &str = "status";
 const ITEM_DASHBOARD: &str = "open_dashboard";
 const ITEM_SETTINGS: &str = "open_settings";
 const ITEM_START: &str = "start_server";
@@ -18,6 +19,10 @@ const ITEM_STOP: &str = "stop_server";
 const ITEM_LOGS: &str = "view_logs";
 const ITEM_COPY_URL: &str = "copy_openai_url";
 const ITEM_QUIT: &str = "quit";
+
+fn status_menu_text(state: &ServerState) -> String {
+    format!("Status: {}", state_label(state))
+}
 
 const ICON_STOPPED: &[u8] = include_bytes!("../icons/tray/stopped.png");
 const ICON_STARTING: &[u8] = include_bytes!("../icons/tray/starting.png");
@@ -36,6 +41,9 @@ fn state_icon_bytes(state: &ServerState) -> &'static [u8] {
 }
 
 pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result<()> {
+    let status = MenuItemBuilder::with_id(ITEM_STATUS, status_menu_text(&ServerState::Stopped))
+        .enabled(false)
+        .build(app)?;
     let dashboard = MenuItemBuilder::with_id(ITEM_DASHBOARD, "Open Dashboard").build(app)?;
     let settings = MenuItemBuilder::with_id(ITEM_SETTINGS, "Settings…").build(app)?;
     let copy_url =
@@ -48,6 +56,8 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
     let quit = MenuItemBuilder::with_id(ITEM_QUIT, "Quit").build(app)?;
 
     let menu = MenuBuilder::new(app)
+        .item(&status)
+        .separator()
         .items(&[&dashboard, &settings])
         .separator()
         .item(&copy_url)
@@ -109,12 +119,13 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                         copy_openai_base_url_to_clipboard(&app_handle, supervisor).await;
                     });
                 }
+                ITEM_STATUS => {}
                 _ => {}
             }
         })
         .build(app)?;
 
-    spawn_state_watcher(app.clone(), supervisor, start, stop);
+    spawn_state_watcher(app.clone(), supervisor, status, start, stop);
     Ok(())
 }
 
@@ -192,6 +203,7 @@ fn open_logs_window(app: &AppHandle) -> tauri::Result<()> {
 fn spawn_state_watcher(
     app: AppHandle,
     supervisor: Arc<Supervisor>,
+    status_item: MenuItem<tauri::Wry>,
     start_item: MenuItem<tauri::Wry>,
     stop_item: MenuItem<tauri::Wry>,
 ) {
@@ -209,6 +221,7 @@ fn spawn_state_watcher(
                         let _ = tray.set_icon(Some(img));
                     }
                 }
+                let _ = status_item.set_text(status_menu_text(&state));
                 let _ = start_item.set_enabled(start_enabled(&state));
                 let _ = stop_item.set_enabled(stop_enabled(&state));
             }
@@ -295,6 +308,35 @@ mod tests {
         assert!(stop_enabled(&ServerState::TrainingActive));
         assert!(!stop_enabled(&ServerState::Stopped));
         assert!(!stop_enabled(&ServerState::Error("x".into())));
+    }
+
+    #[test]
+    fn status_text_matches_label() {
+        assert_eq!(
+            format!("Status: {}", state_label(&ServerState::Stopped)),
+            "Status: Stopped"
+        );
+        assert_eq!(
+            format!("Status: {}", state_label(&ServerState::Starting)),
+            "Status: Starting…"
+        );
+        assert_eq!(
+            format!("Status: {}", state_label(&ServerState::Running)),
+            "Status: Running"
+        );
+        assert_eq!(
+            format!("Status: {}", state_label(&ServerState::TrainingActive)),
+            "Status: Training"
+        );
+        assert_eq!(
+            format!("Status: {}", state_label(&ServerState::Error("boom".into()))),
+            "Status: Error: boom"
+        );
+        // Helper must match the inline format used by the watcher.
+        assert_eq!(
+            status_menu_text(&ServerState::Running),
+            format!("Status: {}", state_label(&ServerState::Running))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Add a disabled, non-clickable **Status: <state>** item as the first row of the tray menu. Previously the current server state was only surfaced in the tray tooltip, which requires hovering.

## Changes

- `desktop/src/tray.rs`:
  - New `ITEM_STATUS` constant and `status_menu_text(state)` helper that formats as `Status: <label>` using the existing `state_label`.
  - Build a disabled `MenuItem` with initial text `Status: Stopped` and insert it as the first item in the tray menu, followed by a separator.
  - Wire the status item through to `spawn_state_watcher`; on each state transition the watcher calls `status_item.set_text(status_menu_text(&state))`.
  - Defensive no-op match arm for `ITEM_STATUS` in `on_menu_event` (it can't fire while disabled).
  - New unit test `status_text_matches_label` verifies the format for all `ServerState` variants (Stopped / Starting / Running / Training / Error) and that the helper matches the inline format.

## Menu order (now)

1. `Status: <state>` (disabled)
2. ---
3. Open Dashboard, Settings…
4. ---
5. Copy OpenAI Base URL
6. ---
7. Start Server, Stop Server, View Logs
8. ---
9. Quit

## Testing

`cargo check` fails in the Cloud Eric sandbox at `glib-sys` — GTK/webkit2gtk system libs are not available there (expected, see agent note `tauri-cargo-check-gtk-missing`). CI validates on real Ubuntu / Windows runners.

Tail of local `cargo check`:

```
pkg-config exited with status code 1
> PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags glib-2.0 'glib-2.0 >= 2.70'

The system library `glib-2.0` required by crate `glib-sys` was not found.
```

The change is confined to `desktop/src/tray.rs` and does not touch any other crate or platform dependency. All existing tray unit tests remain in place; one new test is added.