### PR TITLE
desktop: copy logs button in log viewer

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -59,6 +59,21 @@ async fn server_logs(sup: State<'_, Arc<Supervisor>>) -> Result<Vec<String>, Str
 }
 
 #[tauri::command]
+async fn copy_logs(
+    app: tauri::AppHandle,
+    sup: State<'_, Arc<Supervisor>>,
+) -> Result<usize, String> {
+    use tauri_plugin_clipboard_manager::ClipboardExt;
+    let lines = sup.logs().await;
+    let text = lines.join("\n");
+    let count = lines.len();
+    app.clipboard()
+        .write_text(text)
+        .map_err(|e| format!("clipboard write failed: {}", e))?;
+    Ok(count)
+}
+
+#[tauri::command]
 async fn get_settings(state: State<'_, SettingsState>) -> Result<Settings, String> {
     Ok(state.read().await.clone())
 }
@@ -170,6 +185,7 @@ fn main() {
             stop_server,
             server_state,
             server_logs,
+            copy_logs,
             get_settings,
             set_settings,
             get_kiln_url,

--- a/desktop/ui/logs.html
+++ b/desktop/ui/logs.html
@@ -58,6 +58,8 @@
         cursor: pointer;
       }
       button:hover { background: #3b7af5; }
+      button#copy.flash { background: #245a32; }
+      button#copy.flash-warn { background: #5a3324; }
       #log {
         flex: 1 1 auto;
         margin: 0;
@@ -82,6 +84,7 @@
     <header>
       <h1>Kiln server logs</h1>
       <label><input type="checkbox" id="autoscroll" checked /> Auto-scroll</label>
+      <button id="copy" type="button" title="Copy all log lines to clipboard">Copy</button>
       <button id="clear" type="button">Clear view</button>
     </header>
     <div id="log" class="empty">(no log lines yet)</div>
@@ -92,6 +95,27 @@
       const logEl = document.getElementById("log");
       const autoscrollEl = document.getElementById("autoscroll");
       const clearEl = document.getElementById("clear");
+      const copyEl = document.getElementById("copy");
+
+      copyEl.addEventListener("click", async () => {
+        if (!invoke) return;
+        try {
+          const count = await invoke("copy_logs");
+          copyEl.textContent = count > 0 ? `Copied (${count} lines)` : "Nothing to copy";
+          copyEl.classList.add("flash");
+          setTimeout(() => {
+            copyEl.textContent = "Copy";
+            copyEl.classList.remove("flash");
+          }, 1500);
+        } catch (err) {
+          copyEl.textContent = "Copy failed";
+          copyEl.classList.add("flash-warn");
+          setTimeout(() => {
+            copyEl.textContent = "Copy";
+            copyEl.classList.remove("flash-warn");
+          }, 1800);
+        }
+      });
 
       // Lines beyond `baseline` are shown. "Clear view" sets baseline to the
       // current line count so the user sees only new lines from then on. The


### PR DESCRIPTION
## What
Add a Copy button to the kiln-desktop log viewer (desktop/ui/logs.html) that copies all buffered server stdout/stderr to the clipboard via a new `copy_logs` Tauri command in desktop/src/main.rs. Mirrors the existing Copy OpenAI Base URL pattern (uses `tauri_plugin_clipboard_manager::ClipboardExt`).

## Why
Users debugging server issues had no quick way to grab or share captured logs — only Auto-scroll and Clear view existed in the log viewer header.

## Test
- `cargo check` runs in CI on Linux + Windows (no GPU needed).
- Local `cargo check` in Cloud Eric fails at glib-sys as expected (missing GTK system libs); CI validates.
- Manual: open Logs window, click Copy, paste — clipboard contains all log lines joined by newline. Button flashes "Copied (N lines)" for 1.5s then restores. On error it flashes "Copy failed" for 1.8s.