### PR TITLE
desktop: View Logs and Settings buttons in dashboard toolbar

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -78,6 +78,16 @@ async fn get_settings(state: State<'_, SettingsState>) -> Result<Settings, Strin
     Ok(state.read().await.clone())
 }
 
+#[tauri::command]
+async fn open_settings(app: AppHandle) -> Result<(), String> {
+    tray::open_settings_window(&app).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn open_logs(app: AppHandle) -> Result<(), String> {
+    tray::open_logs_window(&app).map_err(|e| e.to_string())
+}
+
 /// Build the OpenAI-compatible base URL for a given host/port. Kept as a pure
 /// helper so it can be unit-tested without a Tauri runtime.
 pub fn openai_base_url(host: &str, port: u16) -> String {
@@ -189,7 +199,9 @@ fn main() {
             get_settings,
             set_settings,
             get_kiln_url,
-            get_openai_base_url
+            get_openai_base_url,
+            open_settings,
+            open_logs
         ])
         .run(tauri::generate_context!())
         .expect("error while running kiln-desktop");

--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -140,7 +140,7 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
     Ok(())
 }
 
-fn open_settings_window(app: &AppHandle) -> tauri::Result<()> {
+pub(crate) fn open_settings_window(app: &AppHandle) -> tauri::Result<()> {
     if let Some(win) = app.get_webview_window("settings") {
         win.show()?;
         win.set_focus()?;
@@ -195,7 +195,7 @@ async fn copy_openai_base_url_to_clipboard(app: &AppHandle, supervisor: Arc<Supe
     }
 }
 
-fn open_logs_window(app: &AppHandle) -> tauri::Result<()> {
+pub(crate) fn open_logs_window(app: &AppHandle) -> tauri::Result<()> {
     if let Some(win) = app.get_webview_window("logs") {
         win.show()?;
         win.set_focus()?;

--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -92,6 +92,8 @@
   </head>
   <body>
     <div id="toolbar">
+      <button id="open-logs" title="Open the log viewer window">View Logs</button>
+      <button id="open-settings" title="Open the settings window">Settings</button>
       <button id="copy-url" title="Copy the OpenAI-compatible base URL for this server">Copy OpenAI base URL</button>
     </div>
     <iframe id="frame" class="hidden" title="Kiln UI"></iframe>
@@ -250,6 +252,15 @@
       }
 
       copyBtn.addEventListener("click", copyOpenAiBaseUrl);
+
+      const logsBtn = document.getElementById("open-logs");
+      const settingsBtn = document.getElementById("open-settings");
+      logsBtn.addEventListener("click", async () => {
+        try { await invoke("open_logs"); } catch (e) { console.error("open_logs failed", e); }
+      });
+      settingsBtn.addEventListener("click", async () => {
+        try { await invoke("open_settings"); } catch (e) { console.error("open_settings failed", e); }
+      });
 
       window.addEventListener("DOMContentLoaded", load);
     </script>


### PR DESCRIPTION
Adds two toolbar buttons to the dashboard window so users can open the logs and settings windows without going back to the tray. Both wire to new tauri commands that delegate to the existing window-builders in tray.rs.

## What
- Make tray::open_settings_window and tray::open_logs_window pub(crate)
- Add open_settings and open_logs tauri commands in main.rs
- Add View Logs and Settings buttons to dashboard.html toolbar

## Why
Dashboard toolbar previously only had Copy OpenAI base URL; users had to right-click the tray to reach Settings or View Logs.

## Validation
cargo check was not run locally — the desktop crate's transitive Tauri deps require GTK/webkit2gtk system libs that aren't installed in the Cloud Eric sandbox (per the kiln tauri-cargo-check-gtk-missing pattern). CI on ubuntu-22.04 and windows-latest will validate the build.