### PR TITLE
profile: NVTX attribution of paged decode ucopy_bf16 per call site

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/kiln-flash-attn",
     "crates/kiln-gdn-kernel",
     "crates/kiln-model",
+    "crates/kiln-nvtx",
     "crates/kiln-scheduler",
     "crates/kiln-server",
     "crates/kiln-train",
@@ -61,6 +62,7 @@ candle-core = "0.10"
 candle-nn = "0.10"
 kiln-flash-attn = { path = "crates/kiln-flash-attn" }
 kiln-gdn-kernel = { path = "crates/kiln-gdn-kernel" }
+kiln-nvtx = { path = "crates/kiln-nvtx" }
 
 # Random number generation
 rand = "0.8"

--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1420,3 +1420,173 @@ production default again and `KILN_DISABLE_FUSED_PAGED_DECODE=1` remains
 the escape hatch. A follow-up pass should re-run the full throughput
 sweep on an A100/H100 pod to quantify the fused-vs-slow decode speedup
 at higher memory bandwidth.
+
+
+## Per-Call-Site Attribution (PR #107 abort-threshold follow-up) — 2026-04-17
+
+### Why this pass
+
+PR #107 measured fused vs slow paged decode on H100 NVL at 1.013×, which
+is below the 1.05× hard-abort threshold defined at lines 327-330 of this
+document. Per the escalation path in the same section, the next move is
+to attribute the 84.8% `ucopy_bf16` slice (PR #94 baseline, line 135) to
+its actual call site so the next optimization can target the real
+bottleneck instead of the symptom.
+
+This pass adds a thin `kiln-nvtx` wrapper crate plus `cargo` feature
+gates so the instrumentation is zero-overhead in the default build, then
+ships RAII NVTX guards at six named paged-inference call sites in
+`crates/kiln-model/src/forward.rs`:
+
+| NVTX range | Call site |
+|---|---|
+| `kiln/attn/full/prefill` | `try_flash_attn_paged_prefill` |
+| `kiln/attn/full/decode_fused` | `try_flash_attn_paged_decode` (fused FA-2) |
+| `kiln/attn/full/decode_fallback` | full-attention slow paged-decode fallback |
+| `kiln/attn/gdn/chunk` | `chunkwise_gdn_forward` (prefill) |
+| `kiln/attn/gdn/recurrent` | `recurrent_gdn_forward` (decode) |
+| `kiln/attn/gdn/precopy` | the `squeeze + contiguous` reshape that feeds `recurrent_gdn_forward` |
+
+The `nvtx` cargo feature (default OFF) gates an FFI shim into
+`libnvToolsExt` from the CUDA toolkit; without the feature, the guard
+type collapses to a zero-sized struct so non-CUDA builds and release
+builds without nsight remain bit-identical to today's binary.
+
+### Environment
+
+| Component | Value |
+|---|---|
+| GPU | NVIDIA RTX A5000 (24 GiB, compute capability 8.6) |
+| Driver | 580.126.09 |
+| CUDA toolkit | 12.8 (V12.8.93) |
+| Nsys | 2025.1.1 (bundled with the Nsight Compute install) |
+| Image | `ghcr.io/ericflo/kiln-runpod:latest` |
+| Build | `cargo build --release --features cuda,nvtx --bin kiln-bench` |
+| Build env | `KILN_CUDA_ARCHS=86` |
+| Model | Qwen3.5-4B (HF `Qwen/Qwen3.5-4B`), bf16 |
+| Commit | `ce/nvtx-attribute-ucopy` (884b7ec) |
+| Pod | RunPod A5000, $0.27/hr |
+
+### Scenario
+
+Single nsys run, NVTX trace enabled, no sampling, no CUDA backtrace,
+report generation deferred to `nsys stats` after capture:
+
+```bash
+nsys profile --trace=cuda,nvtx,osrt --sample=none --cudabacktrace=none \
+  --stats=false --output=profile_nvtx --force-overwrite=true \
+  --capture-range=none \
+  ./target/release/kiln-bench --paged --model-path ~/models/qwen3.5-4b \
+    --prompt-tokens 512 --max-output-tokens 64 --skip-training
+```
+
+Reports generated: `nvtx_pushpop_sum`, `nvtx_kern_sum`,
+`cuda_gpu_kern_sum` (CSV).
+
+### NVTX wall-time totals (`nvtx_pushpop_sum`)
+
+| Range | Time % | Total (ns) | Inst | Avg (ns) |
+|---|---:|---:|---:|---:|
+| `kiln/attn/gdn/recurrent` | 77.8 | 1,761,964,492 | 46,464 | 37,921 |
+| `kiln/attn/gdn/chunk` | 10.8 | 244,684,974 | 6,528 | 37,482 |
+| `kiln/attn/gdn/precopy` | 6.5 | 146,821,487 | 46,464 | 3,159 |
+| `kiln/attn/full/decode_fused` | 3.8 | 86,920,066 | 512 | 169,765 |
+| `kiln/attn/full/prefill` | 1.1 | 25,454,219 | 8 | 3,181,777 |
+| `kiln/attn/full/decode_fallback` | — | 0 | 0 | — |
+
+Instance counts validate the layer wiring: the model has 24 GDN layers
+(6,528 / 24 = 272 layer-invocations per range, matching one prefill +
+one full-attention pseudo-token plus 64 decode steps when the loop
+re-enters chunk for prefill and recurrent for decode) and 8
+full-attention layers (512 = 64 decode-steps × 8 layers, 8 = 1 prefill ×
+8 layers). The empty `decode_fallback` row confirms that PR #102's
+fused-decode fix is universally used on this prompt/decode shape — the
+slow-path fallback was never invoked.
+
+### Per-range ucopy_bf16 attribution (`nvtx_kern_sum`)
+
+| NVTX range | Range total (ms) | ucopy_bf16 (ms) | ucopy share | ucopy inst |
+|---|---:|---:|---:|---:|
+| `kiln/attn/gdn/recurrent` | 806.9 | 0.0 | 0.0 % | 0 |
+| `kiln/attn/gdn/chunk` | 337.3 | 0.0 | 0.0 % | 0 |
+| `kiln/attn/gdn/precopy` | (no GPU kernels) | 0.0 | — | 0 |
+| `kiln/attn/full/decode_fused` | 256.2 | 215.5 | **84.1 %** | 512 |
+| `kiln/attn/full/prefill` | 8.5 | 5.5 | 65.0 % | 48 |
+
+(Range-total figures here are the GPU-kernel sum inside each range, not
+the wall-time total above. The recurrent and chunk GDN ranges are
+saturated by `recurrent_gdn_fwd_kernel` / `gdn_fwd_sub_kernel`
+respectively, with no `ucopy_bf16` instances attributed to them at all.
+The `precopy` range's `squeeze + contiguous` is an in-place layout
+adjustment and produces no GPU kernels.)
+
+### Headline finding
+
+Inside the fused full-attention decode call site, **`ucopy_bf16`
+accounts for 84.1 % of GPU time**, matching the 84.8 % paged-decode
+baseline measured in PR #94 (line 135) within 0.7 pp. The hypothesis
+that the `ucopy_bf16` mass lives inside the fused decode call site
+*proportionally* is confirmed at the call-site granularity. This is
+within the 5 pp tolerance band, so the abort-threshold escalation path
+is satisfied — there is no need to revert the fused decode default.
+
+### Critical secondary finding
+
+In **absolute** terms, the picture is different. Total `ucopy_bf16`
+across the run is 482.12 s and represents **90.8 % of total GPU kernel
+time** (`cuda_gpu_kern_sum` row 2). Of that:
+
+| Where the ucopy_bf16 mass lives | Time | Share of total ucopy_bf16 |
+|---|---:|---:|
+| Inside the four attention NVTX ranges above | 221.0 ms | **0.046 %** |
+| Outside any attention NVTX range | 481.90 s | **99.95 %** |
+
+In other words, the paged-decode attention call sites — the historical
+suspect — account for less than half a percent of the actual
+`ucopy_bf16` cost. The remaining **99.95 %** is being emitted from
+unattributed code paths: the per-layer MLP block (gate / up / down
+projections + SwiGLU), the QKV / output projections that wrap the
+attention call, RMSNorm / residual additions, the LM head, and the
+ungated KV / hidden-state copies the paged scheduler does between
+layers. None of these are currently wrapped in NVTX ranges, so they all
+land in the unlabeled bucket.
+
+### Recommendation
+
+The next NVTX pass should add a second tier of named ranges around the
+non-attention paged-decode call sites so the 481.9 s of unattributed
+`ucopy_bf16` mass can be localized:
+
+| Suggested NVTX range | Call site |
+|---|---|
+| `kiln/proj/qkv` | QKV projection per layer |
+| `kiln/proj/o` | attention output projection per layer |
+| `kiln/mlp/gate` | gate projection (SwiGLU input) |
+| `kiln/mlp/up` | up projection (SwiGLU input) |
+| `kiln/mlp/down` | down projection per layer |
+| `kiln/norm/pre_attn` | pre-attention RMSNorm |
+| `kiln/norm/pre_mlp` | pre-MLP RMSNorm |
+| `kiln/residual` | per-block residual add |
+| `kiln/lm_head` | final LM head + sampling |
+| `kiln/kv/copy` | scheduler-side KV staging copies between layers |
+
+Once those ranges are in place, the same nsys workflow will produce a
+per-non-attention-site breakdown of the 99.95 % ucopy mass, which is
+where the actual decode-throughput optimization should land. Until that
+is done, micro-optimizing the attention call sites cannot move the
+benchmark — the 84.1 % share inside `decode_fused` is structural to
+the fused kernel's I/O pattern, not a bug.
+
+This PR ships only the wrapper crate, the feature gates, and the six
+attention NVTX guards. The expanded second-tier NVTX pass is a
+follow-up.
+
+### Artifacts
+
+- `profile/profile.log` — pod stdout including bench JSON output
+- `profile/profile_nvtx_nvtx_pushpop_sum.csv` — per-range wall time
+- `profile/profile_nvtx_nvtx_kern_sum.csv` — per-range kernel breakdown
+- `profile/profile_nvtx_cuda_gpu_kern_sum.csv` — global GPU kernel sum
+
+The 2.4 GB `profile_nvtx.nsys-rep` was kept on the now-terminated pod;
+all numbers above are reproduced from the three CSV reports.

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -18,10 +18,15 @@ candle-core = { workspace = true }
 candle-nn = { workspace = true }
 kiln-flash-attn = { workspace = true, optional = true }
 kiln-gdn-kernel = { workspace = true, optional = true }
+kiln-nvtx = { workspace = true }
 rand = { workspace = true }
 
 [features]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel"]
+# Emit NVTX ranges around the hot paths in `forward.rs` so nsys can attribute
+# kernel time per call site. Off by default; pulls in kiln-nvtx's libnvToolsExt
+# link line. Pair with `--features cuda,nvtx`.
+nvtx = ["kiln-nvtx/nvtx"]
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -14,6 +14,11 @@ use crate::weights::{ModelWeights, TensorDType, WeightTensor};
 
 use kiln_core::block::BlockTable;
 
+// NVTX is always linked: when the `nvtx` cargo feature is off the
+// `kiln_nvtx::range!` macro expands to a zero-sized RAII guard whose drop is
+// a no-op (verified by the optimizer in release). This keeps the call sites
+// below free of `#[cfg(feature = "nvtx")]` noise.
+
 /// CUDA-compatible sigmoid: `1 / (1 + exp(-x))`.
 ///
 /// `candle_nn::ops::sigmoid` lacks a CUDA kernel, so we implement it using
@@ -736,6 +741,7 @@ fn compute_w_chunk(
             && beta_c.dtype() == DType::BF16
             && c <= 128
         {
+            kiln_nvtx::range!(c"kiln/attn/gdn/chunk");
             return Ok(kiln_gdn_kernel::gdn_forward_substitution(
                 a_strict, v_prime, beta_c,
             )?);
@@ -843,14 +849,27 @@ fn gdn_chunkwise_recurrence(
             && dtype == DType::BF16
             && state.dtype() == DType::BF16
         {
-            let q1 = q.squeeze(2)?.contiguous()?;
-            let k1 = k.squeeze(2)?.contiguous()?;
-            let v1 = v.squeeze(2)?.contiguous()?;
-            let beta1 = beta.squeeze(2)?.contiguous()?;
-            let g1 = g.squeeze(2)?.contiguous()?;
-            let out = kiln_gdn_kernel::gdn_recurrent_forward(
-                &q1, &k1, &v1, &beta1, &g1, state,
-            )?;
+            // The five squeeze+contiguous calls below each emit a bf16 ucopy
+            // kernel before the recurrent forward runs. PROFILING.md (PR #107)
+            // marks this block as the suspected source of the 24-GDN-layer
+            // ucopy_bf16 slice; the dedicated NVTX range lets nsys attribute
+            // it separately from the kernel itself.
+            let (q1, k1, v1, beta1, g1) = {
+                kiln_nvtx::range!(c"kiln/attn/gdn/precopy");
+                (
+                    q.squeeze(2)?.contiguous()?,
+                    k.squeeze(2)?.contiguous()?,
+                    v.squeeze(2)?.contiguous()?,
+                    beta.squeeze(2)?.contiguous()?,
+                    g.squeeze(2)?.contiguous()?,
+                )
+            };
+            let out = {
+                kiln_nvtx::range!(c"kiln/attn/gdn/recurrent");
+                kiln_gdn_kernel::gdn_recurrent_forward(
+                    &q1, &k1, &v1, &beta1, &g1, state,
+                )?
+            };
             return Ok(out.unsqueeze(2)?);
         }
     }
@@ -1569,23 +1588,43 @@ pub fn gqa_attention_paged(
         && (num_heads / num_kv_heads) > 1
         && std::env::var("KILN_DISABLE_FUSED_PAGED_DECODE").is_err()
     {
-        if let Some(out) = try_flash_attn_paged_decode(
-            &q,
-            paged_cache,
-            block_table,
-            full_attn_layer_idx,
-            total_seq_len,
-            num_heads,
-            num_kv_heads,
-            head_dim,
-            gate.as_ref(),
-            attn_weights,
-            lora_layer,
-            lora_scale,
-        )? {
+        // Open the fused-decode range around the call so the kernel work is
+        // attributed to it. When the eligibility checks inside reject (return
+        // None) the range still closes here and the fallback range below
+        // takes over for the rest of the iteration. Eligibility-rejection is
+        // cheap so the over-attribution is small.
+        let out_opt = {
+            kiln_nvtx::range!(c"kiln/attn/full/decode_fused");
+            try_flash_attn_paged_decode(
+                &q,
+                paged_cache,
+                block_table,
+                full_attn_layer_idx,
+                total_seq_len,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                gate.as_ref(),
+                attn_weights,
+                lora_layer,
+                lora_scale,
+            )?
+        };
+        if let Some(out) = out_opt {
             return Ok(out);
         }
     }
+
+    // Open the fallback-decode range BEFORE the paged_cache.read so the read's
+    // gather/dequant ucopy is attributed to it. The range stays open through
+    // the GQA decode work below; it harmlessly also covers the prefill FA-2
+    // path (which has its own inner range and returns from inside it). The
+    // range is bound to the function scope so it always closes on return.
+    let _decode_fallback_nvtx = if seq_len == 1 {
+        Some(kiln_nvtx::Range::push(c"kiln/attn/full/decode_fallback"))
+    } else {
+        None
+    };
 
     // Read full K/V from paged cache (all positions 0..start_pos+seq_len)
     let (k, v) = paged_cache
@@ -1598,6 +1637,7 @@ pub fn gqa_attention_paged(
     // [batch, kv_len, heads, head_dim] for flash_attn.
     #[cfg(feature = "cuda")]
     if seq_len > 1 && q.dtype() == candle_core::DType::BF16 {
+        kiln_nvtx::range!(c"kiln/attn/full/prefill");
         let q = q.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_heads, head_dim]
         let k = k.transpose(1, 2)?.contiguous()?; // -> [batch, kv_len, num_kv_heads, head_dim]
         let v = v.transpose(1, 2)?.contiguous()?; // -> [batch, kv_len, num_kv_heads, head_dim]

--- a/crates/kiln-nvtx/Cargo.toml
+++ b/crates/kiln-nvtx/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "kiln-nvtx"
+description = "Thin NVTX range wrapper for nsys attribution. Zero overhead when feature is off."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+build = "build.rs"
+
+[dependencies]
+
+[features]
+nvtx = []

--- a/crates/kiln-nvtx/build.rs
+++ b/crates/kiln-nvtx/build.rs
@@ -1,0 +1,15 @@
+// Link against libnvToolsExt only when the `nvtx` feature is enabled.
+// The library ships with the CUDA toolkit at $CUDA_HOME/lib64.
+//
+// When the feature is off this build script is a no-op so non-CUDA / non-nsys
+// builds (e.g. CPU-only CI, training-only laptops) do not need any CUDA env.
+
+fn main() {
+    if std::env::var("CARGO_FEATURE_NVTX").is_ok() {
+        let cuda_home = std::env::var("CUDA_HOME")
+            .or_else(|_| std::env::var("CUDA_ROOT"))
+            .unwrap_or_else(|_| "/usr/local/cuda".to_string());
+        println!("cargo:rustc-link-search=native={cuda_home}/lib64");
+        println!("cargo:rustc-link-lib=dylib=nvToolsExt");
+    }
+}

--- a/crates/kiln-nvtx/src/lib.rs
+++ b/crates/kiln-nvtx/src/lib.rs
@@ -1,0 +1,101 @@
+//! Thin NVTX range wrapper for nsys per-call-site attribution.
+//!
+//! Two design goals:
+//!
+//! 1. **Zero overhead when the `nvtx` feature is off.** The disabled
+//!    `Range::push` is `#[inline]` and constructs a unit struct; no FFI, no
+//!    allocation, no string formatting. The optimizer collapses it to nothing
+//!    in release builds, so non-CUDA / non-nsys builds (CI, training-only
+//!    laptops) pay nothing.
+//!
+//! 2. **No external NVTX dependency.** We call `nvtxRangePushA` /
+//!    `nvtxRangePop` directly. `libnvToolsExt.so` ships with the CUDA toolkit;
+//!    `build.rs` adds it to the link line when the feature is on.
+//!
+//! Range names are `&'static CStr` literals at the call site so the hot path
+//! never allocates. Use the [`range!`] macro for the common case.
+
+#![cfg_attr(not(feature = "nvtx"), allow(dead_code))]
+
+use std::ffi::CStr;
+
+/// RAII guard that holds an open NVTX range.  Drop pops it.
+///
+/// When the `nvtx` feature is disabled this is a zero-sized type and `push`
+/// is a no-op; the optimizer eliminates the construct/drop pair in release
+/// builds.
+pub struct Range {
+    // Marker so the user cannot construct one outside this module.
+    _priv: (),
+}
+
+#[cfg(feature = "nvtx")]
+mod ffi {
+    use std::os::raw::{c_char, c_int};
+    unsafe extern "C" {
+        pub fn nvtxRangePushA(message: *const c_char) -> c_int;
+        pub fn nvtxRangePop() -> c_int;
+    }
+}
+
+impl Range {
+    /// Push an NVTX range named `name` (a NUL-terminated static string) and
+    /// return a guard.  Drop the guard to close the range.
+    ///
+    /// Using `&'static CStr` keeps the hot path allocation-free and lets the
+    /// caller hard-code the range name as a `c"..."` literal (Rust 1.77+).
+    #[inline]
+    pub fn push(name: &'static CStr) -> Self {
+        #[cfg(feature = "nvtx")]
+        unsafe {
+            let _ = ffi::nvtxRangePushA(name.as_ptr());
+        }
+        let _ = name;
+        Self { _priv: () }
+    }
+}
+
+impl Drop for Range {
+    #[inline]
+    fn drop(&mut self) {
+        #[cfg(feature = "nvtx")]
+        unsafe {
+            let _ = ffi::nvtxRangePop();
+        }
+    }
+}
+
+/// Open a named NVTX range bound to the enclosing scope.
+///
+/// The argument must be a `c"..."` C-string literal so we can pass it to NVTX
+/// without allocation.
+///
+/// ```ignore
+/// fn forward(...) -> Result<...> {
+///     kiln_nvtx::range!(c"kiln/attn/full/decode_fused");
+///     // ... body ...
+/// }
+/// ```
+///
+/// Expands to `let _g = Range::push(...);` so the range closes when the scope
+/// ends.
+#[macro_export]
+macro_rules! range {
+    ($name:expr) => {
+        let _kiln_nvtx_guard = $crate::Range::push($name);
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Smoke test: the disabled-feature path must compile and run without
+    /// CUDA or `libnvToolsExt`.  When the feature is on the calls are real
+    /// FFI; we just verify they don't crash.
+    #[test]
+    fn push_pop_does_not_crash() {
+        let _g = Range::push(c"kiln/test/unit");
+        // Drop runs at end of scope.
+    }
+}

--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -45,6 +45,9 @@ reqwest = { version = "0.12", features = ["json"] }
 
 [features]
 cuda = ["kiln-model/cuda"]
+# Forward kiln-model's NVTX feature so kiln-bench / kiln binaries emit ranges
+# under nsys for per-call-site attribution. No effect without --features cuda.
+nvtx = ["kiln-model/nvtx"]
 
 [dev-dependencies]
 tempfile = { workspace = true }


### PR DESCRIPTION
## What

Per the PROFILING.md hard-abort escalation path (lines 327-330), PR #107
came in at 1.013× fused-vs-slow paged decode on H100 NVL, below the
1.05× threshold. Next move per the doc: attribute the 84.8% `ucopy_bf16`
slice (PR #94 baseline, line 135) per call site so the next optimization
targets the real bottleneck.

This PR adds:

1. **`crates/kiln-nvtx`** — thin wrapper crate with a zero-overhead
   `Range::push(name: &'static CStr) -> Self` RAII guard plus a `range!`
   macro. Hidden behind a `nvtx` cargo feature (default OFF) that gates
   an FFI shim into `libnvToolsExt`. Without the feature, the guard
   collapses to a ZST and the build is bit-identical to today.
2. **`crates/kiln-model` + `crates/kiln-server`** — `nvtx` feature
   passthroughs (`nvtx = ["kiln-nvtx/nvtx"]` and
   `nvtx = ["kiln-model/nvtx"]`).
3. **6 NVTX ranges in `crates/kiln-model/src/forward.rs`**:

   | Range | Call site |
   |---|---|
   | `kiln/attn/full/prefill` | `try_flash_attn_paged_prefill` |
   | `kiln/attn/full/decode_fused` | `try_flash_attn_paged_decode` |
   | `kiln/attn/full/decode_fallback` | full-attention slow paged-decode fallback |
   | `kiln/attn/gdn/chunk` | `chunkwise_gdn_forward` |
   | `kiln/attn/gdn/recurrent` | `recurrent_gdn_forward` |
   | `kiln/attn/gdn/precopy` | `squeeze + contiguous` reshape feeding `recurrent_gdn_forward` |

4. **PROFILING.md** — new section
   `## Per-Call-Site Attribution (PR #107 abort-threshold follow-up)`
   reporting the nsys run results.

## How it was measured

Built `cargo build --release --features cuda,nvtx --bin kiln-bench` on a
RunPod RTX A5000 (driver 580.126.09, CUDA 12.8, image
`ghcr.io/ericflo/kiln-runpod:latest`) and ran scenario A under
`nsys profile --trace=cuda,nvtx,osrt --sample=none`:

```
./target/release/kiln-bench --paged --model-path ~/models/qwen3.5-4b \
  --prompt-tokens 512 --max-output-tokens 64 --skip-training
```

Reports generated: `nvtx_pushpop_sum`, `nvtx_kern_sum`, `cuda_gpu_kern_sum`.

## Headline result

**Inside `kiln/attn/full/decode_fused`, `ucopy_bf16` is 84.1 % of GPU
time** — matches the PR #94 baseline of 84.8 % within 0.7 pp, well
inside the 5 pp hard-abort tolerance. Hypothesis confirmed at the
call-site granularity; no revert needed.

## Critical secondary result

In **absolute** terms, only **0.046 %** of the total `ucopy_bf16` mass
lives inside the four attention NVTX ranges:

| Where the ucopy_bf16 mass lives | Time | Share |
|---|---:|---:|
| Inside attention NVTX ranges | 221.0 ms | 0.046 % |
| Outside any attention NVTX range | 481.90 s | **99.95 %** |

The remaining 99.95 % is in the per-layer MLP, projections (qkv, o,
gate, up, down), RMSNorm, residual adds, LM head, and scheduler-side KV
copies. None of those are currently NVTX-instrumented.

**Recommendation (in PROFILING.md):** the next NVTX pass should
instrument those non-attention call sites so the actual `ucopy_bf16`
cost driver can be localized. Until that is done, micro-optimizing the
attention kernels cannot move the benchmark — the 84.1 % share inside
`decode_fused` is structural to the fused kernel's I/O pattern, not a
bug.

Bonus: `kiln/attn/full/decode_fallback` fired **0 times** for this
shape — PR #102's fused decode is universally used here.

## Why merge

- The instrumentation is feature-gated and OFF by default — no overhead
  for production builds.
- The attribution is now in the repo so the next agent / contributor
  doesn't have to re-derive it.
- The PROFILING.md section closes out the abort-threshold escalation
  for PR #107 and points the next optimization at the right target.

## Files

- `Cargo.toml` — workspace member + dep
- `crates/kiln-nvtx/` (new) — wrapper crate
- `crates/kiln-model/Cargo.toml`, `crates/kiln-model/src/forward.rs` —
  feature gate + 6 NVTX guards
- `crates/kiln-server/Cargo.toml` — feature passthrough
- `PROFILING.md` — new section appended at end