### PR TITLE
desktop: Restart now button in Settings after save

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -49,6 +49,11 @@ async fn stop_server(sup: State<'_, Arc<Supervisor>>) -> Result<(), String> {
 }
 
 #[tauri::command]
+async fn restart_server(sup: State<'_, Arc<Supervisor>>) -> Result<(), String> {
+    sup.restart().await
+}
+
+#[tauri::command]
 async fn server_state(sup: State<'_, Arc<Supervisor>>) -> Result<ServerState, String> {
     Ok(sup.state().await)
 }
@@ -193,6 +198,7 @@ fn main() {
         .invoke_handler(tauri::generate_handler![
             start_server,
             stop_server,
+            restart_server,
             server_state,
             server_logs,
             copy_logs,

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -148,6 +148,7 @@
 
       <div class="actions">
         <button class="secondary" id="reload">Reload</button>
+        <button class="secondary" id="restart" hidden>Restart now</button>
         <button id="save">Save</button>
       </div>
       <div class="status" id="status"></div>
@@ -157,6 +158,7 @@
       const invoke = window.__TAURI__.core.invoke;
       const dialog = window.__TAURI__.dialog;
       const statusEl = document.getElementById("status");
+      const restartBtn = document.getElementById("restart");
 
       const fields = [
         "kiln_binary", "model_path", "host", "port",
@@ -221,10 +223,16 @@
         statusEl.className = err ? "status error" : "status";
       }
 
+      function hideRestart() {
+        restartBtn.hidden = true;
+        restartBtn.disabled = false;
+      }
+
       async function load() {
         try {
           const s = await invoke("get_settings");
           writeForm(s);
+          hideRestart();
           setStatus("Loaded.");
         } catch (e) {
           setStatus("Failed to load: " + e, true);
@@ -234,14 +242,43 @@
       async function save() {
         try {
           await invoke("set_settings", { new: readForm() });
-          setStatus("Saved. New settings apply on next Start.");
+          let running = false;
+          try {
+            const state = await invoke("server_state");
+            const kind = state && state.kind;
+            running = kind === "Starting" || kind === "Running" || kind === "TrainingActive";
+          } catch (e) {
+            // If state lookup fails, fall back to the no-restart message.
+          }
+          if (running) {
+            setStatus("Saved. Restart server to apply new settings.");
+            restartBtn.hidden = false;
+            restartBtn.disabled = false;
+          } else {
+            hideRestart();
+            setStatus("Saved. New settings apply on next Start.");
+          }
         } catch (e) {
           setStatus("Save failed: " + e, true);
         }
       }
 
+      async function restart() {
+        restartBtn.disabled = true;
+        setStatus("Restarting…");
+        try {
+          await invoke("restart_server");
+          hideRestart();
+          setStatus("Restarted. New settings are now applied.");
+        } catch (e) {
+          restartBtn.disabled = false;
+          setStatus("Restart failed: " + e, true);
+        }
+      }
+
       document.getElementById("reload").addEventListener("click", load);
       document.getElementById("save").addEventListener("click", save);
+      restartBtn.addEventListener("click", restart);
       document.getElementById("pick_kiln_binary").addEventListener("click", () =>
         pickPath("kiln_binary", { multiple: false, directory: false, title: "Select kiln binary" })
       );


### PR DESCRIPTION
## What
Adds an inline "Restart now" button to the Settings window that appears after a successful save when the kiln server is running. Previously users had to open the tray menu and hit Restart to apply new settings.

## Why
UX polish — the most common reason to open Settings is to change a value and want it to take effect. Requiring a round-trip through the tray menu is friction.

## Changes
- `desktop/src/main.rs`: new `restart_server` Tauri command wrapping `Supervisor::restart()`, registered in `invoke_handler!`
- `desktop/ui/settings.html`: post-save check of `server_state`; reveal Restart button and update status when server is running; handler invokes `restart_server`

## Behavior
- Server stopped/error: status = "Saved. New settings apply on next Start." (unchanged)
- Server running/starting/training: status = "Saved. Restart server to apply new settings." + inline Restart now button
- Click Restart now → button disables, status "Restarting…", then "Restarted. New settings are now applied." on success
- Restart button stays hidden on initial load and after Reload

## Validation
- `cargo check --manifest-path desktop/Cargo.toml` fails in Cloud Eric at `gobject-sys` build (GTK/webkit2gtk system libs unavailable — expected per known limitation). CI on ubuntu-22.04 + windows-latest validates the full build.