### PR TITLE
desktop: Save logs to file

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -79,6 +79,18 @@ async fn copy_logs(
 }
 
 #[tauri::command]
+async fn save_logs_to_file(
+    path: String,
+    sup: State<'_, Arc<Supervisor>>,
+) -> Result<usize, String> {
+    let lines = sup.logs().await;
+    let count = lines.len();
+    let text = lines.join("\n");
+    std::fs::write(&path, text).map_err(|e| format!("write failed: {}", e))?;
+    Ok(count)
+}
+
+#[tauri::command]
 async fn get_settings(state: State<'_, SettingsState>) -> Result<Settings, String> {
     Ok(state.read().await.clone())
 }
@@ -202,6 +214,7 @@ fn main() {
             server_state,
             server_logs,
             copy_logs,
+            save_logs_to_file,
             get_settings,
             set_settings,
             get_kiln_url,

--- a/desktop/ui/logs.html
+++ b/desktop/ui/logs.html
@@ -79,8 +79,8 @@
         cursor: pointer;
       }
       button:hover { background: #3b7af5; }
-      button#copy.flash { background: #245a32; }
-      button#copy.flash-warn { background: #5a3324; }
+      button#copy.flash, button#save.flash { background: #245a32; }
+      button#copy.flash-warn, button#save.flash-warn { background: #5a3324; }
       #log {
         flex: 1 1 auto;
         margin: 0;
@@ -108,6 +108,7 @@
       <input type="search" id="filter" placeholder="Filter…" autocomplete="off" spellcheck="false" />
       <span id="filter-count" class="hidden"></span>
       <button id="copy" type="button" title="Copy all log lines to clipboard">Copy</button>
+      <button id="save" type="button" title="Save all log lines to a file">Save…</button>
       <button id="clear" type="button">Clear view</button>
     </header>
     <div id="log" class="empty">(no log lines yet)</div>
@@ -119,6 +120,7 @@
       const autoscrollEl = document.getElementById("autoscroll");
       const clearEl = document.getElementById("clear");
       const copyEl = document.getElementById("copy");
+      const saveEl = document.getElementById("save");
       const filterEl = document.getElementById("filter");
       const filterCountEl = document.getElementById("filter-count");
 
@@ -142,6 +144,36 @@
             copyEl.textContent = "Copy";
             copyEl.classList.remove("flash-warn");
           }, 1800);
+        }
+      });
+
+      saveEl.addEventListener("click", async () => {
+        if (!invoke) return;
+        try {
+          const dialog = window.__TAURI__ && window.__TAURI__.dialog;
+          if (!dialog) {
+            throw new Error("dialog plugin unavailable");
+          }
+          const ts = new Date().toISOString().replace(/[:.]/g, "-").replace("T", "_").slice(0, 19);
+          const path = await dialog.save({
+            defaultPath: `kiln-logs-${ts}.log`,
+            filters: [{ name: "Log files", extensions: ["log", "txt"] }],
+          });
+          if (!path) return;
+          const count = await invoke("save_logs_to_file", { path });
+          saveEl.textContent = count > 0 ? `Saved (${count} lines)` : "Nothing to save";
+          saveEl.classList.add("flash");
+          setTimeout(() => {
+            saveEl.textContent = "Save…";
+            saveEl.classList.remove("flash");
+          }, 1800);
+        } catch (err) {
+          saveEl.textContent = "Save failed";
+          saveEl.classList.add("flash-warn");
+          setTimeout(() => {
+            saveEl.textContent = "Save…";
+            saveEl.classList.remove("flash-warn");
+          }, 2400);
         }
       });
 


### PR DESCRIPTION
## What
Adds a "Save…" button to the Logs window that prompts a native save dialog and writes the captured stdout/stderr to a `.log`/`.txt` file.

## Why
Clipboard copy works for short captures, but for long-running sessions or bug reports a real file is the standard expectation — easier to attach and avoids clipboard size truncation.

## Implementation
- New `save_logs_to_file(path)` Tauri command in `desktop/src/main.rs` — writes the supervisor's full ring buffer (joined with newlines) to the chosen path via `std::fs::write`. Mirrors the existing `copy_logs` shape.
- Registered the command in `invoke_handler!` alongside `copy_logs`.
- New `Save…` button in `desktop/ui/logs.html` next to the existing `Copy` button. Click handler opens `window.__TAURI__.dialog.save({ defaultPath: 'kiln-logs-<ts>.log', filters: [{ name: 'Log files', extensions: ['log', 'txt'] }] })`, then invokes `save_logs_to_file`. Same flash / flash-warn UX as Copy.
- CSS `.flash` / `.flash-warn` rules extended to also target `#save`.
- No new permissions needed — `dialog:default` (in `desktop/capabilities/default.json`) already grants `dialog:allow-save`, and the actual file write happens in Rust via `std::fs`, so no `fs` permission is required.

## Scope
- Saves the full unfiltered ring buffer (matches existing Copy semantics). A "save filtered view" mode is intentionally out of scope.

## Test
- `cargo check` cannot run in the Cloud Eric sandbox (crates.io SSL cert error from this network); GitHub Actions CI validates the build on Linux + Windows.
- Manual: open the Logs window, click `Save…`, pick a path, verify the file contents match the visible (unfiltered) log buffer and the button confirms `Saved (N lines)`.