### PR TITLE
perf: precompute embed_tokens.t() once at load (PR #113 lm_head hotspot)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -108,6 +108,10 @@ fn flash_attention_forward(
 pub struct GpuWeights {
     /// Token embedding table: [vocab_size, hidden_size]
     pub embed_tokens: Tensor,
+    /// Pre-transposed token embedding table for tied LM head: [hidden_size, vocab_size], contiguous.
+    /// Computed once at load to avoid re-transposing the ~778 MiB bf16 matrix on every decode step
+    /// (was 48% of ucopy_bf16 / ~43% of GPU time per PR #113 profile).
+    pub embed_tokens_t: Tensor,
     /// Per-layer weights
     pub layers: Vec<GpuLayerWeights>,
     /// Final RMSNorm weight: [hidden_size]
@@ -241,6 +245,11 @@ impl GpuWeights {
     ) -> Result<Self> {
         let embed_tokens =
             weight_to_tensor(&weights.embedding.embed_tokens, device).context("embed_tokens")?;
+        let embed_tokens_t = embed_tokens
+            .t()
+            .context("embed_tokens transpose")?
+            .contiguous()
+            .context("embed_tokens transpose contiguous")?;
         let final_norm = weight_to_tensor(&weights.final_norm, device).context("final_norm")?;
         let rotary_inv_freq =
             compute_rotary_inv_freq(config.rotary_dim(), config.rope_theta, device)
@@ -302,6 +311,7 @@ impl GpuWeights {
 
         Ok(Self {
             embed_tokens,
+            embed_tokens_t,
             layers,
             final_norm,
             rotary_inv_freq,
@@ -2132,7 +2142,7 @@ pub fn model_forward(
     let logits = {
         kiln_nvtx::range!(c"kiln/lm_head");
         hidden = rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?;
-        hidden.broadcast_matmul(&weights.embed_tokens.t()?)?
+        hidden.broadcast_matmul(&weights.embed_tokens_t)?
     };
 
     Ok(logits)
@@ -2261,7 +2271,7 @@ pub fn model_forward_head(
 ) -> Result<Tensor> {
     kiln_nvtx::range!(c"kiln/lm_head");
     let normed = rms_norm(hidden, &weights.final_norm, config.rms_norm_eps)?;
-    let logits = normed.broadcast_matmul(&weights.embed_tokens.t()?)?;
+    let logits = normed.broadcast_matmul(&weights.embed_tokens_t)?;
     Ok(logits)
 }
 
@@ -2385,7 +2395,7 @@ pub fn model_forward_paged(
     let logits = {
         kiln_nvtx::range!(c"kiln/lm_head");
         hidden = rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?;
-        hidden.broadcast_matmul(&weights.embed_tokens.t()?)?
+        hidden.broadcast_matmul(&weights.embed_tokens_t)?
     };
 
     Ok(logits)
@@ -2923,6 +2933,7 @@ mod tests {
         };
 
         let embed_tokens = randn(&[vocab_size, hidden_size])?;
+        let embed_tokens_t = embed_tokens.t()?.contiguous()?;
         let final_norm = Tensor::zeros(hidden_size, DType::F32, device)?;
 
         let mut layers = Vec::with_capacity(num_layers);
@@ -2952,6 +2963,7 @@ mod tests {
 
         Ok(GpuWeights {
             embed_tokens,
+            embed_tokens_t,
             layers,
             final_norm,
             rotary_inv_freq,
@@ -3248,6 +3260,7 @@ mod tests {
         };
 
         let embed_tokens = randn(&[vocab_size, hidden_size])?;
+        let embed_tokens_t = embed_tokens.t()?.contiguous()?;
         let final_norm = Tensor::zeros(hidden_size, DType::F32, device)?;
 
         // For linear attention: nk heads with key_head_dim, nv heads with value_head_dim
@@ -3303,6 +3316,7 @@ mod tests {
 
         Ok(GpuWeights {
             embed_tokens,
+            embed_tokens_t,
             layers,
             final_norm,
             rotary_inv_freq,

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1057,6 +1057,7 @@ mod tests {
         let head_dim = config.head_dim;
 
         let embed = Tensor::randn(0.0_f32, 0.02, (vocab, h), device).unwrap();
+        let embed_t = embed.t().unwrap().contiguous().unwrap();
         let final_norm = Tensor::zeros((h,), candle_core::DType::F32, device).unwrap();
 
         let layer = crate::forward::GpuLayerWeights {
@@ -1092,6 +1093,7 @@ mod tests {
 
         GpuWeights {
             embed_tokens: embed,
+            embed_tokens_t: embed_t,
             layers: vec![layer],
             final_norm,
             rotary_inv_freq,

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -54,6 +54,7 @@ fn tiny_weights(config: &ModelConfig, device: &Device) -> GpuWeights {
     let head_dim = config.head_dim;
 
     let embed = Tensor::randn(0.0_f32, 0.02, (vocab, h), device).unwrap();
+    let embed_t = embed.t().unwrap().contiguous().unwrap();
     let final_norm = Tensor::zeros((h,), DType::F32, device).unwrap();
 
     let layer = GpuLayerWeights {
@@ -83,6 +84,7 @@ fn tiny_weights(config: &ModelConfig, device: &Device) -> GpuWeights {
 
     GpuWeights {
         embed_tokens: embed,
+        embed_tokens_t: embed_t,
         layers: vec![layer],
         final_norm,
         rotary_inv_freq,

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -1422,6 +1422,7 @@ mod tests {
         let vocab = config.vocab_size;
 
         let embed_tokens = Tensor::randn(0.0f32, 0.02, (vocab, h), device)?;
+        let embed_tokens_t = embed_tokens.t()?.contiguous()?;
         let final_norm = Tensor::zeros(h, DType::F32, device)?; // (1+w)*x, so zeros = identity
 
         let mut layers = Vec::new();
@@ -1479,6 +1480,7 @@ mod tests {
 
         Ok(GpuWeights {
             embed_tokens,
+            embed_tokens_t,
             layers,
             final_norm,
             rotary_inv_freq,


### PR DESCRIPTION
## Summary

Cache the transposed tied embedding matrix on `GpuWeights` once at load so the LM head matmul reuses it every decode step instead of rematerializing the ~778 MiB bf16 transpose on every token.

## Why

PR #113 tier-2 NVTX attribution showed `kiln/lm_head` was **48.06% of ucopy_bf16** (206.77s of 430.27s) on the decode bench — ~43% of total GPU time. The 1,970 × ~105 ms invocations match the cost of rebuilding the tied `[vocab=151936, hidden=2560]` bf16 transpose per token.

## Changes

- Add `embed_tokens_t: Tensor` field to `GpuWeights` (computed once in `from_model_weights` via `embed_tokens.t()?.contiguous()?`).
- Replace 3 `weights.embed_tokens.t()?` call sites in `crates/kiln-model/src/forward.rs` (decode + prefill + GDN paths) with `&weights.embed_tokens_t`.
- Update `GpuWeights` struct literals in:
  - `crates/kiln-model/src/generate.rs`
  - `crates/kiln-server/tests/real_model_integration.rs`
  - `crates/kiln-train/src/trainer.rs`
  - Test fixtures `make_tiny_gpu_weights` / `make_hybrid_gpu_weights` in `forward.rs`

Net diff: **+23 / -3 lines** across 4 files.

## Expected impact

Eliminates ~778 MiB of bf16 transpose rematerialization per decode token. Based on PR #113 attribution, `kiln/lm_head` ucopy_bf16 should drop by ≥90% (near zero — the remaining matmul copies are output-side, not weight transposes).

## Validation

Validated on RunPod A6000 (CUDA 12.8 toolkit) with `KILN_CUDA_ARCHS=86`:

- **Build**: `cargo build --release --features cuda -p kiln-model` ✅
- **Tests**: `cargo test --release --features cuda -p kiln-model -- --test-threads=1` → **123 passed / 2 failed**

The 2 failing tests are `test_gdn_kernel_matches_fallback` and `test_gdn_recurrent_kernel_matches_reference`. They fail with `CUDA_ERROR_UNSUPPORTED_PTX_VERSION` — an environmental mismatch between the CUDA 12.8 toolkit's generated PTX and the pod driver (12.7 / 565.57.01). **I verified both tests fail identically on unmodified `main`** on the same pod, so this is pre-existing and unrelated to the embed_tokens change.

## Not yet measured

Bench to confirm the ≥90% `kiln/lm_head` ucopy_bf16 reduction requires the full Qwen3.5-4B weights (~8 GB). That was deferred from this PR's validation budget. The change is a provably-correct algebraic refactor (pre-transpose a const tied matrix once vs every token), so I'm comfortable landing it and attaching a follow-up bench run. If you'd prefer I block on the measurement, ping me and I'll rerun with weights mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)