### PR TITLE
desktop: Show server uptime in status badge

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -376,13 +376,46 @@
         Error: { cls: "state-error", label: "Error" },
         Unknown: { cls: "state-unknown", label: "Unknown" },
       };
+      const UPTIME_STATES = ["Running", "TrainingActive"];
+      let runningSinceMs = null;
+      let currentKind = null;
+      let currentTooltip = null;
+
+      function formatUptime(ms) {
+        const totalSec = Math.max(0, Math.floor(ms / 1000));
+        if (totalSec < 60) return `${totalSec}s`;
+        const totalMin = Math.floor(totalSec / 60);
+        const sec = totalSec % 60;
+        if (totalMin < 60) return sec > 0 ? `${totalMin}m ${sec}s` : `${totalMin}m`;
+        const totalHr = Math.floor(totalMin / 60);
+        const min = totalMin % 60;
+        if (totalHr < 24) return min > 0 ? `${totalHr}h ${min}m` : `${totalHr}h`;
+        const day = Math.floor(totalHr / 24);
+        const hr = totalHr % 24;
+        return hr > 0 ? `${day}d ${hr}h` : `${day}d`;
+      }
 
       function applyStatusBadge(kind, tooltip) {
         const info = STATE_INFO[kind] || STATE_INFO.Unknown;
         statusBadge.classList.remove(...STATE_CLASSES);
         statusBadge.classList.add(info.cls);
-        statusBadgeLabel.textContent = info.label;
+        if (UPTIME_STATES.includes(kind)) {
+          if (runningSinceMs === null) runningSinceMs = Date.now();
+          const elapsed = Date.now() - runningSinceMs;
+          statusBadgeLabel.textContent = `${info.label} · ${formatUptime(elapsed)}`;
+        } else {
+          runningSinceMs = null;
+          statusBadgeLabel.textContent = info.label;
+        }
+        currentKind = kind;
+        currentTooltip = tooltip || null;
         statusBadge.title = tooltip || `Kiln server state: ${info.label}`;
+      }
+
+      function tickUptime() {
+        if (currentKind && UPTIME_STATES.includes(currentKind)) {
+          applyStatusBadge(currentKind, currentTooltip);
+        }
       }
 
       function parseServerState(state) {
@@ -488,6 +521,7 @@
         load();
         pollServerState();
         setInterval(pollServerState, 2000);
+        setInterval(tickUptime, 1000);
       });
     </script>
   </body>


### PR DESCRIPTION
## Summary
Adds elapsed uptime to the dashboard status badge while the server is Running or TrainingActive, per the Core UX section of the project description (which explicitly calls for server uptime on the dashboard). Today the badge only shows the state name with no time information.

After this change, the badge label reads e.g. `Running · 3s` one second after the server transitions to Running, `Running · 3m 24s` after a few minutes, and `Training · 15s` while a training job is active. When the server stops (or transitions to Starting/Error/Unknown), the counter resets and the label reverts to just the state name.

## Implementation
Pure frontend change. Single file: `desktop/ui/dashboard.html`.

- Client-side uptime tracking via `runningSinceMs` — set when transitioning into Running/TrainingActive, reset on any other state.
- `formatUptime(ms)` helper formats compactly: `Xs` under 60s, `Xm Ys` under an hour (omits `Ys` when 0), `Xh Ym` under a day, `Xd Yh` otherwise.
- `applyStatusBadge(kind, tooltip)` now composes the label as `${baseLabel} · ${formatted}` when in a running state.
- New 1-second `setInterval(tickUptime, 1000)` re-applies the badge so uptime ticks up smoothly between the 2-second `pollServerState` cycles. `tickUptime` uses cached `currentKind`/`currentTooltip` so it does not re-query the backend.
- Tooltip logic is preserved — uptime goes only in the visible label.

No Rust changes, no new Tauri commands, no layout or CSS changes.

## Validation
- `cd desktop && cargo check` — fails locally in Cloud Eric on missing `glib-2.0` / webkit2gtk system libs (expected; sessions cannot build Tauri). CI on this PR validates the full build.
- Manual review of the diff confirms only `desktop/ui/dashboard.html` changed (+35 / -1).

## Test plan
- [ ] Windows and Linux CI builds pass
- [ ] Launch dashboard, start the server: badge transitions from `Starting` to `Running · 0s` and increments every second
- [ ] Submit a training job: badge switches to `Training · Xs` while active
- [ ] Stop the server: badge returns to `Stopped` with no time suffix; next start begins at `Running · 0s`