### PR TITLE
desktop: wire Tauri auto-updater plumbing

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -59,6 +59,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: desktop
           tagName: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && github.ref_name || '' }}

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -19,6 +19,8 @@ tauri-plugin-shell = "2"
 tauri-plugin-autostart = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "sync", "time", "io-util"] }

--- a/desktop/capabilities/default.json
+++ b/desktop/capabilities/default.json
@@ -6,6 +6,8 @@
   "permissions": [
     "core:default",
     "dialog:default",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "updater:default",
+    "process:default"
   ]
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -177,6 +177,8 @@ fn main() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,
             None,

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -71,7 +71,7 @@
       "endpoints": [
         "https://github.com/ericflo/kiln/releases/latest/download/latest.json"
       ],
-      "pubkey": "RWSPRB7L9YJyJTeFv2viqQXbluv8fOskKFZyIbTuZZzfnTrcfefZe36r"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDI1NzI4MkY1Q0IxRTQ0OEYKUldTUFJCN0w5WUp5SlRlRnYydmlxUVhibHV2OGZPc2tLRlp5SWJUdVpaemZuVHJjZmVmWmUzNnIK"
     }
   }
 }

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -52,6 +52,7 @@
   },
   "bundle": {
     "active": true,
+    "createUpdaterArtifacts": true,
     "targets": ["deb", "appimage", "msi", "nsis"],
     "icon": [
       "icons/32x32.png",
@@ -62,5 +63,15 @@
     "category": "DeveloperTool",
     "shortDescription": "System tray app for the kiln local LLM server",
     "longDescription": "Kiln Desktop supervises the kiln local LLM server as a subprocess and exposes status, settings, and dashboard windows through a system tray. Windows and Linux only; kiln requires CUDA."
+  },
+  "plugins": {
+    "updater": {
+      "active": true,
+      "dialog": false,
+      "endpoints": [
+        "https://github.com/ericflo/kiln/releases/latest/download/latest.json"
+      ],
+      "pubkey": "RWSPRB7L9YJyJTeFv2viqQXbluv8fOskKFZyIbTuZZzfnTrcfefZe36r"
+    }
   }
 }


### PR DESCRIPTION
## What

Wires Tauri v2 auto-update infrastructure into kiln-desktop so future releases can deliver signed updates to users.

Changes:
- `desktop/Cargo.toml` — add `tauri-plugin-updater` and `tauri-plugin-process`
- `desktop/tauri.conf.json` — set `bundle.createUpdaterArtifacts = true`; add top-level `plugins.updater` with the GitHub Releases endpoint and embedded minisign pubkey
- `desktop/src/main.rs` — register both plugins in the Builder chain
- `desktop/capabilities/default.json` — grant `updater:default` and `process:default`
- `.github/workflows/desktop-build.yml` — pass `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` secrets to the `tauri-action` step

## How updates flow

On the next tagged release (`desktop-v0.1.1+`), `tauri-action` will:
1. Build platform bundles
2. Sign them with the minisign private key
3. Generate `latest.json` (manifest) and `.sig` files
4. Attach all artifacts to the GitHub Release

Installed clients hit `https://github.com/ericflo/kiln/releases/latest/download/latest.json`, verify the manifest signature against the embedded pubkey (`RWSPRB7L9YJyJTeFv2viqQXbluv8fOskKFZyIbTuZZzfnTrcfefZe36r`), and download/apply the update if newer.

## Migration note

Users running the existing `v0.1.0` (unsigned, no updater plugin) will NOT auto-update to `v0.1.1` — they must download manually one more time. From `v0.1.1` forward, auto-update works.

## Follow-up

PR #2 will add the user-facing UX: a "Check for Updates" tray menu item, periodic background checks, and an in-app update dialog wired to `tauri-plugin-updater`'s API.

## Local validation

- `jq .` validates both JSON files
- `cargo metadata --format-version 1` resolves the new dependency tree cleanly (downloaded `tauri-plugin-updater`, `tauri-plugin-process`, and transitives)
- `cargo check` is not runnable in Cloud Eric — the Tauri crate requires GTK/webkit2gtk system libs that aren't installed (known limitation; see `tauri-cargo-check-gtk-missing` note). CI on `ubuntu-22.04` and `windows-latest` validates the full build.