### PR TITLE
desktop: Check for Updates menu item + dashboard button

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -11,6 +11,7 @@ use settings::{apply_to_supervisor_config, Settings};
 use supervisor::{ServerState, Supervisor, SupervisorConfig};
 use tauri::{AppHandle, Manager, State};
 use tauri_plugin_autostart::{ManagerExt, MacosLauncher};
+use tauri_plugin_updater::UpdaterExt;
 use tokio::sync::RwLock;
 
 /// Reconcile the OS autostart registration with the desired `launch_at_login`
@@ -103,6 +104,54 @@ async fn open_settings(app: AppHandle) -> Result<(), String> {
 #[tauri::command]
 async fn open_logs(app: AppHandle) -> Result<(), String> {
     tray::open_logs_window(&app).map_err(|e| e.to_string())
+}
+
+#[derive(serde::Serialize)]
+struct UpdateCheckResult {
+    available: bool,
+    version: Option<String>,
+    current_version: Option<String>,
+    notes: Option<String>,
+}
+
+/// Ask the configured updater endpoint whether a new release is available.
+/// The frontend uses the result to prompt the user to install via
+/// `install_update`.
+#[tauri::command]
+async fn check_for_updates(app: AppHandle) -> Result<UpdateCheckResult, String> {
+    let updater = app.updater().map_err(|e| e.to_string())?;
+    let update = updater.check().await.map_err(|e| e.to_string())?;
+    match update {
+        Some(u) => Ok(UpdateCheckResult {
+            available: true,
+            version: Some(u.version.clone()),
+            current_version: Some(u.current_version.clone()),
+            notes: u.body.clone(),
+        }),
+        None => Ok(UpdateCheckResult {
+            available: false,
+            version: None,
+            current_version: None,
+            notes: None,
+        }),
+    }
+}
+
+/// Re-check, then download and install the available update, then restart the
+/// app. We re-check rather than caching an `Update` handle because Tauri
+/// commands are stateless and the small race window is acceptable.
+#[tauri::command]
+async fn install_update(app: AppHandle) -> Result<(), String> {
+    let updater = app.updater().map_err(|e| e.to_string())?;
+    let update = updater.check().await.map_err(|e| e.to_string())?;
+    let Some(update) = update else {
+        return Err("No update available".to_string());
+    };
+    update
+        .download_and_install(|_chunk, _total| {}, || {})
+        .await
+        .map_err(|e| e.to_string())?;
+    app.restart();
 }
 
 /// Build the OpenAI-compatible base URL for a given host/port. Kept as a pure
@@ -222,7 +271,9 @@ fn main() {
             get_kiln_url,
             get_openai_base_url,
             open_settings,
-            open_logs
+            open_logs,
+            check_for_updates,
+            install_update
         ])
         .run(tauri::generate_context!())
         .expect("error while running kiln-desktop");

--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -19,6 +19,7 @@ const ITEM_STOP: &str = "stop_server";
 const ITEM_RESTART: &str = "restart_server";
 const ITEM_LOGS: &str = "view_logs";
 const ITEM_COPY_URL: &str = "copy_openai_url";
+const ITEM_CHECK_UPDATES: &str = "check_updates";
 const ITEM_QUIT: &str = "quit";
 
 fn status_menu_text(state: &ServerState) -> String {
@@ -57,6 +58,8 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
         .enabled(false)
         .build(app)?;
     let logs = MenuItemBuilder::with_id(ITEM_LOGS, "View Logs").build(app)?;
+    let check_updates =
+        MenuItemBuilder::with_id(ITEM_CHECK_UPDATES, "Check for Updates…").build(app)?;
     let quit = MenuItemBuilder::with_id(ITEM_QUIT, "Quit").build(app)?;
 
     let menu = MenuBuilder::new(app)
@@ -67,6 +70,8 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
         .item(&copy_url)
         .separator()
         .items(&[&start, &stop, &restart, &logs])
+        .separator()
+        .item(&check_updates)
         .separator()
         .item(&quit)
         .build()?;
@@ -128,6 +133,20 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                     let supervisor = Arc::clone(&supervisor);
                     tauri::async_runtime::spawn(async move {
                         copy_openai_base_url_to_clipboard(&app_handle, supervisor).await;
+                    });
+                }
+                ITEM_CHECK_UPDATES => {
+                    if let Err(e) = open_dashboard_window(&app_handle) {
+                        eprintln!("[tray] open_dashboard_window failed: {}", e);
+                    }
+                    // Give a freshly-opened dashboard window a moment to mount
+                    // its event listener before we emit, so the request isn't
+                    // dropped on cold open.
+                    tauri::async_runtime::spawn(async move {
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                        if let Err(e) = app_handle.emit("menu://check-updates", ()) {
+                            eprintln!("[tray] emit menu://check-updates failed: {}", e);
+                        }
                     });
                 }
                 ITEM_STATUS => {}

--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -91,6 +91,9 @@
       #stop-server.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
       #copy-url.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
       #copy-url.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
+      #check-updates-btn.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
+      #check-updates-btn.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
+      #check-updates-btn:disabled { background: #2a2f3a; color: #6c7280; cursor: default; }
       #status-badge {
         display: inline-flex;
         align-items: center;
@@ -231,6 +234,7 @@
         <code id="vram-value" class="empty">—</code>
       </span>
       <button id="copy-url" title="Copy the OpenAI-compatible base URL for this server">Copy OpenAI base URL</button>
+      <button id="check-updates-btn" title="Check for an updated version of Kiln Desktop">Check for Updates</button>
     </div>
     <iframe id="frame" class="hidden" title="Kiln UI"></iframe>
     <div id="status">
@@ -675,6 +679,93 @@
       }
 
       window.addEventListener("focus", refreshModelPath);
+
+      const checkUpdatesBtn = document.getElementById("check-updates-btn");
+      const CHECK_UPDATES_LABEL = "Check for Updates";
+      let checkUpdatesResetTimer = null;
+      let updateCheckInFlight = false;
+
+      function flashCheckUpdatesBtn(label, cls, durationMs) {
+        if (checkUpdatesResetTimer) {
+          clearTimeout(checkUpdatesResetTimer);
+          checkUpdatesResetTimer = null;
+        }
+        checkUpdatesBtn.textContent = label;
+        checkUpdatesBtn.classList.remove("flash", "flash-warn");
+        if (cls) checkUpdatesBtn.classList.add(cls);
+        checkUpdatesResetTimer = setTimeout(() => {
+          checkUpdatesBtn.textContent = CHECK_UPDATES_LABEL;
+          checkUpdatesBtn.classList.remove("flash", "flash-warn");
+          checkUpdatesBtn.disabled = false;
+          checkUpdatesResetTimer = null;
+        }, durationMs || 3000);
+      }
+
+      async function triggerUpdateCheck() {
+        if (updateCheckInFlight) return;
+        if (!invoke) {
+          flashCheckUpdatesBtn("Tauri bridge unavailable", "flash-warn");
+          return;
+        }
+        updateCheckInFlight = true;
+        if (checkUpdatesResetTimer) {
+          clearTimeout(checkUpdatesResetTimer);
+          checkUpdatesResetTimer = null;
+        }
+        checkUpdatesBtn.disabled = true;
+        checkUpdatesBtn.textContent = "Checking…";
+        checkUpdatesBtn.classList.remove("flash", "flash-warn");
+        let result;
+        try {
+          result = await invoke("check_for_updates");
+        } catch (err) {
+          updateCheckInFlight = false;
+          flashCheckUpdatesBtn("Check failed", "flash-warn");
+          console.error("check_for_updates failed", err);
+          return;
+        }
+        if (!result || !result.available) {
+          updateCheckInFlight = false;
+          flashCheckUpdatesBtn("Up to date", "flash");
+          return;
+        }
+        const version = result.version || "(unknown)";
+        const notes = (result.notes || "").trim();
+        const promptLines = [`Version ${version} is available. Install and restart?`];
+        if (notes) {
+          const trimmed = notes.length > 400 ? notes.slice(0, 400) + "…" : notes;
+          promptLines.push("", trimmed);
+        }
+        const proceed = window.confirm(promptLines.join("\n"));
+        if (!proceed) {
+          updateCheckInFlight = false;
+          flashCheckUpdatesBtn(`v${version} available`, "flash", 4000);
+          return;
+        }
+        checkUpdatesBtn.textContent = "Installing…";
+        try {
+          await invoke("install_update");
+          // app.restart() should have terminated the process by now; if we
+          // get here something went wrong.
+          flashCheckUpdatesBtn("Restart pending…", "flash", 5000);
+        } catch (err) {
+          flashCheckUpdatesBtn("Install failed", "flash-warn");
+          console.error("install_update failed", err);
+        } finally {
+          updateCheckInFlight = false;
+        }
+      }
+
+      checkUpdatesBtn.addEventListener("click", triggerUpdateCheck);
+
+      const tauriEvent = window.__TAURI__ && window.__TAURI__.event;
+      if (tauriEvent && typeof tauriEvent.listen === "function") {
+        tauriEvent.listen("menu://check-updates", () => {
+          triggerUpdateCheck();
+        }).catch((err) => {
+          console.error("listen menu://check-updates failed", err);
+        });
+      }
 
       window.addEventListener("DOMContentLoaded", () => {
         load();


### PR DESCRIPTION
Builds on #126 (Tauri auto-updater plumbing) by adding the user-visible
trigger that was missing — Tauri does not auto-check on launch unless
something calls `updater().check()`, so without a UI entry point users
have no way to discover or install an update.

## What changes

**Rust side (`desktop/src/main.rs`):**
- New `check_for_updates` Tauri command. Returns
  `{ available: bool, version: Option<String>, current_version: Option<String>, notes: Option<String> }`
  using `tauri_plugin_updater::UpdaterExt`.
- New `install_update` command. Re-checks (commands are stateless, so we
  can't cache the `Update` handle from the prior call; the small race
  window is acceptable), then `download_and_install(...)`, then
  `app.restart()`. Restart returns `!`, so control never reaches the
  end of the function.
- Both registered in `invoke_handler`.

**Tray (`desktop/src/tray.rs`):**
- New `ITEM_CHECK_UPDATES` menu item ("Check for Updates…") placed
  above Quit, separated from the server-control block.
- Click handler opens the dashboard window if hidden, sleeps 500ms so a
  freshly mounted page has time to register its listener, then emits a
  `menu://check-updates` event. The dashboard's listener triggers the
  same flow as the toolbar button.

**Dashboard (`desktop/ui/dashboard.html`):**
- New `#check-updates-btn` in the toolbar, next to "Copy OpenAI base URL".
- `triggerUpdateCheck()` invokes the Rust command, flashes "Up to date"
  if no update, otherwise pops a native `confirm()` with the version and
  truncated release notes. On confirm, invokes `install_update` and the
  app restarts; on dismiss, it briefly flashes "vX.Y.Z available" so the
  state isn't lost.
- Listens for `menu://check-updates` so the tray entry hits the same
  function. An in-flight guard prevents double-invokes from quick
  successive clicks.

## What does not change

- No new dependencies. `tauri-plugin-updater` and `tauri-plugin-process`
  were already in `desktop/Cargo.toml` (#126).
- `desktop/capabilities/default.json` is unchanged. `updater:default`
  and `process:default` were granted in #126; `core:event:listen` is
  part of `core:default`.
- `desktop/tauri.conf.json` is unchanged — the `plugins.updater` block,
  endpoint, and embedded pubkey from #126 are correct.
- No background polling and no auto-prompt on launch — that is
  out of scope per the task spec; this PR adds only the explicit
  user-triggered check.
- `desktop/ui/logs.html` and `desktop/ui/settings.html` are untouched.

## Validation

- `cargo metadata --format-version 1` resolves cleanly.
- `cargo check` cannot run in Cloud Eric because GTK / webkit2gtk
  system libs aren't installed in the agent pod (a known limitation —
  `apt install libwebkit2gtk-4.1-dev …` is the CI fix and isn't
  available here). The Ubuntu and Windows runners in
  `.github/workflows/desktop.yml` build the full crate.
- `tauri.conf.json` and `capabilities/default.json` parse as valid JSON.