### PR TITLE
perf: cache pre-transposed MLP/attention projection weights (2.33x decode speedup)

### DIFF
--- a/BENCH_PROJT.md
+++ b/BENCH_PROJT.md
@@ -1,0 +1,60 @@
+# Projection Transpose Cache Benchmark
+
+Benchmark for `ce/cache-projection-transposes` (commit 1759e33) vs `main` (commit d5c6e83), measured on RunPod NVIDIA RTX A6000 (driver 550.127.08, CUDA 12.4) with `kiln-runpod:latest`.
+
+Bench command (identical for both binaries):
+
+```
+./target/release/kiln-bench --model-path /workspace/models/qwen3.5-4b \
+    --prompt-tokens 512 --max-output-tokens 256 --skip-training --paged
+```
+
+## Headline: decode is 2.33× faster
+
+| Metric                              | main (d5c6e83) | branch (1759e33) | Δ        |
+|-------------------------------------|----------------|------------------|----------|
+| **Decode tok/s** (paged latency)    | **7.61**       | **17.70**        | **+133%** |
+| Mean inter-token latency            | 131.4 ms       | 56.5 ms          | −57%     |
+| P50 inter-token latency             | 131.3 ms       | 55.5 ms          | −58%     |
+| P99 inter-token latency             | 136.2 ms       | 65.2 ms          | −52%     |
+
+Hits the high end of the predicted 1.8–2.5× decode ITL range from the PR description, and clears the 5% justification floor by a wide margin.
+
+## Throughput (single sequence, prefill+decode combined)
+
+| Batch | main tok/s | branch tok/s | Δ     |
+|-------|------------|--------------|-------|
+| 1     | 7.35       | 17.13        | +133% |
+| 4     | 7.27       | 16.99        | +134% |
+| 8     | 7.27       | 16.86        | +132% |
+| 16    | 7.30       | 16.84        | +131% |
+
+Steady-state throughput improvement matches the latency-phase decode improvement, confirming the win is real and not an artifact of a single timing.
+
+## Prefill regression on the paged latency path (flagged)
+
+| Metric                          | main      | branch    | Δ         |
+|---------------------------------|-----------|-----------|-----------|
+| Latency-phase prefill (506 tok) | 523.8 ms  | 10724.2 ms | **+1947%** |
+| Latency-phase prefill tok/s     | 966 tok/s | 47 tok/s  | −95%      |
+
+The single-shot `--paged` prefill measured by the latency phase regressed sharply on the branch. This appears to be a one-time cost on the first paged forward (likely a per-_t-tensor allocation or kernel JIT cost on the new code path) — the throughput phase, which warms up before measuring, sees no equivalent regression: prefill amortizes to <1 s per 506-token prompt in steady state on both binaries.
+
+Net effect for typical workloads (prompt + multi-token decode): **branch is 2.3× faster end-to-end** at every batch size measured. The cold-paged-prefill spike is worth follow-up but does not block this PR — the decode hot path is what kiln pays for in production.
+
+## VRAM cost
+
+| Metric           | main      | branch    | Δ         |
+|------------------|-----------|-----------|-----------|
+| Model VRAM       | 9526 MB   | 14422 MB  | +4896 MB  |
+| Peak runtime VRAM | ~10088 MB | ~14952 MB | +4864 MB  |
+
+~4.9 GB extra VRAM for the seven cached `_t` tensors at bf16 (gate/up/down + q/k/v/o per layer). Below the PR estimate of ~8.7 GB and well within the A6000 48 GB budget.
+
+## Hardware
+
+- GPU: NVIDIA RTX A6000 (49140 MB)
+- Driver: 550.127.08
+- CUDA: 12.4
+- Image: `ghcr.io/ericflo/kiln-runpod:latest`
+- Build: `cargo build --release --features cuda --bin kiln-bench`

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use candle_core::{DType, Device, Tensor};
 
 use crate::kv_cache::KvCache;
-use crate::lora_loader::{linear_with_lora, LoraLayerWeights, LoraWeights};
+use crate::lora_loader::{linear_with_lora_t, LoraLayerWeights, LoraWeights};
 use crate::paged_kv_cache::PagedKvCache;
 use crate::weights::{ModelWeights, TensorDType, WeightTensor};
 
@@ -162,6 +162,13 @@ pub struct GpuFullAttentionWeights {
     pub o_proj: Tensor,
     pub q_norm: Tensor,
     pub k_norm: Tensor,
+    /// Pre-transposed q_proj for the forward hot path (contiguous).
+    /// Avoids re-transposing bf16 projection weights on every layer / every step.
+    /// Per PR #124 PROFILING.md: attention projection ucopy_bf16 was ~6.9% of decode GPU time.
+    pub q_proj_t: Tensor,
+    pub k_proj_t: Tensor,
+    pub v_proj_t: Tensor,
+    pub o_proj_t: Tensor,
 }
 
 pub struct GpuLinearAttentionWeights {
@@ -180,6 +187,13 @@ pub struct GpuFfnWeights {
     pub gate_proj: Tensor,
     pub up_proj: Tensor,
     pub down_proj: Tensor,
+    /// Pre-transposed MLP projections for the forward hot path (contiguous).
+    /// Avoids re-transposing bf16 projection weights on every layer / every step.
+    /// Per PR #124 PROFILING.md: MLP projection ucopy_bf16 was 50.7% of decode GPU time
+    /// (61.8% of all ucopy_bf16 mass). Same class of fix as PR #117 (embed_tokens_t).
+    pub gate_proj_t: Tensor,
+    pub up_proj_t: Tensor,
+    pub down_proj_t: Tensor,
 }
 
 /// State for Gated DeltaNet linear attention layers.
@@ -266,13 +280,29 @@ impl GpuWeights {
 
             let attention = match &lw.attention {
                 crate::weights::AttentionWeights::Full(attn) => {
+                    let q_proj = weight_to_tensor(&attn.q_proj, device).context(ctx("q_proj"))?;
+                    let k_proj = weight_to_tensor(&attn.k_proj, device).context(ctx("k_proj"))?;
+                    let v_proj = weight_to_tensor(&attn.v_proj, device).context(ctx("v_proj"))?;
+                    let o_proj = weight_to_tensor(&attn.o_proj, device).context(ctx("o_proj"))?;
+                    let q_proj_t = q_proj.t().context(ctx("q_proj.t"))?
+                        .contiguous().context(ctx("q_proj.t contiguous"))?;
+                    let k_proj_t = k_proj.t().context(ctx("k_proj.t"))?
+                        .contiguous().context(ctx("k_proj.t contiguous"))?;
+                    let v_proj_t = v_proj.t().context(ctx("v_proj.t"))?
+                        .contiguous().context(ctx("v_proj.t contiguous"))?;
+                    let o_proj_t = o_proj.t().context(ctx("o_proj.t"))?
+                        .contiguous().context(ctx("o_proj.t contiguous"))?;
                     GpuAttentionWeights::Full(GpuFullAttentionWeights {
-                        q_proj: weight_to_tensor(&attn.q_proj, device).context(ctx("q_proj"))?,
-                        k_proj: weight_to_tensor(&attn.k_proj, device).context(ctx("k_proj"))?,
-                        v_proj: weight_to_tensor(&attn.v_proj, device).context(ctx("v_proj"))?,
-                        o_proj: weight_to_tensor(&attn.o_proj, device).context(ctx("o_proj"))?,
+                        q_proj,
+                        k_proj,
+                        v_proj,
+                        o_proj,
                         q_norm: weight_to_tensor(&attn.q_norm, device).context(ctx("q_norm"))?,
                         k_norm: weight_to_tensor(&attn.k_norm, device).context(ctx("k_norm"))?,
+                        q_proj_t,
+                        k_proj_t,
+                        v_proj_t,
+                        o_proj_t,
                     })
                 }
                 crate::weights::AttentionWeights::Linear(attn) => {
@@ -295,10 +325,22 @@ impl GpuWeights {
                 }
             };
 
+            let gate_proj = weight_to_tensor(&lw.mlp.gate_proj, device).context(ctx("gate_proj"))?;
+            let up_proj = weight_to_tensor(&lw.mlp.up_proj, device).context(ctx("up_proj"))?;
+            let down_proj = weight_to_tensor(&lw.mlp.down_proj, device).context(ctx("down_proj"))?;
+            let gate_proj_t = gate_proj.t().context(ctx("gate_proj.t"))?
+                .contiguous().context(ctx("gate_proj.t contiguous"))?;
+            let up_proj_t = up_proj.t().context(ctx("up_proj.t"))?
+                .contiguous().context(ctx("up_proj.t contiguous"))?;
+            let down_proj_t = down_proj.t().context(ctx("down_proj.t"))?
+                .contiguous().context(ctx("down_proj.t contiguous"))?;
             let mlp = GpuFfnWeights {
-                gate_proj: weight_to_tensor(&lw.mlp.gate_proj, device).context(ctx("gate_proj"))?,
-                up_proj: weight_to_tensor(&lw.mlp.up_proj, device).context(ctx("up_proj"))?,
-                down_proj: weight_to_tensor(&lw.mlp.down_proj, device).context(ctx("down_proj"))?,
+                gate_proj,
+                up_proj,
+                down_proj,
+                gate_proj_t,
+                up_proj_t,
+                down_proj_t,
             };
 
             layers.push(GpuLayerWeights {
@@ -470,40 +512,40 @@ fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor, head_dim: usize, rotary_di
 /// Computes: down_proj @ (silu(gate_proj @ x) * (up_proj @ x))
 ///
 /// `x`: [batch, seq_len, hidden_size]
-/// `gate_proj`: [intermediate_size, hidden_size]
-/// `up_proj`: [intermediate_size, hidden_size]
-/// `down_proj`: [hidden_size, intermediate_size]
+/// `gate_proj_t`: [hidden_size, intermediate_size] (pre-transposed)
+/// `up_proj_t`: [hidden_size, intermediate_size] (pre-transposed)
+/// `down_proj_t`: [intermediate_size, hidden_size] (pre-transposed)
 ///
 /// Returns: [batch, seq_len, hidden_size]
 pub fn swiglu_ffn(
     x: &Tensor,
-    gate_proj: &Tensor,
-    up_proj: &Tensor,
-    down_proj: &Tensor,
+    gate_proj_t: &Tensor,
+    up_proj_t: &Tensor,
+    down_proj_t: &Tensor,
     lora: Option<(&LoraLayerWeights, f32)>,
 ) -> Result<Tensor> {
     let (lora_layer, lora_scale) = match lora {
         Some((l, s)) => (Some(l), s),
         None => (None, 0.0),
     };
-    // x @ gate_proj^T -> [batch, seq_len, intermediate_size]
+    // x @ gate_proj_t -> [batch, seq_len, intermediate_size]
     let gate = {
         kiln_nvtx::range!(c"kiln/mlp/gate");
-        linear_with_lora(x, gate_proj, lora_layer.and_then(|l| l.gate_proj.as_ref()), lora_scale)?
+        linear_with_lora_t(x, gate_proj_t, lora_layer.and_then(|l| l.gate_proj.as_ref()), lora_scale)?
     };
     // SiLU activation: x * sigmoid(x)
     let gate = cuda_silu(&gate)?;
-    // x @ up_proj^T -> [batch, seq_len, intermediate_size]
+    // x @ up_proj_t -> [batch, seq_len, intermediate_size]
     let up = {
         kiln_nvtx::range!(c"kiln/mlp/up");
-        linear_with_lora(x, up_proj, lora_layer.and_then(|l| l.up_proj.as_ref()), lora_scale)?
+        linear_with_lora_t(x, up_proj_t, lora_layer.and_then(|l| l.up_proj.as_ref()), lora_scale)?
     };
     // Element-wise multiply
     let hidden = (gate * up)?;
-    // hidden @ down_proj^T -> [batch, seq_len, hidden_size]
+    // hidden @ down_proj_t -> [batch, seq_len, hidden_size]
     let out = {
         kiln_nvtx::range!(c"kiln/mlp/down");
-        linear_with_lora(&hidden, down_proj, lora_layer.and_then(|l| l.down_proj.as_ref()), lora_scale)?
+        linear_with_lora_t(&hidden, down_proj_t, lora_layer.and_then(|l| l.down_proj.as_ref()), lora_scale)?
     };
     Ok(out)
 }
@@ -1242,9 +1284,9 @@ pub fn gqa_attention(
     };
     let (q_raw, k, v) = {
         kiln_nvtx::range!(c"kiln/proj/qkv");
-        let q_raw = linear_with_lora(x, &attn_weights.q_proj, lora_layer.and_then(|l| l.q_proj.as_ref()), lora_scale)?;
-        let k = linear_with_lora(x, &attn_weights.k_proj, lora_layer.and_then(|l| l.k_proj.as_ref()), lora_scale)?;
-        let v = linear_with_lora(x, &attn_weights.v_proj, lora_layer.and_then(|l| l.v_proj.as_ref()), lora_scale)?;
+        let q_raw = linear_with_lora_t(x, &attn_weights.q_proj_t, lora_layer.and_then(|l| l.q_proj.as_ref()), lora_scale)?;
+        let k = linear_with_lora_t(x, &attn_weights.k_proj_t, lora_layer.and_then(|l| l.k_proj.as_ref()), lora_scale)?;
+        let v = linear_with_lora_t(x, &attn_weights.v_proj_t, lora_layer.and_then(|l| l.v_proj.as_ref()), lora_scale)?;
         (q_raw, k, v)
     };
 
@@ -1295,7 +1337,7 @@ pub fn gqa_attention(
         };
         let out = {
             kiln_nvtx::range!(c"kiln/proj/o");
-            linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
+            linear_with_lora_t(&attn_output, &attn_weights.o_proj_t, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
         };
         return Ok(out);
     }
@@ -1368,7 +1410,7 @@ pub fn gqa_attention(
     // Output projection
     let out = {
         kiln_nvtx::range!(c"kiln/proj/o");
-        linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
+        linear_with_lora_t(&attn_output, &attn_weights.o_proj_t, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
     };
     Ok(out)
 }
@@ -1522,9 +1564,9 @@ fn try_flash_attn_paged_decode(
 
     let out = {
         kiln_nvtx::range!(c"kiln/proj/o");
-        linear_with_lora(
+        linear_with_lora_t(
             &attn_output,
-            &attn_weights.o_proj,
+            &attn_weights.o_proj_t,
             lora_layer.and_then(|l| l.o_proj.as_ref()),
             lora_scale,
         )?
@@ -1566,9 +1608,9 @@ pub fn gqa_attention_paged(
     };
     let (q_raw, k, v) = {
         kiln_nvtx::range!(c"kiln/proj/qkv");
-        let q_raw = linear_with_lora(x, &attn_weights.q_proj, lora_layer.and_then(|l| l.q_proj.as_ref()), lora_scale)?;
-        let k = linear_with_lora(x, &attn_weights.k_proj, lora_layer.and_then(|l| l.k_proj.as_ref()), lora_scale)?;
-        let v = linear_with_lora(x, &attn_weights.v_proj, lora_layer.and_then(|l| l.v_proj.as_ref()), lora_scale)?;
+        let q_raw = linear_with_lora_t(x, &attn_weights.q_proj_t, lora_layer.and_then(|l| l.q_proj.as_ref()), lora_scale)?;
+        let k = linear_with_lora_t(x, &attn_weights.k_proj_t, lora_layer.and_then(|l| l.k_proj.as_ref()), lora_scale)?;
+        let v = linear_with_lora_t(x, &attn_weights.v_proj_t, lora_layer.and_then(|l| l.v_proj.as_ref()), lora_scale)?;
         (q_raw, k, v)
     };
 
@@ -1690,7 +1732,7 @@ pub fn gqa_attention_paged(
         };
         let out = {
             kiln_nvtx::range!(c"kiln/proj/o");
-            linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
+            linear_with_lora_t(&attn_output, &attn_weights.o_proj_t, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
         };
         return Ok(out);
     }
@@ -1756,7 +1798,7 @@ pub fn gqa_attention_paged(
         };
         let out = {
             kiln_nvtx::range!(c"kiln/proj/o");
-            linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
+            linear_with_lora_t(&attn_output, &attn_weights.o_proj_t, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
         };
         return Ok(out);
     }
@@ -1804,7 +1846,7 @@ pub fn gqa_attention_paged(
 
     let out = {
         kiln_nvtx::range!(c"kiln/proj/o");
-        linear_with_lora(&attn_output, &attn_weights.o_proj, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
+        linear_with_lora_t(&attn_output, &attn_weights.o_proj_t, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
     };
     Ok(out)
 }
@@ -1930,9 +1972,9 @@ pub fn transformer_block(
     // Feed-forward network
     let ffn_out = swiglu_ffn(
         &normed,
-        &layer.mlp.gate_proj,
-        &layer.mlp.up_proj,
-        &layer.mlp.down_proj,
+        &layer.mlp.gate_proj_t,
+        &layer.mlp.up_proj_t,
+        &layer.mlp.down_proj_t,
         lora,
     )?;
 
@@ -2012,9 +2054,9 @@ pub fn transformer_block_paged(
     // Feed-forward network
     let ffn_out = swiglu_ffn(
         &normed,
-        &layer.mlp.gate_proj,
-        &layer.mlp.up_proj,
-        &layer.mlp.down_proj,
+        &layer.mlp.gate_proj_t,
+        &layer.mlp.up_proj_t,
+        &layer.mlp.down_proj_t,
         lora,
     )?;
 
@@ -2122,9 +2164,9 @@ pub fn model_forward(
                 };
                 let ffn_out = swiglu_ffn(
                     &normed_post,
-                    &layer.mlp.gate_proj,
-                    &layer.mlp.up_proj,
-                    &layer.mlp.down_proj,
+                    &layer.mlp.gate_proj_t,
+                    &layer.mlp.up_proj_t,
+                    &layer.mlp.down_proj_t,
                     layer_lora,
                 )?;
                 hidden = {
@@ -2228,9 +2270,9 @@ pub fn model_forward_segment(
                 };
                 let ffn_out = swiglu_ffn(
                     &normed_post,
-                    &layer.mlp.gate_proj,
-                    &layer.mlp.up_proj,
-                    &layer.mlp.down_proj,
+                    &layer.mlp.gate_proj_t,
+                    &layer.mlp.up_proj_t,
+                    &layer.mlp.down_proj_t,
                     layer_lora,
                 )?;
                 hidden = {
@@ -2377,9 +2419,9 @@ pub fn model_forward_paged(
                 };
                 let ffn_out = swiglu_ffn(
                     &normed_post,
-                    &layer.mlp.gate_proj,
-                    &layer.mlp.up_proj,
-                    &layer.mlp.down_proj,
+                    &layer.mlp.gate_proj_t,
+                    &layer.mlp.up_proj_t,
+                    &layer.mlp.down_proj_t,
                     layer_lora,
                 )?;
                 hidden = {
@@ -2616,8 +2658,11 @@ mod tests {
         let gate = Tensor::randn(0.0_f32, 0.1, (intermediate, hidden), &device)?;
         let up = Tensor::randn(0.0_f32, 0.1, (intermediate, hidden), &device)?;
         let down = Tensor::randn(0.0_f32, 0.1, (hidden, intermediate), &device)?;
+        let gate_t = gate.t()?.contiguous()?;
+        let up_t = up.t()?.contiguous()?;
+        let down_t = down.t()?.contiguous()?;
 
-        let result = swiglu_ffn(&x, &gate, &up, &down, None)?;
+        let result = swiglu_ffn(&x, &gate_t, &up_t, &down_t, None)?;
         assert_eq!(result.dims(), &[batch, seq_len, hidden]);
 
         Ok(())
@@ -2634,8 +2679,11 @@ mod tests {
         let gate = Tensor::zeros((intermediate, hidden), DType::F32, &device)?;
         let up = Tensor::ones((intermediate, hidden), DType::F32, &device)?;
         let down = Tensor::ones((hidden, intermediate), DType::F32, &device)?;
+        let gate_t = gate.t()?.contiguous()?;
+        let up_t = up.t()?.contiguous()?;
+        let down_t = down.t()?.contiguous()?;
 
-        let result = swiglu_ffn(&x, &gate, &up, &down, None)?;
+        let result = swiglu_ffn(&x, &gate_t, &up_t, &down_t, None)?;
         let vals = result.to_vec3::<f32>()?;
 
         for v in &vals[0][0] {
@@ -2681,13 +2729,25 @@ mod tests {
         hidden: usize,
         device: &Device,
     ) -> Result<GpuFullAttentionWeights> {
+        let q_proj = Tensor::randn(0.0_f32, 0.02, (num_heads * head_dim, hidden), device)?;
+        let k_proj = Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, hidden), device)?;
+        let v_proj = Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, hidden), device)?;
+        let o_proj = Tensor::randn(0.0_f32, 0.02, (hidden, num_heads * head_dim), device)?;
+        let q_proj_t = q_proj.t()?.contiguous()?;
+        let k_proj_t = k_proj.t()?.contiguous()?;
+        let v_proj_t = v_proj.t()?.contiguous()?;
+        let o_proj_t = o_proj.t()?.contiguous()?;
         Ok(GpuFullAttentionWeights {
-            q_proj: Tensor::randn(0.0_f32, 0.02, (num_heads * head_dim, hidden), device)?,
-            k_proj: Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, hidden), device)?,
-            v_proj: Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, hidden), device)?,
-            o_proj: Tensor::randn(0.0_f32, 0.02, (hidden, num_heads * head_dim), device)?,
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
             q_norm: Tensor::zeros(head_dim, DType::F32, device)?,
             k_norm: Tensor::zeros(head_dim, DType::F32, device)?,
+            q_proj_t,
+            k_proj_t,
+            v_proj_t,
+            o_proj_t,
         })
     }
 
@@ -2796,6 +2856,13 @@ mod tests {
         let x = Tensor::randn(0.0_f32, 1.0, (batch, seq_len, hidden), &device)?;
         let positions: Vec<u32> = (0..seq_len as u32).collect();
 
+        let gate_proj = Tensor::randn(0.0_f32, 0.02, (intermediate, hidden), &device)?;
+        let up_proj = Tensor::randn(0.0_f32, 0.02, (intermediate, hidden), &device)?;
+        let down_proj = Tensor::randn(0.0_f32, 0.02, (hidden, intermediate), &device)?;
+        let gate_proj_t = gate_proj.t()?.contiguous()?;
+        let up_proj_t = up_proj.t()?.contiguous()?;
+        let down_proj_t = down_proj.t()?.contiguous()?;
+
         let layer = GpuLayerWeights {
             input_layernorm: Tensor::zeros(hidden, DType::F32, &device)?,
             post_attention_layernorm: Tensor::zeros(hidden, DType::F32, &device)?,
@@ -2803,9 +2870,12 @@ mod tests {
                 make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?,
             ),
             mlp: GpuFfnWeights {
-                gate_proj: Tensor::randn(0.0_f32, 0.02, (intermediate, hidden), &device)?,
-                up_proj: Tensor::randn(0.0_f32, 0.02, (intermediate, hidden), &device)?,
-                down_proj: Tensor::randn(0.0_f32, 0.02, (hidden, intermediate), &device)?,
+                gate_proj,
+                up_proj,
+                down_proj,
+                gate_proj_t,
+                up_proj_t,
+                down_proj_t,
             },
         };
 
@@ -2831,6 +2901,13 @@ mod tests {
         let x = Tensor::ones((1, 2, hidden), DType::F32, &device)?;
         let positions = vec![0u32, 1];
 
+        let gate_proj = Tensor::randn(0.0_f32, 0.02, (intermediate, hidden), &device)?;
+        let up_proj = Tensor::randn(0.0_f32, 0.02, (intermediate, hidden), &device)?;
+        let down_proj = Tensor::randn(0.0_f32, 0.02, (hidden, intermediate), &device)?;
+        let gate_proj_t = gate_proj.t()?.contiguous()?;
+        let up_proj_t = up_proj.t()?.contiguous()?;
+        let down_proj_t = down_proj.t()?.contiguous()?;
+
         let layer = GpuLayerWeights {
             input_layernorm: Tensor::zeros(hidden, DType::F32, &device)?,
             post_attention_layernorm: Tensor::zeros(hidden, DType::F32, &device)?,
@@ -2838,9 +2915,12 @@ mod tests {
                 make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?,
             ),
             mlp: GpuFfnWeights {
-                gate_proj: Tensor::randn(0.0_f32, 0.02, (intermediate, hidden), &device)?,
-                up_proj: Tensor::randn(0.0_f32, 0.02, (intermediate, hidden), &device)?,
-                down_proj: Tensor::randn(0.0_f32, 0.02, (hidden, intermediate), &device)?,
+                gate_proj,
+                up_proj,
+                down_proj,
+                gate_proj_t,
+                up_proj_t,
+                down_proj_t,
             },
         };
 
@@ -2880,6 +2960,9 @@ mod tests {
                 gate_proj: Tensor::zeros((1, hidden), DType::F32, &device)?,
                 up_proj: Tensor::zeros((1, hidden), DType::F32, &device)?,
                 down_proj: Tensor::zeros((hidden, 1), DType::F32, &device)?,
+                gate_proj_t: Tensor::zeros((hidden, 1), DType::F32, &device)?,
+                up_proj_t: Tensor::zeros((hidden, 1), DType::F32, &device)?,
+                down_proj_t: Tensor::zeros((1, hidden), DType::F32, &device)?,
             },
         };
 
@@ -2938,21 +3021,42 @@ mod tests {
 
         let mut layers = Vec::with_capacity(num_layers);
         for _ in 0..num_layers {
+            let q_proj = randn(&[num_heads * head_dim, hidden_size])?;
+            let k_proj = randn(&[num_kv_heads * head_dim, hidden_size])?;
+            let v_proj = randn(&[num_kv_heads * head_dim, hidden_size])?;
+            let o_proj = randn(&[hidden_size, num_heads * head_dim])?;
+            let q_proj_t = q_proj.t()?.contiguous()?;
+            let k_proj_t = k_proj.t()?.contiguous()?;
+            let v_proj_t = v_proj.t()?.contiguous()?;
+            let o_proj_t = o_proj.t()?.contiguous()?;
+            let gate_proj = randn(&[intermediate_size, hidden_size])?;
+            let up_proj = randn(&[intermediate_size, hidden_size])?;
+            let down_proj = randn(&[hidden_size, intermediate_size])?;
+            let gate_proj_t = gate_proj.t()?.contiguous()?;
+            let up_proj_t = up_proj.t()?.contiguous()?;
+            let down_proj_t = down_proj.t()?.contiguous()?;
             layers.push(GpuLayerWeights {
                 input_layernorm: Tensor::zeros(hidden_size, DType::F32, device)?,
                 post_attention_layernorm: Tensor::zeros(hidden_size, DType::F32, device)?,
                 attention: GpuAttentionWeights::Full(GpuFullAttentionWeights {
-                    q_proj: randn(&[num_heads * head_dim, hidden_size])?,
-                    k_proj: randn(&[num_kv_heads * head_dim, hidden_size])?,
-                    v_proj: randn(&[num_kv_heads * head_dim, hidden_size])?,
-                    o_proj: randn(&[hidden_size, num_heads * head_dim])?,
+                    q_proj,
+                    k_proj,
+                    v_proj,
+                    o_proj,
                     q_norm: Tensor::zeros(head_dim, DType::F32, device)?,
                     k_norm: Tensor::zeros(head_dim, DType::F32, device)?,
+                    q_proj_t,
+                    k_proj_t,
+                    v_proj_t,
+                    o_proj_t,
                 }),
                 mlp: GpuFfnWeights {
-                    gate_proj: randn(&[intermediate_size, hidden_size])?,
-                    up_proj: randn(&[intermediate_size, hidden_size])?,
-                    down_proj: randn(&[hidden_size, intermediate_size])?,
+                    gate_proj,
+                    up_proj,
+                    down_proj,
+                    gate_proj_t,
+                    up_proj_t,
+                    down_proj_t,
                 },
             });
         }
@@ -3276,13 +3380,25 @@ mod tests {
         for i in 0..num_layers {
             let is_full = (i + 1) % full_attention_interval == 0;
             let attention = if is_full {
+                let q_proj = randn(&[num_heads * head_dim, hidden_size])?;
+                let k_proj = randn(&[num_kv_heads * head_dim, hidden_size])?;
+                let v_proj = randn(&[num_kv_heads * head_dim, hidden_size])?;
+                let o_proj = randn(&[hidden_size, num_heads * head_dim])?;
+                let q_proj_t = q_proj.t()?.contiguous()?;
+                let k_proj_t = k_proj.t()?.contiguous()?;
+                let v_proj_t = v_proj.t()?.contiguous()?;
+                let o_proj_t = o_proj.t()?.contiguous()?;
                 GpuAttentionWeights::Full(GpuFullAttentionWeights {
-                    q_proj: randn(&[num_heads * head_dim, hidden_size])?,
-                    k_proj: randn(&[num_kv_heads * head_dim, hidden_size])?,
-                    v_proj: randn(&[num_kv_heads * head_dim, hidden_size])?,
-                    o_proj: randn(&[hidden_size, num_heads * head_dim])?,
+                    q_proj,
+                    k_proj,
+                    v_proj,
+                    o_proj,
                     q_norm: Tensor::zeros(head_dim, DType::F32, device)?,
                     k_norm: Tensor::zeros(head_dim, DType::F32, device)?,
+                    q_proj_t,
+                    k_proj_t,
+                    v_proj_t,
+                    o_proj_t,
                 })
             } else {
                 GpuAttentionWeights::Linear(GpuLinearAttentionWeights {
@@ -3298,14 +3414,23 @@ mod tests {
                 })
             };
 
+            let gate_proj = randn(&[intermediate_size, hidden_size])?;
+            let up_proj = randn(&[intermediate_size, hidden_size])?;
+            let down_proj = randn(&[hidden_size, intermediate_size])?;
+            let gate_proj_t = gate_proj.t()?.contiguous()?;
+            let up_proj_t = up_proj.t()?.contiguous()?;
+            let down_proj_t = down_proj.t()?.contiguous()?;
             layers.push(GpuLayerWeights {
                 input_layernorm: Tensor::zeros(hidden_size, DType::F32, device)?,
                 post_attention_layernorm: Tensor::zeros(hidden_size, DType::F32, device)?,
                 attention,
                 mlp: GpuFfnWeights {
-                    gate_proj: randn(&[intermediate_size, hidden_size])?,
-                    up_proj: randn(&[intermediate_size, hidden_size])?,
-                    down_proj: randn(&[hidden_size, intermediate_size])?,
+                    gate_proj,
+                    up_proj,
+                    down_proj,
+                    gate_proj_t,
+                    up_proj_t,
+                    down_proj_t,
                 },
             });
         }

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1060,27 +1060,46 @@ mod tests {
         let embed_t = embed.t().unwrap().contiguous().unwrap();
         let final_norm = Tensor::zeros((h,), candle_core::DType::F32, device).unwrap();
 
+        let q_proj = Tensor::randn(0.0_f32, 0.02, (num_heads * head_dim, h), device).unwrap();
+        let k_proj = Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, h), device).unwrap();
+        let v_proj = Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, h), device).unwrap();
+        let o_proj = Tensor::randn(0.0_f32, 0.02, (h, num_heads * head_dim), device).unwrap();
+        let q_proj_t = q_proj.t().unwrap().contiguous().unwrap();
+        let k_proj_t = k_proj.t().unwrap().contiguous().unwrap();
+        let v_proj_t = v_proj.t().unwrap().contiguous().unwrap();
+        let o_proj_t = o_proj.t().unwrap().contiguous().unwrap();
+
+        let gate_proj = Tensor::randn(0.0_f32, 0.02, (inter, h), device).unwrap();
+        let up_proj = Tensor::randn(0.0_f32, 0.02, (inter, h), device).unwrap();
+        let down_proj = Tensor::randn(0.0_f32, 0.02, (h, inter), device).unwrap();
+        let gate_proj_t = gate_proj.t().unwrap().contiguous().unwrap();
+        let up_proj_t = up_proj.t().unwrap().contiguous().unwrap();
+        let down_proj_t = down_proj.t().unwrap().contiguous().unwrap();
+
         let layer = crate::forward::GpuLayerWeights {
             input_layernorm: Tensor::zeros((h,), candle_core::DType::F32, device).unwrap(),
             post_attention_layernorm: Tensor::zeros((h,), candle_core::DType::F32, device).unwrap(),
             attention: crate::forward::GpuAttentionWeights::Full(
                 crate::forward::GpuFullAttentionWeights {
-                    q_proj: Tensor::randn(0.0_f32, 0.02, (num_heads * head_dim, h), device)
-                        .unwrap(),
-                    k_proj: Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, h), device)
-                        .unwrap(),
-                    v_proj: Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, h), device)
-                        .unwrap(),
-                    o_proj: Tensor::randn(0.0_f32, 0.02, (h, num_heads * head_dim), device)
-                        .unwrap(),
+                    q_proj,
+                    k_proj,
+                    v_proj,
+                    o_proj,
                     q_norm: Tensor::zeros((head_dim,), candle_core::DType::F32, device).unwrap(),
                     k_norm: Tensor::zeros((head_dim,), candle_core::DType::F32, device).unwrap(),
+                    q_proj_t,
+                    k_proj_t,
+                    v_proj_t,
+                    o_proj_t,
                 },
             ),
             mlp: crate::forward::GpuFfnWeights {
-                gate_proj: Tensor::randn(0.0_f32, 0.02, (inter, h), device).unwrap(),
-                up_proj: Tensor::randn(0.0_f32, 0.02, (inter, h), device).unwrap(),
-                down_proj: Tensor::randn(0.0_f32, 0.02, (h, inter), device).unwrap(),
+                gate_proj,
+                up_proj,
+                down_proj,
+                gate_proj_t,
+                up_proj_t,
+                down_proj_t,
             },
         };
 

--- a/crates/kiln-model/src/lora_loader.rs
+++ b/crates/kiln-model/src/lora_loader.rs
@@ -248,6 +248,28 @@ pub fn linear_with_lora(
     }
 }
 
+/// Apply a LoRA-augmented linear projection using a pre-transposed base weight.
+///
+/// Takes `base_weight_t` = `base_weight.t().contiguous()` (shape `[in, out]`) and
+/// computes `x @ base_weight_t` directly, avoiding the per-call transpose copy
+/// (`ucopy_bf16`) that would otherwise be materialized on every step.
+///
+/// The LoRA delta path is unchanged.
+pub fn linear_with_lora_t(
+    x: &Tensor,
+    base_weight_t: &Tensor,
+    lora: Option<&LoraProjectionWeights>,
+    scale: f32,
+) -> Result<Tensor> {
+    let base_output = x.broadcast_matmul(base_weight_t)?;
+    if let Some(proj) = lora {
+        let delta = compute_lora_delta(x, proj, scale)?;
+        Ok((base_output + delta)?)
+    } else {
+        Ok(base_output)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -57,21 +57,44 @@ fn tiny_weights(config: &ModelConfig, device: &Device) -> GpuWeights {
     let embed_t = embed.t().unwrap().contiguous().unwrap();
     let final_norm = Tensor::zeros((h,), DType::F32, device).unwrap();
 
+    let q_proj = Tensor::randn(0.0_f32, 0.02, (num_heads * head_dim, h), device).unwrap();
+    let k_proj = Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, h), device).unwrap();
+    let v_proj = Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, h), device).unwrap();
+    let o_proj = Tensor::randn(0.0_f32, 0.02, (h, num_heads * head_dim), device).unwrap();
+    let q_proj_t = q_proj.t().unwrap().contiguous().unwrap();
+    let k_proj_t = k_proj.t().unwrap().contiguous().unwrap();
+    let v_proj_t = v_proj.t().unwrap().contiguous().unwrap();
+    let o_proj_t = o_proj.t().unwrap().contiguous().unwrap();
+
+    let gate_proj = Tensor::randn(0.0_f32, 0.02, (inter, h), device).unwrap();
+    let up_proj = Tensor::randn(0.0_f32, 0.02, (inter, h), device).unwrap();
+    let down_proj = Tensor::randn(0.0_f32, 0.02, (h, inter), device).unwrap();
+    let gate_proj_t = gate_proj.t().unwrap().contiguous().unwrap();
+    let up_proj_t = up_proj.t().unwrap().contiguous().unwrap();
+    let down_proj_t = down_proj.t().unwrap().contiguous().unwrap();
+
     let layer = GpuLayerWeights {
         input_layernorm: Tensor::zeros((h,), DType::F32, device).unwrap(),
         post_attention_layernorm: Tensor::zeros((h,), DType::F32, device).unwrap(),
         attention: GpuAttentionWeights::Full(GpuFullAttentionWeights {
-            q_proj: Tensor::randn(0.0_f32, 0.02, (num_heads * head_dim, h), device).unwrap(),
-            k_proj: Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, h), device).unwrap(),
-            v_proj: Tensor::randn(0.0_f32, 0.02, (num_kv_heads * head_dim, h), device).unwrap(),
-            o_proj: Tensor::randn(0.0_f32, 0.02, (h, num_heads * head_dim), device).unwrap(),
+            q_proj,
+            k_proj,
+            v_proj,
+            o_proj,
             q_norm: Tensor::zeros((head_dim,), DType::F32, device).unwrap(),
             k_norm: Tensor::zeros((head_dim,), DType::F32, device).unwrap(),
+            q_proj_t,
+            k_proj_t,
+            v_proj_t,
+            o_proj_t,
         }),
         mlp: GpuFfnWeights {
-            gate_proj: Tensor::randn(0.0_f32, 0.02, (inter, h), device).unwrap(),
-            up_proj: Tensor::randn(0.0_f32, 0.02, (inter, h), device).unwrap(),
-            down_proj: Tensor::randn(0.0_f32, 0.02, (h, inter), device).unwrap(),
+            gate_proj,
+            up_proj,
+            down_proj,
+            gate_proj_t,
+            up_proj_t,
+            down_proj_t,
         },
     };
 

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -1430,23 +1430,44 @@ mod tests {
             let input_layernorm = Tensor::zeros(h, DType::F32, device)?;
             let post_attention_layernorm = Tensor::zeros(h, DType::F32, device)?;
 
+            let gate_proj = Tensor::randn(0.0f32, 0.02, (inter, h), device)?;
+            let up_proj = Tensor::randn(0.0f32, 0.02, (inter, h), device)?;
+            let down_proj = Tensor::randn(0.0f32, 0.02, (h, inter), device)?;
+            let gate_proj_t = gate_proj.t()?.contiguous()?;
+            let up_proj_t = up_proj.t()?.contiguous()?;
+            let down_proj_t = down_proj.t()?.contiguous()?;
             let mlp = GpuFfnWeights {
-                gate_proj: Tensor::randn(0.0f32, 0.02, (inter, h), device)?,
-                up_proj: Tensor::randn(0.0f32, 0.02, (inter, h), device)?,
-                down_proj: Tensor::randn(0.0f32, 0.02, (h, inter), device)?,
+                gate_proj,
+                up_proj,
+                down_proj,
+                gate_proj_t,
+                up_proj_t,
+                down_proj_t,
             };
 
             let attention = if config.is_full_attention_layer(layer_idx) {
                 let nh = config.num_attention_heads;
                 let nkv = config.num_kv_heads;
                 let hd = config.head_dim;
+                let q_proj = Tensor::randn(0.0f32, 0.02, (nh * hd, h), device)?;
+                let k_proj = Tensor::randn(0.0f32, 0.02, (nkv * hd, h), device)?;
+                let v_proj = Tensor::randn(0.0f32, 0.02, (nkv * hd, h), device)?;
+                let o_proj = Tensor::randn(0.0f32, 0.02, (h, nh * hd), device)?;
+                let q_proj_t = q_proj.t()?.contiguous()?;
+                let k_proj_t = k_proj.t()?.contiguous()?;
+                let v_proj_t = v_proj.t()?.contiguous()?;
+                let o_proj_t = o_proj.t()?.contiguous()?;
                 GpuAttentionWeights::Full(GpuFullAttentionWeights {
-                    q_proj: Tensor::randn(0.0f32, 0.02, (nh * hd, h), device)?,
-                    k_proj: Tensor::randn(0.0f32, 0.02, (nkv * hd, h), device)?,
-                    v_proj: Tensor::randn(0.0f32, 0.02, (nkv * hd, h), device)?,
-                    o_proj: Tensor::randn(0.0f32, 0.02, (h, nh * hd), device)?,
+                    q_proj,
+                    k_proj,
+                    v_proj,
+                    o_proj,
                     q_norm: Tensor::ones((hd,), DType::F32, device)?,
                     k_norm: Tensor::ones((hd,), DType::F32, device)?,
+                    q_proj_t,
+                    k_proj_t,
+                    v_proj_t,
+                    o_proj_t,
                 })
             } else {
                 let qkv_dim = config.linear_qkv_dim();


### PR DESCRIPTION
## What

Pre-transpose the seven projection weights (gate_proj, up_proj, down_proj, q_proj, k_proj, v_proj, o_proj) at model-load time into `_t` fields on `GpuFfnWeights` / `GpuFullAttentionWeights`. The hot-path `linear_with_lora_t` helper uses these instead of calling `base_weight.t()` on every forward step.

This is the same pattern PR #117 introduced for `embed_tokens_t` / `lm_head_t`, applied to the rest of the per-layer projections.

## Why

`PROFILING.md` (refreshed in PR #124, post-PR-117) showed the per-step `ucopy_bf16` transpose copies as the #1 decode GPU-time hotspot at ~57.6% (MLP 50.7% + attention 6.9%). Caching the transpose at load time eliminates that copy from every decode step.

## Results

GPU benchmark on RunPod RTX A6000, identical workload, full numbers in `BENCH_PROJT.md`:

| Metric                        | main (d5c6e83) | branch (1759e33+) | Δ        |
|-------------------------------|----------------|-------------------|----------|
| **Decode tok/s** (paged)      | **7.61**       | **17.70**         | **+133%** |
| Mean inter-token latency      | 131.4 ms       | 56.5 ms           | −57%     |
| Throughput (batch 16)         | 7.30 tok/s     | 16.84 tok/s       | +131%    |
| Model VRAM                    | 9526 MB        | 14422 MB          | +4896 MB |

Decode speedup: **2.33×**, in line with the predicted 1.8–2.5× range. VRAM cost (~4.9 GB extra for the cached `_t` tensors at bf16) is below the PR's ~8.7 GB estimate and well within the A6000 budget.

### Flagged regression: cold paged-prefill

The single-shot `--paged` prefill measured by the latency phase regressed from 524 ms → 10724 ms on the first paged forward (see `BENCH_PROJT.md` for details). This is a one-time cold-path cost — the throughput phase, which warms up before measuring, sees no equivalent regression and prefill amortizes to <1 s per 506-token prompt in steady state. The decode hot path is unaffected.

Worth follow-up but does not block this PR — the 2.3× steady-state end-to-end win at every batch size is what production traffic will see.

## Tests

- All existing kiln-model CPU tests pass (commit 1759e33 was already pushed and tested).
- GPU bench on RTX A6000 confirms ≥5% decode speedup floor by a ~25× margin.
