### PR TITLE
CE: docs — mark chunk_gla_fwd vendor as landed (PR #80); redirect next target

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -2351,6 +2351,15 @@ the profile to expose the next tier of cost (RMSNorm + GDN body).
 > via `recurrent_gdn_fwd_kernel`) would amortize launch overhead and
 > cut the residual 24 % of NVTX wallclock those four ranges
 > occupy.
+>
+> **Not next target — already vendored**: the project's "Current
+> optimization queue" item *Vendor fla-org chunk_gla_fwd (minimal)*
+> landed in PR #80 (commit `0c9c519`, crate `kiln-gdn-kernel`,
+> kernels `gdn_fwd_sub_kernel` for chunkwise prefill and
+> `recurrent_gdn_fwd_kernel` for seq_len==1 decode). Both are
+> already in the per-kernel tables above and are *not* the next
+> hotspot. Planning loops re-proposing "vendor chunk_gla_fwd" should
+> redirect to the RMSNorm-fusion or GDN-body-vendor items.
 
 ### Comparison table — pre-fix vs. post-fix
 

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -1,22 +1,62 @@
 //! Vendored Gated DeltaNet (GDN) chunk forward-substitution CUDA kernel.
 //!
-//! This crate provides [`gdn_forward_substitution`], a thin candle wrapper
-//! around a single fused CUDA kernel that replaces the per-token forward
-//! substitution loop in kiln's chunkwise analytical GDN recurrence:
+//! # Provenance: fla-org `chunk_gla_fwd`
 //!
-//! ```text
-//! W[t, :] = beta[t] * ( V_prime[t, :]
-//!                      - sum_{i<t} A_strict[t, i] * W[i, :] )
-//! ```
+//! This crate is the vendored port of
+//! [`fla-org/flash-linear-attention`](https://github.com/fla-org/flash-linear-attention)'s
+//! `chunk_gla_fwd` Triton kernel (source: `fla/ops/gla/chunk.py`) into
+//! raw CUDA C. It landed as PR #80 (commit `0c9c519`) and fulfills the
+//! "Phase 6 — Vendor fla-org chunk_gla_fwd (minimal)" item from the
+//! project's performance-optimization queue in the project description.
 //!
-//! The kernel is intentionally narrow:
-//!   - bf16 activations only.
+//! Any follow-up planning task titled "vendor chunk_gla_fwd" should
+//! re-verify current `PROFILING.md` before opening a new PR — the core
+//! vendor is here, and the per-token Rust forward-sub loop it replaced
+//! is gone from the CUDA path. The remaining candle ops in
+//! `kiln-model::forward::gdn_chunkwise_recurrence` (cumsum + exp decay
+//! matrix, KKT/QKT matmuls, intra-chunk `B_mask @ W`, final state
+//! update) are *not* inside this vendor's scope; they are distinct
+//! operations the scheduler launches per chunk.
+//!
+//! # API
+//!
+//! - [`gdn_forward_substitution`] — chunkwise prefill forward-sub step.
+//!   Thin candle wrapper around a single fused CUDA kernel that
+//!   replaces the per-token forward-substitution loop in kiln's
+//!   chunkwise analytical GDN recurrence:
+//!
+//!   ```text
+//!   W[t, :] = beta[t] * ( V_prime[t, :]
+//!                        - sum_{i<t} A_strict[t, i] * W[i, :] )
+//!   ```
+//!
+//! - [`gdn_recurrent_forward`] — seq_len==1 decode fast path. Collapses
+//!   the single-token GDN recurrence (decay, delta, state-update,
+//!   output projection) into one block per `(batch, head)`.
+//!
+//! # Envelope
+//!
+//! The kernels are intentionally narrow (per the project's
+//! "minimal-scope vendoring" policy):
+//!
+//!   - bf16 activations, F32 accumulators inside the kernel.
+//!   - Causal / forward-pass only.
 //!   - `dv` <= 1024 (kiln uses 128).
-//!   - `chunk_size` <= 128 (kiln uses 64).
-//!   - One block per (batch, head); no tensor-core path.
+//!   - `chunk_size` <= 128 (kiln uses 64) for forward-sub.
+//!   - `dk` <= 256 (kiln uses 128) for recurrent.
+//!   - One CUDA block per `(batch, head)`; no tensor-core path.
 //!
-//! Anything outside that envelope should fall back to the Rust+candle
-//! implementation in `kiln-model::forward`.
+//! Anything outside that envelope falls back to the Rust+candle
+//! reference in `kiln-model::forward::compute_w_chunk_fallback`, which
+//! also serves as the correctness oracle for
+//! `test_gdn_kernel_matches_fallback`.
+//!
+//! # Not yet vendored
+//!
+//! Per `PROFILING.md` (post-PR #130, Phase 6), the next GDN-side
+//! targets are the GDN body ranges (`gated_norm`, `gates`, `conv`,
+//! `qk_norm`) and the two RMSNorm stages — these are upstream of the
+//! chunkwise recurrence and are *not* covered by this crate.
 
 use candle_core::{
     backend::BackendStorage,


### PR DESCRIPTION
## Summary

The project's "Current optimization queue" item *Vendor fla-org chunk_gla_fwd (minimal)* was landed by **PR #80** (commit `0c9c519`, 2026-04-16). This PR is a **documentation-only** change that records that provenance in two places so future planning loops do not re-propose the same work.

No code. No kernels. No build change. No behavior change.

## Why

A fresh planning task was opened asking to "port the GDN chunkwise Triton kernel to raw CUDA" and "create a new crate `kiln-gdn-kernel/` following `kiln-flash-attn/` layout." The scope, envelope, deliverables, and parity-test spec matched PR #80 *exactly*:

| Task deliverable | Current state on `main` |
| --- | --- |
| New crate `kiln-gdn-kernel/` with `csrc/ + src/lib.rs + build.rs` | Exists since PR #80 |
| C-ABI wrapper (thin, ~200–400 lines) | `kiln_gdn_forward_substitution` + `kiln_gdn_recurrent_forward` |
| Rust FFI + safe candle wrapper | `gdn_forward_substitution` + `gdn_recurrent_forward` |
| bf16 activations, F32 accumulators, causal, fwd-only | Envelope matches |
| Wired into `kiln-model` chunkwise GDN path, cuda-feature-gated | `compute_w_chunk` at `forward.rs:819` |
| Parity test `max_abs_diff < 1e-2` vs candle reference | `test_gdn_kernel_matches_fallback` at `forward.rs:3903` |

Per project policy ("Verify the remaining scope still exists before creating any phased task") and the `kernel-vendor-precondition-check` note ("If X < threshold, stop before any pod cost"), no A6000 was spun up past an initial terminated-immediately launch. Cost: ~\$0.04.

## Changes

**`crates/kiln-gdn-kernel/src/lib.rs`** — expand the module-level doc to:
- Name `chunk_gla_fwd` explicitly so grep/search finds it.
- Point at the upstream Triton source (`fla/ops/gla/chunk.py`).
- List both vendored entry points and their call-site semantics.
- Call out what is **not** in scope for this crate (decay matrix, KKT/QKT, `B_mask @ W` intra-chunk, state update) so the next optimization target is unambiguous.

**`PROFILING.md`** — append a "**Not next target — already vendored**" callout to the "Recommended next optimization target" section of the post-PR #130 Phase 6 profile, redirecting any re-proposal of "vendor chunk_gla_fwd" to the RMSNorm-fusion or GDN-body-vendor items the profile actually surfaces as the current hotspot.

## Verification

Documentation-only diff:

```
 PROFILING.md                      |  9 +++++
 crates/kiln-gdn-kernel/src/lib.rs | 66 ++++++++++++++++++++++++++-----------
 2 files changed, 62 insertions(+), 13 deletions(-)
```

No Rust source, no CUDA source, no build.rs, no tests, no kernel changes. `cargo check` / `cargo test` behavior is unchanged by this PR.

## Test plan

- [x] Diff is documentation-only (verified by `git diff --stat`).
- [x] No changes to `*.rs` code paths, `*.cu`, `*.h`, `Cargo.toml`, `build.rs`, or any test.
- [x] No runtime cost burn — pod launched and immediately terminated after precondition check.