### PR TITLE
CE: Fuse pre-norm RMSNorm into single CUDA kernel (1.215x paged decode)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/kiln-gdn-kernel",
     "crates/kiln-model",
     "crates/kiln-nvtx",
+    "crates/kiln-rmsnorm-kernel",
     "crates/kiln-scheduler",
     "crates/kiln-server",
     "crates/kiln-train",
@@ -63,6 +64,7 @@ candle-nn = "0.10"
 kiln-flash-attn = { path = "crates/kiln-flash-attn" }
 kiln-gdn-kernel = { path = "crates/kiln-gdn-kernel" }
 kiln-nvtx = { path = "crates/kiln-nvtx" }
+kiln-rmsnorm-kernel = { path = "crates/kiln-rmsnorm-kernel" }
 
 # Random number generation
 rand = "0.8"

--- a/PROFILING.md
+++ b/PROFILING.md
@@ -2335,22 +2335,23 @@ the profile to expose the next tier of cost (RMSNorm + GDN body).
 
 ### Recommended next optimization target
 
-> **Decode**: with the GDN projection `ucopy_bf16` mass eliminated,
-> the next decode tier is the two RMSNorm stages
-> (`kiln/norm/pre_mlp` + `kiln/norm/pre_attn`) and the GDN body
-> kernels (`gated_norm`, `gates`, `conv`, `qk_norm`), which are now
-> the relative top of the profile. Fusing `pre_*norm + projection`
-> into a single kernel per layer is the same class of fix that
-> collapsed the projection cost; on Qwen3.5-4B it would target the
-> remaining ~13 % of decode wallclock that the two RMSNorms occupy
-> in the post-fix profile.
+> **Not next target — landed in this PR**: fusing the two RMSNorm
+> stages (`kiln/norm/pre_mlp` + `kiln/norm/pre_attn`, combined ~22 %
+> of decode NVTX in the prior profile) was the recommended next
+> decode-tier fix. It landed as the Liger-style fused RMSNorm CUDA
+> kernel in crate `kiln-rmsnorm-kernel` (this PR), collapsing
+> candle's ~11-launch op chain into a single fused kernel. Measured
+> decode ITL (paged, 506-token prompt) improved **27.67 ms →
+> 22.77 ms (1.215×)** with peak VRAM unchanged (16 840 MB). See the
+> "Phase 6 — Fused RMSNorm" section below.
 >
-> **Secondary**: the GDN body (`gated_norm`, `gates`, `conv`,
-> `qk_norm`) is currently expressed as candle ops; vendoring a fused
-> Triton/CUDA kernel for the recurrent step (already partially done
-> via `recurrent_gdn_fwd_kernel`) would amortize launch overhead and
-> cut the residual 24 % of NVTX wallclock those four ranges
-> occupy.
+> **Decode (next)**: with the RMSNorm mass collapsed, the GDN body
+> kernels (`gated_norm`, `gates`, `conv`, `qk_norm`) are now the
+> relative top of the profile. These are still expressed as candle
+> ops; vendoring a fused Triton/CUDA kernel for the recurrent GDN
+> body step (already partially done via `recurrent_gdn_fwd_kernel`)
+> would amortize launch overhead and cut the residual ~38 % of
+> decode NVTX wallclock those four ranges occupy.
 >
 > **Not next target — already vendored**: the project's "Current
 > optimization queue" item *Vendor fla-org chunk_gla_fwd (minimal)*
@@ -2359,7 +2360,7 @@ the profile to expose the next tier of cost (RMSNorm + GDN body).
 > `recurrent_gdn_fwd_kernel` for seq_len==1 decode). Both are
 > already in the per-kernel tables above and are *not* the next
 > hotspot. Planning loops re-proposing "vendor chunk_gla_fwd" should
-> redirect to the RMSNorm-fusion or GDN-body-vendor items.
+> redirect to the GDN-body-vendor item above.
 
 ### Comparison table — pre-fix vs. post-fix
 
@@ -2398,3 +2399,139 @@ Timing-only metrics (ITL, prefill latency, throughput) were taken
 from unprofiled `kiln-bench` runs on the same pod and the fix
 commit; those runs are preserved in the committed `*_bench.log`
 files.
+
+---
+
+# Kiln Profiling Report — Phase 6, Fused RMSNorm Kernel
+
+## Summary
+
+This round fuses the pre-norm RMSNorm into a single CUDA kernel,
+collapsing candle's ~11-launch op chain
+(`cast → sqr → mean → add_eps → sqrt → recip → bmul → cast(w) →
+ones_like → add → bmul → cast_back`) into one kernel per call.
+
+The recommendation from the previous round (PR #130 section above)
+explicitly named this as the next decode-tier target:
+
+> "Fusing `pre_*norm + projection` into a single kernel per layer
+> … would target the remaining ~13 % of decode wallclock that the
+> two RMSNorms occupy in the post-fix profile."
+
+This PR lands the fused-RMSNorm half of that target. Body-side
+fusion with the subsequent GEMM is left for a follow-up.
+
+## Fix Summary
+
+- **New crate**: `kiln-rmsnorm-kernel` (workspace member)
+  - `csrc/fused_rmsnorm.cu` — Liger-style fused kernel: one block
+    per row, 256 threads/block, `__shfl_xor_sync` warp reduction +
+    shared-memory block reduction, F32 accumulation + F32 epilogue
+    with bf16 load/store. Implements Qwen3.5's **`(1 + weight) * x *
+    rsqrt(mean(x²) + eps)`** formulation. Envelope: `hidden_size ≤
+    8192`, bf16 activations, row-major contiguous rows.
+  - `csrc/fused_rmsnorm.h` — C-ABI:
+    `kiln_fused_rmsnorm(x_bf16, w_bf16, out_bf16, rows, hidden, eps,
+    stream) -> status`. Pattern matches `kiln-flash-attn` and
+    `kiln-gdn-kernel`.
+  - `build.rs` — compiles the `.cu` via the `cc` crate for archs
+    `80;86;89;90` (override via `KILN_CUDA_ARCHS`).
+  - `src/lib.rs` — Rust FFI wrapper with `supports()` and
+    `fused_rmsnorm()`. Guards on `DType::BF16`, contiguous rows,
+    non-empty input, `hidden ≤ 8192`, and a `Cuda` device. Uses
+    `storage_and_layout` + `as_cuda_slice::<bf16>()` +
+    `.device_ptr()` + `.cu_stream() as *mut c_void` to match the
+    existing vendored-kernel pattern.
+
+- **Integration** (`kiln-model/src/forward.rs`): the `rms_norm`
+  helper now dispatches to the fused kernel when `feature = "cuda"`
+  is enabled, the env toggle `KILN_DISABLE_RMSNORM_KERNEL` is
+  unset, and `kiln_rmsnorm_kernel::supports(&x, &weight)` returns
+  true. Otherwise it falls back to the original candle op chain
+  (preserved verbatim as `rms_norm_fallback`). The dispatch point
+  is intentionally inside the single `rms_norm` helper so every
+  call site (`transformer_block`, `transformer_block_paged`, and
+  the GDN `model_forward` paths) picks up the fused kernel
+  transparently.
+
+- **Workspace glue**: `kiln-rmsnorm-kernel` added to
+  `Cargo.toml` members, `workspace.dependencies`, and `kiln-model`
+  enables it under the existing `cuda` feature (same pattern as
+  `kiln-flash-attn` and `kiln-gdn-kernel`).
+
+## Parity
+
+All 3 in-crate unit tests pass with tolerance **1e-2** max abs
+diff vs the candle op chain on deterministic LCG inputs
+(`candle-core 0.10`, A6000, bf16):
+
+| Test | Shape | Result |
+| --- | --- | --- |
+| `parity_decode_row` | `[1, 2560]` (hot decode path) | **ok** |
+| `parity_multi_row` | `[512, 2560]` (prefill path) | **ok** |
+| `parity_with_batch_dim` | `[2, 3, 2560]` (batched) | **ok** |
+
+```
+running 3 tests
+test tests::parity_multi_row ... ok
+test tests::parity_decode_row ... ok
+test tests::parity_with_batch_dim ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored
+```
+
+## Benchmark — Paged production path (506 tokens, 128 decoded)
+
+Captured on the same RunPod A6000 pod (`na9gxbvmn0chht`) against
+the Qwen3.5-4B baseline, same model, same prompt, same pod, `main`
+vs `ce/fuse-pre-norm-projection`:
+
+| Metric | Pre-fix (`main` @ `9b7e09d`) | **Post-fix (this PR)** | Δ |
+| --- | ---: | ---: | ---: |
+| Mean ITL (paged) | 27.67 ms | **22.77 ms** | −17.7 % (**1.215×**) |
+| P50 ITL (paged) | 27.59 ms | **22.65 ms** | −17.9 % (1.218×) |
+| P99 ITL (paged) | 37.48 ms | **28.13 ms** | −25.0 % (1.332×) |
+| Decode throughput (paged, single) | 36.15 tok/s | **43.91 tok/s** | +21.5 % |
+| Prefill @ 506 tokens (paged) | 424.2 ms (1 193 tok/s) | **405.8 ms (1 247 tok/s)** | −4.3 % (+4.5 % tok/s) |
+| Peak inference VRAM | 16 840 MB | **16 840 MB** | 0 MB (within ±500 MB) |
+
+Non-paged path (`generate_from_tokens`) also improved:
+
+| Metric | Pre-fix | **Post-fix** | Δ |
+| --- | ---: | ---: | ---: |
+| Mean ITL (non-paged) | 26.73 ms | **24.27 ms** | −9.2 % (1.101×) |
+| P50 ITL (non-paged) | 26.47 ms | **24.01 ms** | −9.3 % (1.103×) |
+| P99 ITL (non-paged) | 29.02 ms | **28.05 ms** | −3.3 % |
+| Decode throughput (non-paged, single) | 37.42 tok/s | **41.21 tok/s** | +10.1 % |
+
+### Acceptance criteria (from task spec)
+
+| Criterion | Target | **Result** |
+| --- | --- | --- |
+| Parity vs candle op chain | `max_abs_diff < 1e-2` | ✅ all 3 shapes |
+| Decode ITL speedup (paged) | 1.15×–1.35× (hard floor 1.05×) | ✅ **1.215×** |
+| Prefill @ 506 tokens (paged) | regression ≤ ±3 % | ✅ **−4.3 % (improvement)** |
+| Peak inference VRAM | within ±500 MB of main | ✅ **0 MB delta** |
+
+The ~13 % decode-wallclock envelope quoted in the prior section
+(`pre_attn` 11.1 % + `pre_mlp` 11.0 %, combined 22.1 % of decode
+NVTX) cashed in at **17.7 %** of total paged decode wallclock. The
+extra headroom comes from collapsed launch overhead: the fused
+kernel replaces ~11 kernel launches × 32 layers × 2 norms
+(~700 fewer launches per decode step in the non-paged path,
+similar on the paged path) with a single launch per norm call.
+
+## Artifacts
+
+- Baseline (main) bench: `/tmp/bench-main-final.log` on the pod
+  (discarded at pod termination; numbers reproduced in the tables
+  above).
+- Branch bench: `/tmp/branch-run.log` on the pod (same).
+- Unit tests: `cargo test --release -p kiln-rmsnorm-kernel` — 3/3
+  pass on A6000.
+
+No new CSV / nsys artifacts were collected for this round — the
+improvement target (two RMSNorm NVTX ranges) and its size were
+already characterized by the prior round's CSVs (committed in PR
+#130). The only new evidence needed for this PR is the unprofiled
+timing comparison and the parity tests, both included above.

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -18,11 +18,12 @@ candle-core = { workspace = true }
 candle-nn = { workspace = true }
 kiln-flash-attn = { workspace = true, optional = true }
 kiln-gdn-kernel = { workspace = true, optional = true }
+kiln-rmsnorm-kernel = { workspace = true, optional = true }
 kiln-nvtx = { workspace = true }
 rand = { workspace = true }
 
 [features]
-cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel"]
+cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel", "dep:kiln-rmsnorm-kernel"]
 # Emit NVTX ranges around the hot paths in `forward.rs` so nsys can attribute
 # kernel time per call site. Off by default; pulls in kiln-nvtx's libnvToolsExt
 # link line. Pair with `--features cuda,nvtx`.

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -414,7 +414,28 @@ pub fn embedding_lookup(token_ids: &[u32], embed_weights: &Tensor) -> Result<Ten
 /// `eps`: small constant for numerical stability (1e-6 for Qwen3.5-4B)
 ///
 /// Returns: same shape as `x`.
+///
+/// On CUDA+bf16 inputs within the kernel envelope (hidden <= 8192), dispatches
+/// to `kiln_rmsnorm_kernel::fused_rmsnorm`, which collapses the ~11 candle op
+/// launches (to_dtype, sqr, mean_keepdim, +eps, sqrt, recip, broadcast_mul,
+/// to_dtype, ones_like + w, broadcast_mul, to_dtype) into a single fused kernel.
+/// Falls back to the candle-op path on CPU, non-bf16, or out-of-envelope inputs.
 pub fn rms_norm(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
+    #[cfg(feature = "cuda")]
+    {
+        let disabled = std::env::var("KILN_DISABLE_RMSNORM_KERNEL").is_ok();
+        if !disabled && kiln_rmsnorm_kernel::supports(x, weight) {
+            return kiln_rmsnorm_kernel::fused_rmsnorm(x, weight, eps as f32)
+                .context("fused_rmsnorm kernel failed");
+        }
+    }
+    rms_norm_fallback(x, weight, eps)
+}
+
+/// Candle-op reference RMSNorm. Kept as the CPU path and as the correctness
+/// oracle for the fused CUDA kernel. Matches HF semantics exactly:
+/// `out = (1 + w) * x * rsqrt(mean(x^2) + eps)` with F32 reduction and epilogue.
+pub fn rms_norm_fallback(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
     let x_f32 = x.to_dtype(DType::F32)?;
     let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
     let rms_inv = (variance + eps)?.sqrt()?.recip()?;

--- a/crates/kiln-rmsnorm-kernel/Cargo.toml
+++ b/crates/kiln-rmsnorm-kernel/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kiln-rmsnorm-kernel"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Fused RMSNorm CUDA kernel (Liger-style) with C-ABI wrapper — collapses candle's ~11 launches into one"
+build = "build.rs"
+
+[dependencies]
+candle-core = { workspace = true, features = ["cuda"] }
+half = "2"
+
+[build-dependencies]
+cc = "1"

--- a/crates/kiln-rmsnorm-kernel/build.rs
+++ b/crates/kiln-rmsnorm-kernel/build.rs
@@ -1,0 +1,95 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let cuda_root = match find_cuda_root() {
+        Some(p) => p,
+        None => {
+            println!("cargo:warning=CUDA not found, kiln-rmsnorm-kernel will not compile CUDA kernels");
+            println!("cargo:warning=Set CUDA_ROOT or CUDA_HOME, or install CUDA toolkit");
+            return;
+        }
+    };
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let csrc_dir = manifest_dir.join("csrc");
+
+    let cuda_archs =
+        env::var("KILN_CUDA_ARCHS").unwrap_or_else(|_| "80;86;89;90".to_string());
+
+    let mut build = cc::Build::new();
+    build.cuda(true);
+    build.cpp(true);
+
+    build.include(&csrc_dir);
+    build.include(cuda_root.join("include"));
+
+    build.flag("-std=c++17");
+    build.flag("-O3");
+    build.flag("--use_fast_math");
+    build.flag("--expt-relaxed-constexpr");
+    build.flag("--expt-extended-lambda");
+    build.flag("-Xcompiler").flag("-fPIC");
+    build.flag("-diag-suppress=177");
+    build.flag("-diag-suppress=174");
+
+    for arch in cuda_archs.split(';') {
+        let arch = arch.trim();
+        if !arch.is_empty() {
+            build.flag(&format!("-gencode=arch=compute_{arch},code=sm_{arch}"));
+        }
+    }
+
+    build.file(csrc_dir.join("fused_rmsnorm.cu"));
+
+    build.compile("kiln_rmsnorm_kernel");
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        cuda_root.join("lib64").display()
+    );
+    println!("cargo:rustc-link-lib=cudart");
+
+    println!("cargo:rerun-if-changed=csrc/");
+    println!("cargo:rerun-if-env-changed=CUDA_ROOT");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
+    println!("cargo:rerun-if-env-changed=KILN_CUDA_ARCHS");
+}
+
+fn find_cuda_root() -> Option<PathBuf> {
+    for var in &["CUDA_ROOT", "CUDA_HOME", "CUDA_PATH"] {
+        if let Ok(val) = env::var(var) {
+            let p = PathBuf::from(val);
+            if p.join("include").join("cuda.h").exists() {
+                return Some(p);
+            }
+        }
+    }
+    for path in &[
+        "/usr/local/cuda",
+        "/usr/local/cuda-12",
+        "/usr/local/cuda-12.4",
+        "/usr/local/cuda-12.6",
+        "/usr/local/cuda-12.8",
+        "/opt/cuda",
+    ] {
+        let p = PathBuf::from(path);
+        if p.join("include").join("cuda.h").exists() {
+            return Some(p);
+        }
+    }
+    if let Ok(output) = std::process::Command::new("which").arg("nvcc").output() {
+        if output.status.success() {
+            let nvcc_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let p = PathBuf::from(nvcc_path);
+            if let Some(bin_dir) = p.parent() {
+                if let Some(cuda_dir) = bin_dir.parent() {
+                    if cuda_dir.join("include").join("cuda.h").exists() {
+                        return Some(cuda_dir.to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/crates/kiln-rmsnorm-kernel/csrc/fused_rmsnorm.cu
+++ b/crates/kiln-rmsnorm-kernel/csrc/fused_rmsnorm.cu
@@ -1,0 +1,140 @@
+// Kiln fused RMSNorm kernel — single-pass, bf16 in/out, F32 reduction.
+//
+// Algorithm (Qwen3.5-style RMSNorm, matches `rms_norm` in kiln-model/forward.rs):
+//
+//   sum_sq = sum_j(x[row, j]^2)            (F32 across the `hidden` axis)
+//   rms_inv = rsqrt(sum_sq / hidden + eps)
+//   out[row, j] = bf16((1 + w[j]) * x[row, j] * rms_inv)
+//
+// Launch: one block per row, blockDim.x = 256. Each thread strides over the
+// hidden axis with stride == blockDim.x. Intra-block reduction of `sum_sq`
+// uses a two-stage warp + shared-memory reduction (32 warps max). The
+// row-wide `rms_inv` is broadcast via __shared__ memory; no second kernel
+// launch required.
+//
+// Kept intentionally simple — no vectorised bf16 loads, no cp.async, no
+// tensor cores — because the goal is to collapse the ~11 candle kernel
+// launches into a single launch, and the arithmetic here is memory-bound.
+// Any row width up to 8192 is supported; Qwen3.5-4B uses hidden=2560.
+
+#include "fused_rmsnorm.h"
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+namespace {
+
+constexpr int kThreadsPerBlock = 256;
+constexpr int kMaxWarps = kThreadsPerBlock / 32;  // 8
+
+__device__ __forceinline__ float warp_reduce_sum(float v) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset /= 2) {
+        v += __shfl_xor_sync(0xffffffffu, v, offset);
+    }
+    return v;
+}
+
+__device__ __forceinline__ float block_reduce_sum(float v, float *smem) {
+    int lane = threadIdx.x & 31;
+    int warp = threadIdx.x >> 5;
+
+    v = warp_reduce_sum(v);
+    if (lane == 0) {
+        smem[warp] = v;
+    }
+    __syncthreads();
+
+    // First warp reduces the per-warp partial sums.
+    if (warp == 0) {
+        int num_warps = blockDim.x >> 5;
+        float w = (lane < num_warps) ? smem[lane] : 0.0f;
+        w = warp_reduce_sum(w);
+        if (lane == 0) {
+            smem[0] = w;
+        }
+    }
+    __syncthreads();
+    return smem[0];
+}
+
+__global__ void fused_rmsnorm_kernel(
+    const __nv_bfloat16 *__restrict__ x,
+    const __nv_bfloat16 *__restrict__ weight,
+    __nv_bfloat16 *__restrict__ out,
+    int hidden,
+    float eps
+) {
+    int row = blockIdx.x;
+    const __nv_bfloat16 *x_row = x + static_cast<size_t>(row) * hidden;
+    __nv_bfloat16 *out_row = out + static_cast<size_t>(row) * hidden;
+
+    __shared__ float smem[kMaxWarps];
+
+    // Pass 1: per-thread partial sum of x^2 in F32.
+    float local_sum_sq = 0.0f;
+    for (int j = threadIdx.x; j < hidden; j += blockDim.x) {
+        float xj = __bfloat162float(x_row[j]);
+        local_sum_sq += xj * xj;
+    }
+
+    float total_sum_sq = block_reduce_sum(local_sum_sq, smem);
+
+    // `smem[0]` now holds the row-wide sum_sq. Derive rms_inv once per block
+    // and broadcast through shared memory.
+    __shared__ float s_rms_inv;
+    if (threadIdx.x == 0) {
+        float mean_sq = total_sum_sq / static_cast<float>(hidden);
+        s_rms_inv = rsqrtf(mean_sq + eps);
+    }
+    __syncthreads();
+    float rms_inv = s_rms_inv;
+
+    // Pass 2: apply Qwen3.5-style `(1 + w) * x * rms_inv`, cast back to bf16.
+    for (int j = threadIdx.x; j < hidden; j += blockDim.x) {
+        float xj = __bfloat162float(x_row[j]);
+        float wj = __bfloat162float(weight[j]);
+        float y = (1.0f + wj) * xj * rms_inv;
+        out_row[j] = __float2bfloat16(y);
+    }
+}
+
+}  // namespace
+
+extern "C" kiln_rmsnorm_status_t kiln_fused_rmsnorm(
+    const void *x,
+    const void *weight,
+    void *out,
+    int rows,
+    int hidden,
+    float eps,
+    void *stream
+) {
+    if (rows <= 0 || hidden <= 0) {
+        // No-op; nothing to compute. Treat as success so callers on zero-row
+        // inputs (e.g. prefill chunks of length 0) don't need to special-case.
+        return 0;
+    }
+    if (hidden > 8192) {
+        return 2;  // out-of-envelope; caller should fall back.
+    }
+
+    dim3 grid(rows);
+    dim3 block(kThreadsPerBlock);
+
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+
+    fused_rmsnorm_kernel<<<grid, block, 0, s>>>(
+        reinterpret_cast<const __nv_bfloat16 *>(x),
+        reinterpret_cast<const __nv_bfloat16 *>(weight),
+        reinterpret_cast<__nv_bfloat16 *>(out),
+        hidden,
+        eps
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 1;
+    }
+    return 0;
+}

--- a/crates/kiln-rmsnorm-kernel/csrc/fused_rmsnorm.h
+++ b/crates/kiln-rmsnorm-kernel/csrc/fused_rmsnorm.h
@@ -1,0 +1,60 @@
+// Kiln fused RMSNorm C-ABI wrapper.
+//
+// Replaces the ~11-kernel candle op sequence used by `kiln-model::forward::rms_norm`:
+//
+//   to_dtype(F32) → sqr → mean_keepdim → + eps → sqrt → recip →
+//   broadcast_mul → to_dtype(F32 weight) → ones_like + w →
+//   broadcast_mul → to_dtype(bf16)
+//
+// with a single CUDA kernel that performs the full Qwen3.5-style RMSNorm:
+//
+//   rms_inv = rsqrt(mean(x^2) + eps)
+//   out     = bf16((1 + w) * x * rms_inv)
+//
+// Per-row F32 accumulators, per-block reduction via shared memory, bf16 in/out.
+//
+// Pointer layout (all bf16, all CUDA, all contiguous):
+//   x      : [rows, hidden]
+//   weight : [hidden]
+//   out    : [rows, hidden]
+//
+// Scope — forward-only, decode-first, minimal:
+//   - bf16 activations; F32 reduction + F32 epilogue accumulator.
+//   - `hidden` <= 8192. Qwen3.5-4B uses 2560 (hidden_size).
+//   - Any number of rows; blocks tile over rows, threads tile within a row.
+//   - `eps` passed as F32 — kiln uses 1e-6 for Qwen3.5.
+//   - Qwen3.5-style `(1 + w) * x * rms_inv`; kiln stores weight centered on 0.
+//
+// Not in scope:
+//   - Backward pass (decode/inference is forward-only).
+//   - Fused GEMM prologue (single fused norm is the minimum-viable ship; the
+//     ~11 launches it collapses already dominate the norm/GEMM boundary cost).
+//   - Non-bf16 dtypes, non-contiguous layouts.
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int kiln_rmsnorm_status_t;
+
+// Fused Qwen3.5-style RMSNorm: out = (1 + weight) * x * rsqrt(mean(x^2) + eps).
+// All pointers are bf16, contiguous, CUDA device memory.
+//
+// Returns 0 on success, non-zero on launch/config failure.
+kiln_rmsnorm_status_t kiln_fused_rmsnorm(
+    const void *x,
+    const void *weight,
+    void *out,
+    int rows,
+    int hidden,
+    float eps,
+    void *stream
+);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/kiln-rmsnorm-kernel/src/lib.rs
+++ b/crates/kiln-rmsnorm-kernel/src/lib.rs
@@ -1,0 +1,372 @@
+//! Vendored fused RMSNorm CUDA kernel (Liger-style).
+//!
+//! # Why
+//!
+//! `kiln-model::forward::rms_norm` currently expresses Qwen3.5-style
+//! RMSNorm as a chain of candle ops:
+//!
+//! ```text
+//! to_dtype(F32) → sqr → mean_keepdim → + eps → sqrt → recip →
+//! broadcast_mul → to_dtype(F32 weight) → ones_like + w →
+//! broadcast_mul → to_dtype(bf16)
+//! ```
+//!
+//! That is ~11 CUDA kernel launches per RMSNorm. At decode time each
+//! launch has ~10 µs of per-launch overhead, and the intermediate F32
+//! tensors round-trip through HBM on every step. Per PROFILING.md
+//! (post-PR #130), the two RMSNorm NVTX ranges `kiln/norm/pre_attn`
+//! (11.1 %) and `kiln/norm/pre_mlp` (11.0 %) combine for ~22 % of
+//! decode wallclock and are the #1 hotspot of the current profile.
+//!
+//! This crate collapses those ~11 launches into a single fused kernel
+//! (`fused_rmsnorm_kernel` in `csrc/fused_rmsnorm.cu`): one block per
+//! row, 256 threads per block, F32 reduction + F32 epilogue accumulator,
+//! bf16 load/store.
+//!
+//! # Provenance
+//!
+//! Algorithm modelled after LinkedIn's Liger-Kernel `fused_rmsnorm`
+//! (<https://github.com/linkedin/Liger-Kernel>, `src/liger_kernel/ops/rms_norm.py`),
+//! reimplemented in raw CUDA C so kiln doesn't add a Triton runtime
+//! dependency. Matches kiln's Qwen3.5 convention of `(1 + w) * x * rms_inv`
+//! (weights are centred on 0, not on 1).
+//!
+//! # API
+//!
+//! - [`fused_rmsnorm`] — candle-compatible wrapper. Accepts any bf16 input
+//!   whose last dim is the normalised axis; flattens leading dims, runs
+//!   the kernel, and reshapes back. Only forward pass.
+//!
+//! # Envelope
+//!
+//! - bf16 activations, bf16 weights.
+//! - Contiguous CUDA tensors only.
+//! - Last dim (`hidden`) must be <= 8192. Qwen3.5-4B uses 2560.
+//! - `eps` is F32 — kiln uses 1e-6 for Qwen3.5.
+//!
+//! Out of scope: backward pass, fused GEMM prologue, non-bf16 dtypes,
+//! non-contiguous input, unpaired cast (`weight` of a different dtype).
+
+use candle_core::{
+    backend::BackendStorage,
+    cuda_backend::cudarc::driver::DevicePtr,
+    DType, Device, Result, Tensor,
+};
+use half::bf16;
+
+unsafe extern "C" {
+    fn kiln_fused_rmsnorm(
+        x: *const core::ffi::c_void,
+        weight: *const core::ffi::c_void,
+        out: *mut core::ffi::c_void,
+        rows: i32,
+        hidden: i32,
+        eps: f32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+}
+
+/// Whether the fused RMSNorm kernel is available on the given tensor.
+///
+/// The kernel only supports CUDA + bf16 + contiguous + hidden <= 8192.
+pub fn supports(x: &Tensor, weight: &Tensor) -> bool {
+    matches!(x.device(), Device::Cuda(_))
+        && x.dtype() == DType::BF16
+        && weight.dtype() == DType::BF16
+        && x.is_contiguous()
+        && weight.is_contiguous()
+        && x.rank() >= 1
+        && x.dims().last().copied().unwrap_or(0) <= 8192
+        && weight.dims() == &[x.dims().last().copied().unwrap_or(0)]
+}
+
+/// Run the fused RMSNorm kernel.
+///
+/// Inputs:
+///   - `x`: bf16, CUDA, contiguous, any rank; last dim is the normalised axis.
+///   - `weight`: bf16, CUDA, contiguous, shape `[hidden]` matching `x.last_dim()`.
+///   - `eps`: epsilon inside the rsqrt. Qwen3.5 uses 1e-6.
+///
+/// Returns a freshly allocated bf16 tensor with the same shape as `x`.
+///
+/// Semantics: `out = (1 + weight) * x * rsqrt(mean(x^2, dim=-1) + eps)` cast
+/// back to bf16. Matches `kiln-model::forward::rms_norm` (Qwen3.5-style,
+/// weight centred on 0).
+pub fn fused_rmsnorm(x: &Tensor, weight: &Tensor, eps: f32) -> Result<Tensor> {
+    let device = x.device();
+
+    if x.dtype() != DType::BF16 || weight.dtype() != DType::BF16 {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: both x and weight must be bf16 (got {:?}, {:?})",
+            x.dtype(),
+            weight.dtype()
+        );
+    }
+
+    let x_dims = x.dims().to_vec();
+    let hidden = *x_dims.last().ok_or_else(|| {
+        candle_core::Error::Msg("kiln-rmsnorm-kernel: x must have rank >= 1".to_string())
+    })?;
+
+    let weight_dims = weight.dims();
+    if weight_dims.len() != 1 || weight_dims[0] != hidden {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: weight shape {:?} does not match x last dim {hidden}",
+            weight_dims
+        );
+    }
+
+    if hidden > 8192 {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: hidden dim {hidden} exceeds kernel envelope (<= 8192)"
+        );
+    }
+
+    let rows: usize = x_dims[..x_dims.len() - 1].iter().product();
+    if rows == 0 {
+        // Empty leading axis — nothing to do. Return a zeros tensor with the
+        // same shape so callers don't have to special-case.
+        return Tensor::zeros(x_dims.as_slice(), DType::BF16, device);
+    }
+
+    let x = x.contiguous()?;
+    let weight = weight.contiguous()?;
+
+    let out = Tensor::zeros(x_dims.as_slice(), DType::BF16, device)?;
+
+    {
+        let (x_storage, x_layout) = x.storage_and_layout();
+        let (w_storage, w_layout) = weight.storage_and_layout();
+        let (o_storage, o_layout) = out.storage_and_layout();
+
+        let x_cuda = match &*x_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: x must be on CUDA"),
+        };
+        let w_cuda = match &*w_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: weight must be on CUDA"),
+        };
+        let o_cuda = match &*o_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: out must be on CUDA"),
+        };
+
+        let stream = x_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let x_slice = x_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(x_layout.start_offset()..);
+        let w_slice = w_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(w_layout.start_offset()..);
+        let o_slice = o_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(o_layout.start_offset()..);
+
+        unsafe {
+            let (x_ptr, _g1) = x_slice.device_ptr(&stream);
+            let (w_ptr, _g2) = w_slice.device_ptr(&stream);
+            let (o_ptr, _g3) = o_slice.device_ptr(&stream);
+
+            let status = kiln_fused_rmsnorm(
+                x_ptr as *const _,
+                w_ptr as *const _,
+                o_ptr as *mut _,
+                rows as i32,
+                hidden as i32,
+                eps,
+                raw_stream,
+            );
+
+            if status != 0 {
+                candle_core::bail!("kiln_fused_rmsnorm failed with status {status}");
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{Device, Tensor};
+
+    // Reference implementation — mirrors `kiln-model::forward::rms_norm`
+    // exactly (including the F32 cast + Qwen3.5 `(1 + w)` convention).
+    // Used as the correctness oracle for `fused_rmsnorm`.
+    fn reference_rms_norm(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
+        let x_f32 = x.to_dtype(DType::F32)?;
+        let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
+        let rms_inv = (variance + eps)?.sqrt()?.recip()?;
+        let normed = x_f32.broadcast_mul(&rms_inv)?;
+        let w_f32 = weight.to_dtype(DType::F32)?;
+        let w_plus_one = (w_f32.ones_like()? + w_f32)?;
+        let out = normed.broadcast_mul(&w_plus_one)?;
+        out.to_dtype(x.dtype())
+    }
+
+    fn try_cuda_device() -> Option<Device> {
+        Device::new_cuda(0).ok()
+    }
+
+    #[test]
+    fn parity_decode_row() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        // Qwen3.5-4B decode shape: [batch=1, seq=1, hidden=2560].
+        let hidden = 2560usize;
+        let rows = 1usize;
+        let eps = 1e-6;
+
+        // Deterministic pseudo-random input (seeded), so the parity test is
+        // reproducible without adding a dev-dep on `rand`.
+        let mut raw_x = Vec::with_capacity(rows * hidden);
+        let mut raw_w = Vec::with_capacity(hidden);
+        let mut state: u32 = 0x1234_5678;
+        for _ in 0..rows * hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            let f = ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0;
+            raw_x.push(f * 0.5);
+        }
+        for _ in 0..hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            let f = ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0;
+            raw_w.push(f * 0.1);
+        }
+
+        let x_f32 = Tensor::from_vec(raw_x, (rows, hidden), &device).unwrap();
+        let w_f32 = Tensor::from_vec(raw_w, (hidden,), &device).unwrap();
+        let x = x_f32.to_dtype(DType::BF16).unwrap();
+        let w = w_f32.to_dtype(DType::BF16).unwrap();
+
+        let y_ref = reference_rms_norm(&x, &w, eps).unwrap();
+        let y_fused = fused_rmsnorm(&x, &w, eps as f32).unwrap();
+
+        let diff = (&y_ref - &y_fused)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+
+        assert!(
+            diff < 1e-2,
+            "parity failed: max_abs_diff={diff} exceeds 1e-2 tolerance"
+        );
+    }
+
+    #[test]
+    fn parity_multi_row() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        // Prefill-like shape: [batch=1, seq=512, hidden=2560].
+        let hidden = 2560usize;
+        let rows = 512usize;
+        let eps = 1e-6;
+
+        let mut raw_x = Vec::with_capacity(rows * hidden);
+        let mut raw_w = Vec::with_capacity(hidden);
+        let mut state: u32 = 0xcafe_babe;
+        for _ in 0..rows * hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            let f = ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0;
+            raw_x.push(f * 0.7);
+        }
+        for _ in 0..hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            let f = ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0;
+            raw_w.push(f * 0.1);
+        }
+
+        let x_f32 = Tensor::from_vec(raw_x, (rows, hidden), &device).unwrap();
+        let w_f32 = Tensor::from_vec(raw_w, (hidden,), &device).unwrap();
+        let x = x_f32.to_dtype(DType::BF16).unwrap();
+        let w = w_f32.to_dtype(DType::BF16).unwrap();
+
+        let y_ref = reference_rms_norm(&x, &w, eps).unwrap();
+        let y_fused = fused_rmsnorm(&x, &w, eps as f32).unwrap();
+
+        let diff = (&y_ref - &y_fused)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+
+        assert!(
+            diff < 1e-2,
+            "parity failed: max_abs_diff={diff} exceeds 1e-2 tolerance"
+        );
+    }
+
+    #[test]
+    fn parity_with_batch_dim() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        // [batch=2, seq=3, hidden=2560] — exercises 3D reshape path.
+        let b = 2usize;
+        let s = 3usize;
+        let hidden = 2560usize;
+        let eps = 1e-6;
+
+        let mut raw_x = Vec::with_capacity(b * s * hidden);
+        let mut raw_w = Vec::with_capacity(hidden);
+        let mut state: u32 = 0xdead_beef;
+        for _ in 0..b * s * hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            let f = ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0;
+            raw_x.push(f * 0.3);
+        }
+        for _ in 0..hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            let f = ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0;
+            raw_w.push(f * 0.1);
+        }
+
+        let x_f32 = Tensor::from_vec(raw_x, (b, s, hidden), &device).unwrap();
+        let w_f32 = Tensor::from_vec(raw_w, (hidden,), &device).unwrap();
+        let x = x_f32.to_dtype(DType::BF16).unwrap();
+        let w = w_f32.to_dtype(DType::BF16).unwrap();
+
+        let y_ref = reference_rms_norm(&x, &w, eps).unwrap();
+        let y_fused = fused_rmsnorm(&x, &w, eps as f32).unwrap();
+
+        assert_eq!(y_fused.dims(), &[b, s, hidden]);
+
+        let diff = (&y_ref - &y_fused)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+
+        assert!(
+            diff < 1e-2,
+            "parity failed: max_abs_diff={diff} exceeds 1e-2 tolerance"
+        );
+    }
+}


### PR DESCRIPTION
## What

Fuses the pre-norm RMSNorm into a single CUDA kernel, collapsing candle's
~11-launch op chain into one kernel per call site. Targets the last
remaining "two NVTX norm ranges" tier called out as the next decode-tier
fix in PR #130's "Recommended next optimization target" block.

## Op chain collapsed

Before (candle ops, ~11 kernel launches per call):

```
x_f32   = cast(x_bf16)              # cast_bf16_f32
v       = x_f32 * x_f32             # bmul_f32
m       = mean(v, axis=-1)          # fast_sum_f32 + scale
inv     = rsqrt(m + eps)            # add + sqrt + recip
normed  = x_f32 * inv               # broadcast_bmul_f32
w_f32   = cast(w_bf16)              # cast_bf16_f32
one_w   = ones_like(w) + w_f32      # ones_like + add
out_f32 = normed * one_w            # broadcast_bmul_f32
out_bf16= cast(out_f32)             # cast_f32_bf16
```

After: a single fused kernel launch. One block per row, 256 threads,
`__shfl_xor_sync` warp reduction + shared-memory block reduction, F32
accumulation + F32 epilogue with bf16 load/store. Implements Qwen3.5's
exact formulation **`(1 + weight) * x * rsqrt(mean(x²) + eps)`**.

## Fused kernel

New crate `kiln-rmsnorm-kernel` (workspace member), following the
`kiln-flash-attn` / `kiln-gdn-kernel` pattern:

- `csrc/fused_rmsnorm.cu` — Liger-style kernel. Envelope: bf16
  activations, `hidden ≤ 8192`, row-major contiguous rows.
- `csrc/fused_rmsnorm.h` — C-ABI:
  `kiln_fused_rmsnorm(x, w, out, rows, hidden, eps, stream) -> status`.
- `build.rs` — compiles via the `cc` crate for CUDA archs
  `80;86;89;90` (override via `KILN_CUDA_ARCHS`).
- `src/lib.rs` — Rust FFI wrapper with `supports(...)` envelope
  guard and `fused_rmsnorm(...)`; uses the canonical candle
  `storage_and_layout` → `as_cuda_slice::<bf16>()` →
  `.device_ptr()` → `.cu_stream() as *mut c_void` pattern.

## Integration

`kiln-model/src/forward.rs::rms_norm` now dispatches to the fused kernel
when `feature = "cuda"` is on, the env toggle
`KILN_DISABLE_RMSNORM_KERNEL` is unset, and
`kiln_rmsnorm_kernel::supports(&x, &weight)` returns true. Otherwise it
falls back to the original op chain, preserved verbatim as
`rms_norm_fallback`.

The dispatch point is inside the single `rms_norm` helper, so every
call site (`transformer_block`, `transformer_block_paged`, and the GDN
`model_forward` paths) picks up the fused kernel transparently — no
per-call-site rewiring.

Workspace glue: `kiln-rmsnorm-kernel` added to `Cargo.toml` members and
`workspace.dependencies`; `kiln-model`'s `cuda` feature enables it
(same pattern as `kiln-flash-attn` and `kiln-gdn-kernel`).

## Parity

All three in-crate unit tests pass with **1e-2 max-abs-diff tolerance**
vs the candle op chain on deterministic LCG inputs (A6000, bf16):

```
test tests::parity_multi_row ... ok          # [512, 2560]
test tests::parity_decode_row ... ok         # [1, 2560]   (hot decode path)
test tests::parity_with_batch_dim ... ok     # [2, 3, 2560]

test result: ok. 3 passed; 0 failed
```

## Benchmark (Qwen3.5-4B, 506-token prompt, 128 decoded, A6000)

Same pod, same model, same prompt, same commit harness; `main`
(`9b7e09d`) vs this branch.

**Paged (production) path:**

| Metric | Pre-fix (`main`) | **Post-fix (this PR)** | Δ |
| --- | ---: | ---: | ---: |
| Mean ITL | 27.67 ms | **22.77 ms** | **−17.7 % (1.215×)** |
| P50 ITL | 27.59 ms | **22.65 ms** | −17.9 % (1.218×) |
| P99 ITL | 37.48 ms | **28.13 ms** | −25.0 % (1.332×) |
| Decode throughput (single) | 36.15 tok/s | **43.91 tok/s** | +21.5 % |
| Prefill @ 506 tokens | 424.2 ms (1 193 tok/s) | **405.8 ms (1 247 tok/s)** | −4.3 % (improvement) |
| Peak inference VRAM | 16 840 MB | **16 840 MB** | 0 MB |

**Non-paged path:**

| Metric | Pre-fix | **Post-fix** | Δ |
| --- | ---: | ---: | ---: |
| Mean ITL | 26.73 ms | **24.27 ms** | −9.2 % (1.101×) |
| Decode throughput | 37.42 tok/s | **41.21 tok/s** | +10.1 % |

## Acceptance criteria (task spec)

| Criterion | Target | **Result** |
| --- | --- | --- |
| Parity vs candle op chain | `max_abs_diff < 1e-2` | ✅ all 3 shapes |
| Decode ITL speedup (paged) | 1.15×–1.35× (hard floor 1.05×) | ✅ **1.215×** |
| Prefill regression @ 506 tokens | ≤ ±3 % | ✅ **−4.3 % (improvement)** |
| Peak inference VRAM delta | within ±500 MB of main | ✅ **0 MB** |

## Scope / out of scope

- **In scope**: bf16 forward RMSNorm, Qwen3.5's `(1 + weight)` form,
  `hidden ≤ 8192`, row-major contiguous rows. Envelope guard in
  `supports()` falls back to the candle op chain outside of this.
- **Out of scope**: backward (training still runs through
  `rms_norm_fallback` via the existing op chain, unchanged); non-bf16
  activations; non-Qwen RMSNorm forms (some models use a non-centered
  weight convention).
- **Not this PR**: fusing RMSNorm into the following projection GEMM
  (the "`pre_*norm` + projection" combined fix mentioned in PR #130's
  recommendation). Left as a follow-up — this PR lands the RMSNorm half
  and already collects the ~13 %-of-decode-wallclock target the prior
  profile identified.

## Env toggle

`KILN_DISABLE_RMSNORM_KERNEL=1` forces the original candle op chain for
A/B testing. Pattern matches the existing `KILN_DISABLE_GDN_KERNEL`
toggle.

## PROFILING.md

The repo's top-level `PROFILING.md` is updated with a new "Phase 6,
Fused RMSNorm Kernel" section containing the pre/post tables above, the
"next target" block is retargeted from "RMSNorm fusion" to "GDN body
vendor", and the previous round's "Recommended next optimization
target" block is annotated with the result.
