### PR TITLE
CE: desktop: show active adapter in dashboard toolbar

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -199,6 +199,64 @@ async fn get_openai_base_url(
     }
 }
 
+#[derive(serde::Serialize)]
+struct ActiveAdapterInfo {
+    active: Option<String>,
+    available_count: usize,
+}
+
+/// Report the currently active LoRA adapter (if any) plus the count of
+/// adapters available on disk by polling GET /v1/adapters on the kiln
+/// server. Returns an empty result on any HTTP/parse error so the UI can
+/// degrade gracefully rather than throwing.
+#[tauri::command]
+async fn get_active_adapter(
+    state: State<'_, SettingsState>,
+    sup: State<'_, Arc<Supervisor>>,
+) -> Result<ActiveAdapterInfo, String> {
+    let server_state = sup.state().await;
+    let url = match server_state {
+        ServerState::Stopped | ServerState::Error(_) => {
+            return Ok(ActiveAdapterInfo {
+                active: None,
+                available_count: 0,
+            });
+        }
+        ServerState::Starting | ServerState::Running | ServerState::TrainingActive => {
+            let s = state.read().await;
+            format!("http://{}:{}/v1/adapters", s.host, s.port)
+        }
+    };
+
+    #[derive(serde::Deserialize)]
+    struct Response {
+        active: Option<String>,
+        available: Vec<serde_json::Value>,
+    }
+
+    let empty = ActiveAdapterInfo {
+        active: None,
+        available_count: 0,
+    };
+
+    let resp = match reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await
+    {
+        Ok(r) if r.status().is_success() => r,
+        _ => return Ok(empty),
+    };
+    match resp.json::<Response>().await {
+        Ok(r) => Ok(ActiveAdapterInfo {
+            active: r.active,
+            available_count: r.available.len(),
+        }),
+        Err(_) => Ok(empty),
+    }
+}
+
 /// Persist the supplied settings to disk and rebuild the supervisor's
 /// `SupervisorConfig`. A currently-running server is NOT restarted; the new
 /// args take effect on the next `start_server` call.
@@ -270,6 +328,7 @@ fn main() {
             set_settings,
             get_kiln_url,
             get_openai_base_url,
+            get_active_adapter,
             open_settings,
             open_logs,
             check_for_updates,

--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -213,6 +213,43 @@
         font-family: inherit;
         user-select: none;
       }
+      #adapter-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 10px;
+        font-size: 12px;
+        background: #1b1e24;
+        color: #a8aeb8;
+        border: 1px solid #2a2f3a;
+        border-radius: 6px;
+        max-width: 220px;
+        overflow: hidden;
+      }
+      #adapter-pill .adapter-label {
+        color: #6c7280;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+        flex-shrink: 0;
+      }
+      #adapter-name {
+        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+        background: transparent;
+        padding: 0;
+        font-size: 12px;
+        color: inherit;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        user-select: text;
+        min-width: 0;
+      }
+      #adapter-name.empty {
+        color: #6c7280;
+        font-family: inherit;
+        user-select: none;
+      }
     </style>
   </head>
   <body>
@@ -232,6 +269,10 @@
       <span id="vram-pill" title="Model / Total VRAM — server not running">
         <span class="vram-label">VRAM:</span>
         <code id="vram-value" class="empty">—</code>
+      </span>
+      <span id="adapter-pill" title="Active LoRA adapter — none">
+        <span class="adapter-label">Adapter:</span>
+        <code id="adapter-name" class="empty">—</code>
       </span>
       <button id="copy-url" title="Copy the OpenAI-compatible base URL for this server">Copy OpenAI base URL</button>
       <button id="check-updates-btn" title="Check for an updated version of Kiln Desktop">Check for Updates</button>
@@ -613,6 +654,63 @@
         }
       }
 
+      const adapterPill = document.getElementById("adapter-pill");
+      const adapterNameEl = document.getElementById("adapter-name");
+      const ADAPTER_EMPTY_LABEL = "—";
+      const ADAPTER_EMPTY_TITLE = "Active LoRA adapter — none";
+      const ADAPTER_VISIBLE_STATES = ["Starting", "Running", "TrainingActive"];
+      let cachedAdapterText = null;
+
+      function setAdapterDisplay(text, tooltip, isEmptyStyle) {
+        adapterNameEl.textContent = text;
+        if (isEmptyStyle) {
+          adapterNameEl.classList.add("empty");
+        } else {
+          adapterNameEl.classList.remove("empty");
+        }
+        adapterPill.title = tooltip;
+      }
+
+      function clearAdapterDisplay() {
+        if (cachedAdapterText !== null) {
+          cachedAdapterText = null;
+          setAdapterDisplay(ADAPTER_EMPTY_LABEL, ADAPTER_EMPTY_TITLE, true);
+        }
+      }
+
+      async function refreshAdapterInfo(kind) {
+        if (!invoke || !ADAPTER_VISIBLE_STATES.includes(kind)) {
+          clearAdapterDisplay();
+          return;
+        }
+        let info;
+        try {
+          info = await invoke("get_active_adapter");
+        } catch (_) {
+          clearAdapterDisplay();
+          return;
+        }
+        if (info && info.active) {
+          const text = info.active;
+          if (text !== cachedAdapterText) {
+            cachedAdapterText = text;
+            setAdapterDisplay(text, `Active LoRA adapter: ${text}`, false);
+          }
+        } else if (info && info.available_count > 0) {
+          const text = "none";
+          if (text !== cachedAdapterText) {
+            cachedAdapterText = text;
+            setAdapterDisplay(
+              text,
+              `No LoRA adapter loaded (${info.available_count} available on disk)`,
+              false
+            );
+          }
+        } else {
+          clearAdapterDisplay();
+        }
+      }
+
       function updateStopBtnVisibility(kind) {
         const shouldShow = STOP_ACTIVE_STATES.includes(kind);
         stopBtn.classList.toggle("hidden", !shouldShow);
@@ -628,6 +726,7 @@
           applyStatusBadge("Unknown", "Tauri bridge unavailable");
           await refreshBaseUrl("Unknown");
           await refreshVramInfo("Unknown", null);
+          await refreshAdapterInfo("Unknown");
           updateStopBtnVisibility("Unknown");
           return;
         }
@@ -641,12 +740,14 @@
           applyStatusBadge(kind, tooltip);
           await refreshBaseUrl(kind);
           await refreshVramInfo(kind, cachedBaseUrl);
+          await refreshAdapterInfo(kind);
           updateStopBtnVisibility(kind);
           stateFailureLogged = false;
         } catch (err) {
           applyStatusBadge("Unknown", "Could not read server state");
           await refreshBaseUrl("Unknown");
           await refreshVramInfo("Unknown", null);
+          await refreshAdapterInfo("Unknown");
           updateStopBtnVisibility("Unknown");
           if (!stateFailureLogged) {
             console.error("server_state poll failed", err);


### PR DESCRIPTION
## What
Adds an Adapter pill to the dashboard toolbar that shows the active LoRA adapter name (or 'none' when no adapter is loaded but adapters exist on disk; '—' when no adapters are present at all). Polls GET /v1/adapters in the existing toolbar refresh tick (every 2s), via a new Tauri command `get_active_adapter`.

## Why
The project spec calls for an adapters list in the Dashboard window. The MVP relies on the embedded /ui iframe; this small native pill surfaces the active adapter at a glance without leaving the toolbar — matching the existing model-path-pill / vram-pill pattern.

## Changes
- **desktop/src/main.rs** — new `#[tauri::command] async fn get_active_adapter` that reads supervisor state, fetches `http://{host}:{port}/v1/adapters` with a 2s timeout via the already-vendored reqwest client, and returns `{ active: Option<String>, available_count: usize }`. Returns the empty result on any HTTP/parse error so the UI degrades gracefully rather than throwing.
- **desktop/ui/dashboard.html** — new `#adapter-pill` toolbar element next to the VRAM pill (CSS mirrors `#vram-pill`). `refreshAdapterInfo(kind)` is invoked from the existing `pollServerState` tick. Display rules:
  - active adapter present → adapter name (mono font)
  - active=null but `available_count > 0` → "none"
  - `available_count == 0` or non-Running-ish state → "—" with empty class

## Validation
Skipped local `cd desktop && cargo check` — Cloud Eric pods can't compile Tauri v2 crates because GTK/webkit2gtk system libraries (gobject-2.0, glib-2.0, webkit2gtk-4.1) are not installed and CLAUDE.md forbids installing system packages. The kiln CI workflow on real Linux runners installs libwebkit2gtk-4.1-dev and friends via apt and will validate the build there.

The new `get_active_adapter` command is a small piece of glue (state read + reqwest GET + serde parse) that mirrors the existing `get_openai_base_url` / `get_kiln_url` patterns — there's no extractable pure helper to scratch-crate validate.