### PR TITLE
CE: desktop: show training status pill in dashboard toolbar

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -257,6 +257,85 @@ async fn get_active_adapter(
     }
 }
 
+#[derive(serde::Serialize)]
+struct ActiveTrainingJob {
+    job_id: String,
+    state: String,
+    progress: Option<f64>,
+    current_loss: Option<f64>,
+    adapter_name: Option<String>,
+}
+
+#[derive(serde::Serialize, Default)]
+struct TrainingStatusInfo {
+    active: Option<ActiveTrainingJob>,
+    total_jobs: usize,
+}
+
+/// Report the currently-running training job (if any) plus the total number
+/// of jobs known to the kiln server by polling GET /v1/train/status. Returns
+/// an empty result on any HTTP/parse error or when the server is
+/// Stopped/Error so the UI can degrade gracefully.
+#[tauri::command]
+async fn get_training_status(
+    state: State<'_, SettingsState>,
+    sup: State<'_, Arc<Supervisor>>,
+) -> Result<TrainingStatusInfo, String> {
+    let server_state = sup.state().await;
+    let url = match server_state {
+        ServerState::Stopped | ServerState::Error(_) => {
+            return Ok(TrainingStatusInfo::default());
+        }
+        ServerState::Starting | ServerState::Running | ServerState::TrainingActive => {
+            let s = state.read().await;
+            format!("http://{}:{}/v1/train/status", s.host, s.port)
+        }
+    };
+
+    #[derive(serde::Deserialize)]
+    struct Job {
+        job_id: String,
+        state: String,
+        #[serde(default)]
+        progress: Option<f64>,
+        #[serde(default)]
+        current_loss: Option<f64>,
+        #[serde(default)]
+        adapter_name: Option<String>,
+    }
+
+    let resp = match reqwest::Client::new()
+        .get(&url)
+        .timeout(std::time::Duration::from_secs(2))
+        .send()
+        .await
+    {
+        Ok(r) if r.status().is_success() => r,
+        _ => return Ok(TrainingStatusInfo::default()),
+    };
+    let jobs: Vec<Job> = match resp.json().await {
+        Ok(j) => j,
+        Err(_) => return Ok(TrainingStatusInfo::default()),
+    };
+
+    let active = jobs
+        .iter()
+        .find(|j| j.state.eq_ignore_ascii_case("running"))
+        .or_else(|| jobs.first())
+        .map(|j| ActiveTrainingJob {
+            job_id: j.job_id.clone(),
+            state: j.state.clone(),
+            progress: j.progress,
+            current_loss: j.current_loss,
+            adapter_name: j.adapter_name.clone(),
+        });
+
+    Ok(TrainingStatusInfo {
+        active,
+        total_jobs: jobs.len(),
+    })
+}
+
 /// Persist the supplied settings to disk and rebuild the supervisor's
 /// `SupervisorConfig`. A currently-running server is NOT restarted; the new
 /// args take effect on the next `start_server` call.
@@ -329,6 +408,7 @@ fn main() {
             get_kiln_url,
             get_openai_base_url,
             get_active_adapter,
+            get_training_status,
             open_settings,
             open_logs,
             check_for_updates,

--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -250,6 +250,43 @@
         font-family: inherit;
         user-select: none;
       }
+      #training-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 10px;
+        font-size: 12px;
+        background: #1b1e24;
+        color: #a8aeb8;
+        border: 1px solid #2a2f3a;
+        border-radius: 6px;
+        max-width: 260px;
+        overflow: hidden;
+      }
+      #training-pill .training-label {
+        color: #6c7280;
+        font-size: 11px;
+        text-transform: uppercase;
+        letter-spacing: 0.3px;
+        flex-shrink: 0;
+      }
+      #training-value {
+        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+        background: transparent;
+        padding: 0;
+        font-size: 12px;
+        color: inherit;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        user-select: text;
+        min-width: 0;
+      }
+      #training-value.empty {
+        color: #6c7280;
+        font-family: inherit;
+        user-select: none;
+      }
     </style>
   </head>
   <body>
@@ -273,6 +310,10 @@
       <span id="adapter-pill" title="Active LoRA adapter — none">
         <span class="adapter-label">Adapter:</span>
         <code id="adapter-name" class="empty">—</code>
+      </span>
+      <span id="training-pill" title="Training status — server not running">
+        <span class="training-label">Training:</span>
+        <code id="training-value" class="empty">—</code>
       </span>
       <button id="copy-url" title="Copy the OpenAI-compatible base URL for this server">Copy OpenAI base URL</button>
       <button id="check-updates-btn" title="Check for an updated version of Kiln Desktop">Check for Updates</button>
@@ -711,6 +752,91 @@
         }
       }
 
+      const trainingPill = document.getElementById("training-pill");
+      const trainingValueEl = document.getElementById("training-value");
+      const TRAINING_EMPTY_LABEL = "—";
+      const TRAINING_EMPTY_TITLE = "Training status — server not running";
+      const TRAINING_IDLE_TITLE = "No training jobs";
+      const TRAINING_VISIBLE_STATES = ["Starting", "Running", "TrainingActive"];
+      let cachedTrainingText = null;
+
+      function setTrainingDisplay(text, tooltip, isEmptyStyle) {
+        trainingValueEl.textContent = text;
+        if (isEmptyStyle) {
+          trainingValueEl.classList.add("empty");
+        } else {
+          trainingValueEl.classList.remove("empty");
+        }
+        trainingPill.title = tooltip;
+      }
+
+      function clearTrainingDisplay() {
+        if (cachedTrainingText !== null) {
+          cachedTrainingText = null;
+          setTrainingDisplay(TRAINING_EMPTY_LABEL, TRAINING_EMPTY_TITLE, true);
+        }
+      }
+
+      function formatTrainingText(active) {
+        const stateRaw = (active.state || "").toString();
+        const stateLabel = stateRaw
+          ? stateRaw.charAt(0).toUpperCase() + stateRaw.slice(1).toLowerCase()
+          : "Unknown";
+        const parts = [stateLabel];
+        if (typeof active.progress === "number" && isFinite(active.progress)) {
+          const pct = Math.max(0, Math.min(100, active.progress * 100));
+          parts.push(`${pct.toFixed(0)}%`);
+        }
+        let text = parts.join(" ");
+        if (typeof active.current_loss === "number" && isFinite(active.current_loss)) {
+          text += ` (loss ${active.current_loss.toFixed(2)})`;
+        }
+        return text;
+      }
+
+      async function refreshTrainingInfo(kind) {
+        if (!invoke || !TRAINING_VISIBLE_STATES.includes(kind)) {
+          clearTrainingDisplay();
+          return;
+        }
+        let info;
+        try {
+          info = await invoke("get_training_status");
+        } catch (_) {
+          clearTrainingDisplay();
+          return;
+        }
+        if (info && info.active) {
+          const text = formatTrainingText(info.active);
+          const tooltipBits = [`Training job ${info.active.job_id}`];
+          if (info.active.adapter_name) {
+            tooltipBits.push(`adapter: ${info.active.adapter_name}`);
+          }
+          if (typeof info.total_jobs === "number" && info.total_jobs > 1) {
+            tooltipBits.push(`${info.total_jobs} total jobs`);
+          }
+          const tooltip = tooltipBits.join(" — ");
+          if (text !== cachedTrainingText) {
+            cachedTrainingText = text;
+            setTrainingDisplay(text, tooltip, false);
+          } else {
+            trainingPill.title = tooltip;
+          }
+        } else {
+          const text = "idle";
+          const tooltip =
+            info && typeof info.total_jobs === "number" && info.total_jobs > 0
+              ? `${info.total_jobs} training jobs — none running`
+              : TRAINING_IDLE_TITLE;
+          if (text !== cachedTrainingText) {
+            cachedTrainingText = text;
+            setTrainingDisplay(text, tooltip, false);
+          } else {
+            trainingPill.title = tooltip;
+          }
+        }
+      }
+
       function updateStopBtnVisibility(kind) {
         const shouldShow = STOP_ACTIVE_STATES.includes(kind);
         stopBtn.classList.toggle("hidden", !shouldShow);
@@ -727,6 +853,7 @@
           await refreshBaseUrl("Unknown");
           await refreshVramInfo("Unknown", null);
           await refreshAdapterInfo("Unknown");
+          await refreshTrainingInfo("Unknown");
           updateStopBtnVisibility("Unknown");
           return;
         }
@@ -741,6 +868,7 @@
           await refreshBaseUrl(kind);
           await refreshVramInfo(kind, cachedBaseUrl);
           await refreshAdapterInfo(kind);
+          await refreshTrainingInfo(kind);
           updateStopBtnVisibility(kind);
           stateFailureLogged = false;
         } catch (err) {
@@ -748,6 +876,7 @@
           await refreshBaseUrl("Unknown");
           await refreshVramInfo("Unknown", null);
           await refreshAdapterInfo("Unknown");
+          await refreshTrainingInfo("Unknown");
           updateStopBtnVisibility("Unknown");
           if (!stateFailureLogged) {
             console.error("server_state poll failed", err);


### PR DESCRIPTION
## What
Add a Training toolbar pill to the kiln-desktop dashboard that polls `/v1/train/status` and surfaces the running job (state + progress% + loss) or `idle` when no jobs are active. Mirrors the existing adapter-pill / vram-pill pattern.

## Why
Spec calls for training queue visibility (pending/running/done with current loss + step) on the dashboard. The pill gives a quick at-a-glance read without needing to open the embedded `/ui` train tab.

## Changes
- `desktop/src/main.rs` — new `get_training_status` Tauri command that hits `/v1/train/status` with a 2s timeout, picks the first Running job (falls back to first entry), and returns `{ active: { state, progress, current_loss, adapter_name, job_id }, total_jobs }`. Returns empty on any HTTP/parse error or when server is Stopped/Error. Registered in `invoke_handler!`.
- `desktop/ui/dashboard.html` — new `#training-pill` CSS/markup alongside the adapter pill, polled inside `pollServerState` right after `refreshAdapterInfo`. Formats as `Running 23% (loss 1.42)` when active, `idle` when no jobs, hidden to `—` when server is Stopped/Error. Uses the same `cachedTrainingText` churn-avoidance pattern.

Note: kiln-server serializes `TrainingState` as snake_case (e.g. `"running"`), so the match is case-insensitive and the displayed label is title-cased on the client side.

## Validation
Local `cargo check` skipped — Cloud Eric pods lack GTK/webkit2gtk (known kiln-desktop limitation). CI validates on ubuntu-22.04 + windows-latest.