### PR TITLE
CE: desktop: show app version in settings window

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -106,6 +106,11 @@ async fn open_logs(app: AppHandle) -> Result<(), String> {
     tray::open_logs_window(&app).map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+fn get_app_version() -> String {
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
 #[derive(serde::Serialize)]
 struct UpdateCheckResult {
     available: bool,
@@ -411,6 +416,7 @@ fn main() {
             get_training_status,
             open_settings,
             open_logs,
+            get_app_version,
             check_for_updates,
             install_update
         ])

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -80,6 +80,7 @@
       .status { margin-top: 8px; font-size: 12px; color: #7fbf7f; min-height: 16px; }
       .status.error { color: #f08080; }
       .todo { color: #a8aeb8; font-size: 11px; margin-top: 4px; }
+      .version-footer { margin-top: 16px; color: #6c7280; font-size: 11px; text-align: right; }
     </style>
   </head>
   <body>
@@ -152,6 +153,7 @@
         <button id="save">Save</button>
       </div>
       <div class="status" id="status"></div>
+      <div class="version-footer">Kiln Desktop v<span id="app-version">—</span></div>
     </div>
 
     <script>
@@ -288,6 +290,9 @@
       document.getElementById("pick_adapter_dir").addEventListener("click", () =>
         pickPath("adapter_dir", { multiple: false, directory: true, title: "Select adapter directory" })
       );
+      invoke("get_app_version").then(v => {
+        document.getElementById("app-version").textContent = v;
+      }).catch(() => {});
       load();
     </script>
   </body>


### PR DESCRIPTION
## What
Add a `get_app_version` Tauri command and display Kiln Desktop version in the settings window footer.

## Why
Users had no persistent way to see their installed version. `check_for_updates` only returns `current_version` when an update is available; when up-to-date, nothing surfaces the version. This matters for bug reports and confirming updates actually installed.

## Validation
Note: `cargo check` is expected to fail in CE sessions due to missing GTK/webkit2gtk system libs (see agent note tauri-cargo-check-gtk-missing). Real build validated by desktop-build.yml CI on ubuntu-22.04 and windows-latest runners. Changes are small and localized: one new command reading `env!(CARGO_PKG_VERSION)` plus a static footer element.