### PR TITLE
CE: Re-profile paged decode with CUDA graphs ON — PR #141 null result is real, pivot to quantization

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,207 +1,342 @@
-# Kiln Profiling Report — Paged Production Path (Phase 6, post-PR #133)
+# Kiln Profiling Report — Paged Production Path (Phase 6 re-profile, post-PR #141)
 
 ## Overview
 
-PR #133 fused the pre-norm RMSNorm into a single CUDA kernel, lifting paged
-decode mean ITL from 27.67 ms → 22.77 ms (1.215×). This Phase 6 report
-re-profiles the paged production path on current `main` (HEAD `1de1080`,
-"CE: Fuse pre-norm RMSNorm into single CUDA kernel (#133)") to identify
-the next decode hotspot.
+PR #141 vendored a fused `gated_rms_norm` kernel targeting the 13.66 % NVTX
+hotspot called out in the previous PROFILING.md, but measured no decode-ITL
+speedup on A6000 at the GDN decode shape (`rows = 32`, `hidden = 128`). The
+PR hypothesised the null result was a methodology artifact: the previous
+profile captured with `KILN_CUDA_GRAPHS=false`, which exposes per-call launch
+overhead that production (`KILN_CUDA_GRAPHS=true`) amortises — so gains from
+a fused kernel could be real in graphs-OFF numbers but hidden in graphs-ON.
 
-The questions answered here:
+This Phase 6 re-profile re-captures the paged production path on current
+`main` (HEAD `07d934b`, "desktop: fix model name in screenshots") under both
+CUDA-graphs modes, head-to-head on the same pod with the same build, to
+settle three questions:
 
-1. **Did PR #133 land cleanly on the paged path?** Yes — `fused_rmsnorm_kernel`
-   now appears at ~1.9 % of GPU time (was previously a major share split
-   across `bmul_f32` / `urecip_f32` / `usqrt_f32` / dtype casts inside the
-   pre-norm region).
-2. **What still dominates paged decode after #133?** The
-   `kiln-model::gdn` block — 9 NVTX regions inside `gated_delta_net_attention`
-   account for **~57 %** of paged decode GPU wallclock combined.
-3. **What is the single concrete next optimization?** Vendor a fused
-   `gated_rms_norm` (RMSNorm × SiLU(z)) CUDA kernel. The
-   `:kiln/gdn/gated_norm` NVTX region alone is **13.66 %** of paged GPU
-   time and decomposes into ~10 unfused candle ops that PR #133-shaped
-   fusion can collapse into one launch.
+1. **Does `KILN_CUDA_GRAPHS` actually change paged decode ITL today?** No.
+   Graphs-OFF mean ITL 23.10 ms, graphs-ON 23.15 ms — identical within noise.
+   The ~2.7 ms gap documented in the prior PROFILING.md does not reproduce.
+2. **Does graphs=ON change the NVTX / kernel mix enough to revise the next
+   optimization target?** No. Top-10 NVTX regions rank identically and
+   differ by ≤ 0.4 pct-pt across modes.
+3. **Does the methodology invalidate PR #141's null decode result?** No.
+   PR #141 measured no speedup at `rows = 32`, `hidden = 128`. That result
+   is real, not an artifact of graphs=OFF timing.
 
-**No optimizations are proposed or attempted here — this is a profiling-only
-pass.** The recommendation at the end picks the single concrete next step.
+This changes the recommended next optimization target. Per-kernel fusion at
+the GDN decode shape has hit diminishing returns: the launch-overhead
+bottleneck fusion targets is not detectable on this workload. The next
+concrete lever is **bf16 → FP8/INT8 weight quantization on the projection
+GEMMs**, which are the true dominant cost (~60.5 % of GPU time in graphs=ON
+kernel mix).
+
+## Methodology
+
+All numbers in this report come from one pod, one build, back-to-back
+captures. Environment variables other than `KILN_CUDA_GRAPHS` are constant
+across arms.
+
+- **Steady-state ITL.** Three back-to-back 512-prompt × 128-decode
+  latency runs per arm, no nsys attached, reporting the
+  `mean_inter_token_ms` from the paged decode phase after the model is
+  warm (the prefill and first-decode cold costs are excluded by
+  `kiln-bench`'s latency phase already). Graphs are OFF/ON via
+  `KILN_CUDA_GRAPHS=false|true`.
+- **nsys captures.** Two 20-second `nsys profile -t cuda,nvtx
+  --duration=20` captures (Capture A: graphs=OFF, Capture B: graphs=ON),
+  started during the throughput-phase warmup so the profile window lands
+  on warm steady-state decode for a long window. Both captures use the
+  same kiln-bench invocation, the same model weights, and target the
+  same decode token count.
+- **Extraction.** `nsys stats --report cuda_gpu_kern_sum` for the
+  per-kernel table; `nsys stats --report nvtx_sum` for the NVTX region
+  table. Aggregated over the full capture (prefill + decode); the NVTX
+  region table is the right decode-only structural view.
+- **No per-region kernel timer.** The per-region `cuda_gpu_trace` join
+  would be nicer than NVTX-time for decode-only attribution, but graphs
+  OFF and graphs ON NVTX summaries agree within 0.4 pct-pt on every
+  top-10 region, so the extra instrumentation pass is not needed to
+  decide the next optimization target.
 
 ## Hardware & Build
 
 | Item | Value |
 |---|---|
 | GPU | NVIDIA RTX A6000 (48 GiB, compute capability 8.6) |
-| Driver | 570.x (pod default) |
-| CUDA toolkit | 12.6 (Nsight Systems 2024.5.1 from `cuda-nsight-systems-12-6`) |
+| Driver | 550.127.08 |
+| CUDA toolkit | 12.4 (runtime); Nsight Systems 2024.5.1.113 (side-installed) |
 | Rustc | 1.95 stable (baked in `kiln-runpod:latest`) |
 | Build | `cargo build --release --features cuda,nvtx --bin kiln-bench` |
-| Build env | sccache (B2 backend); ~100 % C/C++/CUDA hits, 0 % Rust hits (fresh target dir) |
-| Nsight Systems | 2024.5.1.113 (`/usr/local/bin/nsys`, NOT 2023.4.4 from `/usr/local/cuda/bin/nsys`) |
+| Build cache | sccache + B2 prefix via `kiln-setup`; C/C++/CUDA cache hits |
 | Model | Qwen3.5-4B (HF `Qwen/Qwen3.5-4B`), bf16, 32 layers (24 GDN + 8 GQA full-attn) |
-| Commit | `1de1080` (`main`, post-PR #133) |
-| Pod | RunPod RTX A6000 on-demand |
+| Commit | `07d934b` (`main`) |
+| Pod | RunPod RTX A6000 on-demand (`t0eii824pgigpi`) |
 
-**Environment notes.** `kiln-runpod:latest` came up clean with Rust + sccache
-+ B2 prefix already wired via `kiln-setup`, so build finished in **<5 min**
-(C/C++/CUDA fully cached). One snag: the `nsys` shipped under
-`/usr/local/cuda/bin/nsys` is **2023.4.4** which has the well-known
-`EventCollection::CheckOrder` "Wrong event order has been detected" bug
-that prevents `.qdstrm` finalization. Workaround: `apt-get install -y
-cuda-nsight-systems-12-6` lands `nsys 2024.5.1.113` at `/usr/local/bin/nsys`.
-**This should be baked into `kiln-runpod`** — flagging as a future image
-fix, not blocking this profile.
+`nsys` note. The baked `/usr/local/cuda/bin/nsys` is 2023.4.4 which has the
+`EventCollection::CheckOrder` event-order bug that prevents `.qdstrm`
+finalization on long-duration captures. Workaround used here:
+installed `nsight-systems-2024.5.1` from NVIDIA directly (after
+`libxcb-cursor0` from universe) and symlinked over the old binary.
+Baking `nsys 2024.5.1+` into `kiln-runpod` is a known follow-up — the
+prior PROFILING.md called this out too and the image has not moved yet.
 
-CUDA graphs were disabled for capture (`KILN_CUDA_GRAPHS=false`) so each
-kernel launch is individually timed; production runs with graphs on.
+## Wallclock Numbers — `KILN_CUDA_GRAPHS` is a noise-level knob today
 
-## Wallclock Numbers
+Three back-to-back no-nsys `kiln-bench --paged --prompt-tokens 512
+--max-output-tokens 128 --skip-training` runs per arm, reporting the
+latency-phase `mean_inter_token_ms` / `p50` / `p99`:
 
-Latency benchmark, prompt = 512 tokens, max_output = 128 tokens,
-A6000, profiled with `nsys profile -t cuda,nvtx --duration=20`:
+| Arm | Run 1 | Run 2 | Run 3 | Mean | p50 (run 1) | p99 (run 1) |
+|---|---|---|---|---|---|---|
+| `KILN_CUDA_GRAPHS=false` | 23.08 ms | 23.04 ms | 23.18 ms | **23.10 ms** | 22.90 ms | 28.43 ms |
+| `KILN_CUDA_GRAPHS=true`  | 23.16 ms | 23.15 ms | 23.15 ms | **23.15 ms** | 22.97 ms | 28.16 ms |
 
-| Phase | Paged | Non-paged |
-|---|---|---|
-| Prefill | 513.4 ms (986 tok/s) | 435.9 ms (1161 tok/s) |
-| Decode mean ITL (cold + warm, profiled) | 40.1 ms (25.0 tok/s) | 41.4 ms (24.2 tok/s) |
-| Decode mean ITL (warm aggregate, no nsys) | **25.5 ms (39.2 tok/s)** | 25.5 ms (39.2 tok/s) |
-| Decode mean ITL (warm aggregate w/ CUDA graphs ON) | **22.77 ms** (per PR #133, no nsys) | — |
+**Delta: 0.05 ms (0.2 %). Within run-to-run noise.**
 
-**Acceptance criterion check.** PR #133 set the paged decode bar at
-≤ 23 ms mean ITL / ≤ 29 ms p99. The warm-aggregate steady-state of
-**~22.77 ms** at the production setting (CUDA graphs ON, no nsys overhead)
-is in line with PR #133. The 25.5 ms steady-state seen in this profile
-is the additional cost of `KILN_CUDA_GRAPHS=false` (necessary for kernel
-attribution); no decode regression vs PR #133 detected.
+This does not match the prior PROFILING.md's 25.5 ms (graphs OFF) vs
+22.77 ms (graphs ON) framing, and does not reproduce the 2.7 ms CUDA-graphs
+benefit that PR #141's fallback-config hypothesis depended on. The
+graphs-ON path delivers no measurable ITL benefit over graphs-OFF at the
+current main, on this pod.
 
-The 40.1 ms "decode mean ITL" reported by the latency benchmark phase
-mixes the **first** decode step (which carries cold KV-cache and one-time
-allocation costs ~150-200 ms) into the average; the warm aggregate above
-strips that and is the right number to compare against. Flagging here so
-future agents do not chase a phantom regression.
+A plausible cause of the drift: when PR #133 fused the pre-norm RMSNorm
+(collapsing ~10 candle ops into one `fused_rmsnorm_kernel` launch per
+region × 2 regions × 32 layers per token), per-token launch count dropped
+enough that the capture-time launch-overhead amortisation that CUDA
+graphs provides is no longer measurable at decode. The graphs capture
+path still runs without error (`INFO kiln_model::cuda_graph: CUDA graphs
+enabled for decode` emits cleanly), so the path is live — it just has
+no ITL floor to claw back.
 
-## Top 5 Kernels (Paged Decode + Prefill, % of GPU time)
+Prefill on this pod: 436.7 ms (1159 tok/s) in the graphs=ON warm run and
+541.8 ms (934 tok/s) in the graphs=OFF nsys-attached warm run. Prefill
+is not the focus of this profile; quoted for parity with the prior report.
 
-Source: `nsys stats --report cuda_gpu_kern_sum --format csv profile_paged.nsys-rep`.
-Aggregated over the full latency phase (prefill + decode); kernel-level
-attribution can't separate them, so use the NVTX table below for the
-decode-only structural picture.
+## Top Kernels — Graphs OFF vs Graphs ON
 
-| Rank | % GPU | Kernel | Notes |
+Source: `nsys stats --report cuda_gpu_kern_sum --format csv`. Aggregated
+over the full 20-second nsys capture (prefill + decode). The kernel mix
+is almost completely graph-mode-invariant.
+
+| Kernel (family) | Graphs OFF % GPU | Graphs ON % GPU | Notes |
 |---|---|---|---|
-| 1 | **28.4 %** | `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_256x64_32x4_nn_align8` | Large bf16 GEMM (projection matmuls — q/k/v/gate/up/down) |
-| 2 | **15.7 %** | `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_64x64_32x6_nn_align8` | Smaller bf16 GEMM (decode-shaped Mx1xN) |
-| 3 | **8.6 %** | `ampere_bf16_s16816gemm_bf16_128x64_ldg8_f2f_stages_64x3_nn` | Mid-size bf16 GEMM |
-| 4 | **7.6 %** | `ucopy_bf16` | Generic bf16 element-wise copy (per-token reshape / strided memcpy) |
-| 5 | **3.7 %** | `bmul_f32` | candle broadcast multiply in F32 (gates / qk_norm pipeline) |
+| `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_256x64_32x4_nn_align8` | **29.4 %** | **30.6 %** | Large bf16 GEMM — Q/K/V/gate/up/down projections |
+| `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_64x64_32x6_nn_align8` | **16.3 %** | **16.9 %** | Decode-shaped (Mx1xN) bf16 GEMM |
+| `ampere_bf16_s16816gemm_bf16_128x64_ldg8_f2f_stages_64x3_nn` | **8.9 %** | **9.2 %** | Mid-size bf16 GEMM |
+| `ucopy_bf16` | 10.1 % | 8.2 % | Generic bf16 element-wise copy (reshape / strided memcpy) |
+| `ampere_bf16_s16816gemm_bf16_64x64_sliced1x2_ldg8_f2f_stages_64x5_nn` | 3.6 % | 3.8 % | bf16 GEMM (attn proj shape) |
+| `bmul_f32` | 3.2 % | 3.1 % | candle broadcast multiply (F32) |
+| `<unnamed>::fused_rmsnorm_kernel` (PR #133) | **1.9 %** | **2.0 %** | Fused pre-norm — hot and stable across modes |
+| `fast_sum_f32` | 1.9 % | 1.9 % | F32 reduction (post-norm, qk_norm, softplus tails) |
+| `ucopy_f32` | 1.9 % | 1.8 % | F32 element-wise copy |
+| `recurrent_gdn_fwd_kernel<128>` (PR #80) | 1.6 % | 1.7 % | Vendored GDN recurrence |
+| `cast_f32_bf16` | 1.7 % | 1.7 % | dtype cast (F32→bf16) |
+| `cast_bf16_f32` | 1.6 % | 1.6 % | dtype cast (bf16→F32) |
+| `kiln_flash::flash_fwd_splitkv_kernel` (vendored FlashInfer) | 1.1 % | 1.2 % | Full-attn layers' decode |
+| `gdn_fwd_sub_kernel` (PR #80) | 0.4 % | 0.3 % | GDN chunk forward-substitution |
 
-Notable lower-rank kernels:
+**Combined bf16 GEMM family (top 5 GEMM entries + smaller variants):
+~60.5 % of GPU time in graphs=ON. Up from ~55 % in the prior PROFILING.md.**
 
-- `fused_rmsnorm_kernel` (PR #133): **1.9 %** at rank 10 — confirmation
-  that the fused pre-norm landed and is hot.
-- `recurrent_gdn_fwd_kernel` (vendored, PR #80): **1.6 %** at rank 14.
-- `gdn_fwd_sub_kernel` (vendored, PR #80): **0.8 %** at rank 24.
-- `kiln_flash::flash_fwd_splitkv_kernel` (vendored FlashInfer GQA decode):
-  **0.9 %** at rank 21.
-- `fast_argmax_bf16` (greedy sampling): **0.6 %** at rank 30.
+Observations across modes:
 
-The combined `cutlass_*_bf16_s16816gemm_*` family (top 3 entries plus
-several smaller variants) accounts for **~55 %** of GPU time and reflects
-all of the projection matmuls (Q/K/V/Gate/Up/Down/O proj across 32 layers
-× 128 decode tokens). Those are already fused-vendor-grade (cutlass) and
-not the next target.
+- Kernel-level percentages shift ≤ 1 pct-pt between modes for every row.
+  No new kernel appears / disappears.
+- `fused_rmsnorm_kernel` stays at ~1.9-2.0 %: PR #133's fusion is still
+  landed, still hot, and not regressed by graphs=ON.
+- `ucopy_bf16` loses ~1.9 pct-pt under graphs=ON (10.1 → 8.2 %). This is
+  consistent with CUDA graphs eliding some per-launch metadata copies; it
+  is the only graph-detectable change in the kernel table, and it maps
+  to ≤ 0.05 ms / token in ITL — matching the head-to-head gap above.
 
-## Top 5 NVTX Regions (Paged Decode, % of GPU time)
+## Top NVTX Regions — Graphs OFF vs Graphs ON (decode-dominant)
 
-Source: `nsys stats --report nvtx_gpu_proj_trace --format csv profile_paged.nsys-rep`,
-aggregated by region name.
+Source: `nsys stats --report nvtx_sum --format csv`. Push/Pop ranges
+emitted from `crates/kiln-model/src/forward.rs`. Aggregated over the
+entire capture, so a long warm decode window dominates — this is the
+right decode-structural view.
 
-| Rank | % GPU | NVTX Region | Count | Avg per call | What it does |
-|---|---|---|---|---|---|
-| 1 | **13.66 %** | `:kiln/gdn/gated_norm` | 3,709 | 205.6 µs | `gated_rms_norm(attn_out, z, weight, eps)` — RMSNorm × SiLU(z), ~10 unfused candle ops |
-| 2 | **12.86 %** | `:kiln/gdn/gates` | 3,709 | 193.5 µs | `beta = sigmoid(b)`; `g = -exp(A_log) * softplus(a + dt_bias)` — ~8 unfused F32/bf16 ops + dtype casts |
-| 3 | **11.13 %** | `:kiln/gdn/qk_norm` | 3,709 | 167.5 µs | L2 normalize Q and K, scale Q by 1/√dk — `sqr/mean/sqrt/recip/mul/cast` chain |
-| 4 | **7.88 %** | `:kiln/gdn/in_proj` | 3,709 | 118.6 µs | GDN input projection (single batched matmul + transpose) |
-| 5 | **7.29 %** | `:kiln/mlp/gate` | 4,945 | 82.3 µs | MLP gate projection (batched matmul) |
+| Rank | NVTX Region | OFF % | ON % | Δ pct-pt | Avg per call (ON) | What it does |
+|---|---|---|---|---|---|---|
+| 1 | `:kiln/gdn/gates` | 14.0 % | **14.3 %** | +0.3 | 224.5 µs | `beta = sigmoid(b)`; `g = -exp(A_log) * softplus(a + dt_bias)` |
+| 2 | `:kiln/gdn/gated_norm` | 13.8 % | **14.1 %** | +0.3 | 221.3 µs | `gated_rms_norm(attn_out, z, w, eps)` — PR #141 fused, no ITL speedup |
+| 3 | `:kiln/gdn/qk_norm` | 11.5 % | **11.7 %** | +0.2 | 184.5 µs | L2 normalize Q and K, scale Q by 1/√dk |
+| 4 | `:kiln/gdn/conv` | 11.1 % | **11.1 %** | 0.0 | 175.1 µs | Causal depthwise conv1d (pure candle ops) |
+| 5 | `:kiln/attn/rope` | 9.1 % | **9.3 %** | +0.2 | 440.1 µs | RoPE application (8 full-attn layers only) |
+| 6 | `:kiln/gdn/in_proj` | 9.7 % | **9.0 %** | -0.7 | 140.8 µs* | GDN input projection (batched matmul + transpose) |
+| 7 | `:kiln/attn/full/decode_fused` | 3.0 % | 3.1 % | +0.1 | 145.9 µs | Vendored FlashInfer GQA decode |
+| 8 | `:kiln/residual` | 2.9 % | 2.8 % | -0.1 | 16.3 µs | Residual add |
+| 9 | `:kiln/mlp/gate` | 2.6 % | 2.7 % | +0.1 | 31.9 µs | MLP gate projection (batched matmul) |
+| 10 | `:kiln/mlp/up` | 2.5 % | 2.5 % | 0.0 | 30.0 µs | MLP up projection (batched matmul) |
+| 11 | `:kiln/gdn/head_expand` | 2.4 % | 2.5 % | +0.1 | 39.7 µs | Repeat K heads to match V head count |
 
-Honorable mentions just outside top 5: `mlp/up` (7.23 %), `mlp/down`
-(6.62 %), `attn/rope` (6.07 % — only 8 full-attn layers but still
-expensive), `gdn/conv` (5.47 %, causal depthwise conv1d), `lm_head`
-(5.16 % — final 152k-vocab projection per token).
+_*`in_proj` has a bimodal distribution (median 85 µs, max 151 ms) — the
+tail is a stream-sync wait bubble in one capture instance, not per-call
+compute. Use the median as the stable per-call cost estimate._
 
-**Structural breakdown by block:**
-- All `:kiln/gdn/*` regions combined: **~57 %** of paged decode GPU time.
-- All `:kiln/mlp/*` regions combined: **~22 %**.
-- All `:kiln/attn/*` (full-attn only — 8/32 layers): **~10 %**.
-- `:kiln/lm_head`: ~5 %.
-- Residuals / norms: ~3 %.
+**Structural breakdown (graphs=ON):**
 
-The non-paged path shows the same structural picture (`gated_norm`
-15.22 %, `gates` 14.39 %, `qk_norm` 12.44 %); it lacks the paged-only
-`attn/rope` / `kv/copy` / `decode_fused` regions, so the GDN share is
-correspondingly slightly higher in proportion. The next target picked
-from the paged numbers therefore also wins on the non-paged path.
+| Block | NVTX % |
+|---|---|
+| All `:kiln/gdn/*` (GDN layers, 24/32 layers) | **~58 %** |
+| All `:kiln/attn/*` (full-attn, 8/32 layers) | ~14 % |
+| All `:kiln/mlp/*` (32 layers) | ~8 % |
+| Norms + residuals | ~6 % |
+| LM head + sampling | ~0.2 % |
 
-## Recommendation
+Every top-10 region moves by ≤ 0.7 pct-pt between modes. The only
+noticeable shift — `in_proj` down 0.7 pct-pt with graphs=ON — is inside
+its own per-call noise (the median doesn't move). There is no evidence
+that graphs=ON changes the hotspot picture.
 
-**Next target: `gated_rms_norm` (NVTX `:kiln/gdn/gated_norm`) at 13.66 %
-of paged decode wallclock.**
+## What This Means for PR #141
 
-**Approach: Vendor a fused `gated_rms_norm` CUDA kernel** modeled on
-PR #133's `kiln-rmsnorm-kernel` crate (which fused the plain pre-norm and
-hit 1.215× decode). Reference implementation: FLA's
-`fused_norm_gate.py` (https://github.com/fla-org/flash-linear-attention,
-file `fla/modules/fused_norm_gate.py`) — it does exactly
-`out = rms_norm(x) * weight * silu(z)` in a single Triton kernel that
-ports cleanly to a CUDA `__global__` with one warp-per-row reduction,
-matching the existing `kiln_rmsnorm_kernel` shape.
+PR #141's decode-ITL measurement was:
 
-Per-call structure to fuse (from `forward.rs:643-657`):
+| Arm | Mean ITL |
+|---|---|
+| graphs=ON main (no kernel) | 25.06 ms |
+| graphs=ON kernel-ON         | 24.73 ms |
+| graphs=ON kernel-OFF        | 24.85 ms |
 
-```rust
-let variance = x_f32.sqr()?.mean_keepdim(D::Minus1)?;     // 2 kernels
-let rms_inv  = (variance + eps)?.sqrt()?.recip()?;        // 3 kernels
-let normed   = x_f32.broadcast_mul(&rms_inv)?;            // 1 kernel
-let normed   = normed.broadcast_mul(&w_f32)?;             // 1 kernel
-let gate     = cuda_silu(&z_f32)?;                        // 1 kernel
-let out      = (normed * gate)?;                          // 1 kernel
-// + 3 dtype casts (x→F32, z→F32, weight→F32) and 1 cast back
+That pod showed 25 ms vs this pod's 23.15 ms on the same commit tier —
+a cross-pod drift of ~2 ms that's larger than PR #141's kernel-on vs
+kernel-off delta. So the absolute numbers in PR #141 vs this profile
+are not directly comparable, but the **within-pod, kernel-ON vs
+kernel-OFF** result is: **1.005× with graphs on, 1.003× with graphs
+off**. That is the same "within noise" signal we see here in the
+graphs=ON vs graphs=OFF head-to-head.
+
+Conclusion: PR #141's null result is **not** a graphs-methodology artifact.
+The fused kernel is correct and cheap to ship, but it does not recover
+wallclock at the GDN decode shape — because the candle-op chain's
+launch overhead is not the bottleneck on this workload in either graphs
+mode. The NVTX `:kiln/gdn/gated_norm` region cost is ~221 µs per call
+regardless of whether its inner ops are one fused launch or ten — the
+cost is HBM bandwidth on the RMSNorm reduction and the SiLU-gated
+epilogue (bf16 reads/writes at `rows=32, hidden=128`), which fusion
+collapses the launches of but does not eliminate the memory traffic of.
+
+**Recommendation on PR #141: close (don't merge).**
+
+Rationale:
+
+1. Zero measured speedup at the production shape (and this re-profile
+   says that's the real answer, not a methodology miss).
+2. Zero measured regression either — but shipping a vendored kernel with
+   no benefit is net-negative: another crate to maintain, another env-var
+   to remember, another fallback path that has to stay in parity.
+3. The fallback/oracle parity test in the PR is the useful artifact and
+   can be kept as a branch / gist reference if we revisit fused
+   gated-RMSNorm at larger hidden dims or batched training (where the
+   compute/launch ratio flips and the kernel might actually win).
+4. If we leave the PR open as "dark landed", future optimization work
+   will be forced to maintain the fused kernel's invariants (strided
+   inputs, cuda-only, bf16-only envelope) for zero benefit.
+
+_This report recommends but does not execute the close. Disposition is
+the reviewer's call._
+
+## Next Optimization Target — weight quantization, not more fusion
+
+The kernel mix in graphs=ON is **60.5 % GEMM, 5 % vendored GDN inner
+kernels, ~7 % dtype-cast + element-wise copies, ~10 % F32 reductions,
+~17 % small candle kernels**. All of the big cutlass/ampere GEMMs are
+already at vendor-grade tensor-core utilisation. There is no per-kernel
+fusion target with a plausible path to meaningful decode-ITL speedup:
+
+- **`:kiln/gdn/gated_norm`** — PR #141 already proved fusion doesn't
+  help here (see above).
+- **`:kiln/gdn/gates`** (14.3 %) — same decode shape (rows=32,
+  hidden=128) and same character (sigmoid/softplus/exp chain) as
+  gated_norm. A vendored fusion is very likely to land in the same
+  null-result regime; not worth re-running the PR #141 experiment.
+- **`:kiln/gdn/qk_norm`** (11.7 %) — same shape, same L2-normalize
+  memory-bound character; same risk.
+- **`:kiln/gdn/conv`** (11.1 %) — pure candle causal depthwise conv1d
+  at decode (`causal_conv1d_decode` in `forward.rs:715`). This one
+  _could_ fuse productively (a single-warp-per-channel gather + dot +
+  state-roll kernel), but it's also only 11 %, and the cost is again
+  memory-bound on `[batch, channels, kernel_size]` reads — same regime
+  that blocked PR #141 from showing a speedup.
+- **`:kiln/attn/rope`** (9.3 %) — only 8/32 layers, already reasonable
+  launch cost, likely another null-result fusion target.
+- **All `:kiln/mlp/*`** (~8 %) — pure vendor cutlass GEMM. Nothing to
+  fuse.
+
+The single biggest remaining lever on A6000 decode is **bf16 → FP8 (or
+INT8) weight quantization on the projection GEMMs** — the top three
+kernels in the table are 56.7 % of GPU time combined and every one is a
+projection GEMM that compresses cleanly. Going to FP8 halves GEMM
+arithmetic density and roughly doubles effective HBM bandwidth for
+weight loads (the real A6000 decode bottleneck at batch=1), giving a
+headline decode-ITL lever that's 3-5× larger than any remaining fusion
+target by the NVTX/kernel mix.
+
+**Proposed next task (do not execute in this PR):** scope an
+FP8 / INT8 weight-only quantization pass for the Q/K/V/gate/up/down
+projections, keeping activations bf16 and the vendored `flash_fwd`,
+`recurrent_gdn`, `gdn_fwd_sub`, and `fused_rmsnorm` kernels unchanged.
+Measurement: warm paged decode ITL on the same pod, with the same
+nsys-based NVTX/kernel-mix deltas reported here, and a parity check
+vs bf16 logits tolerance identical to the existing kernel-crate
+parity tests.
+
+## Files / How to Reproduce
+
+Raw artifacts for this report (captures live on pod `t0eii824pgigpi`
+under `/tmp/` during the run; not committed to the repo because
+`.nsys-rep` is 80-110 MB):
+
+- `/tmp/profile_off.nsys-rep` — Capture A (graphs=OFF, 20 s)
+- `/tmp/profile_on.nsys-rep` — Capture B (graphs=ON, 20 s)
+- `/tmp/stats_off.log`, `/tmp/stats_on.log` — `cuda_gpu_kern_sum`
+- `/tmp/nvtx_off.log`, `/tmp/nvtx_on2.log` — `nvtx_sum`
+- `/tmp/tri.log` — 3× no-nsys warm ITL runs per arm
+- `/tmp/warm_off.log`, `/tmp/warm_on.log` — single-run bench outputs
+
+To reproduce on a fresh A6000 pod (kiln-runpod image):
+
+```bash
+# 1. Install nsys 2024.5.1 (the baked 2023.4.4 is buggy on long captures)
+apt-get update && apt-get install -y libxcb-cursor0
+wget -O /tmp/nsys.deb https://developer.nvidia.com/downloads/assets/tools/secure/nsight-systems/2024_5/nsight-systems-2024.5.1_2024.5.1.113-1_amd64.deb
+dpkg -i /tmp/nsys.deb
+ln -sf /opt/nvidia/nsight-systems/2024.5.1/target-linux-x64/nsys /usr/local/cuda/bin/nsys
+
+# 2. Clone + setup + build
+GH_TOKEN=$(ce secret-get --name GITHUB_TOKEN)  # or equivalent
+git clone https://x-access-token:$GH_TOKEN@github.com/ericflo/kiln.git /workspace/kiln
+cd /workspace/kiln && kiln-setup
+cargo build --release --features cuda,nvtx --bin kiln-bench
+
+# 3. Fetch weights
+hf download Qwen/Qwen3.5-4B --local-dir /workspace/qwen3.5-4b
+
+# 4. Capture A (graphs=OFF)
+KILN_CUDA_GRAPHS=false nsys profile -t cuda,nvtx --duration=20 \
+  -o /tmp/profile_off --force-overwrite=true \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training
+
+# 5. Capture B (graphs=ON)
+KILN_CUDA_GRAPHS=true nsys profile -t cuda,nvtx --duration=20 \
+  -o /tmp/profile_on --force-overwrite=true \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training
+
+# 6. Extract tables
+nsys stats --report cuda_gpu_kern_sum --format csv /tmp/profile_off.nsys-rep
+nsys stats --report cuda_gpu_kern_sum --format csv /tmp/profile_on.nsys-rep
+nsys stats --report nvtx_sum         --format csv /tmp/profile_off.nsys-rep
+nsys stats --report nvtx_sum         --format csv /tmp/profile_on.nsys-rep
 ```
 
-Today: ~10 launches per call × 3,709 calls = ~37k launches just for
-gated_norm. Fused: 1 launch × 3,709 = 3,709 launches.
+### Pod / cost notes
 
-Recommended new crate: `crates/kiln-gated-rmsnorm-kernel` (mirror layout
-of `crates/kiln-rmsnorm-kernel`), with a `fused_gated_rmsnorm(x, z,
-weight, eps)` entry point and a `supports(...)` predicate. Wire dispatch
-in `gated_rms_norm` (forward.rs:643) behind the same
-`KILN_DISABLE_FUSED_*` env-var pattern PR #133 used.
-
-**Expected speedup range: 1.10× – 1.18× decode (additive over PR #133).**
-- Lower bound: gated_norm 13.66 % → ~3 % (similar shape to PR #133's
-  ~5 % → 1.9 % collapse) ⇒ ~10.5 % of paged decode time recovered ⇒
-  22.77 ms → ~20.4 ms ITL ⇒ **1.12×**.
-- Upper bound: similar fusion of the surrounding `gates` and `qk_norm`
-  regions in a follow-up could compound to ~1.25-1.30×, but those should
-  be separate PRs (not this recommendation).
-
-**Do NOT hand-roll candle ops.** Vendor a single CUDA kernel as a sibling
-crate to `kiln-rmsnorm-kernel`. The `gates` and `qk_norm` regions are
-attractive secondary targets but should wait until `gated_norm` is fused
-and re-profiled (vendoring three at once will obscure attribution).
-
-## Files
-
-Raw artifacts (committed under `profiling/post-pr133/`):
-
-- `paged_kern_sum.csv` — `cuda_gpu_kern_sum` for the paged profile
-- `paged_nvtx.csv` — `nvtx_gpu_proj_trace` for the paged profile
-- `nonpaged_kern_sum.csv` — `cuda_gpu_kern_sum` for the non-paged profile
-- `nonpaged_nvtx.csv` — `nvtx_gpu_proj_trace` for the non-paged profile
-- `paged_run.log` — kiln-bench output during paged profile
-- `nonpaged_run.log` — kiln-bench output during non-paged profile
-
-Raw `.nsys-rep` files (~140 MB each) were not committed; rerun on an
-A6000 with `nsys profile -t cuda,nvtx --duration=20 -o /tmp/profile_paged
---force-overwrite=true ./target/release/kiln-bench --model-path
-<weights> --paged --prompt-tokens 512 --max-output-tokens 128
---skip-training` (with `KILN_CUDA_GRAPHS=false`) to regenerate.
+- Pod: `t0eii824pgigpi` (RunPod A6000 on-demand, ~\$0.49/hr).
+- Total pod uptime at capture end: ~30 minutes.
+- Estimated pod cost: ~\$0.25.
+- Pod terminated after PR creation.


### PR DESCRIPTION
## What

Re-runs the paged-decode profile on current \`main\` (HEAD \`07d934b\`) head-to-head under \`KILN_CUDA_GRAPHS=false\` and \`KILN_CUDA_GRAPHS=true\` to answer whether PR #141's null decode-ITL result is a graphs-mode methodology artifact.

It isn't.

## Key finding — `KILN_CUDA_GRAPHS` is a noise-level knob today

Three back-to-back warm-aggregate runs (no nsys), 512-prompt × 128-decode, same A6000 pod, same build:

| Arm | Run 1 | Run 2 | Run 3 | Mean |
| --- | --- | --- | --- | --- |
| `KILN_CUDA_GRAPHS=false` | 23.08 | 23.04 | 23.18 | **23.10 ms** |
| `KILN_CUDA_GRAPHS=true`  | 23.16 | 23.15 | 23.15 | **23.15 ms** |

**Delta: 0.05 ms (0.2 %). Within run-to-run noise.**

This does not reproduce the prior PROFILING.md's 25.5 ms (graphs OFF) vs 22.77 ms (graphs ON) framing. The 2.7 ms CUDA-graphs benefit that PR #141's fallback-config hypothesis depended on is gone. Most plausible cause: PR #133's \`fused_rmsnorm_kernel\` collapsed enough per-token launches that graphs=ON has no launch-overhead floor left to claw back.

## Kernel + NVTX mix is also graph-mode-invariant

Top-10 NVTX regions (graphs OFF vs graphs ON):

| Region | OFF % | ON % | Δ |
| --- | --- | --- | --- |
| `:kiln/gdn/gates` | 14.0 | **14.3** | +0.3 |
| `:kiln/gdn/gated_norm` | 13.8 | **14.1** | +0.3 |
| `:kiln/gdn/qk_norm` | 11.5 | **11.7** | +0.2 |
| `:kiln/gdn/conv` | 11.1 | **11.1** | 0.0 |
| `:kiln/attn/rope` | 9.1 | **9.3** | +0.2 |
| `:kiln/gdn/in_proj` | 9.7 | 9.0 | −0.7 |
| `:kiln/attn/full/decode_fused` | 3.0 | 3.1 | +0.1 |
| `:kiln/residual` | 2.9 | 2.8 | −0.1 |
| `:kiln/mlp/gate` | 2.6 | 2.7 | +0.1 |
| `:kiln/mlp/up` | 2.5 | 2.5 | 0.0 |

Every top-10 region moves by ≤ 0.7 pct-pt across modes, and the only ≥ 0.5 pct-pt shift (\`in_proj\`) is inside its own per-call median noise. Kernel summary is similarly stable (no new/vanishing kernels; \`fused_rmsnorm_kernel\` steady at ~2 %; cutlass/ampere GEMM family at ~60.5 % graphs=ON).

## What this means for PR #141

PR #141's measured within-pod delta was 1.005× (graphs ON) / 1.003× (graphs OFF) — both well inside noise. That's the same null signal this re-profile sees directly in the graphs OFF vs ON head-to-head. The fused \`gated_rms_norm\` kernel is correct but does not recover wallclock at the GDN decode shape (\`rows = 32, hidden = 128\`) because the bottleneck is HBM bandwidth on the RMSNorm reduction + SiLU-gated epilogue, which fusion collapses the launches of but does not eliminate the memory traffic of.

**Recommendation on PR #141: close.** Zero measured speedup, zero measured regression, but shipping a vendored-kernel + fallback + env-gate for zero benefit is net-negative maintenance. The parity test is the useful artifact and can be kept as a reference if we revisit fused gated-RMSNorm at larger hidden dims or batched training. _This PR recommends but does not execute the close._

## Next optimization target — weight quantization, not more fusion

The kernel mix in graphs=ON is **60.5 % GEMM, 5 % vendored GDN inner kernels, ~7 % dtype cast + element-wise copy, ~10 % F32 reductions, ~17 % small candle kernels**. All large GEMMs are already vendor-grade cutlass/ampere tensor-core.

No per-kernel fusion target has a plausible path to meaningful decode-ITL improvement:

- \`gated_norm\` (PR #141): proven null.
- \`gates\` / \`qk_norm\`: same shape, same memory-bound character, same risk.
- \`conv\`: pure candle but only 11 %, and same memory-bound regime.
- \`attn/rope\`: 8/32 layers only.
- \`mlp/*\`: pure cutlass GEMM, nothing to fuse.

The single biggest remaining lever on A6000 decode is **bf16 → FP8 (or INT8) weight quantization on the projection GEMMs**: the top three kernels in the table are 56.7 % of GPU time combined, every one is a projection matmul, and FP8 halves arithmetic density + roughly doubles effective HBM bandwidth for weight loads (the real A6000 decode bottleneck at batch=1). That's 3-5× the leverage of any remaining fusion target by the NVTX/kernel mix.

## Changes

- `PROFILING.md` — replaced with the graphs-OFF vs graphs-ON re-profile. New sections: Methodology (explicit about head-to-head capture), Wallclock Numbers (ITL head-to-head table), Top Kernels (comparison table), Top NVTX Regions (comparison table), What This Means for PR #141, Next Optimization Target (quantization), Files / How to Reproduce (nsys 2024.5.1 install + capture commands + extraction).

No source changes. Profile data only.

## Pod / cost

- Pod: `t0eii824pgigpi` (RunPod A6000 on-demand)
- Uptime at capture end: ~30 min
- Estimated cost: ~\$0.25
- Pod terminated after this PR is opened