### PR TITLE
CE: Vendor Marlin W4A16 GEMM kernel (kernel-only crate, parity test)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kiln-marlin-gemm"
+version = "0.1.0"
+dependencies = [
+ "candle-core",
+ "cc",
+ "half",
+]
+
+[[package]]
 name = "kiln-model"
 version = "0.1.0"
 dependencies = [
@@ -1852,6 +1861,7 @@ dependencies = [
  "kiln-core",
  "kiln-flash-attn",
  "kiln-gdn-kernel",
+ "kiln-marlin-gemm",
  "kiln-nvtx",
  "kiln-rmsnorm-kernel",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/kiln-core",
     "crates/kiln-flash-attn",
     "crates/kiln-gdn-kernel",
+    "crates/kiln-marlin-gemm",
     "crates/kiln-model",
     "crates/kiln-nvtx",
     "crates/kiln-rmsnorm-kernel",
@@ -11,8 +12,8 @@ members = [
     "crates/kiln-server",
     "crates/kiln-train",
 ]
-# kiln-flash-attn, kiln-gdn-kernel, and kiln-rmsnorm-kernel unconditionally
-# depend on candle-core/cuda, which pulls cudarc into any
+# kiln-flash-attn, kiln-gdn-kernel, kiln-marlin-gemm, and kiln-rmsnorm-kernel
+# unconditionally depend on candle-core/cuda, which pulls cudarc into any
 # `cargo build --workspace` and fails to link on non-CUDA hosts (notably
 # macOS). They're only compiled when a downstream crate opts in via
 # --features cuda, which activates them as optional dependencies.
@@ -79,6 +80,7 @@ candle-core = "0.10"
 candle-nn = "0.10"
 kiln-flash-attn = { path = "crates/kiln-flash-attn" }
 kiln-gdn-kernel = { path = "crates/kiln-gdn-kernel" }
+kiln-marlin-gemm = { path = "crates/kiln-marlin-gemm" }
 kiln-nvtx = { path = "crates/kiln-nvtx" }
 kiln-rmsnorm-kernel = { path = "crates/kiln-rmsnorm-kernel" }
 # Apple's MLX framework via unofficial Rust bindings. Wave 2 peak-perf

--- a/crates/kiln-marlin-gemm/Cargo.toml
+++ b/crates/kiln-marlin-gemm/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kiln-marlin-gemm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Vendored IST-DASLab/marlin W4A16 GEMM CUDA kernel with a thin BF16 C-ABI wrapper"
+build = "build.rs"
+
+[dependencies]
+candle-core = { workspace = true, features = ["cuda"] }
+half = "2"
+
+[build-dependencies]
+cc = "1"

--- a/crates/kiln-marlin-gemm/build.rs
+++ b/crates/kiln-marlin-gemm/build.rs
@@ -1,0 +1,109 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let cuda_root = match find_cuda_root() {
+        Some(p) => p,
+        None => {
+            println!(
+                "cargo:warning=CUDA not found, kiln-marlin-gemm will not compile CUDA kernels"
+            );
+            println!("cargo:warning=Set CUDA_ROOT or CUDA_HOME, or install CUDA toolkit");
+            return;
+        }
+    };
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let csrc_dir = manifest_dir.join("csrc");
+
+    // Marlin requires sm_80+ (cp.async, mma.m16n8k16, ldmatrix). We default to
+    // the same arch list as the other kiln CUDA crates; users can still
+    // override via KILN_CUDA_ARCHS if they need to drop a target.
+    let cuda_archs =
+        env::var("KILN_CUDA_ARCHS").unwrap_or_else(|_| "80;86;89;90".to_string());
+
+    let mut build = cc::Build::new();
+    build.cuda(true);
+    build.cpp(true);
+
+    build.include(&csrc_dir);
+    build.include(cuda_root.join("include"));
+
+    build.flag("-std=c++17");
+    build.flag("-O3");
+    build.flag("--use_fast_math");
+    build.flag("--expt-relaxed-constexpr");
+    build.flag("--expt-extended-lambda");
+    build.flag("-Xcompiler").flag("-fPIC");
+    // Suppress diag-suppress noise from the vendored kernel (unused vars in
+    // the unused CALL_IF arms after templating).
+    build.flag("-diag-suppress=177");
+    build.flag("-diag-suppress=174");
+    // The Marlin source uses `groupsize / thread_k_blocks` style expressions
+    // inside CALL_IF arms that are unreachable for the per-column case
+    // (group_blocks == -1). NVCC still type-checks the dead branches and warns
+    // about division by zero / unreachable code; suppress those so the build
+    // log stays focused on real issues.
+    build.flag("-diag-suppress=39");
+    build.flag("-diag-suppress=179");
+
+    for arch in cuda_archs.split(';') {
+        let arch = arch.trim();
+        if !arch.is_empty() {
+            build.flag(&format!("-gencode=arch=compute_{arch},code=sm_{arch}"));
+        }
+    }
+
+    build.file(csrc_dir.join("marlin_kernel.cu"));
+
+    build.compile("kiln_marlin_gemm");
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        cuda_root.join("lib64").display()
+    );
+    println!("cargo:rustc-link-lib=cudart");
+
+    println!("cargo:rerun-if-changed=csrc/");
+    println!("cargo:rerun-if-env-changed=CUDA_ROOT");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
+    println!("cargo:rerun-if-env-changed=KILN_CUDA_ARCHS");
+}
+
+fn find_cuda_root() -> Option<PathBuf> {
+    for var in &["CUDA_ROOT", "CUDA_HOME", "CUDA_PATH"] {
+        if let Ok(val) = env::var(var) {
+            let p = PathBuf::from(val);
+            if p.join("include").join("cuda.h").exists() {
+                return Some(p);
+            }
+        }
+    }
+    for path in &[
+        "/usr/local/cuda",
+        "/usr/local/cuda-12",
+        "/usr/local/cuda-12.4",
+        "/usr/local/cuda-12.6",
+        "/usr/local/cuda-12.8",
+        "/opt/cuda",
+    ] {
+        let p = PathBuf::from(path);
+        if p.join("include").join("cuda.h").exists() {
+            return Some(p);
+        }
+    }
+    if let Ok(output) = std::process::Command::new("which").arg("nvcc").output() {
+        if output.status.success() {
+            let nvcc_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let p = PathBuf::from(nvcc_path);
+            if let Some(bin_dir) = p.parent() {
+                if let Some(cuda_dir) = bin_dir.parent() {
+                    if cuda_dir.join("include").join("cuda.h").exists() {
+                        return Some(cuda_dir.to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/crates/kiln-marlin-gemm/csrc/marlin_kernel.cu
+++ b/crates/kiln-marlin-gemm/csrc/marlin_kernel.cu
@@ -1,0 +1,863 @@
+/*
+ * Copyright (C) Marlin.2024 Elias Frantar (elias.frantar@ist.ac.at)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef MARLIN_CUDA_KERNEL_CUH
+#define MARLIN_CUDA_KERNEL_CUH
+
+
+#include <cuda.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <iostream>
+
+
+constexpr int ceildiv(int a, int b) {
+  return (a + b - 1) / b;
+}
+
+// Instances of `Vec` are used to organize groups of >>registers<<, as needed for instance as inputs to tensor core
+// operations. Consequently, all corresponding index accesses must be compile-time constants, which is why we
+// extensively use `#pragma unroll` throughout the kernel code to guarantee this.
+template <typename T, int n>
+struct Vec {
+  T elems[n];
+  __device__ T& operator[](int i) {
+    return elems[i];
+  }
+};
+
+using I4 = Vec<int, 4>;
+
+// Matrix fragments for tensor core instructions; their precise layout is documented here: 
+// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#matrix-fragments-for-mma-m16n8k16-with-floating-point-type
+using FragA = Vec<half2, 4>;
+using FragB = Vec<half2, 2>;
+using FragC = Vec<float, 4>;
+using FragS = Vec<half2, 1>; // quantization scales
+
+// Predicated asynchronous global->shared copy; used for inputs A where we apply predication to handle batchsizes that
+// are not multiples of 16.
+__device__ inline void cp_async4_pred(void* smem_ptr, const void* glob_ptr, bool pred = true) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "{\n"
+    "   .reg .pred p;\n"
+    "   setp.ne.b32 p, %0, 0;\n"
+    "   @p cp.async.cg.shared.global [%1], [%2], %3;\n"
+    "}\n" :: "r"((int) pred), "r"(smem), "l"(glob_ptr), "n"(BYTES)
+  );
+}
+
+// Asynchronous global->shared copy with a cache hint indicating that the values may be evicted immediately; used for
+// quantized weights B, which are only accessed precisely once and should thus not pollute the L2 cache which we need
+// for inputs A and outputs C. 
+__device__ inline void cp_async4_stream(void* smem_ptr, const void* glob_ptr) {
+  const int BYTES = 16;
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "{\n"
+    "   .reg .b64 p;\n"
+    "   createpolicy.fractional.L2::evict_first.b64 p, 1.0;"
+    "   cp.async.cg.shared.global.L2::cache_hint [%0], [%1], %2, p;\n"
+    "}\n" :: "r"(smem), "l"(glob_ptr), "n"(BYTES)
+  );
+}
+
+// Async copy fence.
+__device__ inline void cp_async_fence() {
+  asm volatile("cp.async.commit_group;\n" ::);
+}
+
+// Wait until at most `n` async copy stages are still pending.
+template <int n>
+__device__ inline void cp_async_wait() {
+  asm volatile("cp.async.wait_group %0;\n" :: "n"(n));
+}
+
+// m16n8k16 tensor core mma instruction with fp16 inputs and fp32 output/accumulation.
+__device__ inline void mma(const FragA& a_frag, const FragB& frag_b, FragC& frag_c) {
+  const uint32_t* a = reinterpret_cast<const uint32_t*>(&a_frag);
+  const uint32_t* b = reinterpret_cast<const uint32_t*>(&frag_b);
+  float* c = reinterpret_cast<float*>(&frag_c);
+  asm volatile(
+    "mma.sync.aligned.m16n8k16.row.col.f32.f16.f16.f32 "
+    "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%10,%11,%12,%13};\n"
+    : "=f"(c[0]), "=f"(c[1]), "=f"(c[2]), "=f"(c[3])
+    :  "r"(a[0]),  "r"(a[1]),  "r"(a[2]),  "r"(a[3]),  "r"(b[0]),  "r"(b[1]),
+       "f"(c[0]),  "f"(c[1]),  "f"(c[2]),  "f"(c[3])
+  );
+}
+
+// Instruction for loading a full 16x16 matrix fragment of operand A from shared memory, directly in tensor core layout.
+__device__ inline void ldsm4(FragA& frag_a, const void* smem_ptr) {
+  uint32_t* a = reinterpret_cast<uint32_t*>(&frag_a);
+  uint32_t smem = static_cast<uint32_t>(__cvta_generic_to_shared(smem_ptr));
+  asm volatile(
+    "ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+    : "=r"(a[0]), "=r"(a[1]), "=r"(a[2]), "=r"(a[3]) : "r"(smem)
+  );
+}
+
+// Lookup-table based 3-input logical operation; explicitly used for dequantization as the compiler does not seem to
+// automatically recognize it in all cases. 
+template <int lut>
+__device__ inline int lop3(int a, int b, int c) {
+  int res;
+  asm volatile(
+    "lop3.b32 %0, %1, %2, %3, %4;\n"
+    : "=r"(res) : "r"(a), "r"(b), "r"(c), "n"(lut)
+  );
+  return res;
+}
+
+// Efficiently dequantize an int32 value into a full B-fragment of 4 fp16 values.
+// We mostly follow the strategy in the link below, with some small changes:
+// https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/cutlass_extensions/include/cutlass_extensions/interleaved_numeric_conversion.h
+__device__ inline FragB dequant(int q) {
+  const int LO = 0x000f000f;
+  const int HI = 0x00f000f0;
+  const int EX = 0x64006400;
+  // Guarantee that the `(a & b) | c` operations are LOP3s.
+  int lo = lop3<(0xf0 & 0xcc) | 0xaa>(q, LO, EX);
+  int hi = lop3<(0xf0 & 0xcc) | 0xaa>(q, HI, EX);
+  // We want signed int4 outputs, hence we fuse the `-8` symmetric zero point directly into `SUB` and `ADD`.
+  const int SUB = 0x64086408;
+  const int MUL = 0x2c002c00;
+  const int ADD = 0xd480d480;
+  FragB frag_b;
+  frag_b[0] = __hsub2(
+    *reinterpret_cast<half2*>(&lo),
+    *reinterpret_cast<const half2*>(&SUB)
+  );
+  frag_b[1] = __hfma2(
+    *reinterpret_cast<half2*>(&hi),
+    *reinterpret_cast<const half2*>(&MUL), *reinterpret_cast<const half2*>(&ADD)
+  );
+  return frag_b;
+}
+
+// Multiply dequantized values by the corresponding quantization scale; used only for grouped quantization.
+__device__ inline void scale(FragB& frag_b, FragS& frag_s, int i) {
+  half2 s = __half2half2(reinterpret_cast<__half*>(&frag_s)[i]);
+  frag_b[0] = __hmul2(frag_b[0], s);
+  frag_b[1] = __hmul2(frag_b[1], s);
+}
+
+// Wait until barrier reaches `count`, then lock for current threadblock.
+__device__ inline void barrier_acquire(int* lock, int count) {
+  if (threadIdx.x == 0) {
+    int state = -1;
+    do
+      // Guarantee that subsequent writes by this threadblock will be visible globally.
+      asm volatile ("ld.global.acquire.gpu.b32 %0, [%1];\n" : "=r"(state) : "l"(lock));
+    while (state != count);
+  }
+  __syncthreads();
+}
+
+// Release barrier and increment visitation count.
+__device__ inline void barrier_release(int* lock, bool reset = false) {
+  __syncthreads();
+  if (threadIdx.x == 0) {
+    if (reset) {
+      lock[0] = 0;
+      return;
+    }
+    int val = 1;
+    // Make sure that all writes since acquiring this barrier are visible globally, while releasing the barrier. 
+    asm volatile ("fence.acq_rel.gpu;\n");
+    asm volatile ("red.relaxed.gpu.global.add.s32 [%0], %1;\n" : : "l"(lock), "r"(val)); 
+  }
+}
+
+
+template <
+  const int threads, // number of threads in a threadblock
+  const int thread_m_blocks, // number of 16x16 blocks in the m dimension (batchsize) of the threadblock 
+  const int thread_n_blocks, // same for n dimension (output) 
+  const int thread_k_blocks, // same for k dimension (reduction)
+  const int stages, // number of stages for the async global->shared fetch pipeline
+  const int group_blocks = -1 // number of consecutive 16x16 blocks with a separate quantization scale
+>
+__global__ void Marlin(
+  const int4* __restrict__ A, // fp16 input matrix of shape mxk 
+  const int4* __restrict__ B, // 4bit quantized weight matrix of shape kxn 
+        int4* __restrict__ C, // fp16 output buffer of shape mxn
+  const int4* __restrict__ s, // fp16 quantization scales of shape (k/groupsize)xn 
+  int  prob_m, // batch dimension m
+  int  prob_n, // output dimension n
+  int  prob_k, // reduction dimension k
+  int* locks // extra global storage for barrier synchronization 
+) {
+  // Each threadblock processes one "stripe" of the B matrix with (roughly) the same size, which might involve multiple 
+  // column "slices" (of width 16 * `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM example: 
+  //   0 1 3 
+  //   0 2 3
+  //   1 2 4
+  // While this kind of partitioning makes things somewhat more complicated, it ensures good utilization of all SMs
+  // for many kinds of shape and GPU configurations, while requiring as few slow global cross-threadblock reductions as 
+  // possible.
+  
+  // For larger GEMMs we run multiple batchsize 64 versions in parallel for a better partitioning with less reductions
+  int parallel = 1;
+  if (prob_m > 16 * thread_m_blocks) {
+    parallel = prob_m / (16 * thread_m_blocks);
+    prob_m = 16 * thread_m_blocks;
+  }
+
+  int k_tiles = prob_k / 16 / thread_k_blocks;
+  int n_tiles = prob_n / 16 / thread_n_blocks;
+  int iters = ceildiv(k_tiles * n_tiles * parallel, gridDim.x);
+  // Ensure that the number of tiles in each stripe is a multiple of the groupsize; this avoids an annoying special case
+  // where a stripe starts in the middle of group.
+  if (group_blocks != -1)
+    iters = (group_blocks / thread_k_blocks) * ceildiv(iters, (group_blocks / thread_k_blocks));
+
+  int slice_row = (iters * blockIdx.x) % k_tiles;
+  int slice_col_par = (iters * blockIdx.x) / k_tiles;
+  int slice_col = slice_col_par;
+  int slice_iters; // number of threadblock tiles in the current slice
+  int slice_count = 0; // total number of active threadblocks in the current slice
+  int slice_idx; // index of threadblock in current slice; numbered bottom to top
+
+  // We can easily implement parallel problem execution by just remapping indices and advancing global pointers
+  if (slice_col_par >= n_tiles) {
+    A += (slice_col_par / n_tiles) * 16 * thread_m_blocks * prob_k / 8;
+    C += (slice_col_par / n_tiles) * 16 * thread_m_blocks * prob_n / 8;
+    locks += (slice_col_par / n_tiles) * n_tiles;
+    slice_col = slice_col_par % n_tiles;
+  }
+
+  // Compute all information about the current slice which is required for synchronization.
+  auto init_slice = [&] () {
+    slice_iters = iters * (blockIdx.x + 1) - (k_tiles * slice_col_par + slice_row);
+    if (slice_iters < 0 || slice_col_par >= n_tiles * parallel)
+      slice_iters = 0;
+    if (slice_iters == 0)
+      return;
+    if (slice_row + slice_iters > k_tiles) 
+      slice_iters = k_tiles - slice_row;
+    slice_count = 1;
+    slice_idx = 0;
+    int col_first = iters * ceildiv(k_tiles * slice_col_par, iters);
+    if (col_first <= k_tiles * (slice_col_par + 1)) {
+      int col_off = col_first - k_tiles * slice_col_par;
+      slice_count = ceildiv(k_tiles - col_off, iters);
+      if (col_off > 0)
+        slice_count++;
+      int delta_first = iters * blockIdx.x - col_first;
+      if (delta_first < 0 || (col_off == 0 && delta_first == 0))
+        slice_idx = slice_count - 1;
+      else {
+        slice_idx = slice_count - 1 - delta_first / iters;
+        if (col_off > 0)
+          slice_idx--;
+      }
+    }
+    if (slice_col == n_tiles) {
+      A += 16 * thread_m_blocks * prob_k / 8;
+      C += 16 * thread_m_blocks * prob_n / 8;
+      locks += n_tiles;
+      slice_col = 0;
+    }
+  };
+  init_slice();
+
+  int a_gl_stride = prob_k / 8; // stride of the A matrix in global memory
+  // We typically use `constexpr` to indicate that this value is a compile-time constant
+  constexpr int a_sh_stride = 16 * thread_k_blocks / 8; // stride of an A matrix tile in shared memory
+  constexpr int a_gl_rd_delta_o = 16 * thread_k_blocks / 8; // delta between subsequent A tiles in global memory
+  int a_gl_rd_delta_i = a_gl_stride * (threads / a_gl_rd_delta_o); // between subsequent accesses within a tile
+  constexpr int a_sh_wr_delta = a_sh_stride * (threads / a_gl_rd_delta_o); // between shared memory writes
+  constexpr int a_sh_rd_delta_o = 2 * ((threads / 32) / (thread_n_blocks / 4)); // between shared memory tile reads
+  constexpr int a_sh_rd_delta_i = a_sh_stride * 16; // within a shared memory tile
+  constexpr int a_sh_stage = a_sh_stride * (16 * thread_m_blocks); // overall size of a tile
+  constexpr int a_sh_wr_iters = ceildiv(a_sh_stage, a_sh_wr_delta); // number of shared write iterations for a tile
+
+  int b_gl_stride = 16 * prob_n / 32;
+  constexpr int b_sh_stride = 32 * thread_n_blocks / 4;
+  int b_gl_rd_delta_o = b_gl_stride * thread_k_blocks;
+  int b_gl_rd_delta_i = b_gl_stride * (threads / b_sh_stride);
+  constexpr int b_sh_wr_delta = threads;
+  constexpr int b_sh_rd_delta = threads;
+  constexpr int b_sh_stage = b_sh_stride * thread_k_blocks;
+  constexpr int b_sh_wr_iters = b_sh_stage / b_sh_wr_delta;
+
+  int s_gl_stride = prob_n / 8;
+  constexpr int s_sh_stride = 16 * thread_n_blocks / 8;
+  constexpr int s_sh_stage = s_sh_stride;
+  int s_gl_rd_delta = s_gl_stride;
+
+  // Global A read index of current thread.
+  int a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+  a_gl_rd += a_gl_rd_delta_o * slice_row;
+  // Shared write index of current thread.
+  int a_sh_wr = a_sh_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+  // Shared read index.
+  int a_sh_rd = a_sh_stride * ((threadIdx.x % 32) % 16) + (threadIdx.x % 32) / 16;
+  a_sh_rd += 2 * ((threadIdx.x / 32) / (thread_n_blocks / 4));
+
+  int b_gl_rd = b_gl_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
+  b_gl_rd += b_sh_stride * slice_col;
+  b_gl_rd += b_gl_rd_delta_o * slice_row;
+  int b_sh_wr = threadIdx.x;
+  int b_sh_rd = threadIdx.x;
+
+  int s_gl_rd = s_gl_stride * ((thread_k_blocks * slice_row) / group_blocks) + s_sh_stride * slice_col + threadIdx.x;
+  int s_sh_wr = threadIdx.x;
+  int s_sh_rd;
+  // We use a different scale layout for grouped and column-wise quantization as we scale a `half2` tile in column-major
+  // layout in the former and in row-major in the latter case.
+  if (group_blocks != -1)
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) / 4;
+  else
+    s_sh_rd = 8 * ((threadIdx.x / 32) % (thread_n_blocks / 4)) + (threadIdx.x % 32) % 4;
+  
+  // Precompute which thread should not read memory in which iterations; this is needed if there are more threads than
+  // required for a certain tilesize or when the batchsize is not a multiple of 16.
+  bool a_sh_wr_pred[a_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < a_sh_wr_iters; i++)
+    a_sh_wr_pred[i] = a_sh_wr_delta * i + a_sh_wr < a_sh_stride * prob_m;
+  bool s_sh_wr_pred = threadIdx.x < s_sh_stride;
+
+  // To ensure that writing and reading A tiles to/from shared memory, the latter in fragment format, is fully bank
+  // conflict free, we need to use a rather fancy XOR-based layout. The key here is that neither reads nor writes of 
+  // the 16-byte `int4` blocks of 8 consecutive threads involve the same shared memory banks. Further, it seems (based
+  // on NSight-Compute) that each warp must also write a consecutive memory segment?
+  auto transform_a = [&] (int i) {
+    int row = i / a_gl_rd_delta_o;
+    return a_gl_rd_delta_o * row + (i % a_gl_rd_delta_o) ^ row;
+  };
+  // Since the computation of this remapping is non-trivial and, due to our main loop unrolls, all shared memory 
+  // accesses are static, we simply precompute both transformed reads and writes.
+  int a_sh_wr_trans[a_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < a_sh_wr_iters; i++)
+    a_sh_wr_trans[i] = transform_a(a_sh_wr_delta * i + a_sh_wr);
+  int a_sh_rd_trans[b_sh_wr_iters][thread_m_blocks];
+  #pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++) {
+    #pragma unroll
+    for (int j = 0; j < thread_m_blocks; j++)
+      a_sh_rd_trans[i][j] = transform_a(a_sh_rd_delta_o * i + a_sh_rd_delta_i * j + a_sh_rd); 
+  }
+
+  // Since B-accesses have non-constant stride they have to be computed at runtime; we break dependicies between
+  // subsequent accesses with a tile by maintining multiple pointers (we have enough registers), a tiny optimization.
+  const int4* B_ptr[b_sh_wr_iters];
+  #pragma unroll
+  for (int i = 0; i < b_sh_wr_iters; i++)
+    B_ptr[i] = B + b_gl_rd_delta_i * i + b_gl_rd;
+
+  extern __shared__ int4 sh[];
+  // Shared memory storage for global fetch pipelines. 
+  int4* sh_a = sh;
+  int4* sh_b = sh_a + (stages * a_sh_stage);
+  int4* sh_s = sh_b + (stages * b_sh_stage);
+  // Register storage for double buffer of shared memory reads. 
+  FragA frag_a[2][thread_m_blocks];
+  I4 frag_b_quant[2];
+  FragC frag_c[thread_m_blocks][4][2];
+  FragS frag_s[2][4];
+
+  // Zero accumulators.
+  auto zero_accums = [&] () {
+    #pragma unroll
+    for (int i = 0; i < thread_m_blocks * 4 * 2 * 4; i++)
+      reinterpret_cast<float*>(frag_c)[i] = 0;
+  };
+
+  // Asynchronously fetch the next A, B and s tile from global to the next shared memory pipeline location.
+  auto fetch_to_shared = [&] (int pipe, int a_off, bool pred = true) {
+    if (pred) {
+      int4* sh_a_stage = sh_a + a_sh_stage * pipe;
+      #pragma unroll
+      for (int i = 0; i < a_sh_wr_iters; i++) {
+        cp_async4_pred(
+          &sh_a_stage[a_sh_wr_trans[i]],
+          &A[a_gl_rd_delta_i * i + a_gl_rd + a_gl_rd_delta_o * a_off],
+          a_sh_wr_pred[i]
+        );
+      }
+      int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+      #pragma unroll
+      for (int i = 0; i < b_sh_wr_iters; i++) {
+        cp_async4_stream(&sh_b_stage[b_sh_wr_delta * i + b_sh_wr], B_ptr[i]);
+        B_ptr[i] += b_gl_rd_delta_o;
+      }
+      // Only fetch scales if this tile starts a new group
+      if (group_blocks != -1 && pipe % (group_blocks / thread_k_blocks) == 0) {
+        int4* sh_s_stage = sh_s + s_sh_stage * pipe;
+        if (s_sh_wr_pred)
+          cp_async4_stream(&sh_s_stage[s_sh_wr], &s[s_gl_rd]);
+        s_gl_rd += s_gl_rd_delta;
+      }
+    }
+    // Insert a fence even when we are winding down the pipeline to ensure that waiting is also correct at this point.
+    cp_async_fence();
+  };
+
+  // Wait until the next thread tile has been loaded to shared memory.
+  auto wait_for_stage = [&] () {
+    // We only have `stages - 2` active fetches since we are double buffering and can only issue the next fetch when
+    // it is guaranteed that the previous shared memory load is fully complete (as it may otherwise be overwritten).
+    cp_async_wait<stages - 2>();
+    __syncthreads();
+  };
+
+  // Load the next sub-tile from the current location in the shared memory pipe into the current register buffer.
+  auto fetch_to_registers = [&] (int k, int pipe) {
+    // It may seem inefficient that we reload the groups for every sub-tile; however, this does not seem to be a
+    // significant bottleneck, while some theoretically better attempts have lead to bad instruction ordering by the
+    // compiler and correspondingly a noticable drop in performance.
+    if (group_blocks != -1) {
+      int4* sh_s_stage = sh_s + s_sh_stage * ((group_blocks / thread_k_blocks) * (pipe / (group_blocks / thread_k_blocks)));
+      reinterpret_cast<int4*>(&frag_s[k % 2])[0] = sh_s_stage[s_sh_rd];
+    }
+    int4* sh_a_stage = sh_a + a_sh_stage * pipe;
+    #pragma unroll
+    for (int i = 0; i < thread_m_blocks; i++)
+      ldsm4(frag_a[k % 2][i], &sh_a_stage[a_sh_rd_trans[k % b_sh_wr_iters][i]]);
+    int4* sh_b_stage = sh_b + b_sh_stage * pipe;
+    frag_b_quant[k % 2] = *reinterpret_cast<I4*>(&sh_b_stage[b_sh_rd_delta * (k % b_sh_wr_iters) + b_sh_rd]);
+  };
+
+  // Execute the actual tensor core matmul of a sub-tile. 
+  auto matmul = [&] (int k) {
+    // We have the m dimension as the inner loop in order to encourage overlapping dequantization and matmul operations.
+    #pragma unroll
+    for (int j = 0; j < 4; j++) {
+      int b_quant = frag_b_quant[k % 2][j];
+      int b_quant_shift = b_quant >> 8;
+      FragB frag_b0 = dequant(b_quant);
+      // If there are no groups, we can just scale the final output once and can avoid doing so for each weight.
+      if (group_blocks != -1)
+        scale(frag_b0, frag_s[k % 2][j], 0);
+      FragB frag_b1 = dequant(b_quant_shift);
+      if (group_blocks != -1)
+        scale(frag_b1, frag_s[k % 2][j], 1);
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        mma(frag_a[k % 2][i], frag_b0, frag_c[i][j][0]);
+        mma(frag_a[k % 2][i], frag_b1, frag_c[i][j][1]);
+      }
+    }
+  };
+
+  // Since we slice across the k dimension of a tile in order to increase the number of warps while keeping the n
+  // dimension of a tile reasonable, we have multiple warps that accumulate their partial sums of the same output
+  // location; which we have to reduce over in the end. We do in shared memory.
+  auto thread_block_reduce = [&] () {
+    constexpr int red_off = threads / b_sh_stride / 2;
+    if (red_off >= 1) {
+      int red_idx = threadIdx.x / b_sh_stride;
+      constexpr int red_sh_stride = b_sh_stride * 4 * 2;
+      constexpr int red_sh_delta = b_sh_stride; 
+      int red_sh_rd = red_sh_stride * (threadIdx.x / b_sh_stride) + (threadIdx.x % b_sh_stride);
+
+      // Parallel logarithmic shared memory reduction. We make sure to avoid any unnecessary read or write iterations,
+      // e.g., for two warps we write only once by warp 1 and read only once by warp 0. 
+
+      #pragma unroll
+      for (int m_block = 0; m_block < thread_m_blocks; m_block++) {
+        #pragma unroll
+        for (int i = red_off; i > 0; i /= 2) {
+          if (i <= red_idx && red_idx < 2 * i) {
+            #pragma unroll
+            for (int j = 0; j < 4 * 2; j++) {
+              int red_sh_wr = red_sh_delta * j + (red_sh_rd - red_sh_stride * i);
+              if (i < red_off) {
+                float* c_rd = reinterpret_cast<float*>(&sh[red_sh_delta * j + red_sh_rd]);
+                float* c_wr = reinterpret_cast<float*>(&sh[red_sh_wr]);
+                #pragma unroll
+                for (int k = 0; k < 4; k++)
+                  reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + j][k] += c_rd[k] + c_wr[k];
+              }
+              sh[red_sh_wr] = reinterpret_cast<int4*>(&frag_c)[4 * 2 * m_block + j];
+            }
+          }
+          __syncthreads();
+        }
+        if (red_idx == 0) {
+          #pragma unroll
+          for (int i = 0; i < 4 * 2; i++) {
+            float* c_rd = reinterpret_cast<float*>(&sh[red_sh_delta * i + red_sh_rd]);
+            #pragma unroll
+            for (int j = 0; j < 4; j++)
+              reinterpret_cast<FragC*>(frag_c)[4 * 2 * m_block + i][j] += c_rd[j];
+          }
+        }
+        __syncthreads();
+      }
+    }
+  };
+
+  // Since multiple threadblocks may process parts of the same column slice, we finally have to globally reduce over
+  // the results. As the striped partioning minimizes the number of such reductions and our outputs are usually rather
+  // small, we perform this reduction serially in L2 cache.
+  auto global_reduce = [&] (bool first = false, bool last = false) {
+    // We are very careful here to reduce directly in the output buffer to maximize L2 cache utilization in this step. 
+    // To do this, we write out results in FP16 (but still reduce with FP32 compute).
+    constexpr int active_threads = 32 * thread_n_blocks / 4;
+    if (threadIdx.x < active_threads) {
+      int c_gl_stride = prob_n / 8;
+      int c_gl_wr_delta_o = 8 * c_gl_stride;
+      int c_gl_wr_delta_i = 4 * (active_threads / 32);
+      int c_gl_wr = c_gl_stride * ((threadIdx.x % 32) / 4) + 4 * (threadIdx.x / 32) + threadIdx.x % 4;
+      c_gl_wr += (2 * thread_n_blocks) * slice_col;
+      constexpr int c_sh_wr_delta = active_threads;
+      int c_sh_wr = threadIdx.x;
+
+      int row = (threadIdx.x % 32) / 4;
+
+      if (!first) {
+        // Interestingly, doing direct global accesses here really seems to mess up the compiler and lead to slowdowns,
+        // hence we also use async-copies even though these fetches are not actually asynchronous.
+        #pragma unroll
+        for (int i = 0; i < thread_m_blocks * 4; i++) {
+          cp_async4_pred(
+            &sh[c_sh_wr + c_sh_wr_delta * i],
+            &C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)],
+            i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m
+          );
+        }
+        cp_async_fence();
+        cp_async_wait<0>();
+      }
+
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks * 4; i++) {
+        if (i < (thread_m_blocks - 1) * 4 || 8 * (i / 2) + row < prob_m) {
+          if (!first) {
+            int4 c_red = sh[c_sh_wr + i * c_sh_wr_delta];
+            #pragma unroll
+            for (int j = 0; j < 2 * 4; j++) {
+              reinterpret_cast<float*>(&frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4)] += __half2float(
+                reinterpret_cast<__half*>(&c_red)[j]
+              );
+            }
+          }
+          if (!last) {
+            int4 c;
+            #pragma unroll
+            for (int j = 0; j < 2 * 4; j++) {
+              reinterpret_cast<__half*>(&c)[j] = __float2half(
+                reinterpret_cast<float*>(&frag_c)[4 * 2 * 4 * (i / 4) + 4 * j + (i % 4)]
+              );
+            }
+            C[c_gl_wr + c_gl_wr_delta_o * (i / 2) + c_gl_wr_delta_i * (i % 2)] = c;
+          }
+        }
+      }
+    }
+  };
+
+  // Write out the reduce final result in the correct layout. We only actually reshuffle matrix fragments in this step,
+  // the reduction above is performed in fragment layout. 
+  auto write_result = [&] () {
+    int c_gl_stride = prob_n / 8;
+    constexpr int c_sh_stride = 2 * thread_n_blocks + 1;
+    int c_gl_wr_delta = c_gl_stride * (threads / (2 * thread_n_blocks));
+    constexpr int c_sh_rd_delta = c_sh_stride * (threads / (2 * thread_n_blocks));
+
+    int c_gl_wr = c_gl_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
+    c_gl_wr += (2 * thread_n_blocks) * slice_col;
+    int c_sh_wr = (4 * c_sh_stride) * ((threadIdx.x % 32) / 4) + (threadIdx.x % 32) % 4;
+    c_sh_wr += 32 * (threadIdx.x / 32);
+    int c_sh_rd = c_sh_stride * (threadIdx.x / (2 * thread_n_blocks)) + (threadIdx.x % (2 * thread_n_blocks));
+
+    int c_gl_wr_end = c_gl_stride * prob_m;
+
+    // We first reorder in shared memory to guarantee the most efficient final global write patterns
+    auto write = [&] (int idx, float c0, float c1, FragS& s) {
+      half2 res = __halves2half2(__float2half(c0), __float2half(c1));
+      if (group_blocks == -1) // for per-column quantization we finally apply the scale here
+        res = __hmul2(res, s[0]);
+      ((half2*) sh)[idx] = res;
+    };
+    if (threadIdx.x / 32 < thread_n_blocks / 4) {
+      #pragma unroll
+      for (int i = 0; i < thread_m_blocks; i++) {
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+          int wr = c_sh_wr + 8 * j;
+          write(wr + (4 * c_sh_stride) * 0 + 0, frag_c[i][j][0][0], frag_c[i][j][0][1], frag_s[j / 2][2 * (j % 2) + 0]);
+          write(wr + (4 * c_sh_stride) * 8 + 0, frag_c[i][j][0][2], frag_c[i][j][0][3], frag_s[j / 2][2 * (j % 2) + 0]);
+          write(wr + (4 * c_sh_stride) * 0 + 4, frag_c[i][j][1][0], frag_c[i][j][1][1], frag_s[j / 2][2 * (j % 2) + 1]);
+          write(wr + (4 * c_sh_stride) * 8 + 4, frag_c[i][j][1][2], frag_c[i][j][1][3], frag_s[j / 2][2 * (j % 2) + 1]);
+        }
+        c_sh_wr += 16 * (4 * c_sh_stride);
+      }
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int i = 0; i < ceildiv(16 * thread_m_blocks, threads / (2 * thread_n_blocks)); i++) {
+      if (c_gl_wr < c_gl_wr_end) {
+        C[c_gl_wr] = sh[c_sh_rd];
+        c_gl_wr += c_gl_wr_delta;
+        c_sh_rd += c_sh_rd_delta;
+      }
+    }
+  };
+
+  // Start global fetch and register load pipelines. 
+  auto start_pipes = [&] () {
+    #pragma unroll
+    for (int i = 0; i < stages - 1; i++)
+      fetch_to_shared(i, i, i < slice_iters);
+    zero_accums();
+    wait_for_stage();
+    fetch_to_registers(0, 0);
+    a_gl_rd += a_gl_rd_delta_o * (stages - 1);
+  };
+  start_pipes();
+
+  // Main loop.
+  while (slice_iters) {
+    // We unroll over both the global fetch and the register load pipeline to ensure all shared memory accesses are
+    // static. Note that both pipelines have even length meaning that the next iteration will always start at index 0.
+    #pragma unroll
+    for (int pipe = 0; pipe < stages;) {
+      #pragma unroll
+      for (int k = 0; k < b_sh_wr_iters; k++) {
+        fetch_to_registers(k + 1, pipe % stages);
+        if (k == b_sh_wr_iters - 2) {
+          fetch_to_shared((pipe + stages - 1) % stages, pipe, slice_iters >= stages);
+          pipe++;
+          wait_for_stage();
+        }
+        matmul(k);
+      }
+      slice_iters--;
+      if (slice_iters == 0)
+        break;
+    }
+    a_gl_rd += a_gl_rd_delta_o * stages;
+
+    // Process results and, if necessary, proceed to the next column slice. While this pattern may not be the most
+    // readable, other ways of writing the loop seemed to noticeably worse performance after compliation.
+    if (slice_iters == 0) {
+      cp_async_wait<0>();
+      bool last = slice_idx == slice_count - 1;
+      // For per-column scales, we only fetch them here in the final step before write-out
+      if (group_blocks == -1 && last) {
+        if (s_sh_wr_pred)
+          cp_async4_stream(&sh_s[s_sh_wr], &s[s_gl_rd]);
+        cp_async_fence();
+      }
+      thread_block_reduce();
+      if (group_blocks == -1 && last) {
+        cp_async_wait<0>();
+        __syncthreads();
+        if (threadIdx.x / 32 < thread_n_blocks / 4) {
+          reinterpret_cast<int4*>(&frag_s)[0] = sh_s[s_sh_rd + 0];
+          reinterpret_cast<int4*>(&frag_s)[1] = sh_s[s_sh_rd + 4];
+        }
+      }
+      if (slice_count > 1) { // only globally reduce if there is more than one block in a slice
+        barrier_acquire(&locks[slice_col], slice_idx);
+        global_reduce(slice_idx == 0, last);
+        barrier_release(&locks[slice_col], last);
+      }
+      if (last) // only the last block in a slice actually writes the result
+        write_result();
+      slice_row = 0;
+      slice_col_par++;
+      slice_col++;
+      init_slice();
+      if (slice_iters) {
+        a_gl_rd = a_gl_stride * (threadIdx.x / a_gl_rd_delta_o) + (threadIdx.x % a_gl_rd_delta_o);
+        #pragma unroll
+        for (int i = 0; i < b_sh_wr_iters; i++)
+          B_ptr[i] += b_sh_stride - b_gl_rd_delta_o * k_tiles;
+        if (slice_col == 0) {
+          #pragma unroll
+          for (int i = 0; i < b_sh_wr_iters; i++)
+            B_ptr[i] -= b_gl_stride;
+        }
+        s_gl_rd = s_sh_stride * slice_col + threadIdx.x;
+        start_pipes();
+      }
+    }
+  }
+}
+
+
+// 8 warps are a good choice since every SM has 4 schedulers and having more than 1 warp per schedule allows some more
+// latency hiding. At the same time, we want relatively few warps to have many registers per warp and small tiles.
+const int THREADS = 256;
+const int STAGES = 4; // 4 pipeline stages fit into shared memory
+const int SHARED_MEM = 96 * 1024; // max shared memory on compute capability 8.6 (< 8.0)
+
+#define CALL_IF(THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, GROUP_BLOCKS) \
+  else if ( \
+    thread_m_blocks == THREAD_M_BLOCKS && thread_n_blocks == THREAD_N_BLOCKS && thread_k_blocks == THREAD_K_BLOCKS && \
+    group_blocks == GROUP_BLOCKS \
+  ) { \
+    cudaFuncSetAttribute( \
+      Marlin<THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS>, \
+      cudaFuncAttributeMaxDynamicSharedMemorySize, \
+      SHARED_MEM \
+    ); \
+    Marlin< \
+      THREADS, THREAD_M_BLOCKS, THREAD_N_BLOCKS, THREAD_K_BLOCKS, STAGES, GROUP_BLOCKS \
+    ><<<blocks, THREADS, SHARED_MEM, stream>>>( \
+      A_ptr, B_ptr, C_ptr, s_ptr, \
+      prob_m, prob_n, prob_k, \
+      locks \
+    ); \
+  }
+
+const int ERR_PROB_SHAPE = 1;
+const int ERR_KERN_SHAPE = 2;
+
+int marlin_cuda(
+  const void* A,
+  const void* B,
+        void* C,
+        void* s,
+  int prob_m,
+  int prob_n,
+  int prob_k,
+  void* workspace,
+  int groupsize = -1,
+  int dev = 0,
+  cudaStream_t stream = 0,
+  int thread_k = -1,
+  int thread_n = -1,
+  int sms = -1,
+  int max_par = 16
+) {
+  int tot_m = prob_m;
+  int tot_m_blocks = ceildiv(tot_m, 16);
+  int pad = 16 * tot_m_blocks - tot_m;
+
+  if (sms == -1)
+    cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev);
+  if (thread_k == -1 || thread_n == -1) {
+    if (prob_m <= 16) {
+      // For small batchizes, better partioning is slightly more important than better compute utilization
+      thread_k = 128;
+      thread_n = 128;
+    } else {
+      thread_k = 64;
+      thread_n = 256;
+    }
+  }
+
+  int thread_k_blocks = thread_k / 16;
+  int thread_n_blocks = thread_n / 16;
+  int group_blocks = (groupsize == -1) ? -1 : groupsize / 16;
+  int blocks = sms;
+
+  if (prob_n % thread_n != 0 || prob_k % thread_k != 0 || (group_blocks != -1 && prob_k % group_blocks != 0))
+    return ERR_PROB_SHAPE;
+  if (prob_m == 0 || prob_n == 0 || prob_k == 0)
+    return 0;
+
+  const int4* A_ptr = (const int4*) A;
+  const int4* B_ptr = (const int4*) B;
+  int4* C_ptr = (int4*) C;
+  const int4* s_ptr = (const int4*) s;
+
+  int cols = prob_n / thread_n;
+  int* locks = (int*) workspace;
+
+  int ret = 0;
+  for (int i = 0; i < tot_m_blocks; i += 4) {
+    int thread_m_blocks = tot_m_blocks - i;
+    prob_m = tot_m - 16 * i;
+    int par = 1;
+    if (thread_m_blocks > 4) {
+      // Note that parallel > 1 currently only works for inputs without any padding
+      par = (16 * thread_m_blocks - pad) / 64;
+      if (par > max_par)
+        par = max_par;
+      prob_m = 64 * par;
+      i += 4 * (par - 1);
+      thread_m_blocks = 4;
+    }
+    
+    // For compilation speed, we only define the kernel configurations that have seemed useful (in terms of performance)
+    // in our testing, however many more are, in principle, possible.
+    if (false) {}
+    CALL_IF(1,  8,  8, -1)
+    CALL_IF(1,  8,  8,  8)
+    CALL_IF(1, 16,  4, -1)
+    CALL_IF(1, 16,  4,  8)
+    CALL_IF(2, 16,  4, -1)
+    CALL_IF(2, 16,  4,  8)
+    CALL_IF(3, 16,  4, -1)
+    CALL_IF(3, 16,  4,  8)
+    CALL_IF(4, 16,  4, -1)
+    CALL_IF(4, 16,  4,  8)
+    else
+      ret = ERR_KERN_SHAPE;
+
+    A_ptr += 16 * thread_m_blocks * (prob_k / 8) * par;
+    C_ptr += 16 * thread_m_blocks * (prob_n / 8) * par;
+  }
+
+  return ret;
+}
+
+
+// =============================================================================
+// Kiln C-ABI shim (added to the vendored kernel; everything above this point
+// is upstream IST-DASLab/marlin@1f25790bdd49fba53106164a24666dade68d7c90
+// verbatim).
+//
+// `marlin_cuda` above uses C++ default arguments and `cudaStream_t` in its
+// signature, neither of which are FFI-safe. This wrapper exposes a fixed C
+// signature that the Rust crate links against.
+// =============================================================================
+extern "C" int kiln_marlin_w4a16_gemm(
+    const void* A,
+    const void* B,
+    void* C,
+    void* s,
+    int prob_m,
+    int prob_n,
+    int prob_k,
+    void* workspace,
+    int groupsize,
+    int dev,
+    void* stream,
+    int thread_k,
+    int thread_n,
+    int sms,
+    int max_par
+) {
+  return marlin_cuda(
+    A, B, C, s,
+    prob_m, prob_n, prob_k,
+    workspace,
+    groupsize,
+    dev,
+    reinterpret_cast<cudaStream_t>(stream),
+    thread_k,
+    thread_n,
+    sms,
+    max_par
+  );
+}
+
+
+#endif

--- a/crates/kiln-marlin-gemm/csrc/marlin_kernel.h
+++ b/crates/kiln-marlin-gemm/csrc/marlin_kernel.h
@@ -1,0 +1,59 @@
+// Kiln Marlin W4A16 GEMM C-ABI wrapper.
+//
+// Exposes a fixed-signature C entry point around the vendored
+// IST-DASLab/marlin (commit 1f25790) `marlin_cuda` function. Marlin is a
+// 4-bit weight, 16-bit activation matrix multiply that uses tensor-core
+// `mma.m16n8k16.f32.f16.f16.f32` instructions; the kernel itself is FP16
+// activation-only. The Rust crate (`kiln-marlin-gemm`) provides a BF16
+// activation interface by casting bf16 -> fp16 on the way in and fp16 -> bf16
+// on the way out.
+//
+// Layout of inputs (all CUDA device pointers, all row-major contiguous):
+//
+//   A:   fp16, shape [prob_m, prob_k]
+//   B:   int32 packed weights, shape [prob_k / 16, prob_n * 16 / 8] in the
+//        Marlin tile/permute layout (NOT raw GPTQ qweight). See the Python
+//        reference packer in upstream `marlin/__init__.py::Layer.pack` and
+//        the Rust port in `kiln-marlin-gemm`'s tests for the exact ordering.
+//   C:   fp16, shape [prob_m, prob_n] (output, written by the kernel)
+//   s:   fp16, shape [prob_k / groupsize, prob_n] (per-group scales, also
+//        permuted into Marlin's expected scale layout)
+//
+// `workspace` must be an int32 device buffer of at least
+// `(prob_n / 128) * max_par` zero-initialized entries.
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int kiln_marlin_status_t;
+
+// Status codes mirror the upstream constants: 0 on success, 1 if the problem
+// shape is unsupported under the chosen tile sizes (`prob_n % thread_n != 0`,
+// etc.), 2 if no kernel template was instantiated for the chosen
+// (thread_m_blocks, thread_n_blocks, thread_k_blocks, group_blocks) tuple.
+kiln_marlin_status_t kiln_marlin_w4a16_gemm(
+    const void *A,
+    const void *B,
+    void *C,
+    void *s,
+    int prob_m,
+    int prob_n,
+    int prob_k,
+    void *workspace,
+    int groupsize,
+    int dev,
+    void *stream,
+    int thread_k,
+    int thread_n,
+    int sms,
+    int max_par
+);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/kiln-marlin-gemm/src/lib.rs
+++ b/crates/kiln-marlin-gemm/src/lib.rs
@@ -1,0 +1,527 @@
+//! Vendored Marlin W4A16 GEMM CUDA kernel.
+//!
+//! # Provenance: IST-DASLab/marlin
+//!
+//! This crate is the vendored port of
+//! [`IST-DASLab/marlin`](https://github.com/IST-DASLab/marlin) at upstream
+//! commit `1f25790bdd49fba53106164a24666dade68d7c90`. The single CUDA
+//! translation unit `csrc/marlin_kernel.cu` is the upstream
+//! `marlin/marlin_cuda_kernel.cu` verbatim, with one tiny addition at the
+//! bottom of the file: an `extern "C"` shim, [`kiln_marlin_w4a16_gemm`],
+//! that exposes the otherwise-`cudaStream_t`-typed entry point through a
+//! C-ABI signature so cargo's `cc` build can link it from Rust.
+//!
+//! # Scope (kernel-only crate, Phase 6)
+//!
+//! Per the project's "minimal-scope vendoring" policy, this crate ships
+//! the kernel and a parity test only. There is no `kiln-model` /
+//! `forward.rs` integration yet — that lands in a follow-up PR.
+//!
+//! Within this crate the supported envelope is:
+//!
+//!   - **Activations:** bf16 in / bf16 out, as the rest of kiln. The kernel
+//!     itself is FP16-only (it uses `mma.m16n8k16.f32.f16.f16.f32`), so the
+//!     wrapper casts bf16 → fp16 on the way in and fp16 → bf16 on the way
+//!     out. A future integration PR can revisit this if a fused bf16-cast
+//!     kernel becomes worthwhile.
+//!   - **Weights:** symmetric INT4, packed into Marlin's tiled / permuted
+//!     `int32` layout (NOT raw GPTQ `qweight`). See [`pack`].
+//!   - **Group size:** `-1` (per-column) or `128`. Marlin's
+//!     `CALL_IF` table only instantiates `group_blocks ∈ {-1, 8}`.
+//!   - **Shape constraints:** `prob_k % 128 == 0`, `prob_n % 256 == 0`,
+//!     same as upstream `marlin/__init__.py::Layer.__init__`.
+//!   - **Forward only.** No backward, no quant kernel.
+//!
+//! # API
+//!
+//! - [`marlin_w4a16_gemm`] — the BF16-facing matmul wrapper. Takes
+//!   `[m, k] bf16`, `[k/16, n*16/8] i32`, `[k/groupsize, n] f16`, and
+//!   returns `[m, n] bf16`.
+//! - [`pack`] — pure-Rust port of the upstream Python packer
+//!   (`marlin/__init__.py::Layer.pack`). Both the parity test and any
+//!   future integration code use this to build the Marlin-format `B` and
+//!   permuted scales from a fake-quantized fp32 weight matrix.
+
+use candle_core::{
+    backend::BackendStorage,
+    cuda_backend::cudarc::driver::DevicePtr,
+    DType, Result, Tensor,
+};
+use half::{bf16, f16};
+
+unsafe extern "C" {
+    fn kiln_marlin_w4a16_gemm(
+        a: *const core::ffi::c_void,
+        b: *const core::ffi::c_void,
+        c: *mut core::ffi::c_void,
+        s: *const core::ffi::c_void,
+        prob_m: i32,
+        prob_n: i32,
+        prob_k: i32,
+        workspace: *mut core::ffi::c_void,
+        groupsize: i32,
+        dev: i32,
+        stream: *mut core::ffi::c_void,
+        thread_k: i32,
+        thread_n: i32,
+        sms: i32,
+        max_par: i32,
+    ) -> i32;
+}
+
+/// Marlin's default `max_par` from `marlin/__init__.py`.
+const DEFAULT_MAX_PAR: i32 = 16;
+
+/// Workspace tile size in `n` (Marlin's smallest `thread_n`).
+const WORKSPACE_TILE_N: usize = 128;
+
+/// Run the vendored Marlin W4A16 GEMM with a BF16 activation interface.
+///
+/// Inputs (all CUDA, all contiguous):
+///
+///   - `a`           : `[m, k]` bf16 input matrix.
+///   - `b_packed`    : `[k / 16, n * 16 / 8]` i32, in Marlin's tiled /
+///                     permuted packed layout (see [`pack::pack_weights`]).
+///   - `scales`      : `[k / groupsize, n]` f16, Marlin-permuted (see
+///                     [`pack::permute_scales`]). Use `groupsize = k` for
+///                     per-column quantization.
+///   - `groupsize`   : Quantization group size. Must be `-1` (== `k`) or
+///                     `128`.
+///
+/// Returns a freshly allocated `[m, n]` bf16 tensor.
+///
+/// # Constraints
+///
+///   - `k % 128 == 0`
+///   - `n % 256 == 0`
+///   - `m >= 1` (the kernel pads `m` up to a multiple of 16 internally)
+///   - `groupsize in { -1, 128 }`
+pub fn marlin_w4a16_gemm(
+    a: &Tensor,
+    b_packed: &Tensor,
+    scales: &Tensor,
+    groupsize: i32,
+) -> Result<Tensor> {
+    let device = a.device();
+    if !device.is_cuda() {
+        candle_core::bail!("kiln-marlin-gemm: a must be on CUDA");
+    }
+
+    let (m, k) = a.dims2()?;
+    let (b_rows, b_cols) = b_packed.dims2()?;
+    let (s_rows, n) = scales.dims2()?;
+
+    if k % 128 != 0 {
+        candle_core::bail!("kiln-marlin-gemm: k must be a multiple of 128 (got {k})");
+    }
+    if n % 256 != 0 {
+        candle_core::bail!("kiln-marlin-gemm: n must be a multiple of 256 (got {n})");
+    }
+
+    if b_rows != k / 16 || b_cols != n * 16 / 8 {
+        candle_core::bail!(
+            "kiln-marlin-gemm: b_packed shape [{b_rows}, {b_cols}] does not match expected \
+             [k/16={}, n*16/8={}] for k={k}, n={n}",
+            k / 16,
+            n * 16 / 8,
+        );
+    }
+
+    if !(groupsize == -1 || groupsize == 128) {
+        candle_core::bail!(
+            "kiln-marlin-gemm: groupsize must be -1 or 128 (got {groupsize})"
+        );
+    }
+    // `groupsize_for_dims` is the actual chunk size in K used for sizing the
+    // scales tensor; `-1` means per-column, i.e. one row of scales total.
+    // The kernel itself takes `-1` as a sentinel for per-column, so we keep
+    // `groupsize` as-is when forwarding to the FFI call.
+    let groupsize_for_dims: usize = if groupsize == -1 { k } else { groupsize as usize };
+    if groupsize_for_dims > k || k % groupsize_for_dims != 0 {
+        candle_core::bail!(
+            "kiln-marlin-gemm: k={k} must be divisible by groupsize={groupsize}"
+        );
+    }
+
+    let expected_s_rows = k / groupsize_for_dims;
+    if s_rows != expected_s_rows {
+        candle_core::bail!(
+            "kiln-marlin-gemm: scales rows {s_rows} != expected {expected_s_rows} \
+             (k={k}, groupsize={groupsize})"
+        );
+    }
+
+    if a.dtype() != DType::BF16 {
+        candle_core::bail!("kiln-marlin-gemm: a must be bf16 (got {:?})", a.dtype());
+    }
+    if b_packed.dtype() != DType::I32 {
+        candle_core::bail!(
+            "kiln-marlin-gemm: b_packed must be i32 (got {:?})",
+            b_packed.dtype()
+        );
+    }
+    if scales.dtype() != DType::F16 {
+        candle_core::bail!("kiln-marlin-gemm: scales must be f16 (got {:?})", scales.dtype());
+    }
+
+    // The kernel is FP16-only; cast bf16 -> fp16 on the way in.
+    let a_fp16 = a.to_dtype(DType::F16)?.contiguous()?;
+    let b_packed = b_packed.contiguous()?;
+    let scales = scales.contiguous()?;
+
+    // Output is fp16 (kernel writes here), then we cast back to bf16.
+    let c_fp16 = Tensor::zeros((m, n), DType::F16, device)?;
+
+    // Workspace: int32 buffer of size at least (n / 128) * max_par, all zero.
+    let workspace_len = (n / WORKSPACE_TILE_N) * DEFAULT_MAX_PAR as usize;
+    let workspace = Tensor::zeros((workspace_len,), DType::I32, device)?;
+
+    {
+        let (a_storage, a_layout) = a_fp16.storage_and_layout();
+        let (b_storage, b_layout) = b_packed.storage_and_layout();
+        let (c_storage, c_layout) = c_fp16.storage_and_layout();
+        let (s_storage, s_layout) = scales.storage_and_layout();
+        let (w_storage, w_layout) = workspace.storage_and_layout();
+
+        let a_cuda = match &*a_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-marlin-gemm: a must be on CUDA"),
+        };
+        let b_cuda = match &*b_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-marlin-gemm: b_packed must be on CUDA"),
+        };
+        let c_cuda = match &*c_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-marlin-gemm: c must be on CUDA"),
+        };
+        let s_cuda = match &*s_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-marlin-gemm: scales must be on CUDA"),
+        };
+        let w_cuda = match &*w_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-marlin-gemm: workspace must be on CUDA"),
+        };
+
+        let stream = a_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+        // candle 0.10's CudaDevice doesn't expose its ordinal publicly. The
+        // Marlin kernel only consults `dev` to call cudaDeviceGetAttribute
+        // when `sms == -1`. Defaulting to 0 is correct on single-GPU pods,
+        // which is what kiln targets today; multi-GPU support would need a
+        // candle API addition to surface the device index.
+        let dev_ord: i32 = 0;
+
+        let a_slice = a_cuda
+            .as_cuda_slice::<f16>()?
+            .slice(a_layout.start_offset()..);
+        let b_slice = b_cuda
+            .as_cuda_slice::<i32>()?
+            .slice(b_layout.start_offset()..);
+        let c_slice = c_cuda
+            .as_cuda_slice::<f16>()?
+            .slice(c_layout.start_offset()..);
+        let s_slice = s_cuda
+            .as_cuda_slice::<f16>()?
+            .slice(s_layout.start_offset()..);
+        let w_slice = w_cuda
+            .as_cuda_slice::<i32>()?
+            .slice(w_layout.start_offset()..);
+
+        unsafe {
+            let (a_ptr, _g1) = a_slice.device_ptr(&stream);
+            let (b_ptr, _g2) = b_slice.device_ptr(&stream);
+            let (c_ptr, _g3) = c_slice.device_ptr(&stream);
+            let (s_ptr, _g4) = s_slice.device_ptr(&stream);
+            let (w_ptr, _g5) = w_slice.device_ptr(&stream);
+
+            let status = kiln_marlin_w4a16_gemm(
+                a_ptr as *const _,
+                b_ptr as *const _,
+                c_ptr as *mut _,
+                s_ptr as *const _,
+                m as i32,
+                n as i32,
+                k as i32,
+                w_ptr as *mut _,
+                groupsize,
+                dev_ord,
+                raw_stream,
+                /* thread_k */ -1,
+                /* thread_n */ -1,
+                /* sms */ -1,
+                DEFAULT_MAX_PAR,
+            );
+
+            if status != 0 {
+                candle_core::bail!(
+                    "kiln_marlin_w4a16_gemm failed with status {status} \
+                     (1=ERR_PROB_SHAPE, 2=ERR_KERN_SHAPE) for m={m}, n={n}, k={k}, \
+                     groupsize={groupsize}"
+                );
+            }
+        }
+    }
+
+    // Cast fp16 output back to bf16 to match the rest of the kiln pipeline.
+    let c_bf16 = c_fp16.to_dtype(DType::BF16)?;
+
+    // Keep types around to silence unused-import warnings on non-CUDA hosts.
+    let _ = std::marker::PhantomData::<bf16>;
+
+    Ok(c_bf16)
+}
+
+/// Pure-Rust port of the upstream Marlin Python packer
+/// (`marlin/__init__.py::_get_perms` and `Layer.pack`).
+///
+/// These helpers exist so the parity test (and any future integration)
+/// can build a Marlin-format `B` and permuted-scale tensor from a
+/// fake-quantized fp32 weight matrix without depending on Python or the
+/// upstream marlin package.
+pub mod pack {
+    use super::*;
+
+    /// Marlin uses 4-bit symmetric quantization with an offset of 8.
+    pub const MAX_Q: i32 = 15;
+    pub const Q_OFFSET: i32 = 8;
+
+    /// Build the Marlin weight permutation array (length 1024).
+    ///
+    /// Mirrors the Python reference in
+    /// `marlin/__init__.py::_get_perms`. The interleave step at the end
+    /// reorders each contiguous group of 8 indices by `[0, 2, 4, 6, 1, 3, 5, 7]`.
+    pub fn build_weight_perm() -> Vec<usize> {
+        let mut perm: Vec<usize> = Vec::with_capacity(1024);
+        for i in 0..32usize {
+            let mut perm1: Vec<usize> = Vec::with_capacity(8);
+            let col = i / 4;
+            for block in [0usize, 1] {
+                let row_seeds = [
+                    2 * (i % 4),
+                    2 * (i % 4) + 1,
+                    2 * (i % 4 + 4),
+                    2 * (i % 4 + 4) + 1,
+                ];
+                for row in row_seeds {
+                    perm1.push(16 * row + col + 8 * block);
+                }
+            }
+            for j in 0..4usize {
+                for &p in perm1.iter() {
+                    perm.push(p + 256 * j);
+                }
+            }
+        }
+        let interleave: [usize; 8] = [0, 2, 4, 6, 1, 3, 5, 7];
+        let mut out = Vec::with_capacity(perm.len());
+        for chunk in perm.chunks_exact(8) {
+            for &idx in &interleave {
+                out.push(chunk[idx]);
+            }
+        }
+        debug_assert_eq!(out.len(), 1024);
+        out
+    }
+
+    /// Marlin per-group-scale permutation (length 64).
+    ///
+    /// Mirrors `_get_perms`'s `scale_perm`:
+    /// `[i + 8*j for i in 0..8 for j in 0..8]`.
+    pub fn build_scale_perm() -> Vec<usize> {
+        let mut sp: Vec<usize> = Vec::with_capacity(64);
+        for i in 0..8usize {
+            for j in 0..8usize {
+                sp.push(i + 8 * j);
+            }
+        }
+        sp
+    }
+
+    /// Marlin per-column-scale permutation (length 32, used when
+    /// `groupsize == -1`).
+    ///
+    /// Mirrors `_get_perms`'s `scale_perm_single`:
+    /// `[2*i + j for i in 0..4 for j in [0,1,8,9,16,17,24,25]]`.
+    pub fn build_scale_perm_single() -> Vec<usize> {
+        let mut sps: Vec<usize> = Vec::with_capacity(32);
+        let inner: [usize; 8] = [0, 1, 8, 9, 16, 17, 24, 25];
+        for i in 0..4usize {
+            for j in inner {
+                sps.push(2 * i + j);
+            }
+        }
+        sps
+    }
+
+    /// Quantize a fp32 weight matrix `[k, n]` (note: NOT transposed —
+    /// row-major in input-feature x output-feature order) into Marlin's
+    /// packed `B` layout `[k/16, n*16/8]` i32, plus the matching permuted
+    /// scales `[k/groupsize, n]` f16.
+    ///
+    /// `groupsize == -1` means per-column quantization.
+    ///
+    /// Returns `(b_packed_i32, scales_f16, dequant_weights_f32)`.
+    /// `dequant_weights_f32` is the round-tripped weight that the kernel
+    /// will effectively multiply against (i.e. the "ground truth" for
+    /// parity checks against a candle bf16 baseline).
+    pub fn quantize_and_pack(
+        weight: &[f32], // row-major [k, n]
+        k: usize,
+        n: usize,
+        groupsize: i64,
+    ) -> (Vec<i32>, Vec<f16>, Vec<f32>) {
+        assert_eq!(weight.len(), k * n);
+        assert_eq!(k % 128, 0, "k must be %128 == 0");
+        assert_eq!(n % 256, 0, "n must be %256 == 0");
+
+        let g = if groupsize == -1 { k } else { groupsize as usize };
+        assert!(
+            k % g == 0,
+            "k={k} must be divisible by groupsize={g}"
+        );
+        let num_groups = k / g;
+
+        // 1) Compute per-(group, column) scales. We use upstream Marlin's
+        //    convention: s = 2 * max(|w|) / 15. The dequant grid is then
+        //    (q - 8) * s for q in 0..=15. We immediately round each scale
+        //    through f16 so the candle baseline below uses the same numeric
+        //    values the kernel will actually load.
+        let mut scales = vec![0.0f32; num_groups * n];
+        for grp in 0..num_groups {
+            for col in 0..n {
+                let mut max_abs = 0.0f32;
+                for r in 0..g {
+                    let v = weight[(grp * g + r) * n + col].abs();
+                    if v > max_abs {
+                        max_abs = v;
+                    }
+                }
+                // Avoid divide-by-zero. 1.0 is harmless because every weight
+                // in the group is exactly zero, so the round-trip is zero.
+                if max_abs == 0.0 {
+                    max_abs = 1.0;
+                }
+                let s_f32 = (2.0 * max_abs) / (MAX_Q as f32);
+                // Round-trip through f16 so kernel-side and candle-side
+                // dequant agree on the scale value bit-for-bit.
+                scales[grp * n + col] = f16::from_f32(s_f32).to_f32();
+            }
+        }
+
+        // 2) Quantize: w_int = clamp(round(w/s) + 8, 0, 15).
+        let mut q = vec![0i32; k * n];
+        let mut dequant = vec![0.0f32; k * n];
+        for r in 0..k {
+            let grp = r / g;
+            for col in 0..n {
+                let s = scales[grp * n + col];
+                let raw = (weight[r * n + col] / s).round() as i32;
+                let shifted = (raw + Q_OFFSET).clamp(0, MAX_Q);
+                q[r * n + col] = shifted;
+                dequant[r * n + col] = (shifted - Q_OFFSET) as f32 * s;
+            }
+        }
+
+        // 3) Apply Marlin's 16x16 tile transpose:
+        //    w = w.reshape(k/16, 16, n/16, 16).permute(0, 2, 1, 3)
+        //          .reshape(k/16, n*16)
+        // Then apply the perm[1024] re-ordering to each row of length n*16
+        // (which is processed as `n*16 // 1024` chunks of 1024 each).
+        let kt = k / 16;
+        let nt = n / 16;
+        let row_len = n * 16;
+        let mut tiled = vec![0i32; kt * row_len];
+        for k_blk in 0..kt {
+            for n_blk in 0..nt {
+                for tk in 0..16usize {
+                    for tn in 0..16usize {
+                        let src = (k_blk * 16 + tk) * n + (n_blk * 16 + tn);
+                        let dst = k_blk * row_len + n_blk * 16 * 16 + tk * 16 + tn;
+                        tiled[dst] = q[src];
+                    }
+                }
+            }
+        }
+
+        let perm = build_weight_perm();
+        assert_eq!(perm.len(), 1024);
+        assert_eq!(row_len % perm.len(), 0);
+        let chunks_per_row = row_len / perm.len();
+        let mut permuted = vec![0i32; kt * row_len];
+        for r in 0..kt {
+            for chunk in 0..chunks_per_row {
+                let base = r * row_len + chunk * perm.len();
+                let src_base = base;
+                for (i, &p) in perm.iter().enumerate() {
+                    permuted[base + i] = tiled[src_base + p];
+                }
+            }
+        }
+
+        // 4) Pack 8 nibbles into one int32 along the last dim:
+        //    res shape (kt, row_len), packed shape (kt, row_len/8).
+        assert_eq!(row_len % 8, 0);
+        let packed_cols = row_len / 8;
+        let mut packed = vec![0i32; kt * packed_cols];
+        for r in 0..kt {
+            for c in 0..packed_cols {
+                let mut acc: u32 = 0;
+                for i in 0..8usize {
+                    let nibble = permuted[r * row_len + c * 8 + i] as u32 & 0xF;
+                    acc |= nibble << (4 * i);
+                }
+                packed[r * packed_cols + c] = acc as i32;
+            }
+        }
+
+        // 5) Permute scales into Marlin's expected layout.
+        let scales_perm = if groupsize == -1 {
+            permute_scales_single(&scales, n)
+        } else {
+            permute_scales_grouped(&scales, num_groups, n)
+        };
+
+        let scales_f16: Vec<f16> = scales_perm.iter().map(|&s| f16::from_f32(s)).collect();
+
+        (packed, scales_f16, dequant)
+    }
+
+    /// Apply Marlin's grouped scale permutation:
+    /// reshape `[num_groups, n]` -> rows of length 64, permute by
+    /// `scale_perm`, then reshape back.
+    fn permute_scales_grouped(scales: &[f32], num_groups: usize, n: usize) -> Vec<f32> {
+        let sp = build_scale_perm();
+        let group_len = sp.len(); // 64
+        assert!(n % group_len == 0);
+        let mut out = vec![0.0f32; num_groups * n];
+        for grp in 0..num_groups {
+            // Each scale row has length n, broken into n/64 sub-rows of 64.
+            let row = &scales[grp * n..(grp + 1) * n];
+            let dst = &mut out[grp * n..(grp + 1) * n];
+            for sub in 0..(n / group_len) {
+                for (i, &p) in sp.iter().enumerate() {
+                    dst[sub * group_len + i] = row[sub * group_len + p];
+                }
+            }
+        }
+        out
+    }
+
+    /// Apply Marlin's per-column (single-group) scale permutation:
+    /// reshape `[1, n]` -> rows of length 32, permute by
+    /// `scale_perm_single`, then reshape back.
+    fn permute_scales_single(scales: &[f32], n: usize) -> Vec<f32> {
+        let sps = build_scale_perm_single();
+        let group_len = sps.len(); // 32
+        assert!(n % group_len == 0);
+        let mut out = vec![0.0f32; n];
+        for sub in 0..(n / group_len) {
+            for (i, &p) in sps.iter().enumerate() {
+                out[sub * group_len + i] = scales[sub * group_len + p];
+            }
+        }
+        out
+    }
+}

--- a/crates/kiln-marlin-gemm/tests/parity.rs
+++ b/crates/kiln-marlin-gemm/tests/parity.rs
@@ -1,0 +1,212 @@
+//! Parity test for kiln-marlin-gemm.
+//!
+//! Builds a small fp32 weight matrix, fake-quantizes it through the same
+//! grid the kernel expects (symmetric INT4, +8 offset, group_size = 128),
+//! runs the Marlin kernel on bf16 activations, and compares the result to
+//! a candle bf16 matmul of `a @ dequant` within a 1e-2 elementwise
+//! tolerance.
+//!
+//! Shapes are chosen to cover the projection dims used by Qwen3.5-4B
+//! (`hidden_size = 2560`, `intermediate_size = 9216`, GQA `head_dim = 256`,
+//! `num_q_heads = 16`, `num_kv_heads = 4`) plus a couple of small smoke
+//! shapes that the upstream Marlin tile constraints (`k % 128 == 0`,
+//! `n % 256 == 0`) admit.
+//!
+//! The whole test no-ops gracefully when CUDA is unavailable so the
+//! workspace `cargo test` on a non-CUDA host (or in a pre-CUDA dev image)
+//! does not break.
+
+use candle_core::{DType, Device, Tensor};
+use kiln_marlin_gemm::{marlin_w4a16_gemm, pack};
+
+fn lcg_seed(state: &mut u64) -> f32 {
+    // Simple deterministic PRNG so we can iterate tolerances without
+    // chasing nondeterminism. Mirrors the LCG used in
+    // kiln-rmsnorm-kernel/tests.
+    *state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+    let bits = ((*state >> 33) as u32) & 0x7fffffff;
+    (bits as f32 / (i32::MAX as f32)) - 0.5
+}
+
+fn fill_weights(k: usize, n: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed;
+    let mut w = vec![0.0f32; k * n];
+    for v in w.iter_mut() {
+        // Roughly N(0, 0.5) — small enough that f16 / bf16 round-trips
+        // are well-conditioned and large enough that the int4 grid is
+        // exercised.
+        *v = lcg_seed(&mut state) * 0.5;
+    }
+    w
+}
+
+fn fill_activations(m: usize, k: usize, seed: u64) -> Vec<f32> {
+    let mut state = seed;
+    let mut a = vec![0.0f32; m * k];
+    for v in a.iter_mut() {
+        *v = lcg_seed(&mut state) * 0.25;
+    }
+    a
+}
+
+fn run_case(device: &Device, m: usize, k: usize, n: usize, groupsize: i64, label: &str) {
+    let weight = fill_weights(k, n, 0xC0FFEE_5EED ^ (k as u64) ^ ((n as u64) << 16));
+    let acts = fill_activations(m, k, 0xDEAD_BEEF ^ (m as u64) ^ ((k as u64) << 24));
+
+    let (b_packed, scales_f16, dequant_f32) = pack::quantize_and_pack(&weight, k, n, groupsize);
+
+    let g = if groupsize == -1 { k } else { groupsize as usize };
+    let num_groups = k / g;
+
+    // Move tensors to CUDA in the dtypes the kernel expects.
+    let a_cpu = Tensor::from_vec(acts.clone(), (m, k), &Device::Cpu)
+        .expect("a_cpu host tensor");
+    let a_bf16 = a_cpu
+        .to_dtype(DType::BF16)
+        .expect("cast a to bf16")
+        .to_device(device)
+        .expect("a -> cuda");
+
+    let b_cuda = Tensor::from_vec(b_packed, (k / 16, n * 16 / 8), &Device::Cpu)
+        .expect("b host tensor")
+        .to_device(device)
+        .expect("b -> cuda");
+
+    // Convert f16 scales into a candle tensor on CUDA. candle accepts
+    // half::f16 directly for Tensor::from_vec.
+    let scales_cuda = Tensor::from_vec(scales_f16, (num_groups, n), &Device::Cpu)
+        .expect("scales host tensor")
+        .to_device(device)
+        .expect("scales -> cuda");
+
+    // --- Run the Marlin kernel.
+    let kernel_out = marlin_w4a16_gemm(&a_bf16, &b_cuda, &scales_cuda, groupsize as i32)
+        .unwrap_or_else(|e| panic!("[{label}] kernel call failed: {e}"));
+
+    assert_eq!(kernel_out.dims(), &[m, n], "[{label}] output shape");
+    assert_eq!(kernel_out.dtype(), DType::BF16, "[{label}] output dtype");
+
+    // --- candle bf16 baseline: a_bf16 @ dequant_bf16.
+    let dequant_cpu = Tensor::from_vec(dequant_f32, (k, n), &Device::Cpu)
+        .expect("dequant host tensor");
+    let dequant_bf16 = dequant_cpu
+        .to_dtype(DType::BF16)
+        .expect("dequant -> bf16")
+        .to_device(device)
+        .expect("dequant -> cuda");
+
+    let baseline = a_bf16
+        .matmul(&dequant_bf16)
+        .expect("baseline matmul");
+
+    // --- Compare elementwise within tolerance.
+    let kernel_f32 = kernel_out.to_dtype(DType::F32).expect("kernel -> f32");
+    let baseline_f32 = baseline.to_dtype(DType::F32).expect("baseline -> f32");
+
+    let diff = (kernel_f32 - &baseline_f32)
+        .expect("diff sub")
+        .abs()
+        .expect("abs");
+    let max_diff = diff
+        .max_keepdim(0)
+        .and_then(|t| t.max_keepdim(1))
+        .and_then(|t| t.to_dtype(DType::F32))
+        .and_then(|t| t.flatten_all())
+        .and_then(|t| t.to_vec1::<f32>())
+        .expect("max diff scalar")[0];
+
+    let baseline_abs = baseline_f32
+        .abs()
+        .and_then(|t| t.max_keepdim(0))
+        .and_then(|t| t.max_keepdim(1))
+        .and_then(|t| t.flatten_all())
+        .and_then(|t| t.to_vec1::<f32>())
+        .expect("baseline abs scalar")[0];
+
+    let rel_diff = max_diff / baseline_abs.max(1e-6);
+    eprintln!(
+        "[{label}] m={m} k={k} n={n} groupsize={groupsize} \
+         max_abs_diff={max_diff:.5} baseline_max={baseline_abs:.5} \
+         rel={rel_diff:.4}"
+    );
+
+    // bf16 has only 7 mantissa bits (~7e-3 quantum). For a length-K dot
+    // product with random-sign accumulation we expect ~sqrt(K) bf16 rounding
+    // events visible in the worst output element, so absolute error grows
+    // with sqrt(K) and with the typical output magnitude. A relative budget
+    // tracks that scaling much better than a fixed 1e-2.
+    //
+    // Budget breakdown:
+    //   * bf16 activation + bf16 accumulate: ~1% relative for k up to ~10k.
+    //   * f16 scale rounding: ~5e-4 relative (already baked into baseline).
+    //   * Marlin's tensor-core path: matches candle's bf16 matmul to within
+    //     bf16 rounding, no extra slack required.
+    //
+    // 2% relative is loose enough for k=9216 mlp_down and tight enough that
+    // a real packing or scale-permutation bug would still trip the test.
+    let rel_tol = 2e-2;
+    let abs_tol = 5e-3;
+    assert!(
+        max_diff < abs_tol || rel_diff < rel_tol,
+        "[{label}] max_abs_diff {max_diff:.6} (rel {rel_diff:.4}) exceeds \
+         tolerance abs<{abs_tol} or rel<{rel_tol} \
+         (baseline_max={baseline_abs:.4}) for m={m}, k={k}, n={n}, groupsize={groupsize}"
+    );
+}
+
+#[test]
+fn marlin_w4a16_gemm_parity_qwen35_4b() {
+    let device = match Device::new_cuda(0).ok() {
+        Some(d) => d,
+        None => {
+            eprintln!("CUDA not available, skipping marlin parity test");
+            return;
+        }
+    };
+
+    // Smoke shape: smallest valid Marlin (k=128 is the minimum k with
+    // group_blocks=8 instantiated; n=256 satisfies n % 256 == 0).
+    run_case(&device, 1, 128, 256, 128, "smoke-decode");
+    run_case(&device, 16, 128, 256, 128, "smoke-prefill");
+
+    // Qwen3.5-4B projections (hidden_size=2560, intermediate_size=9216,
+    // num_q_heads=16, num_kv_heads=4, head_dim=256). All n values are
+    // already %256-aligned. We test the four canonical projection shapes
+    // for both decode (m=1) and a small prefill batch (m=16).
+    let q_proj_n = 16 * 256; // 4096
+    let kv_proj_n = 4 * 256; // 1024
+    let mlp_up_n = 9216; // intermediate_size
+    let mlp_down_k = 9216;
+    let mlp_down_n = 2560; // hidden_size — but %256 not satisfied (2560 IS %256).
+    assert_eq!(2560 % 256, 0, "hidden_size must satisfy Marlin's n%256==0");
+
+    // q_proj: a [m, 2560] @ Wq [2560, 4096]
+    run_case(&device, 1, 2560, q_proj_n, 128, "q_proj-decode");
+    run_case(&device, 16, 2560, q_proj_n, 128, "q_proj-prefill");
+
+    // kv_proj: a [m, 2560] @ Wk [2560, 1024]
+    run_case(&device, 1, 2560, kv_proj_n, 128, "kv_proj-decode");
+    run_case(&device, 16, 2560, kv_proj_n, 128, "kv_proj-prefill");
+
+    // mlp_up / gate_proj: a [m, 2560] @ W [2560, 9216]
+    run_case(&device, 1, 2560, mlp_up_n, 128, "mlp_up-decode");
+
+    // mlp_down: a [m, 9216] @ W [9216, 2560]
+    run_case(&device, 1, mlp_down_k, mlp_down_n, 128, "mlp_down-decode");
+}
+
+#[test]
+fn marlin_w4a16_gemm_parity_per_column() {
+    let device = match Device::new_cuda(0).ok() {
+        Some(d) => d,
+        None => {
+            eprintln!("CUDA not available, skipping marlin parity test");
+            return;
+        }
+    };
+
+    // Per-column quantization (groupsize == -1) is the other Marlin
+    // CALL_IF arm. Cover at least one shape so we don't silently break it.
+    run_case(&device, 1, 256, 256, -1, "per-column-decode");
+    run_case(&device, 16, 256, 256, -1, "per-column-prefill");
+}

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -18,6 +18,7 @@ candle-core = { workspace = true }
 candle-nn = { workspace = true }
 kiln-flash-attn = { workspace = true, optional = true }
 kiln-gdn-kernel = { workspace = true, optional = true }
+kiln-marlin-gemm = { workspace = true, optional = true }
 kiln-rmsnorm-kernel = { workspace = true, optional = true }
 kiln-nvtx = { workspace = true }
 rand = { workspace = true }
@@ -27,7 +28,7 @@ mlx-rs = { workspace = true, optional = true }
 half = { version = "2", optional = true }
 
 [features]
-cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel", "dep:kiln-rmsnorm-kernel"]
+cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel", "dep:kiln-marlin-gemm", "dep:kiln-rmsnorm-kernel"]
 # Enable candle's Metal backend on Apple Silicon. Pulls in candle-metal-kernels
 # (JIT-compiled MSL shaders cached in the MetalDevice); no Xcode required.
 metal = ["candle-core/metal", "candle-nn/metal"]


### PR DESCRIPTION
## What

Phase 6 of the Qwen3.5-4B inference plan. Adds a new sibling crate `kiln-marlin-gemm` that wraps the IST-DASLab Marlin W4A16 GEMM CUDA kernel behind a thin BF16 C-ABI surface, plus a pure-Rust port of the GPTQ-INT4 packing/permutation logic so tests can quantize candle weight matrices directly into the layout the kernel expects.

Vendored from [IST-DASLab/marlin@`1f25790`](https://github.com/IST-DASLab/marlin/commit/1f25790bdd49fba53106164a24666dade68d7c90) — single translation unit `marlin/marlin_cuda_kernel.cu`, unmodified except for the C-ABI entry point.

## Scope

Intentionally kernel-only and feature-gated. **Nothing in `forward.rs` or `quantized.rs` changes.** Mirrors the pattern of #33 (kiln-flash-attn) and #80 (kiln-gdn-kernel) so a follow-up PR can wire `forward.rs` over to Marlin once GPTQ checkpoint repacking is in place.

- bf16 activations (cast to fp16 at the FFI boundary — Marlin's mma path is fp16xfp16->fp32)
- F32 accumulators inside the kernel
- group_size in {128, -1}
- Forward-only
- Ampere+ (sm_80;86;89;90)

## Layout

| Path | Purpose |
|------|---------|
| `csrc/marlin_kernel.cu` + `marlin_kernel.h` | Vendored CUDA kernel + `kiln_marlin_w4a16_gemm` C-ABI entry |
| `src/lib.rs` | `marlin_w4a16_gemm(a, b, scales, groupsize)` candle wrapper + `pack::quantize_and_pack` for tests |
| `build.rs` | `cc::Build`, sm_80;86;89;90, --use_fast_math, links cudart, honors `KILN_CUDA_ARCHS` |
| `tests/parity.rs` | Parity vs candle bf16 matmul on Qwen3.5-4B projection shapes |

## Wiring

- Added to workspace `members` (NOT `default-members` — CUDA-only)
- Added to `[workspace.dependencies]` as `kiln-marlin-gemm`
- Added as optional dep on `kiln-model`, activated by its existing `cuda` feature alongside the other kiln-* CUDA crates

## Validation

Built and tested on RunPod A6000 (kiln-runpod image):

```
PASS [   1.083s] kiln-marlin-gemm::parity marlin_w4a16_gemm_parity_per_column
PASS [   2.740s] kiln-marlin-gemm::parity marlin_w4a16_gemm_parity_qwen35_4b
```

All 10 shape variants pass:

| Shape | groupsize | rel_err |
|-------|-----------|---------|
| smoke-decode (1, 128, 256) | 128 | 0.0051 |
| smoke-prefill (16, 128, 256) | 128 | 0.0040 |
| q_proj-decode (1, 2560, 4096) | 128 | 0.0038 |
| q_proj-prefill (16, 2560, 4096) | 128 | 0.0065 |
| kv_proj-decode (1, 2560, 1024) | 128 | 0.0036 |
| kv_proj-prefill (16, 2560, 1024) | 128 | 0.0049 |
| mlp_up-decode (1, 2560, 9216) | 128 | 0.0034 |
| mlp_down-decode (1, 9216, 2560) | 128 | 0.0046 |
| per-column-decode (1, 256, 256) | -1 | 0.0043 |
| per-column-prefill (16, 256, 256) | -1 | 0.0033 |

Worst-case ~0.7% relative error on k=9216 mlp_down — within the bf16 sqrt(K) accumulation budget. Tolerance is 2% relative OR 5e-3 absolute, which still trips on a real packing or scale-permutation bug (verified by deliberately scrambling perm during bring-up).

## Why

Marlin is the canonical W4A16 GEMM kernel for Ampere+ inference (sm_80+ tensor cores, cp.async, ldmatrix). Landing the kernel as an isolated crate now means the next phase — repacking Qwen's GPTQ checkpoint into Marlin's tile layout at load time and switching `forward.rs` to call it for the four canonical projection shapes — can be a small, focused change.

## Notes for future integration

- The wrapper currently hardcodes device ordinal 0 because candle 0.10 doesn't expose `CudaDevice::ordinal()` publicly. Multi-GPU pods will need a small candle API addition before this can target the right device. Single-GPU is correct today.
- `forward.rs` integration will need to pre-pack GPTQ checkpoints into Marlin's tile layout at load time. The packing logic is already exposed via `pack::quantize_and_pack`; loaders will need a path that takes an existing GPTQ qweight/qzeros pair instead of fp32 weights.