### PR TITLE
desktop: Show kiln port in tray tooltip

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -245,7 +245,12 @@ fn spawn_state_watcher(
             let kind = state_kind(&state);
             if last_kind != Some(kind) {
                 last_kind = Some(kind);
-                let tooltip = format!("kiln: {}", state_label(&state));
+                let port = {
+                    let settings_state = app.state::<Arc<RwLock<Settings>>>();
+                    let s = settings_state.read().await;
+                    s.port
+                };
+                let tooltip = format_tray_tooltip(&state, port);
                 if let Some(tray) = app.tray_by_id(TRAY_ID) {
                     let _ = tray.set_tooltip(Some(tooltip.as_str()));
                     if let Ok(img) = tauri::image::Image::from_bytes(state_icon_bytes(&state)) {
@@ -279,6 +284,14 @@ pub fn state_label(state: &ServerState) -> String {
         ServerState::Running => "Running".to_string(),
         ServerState::TrainingActive => "Training".to_string(),
         ServerState::Error(msg) => format!("Error: {}", msg),
+    }
+}
+
+pub fn format_tray_tooltip(state: &ServerState, port: u16) -> String {
+    match state {
+        ServerState::Running => format!("kiln: Running on :{}", port),
+        ServerState::TrainingActive => format!("kiln: Training on :{}", port),
+        _ => format!("kiln: {}", state_label(state)),
     }
 }
 
@@ -384,6 +397,46 @@ mod tests {
         assert_eq!(
             status_menu_text(&ServerState::Running),
             format!("Status: {}", state_label(&ServerState::Running))
+        );
+    }
+
+    #[test]
+    fn tooltip_includes_port_when_running() {
+        assert_eq!(
+            format_tray_tooltip(&ServerState::Running, 9000),
+            "kiln: Running on :9000"
+        );
+        assert_eq!(
+            format_tray_tooltip(&ServerState::TrainingActive, 9000),
+            "kiln: Training on :9000"
+        );
+    }
+
+    #[test]
+    fn tooltip_omits_port_for_non_active_states() {
+        assert_eq!(
+            format_tray_tooltip(&ServerState::Stopped, 9000),
+            "kiln: Stopped"
+        );
+        assert_eq!(
+            format_tray_tooltip(&ServerState::Starting, 9000),
+            "kiln: Starting…"
+        );
+        assert_eq!(
+            format_tray_tooltip(&ServerState::Error("boom".into()), 9000),
+            "kiln: Error: boom"
+        );
+    }
+
+    #[test]
+    fn tooltip_uses_configured_port() {
+        assert_eq!(
+            format_tray_tooltip(&ServerState::Running, 8000),
+            "kiln: Running on :8000"
+        );
+        assert_eq!(
+            format_tray_tooltip(&ServerState::Running, 12345),
+            "kiln: Running on :12345"
         );
     }
 


### PR DESCRIPTION
## What
Tray tooltip now shows the configured kiln port when the server is Running or TrainingActive:
- `kiln: Running on :9000`
- `kiln: Training on :9000`

Stopped / Starting / Error labels are unchanged.

The port is read from the shared `Arc<RwLock<Settings>>` state (same accessor the supervisor already uses) inside the state watcher, only when the state-kind transition fires — so no extra polling.

## Why
Users hover the tray icon constantly; the port is the one thing they need to point an OpenAI-compatible client at. Surfacing it in the tooltip removes a trip to the dashboard window.

## Tests
Added three unit tests in `desktop/src/tray.rs` for a new pure helper `format_tray_tooltip(&ServerState, u16) -> String`:
- `tooltip_includes_port_when_running` — Running/TrainingActive include `:<port>`
- `tooltip_omits_port_for_non_active_states` — Stopped / Starting / Error unchanged
- `tooltip_uses_configured_port` — formatter uses the port arg (8000, 12345)

Full `cargo check` / `cargo test` on `desktop/` is not runnable in the Cloud Eric session (missing GTK/webkit2gtk system libs — known limitation). Validated the pure tooltip helper in a scratch cargo crate that mirrors the `ServerState` enum and the formatter:

```
running 3 tests
test tests::tooltip_includes_port_when_running ... ok
test tests::tooltip_omits_port_for_non_active_states ... ok
test tests::tooltip_uses_configured_port ... ok
test result: ok. 3 passed; 0 failed
```

The CI matrix (`desktop-build.yml` on ubuntu-latest + windows-latest) will exercise the full Tauri build.