### PR TITLE
desktop: notify on server crash

### DIFF
--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -21,6 +21,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "sync", "time", "io-util"] }

--- a/desktop/capabilities/default.json
+++ b/desktop/capabilities/default.json
@@ -8,6 +8,7 @@
     "dialog:default",
     "clipboard-manager:allow-write-text",
     "updater:default",
-    "process:default"
+    "process:default",
+    "notification:default"
   ]
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -370,6 +370,7 @@ fn main() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
+        .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,
             None,

--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -5,6 +5,7 @@ use tauri::menu::{MenuBuilder, MenuItem, MenuItemBuilder};
 use tauri::tray::TrayIconBuilder;
 use tauri::{AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 use tauri_plugin_clipboard_manager::ClipboardExt;
+use tauri_plugin_notification::NotificationExt;
 use tokio::sync::RwLock;
 
 use crate::settings::Settings;
@@ -244,6 +245,7 @@ fn spawn_state_watcher(
             let state = supervisor.state().await;
             let kind = state_kind(&state);
             if last_kind != Some(kind) {
+                let prev_kind = last_kind;
                 last_kind = Some(kind);
                 let port = {
                     let settings_state = app.state::<Arc<RwLock<Settings>>>();
@@ -261,6 +263,22 @@ fn spawn_state_watcher(
                 let _ = start_item.set_enabled(start_enabled(&state));
                 let _ = stop_item.set_enabled(stop_enabled(&state));
                 let _ = restart_item.set_enabled(restart_enabled(&state));
+
+                // Fire a single native OS notification on entry into Error.
+                // We only notify on the transition into the error kind, not
+                // on every poll while still errored, and we ignore failures
+                // so a broken notification backend can never panic the
+                // watcher loop.
+                if kind == "error" && prev_kind != Some("error") {
+                    if let ServerState::Error(msg) = &state {
+                        let _ = app
+                            .notification()
+                            .builder()
+                            .title("Kiln server crashed")
+                            .body(msg.as_str())
+                            .show();
+                    }
+                }
             }
             tokio::time::sleep(Duration::from_secs(1)).await;
         }
@@ -327,6 +345,12 @@ mod tests {
             state_label(&ServerState::Error("boom".into())),
             "Error: boom"
         );
+    }
+
+    #[test]
+    fn state_kind_for_error_is_error() {
+        assert_eq!(state_kind(&ServerState::Error("boom".into())), "error");
+        assert_eq!(state_kind(&ServerState::Error(String::new())), "error");
     }
 
     #[test]


### PR DESCRIPTION
## What
Adds tauri-plugin-notification and fires a single native OS notification when ServerState transitions into Error. Title: "Kiln server crashed". Body: the underlying error message.

## Why
Users should not have to watch the tray icon to notice a crash. A native notification surfaces the failure immediately on Windows and Linux.

## Notes
- No settings toggle yet — keep PR small. Future PR can add a Notifications section in Settings if Eric wants opt-out.
- cargo check is expected to fail in Cloud Eric due to missing GTK/webkit2gtk system libs; CI on ubuntu-latest and windows-latest validates the build.