### PR TITLE
desktop: dashboard keyboard shortcuts

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -322,11 +322,11 @@
         <code id="training-value" class="empty">—</code>
       </span>
       <span class="toolbar-divider" aria-hidden="true"></span>
-      <button id="copy-url" title="Copy the OpenAI-compatible base URL for this server">Copy OpenAI base URL</button>
+      <button id="copy-url" title="Copy the OpenAI-compatible base URL for this server (Ctrl/Cmd+Shift+C)">Copy OpenAI base URL</button>
       <button id="stop-server" class="hidden" title="Stop the running kiln server">Stop Server</button>
-      <button id="restart-server" class="hidden" title="Restart the kiln server">Restart Server</button>
-      <button id="open-logs" title="Open the log viewer window">View Logs</button>
-      <button id="open-settings" title="Open the settings window">Settings</button>
+      <button id="restart-server" class="hidden" title="Restart the kiln server (Ctrl/Cmd+Shift+R)">Restart Server</button>
+      <button id="open-logs" title="Open the log viewer window (Ctrl/Cmd+L)">View Logs</button>
+      <button id="open-settings" title="Open the settings window (Ctrl/Cmd+,)">Settings</button>
       <button id="check-updates-btn" title="Check for an updated version of Kiln Desktop">Check for Updates</button>
     </div>
     <iframe id="frame" class="hidden" title="Kiln UI"></iframe>
@@ -570,6 +570,33 @@
       }
 
       restartBtn.addEventListener("click", restartServer);
+
+      document.addEventListener("keydown", (e) => {
+        const mod = e.metaKey || e.ctrlKey;
+        if (!mod) return;
+        const target = e.target;
+        if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
+          return;
+        }
+        const shift = e.shiftKey;
+        const key = e.key;
+        const lower = typeof key === "string" ? key.toLowerCase() : "";
+        if (!shift && lower === "l") {
+          e.preventDefault();
+          invoke("open_logs").catch((err) => console.error("open_logs failed", err));
+        } else if (!shift && key === ",") {
+          e.preventDefault();
+          invoke("open_settings").catch((err) => console.error("open_settings failed", err));
+        } else if (shift && lower === "c") {
+          e.preventDefault();
+          copyOpenAiBaseUrl();
+        } else if (shift && lower === "r") {
+          e.preventDefault();
+          if (RESTART_ACTIVE_STATES.includes(currentKind)) {
+            restartServer();
+          }
+        }
+      });
 
       const statusBadge = document.getElementById("status-badge");
       const statusBadgeLabel = statusBadge.querySelector(".label");


### PR DESCRIPTION
## What
Add Ctrl/Cmd keyboard shortcuts to the dashboard window for common toolbar actions:
- Ctrl/Cmd+L → View Logs
- Ctrl/Cmd+, → Settings
- Ctrl/Cmd+Shift+C → Copy OpenAI base URL
- Ctrl/Cmd+Shift+R → Restart Server (only while Running/TrainingActive/Error)

Tooltips on the four buttons now advertise the shortcut.

Implementation: a single `document.addEventListener("keydown", ...)` in `desktop/ui/dashboard.html`. Uses `e.metaKey || e.ctrlKey` so the same binding works on Windows/Linux (Ctrl) and macOS (Cmd). Handler ignores input/textarea/contentEditable targets defensively (the dashboard has none today). Restart shortcut no-ops unless `currentKind` is in `RESTART_ACTIVE_STATES`. Plain Ctrl/Cmd+R is intentionally left alone to avoid fighting the webview reload binding.

## Why
Power-user polish. Opening Settings/Logs and copying the base URL are common flows and keyboard access is expected of a desktop app.

## Testing
- Local `cd desktop && cargo check` fails in Cloud Eric due to missing GTK/webkit2gtk system libs (expected per `tauri-cargo-check-gtk-missing` note); no Rust changed so build impact is zero.
- GitHub Actions will validate macOS/Linux/Windows builds end-to-end.
- Manual verification after install:
  - Focus dashboard, press Ctrl/Cmd+L → log viewer window opens
  - Press Ctrl/Cmd+, → settings window opens
  - Press Ctrl/Cmd+Shift+C while server running → URL in clipboard + green flash; if not running, no-op
  - Press Ctrl/Cmd+Shift+R while Running/TrainingActive/Error → restart flow runs; otherwise no-op