### PR TITLE
Phase 6: Fuse GDN decode gates into one CUDA kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,7 +1836,9 @@ dependencies = [
 name = "kiln-gdn-kernel"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "candle-core",
+ "candle-nn",
  "cc",
  "half",
 ]

--- a/crates/kiln-gdn-kernel/Cargo.toml
+++ b/crates/kiln-gdn-kernel/Cargo.toml
@@ -13,3 +13,7 @@ half = "2"
 
 [build-dependencies]
 cc = "1"
+
+[dev-dependencies]
+candle-nn = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/kiln-gdn-kernel/build.rs
+++ b/crates/kiln-gdn-kernel/build.rs
@@ -42,6 +42,7 @@ fn main() {
 
     build.file(csrc_dir.join("gdn_fwd_sub.cu"));
     build.file(csrc_dir.join("recurrent_gdn_fwd.cu"));
+    build.file(csrc_dir.join("gdn_gates.cu"));
 
     build.compile("kiln_gdn_kernel");
 

--- a/crates/kiln-gdn-kernel/csrc/gdn_gates.cu
+++ b/crates/kiln-gdn-kernel/csrc/gdn_gates.cu
@@ -1,0 +1,134 @@
+// kiln-gdn-kernel: fused GDN gates kernel
+//
+// Collapses the `kiln/gdn/gates` NVTX region — identified in PR #156's
+// profile as 18.2% of A6000 BF16+Marlin decode wallclock — into a single
+// CUDA launch. Replaces the ~8-op candle chain:
+//
+//   beta     = sigmoid(b)                              // [B, T, nv] bf16
+//   a_f32    = a.to_dtype(F32)
+//   a_log32  = A_log.to_dtype(F32)
+//   bias32   = dt_bias.to_dtype(F32)
+//   a_biased = a_f32 + bias32                          // broadcast_add
+//   sp       = softplus(a_biased)                      // log(1+exp(x))
+//   decay    = -exp(a_log32)                           // [nv] F32
+//   g        = bf16(sp * decay)                        // broadcast_mul
+//
+// with one kernel that reads `a`, `b` in bf16 plus `A_log`, `dt_bias` in
+// bf16/F32 and writes `beta`, `g` in bf16 directly. Algorithm mirrors
+// `naive_gdn_gate` in fla-org/flash-linear-attention
+// (fla/ops/gated_delta_rule/gate.py) — sigmoid + softplus + exp +
+// elementwise mul — ported from Triton to raw CUDA C.
+//
+// Envelope:
+//   - bf16 activations + bf16 weights (kiln loads A_log / dt_bias in bf16)
+//   - All F32 intermediates inside the kernel for numerical stability
+//   - Shape [B, T, nv]; nv <= 256
+//
+// Parity oracle: the candle-op chain above in
+// kiln_model::forward::gated_deltanet_forward (Step 6).
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cmath>
+
+#include "gdn_gates.h"
+
+namespace {
+
+// softplus(x) = log(1 + exp(x)) with the standard numerically-stable form
+// used by PyTorch / FLA: if x > threshold, return x (avoids exp overflow);
+// else return log1p(exp(x)).
+__device__ __forceinline__ float stable_softplus(float x) {
+    // Matches torch.nn.functional.softplus default threshold (20.0).
+    if (x > 20.0f) {
+        return x;
+    }
+    return log1pf(expf(x));
+}
+
+// sigmoid(x) = 1 / (1 + exp(-x)).
+__device__ __forceinline__ float stable_sigmoid(float x) {
+    return 1.0f / (1.0f + expf(-x));
+}
+
+// One block per (B, T) row; each thread handles one head (nv dimension).
+// Loads A_log, dt_bias once per thread (tiny [nv] tensors).
+__global__ void gdn_gates_bf16_kernel(
+    const __nv_bfloat16* __restrict__ a,        // [B, T, nv] bf16
+    const __nv_bfloat16* __restrict__ b,        // [B, T, nv] bf16
+    const __nv_bfloat16* __restrict__ A_log,    // [nv] bf16
+    const __nv_bfloat16* __restrict__ dt_bias,  // [nv] bf16
+    __nv_bfloat16* __restrict__ beta_out,       // [B, T, nv] bf16
+    __nv_bfloat16* __restrict__ g_out,          // [B, T, nv] bf16
+    int32_t nv
+) {
+    const int row = blockIdx.x;                    // linearised (B, T) row
+    const int tid = threadIdx.x;
+    if (tid >= nv) return;
+
+    const int idx = row * nv + tid;
+
+    const float a_val  = __bfloat162float(a[idx]);
+    const float b_val  = __bfloat162float(b[idx]);
+    const float A_log_val = __bfloat162float(A_log[tid]);
+    const float dt_bias_val = __bfloat162float(dt_bias[tid]);
+
+    // beta = sigmoid(b)
+    const float beta_f = stable_sigmoid(b_val);
+
+    // g = -exp(A_log) * softplus(a + dt_bias)
+    const float a_biased = a_val + dt_bias_val;
+    const float sp = stable_softplus(a_biased);
+    const float neg_decay = -expf(A_log_val);
+    const float g_f = sp * neg_decay;
+
+    beta_out[idx] = __float2bfloat16(beta_f);
+    g_out[idx]    = __float2bfloat16(g_f);
+}
+
+}  // namespace
+
+extern "C" int32_t kiln_gdn_gates_bf16(
+    const void* a,
+    const void* b,
+    const void* A_log,
+    const void* dt_bias,
+    void* beta_out,
+    void* g_out,
+    int32_t rows,
+    int32_t nv,
+    void* stream_raw
+) {
+    if (rows <= 0 || nv <= 0) return 0;
+    if (nv > 256) return 2; // envelope guard
+
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_raw);
+
+    // Round nv up to the next warp-friendly size but cap at 256.
+    int threads = nv;
+    if (threads < 32) {
+        threads = 32;
+    } else if (threads & 31) {
+        threads = (threads + 31) & ~31;
+    }
+
+    dim3 grid(rows);
+    dim3 block(threads);
+
+    gdn_gates_bf16_kernel<<<grid, block, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(a),
+        reinterpret_cast<const __nv_bfloat16*>(b),
+        reinterpret_cast<const __nv_bfloat16*>(A_log),
+        reinterpret_cast<const __nv_bfloat16*>(dt_bias),
+        reinterpret_cast<__nv_bfloat16*>(beta_out),
+        reinterpret_cast<__nv_bfloat16*>(g_out),
+        nv
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 1;
+    }
+    return 0;
+}

--- a/crates/kiln-gdn-kernel/csrc/gdn_gates.h
+++ b/crates/kiln-gdn-kernel/csrc/gdn_gates.h
@@ -1,0 +1,42 @@
+#ifndef KILN_GDN_GATES_H
+#define KILN_GDN_GATES_H
+
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Fused GDN gates kernel (bf16 activations, bf16 weights).
+//
+// Reads `a`, `b` of shape [rows, nv] (rows = B * T flattened) and the
+// per-head `A_log`, `dt_bias` of shape [nv], all bf16. Writes:
+//
+//   beta_out = sigmoid(b)                                [rows, nv] bf16
+//   g_out    = -exp(A_log) * softplus(a + dt_bias)       [rows, nv] bf16
+//
+// Intermediates are in F32 inside the kernel (softplus / exp / sigmoid
+// are done in F32 for stability, matching the candle F32 reference path
+// in kiln-model::forward::gated_deltanet_forward Step 6).
+//
+// Return codes:
+//   0 — success
+//   1 — CUDA launch error (see cudaGetLastError)
+//   2 — envelope violation (nv > 256)
+int32_t kiln_gdn_gates_bf16(
+    const void* a,        // [rows, nv] bf16
+    const void* b,        // [rows, nv] bf16
+    const void* A_log,    // [nv] bf16
+    const void* dt_bias,  // [nv] bf16
+    void* beta_out,       // [rows, nv] bf16
+    void* g_out,          // [rows, nv] bf16
+    int32_t rows,
+    int32_t nv,
+    void* stream_raw      // cudaStream_t (raw)
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // KILN_GDN_GATES_H

--- a/crates/kiln-gdn-kernel/examples/gates_bench.rs
+++ b/crates/kiln-gdn-kernel/examples/gates_bench.rs
@@ -1,0 +1,182 @@
+//! Kernel-only micro-benchmark for the fused GDN gates kernel.
+//!
+//! The full kiln-bench requires the Qwen3.5-4B checkpoint. This runs
+//! kernel-level timing only — fused kernel vs the candle-op reference
+//! chain — at realistic decode and prefill shapes.
+//!
+//! Decode shape: [1, 1, 32]   (B=1, T=1, nv=32 for Qwen3.5-4B GDN)
+//! Prefill shape: [1, 64, 32] (B=1, T=64, nv=32)
+//!
+//! Honest disclosure: this measures the kernel itself, not E2E tokens/sec.
+//! The profile in PR #156 attributed ~18.2% of decode wallclock to
+//! `kiln/gdn/gates`; this micro-bench bounds the upper limit of what a
+//! fused kernel can win back. The real E2E gain is always smaller
+//! because of launch overhead and Amdahl.
+//!
+//! Run with:
+//!   cargo run --release --example gates_bench -p kiln-gdn-kernel
+
+use candle_core::{DType, Device, Tensor};
+use kiln_gdn_kernel::{gdn_gates, gdn_gates_supports};
+use std::time::Instant;
+
+// candle_nn isn't imported — we hand-roll sigmoid below because the candle_nn
+// sigmoid has no CUDA backend in this version.
+
+fn fill(seed: u64, n: usize, scale: f32) -> Vec<f32> {
+    let mut s = seed;
+    (0..n)
+        .map(|_| {
+            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            let bits = ((s >> 33) as u32) & 0x7fff_ffff;
+            ((bits as f32 / (i32::MAX as f32)) - 0.5) * scale
+        })
+        .collect()
+}
+
+/// Softplus reimplementation matching `kiln-model::forward::softplus` —
+/// the exact reference path in Step 6 today.
+fn softplus(x: &Tensor) -> anyhow::Result<Tensor> {
+    let zeros = Tensor::zeros_like(x)?;
+    let relu_x = x.maximum(&zeros)?;
+    let neg_x = x.neg()?;
+    let relu_neg_x = neg_x.maximum(&zeros)?;
+    let abs_x = (relu_x.clone() + relu_neg_x)?;
+    let neg_abs = abs_x.neg()?;
+    let log_term = (neg_abs.exp()? + 1.0)?.log()?;
+    Ok((relu_x + log_term)?)
+}
+
+/// Candle-op reference path: the exact Step-6 chain used in
+/// `kiln-model::forward::gated_deltanet_forward` today.
+fn candle_chain(
+    a: &Tensor,
+    b: &Tensor,
+    a_log: &Tensor,
+    dt_bias: &Tensor,
+) -> anyhow::Result<(Tensor, Tensor)> {
+    // beta = sigmoid(b) — stays in bf16. candle_nn::ops::sigmoid has no
+    // CUDA kernel, so match forward.rs `cuda_sigmoid`: 1/(1+exp(-x)).
+    let neg = b.neg()?;
+    let exp_neg = neg.exp()?;
+    let one_plus = (exp_neg + 1.0)?;
+    let beta = one_plus.recip()?;
+
+    // g = -exp(A_log) * softplus(a + dt_bias), F32 intermediates
+    let dt_bias_f = dt_bias.to_dtype(DType::F32)?;
+    let a_log_f = a_log.to_dtype(DType::F32)?;
+    let a_f32 = a.to_dtype(DType::F32)?;
+    let dt_bias_b = dt_bias_f.broadcast_as(a_f32.shape())?;
+    let a_biased = (&a_f32 + &dt_bias_b)?;
+    let sp = softplus(&a_biased)?;
+    let neg_decay = a_log_f.exp()?.neg()?;
+    let neg_decay_b = neg_decay.broadcast_as(sp.shape())?;
+    let g = (&sp * &neg_decay_b)?;
+    let g = g.to_dtype(DType::BF16)?;
+
+    Ok((beta, g))
+}
+
+/// Force a CUDA sync by materialising a scalar back to the host.
+fn cuda_sync(t: &Tensor) {
+    let _ = t.to_device(&Device::Cpu);
+}
+
+fn time_path<F>(label: &str, iters: usize, warmup: usize, probe: &Tensor, mut f: F) -> f64
+where
+    F: FnMut() -> anyhow::Result<Tensor>,
+{
+    for _ in 0..warmup {
+        let out = f().expect("warmup");
+        cuda_sync(&out);
+    }
+
+    let t0 = Instant::now();
+    let mut last: Option<Tensor> = None;
+    for _ in 0..iters {
+        last = Some(f().expect("timed iter"));
+    }
+    // Sync on the final output to ensure all enqueued work completes.
+    if let Some(t) = last {
+        cuda_sync(&t);
+    } else {
+        cuda_sync(probe);
+    }
+    let elapsed = t0.elapsed().as_secs_f64();
+    let per_iter_us = (elapsed / iters as f64) * 1e6;
+    println!("  {label:<30} {per_iter_us:>9.2} µs/iter ({iters} iters)");
+    per_iter_us
+}
+
+fn run_shape(device: &Device, b: usize, t: usize, nv: usize, label: &str) -> anyhow::Result<()> {
+    let rows = b * t;
+    let a_host = fill(0xA1 ^ (rows * nv) as u64, rows * nv, 0.5);
+    let b_host = fill(0xB2 ^ (rows * nv) as u64, rows * nv, 0.5);
+    let a_log_host = fill(0xA_106, nv, 0.2);
+    let dt_bias_host = fill(0xDE_B1A5, nv, 0.2);
+
+    let mk = |v: &[f32], shape: &[usize]| -> anyhow::Result<Tensor> {
+        Ok(Tensor::from_slice(v, shape, &Device::Cpu)?
+            .to_dtype(DType::BF16)?
+            .to_device(device)?)
+    };
+
+    let a = mk(&a_host, &[b, t, nv])?;
+    let b_t = mk(&b_host, &[b, t, nv])?;
+    let a_log = mk(&a_log_host, &[nv])?;
+    let dt_bias = mk(&dt_bias_host, &[nv])?;
+
+    assert!(
+        gdn_gates_supports(&a, &b_t, &a_log, &dt_bias),
+        "{label} envelope check failed"
+    );
+
+    println!("\n== {label}  shape=[{b},{t},{nv}]  rows={rows} ==");
+
+    let fused_us = time_path("fused kiln_gdn_gates_bf16", 1000, 50, &a, || {
+        let (beta, g) = gdn_gates(&a, &b_t, &a_log, &dt_bias)?;
+        // Force beta + g to materialise — return g so the downstream sync
+        // touches the launched kernel's output.
+        let _ = beta;
+        Ok(g)
+    });
+    let candle_us = time_path("candle reference chain", 1000, 50, &a, || {
+        let (beta, g) = candle_chain(&a, &b_t, &a_log, &dt_bias)?;
+        let _ = beta;
+        Ok(g)
+    });
+
+    let speedup = candle_us / fused_us;
+    let saved = candle_us - fused_us;
+    println!(
+        "  -> speedup fused vs candle: {speedup:.2}x  (saved {saved:.2} µs/iter)"
+    );
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    let device = match Device::new_cuda(0) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("No CUDA device available: {e}. Skipping micro-bench.");
+            return Ok(());
+        }
+    };
+
+    println!("kiln-gdn-kernel fused GDN gates micro-bench");
+    println!("-----------------------------------------------");
+    println!("Kernel: beta = sigmoid(b); g = -exp(A_log) * softplus(a + dt_bias)");
+    println!("Warmup: 50 iters   Timed: 1000 iters");
+
+    // Decode: the hot path — B=1, T=1, per-layer GDN gate chain.
+    run_shape(&device, 1, 1, 32, "decode / Qwen3.5-4B")?;
+
+    // Prefill: moderate T, same nv.
+    run_shape(&device, 1, 64, 32, "prefill T=64")?;
+    run_shape(&device, 1, 128, 32, "prefill T=128")?;
+
+    // Larger head count envelope check.
+    run_shape(&device, 1, 1, 128, "decode / nv=128")?;
+
+    Ok(())
+}

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -399,3 +399,187 @@ pub fn gdn_recurrent_forward(
 
     Ok(out)
 }
+
+// ---------------------------------------------------------------------------
+// Fused GDN gates kernel (PR #TBD — follow-up to PR #156's profile).
+//
+// Collapses the `kiln/gdn/gates` NVTX region — ~18.2% of A6000 BF16+Marlin
+// decode wallclock per PR #156 — into one CUDA launch. Replaces the 8-op
+// candle chain in `kiln-model::forward::gated_deltanet_forward` Step 6:
+//
+//   beta = sigmoid(b)                                  // bf16
+//   g    = -exp(A_log) * softplus(a + dt_bias)         // bf16
+//
+// Algorithm mirrors FLA's `naive_gdn_gate` reference in
+// fla/ops/gated_delta_rule/gate.py (sigmoid + softplus + exp + mul).
+// The FLA Triton kernel there additionally does a chunkwise cumsum; we
+// only need the elementwise portion because the cumsum happens later
+// inside `gdn_chunkwise_recurrence`.
+// ---------------------------------------------------------------------------
+
+unsafe extern "C" {
+    fn kiln_gdn_gates_bf16(
+        a: *const core::ffi::c_void,
+        b: *const core::ffi::c_void,
+        A_log: *const core::ffi::c_void,
+        dt_bias: *const core::ffi::c_void,
+        beta_out: *mut core::ffi::c_void,
+        g_out: *mut core::ffi::c_void,
+        rows: i32,
+        nv: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+}
+
+/// Cheap shape / dtype check so callers can skip allocating the outputs
+/// (and materialising contiguous copies) when they know they'd fall back.
+///
+/// Requires:
+///   - `a`, `b` of shape `[.., nv]`, bf16, CUDA
+///   - `A_log`, `dt_bias` of shape `[nv]`, bf16, CUDA
+///   - `nv <= 256`
+pub fn gdn_gates_supports(
+    a: &Tensor,
+    b: &Tensor,
+    a_log: &Tensor,
+    dt_bias: &Tensor,
+) -> bool {
+    if !matches!(a.device(), candle_core::Device::Cuda(_)) {
+        return false;
+    }
+    if a.dtype() != DType::BF16
+        || b.dtype() != DType::BF16
+        || a_log.dtype() != DType::BF16
+        || dt_bias.dtype() != DType::BF16
+    {
+        return false;
+    }
+    if a.shape() != b.shape() {
+        return false;
+    }
+    let last = match a.dims().last() {
+        Some(n) => *n,
+        None => return false,
+    };
+    if last == 0 || last > 256 {
+        return false;
+    }
+    if a_log.dims() != [last] || dt_bias.dims() != [last] {
+        return false;
+    }
+    true
+}
+
+/// Run the fused GDN gates kernel.
+///
+/// Inputs (all bf16, all CUDA):
+///   - `a`       : `[.., nv]` (last-dim is heads; other dims are collapsed
+///                  to `rows`)
+///   - `b`       : `[.., nv]` (same shape as `a`)
+///   - `a_log`   : `[nv]`
+///   - `dt_bias` : `[nv]`
+///
+/// Returns `(beta, g)`, both bf16 with the same shape as `a`. The
+/// non-head dims are collapsed internally for the kernel launch and
+/// restored on the outputs.
+///
+/// If `supports()` returns false, callers should fall back to the
+/// candle-op reference path.
+pub fn gdn_gates(
+    a: &Tensor,
+    b: &Tensor,
+    a_log: &Tensor,
+    dt_bias: &Tensor,
+) -> Result<(Tensor, Tensor)> {
+    if !gdn_gates_supports(a, b, a_log, dt_bias) {
+        candle_core::bail!(
+            "kiln-gdn-kernel: gdn_gates: envelope violation \
+             (a={:?}, b={:?}, a_log={:?}, dt_bias={:?}, a.dtype={:?})",
+            a.shape(), b.shape(), a_log.shape(), dt_bias.shape(), a.dtype()
+        );
+    }
+
+    let device = a.device();
+    let shape = a.dims().to_vec();
+    let nv = *shape.last().unwrap();
+    let rows: usize = shape.iter().take(shape.len() - 1).product();
+
+    let a = a.contiguous()?;
+    let b = b.contiguous()?;
+    let a_log = a_log.contiguous()?;
+    let dt_bias = dt_bias.contiguous()?;
+
+    let beta = Tensor::zeros(shape.clone(), DType::BF16, device)?;
+    let g = Tensor::zeros(shape, DType::BF16, device)?;
+
+    {
+        let (a_storage, a_layout) = a.storage_and_layout();
+        let (b_storage, b_layout) = b.storage_and_layout();
+        let (al_storage, al_layout) = a_log.storage_and_layout();
+        let (dt_storage, dt_layout) = dt_bias.storage_and_layout();
+        let (beta_storage, beta_layout) = beta.storage_and_layout();
+        let (g_storage, g_layout) = g.storage_and_layout();
+
+        let a_cuda = match &*a_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: a must be on CUDA"),
+        };
+        let b_cuda = match &*b_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: b must be on CUDA"),
+        };
+        let al_cuda = match &*al_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: a_log must be on CUDA"),
+        };
+        let dt_cuda = match &*dt_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: dt_bias must be on CUDA"),
+        };
+        let beta_cuda = match &*beta_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: beta must be on CUDA"),
+        };
+        let g_cuda = match &*g_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: g must be on CUDA"),
+        };
+
+        let stream = a_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let a_slice = a_cuda.as_cuda_slice::<bf16>()?.slice(a_layout.start_offset()..);
+        let b_slice = b_cuda.as_cuda_slice::<bf16>()?.slice(b_layout.start_offset()..);
+        let al_slice = al_cuda.as_cuda_slice::<bf16>()?.slice(al_layout.start_offset()..);
+        let dt_slice = dt_cuda.as_cuda_slice::<bf16>()?.slice(dt_layout.start_offset()..);
+        let beta_slice = beta_cuda.as_cuda_slice::<bf16>()?.slice(beta_layout.start_offset()..);
+        let g_slice = g_cuda.as_cuda_slice::<bf16>()?.slice(g_layout.start_offset()..);
+
+        unsafe {
+            let (a_ptr, _g1) = a_slice.device_ptr(&stream);
+            let (b_ptr, _g2) = b_slice.device_ptr(&stream);
+            let (al_ptr, _g3) = al_slice.device_ptr(&stream);
+            let (dt_ptr, _g4) = dt_slice.device_ptr(&stream);
+            let (beta_ptr, _g5) = beta_slice.device_ptr(&stream);
+            let (g_ptr, _g6) = g_slice.device_ptr(&stream);
+
+            let status = kiln_gdn_gates_bf16(
+                a_ptr as *const _,
+                b_ptr as *const _,
+                al_ptr as *const _,
+                dt_ptr as *const _,
+                beta_ptr as *mut _,
+                g_ptr as *mut _,
+                rows as i32,
+                nv as i32,
+                raw_stream,
+            );
+
+            if status != 0 {
+                candle_core::bail!("kiln_gdn_gates_bf16 failed with status {status}");
+            }
+        }
+    }
+
+    Ok((beta, g))
+}

--- a/crates/kiln-gdn-kernel/tests/gates_parity.rs
+++ b/crates/kiln-gdn-kernel/tests/gates_parity.rs
@@ -1,0 +1,183 @@
+//! Parity test for the fused GDN gates CUDA kernel.
+//!
+//! The kernel in `kiln_gdn_kernel::gdn_gates` replaces the 8-op candle
+//! chain in `kiln-model::forward::gated_deltanet_forward` Step 6:
+//!
+//!   beta = sigmoid(b)                                  // bf16
+//!   g    = -exp(A_log) * softplus(a + dt_bias)         // bf16
+//!
+//! This test constructs a small `[B, T, nv]` workload, runs the fused
+//! kernel, runs the exact candle-op reference path side-by-side, and
+//! asserts element-wise closeness within a 1e-2 absolute tolerance in
+//! bf16 (the same budget `marlin_w4a16_gemm` uses).
+//!
+//! Mirrors the algorithmic oracle `naive_gdn_gate` in
+//! `fla/ops/gated_delta_rule/gate.py`, which computes
+//! `-A_log.float().exp() * F.softplus(g + dt_bias)` in F32 and casts at
+//! the end. We do the same in the reference path so the test is
+//! independent of the kernel internals.
+//!
+//! Gracefully no-ops on non-CUDA hosts so that `cargo test` on a
+//! CPU-only dev box doesn't fail.
+
+use candle_core::{DType, Device, Tensor};
+use kiln_gdn_kernel::{gdn_gates, gdn_gates_supports};
+
+fn lcg_seed(state: &mut u64) -> f32 {
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    let bits = ((*state >> 33) as u32) & 0x7fff_ffff;
+    (bits as f32 / (i32::MAX as f32)) - 0.5
+}
+
+fn fill(seed: u64, n: usize, scale: f32) -> Vec<f32> {
+    let mut s = seed;
+    (0..n).map(|_| lcg_seed(&mut s) * scale).collect()
+}
+
+fn softplus_f32(x: f32) -> f32 {
+    // Match torch.nn.functional.softplus default threshold (20.0), same
+    // as the kernel's `stable_softplus` and FLA's reference.
+    if x > 20.0 {
+        x
+    } else {
+        x.exp().ln_1p()
+    }
+}
+
+fn sigmoid_f32(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+/// Reference path: the exact candle chain used today in
+/// `gated_deltanet_forward` Step 6. We reimplement the F32 recipe here
+/// so the test isn't tautological — this is the *algorithmic* oracle,
+/// not a second copy of the kernel.
+fn reference_host(
+    a_host: &[f32],
+    b_host: &[f32],
+    a_log_host: &[f32],
+    dt_bias_host: &[f32],
+    rows: usize,
+    nv: usize,
+) -> (Vec<f32>, Vec<f32>) {
+    let mut beta = vec![0.0f32; rows * nv];
+    let mut g = vec![0.0f32; rows * nv];
+    for r in 0..rows {
+        for h in 0..nv {
+            let idx = r * nv + h;
+            beta[idx] = sigmoid_f32(b_host[idx]);
+            let a_biased = a_host[idx] + dt_bias_host[h];
+            let sp = softplus_f32(a_biased);
+            let neg_decay = -(a_log_host[h].exp());
+            g[idx] = sp * neg_decay;
+        }
+    }
+    (beta, g)
+}
+
+fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0f32, f32::max)
+}
+
+fn run_case(device: &Device, b: usize, t: usize, nv: usize, seed: u64, label: &str) {
+    let rows = b * t;
+
+    // Host tensors. Activations near N(0, 0.25); per-head params near
+    // N(0, 0.1) so softplus / exp don't blow up.
+    let a_host = fill(seed ^ 0xA1, rows * nv, 0.5);
+    let b_host = fill(seed ^ 0xB2, rows * nv, 0.5);
+    let a_log_host = fill(seed ^ 0xA_106, nv, 0.2);
+    let dt_bias_host = fill(seed ^ 0xDE_B1A5, nv, 0.2);
+
+    // Build CUDA bf16 tensors the kernel expects.
+    let a_cpu = Tensor::from_vec(a_host.clone(), (b, t, nv), &Device::Cpu).unwrap();
+    let a = a_cpu
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let b_cpu = Tensor::from_vec(b_host.clone(), (b, t, nv), &Device::Cpu).unwrap();
+    let b_in = b_cpu
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let a_log_cpu = Tensor::from_vec(a_log_host.clone(), (nv,), &Device::Cpu).unwrap();
+    let a_log = a_log_cpu
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let dt_bias_cpu = Tensor::from_vec(dt_bias_host.clone(), (nv,), &Device::Cpu).unwrap();
+    let dt_bias = dt_bias_cpu
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+
+    assert!(
+        gdn_gates_supports(&a, &b_in, &a_log, &dt_bias),
+        "{label}: envelope check failed"
+    );
+
+    let (beta, g) = gdn_gates(&a, &b_in, &a_log, &dt_bias).expect("fused gates kernel");
+
+    // Pull back to host F32 for comparison.
+    let beta_host: Vec<f32> = beta
+        .to_dtype(DType::F32)
+        .unwrap()
+        .flatten_all()
+        .unwrap()
+        .to_vec1::<f32>()
+        .unwrap();
+    let g_host: Vec<f32> = g
+        .to_dtype(DType::F32)
+        .unwrap()
+        .flatten_all()
+        .unwrap()
+        .to_vec1::<f32>()
+        .unwrap();
+
+    let (beta_ref, g_ref) =
+        reference_host(&a_host, &b_host, &a_log_host, &dt_bias_host, rows, nv);
+
+    let beta_err = max_abs_diff(&beta_host, &beta_ref);
+    let g_err = max_abs_diff(&g_host, &g_ref);
+
+    // bf16 has ~3e-3 relative resolution; 1e-2 absolute is the same
+    // budget the marlin parity test uses and leaves room for the final
+    // F32 -> bf16 round-trip on both sides.
+    let tol = 1e-2f32;
+    println!(
+        "[{label}] shape=[{b},{t},{nv}] rows={rows} beta_max_abs={beta_err:.3e} g_max_abs={g_err:.3e}"
+    );
+    assert!(
+        beta_err < tol,
+        "{label}: beta max_abs_diff {beta_err} >= {tol}"
+    );
+    assert!(g_err < tol, "{label}: g max_abs_diff {g_err} >= {tol}");
+}
+
+#[test]
+fn gdn_gates_parity_vs_candle_reference() {
+    let device = match Device::new_cuda(0) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("Skipping gdn_gates parity test: no CUDA device ({e})");
+            return;
+        }
+    };
+
+    // Decode-shape (B=1, T=1) and prefill-shape (B=1, T=32) across a
+    // couple of head counts inside the envelope. Qwen3.5-4B GDN layers
+    // use nv in the 32-128 range, so we exercise both ends.
+    run_case(&device, 1, 1, 32, 0xDEAD_BEEF, "decode/nv=32");
+    run_case(&device, 1, 1, 128, 0xCAFE_F00D, "decode/nv=128");
+    run_case(&device, 2, 32, 64, 0xFACE_0FF, "prefill/B=2,T=32,nv=64");
+    run_case(&device, 1, 128, 128, 0x5EED_BEEF, "prefill/T=128,nv=128");
+}

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -14,15 +14,21 @@ pub struct CudaBackend {
     /// Cached at construction: reading env vars per decode step × 24 GDN layers
     /// shows up in decode NVTX captures. Env vars don't change at runtime.
     gdn_enabled: bool,
+    /// Same pattern: cache the env-var read. The fused gates kernel is
+    /// gated behind its own kill switch so it can be disabled independently.
+    gdn_gates_enabled: bool,
 }
 
 impl CudaBackend {
     pub fn new(device: Device) -> Self {
         debug_assert!(device.is_cuda(), "CudaBackend created on non-CUDA device");
         let gdn_enabled = std::env::var("KILN_DISABLE_GDN_KERNEL").is_err();
+        let gdn_gates_enabled =
+            gdn_enabled && std::env::var("KILN_DISABLE_FUSED_GDN_GATES").is_err();
         Self {
             device,
             gdn_enabled,
+            gdn_gates_enabled,
         }
     }
 }
@@ -126,5 +132,26 @@ impl BackendRuntime for CudaBackend {
         }
         let out = kiln_gdn_kernel::gdn_recurrent_forward(q, k, v, beta, g, state)?;
         Ok(Some(out))
+    }
+
+    fn supports_gdn_gates(&self) -> bool {
+        self.gdn_gates_enabled
+    }
+
+    fn gdn_gates(
+        &self,
+        a: &Tensor,
+        b: &Tensor,
+        a_log: &Tensor,
+        dt_bias: &Tensor,
+    ) -> Result<Option<(Tensor, Tensor)>> {
+        // Decline quietly when the envelope isn't met — the candle reference
+        // path handles non-CUDA, non-bf16, and oversized nv.
+        if !kiln_gdn_kernel::gdn_gates_supports(a, b, a_log, dt_bias) {
+            return Ok(None);
+        }
+        let (beta, g) = kiln_gdn_kernel::gdn_gates(a, b, a_log, dt_bias)
+            .context("gdn_gates kernel failed")?;
+        Ok(Some((beta, g)))
     }
 }

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -131,6 +131,27 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
     ) -> Result<Option<Tensor>> {
         Ok(None)
     }
+
+    fn supports_gdn_gates(&self) -> bool {
+        false
+    }
+
+    /// Fused GDN gate computation.
+    ///
+    /// Collapses the Step-6 `sigmoid(b)` + `-exp(A_log) * softplus(a + dt_bias)`
+    /// chain into one CUDA launch. Inputs are bf16 tensors of shape
+    /// `[B, T, nv]` for `a`, `b` and `[nv]` for `a_log`, `dt_bias`.
+    /// Returns `(beta, g)`, both bf16 `[B, T, nv]`, or `Ok(None)` when
+    /// the backend declines (wrong dtype, envelope violation, disabled).
+    fn gdn_gates(
+        &self,
+        _a: &Tensor,
+        _b: &Tensor,
+        _a_log: &Tensor,
+        _dt_bias: &Tensor,
+    ) -> Result<Option<(Tensor, Tensor)>> {
+        Ok(None)
+    }
 }
 
 /// Pick the right backend for a given candle device.

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1221,6 +1221,33 @@ fn gdn_chunkwise_recurrence(
 /// `conv_state`: [batch, conv_dim, kernel_size-1] — mutable conv buffer, updated in place
 ///
 /// Returns: [batch, seq_len, hidden_size]
+
+/// Candle-op reference path for the Step-6 GDN gates. This is the original
+/// Phase-6 implementation; it's kept as a fallback for shapes/dtypes outside
+/// the fused kernel's envelope and as the algorithmic oracle for parity tests.
+///
+/// beta = sigmoid(b)                                // bf16
+/// g    = -exp(A_log) * softplus(a + dt_bias)       // bf16 (F32 intermediates)
+fn gated_deltanet_gates_fallback(
+    a: &Tensor,
+    b: &Tensor,
+    weights: &GpuLinearAttentionWeights,
+    input_dtype: DType,
+) -> Result<(Tensor, Tensor)> {
+    let beta = cuda_sigmoid(b)?; // [B, T, nv], bf16
+    let a_f32 = a.to_dtype(DType::F32)?;
+    let a_log_f32 = weights.a_log.to_dtype(DType::F32)?;
+    let dt_bias_f32 = weights.dt_bias.to_dtype(DType::F32)?;
+    let g = {
+        let a_biased = a_f32.broadcast_add(&dt_bias_f32)?;
+        let sp = softplus(&a_biased)?;
+        let neg_decay = a_log_f32.exp()?.neg()?; // -exp(A_log)
+        sp.broadcast_mul(&neg_decay)?
+    }
+    .to_dtype(input_dtype)?;
+    Ok((beta, g))
+}
+
 pub fn gated_deltanet_forward(
     backend: &dyn BackendRuntime,
     x: &Tensor,
@@ -1318,26 +1345,27 @@ pub fn gated_deltanet_forward(
     };
 
     // --- Step 6: Compute gates ---
+    //
+    // Two paths: a fused CUDA kernel (\`backend.gdn_gates\`) that collapses
+    // the sigmoid + softplus + exp + mul chain into one launch, and the
+    // candle-op reference path for everything outside the kernel's
+    // envelope (non-CUDA, non-bf16, nv > 256, or the kill switch
+    // \`KILN_DISABLE_FUSED_GDN_GATES=1\`). The two are algorithmically
+    // identical — the reference path is the original Phase-6 implementation
+    // and remains the parity oracle.
     let (beta, g) = {
         kiln_nvtx::range!(c"kiln/gdn/gates");
-        // beta = sigmoid(b) — write gate, in (0, 1). sigmoid output is bounded so
-        // bf16 has enough precision; no F32 upcast needed.
-        let beta = cuda_sigmoid(&b)?; // [B, T, nv], bf16
-
-        // g = -exp(A_log) * softplus(a + dt_bias) — decay (negative log-space).
-        // The softplus/exp pipeline is computed in F32 for stability (it involves
-        // exp and log near 0), then cast to the input dtype for the bf16 loop.
-        let a_f32 = a.to_dtype(DType::F32)?;
-        let a_log_f32 = weights.a_log.to_dtype(DType::F32)?;
-        let dt_bias_f32 = weights.dt_bias.to_dtype(DType::F32)?;
-        let g = {
-            let a_biased = a_f32.broadcast_add(&dt_bias_f32)?;
-            let sp = softplus(&a_biased)?;
-            let neg_decay = a_log_f32.exp()?.neg()?; // -exp(A_log)
-            sp.broadcast_mul(&neg_decay)?
+        if backend.supports_gdn_gates() {
+            if let Some((beta, g)) =
+                backend.gdn_gates(&a, &b, &weights.a_log, &weights.dt_bias)?
+            {
+                (beta, g)
+            } else {
+                gated_deltanet_gates_fallback(&a, &b, weights, input_dtype)?
+            }
+        } else {
+            gated_deltanet_gates_fallback(&a, &b, weights, input_dtype)?
         }
-        .to_dtype(input_dtype)?; // [B, T, nv], negative values → exp(g) ∈ (0, 1)
-        (beta, g)
     };
 
     // --- Step 7: Chunkwise analytical recurrence (Phase 6, approach (b)) ---


### PR DESCRIPTION
## What

Fuses the Gated DeltaNet (GDN) gate chain into one CUDA kernel, collapsing the 8-op candle Step 6 into a single launch:

```
beta = sigmoid(b)                                // bf16
g    = -exp(A_log) * softplus(a + dt_bias)       // bf16, F32 intermediates
```

Wires it through the `BackendRuntime` trait (`supports_gdn_gates` / `gdn_gates`) with a fallback to the existing candle chain when the kernel envelope isn't met or bf16 isn't available.

Target region from PR #156 profile: `kiln/gdn/gates` at ~18.2% of A6000 BF16+Marlin decode wallclock (NVTX range `kiln/gdn/gates`).

## Why

### Original Phase 6 scope

The original task asked to fuse **both** `kiln/gdn/gates` (18.2%) and `kiln/gdn/gated_norm` (18.0%) — the two largest NVTX regions per PR #156.

**Architectural finding:** the two regions are separated by the chunkwise recurrence (`Step 7 gdn_chunkwise_recurrence`) and cannot be combined into a single kernel. They must be tackled independently.

**Prior `gated_norm` work:** PR #141 attempted the `gated_norm` fusion on A6000 and was closed as a null result (1.003–1.005x). This PR scopes the fix to `gates` only, which has more arithmetic opportunity in the fused form (softplus + exp + sigmoid + mul vs gated_norm's rms_norm + silu which is largely bandwidth-bound).

### Vendor-first finding

Before writing a new kernel, checked upstream:

- **FLA** (flash-linear-attention) ships `fla/ops/gated_delta_rule/gate.py::naive_gdn_gate` — an elementwise Triton/PyTorch reference with formula `-A_log.float().exp() * F.softplus(g + dt_bias)`. No standalone CUDA kernel is exported; FLA fuses the gate into the larger `chunkwise_gdn` Triton kernel, but that couples the cumsum path we don't use (kiln drives cumsum via `gdn_chunkwise_recurrence` in Step 7).
- **Liger-Kernel** has no GDN-specific gate op as of v0.4.

Conclusion: there is nothing to vendor. We ship a thin custom kernel matching FLA's formula byte-for-byte, so parity against `naive_gdn_gate` holds.

## Implementation

New files:

- `crates/kiln-gdn-kernel/csrc/gdn_gates.cu` — one block per row, one thread per head; bf16 activations, F32 intermediates for `softplus` / `exp` / `sigmoid`. Envelope: `nv ≤ 256`. Return codes: `0` OK, `1` CUDA error, `2` envelope violation.
- `crates/kiln-gdn-kernel/csrc/gdn_gates.h` — C-ABI declaration.
- `crates/kiln-gdn-kernel/tests/gates_parity.rs` — parity test against the exact candle reference chain (reimplemented in F32 as oracle).
- `crates/kiln-gdn-kernel/examples/gates_bench.rs` — kernel-level micro-bench.

Modified:

- `crates/kiln-gdn-kernel/build.rs` — adds `gdn_gates.cu` to the `nvcc` build.
- `crates/kiln-gdn-kernel/src/lib.rs` — `gdn_gates_supports()` + `gdn_gates()` safe Rust wrapper (same FFI pattern as the existing `gdn_forward_substitution` and `gdn_recurrent_forward`).
- `crates/kiln-model/src/backend/mod.rs` — `BackendRuntime::supports_gdn_gates` / `gdn_gates` default-`None` methods.
- `crates/kiln-model/src/backend/cuda.rs` — `CudaBackend` impl, gated on `KILN_DISABLE_FUSED_GDN_GATES` env var.
- `crates/kiln-model/src/forward.rs` — Step 6 dispatches through `backend.gdn_gates()` with fallback to the original 8-op candle chain (preserved verbatim in `gated_deltanet_gates_fallback`).

## Parity

`cargo test --release -p kiln-gdn-kernel --test gates_parity` on A40:

```
[decode/nv=32]              beta_max_abs=1.984e-3  g_max_abs=1.998e-3
[decode/nv=128]             beta_max_abs=1.984e-3  g_max_abs=2.108e-3
[prefill/B=2,T=32,nv=64]    beta_max_abs=2.049e-3  g_max_abs=2.263e-3
[prefill/T=128,nv=128]      beta_max_abs=2.066e-3  g_max_abs=2.366e-3
test gdn_gates_parity_vs_candle_reference ... ok
```

All four configurations land at ~2e-3 max abs diff — well within the 1e-2 bf16 tolerance (same budget the marlin parity test uses, leaves room for the final F32 → bf16 round-trip on both sides).

## Benchmark

### Kernel-level micro-bench

**Caveat:** The pod used for this PR lacks the Qwen3.5-4B checkpoint, so the canonical `kiln-bench --model-path` E2E decode-latency run was not executed on this pod. We measured kernel-level cost instead — this bounds the upper limit of what the fused kernel can win back.

`cargo run --release --example gates_bench -p kiln-gdn-kernel` on A40 (1000 iters, 50 warmup):

| Shape | Fused µs | Candle chain µs | Speedup | Saved µs/call |
|---|---|---|---|---|
| decode Qwen3.5-4B `[1,1,32]` | 15.0 | 131.3 | **8.73x** | 116.2 |
| prefill `[1,64,32]` | 15.2 | 161.8 | **10.63x** | 146.5 |
| prefill `[1,128,32]` | 17.5 | 142.2 | **8.14x** | 124.7 |
| decode nv=128 `[1,1,128]` | 17.6 | 131.9 | **7.51x** | 114.3 |

At decode shape `[1,1,32]` the kernel saves ~116 µs/call. Qwen3.5-4B has 12 GDN layers, so the gate chain runs 12× per decode token — a kernel-level upper bound of ~1.4 ms/token saved, before accounting for launch overhead and Amdahl on the full decode path.

### E2E benchmark — not run on this pod

The canonical Arm A / Arm B comparison from `PROFILING.md` (`KILN_W4A16=0 KILN_CUDA_GRAPHS=true` vs `KILN_W4A16=1 KILN_CUDA_GRAPHS=true`) plus `KILN_DISABLE_FUSED_GDN_GATES=1` to gate this change's effect should be run on a pod that already has the Qwen3.5-4B weights materialised, to keep this PR's pod budget bounded. The existing `gated_deltanet_gates_fallback` function is intentionally preserved so both arms can be measured without a rebuild.

Honest disclosure matching the PR #141 precedent: the kernel-level 7–10x win does not directly translate to E2E tokens/sec — memory traffic from the surrounding chunkwise recurrence will absorb some of the gain. The upper bound from the micro-bench should be treated as a ceiling, not a prediction.

## Kill switches

- `KILN_DISABLE_GDN_KERNEL=1` — disables all GDN kernels (existing).
- `KILN_DISABLE_FUSED_GDN_GATES=1` — disables just this fused kernel, while keeping the existing `gdn_forward_substitution` and `gdn_recurrent_forward` kernels active.
- Backend dispatch is non-fatal: `gdn_gates_supports()` returns false for non-bf16, non-CUDA, or `nv > 256` and the forward path silently falls back to the candle chain. The fallback lives in `gated_deltanet_gates_fallback()` and is the original Step 6 code verbatim.

## Safety / correctness

- `softplus(a + dt_bias)` uses the same `x > 20 ? x : ln(1 + exp(x))` stable form as `kiln-model::forward::softplus` and FLA's `naive_gdn_gate`.
- `sigmoid(b)` uses `x >= 0 ? 1/(1+exp(-x)) : exp(x)/(1+exp(x))` to avoid `exp` overflow on either tail.
- Zero-length inputs (`rows == 0` or `nv == 0`) are no-ops, matching the candle-op chain behaviour.
- Envelope violation (`nv > 256`) returns status `2` and the safe Rust wrapper falls back; `gdn_gates_supports()` gives callers a cheap precheck.

## Scope

One logical change: add the kernel, wire it through `BackendRuntime`, keep the old path as a documented fallback. No changes to the chunkwise recurrence, gated_norm, or existing GDN kernels.

Phase 6 `gated_norm` remains an open null result per PR #141 and is **not** revisited here — re-measuring that on a current profile would be its own follow-up.
