### PR TITLE
desktop: logs window keyboard shortcuts

### DIFF
--- a/desktop/ui/logs.html
+++ b/desktop/ui/logs.html
@@ -105,11 +105,11 @@
     <header>
       <h1>Kiln server logs</h1>
       <label><input type="checkbox" id="autoscroll" checked /> Auto-scroll</label>
-      <input type="search" id="filter" placeholder="Filter…" autocomplete="off" spellcheck="false" />
+      <input type="search" id="filter" placeholder="Filter…" autocomplete="off" spellcheck="false" title="Focus filter (Ctrl/Cmd+F)" />
       <span id="filter-count" class="hidden"></span>
       <button id="copy" type="button" title="Copy all log lines to clipboard">Copy</button>
-      <button id="save" type="button" title="Save all log lines to a file">Save…</button>
-      <button id="clear" type="button">Clear view</button>
+      <button id="save" type="button" title="Save all log lines to a file (Ctrl/Cmd+S)">Save…</button>
+      <button id="clear" type="button" title="Clear view (Ctrl/Cmd+Shift+K)">Clear view</button>
     </header>
     <div id="log" class="empty">(no log lines yet)</div>
     <script defer>
@@ -251,6 +251,33 @@
           baseline = 0;
         }
         render([]);
+      });
+
+      document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape" && document.activeElement === filterEl) {
+          if (filterEl.value.length > 0) {
+            filterEl.value = "";
+            filterEl.dispatchEvent(new Event("input"));
+          }
+          filterEl.blur();
+          e.preventDefault();
+          return;
+        }
+        const mod = e.metaKey || e.ctrlKey;
+        if (!mod) return;
+        const shift = e.shiftKey;
+        const lower = typeof e.key === "string" ? e.key.toLowerCase() : "";
+        if (!shift && lower === "f") {
+          e.preventDefault();
+          filterEl.focus();
+          filterEl.select();
+        } else if (!shift && lower === "s") {
+          e.preventDefault();
+          saveEl.click();
+        } else if (shift && lower === "k") {
+          e.preventDefault();
+          clearEl.click();
+        }
       });
 
       refresh();


### PR DESCRIPTION
Parallel polish to #157 (dashboard shortcuts). Adds keyboard shortcuts to the logs window:

- **Ctrl/Cmd+F** — focus the filter input (and select its contents)
- **Ctrl/Cmd+S** — trigger Save…
- **Ctrl/Cmd+Shift+K** — trigger Clear view (Shift+K mirrors the dashboard convention from #157 and avoids the browser-reserved plain Ctrl+K)
- **Escape** while the filter is focused — blur the filter and clear its value if non-empty (dispatches `input` so the filter count updates)

Updates button/input `title=` attributes to advertise the shortcuts. Ctrl/Cmd+C is intentionally NOT bound so default text-selection copy keeps working; the Copy button stays mouse-only.

Single file change: `desktop/ui/logs.html`. No CSS changes, no new dependencies.

`cargo check` in the Cloud Eric sandbox fails at the `glib-sys` crate due to missing GTK/webkit2gtk system libs — expected per our known-limitation note (`tauri-cargo-check-gtk-missing`). CI validates on GitHub.