### PR TITLE
desktop: settings window keyboard shortcuts

### DIFF
--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -148,9 +148,9 @@
       </fieldset>
 
       <div class="actions">
-        <button class="secondary" id="reload">Reload</button>
+        <button class="secondary" id="reload" title="Reload (Cmd/Ctrl+R)">Reload</button>
         <button class="secondary" id="restart" hidden>Restart now</button>
-        <button id="save">Save</button>
+        <button id="save" title="Save (Cmd/Ctrl+S)">Save</button>
       </div>
       <div class="status" id="status"></div>
       <div class="version-footer">Kiln Desktop v<span id="app-version">—</span></div>
@@ -278,9 +278,25 @@
         }
       }
 
-      document.getElementById("reload").addEventListener("click", load);
-      document.getElementById("save").addEventListener("click", save);
+      const reloadBtn = document.getElementById("reload");
+      const saveBtn = document.getElementById("save");
+      reloadBtn.addEventListener("click", load);
+      saveBtn.addEventListener("click", save);
       restartBtn.addEventListener("click", restart);
+
+      document.addEventListener("keydown", (e) => {
+        const mod = e.metaKey || e.ctrlKey;
+        if (!mod) return;
+        const shift = e.shiftKey;
+        const lower = typeof e.key === "string" ? e.key.toLowerCase() : "";
+        if (!shift && lower === "s") {
+          e.preventDefault();
+          if (!saveBtn.disabled) saveBtn.click();
+        } else if (!shift && lower === "r") {
+          e.preventDefault();
+          if (!reloadBtn.disabled) reloadBtn.click();
+        }
+      });
       document.getElementById("pick_kiln_binary").addEventListener("click", () =>
         pickPath("kiln_binary", { multiple: false, directory: false, title: "Select kiln binary" })
       );


### PR DESCRIPTION
## What

Adds keyboard shortcuts to the settings window, matching parity with #157 (dashboard) and #159 (logs):

- Cmd/Ctrl+S — Save
- Cmd/Ctrl+R — Reload

Tooltips on the Save/Reload buttons updated to show shortcuts.

## Why

Dashboard and logs windows both got keyboard shortcuts in the last two PRs. Settings was the only window without them. Power-user polish parity.

## Test plan

- cargo check fails locally (no GTK in Cloud Eric sessions, documented in agent notes); CI validates full build
- Manual: open settings, press Cmd+S/Ctrl+S → Save fires; Cmd+R/Ctrl+R → Reload fires
- Esc-close skipped: settings.html has no existing Tauri window API import, kept out of scope per task instructions

N/A for deploy-request (desktop-only change in ericflo/kiln, not clouderic).