### PR TITLE
desktop: dashboard first-run empty state

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -336,6 +336,7 @@
       <div id="status-actions">
         <button id="start-server" class="hidden">Start Server</button>
         <button id="retry" class="hidden">Retry</button>
+        <button id="open-settings-btn" class="hidden">Open Settings</button>
       </div>
     </div>
     <script>
@@ -348,6 +349,7 @@
       const detail = document.getElementById("status-detail");
       const retry = document.getElementById("retry");
       const startBtn = document.getElementById("start-server");
+      const settingsNeededBtn = document.getElementById("open-settings-btn");
       const START_LABEL = "Start Server";
 
       function showStatus(titleText, detailText, showRetry, showStart) {
@@ -360,6 +362,21 @@
         startBtn.classList.toggle("hidden", !showStart);
         startBtn.disabled = false;
         startBtn.textContent = START_LABEL;
+        settingsNeededBtn.classList.add("hidden");
+      }
+
+      function showSetupNeeded() {
+        frame.classList.add("hidden");
+        frame.src = "about:blank";
+        status.classList.remove("hidden");
+        title.textContent = "Kiln is not configured yet";
+        detail.textContent =
+          "Set your model path in Settings to get started. Kiln needs to know which model to load.";
+        retry.classList.add("hidden");
+        startBtn.classList.add("hidden");
+        startBtn.disabled = false;
+        startBtn.textContent = START_LABEL;
+        settingsNeededBtn.classList.remove("hidden");
       }
 
       function showFrame(url) {
@@ -378,6 +395,16 @@
             false
           );
           return;
+        }
+        try {
+          const s = await invoke("get_settings");
+          if (!s || !s.model_path || !String(s.model_path).trim()) {
+            showSetupNeeded();
+            return;
+          }
+        } catch (_) {
+          // If settings fetch fails, fall through to the existing flow
+          // so we still surface get_kiln_url errors normally.
         }
         try {
           const url = await invoke("get_kiln_url");
@@ -492,6 +519,9 @@
         try { await invoke("open_logs"); } catch (e) { console.error("open_logs failed", e); }
       });
       settingsBtn.addEventListener("click", async () => {
+        try { await invoke("open_settings"); } catch (e) { console.error("open_settings failed", e); }
+      });
+      settingsNeededBtn.addEventListener("click", async () => {
         try { await invoke("open_settings"); } catch (e) { console.error("open_settings failed", e); }
       });
 


### PR DESCRIPTION
## What

When the kiln server is stopped and no `model_path` is configured in settings, the dashboard now shows a setup prompt with an **Open Settings** button instead of offering Start Server (which would fail with a cryptic kiln error).

## Why

Onboarding gap. A fresh install has no model path configured. Previously, clicking Start Server spawned kiln with no `--model` arg and surfaced a confusing error. This guides first-time users into Settings before they hit that wall.

## Implementation

Pure frontend change in `desktop/ui/dashboard.html`:
- `load()` calls `get_settings` first and shows `showSetupNeeded()` when `model_path` is empty
- New `#open-settings-btn` wired to existing `open_settings` Tauri command
- `showStatus()` hides the new button so it does not persist across state transitions
- No Rust changes, no new commands

## Test plan

- `cargo check` fails locally (no GTK in Cloud Eric sessions, documented in agent notes); CI validates full build
- Manual: launch fresh install → see setup prompt → click Open Settings → configure model → start server from tray → dashboard loads `/ui` normally