### PR TITLE
Phase 6: vendor mamba-ssm causal_conv1d_update CUDA kernel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1811,6 +1811,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kiln-conv1d-kernel"
+version = "0.1.0"
+dependencies = [
+ "candle-core",
+ "cc",
+ "half",
+]
+
+[[package]]
 name = "kiln-core"
 version = "0.1.0"
 dependencies = [
@@ -1860,6 +1869,7 @@ dependencies = [
  "candle-core",
  "candle-nn",
  "half",
+ "kiln-conv1d-kernel",
  "kiln-core",
  "kiln-flash-attn",
  "kiln-gdn-kernel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "crates/kiln-core",
+    "crates/kiln-conv1d-kernel",
     "crates/kiln-flash-attn",
     "crates/kiln-gdn-kernel",
     "crates/kiln-marlin-gemm",
@@ -12,11 +13,12 @@ members = [
     "crates/kiln-server",
     "crates/kiln-train",
 ]
-# kiln-flash-attn, kiln-gdn-kernel, kiln-marlin-gemm, and kiln-rmsnorm-kernel
-# unconditionally depend on candle-core/cuda, which pulls cudarc into any
-# `cargo build --workspace` and fails to link on non-CUDA hosts (notably
-# macOS). They're only compiled when a downstream crate opts in via
-# --features cuda, which activates them as optional dependencies.
+# kiln-conv1d-kernel, kiln-flash-attn, kiln-gdn-kernel, kiln-marlin-gemm,
+# and kiln-rmsnorm-kernel unconditionally depend on candle-core/cuda, which
+# pulls cudarc into any `cargo build --workspace` and fails to link on
+# non-CUDA hosts (notably macOS). They're only compiled when a downstream
+# crate opts in via --features cuda, which activates them as optional
+# dependencies.
 # Excluding them from default-members lets `cargo check`, `cargo build`, and
 # `cargo test` work on any host; Linux+CUDA builds still pull them via feature
 # activation on the real binary target.
@@ -78,6 +80,7 @@ memmap2 = "0.9"
 # Tensor compute
 candle-core = "0.10"
 candle-nn = "0.10"
+kiln-conv1d-kernel = { path = "crates/kiln-conv1d-kernel" }
 kiln-flash-attn = { path = "crates/kiln-flash-attn" }
 kiln-gdn-kernel = { path = "crates/kiln-gdn-kernel" }
 kiln-marlin-gemm = { path = "crates/kiln-marlin-gemm" }

--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,5 +1,69 @@
 # Kiln Profiling Report
 
+
+## Phase 6 — `causal_conv1d_update` vendor decode bench (2026-04-18)
+
+Vendored NVIDIA Mamba's `causal_conv1d_update` into `kiln-conv1d-kernel`
+(cc-crate + Rust FFI wrapper, bf16/causal/fwd-only, cuda-gated,
+sm_86/sm_89/sm_90) and wired `kiln-model/src/backend/cuda.rs` to dispatch
+through a new `BackendRuntime::causal_conv1d_update` hint. The candle
+fallback path is preserved behind the `KILN_DISABLE_FUSED_CONV1D=1` kill
+switch so the same binary can A/B without a rebuild. This replaces the
+`:kiln/gdn/conv` decode region (documented at 12.2 % of decode in the
+earlier nsys breakdown).
+
+**Hardware:** RunPod NVIDIA RTX A6000 on-demand, Driver 580.95.05,
+CUDA 12.8, stock `runpod/pytorch:0.7.0-dev-cu1281-torch271-ubuntu2404`
+plus `cuda-nvcc-12-8 cuda-cudart-dev-12-8 cuda-nvrtc-dev-12-8
+libcublas-dev-12-8 libcurand-dev-12-8`.
+
+**Build:** release, `--features cuda`, `KILN_CUDA_ARCHS=86`,
+`KILN_W4A16=1 KILN_CUDA_GRAPHS=true`.
+
+**Bench:** `kiln-bench --model-path /workspace/qwen3.5-4b --paged
+--prompt-tokens 512 --max-output-tokens 128 --skip-training`, 3 back-to-back
+runs per arm. Decode path = `model_forward_paged` (production
+HTTP/scheduler path). Reporting `decode_tokens_per_sec` and the inter-token
+latency distribution from the latency phase.
+
+### Decode tok/s — 512-prompt × 128-decode
+
+| run    | PRE (candle fallback) tok/s | POST (fused kernel) tok/s |
+| ------ | --------------------------: | ------------------------: |
+| 1      |                       45.10 |                     45.97 |
+| 2      |                       49.04 |                     52.59 |
+| 3      |                       44.08 |                     52.52 |
+| mean   |                       46.07 |                     50.36 |
+| median |                       45.10 |                     52.52 |
+
+Median speedup: **1.164× decode tok/s** (+16.4 %). Mean speedup: **1.093×**
+(+9.3 %). Run 1 of the POST arm underperforms the other two — first-fire
+JIT/kernel-cache warm-up is the likely cause; runs 2–3 converge tightly.
+
+### Inter-token latency (median of 3 runs)
+
+| stat    | PRE ms | POST ms |
+| ------- | -----: | ------: |
+| mean    |  22.17 |   19.04 |
+| p50     |  22.14 |   18.83 |
+| p99     |  26.22 |   24.14 |
+
+Consistent −3 ms mean ITL and −2 ms p99 ITL across runs.
+
+### Parity
+
+`cargo nextest run --release --features cuda -p kiln-model -E
+'test(test_causal_conv1d_update_matches_fallback)'`: PASS.
+
+### Verdict
+
+1.164× decode speedup clears the 1.03× ship floor. Kernel ships default-on;
+`KILN_DISABLE_FUSED_CONV1D=1` retained behind the `BackendRuntime` seam for
+debug/ablation. `:kiln/gdn/conv` is now serviced by the vendored kernel; the
+next decode hotspot on the GDN path is `gdn_recurrent_step` (covered by
+PR #80 / `kiln-gdn-kernel`).
+
+
 ## Phase 6 — chunk-prep fusion prefill bench (2026-04-18)
 
 Measured the Phase 6 `gdn_chunk_prep` fusion (`ce/phase6-chunk-prep-fusion`,

--- a/crates/kiln-conv1d-kernel/Cargo.toml
+++ b/crates/kiln-conv1d-kernel/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "kiln-conv1d-kernel"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Vendored mamba-ssm causal_conv1d_update CUDA kernel (decode-only, bf16, kernel_size=4) with C-ABI wrapper"
+build = "build.rs"
+
+[dependencies]
+candle-core = { workspace = true, features = ["cuda"] }
+half = "2"
+
+[build-dependencies]
+cc = "1"

--- a/crates/kiln-conv1d-kernel/build.rs
+++ b/crates/kiln-conv1d-kernel/build.rs
@@ -1,0 +1,94 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let cuda_root = match find_cuda_root() {
+        Some(p) => p,
+        None => {
+            println!("cargo:warning=CUDA not found, kiln-conv1d-kernel will not compile CUDA kernels");
+            println!("cargo:warning=Set CUDA_ROOT or CUDA_HOME, or install CUDA toolkit");
+            return;
+        }
+    };
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let csrc_dir = manifest_dir.join("csrc");
+
+    let cuda_archs = env::var("KILN_CUDA_ARCHS").unwrap_or_else(|_| "80;86;89;90".to_string());
+
+    let mut build = cc::Build::new();
+    build.cuda(true);
+    build.cpp(true);
+
+    build.include(&csrc_dir);
+    build.include(cuda_root.join("include"));
+
+    build.flag("-std=c++17");
+    build.flag("-O3");
+    build.flag("--use_fast_math");
+    build.flag("--expt-relaxed-constexpr");
+    build.flag("--expt-extended-lambda");
+    build.flag("-Xcompiler").flag("-fPIC");
+    build.flag("-diag-suppress=177");
+    build.flag("-diag-suppress=174");
+
+    for arch in cuda_archs.split(';') {
+        let arch = arch.trim();
+        if !arch.is_empty() {
+            build.flag(&format!("-gencode=arch=compute_{arch},code=sm_{arch}"));
+        }
+    }
+
+    build.file(csrc_dir.join("causal_conv1d_update.cu"));
+
+    build.compile("kiln_conv1d_kernel");
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        cuda_root.join("lib64").display()
+    );
+    println!("cargo:rustc-link-lib=cudart");
+
+    println!("cargo:rerun-if-changed=csrc/");
+    println!("cargo:rerun-if-env-changed=CUDA_ROOT");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
+    println!("cargo:rerun-if-env-changed=KILN_CUDA_ARCHS");
+}
+
+fn find_cuda_root() -> Option<PathBuf> {
+    for var in &["CUDA_ROOT", "CUDA_HOME", "CUDA_PATH"] {
+        if let Ok(val) = env::var(var) {
+            let p = PathBuf::from(val);
+            if p.join("include").join("cuda.h").exists() {
+                return Some(p);
+            }
+        }
+    }
+    for path in &[
+        "/usr/local/cuda",
+        "/usr/local/cuda-12",
+        "/usr/local/cuda-12.4",
+        "/usr/local/cuda-12.6",
+        "/usr/local/cuda-12.8",
+        "/opt/cuda",
+    ] {
+        let p = PathBuf::from(path);
+        if p.join("include").join("cuda.h").exists() {
+            return Some(p);
+        }
+    }
+    if let Ok(output) = std::process::Command::new("which").arg("nvcc").output() {
+        if output.status.success() {
+            let nvcc_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let p = PathBuf::from(nvcc_path);
+            if let Some(bin_dir) = p.parent() {
+                if let Some(cuda_dir) = bin_dir.parent() {
+                    if cuda_dir.join("include").join("cuda.h").exists() {
+                        return Some(cuda_dir.to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu
+++ b/crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu
@@ -1,0 +1,149 @@
+// Kiln causal_conv1d_update kernel — vendored from Dao-AILab/causal-conv1d
+// (mamba-ssm), narrowed to decode-only, bf16 activations/weights, F32 state,
+// kernel_size == 4, silu-fused.
+//
+// # Provenance
+//
+// Algorithm modelled after
+// <https://github.com/Dao-AILab/causal-conv1d> `csrc/causal_conv1d_update.cu`
+// (commit HEAD as of 2026-04-18), kIsCircularBuffer = false branch. The
+// upstream kernel handles arbitrary dtypes, arbitrary kernel widths (2/3/4),
+// seqlen > 1, optional bias, optional circular buffer, and an optional
+// conv_state_indices gather — kiln only needs the single-token,
+// kernel_width=4, bf16, no-bias, linear-buffer path, so this is a reduced
+// specialisation rather than a full port. License: Apache 2.0 (upstream);
+// kiln retains the same licence for the vendored code.
+//
+// # Layout
+//
+// One thread per (batch, channel). Launch:
+//   grid  = dim3(B, (C + threads - 1) / threads)
+//   block = dim3(threads)
+//   threads = 64 (matches upstream).
+//
+// Per thread:
+//   1. Load K-1 floats from conv_state (already F32 in kiln).
+//   2. Load 1 bf16 from x, cast to F32.
+//   3. Load K bf16 weights for this channel, cast to F32.
+//   4. Dot-product into an F32 accumulator.
+//   5. Write the new K-1 state (drop oldest, append newest x).
+//   6. Optionally apply SiLU: out = z / (1 + exp(-z)).
+//   7. Store F32 to out.
+//
+// Because K is fixed at compile time (4) the window + weight loops are fully
+// unrolled and the whole kernel runs out of registers — no shared memory, no
+// atomics, no sync.
+//
+// # Scope
+//
+// - Forward only (mamba-ssm ships a separate backward; we don't need one for
+//   inference).
+// - bf16 activations and bf16 weights. F32 state. F32 output.
+// - kernel_width == 4 (Qwen3.5 GDN). Other widths return status != 0.
+// - No bias, no per-batch conv_state_indices, no circular buffer.
+
+#include "causal_conv1d_update.h"
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+namespace {
+
+constexpr int kThreadsPerBlock = 64;
+constexpr int kWidth = 4;  // specialisation — Qwen3.5 GDN
+
+template <bool kSilu>
+__global__ __launch_bounds__(kThreadsPerBlock) void kiln_conv1d_update_k4_kernel(
+    const __nv_bfloat16 *__restrict__ x,        // [B, C, 1]
+    const __nv_bfloat16 *__restrict__ weight,   // [C, K]
+    float *__restrict__ conv_state,             // [B, C, K-1]
+    float *__restrict__ out,                    // [B, C, 1]
+    int batch,
+    int channels) {
+    const int b = blockIdx.x;
+    const int c = blockIdx.y * kThreadsPerBlock + threadIdx.x;
+    if (c >= channels) return;
+
+    const size_t state_row = (static_cast<size_t>(b) * channels + c) * (kWidth - 1);
+    const size_t xy_row = static_cast<size_t>(b) * channels + c;
+
+    // Load K-1 previous inputs from state (F32).
+    float window[kWidth];
+#pragma unroll
+    for (int i = 0; i < kWidth - 1; ++i) {
+        window[i] = conv_state[state_row + i];
+    }
+
+    // Load current token from x (bf16 -> f32). x is [B, C, 1] so index is `xy_row`.
+    window[kWidth - 1] = __bfloat162float(x[xy_row]);
+
+    // Load K weights for this channel (bf16 -> f32). weight is [C, K].
+    float w[kWidth];
+#pragma unroll
+    for (int i = 0; i < kWidth; ++i) {
+        w[i] = __bfloat162float(weight[static_cast<size_t>(c) * kWidth + i]);
+    }
+
+    // Dot product.
+    float acc = 0.0f;
+#pragma unroll
+    for (int i = 0; i < kWidth; ++i) {
+        acc += window[i] * w[i];
+    }
+
+    // Update state: drop oldest, append newest x. Writes K-1 floats.
+#pragma unroll
+    for (int i = 0; i < kWidth - 1; ++i) {
+        conv_state[state_row + i] = window[i + 1];
+    }
+
+    // SiLU: z / (1 + exp(-z)). Matches cuda_silu() called in forward.rs.
+    if constexpr (kSilu) {
+        acc = acc / (1.0f + __expf(-acc));
+    }
+
+    out[xy_row] = acc;
+}
+
+}  // namespace
+
+extern "C" kiln_conv1d_status_t kiln_causal_conv1d_update_bf16_f32(
+    const void *x,
+    const void *weight,
+    void *conv_state,
+    void *out,
+    int batch,
+    int channels,
+    int kernel_width,
+    int silu,
+    void *stream) {
+    if (kernel_width != kWidth) {
+        return 1;  // unsupported width (only K=4 compiled)
+    }
+    if (batch <= 0 || channels <= 0) {
+        return 2;
+    }
+
+    dim3 grid(batch, (channels + kThreadsPerBlock - 1) / kThreadsPerBlock);
+    dim3 block(kThreadsPerBlock);
+    cudaStream_t cu_stream = static_cast<cudaStream_t>(stream);
+
+    const auto *x_bf = reinterpret_cast<const __nv_bfloat16 *>(x);
+    const auto *w_bf = reinterpret_cast<const __nv_bfloat16 *>(weight);
+    auto *state_f = reinterpret_cast<float *>(conv_state);
+    auto *out_f = reinterpret_cast<float *>(out);
+
+    if (silu != 0) {
+        kiln_conv1d_update_k4_kernel<true><<<grid, block, 0, cu_stream>>>(
+            x_bf, w_bf, state_f, out_f, batch, channels);
+    } else {
+        kiln_conv1d_update_k4_kernel<false><<<grid, block, 0, cu_stream>>>(
+            x_bf, w_bf, state_f, out_f, batch, channels);
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 3;
+    }
+    return 0;
+}

--- a/crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.h
+++ b/crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.h
@@ -1,0 +1,69 @@
+// Kiln vendored causal_conv1d_update C-ABI wrapper.
+//
+// Decode-only (seqlen == 1) single-step variant of the mamba-ssm /
+// Dao-AILab/causal-conv1d `causal_conv1d_update_kernel`, narrowed to kiln's
+// Qwen3.5-4B GDN envelope:
+//   - bf16 activations / bf16 weights.
+//   - F32 conv_state (matches kiln's state init in `LinearAttentionCache`).
+//   - kernel_size == 4, stride == 1, dilation == 1.
+//   - silu fused inline (matches the `cuda_silu` call site in forward.rs).
+//
+// Replaces this candle op chain inside `kiln/gdn/conv` (12.2% of decode
+// wall-clock per PROFILING.md post-#158):
+//
+//   x_f32 = to_dtype(F32)(x)
+//   w_f32 = to_dtype(F32)(weight).reshape((C, K))
+//   state_f32 = to_dtype(F32)(conv_state)
+//   window = cat(state_f32, x_f32, dim=2)
+//   out = sum(window * w_f32.unsqueeze(0), dim=2).unsqueeze(2)
+//   conv_state = window.narrow(2, 1, K-1).contiguous()
+//   out = silu(out)  // caller applies separately in F32
+//
+// …with a single CUDA launch: one thread per (batch, channel), K==4
+// registers for the window, F32 accumulator, F32 state, F32 silu epilogue.
+//
+// Pointer layout (all contiguous CUDA):
+//   x          : bf16, [B, C, 1]
+//   weight     : bf16, [C, 1, K]        (we treat as [C, K] — weight_width_stride = 1)
+//   conv_state : f32,  [B, C, K-1]       — updated in place
+//   out        : f32,  [B, C, 1]
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int kiln_conv1d_status_t;
+
+// Single-step causal depthwise conv1d update with fused SiLU.
+//
+// All pointers are CUDA device memory, contiguous.
+//   x          : bf16, [B, C, 1]
+//   weight     : bf16, [C, K]  (flat; caller's [C, 1, K] view is already contiguous)
+//   conv_state : f32,  [B, C, K-1] — read and written
+//   out        : f32,  [B, C, 1]
+// Shape:
+//   B    = batch
+//   C    = channels
+//   K    = kernel width (must be 4 for the current specialisation)
+//   silu = 1 to fuse SiLU, 0 to leave the raw accumulator (parity-test mode)
+//
+// Returns 0 on success, non-zero on launch/config failure.
+kiln_conv1d_status_t kiln_causal_conv1d_update_bf16_f32(
+    const void *x,
+    const void *weight,
+    void *conv_state,
+    void *out,
+    int batch,
+    int channels,
+    int kernel_width,
+    int silu,
+    void *stream
+);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/kiln-conv1d-kernel/src/lib.rs
+++ b/crates/kiln-conv1d-kernel/src/lib.rs
@@ -1,0 +1,391 @@
+//! Vendored mamba-ssm `causal_conv1d_update` CUDA kernel, narrowed to kiln's
+//! Qwen3.5-4B GDN decode envelope.
+//!
+//! # Why
+//!
+//! `kiln-model::forward::causal_conv1d_decode` expresses the single-step
+//! depthwise conv1d + state update as a chain of candle ops:
+//!
+//! ```text
+//! x_f32     = to_dtype(F32)(x)
+//! w_f32     = to_dtype(F32)(weight).reshape((C, K))
+//! state_f32 = to_dtype(F32)(conv_state)
+//! window    = cat(state_f32, x_f32, dim=2)          // [B, C, K]
+//! out       = sum(window * w.unsqueeze(0), dim=2)   // [B, C]
+//! conv_state = window.narrow(2, 1, K-1).contiguous() // [B, C, K-1]
+//! out       = silu(out.unsqueeze(2))                 // applied by caller
+//! ```
+//!
+//! That is ~6 CUDA launches per GDN layer × 24 layers ≈ 144 launches per
+//! decode step just for the conv. Per PROFILING.md (post-PR #158) the
+//! `kiln/gdn/conv` NVTX region is **12.2 %** of decode wall-clock.
+//!
+//! This crate collapses the whole chain into a single launch:
+//! `kiln_causal_conv1d_update_bf16_f32` — one thread per (batch, channel),
+//! K=4 registers for the window, F32 accumulator, F32 state, F32 silu
+//! epilogue.
+//!
+//! # Provenance
+//!
+//! Algorithm vendored from
+//! [Dao-AILab/causal-conv1d](https://github.com/Dao-AILab/causal-conv1d)
+//! (mamba-ssm) `csrc/causal_conv1d_update.cu`, kIsCircularBuffer=false,
+//! kNBytes=2, kWidth=4 specialisation. License: Apache 2.0 upstream; this
+//! crate retains the same licence for the vendored portion.
+//!
+//! # Scope
+//!
+//! - Decode single-step only (`seq_len == 1`).
+//! - bf16 activations, bf16 weights, F32 state, F32 output.
+//! - `kernel_size == 4` (Qwen3.5 GDN). Other widths return `Ok(None)`.
+//! - No bias (kiln doesn't load conv1d bias — see forward.rs line ~1478).
+//! - No per-batch conv_state_indices / circular buffer.
+//! - SiLU fused inline (matches the `cuda_silu` call immediately after the
+//!   conv in `gated_deltanet_forward`).
+//!
+//! # API
+//!
+//! - [`supports`] — cheap envelope check for the backend trait's
+//!   `supports_causal_conv1d_update` hook.
+//! - [`causal_conv1d_update`] — candle-compatible entry point. Mutates
+//!   `conv_state` in place (matches the candle fallback's semantics).
+
+use candle_core::{
+    backend::BackendStorage, cuda_backend::cudarc::driver::DevicePtr, DType, Device, Result,
+    Tensor,
+};
+use half::bf16;
+
+unsafe extern "C" {
+    fn kiln_causal_conv1d_update_bf16_f32(
+        x: *const core::ffi::c_void,
+        weight: *const core::ffi::c_void,
+        conv_state: *mut core::ffi::c_void,
+        out: *mut core::ffi::c_void,
+        batch: i32,
+        channels: i32,
+        kernel_width: i32,
+        silu: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+}
+
+/// Whether the fused kernel can handle this call.
+///
+/// Returns `true` only for the exact bf16/f32/K=4 envelope the vendored
+/// kernel was specialised for. All other shapes/dtypes should take the
+/// candle fallback path.
+pub fn supports(x: &Tensor, weight: &Tensor, conv_state: &Tensor, kernel_size: usize) -> bool {
+    if kernel_size != 4 {
+        return false;
+    }
+    if !matches!(x.device(), Device::Cuda(_)) {
+        return false;
+    }
+    if x.dtype() != DType::BF16 || weight.dtype() != DType::BF16 {
+        return false;
+    }
+    if conv_state.dtype() != DType::F32 {
+        return false;
+    }
+    // x: [B, C, 1]
+    let Ok((_b, _c, t)) = x.dims3() else {
+        return false;
+    };
+    if t != 1 {
+        return false;
+    }
+    // conv_state: [B, C, K-1]
+    let Ok((_, _, ks)) = conv_state.dims3() else {
+        return false;
+    };
+    if ks != kernel_size - 1 {
+        return false;
+    }
+    true
+}
+
+/// Run the fused causal_conv1d_update kernel.
+///
+/// Inputs:
+///   - `x`: bf16 `[B, C, 1]` — current token per channel (depthwise).
+///   - `weight`: bf16 `[C, 1, K]` (or `[C, K]` after squeeze) — conv weights.
+///   - `conv_state`: F32 `[B, C, K-1]` — rolling buffer, mutated in place.
+///   - `kernel_size`: must be 4.
+///
+/// Output: F32 `[B, C, 1]` with SiLU fused inline. On return, `conv_state`
+/// has been updated to drop the oldest sample and append `x`.
+pub fn causal_conv1d_update(
+    x: &Tensor,
+    weight: &Tensor,
+    conv_state: &mut Tensor,
+    kernel_size: usize,
+) -> Result<Tensor> {
+    if kernel_size != 4 {
+        candle_core::bail!(
+            "kiln-conv1d-kernel: only kernel_size=4 is supported (got {kernel_size})"
+        );
+    }
+
+    let device = x.device();
+
+    let (batch, channels, t) = x.dims3()?;
+    if t != 1 {
+        candle_core::bail!("kiln-conv1d-kernel: decode path requires seq_len=1 (got {t})");
+    }
+
+    // Accept either [C, 1, K] or [C, K] for weight (both are how kiln expresses
+    // depthwise conv weights).
+    let weight_flat = match weight.rank() {
+        3 => {
+            let (c, one, k) = weight.dims3()?;
+            if c != channels || one != 1 || k != kernel_size {
+                candle_core::bail!(
+                    "kiln-conv1d-kernel: weight shape [{c}, {one}, {k}] does not match channels={channels} kernel_size={kernel_size}"
+                );
+            }
+            weight.reshape((channels, kernel_size))?
+        }
+        2 => {
+            let (c, k) = weight.dims2()?;
+            if c != channels || k != kernel_size {
+                candle_core::bail!(
+                    "kiln-conv1d-kernel: weight shape [{c}, {k}] does not match channels={channels} kernel_size={kernel_size}"
+                );
+            }
+            weight.clone()
+        }
+        r => {
+            candle_core::bail!("kiln-conv1d-kernel: weight must be rank 2 or 3 (got rank {r})")
+        }
+    };
+
+    let (bs, cs, ks) = conv_state.dims3()?;
+    if (bs, cs, ks) != (batch, channels, kernel_size - 1) {
+        candle_core::bail!(
+            "kiln-conv1d-kernel: conv_state shape [{bs}, {cs}, {ks}] mismatch with [{batch}, {channels}, {}] ",
+            kernel_size - 1
+        );
+    }
+
+    if x.dtype() != DType::BF16 {
+        candle_core::bail!("kiln-conv1d-kernel: x must be bf16 (got {:?})", x.dtype());
+    }
+    if weight_flat.dtype() != DType::BF16 {
+        candle_core::bail!(
+            "kiln-conv1d-kernel: weight must be bf16 (got {:?})",
+            weight_flat.dtype()
+        );
+    }
+    if conv_state.dtype() != DType::F32 {
+        candle_core::bail!(
+            "kiln-conv1d-kernel: conv_state must be f32 (got {:?})",
+            conv_state.dtype()
+        );
+    }
+
+    let x = x.contiguous()?;
+    let weight_flat = weight_flat.contiguous()?;
+    if !conv_state.is_contiguous() {
+        *conv_state = conv_state.contiguous()?;
+    }
+
+    let out = Tensor::zeros((batch, channels, 1), DType::F32, device)?;
+
+    {
+        let (x_storage, x_layout) = x.storage_and_layout();
+        let (w_storage, w_layout) = weight_flat.storage_and_layout();
+        let (s_storage, s_layout) = conv_state.storage_and_layout();
+        let (o_storage, o_layout) = out.storage_and_layout();
+
+        let x_cuda = match &*x_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-conv1d-kernel: x must be on CUDA"),
+        };
+        let w_cuda = match &*w_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-conv1d-kernel: weight must be on CUDA"),
+        };
+        let s_cuda = match &*s_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-conv1d-kernel: conv_state must be on CUDA"),
+        };
+        let o_cuda = match &*o_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-conv1d-kernel: out must be on CUDA"),
+        };
+
+        let stream = x_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let x_slice = x_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(x_layout.start_offset()..);
+        let w_slice = w_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(w_layout.start_offset()..);
+        let s_slice = s_cuda
+            .as_cuda_slice::<f32>()?
+            .slice(s_layout.start_offset()..);
+        let o_slice = o_cuda
+            .as_cuda_slice::<f32>()?
+            .slice(o_layout.start_offset()..);
+
+        unsafe {
+            let (x_ptr, _g1) = x_slice.device_ptr(&stream);
+            let (w_ptr, _g2) = w_slice.device_ptr(&stream);
+            let (s_ptr, _g3) = s_slice.device_ptr(&stream);
+            let (o_ptr, _g4) = o_slice.device_ptr(&stream);
+
+            let status = kiln_causal_conv1d_update_bf16_f32(
+                x_ptr as *const _,
+                w_ptr as *const _,
+                s_ptr as *mut _,
+                o_ptr as *mut _,
+                batch as i32,
+                channels as i32,
+                kernel_size as i32,
+                1, // silu=true — matches the cuda_silu call immediately after in forward.rs
+                raw_stream,
+            );
+
+            if status != 0 {
+                candle_core::bail!(
+                    "kiln_causal_conv1d_update_bf16_f32 failed with status {status}"
+                );
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::{Device, Tensor};
+
+    // Reference implementation — mirrors `kiln-model::forward::causal_conv1d_decode`
+    // followed by the `cuda_silu(out.to_dtype(F32))` the caller applies.
+    fn reference_decode_with_silu(
+        x: &Tensor,
+        weight: &Tensor,
+        conv_state: &mut Tensor,
+        kernel_size: usize,
+    ) -> Result<Tensor> {
+        let (_batch, channels, _one) = x.dims3()?;
+        let x_f32 = x.to_dtype(DType::F32)?;
+        let w_f32 = weight.to_dtype(DType::F32)?.reshape((channels, kernel_size))?;
+        let window = Tensor::cat(&[&conv_state.clone(), &x_f32], 2)?;
+        let w_expanded = w_f32.unsqueeze(0)?;
+        let output = window.broadcast_mul(&w_expanded)?.sum(2)?.unsqueeze(2)?;
+        *conv_state = window.narrow(2, 1, kernel_size - 1)?.contiguous()?;
+        // SiLU: x / (1 + exp(-x))
+        let ones = output.ones_like()?;
+        let silu = (&output / (ones.clone() + output.neg()?.exp()?)?)?;
+        Ok(silu)
+    }
+
+    fn try_cuda_device() -> Option<Device> {
+        Device::new_cuda(0).ok()
+    }
+
+    fn seeded(n: usize, seed: u32, scale: f32) -> Vec<f32> {
+        let mut v = Vec::with_capacity(n);
+        let mut state = seed;
+        for _ in 0..n {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            let f = ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0;
+            v.push(f * scale);
+        }
+        v
+    }
+
+    #[test]
+    fn parity_qwen35_decode_shape() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        // Qwen3.5-4B decode: batch=1, conv_dim=linear_qkv_dim()=8192, K=4.
+        let batch = 1;
+        let channels = 8192;
+        let kernel_size = 4;
+
+        let raw_x = seeded(batch * channels * 1, 0x1234_5678, 0.5);
+        let raw_w = seeded(channels * kernel_size, 0xfeed_face, 0.1);
+        let raw_state = seeded(batch * channels * (kernel_size - 1), 0xcafe_babe, 0.3);
+
+        let x_f32 = Tensor::from_vec(raw_x, (batch, channels, 1), &device).unwrap();
+        let w_f32 = Tensor::from_vec(raw_w, (channels, 1, kernel_size), &device).unwrap();
+        let state_ref_f32 =
+            Tensor::from_vec(raw_state.clone(), (batch, channels, kernel_size - 1), &device)
+                .unwrap();
+
+        let x = x_f32.to_dtype(DType::BF16).unwrap();
+        let w = w_f32.to_dtype(DType::BF16).unwrap();
+        let mut state_ref = state_ref_f32.clone();
+        let mut state_fused = state_ref_f32.clone();
+
+        let y_ref = reference_decode_with_silu(&x, &w, &mut state_ref, kernel_size).unwrap();
+        let y_fused =
+            causal_conv1d_update(&x, &w, &mut state_fused, kernel_size).unwrap();
+
+        // Output parity.
+        let diff = (&y_ref - &y_fused)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+
+        assert!(
+            diff < 2e-3,
+            "output parity failed: max_abs_diff={diff} exceeds 2e-3 tolerance"
+        );
+
+        // State parity — both paths write the same K-1 previous inputs.
+        let state_diff = (&state_ref - &state_fused)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+
+        assert!(
+            state_diff < 1e-5,
+            "conv_state parity failed: max_abs_diff={state_diff} exceeds 1e-5"
+        );
+    }
+
+    #[test]
+    fn supports_rejects_wrong_width() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        let x = Tensor::zeros((1, 16, 1), DType::BF16, &device).unwrap();
+        let w = Tensor::zeros((16, 1, 3), DType::BF16, &device).unwrap();
+        let s = Tensor::zeros((1, 16, 2), DType::F32, &device).unwrap();
+        assert!(!supports(&x, &w, &s, 3));
+    }
+
+    #[test]
+    fn supports_accepts_qwen_shape() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        let x = Tensor::zeros((1, 8192, 1), DType::BF16, &device).unwrap();
+        let w = Tensor::zeros((8192, 1, 4), DType::BF16, &device).unwrap();
+        let s = Tensor::zeros((1, 8192, 3), DType::F32, &device).unwrap();
+        assert!(supports(&x, &w, &s, 4));
+    }
+}

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -16,6 +16,7 @@ safetensors = { workspace = true }
 memmap2 = { workspace = true }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
+kiln-conv1d-kernel = { workspace = true, optional = true }
 kiln-flash-attn = { workspace = true, optional = true }
 kiln-gdn-kernel = { workspace = true, optional = true }
 kiln-marlin-gemm = { workspace = true, optional = true }
@@ -28,7 +29,7 @@ mlx-rs = { workspace = true, optional = true }
 half = { version = "2", optional = true }
 
 [features]
-cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel", "dep:kiln-marlin-gemm", "dep:kiln-rmsnorm-kernel"]
+cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-conv1d-kernel", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel", "dep:kiln-marlin-gemm", "dep:kiln-rmsnorm-kernel"]
 # Enable candle's Metal backend on Apple Silicon. Pulls in candle-metal-kernels
 # (JIT-compiled MSL shaders cached in the MetalDevice); no Xcode required.
 metal = ["candle-core/metal", "candle-nn/metal"]

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -17,6 +17,10 @@ pub struct CudaBackend {
     /// Same pattern: cache the env-var read. The fused gates kernel is
     /// gated behind its own kill switch so it can be disabled independently.
     gdn_gates_enabled: bool,
+    /// Kill switch for the fused causal_conv1d_update kernel (decode
+    /// kiln/gdn/conv region). When off, forward.rs falls back to the
+    /// candle to_f32/cat/sum/narrow chain.
+    fused_conv1d_enabled: bool,
 }
 
 impl CudaBackend {
@@ -25,10 +29,12 @@ impl CudaBackend {
         let gdn_enabled = std::env::var("KILN_DISABLE_GDN_KERNEL").is_err();
         let gdn_gates_enabled =
             gdn_enabled && std::env::var("KILN_DISABLE_FUSED_GDN_GATES").is_err();
+        let fused_conv1d_enabled = std::env::var("KILN_DISABLE_FUSED_CONV1D").is_err();
         Self {
             device,
             gdn_enabled,
             gdn_gates_enabled,
+            fused_conv1d_enabled,
         }
     }
 }
@@ -174,5 +180,27 @@ impl BackendRuntime for CudaBackend {
         let (beta, g) = kiln_gdn_kernel::gdn_gates(a, b, a_log, dt_bias)
             .context("gdn_gates kernel failed")?;
         Ok(Some((beta, g)))
+    }
+
+    fn supports_causal_conv1d_update(&self) -> bool {
+        self.fused_conv1d_enabled
+    }
+
+    fn causal_conv1d_update(
+        &self,
+        x: &Tensor,
+        weight: &Tensor,
+        conv_state: &mut Tensor,
+        kernel_size: usize,
+    ) -> Result<Option<Tensor>> {
+        if !self.fused_conv1d_enabled {
+            return Ok(None);
+        }
+        if !kiln_conv1d_kernel::supports(x, weight, conv_state, kernel_size) {
+            return Ok(None);
+        }
+        let out = kiln_conv1d_kernel::causal_conv1d_update(x, weight, conv_state, kernel_size)
+            .context("causal_conv1d_update kernel failed")?;
+        Ok(Some(out))
     }
 }

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -173,6 +173,36 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         false
     }
 
+    fn supports_causal_conv1d_update(&self) -> bool {
+        false
+    }
+
+    /// Fused single-step causal depthwise conv1d + state update + silu.
+    ///
+    /// Replaces the candle `to_f32 -> cat(state, x) -> sum(window * weight) ->
+    /// narrow/contiguous -> silu` chain inside `kiln/gdn/conv` with one CUDA
+    /// launch per (batch, channel).
+    ///
+    /// `x`: `[B, C, 1]` bf16 contiguous. `weight`: `[C, 1, K]` bf16 contiguous
+    /// (or `[C, K]` equivalently — width stride = 1). `conv_state`:
+    /// `[B, C, K-1]` F32, mutated in place to drop oldest col and append
+    /// newest `x`. `kernel_size`: must be 4 for the current CUDA
+    /// specialisation.
+    ///
+    /// Returns `Ok(Some(out))` with `out: [B, C, 1]` F32 (silu-fused), or
+    /// `Ok(None)` when the backend declines (wrong dtype, wrong K, envelope
+    /// violation, disabled via env kill switch). When `Some`, the caller must
+    /// NOT apply `silu` again — it is fused into the kernel epilogue.
+    fn causal_conv1d_update(
+        &self,
+        _x: &Tensor,
+        _weight: &Tensor,
+        _conv_state: &mut Tensor,
+        _kernel_size: usize,
+    ) -> Result<Option<Tensor>> {
+        Ok(None)
+    }
+
     /// Fused GDN gate computation.
     ///
     /// Collapses the Step-6 `sigmoid(b)` + `-exp(A_log) * softplus(a + dt_bias)`

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1310,19 +1310,55 @@ pub fn gated_deltanet_forward(
     };
 
     // --- Step 2: Causal depthwise conv1d + SiLU on fused QKV ---
+    //
+    // Decode fast path: a fused CUDA kernel (`backend.causal_conv1d_update`)
+    // collapses the to_f32 / cat / sum / narrow / silu chain into a single
+    // launch per (batch, channel). It returns F32 with SiLU already fused, so
+    // the subsequent `cuda_silu(.to_dtype(F32))` step is skipped. Non-CUDA,
+    // non-bf16, kernel_size != 4, and the `KILN_DISABLE_FUSED_CONV1D` kill
+    // switch all route through the portable candle path below — which is the
+    // parity oracle.
     let mixed_qkv = {
         kiln_nvtx::range!(c"kiln/gdn/conv");
         // Transpose to [B, channels, T] for conv
-        let mixed_qkv = mixed_qkv.transpose(1, 2)?.contiguous()?;
-        let mixed_qkv = if seq_len > 1 {
-            causal_conv1d_prefill(&mixed_qkv, &weights.conv1d, conv_state, kernel_size)?
+        let mixed_qkv_ct = mixed_qkv.transpose(1, 2)?.contiguous()?;
+        let post_silu = if seq_len == 1 && backend.supports_causal_conv1d_update() {
+            match backend.causal_conv1d_update(
+                &mixed_qkv_ct,
+                &weights.conv1d,
+                conv_state,
+                kernel_size,
+            )? {
+                Some(out) => out, // F32, SiLU fused into the kernel epilogue
+                None => {
+                    let y = causal_conv1d_decode(
+                        &mixed_qkv_ct,
+                        &weights.conv1d,
+                        conv_state,
+                        kernel_size,
+                    )?;
+                    cuda_silu(&y.to_dtype(DType::F32)?)?
+                }
+            }
+        } else if seq_len > 1 {
+            let y = causal_conv1d_prefill(
+                &mixed_qkv_ct,
+                &weights.conv1d,
+                conv_state,
+                kernel_size,
+            )?;
+            cuda_silu(&y.to_dtype(DType::F32)?)?
         } else {
-            causal_conv1d_decode(&mixed_qkv, &weights.conv1d, conv_state, kernel_size)?
+            let y = causal_conv1d_decode(
+                &mixed_qkv_ct,
+                &weights.conv1d,
+                conv_state,
+                kernel_size,
+            )?;
+            cuda_silu(&y.to_dtype(DType::F32)?)?
         };
-        // SiLU activation (work in F32 for stability)
-        let mixed_qkv = cuda_silu(&mixed_qkv.to_dtype(DType::F32)?)?;
         // Transpose back to [B, T, qkv_dim]
-        mixed_qkv.transpose(1, 2)?
+        post_silu.transpose(1, 2)?
     };
 
     // --- Step 3: Split into Q, K, V and reshape to heads ---
@@ -4625,4 +4661,98 @@ mod tests {
         Ok(())
     }
 
+    /// Parity check for the fused causal_conv1d_update kernel against the
+    /// portable `causal_conv1d_decode` + `cuda_silu` chain, at Qwen3.5-4B's
+    /// exact decode shape: B=1, C=linear_qkv_dim=8192, K=4.
+    ///
+    /// Verifies (a) the silu-fused F32 output matches within bf16-rounding
+    /// noise and (b) the mutated conv_state matches bit-for-bit (both paths
+    /// write the same K-1 previous inputs from the same bf16 source).
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn test_causal_conv1d_update_matches_fallback() -> Result<()> {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let device = match Device::new_cuda(0) {
+            Ok(d) => d,
+            Err(_) => {
+                eprintln!(
+                    "CUDA not available, skipping test_causal_conv1d_update_matches_fallback"
+                );
+                return Ok(());
+            }
+        };
+
+        let batch = 1usize;
+        let channels = 8192usize; // Qwen3.5-4B linear_qkv_dim
+        let kernel_size = 4usize;
+
+        let mut rng = StdRng::seed_from_u64(0xC0_1DBEEF);
+        let n_x = batch * channels * 1;
+        let n_w = channels * kernel_size;
+        let n_s = batch * channels * (kernel_size - 1);
+
+        let x_data: Vec<f32> = (0..n_x).map(|_| rng.gen_range(-0.5f32..0.5f32)).collect();
+        let w_data: Vec<f32> = (0..n_w).map(|_| rng.gen_range(-0.1f32..0.1f32)).collect();
+        let s_data: Vec<f32> = (0..n_s).map(|_| rng.gen_range(-0.3f32..0.3f32)).collect();
+
+        let x_f32 = Tensor::from_slice(&x_data, (batch, channels, 1), &device)?;
+        let w_f32 = Tensor::from_slice(&w_data, (channels, 1, kernel_size), &device)?;
+        let s_init =
+            Tensor::from_slice(&s_data, (batch, channels, kernel_size - 1), &device)?;
+
+        let x = x_f32.to_dtype(DType::BF16)?;
+        let w = w_f32.to_dtype(DType::BF16)?;
+
+        // Fallback path: candle decode + silu in F32.
+        let mut s_fb = s_init.clone();
+        let out_fb = causal_conv1d_decode(&x, &w, &mut s_fb, kernel_size)?;
+        let out_fb = cuda_silu(&out_fb.to_dtype(DType::F32)?)?;
+
+        // Fused kernel path via the backend dispatch.
+        let backend = crate::backend::for_device(&device);
+        if !backend.supports_causal_conv1d_update() {
+            eprintln!(
+                "backend declines causal_conv1d_update (KILN_DISABLE_FUSED_CONV1D?); skipping"
+            );
+            return Ok(());
+        }
+        let mut s_k = s_init.clone();
+        let out_k = match backend.causal_conv1d_update(&x, &w, &mut s_k, kernel_size)? {
+            Some(t) => t,
+            None => {
+                eprintln!(
+                    "backend declined causal_conv1d_update at Qwen3.5 envelope; skipping"
+                );
+                return Ok(());
+            }
+        };
+
+        // Output parity (silu fused on the kernel side).
+        let diff = (out_k.to_dtype(DType::F32)? - out_fb.to_dtype(DType::F32)?)?;
+        let abs = diff.abs()?;
+        let max = abs.flatten_all()?.max(0)?.to_scalar::<f32>()?;
+        let mean = abs.flatten_all()?.mean(0)?.to_scalar::<f32>()?;
+        eprintln!("conv1d_update vs fallback: max_abs_diff={max:e} mean_abs_diff={mean:e}");
+        assert!(
+            max < 2e-3,
+            "fused conv1d_update output max_abs_diff={max:e} exceeds 2e-3"
+        );
+        assert!(
+            mean < 5e-4,
+            "fused conv1d_update output mean_abs_diff={mean:e} exceeds 5e-4"
+        );
+
+        // State parity — both paths write the same K-1 previous inputs.
+        let sdiff = (s_k.to_dtype(DType::F32)? - s_fb.to_dtype(DType::F32)?)?;
+        let smax = sdiff.abs()?.flatten_all()?.max(0)?.to_scalar::<f32>()?;
+        eprintln!("conv1d_update state parity: max_abs_diff={smax:e}");
+        assert!(
+            smax < 1e-5,
+            "fused conv1d_update state max_abs_diff={smax:e} exceeds 1e-5"
+        );
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Phase 6: vendor `causal_conv1d_update` CUDA kernel

Vendors NVIDIA Mamba's `causal_conv1d_update` into `kiln-conv1d-kernel`, a thin cc-crate + Rust FFI wrapper, and wires the GDN path in `kiln-model/src/backend/cuda.rs` to use it via a new `BackendRuntime::causal_conv1d_update` hint. Fallback to the candle path is preserved behind `KILN_DISABLE_FUSED_CONV1D=1` so the same binary can A/B without rebuild.

### Scope
- New crate `kiln-conv1d-kernel` (`crates/kiln-conv1d-kernel/`) — bf16/causal/fwd-only, cuda-gated, sm_86/sm_89/sm_90.
- `BackendRuntime` seam: `supports_causal_conv1d_update` hint + `causal_conv1d_update` that may return `Ok(None)` for fallback.
- `cuda.rs` wires fused path; env kill-switch `KILN_DISABLE_FUSED_CONV1D=1` forces candle path.
- Parity test `test_causal_conv1d_update_matches_fallback` in `kiln-model`.

### A/B bench on A6000 (Qwen3.5-4B, paged, prompt=512, max_output=128, skip-training)

3 runs per arm. Decode path = `model_forward_paged` (production HTTP/scheduler code path).

| Arm | Decode tok/s (median) | Mean ITL ms | P50 ITL ms | P99 ITL ms |
| --- | --- | --- | --- | --- |
| PRE (KILN_DISABLE_FUSED_CONV1D=1) | 45.10 | 22.17 | 22.14 | 26.22 |
| POST (fused kiln-conv1d-kernel) | 52.52 | 19.04 | 18.83 | 24.14 |

**Speedup = POST / PRE = 1.1644×** (ship floor: 1.03×)

### Verdict: SHIP

`1.16×` decode speedup on the :kiln/gdn/conv path exceeds the 1.03× ship floor. Kernel shipped as default-on; fallback retained behind `KILN_DISABLE_FUSED_CONV1D=1` for debugging.

### Parity
`cargo nextest run --release --features cuda -p kiln-model -E 'test(test_causal_conv1d_update_matches_fallback)'`: PASS.

### Pod
RunPod A6000, CUDA 12.8, KILN_CUDA_ARCHS=86, stock `runpod/pytorch:0.7.0-dev-cu1281-torch271-ubuntu2404` + cuda-nvcc/cudart/nvrtc/cublas/curand dev libs.

