### PR TITLE
desktop: About window

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -23,6 +23,7 @@ const ITEM_LOGS: &str = "view_logs";
 const ITEM_COPY_URL: &str = "copy_openai_url";
 const ITEM_OPEN_IN_BROWSER: &str = "open_in_browser";
 const ITEM_CHECK_UPDATES: &str = "check_updates";
+const ITEM_ABOUT: &str = "about";
 const ITEM_QUIT: &str = "quit";
 
 fn status_menu_text(state: &ServerState) -> String {
@@ -65,6 +66,7 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
     let logs = MenuItemBuilder::with_id(ITEM_LOGS, "View Logs").build(app)?;
     let check_updates =
         MenuItemBuilder::with_id(ITEM_CHECK_UPDATES, "Check for Updates…").build(app)?;
+    let about = MenuItemBuilder::with_id(ITEM_ABOUT, "About Kiln Desktop").build(app)?;
     let quit = MenuItemBuilder::with_id(ITEM_QUIT, "Quit").build(app)?;
 
     let menu = MenuBuilder::new(app)
@@ -77,6 +79,8 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
         .items(&[&start, &stop, &restart, &logs])
         .separator()
         .item(&check_updates)
+        .separator()
+        .item(&about)
         .separator()
         .item(&quit)
         .build()?;
@@ -161,6 +165,11 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                             eprintln!("[tray] emit menu://check-updates failed: {}", e);
                         }
                     });
+                }
+                ITEM_ABOUT => {
+                    if let Err(e) = open_about_window(&app_handle) {
+                        eprintln!("[tray] open_about_window failed: {}", e);
+                    }
                 }
                 ITEM_STATUS => {}
                 _ => {}
@@ -271,6 +280,22 @@ pub(crate) fn open_logs_window(app: &AppHandle) -> tauri::Result<()> {
         .title("Kiln Logs")
         .inner_size(900.0, 600.0)
         .resizable(true)
+        .visible(true)
+        .build()?;
+    win.set_focus()?;
+    Ok(())
+}
+
+pub(crate) fn open_about_window(app: &AppHandle) -> tauri::Result<()> {
+    if let Some(win) = app.get_webview_window("about") {
+        win.show()?;
+        win.set_focus()?;
+        return Ok(());
+    }
+    let win = WebviewWindowBuilder::new(app, "about", WebviewUrl::App("about.html".into()))
+        .title("About Kiln Desktop")
+        .inner_size(420.0, 380.0)
+        .resizable(false)
         .visible(true)
         .build()?;
     win.set_focus()?;

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -44,6 +44,15 @@
         "height": 600,
         "resizable": true,
         "visible": false
+      },
+      {
+        "label": "about",
+        "url": "about.html",
+        "title": "About Kiln Desktop",
+        "width": 420,
+        "height": 380,
+        "resizable": false,
+        "visible": false
       }
     ],
     "security": {

--- a/desktop/ui/about.html
+++ b/desktop/ui/about.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>About Kiln Desktop</title>
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+        background: #0f1115;
+        color: #e6e6e6;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        overflow: hidden;
+      }
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+      .wrap {
+        flex: 1 1 auto;
+        padding: 24px 28px 16px 28px;
+        box-sizing: border-box;
+        overflow-y: auto;
+      }
+      h1 {
+        font-size: 20px;
+        font-weight: 600;
+        margin: 0 0 4px 0;
+        color: #f0f2f6;
+      }
+      .version {
+        color: #a8aeb8;
+        font-size: 13px;
+        margin: 0 0 18px 0;
+        font-variant-numeric: tabular-nums;
+      }
+      p.desc {
+        color: #cfd3da;
+        font-size: 13px;
+        line-height: 1.55;
+        margin: 0 0 14px 0;
+      }
+      .meta {
+        color: #a8aeb8;
+        font-size: 12px;
+        line-height: 1.6;
+        margin: 14px 0 0 0;
+      }
+      .meta a {
+        color: #5f9bff;
+        text-decoration: none;
+      }
+      .meta a:hover {
+        text-decoration: underline;
+      }
+      footer {
+        flex: 0 0 auto;
+        display: flex;
+        justify-content: flex-end;
+        padding: 10px 14px;
+        background: #161922;
+        border-top: 1px solid #232733;
+      }
+      button {
+        background: #2a6df4;
+        color: #fff;
+        border: 0;
+        border-radius: 6px;
+        padding: 6px 14px;
+        font-size: 12px;
+        cursor: pointer;
+      }
+      button:hover { background: #3b7af5; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Kiln Desktop</h1>
+      <p class="version">Version <span id="version">…</span></p>
+      <p class="desc">
+        System tray app for the kiln local LLM server. Spawns and supervises
+        the kiln binary, exposes status and settings, and surfaces the
+        OpenAI-compatible base URL.
+      </p>
+      <p class="meta">
+        Repository:
+        <a id="repo-link" href="https://github.com/ericflo/kiln" target="_blank" rel="noopener noreferrer">github.com/ericflo/kiln</a>
+      </p>
+      <p class="meta">Licensed under MIT.</p>
+      <p class="meta">Built with Tauri.</p>
+    </div>
+    <footer>
+      <button id="close" type="button" title="Close (Esc)">Close</button>
+    </footer>
+    <script defer>
+      const invoke = (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
+        || (window.__TAURI__ && window.__TAURI__.invoke);
+
+      if (invoke) {
+        invoke("get_app_version").then((v) => {
+          document.getElementById("version").textContent = v;
+        }).catch(() => {
+          document.getElementById("version").textContent = "unknown";
+        });
+      } else {
+        document.getElementById("version").textContent = "unknown";
+      }
+
+      const repoLink = document.getElementById("repo-link");
+      repoLink.addEventListener("click", (e) => {
+        const shell = window.__TAURI__ && window.__TAURI__.shell;
+        if (shell && typeof shell.open === "function") {
+          e.preventDefault();
+          shell.open(repoLink.href).catch(() => {});
+        }
+      });
+
+      const closeBtn = document.getElementById("close");
+      function closeWindow() {
+        const win = window.__TAURI__ && window.__TAURI__.window;
+        const cur = win && typeof win.getCurrent === "function" ? win.getCurrent() : null;
+        if (cur && typeof cur.close === "function") {
+          cur.close();
+        } else {
+          window.close();
+        }
+      }
+      closeBtn.addEventListener("click", closeWindow);
+      document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          closeWindow();
+          return;
+        }
+        const mod = e.metaKey || e.ctrlKey;
+        if (!mod) return;
+        const lower = typeof e.key === "string" ? e.key.toLowerCase() : "";
+        if (lower === "w" || lower === "s") {
+          e.preventDefault();
+          closeWindow();
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## What

Adds a small About window reachable from the tray menu.

- New tray menu item **"About Kiln Desktop"**, placed in its own separator section between *Check for Updates…* and *Quit*.
- New `about.html` frontend with:
  - Title + version (populated via the existing `get_app_version` Tauri command).
  - Repository link to `https://github.com/ericflo/kiln` (opens via `window.__TAURI__.shell.open` when available, otherwise plain anchor fallback).
  - Short product description.
  - License line (MIT, per `LICENSE`).
  - "Built with Tauri." acknowledgment.
  - Close button + Esc / Cmd+W / Cmd+S keyboard shortcuts.
- New window entry in `tauri.conf.json` (label `about`, `420x380`, non-resizable, hidden by default).
- New `open_about_window` in `src/tray.rs` that mirrors `open_logs_window` (show+focus if already open, otherwise build a fresh `WebviewWindow`).

## Why

Standard polish — the tray already has Dashboard, Settings, Logs, Check for Updates, and Quit but no way to see the app version or the project's source/license. Fills that gap as part of the desktop polish phase.

## Files changed (3)

- `desktop/ui/about.html` (new)
- `desktop/tauri.conf.json` (append `about` window entry)
- `desktop/src/tray.rs` (`ITEM_ABOUT` const, menu item, handler branch, `open_about_window` fn)

## Validation

- `cargo check` inside `desktop/` fails locally in Cloud Eric with missing `glib-2.0` pkg-config — expected, documented in `kiln/desktop` agent notes; the repo's cross-platform CI matrix (ubuntu-22.04, windows-latest, macos-14) validates the real build.
- Reviewer smoke test: run the desktop app, right-click the tray → **About Kiln Desktop** → window opens showing the version, repo link, and license lines.