### PR TITLE
desktop: about window — diagnostic info

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -112,6 +112,22 @@ fn get_app_version() -> String {
 }
 
 #[derive(serde::Serialize)]
+struct DiagnosticInfo {
+    version: String,
+    os: String,
+    arch: String,
+}
+
+#[tauri::command]
+fn get_diagnostic_info() -> DiagnosticInfo {
+    DiagnosticInfo {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        os: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+    }
+}
+
+#[derive(serde::Serialize)]
 struct UpdateCheckResult {
     available: bool,
     version: Option<String>,
@@ -441,6 +457,7 @@ fn main() {
             open_settings,
             open_logs,
             get_app_version,
+            get_diagnostic_info,
             check_for_updates,
             install_update
         ])

--- a/desktop/ui/about.html
+++ b/desktop/ui/about.html
@@ -60,6 +60,7 @@
         flex: 0 0 auto;
         display: flex;
         justify-content: flex-end;
+        gap: 8px;
         padding: 10px 14px;
         background: #161922;
         border-top: 1px solid #232733;
@@ -74,12 +75,24 @@
         cursor: pointer;
       }
       button:hover { background: #3b7af5; }
+      button.secondary {
+        background: #232733;
+        color: #e6e6e6;
+      }
+      button.secondary:hover { background: #2c313f; }
+      .platform {
+        color: #a8aeb8;
+        font-size: 12px;
+        margin: 0 0 18px 0;
+        font-variant-numeric: tabular-nums;
+      }
     </style>
   </head>
   <body>
     <div class="wrap">
       <h1>Kiln Desktop</h1>
       <p class="version">Version <span id="version">…</span></p>
+      <p class="platform">OS: <span id="platform">…</span></p>
       <p class="desc">
         System tray app for the kiln local LLM server. Spawns and supervises
         the kiln binary, exposes status and settings, and surfaces the
@@ -93,20 +106,38 @@
       <p class="meta">Built with Tauri.</p>
     </div>
     <footer>
+      <button id="copy-diag" class="secondary" type="button" title="Copy version + OS info to clipboard">Copy diagnostic info</button>
       <button id="close" type="button" title="Close (Esc)">Close</button>
     </footer>
     <script defer>
       const invoke = (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
         || (window.__TAURI__ && window.__TAURI__.invoke);
 
+      const versionEl = document.getElementById("version");
+      const platformEl = document.getElementById("platform");
+      const diag = { version: "unknown", os: "unknown", arch: "unknown" };
+
+      function renderDiag() {
+        versionEl.textContent = diag.version;
+        platformEl.textContent = `${diag.os} (${diag.arch})`;
+      }
+
       if (invoke) {
-        invoke("get_app_version").then((v) => {
-          document.getElementById("version").textContent = v;
+        invoke("get_diagnostic_info").then((d) => {
+          if (d && typeof d === "object") {
+            if (d.version) diag.version = d.version;
+            if (d.os) diag.os = d.os;
+            if (d.arch) diag.arch = d.arch;
+          }
+          renderDiag();
         }).catch(() => {
-          document.getElementById("version").textContent = "unknown";
+          invoke("get_app_version").then((v) => {
+            if (v) diag.version = v;
+            renderDiag();
+          }).catch(renderDiag);
         });
       } else {
-        document.getElementById("version").textContent = "unknown";
+        renderDiag();
       }
 
       const repoLink = document.getElementById("repo-link");
@@ -115,6 +146,28 @@
         if (shell && typeof shell.open === "function") {
           e.preventDefault();
           shell.open(repoLink.href).catch(() => {});
+        }
+      });
+
+      const copyBtn = document.getElementById("copy-diag");
+      const COPY_LABEL = "Copy diagnostic info";
+      let copyResetTimer = null;
+      function flashCopy(label) {
+        if (copyResetTimer) clearTimeout(copyResetTimer);
+        copyBtn.textContent = label;
+        copyResetTimer = setTimeout(() => {
+          copyBtn.textContent = COPY_LABEL;
+          copyResetTimer = null;
+        }, 1200);
+      }
+      copyBtn.addEventListener("click", async () => {
+        const text = `Kiln Desktop v${diag.version}\nOS: ${diag.os} (${diag.arch})`;
+        try {
+          await navigator.clipboard.writeText(text);
+          flashCopy("Copied!");
+        } catch (err) {
+          flashCopy("Copy failed");
+          console.error("clipboard.writeText failed", err);
         }
       });
 


### PR DESCRIPTION
## What
About window now shows OS + architecture below the version and has a 'Copy diagnostic info' button that copies a short diagnostic blob (version + OS + arch) to the clipboard — useful for bug reports.

## Why
Polish: makes it trivial for users to share their exact version + platform when filing issues, instead of typing it manually. Builds on #167 (About window).

## Files
- `desktop/src/main.rs` — new `get_diagnostic_info` command returning `{ version, os, arch }` via `std::env::consts::OS/ARCH`; registered in `invoke_handler`. `get_app_version` retained for backward compat and used as a graceful-degradation fallback in the frontend.
- `desktop/ui/about.html` — new 'OS: <os> (<arch>)' line below the version; new 'Copy diagnostic info' secondary button in the footer that writes `Kiln Desktop v{version}\\nOS: {os} ({arch})` via `navigator.clipboard.writeText` (same pattern as dashboard.html Copy URL) and flashes 'Copied!' for 1200ms on success.

## Testing
`cargo check` in `desktop/` fails on Cloud Eric due to missing GTK libs (expected — see tauri-cargo-check-gtk-missing agent note); CI validates the Tauri build on GitHub runners. Uses only existing deps (no new plugin) — `std::env::consts` for OS/arch and the already-granted `clipboard-manager` / browser clipboard API.