### PR TITLE
desktop: graceful quit — stop kiln before exit

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -118,7 +118,12 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                     });
                 }
                 ITEM_QUIT => {
-                    app_handle.exit(0);
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(e) = supervisor.stop().await {
+                            eprintln!("[tray] quit: supervisor.stop failed (continuing): {}", e);
+                        }
+                        app_handle.exit(0);
+                    });
                 }
                 ITEM_DASHBOARD => {
                     if let Err(e) = open_dashboard_window(&app_handle) {


### PR DESCRIPTION
## What
On tray Quit, call `supervisor.stop().await` before `app_handle.exit(0)` so the kiln child process is terminated via its existing shutdown path instead of being orphaned as the parent exits.

## Why
Polish: ensures VRAM/CUDA context is released, port is freed, and no orphan kiln process lingers briefly after Quit. Reuses existing `Supervisor::stop()` logic. Matches the `Arc<Supervisor>` + `tauri::async_runtime::spawn` pattern already used by `ITEM_START`, `ITEM_STOP`, and `ITEM_RESTART`.

## Files
- `desktop/src/tray.rs` — `ITEM_QUIT` handler now spawns an async task that awaits `supervisor.stop()` (best-effort, logs on error) before calling `app_handle.exit(0)`.

## Testing
`cargo check` inside `desktop/` fails on Cloud Eric due to missing GTK/webkit2gtk system libs (expected per tauri-cargo-check-gtk-missing note); CI validates on GitHub runners. The change is a pure reordering using the same `Arc<Supervisor>` and `spawn` pattern as neighboring handlers — no new dependencies, no new commands.