### PR TITLE
Phase 6: fused L2-norm Q+K decode kernel — null result, ship as opt-in

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -133,10 +133,20 @@ groups on our side. Per the `kernel-vendoring-call-pattern-regression` note,
 the scope should be narrowed to the **decode-only (single-token)** call
 pattern so the vendored kernel does not regress prefill / chunk paths — a
 decode-specialized split of `chunk_gla_fwd` (or its underlying block-GLA
-step kernel) is the concrete target. Alternative narrower targets if
-`chunk_gla_fwd` is too broad: a fused `gated_norm`-then-`qk_norm` kernel
-on its own would still claim the **32.4 %** of decode those two regions
-own.
+step kernel) is the concrete target.
+
+> **Update 2026-04-19:** A standalone fused `qk_norm` kernel was attempted
+> as a narrower scope (the 14.9 % `:kiln/gdn/qk_norm` slice in isolation)
+> and produced a **null result** — see "Phase 6 — fused L2-norm Q+K
+> decode kernel (NULL RESULT, 2026-04-19)" below. The kernel is correct
+> but the dispatch overhead under `KILN_CUDA_GRAPHS=true` already
+> amortizes most of the candle-launch cost at replay time, leaving only
+> ~6 % of the qk_norm region to recover. **Do not propose another
+> standalone `qk_norm` fusion** without first invalidating the
+> dispatch-amortization argument. The `chunk_gla_fwd` direction (or a
+> fused `gated_norm + qk_norm` kernel that runs as a single dispatch
+> across both regions, claiming the combined **32.4 %**) is the only
+> remaining sensible scope here.
 
 Do **not** redirect to FlashInfer paged GQA decode: full-attn projections
 on Qwen3.5-4B (24 GDN + 8 full-attn layers) are still only ~3.5 % of
@@ -168,6 +178,160 @@ remains the governing preflight for any future FlashInfer proposal.
 - Total uptime at capture end: ~35 minutes (pull + clone + warmup + 3
   bench runs + 1 nsys capture + stats extraction).
 - Estimated pod cost: **~$0.30** (well under the Phase 6 budget).
+
+
+## Phase 6 — fused L2-norm Q+K decode kernel (NULL RESULT, 2026-04-19)
+
+Vendored a single-launch CUDA kernel that fuses
+`l2_normalize(Q) + scale(Q) + l2_normalize(K) + dtype-cast` (the
+`:kiln/gdn/qk_norm` region) into `kiln-rmsnorm-kernel` as
+`kiln_fused_l2_qk_norm`. The kernel is **correct** (3 parity tests at
+decode/prefill/batch shapes pass; the full 128-test `kiln-model`
+nextest suite passes) but **misses the task's 1.05× decode tok/s abort
+floor**. It is shipped **opt-in only** via
+`KILN_ENABLE_FUSED_L2_QK_NORM=1` — the candle reference path remains the
+production default. See `crates/kiln-model/src/forward.rs` step-5 doc
+comment for the in-tree pointer.
+
+### Bench result (Arm B, RTX A6000, 3 paired runs, 2026-04-19)
+
+`KILN_W4A16=1 KILN_CUDA_GRAPHS=true`, paged 512/128. Baseline disables
+the kernel; fused enables it. Same binary; same warm-up.
+
+| run        | decode tok/s | mean ITL ms | p50 ITL ms | p99 ITL ms |
+| ---------- | -----------: | ----------: | ---------: | ---------: |
+| baseline 1 |        51.67 |       19.35 |      19.12 |      23.85 |
+| baseline 2 |        40.19 |       24.88 |      24.93 |      31.17 |
+| baseline 3 |        50.81 |       19.68 |      19.63 |      24.78 |
+| **median** |    **50.81** |   **19.68** |  **19.63** |  **24.78** |
+| fused 1    |        50.64 |       19.75 |      19.71 |      20.25 |
+| fused 2    |        51.28 |       19.50 |      19.47 |      19.87 |
+| fused 3    |        51.63 |       19.37 |      19.39 |      22.53 |
+| **median** |    **51.28** |   **19.50** |  **19.47** |  **20.25** |
+
+| Metric                     | Baseline (median) | Fused (median) | Delta            |
+| -------------------------- | ----------------: | -------------: | :--------------- |
+| decode tok/s               |             50.81 |          51.28 | **+0.93 % (1.0093×)** |
+| mean ITL                   |          19.68 ms |       19.50 ms | -0.18 ms (-0.92 %) |
+| p50 ITL                    |          19.63 ms |       19.47 ms | -0.16 ms (-0.81 %) |
+| p99 ITL                    |          24.78 ms |       20.25 ms | -4.54 ms (-18.3 %) |
+| best-of-3 decode tok/s     |             51.67 |          51.63 | -0.07 % (0.9994×) |
+| run-to-run range           |   11.48 (40-52)   |   1.00 (50-52) | -10.5 (much tighter) |
+
+**Median speedup = 1.0093× — well below the task's 1.05× hard abort
+floor.** Best-of-3 is actually a hair slower (0.9994×). The only clearly
+positive signal is p99 ITL: tail latency tightens by ~4.5 ms (-18 %),
+and run-to-run variance collapses from an 11 tok/s spread to a 1 tok/s
+spread, suggesting the fused launch removes a small but real source of
+dispatch jitter. That p99 win is not enough to clear the bar.
+
+### Why the kernel won the math but lost the wallclock
+
+Per the post-PR #166 profile above, `:kiln/gdn/qk_norm` was 14.9 % of
+decode = ~2.93 ms of the median 19.68 ms ITL. Even fully eliminating
+that NVTX region would yield at most:
+
+    1 / (1 - 0.149) ≈ **1.175× decode speedup**
+
+The actual 0.18 ms median ITL improvement implies the kernel only
+shaved ~6 % of `:kiln/gdn/qk_norm`'s wallclock — far less than the
+~85 %+ savings that would be needed to land at the 1.05× floor. The
+qk_norm region is dominated not by the per-row arithmetic (rows = 16,
+hidden = 128 — trivially memory-bound at decode shape) but by:
+
+1. **Candle dispatch + graph-replay overhead** that survives the launch
+   collapse. The CUDA-graph capture at decode already amortizes most of
+   the ~11 underlying launches; collapsing them to 1 in the captured
+   graph saves graph nodes but not host-side cost per replay.
+2. **HBM round-trips** for the F32 intermediate buffers (`q_f32`,
+   `k_f32`, `q_squared`, `k_squared`, `q_sum_keepdim`, etc.) that
+   candle materializes. The fused kernel skips those, but the savings
+   per row are tiny relative to the per-block scheduling cost.
+
+The first point is the dominant explanation: under `KILN_CUDA_GRAPHS=true`
+the qk_norm chain is captured once and replayed every decode step, so
+the per-step "11 launches → 1" benefit at host code already mostly
+collapses to a no-op at replay time. That is also why p99 (which
+correlates with off-graph dispatch jitter) shows a clear win while mean
+tok/s does not.
+
+### Why ship the kernel as opt-in instead of deleting it
+
+1. **It is correct** — parity tests pass at decode (16×128), prefill
+   (1×512×128), and small-batch (4×8×128) shapes; the full nextest
+   suite is green. No regression.
+2. **Tail-latency improvement is real** — -18 % p99 ITL and a 10×
+   tighter run-to-run distribution. Workloads sensitive to ITL tail
+   variance (live token streaming, latency-SLO serving) may want to
+   opt in.
+3. **Future re-evaluation is cheap** — if a later optimization (e.g.
+   an opt-out of CUDA graphs at qk_norm, or a wider qk_norm region
+   that includes scale-fused dispatch) shifts the dispatch-overhead
+   balance, the kernel is already wired and tested. No re-implementation
+   needed.
+
+The kernel sits behind `KILN_ENABLE_FUSED_L2_QK_NORM=1` (note: enable,
+not disable). Default decode behavior is unchanged from PR #166.
+
+### Re-visit triggers
+
+A future PR can re-default this kernel to ON only if **all three**
+hold on a fresh `nsys` profile of current `main` using the same
+production path:
+
+1. `:kiln/gdn/qk_norm` NVTX region ≥ **10 %** of decode wall-clock
+   (it is 14.9 % today, but graph-replay amortization may have already
+   reduced it).
+2. The fused kernel produces a median **≥ 1.03×** decode tok/s
+   speedup on a 3-run paired bench (currently 1.0093×).
+3. There is a documented reason the dispatch-overhead amortization
+   no longer dominates (e.g. CUDA graphs disabled at this region for
+   a different reason, or a much wider fused region that includes
+   the upstream `q = a.broadcast_mul(...)` step).
+
+### Code shipped (branch `ce/phase6-qk-norm-fusion`)
+
+- `crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.{h,cu}` — single-block
+  per-row kernel, two warp-shuffle reductions sharing scratch shmem,
+  bf16 in/out, F32 reductions, hidden ≤ 8192 envelope.
+- `crates/kiln-rmsnorm-kernel/build.rs` — adds the new `.cu` to the cc
+  build.
+- `crates/kiln-rmsnorm-kernel/src/lib.rs` — `kiln_fused_l2_qk_norm` FFI
+  decl (line ~69), `supports_l2_qk_norm` capability gate, candle
+  wrapper `fused_l2_qk_norm`, `reference_l2_qk_norm` parity oracle, 3
+  `parity_l2_qk_norm_*` unit tests.
+- `crates/kiln-model/src/forward.rs` — step-5 region updated with the
+  opt-in dispatch (`KILN_ENABLE_FUSED_L2_QK_NORM`) and an in-tree
+  comment pointing here.
+
+### Preflight performed
+
+- HEAD verified `c2579a1` (post-#166).
+- `crates/kiln-rmsnorm-kernel/` already exists from the earlier RMSNorm
+  vendor; this is an additive `.cu` + extern, not a new crate.
+- `gh pr list` showed no overlapping open PR at preflight time.
+- Nextest suite passed before the bench (128 tests, full kiln-model
+  surface).
+
+### Pod / cost
+
+- Pod: `7s9x0e53pjoglc` (RunPod NVIDIA RTX A6000 on-demand, $0.79/hr —
+  spot was unavailable; on-demand mandated by `runpod-always-on-demand`
+  agent note).
+- Total uptime at capture end: ~75 minutes (image pull + manual clone +
+  `kiln-setup` + first build + 6 paired bench runs + result download).
+- Estimated pod cost: **~$1.00**.
+
+### Note on diagnostic capture
+
+`nsys 2023.4.4` (baked in `ghcr.io/ericflo/kiln-runpod:latest`) hits
+the `EventCollection::CheckOrder` finalization bug on this workload —
+the same bug noted in the earlier post-#158 / post-#166 sections. Both
+captures generated valid `.qdstrm` traces but `QdstrmImporter` exited
+non-zero before producing `.nsys-rep`. Bench data alone is the abort
+criterion per the task brief, so the missing NVTX share confirmation
+does not change the result; this is recorded for future captures
+(`nsys 2024.5.1` was used in the post-#166 profile and avoided the bug).
 
 
 ## Not next target — fused_recurrent GDN decode vendor (preflight, 2026-04-18)

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1398,16 +1398,49 @@ pub fn gated_deltanet_forward(
     };
 
     // --- Step 5: L2 normalize Q, K; scale Q by 1/sqrt(dk) ---
-    // Normalize in F32 for numerical stability (sqrt/div), then cast back to
-    // the input dtype so the recurrent loop below runs in bf16 (see Step 7).
+    //
+    // Two paths: a fused CUDA kernel
+    // (`kiln_rmsnorm_kernel::fused_l2_qk_norm`) that collapses the
+    // l2-normalize(Q) + scale(Q) + l2-normalize(K) + dtype-cast chain
+    // (~11 candle launches on tiny per-row tensors at decode shape) into a
+    // single launch, and the candle-op reference path that runs whenever the
+    // kernel is unavailable (CPU, non-bf16, out-of-envelope) or disabled
+    // via `KILN_DISABLE_FUSED_L2_QK_NORM=1`. Both produce bf16 outputs in
+    // `input_dtype`; only the kernel path skips the F32 round-trip through
+    // HBM. The candle path is the parity oracle exercised by
+    // `kiln-rmsnorm-kernel`'s `parity_l2_qk_norm_*` tests.
     let (q, k) = {
         kiln_nvtx::range!(c"kiln/gdn/qk_norm");
-        let q = l2_normalize(&q)?; // F32
-        let k = l2_normalize(&k)?; // F32
         let scale = 1.0 / (dk as f64).sqrt();
-        let q = (q * scale)?.to_dtype(input_dtype)?;
-        let k = k.to_dtype(input_dtype)?;
-        (q, k)
+
+        #[cfg(feature = "cuda")]
+        {
+            let disabled = std::env::var("KILN_DISABLE_FUSED_L2_QK_NORM").is_ok();
+            if !disabled
+                && input_dtype == DType::BF16
+                && kiln_rmsnorm_kernel::supports_l2_qk_norm(&q, &k)
+            {
+                let (q_out, k_out) =
+                    kiln_rmsnorm_kernel::fused_l2_qk_norm(&q, &k, scale as f32, 1e-6)
+                        .context("fused_l2_qk_norm kernel failed")?;
+                (q_out, k_out)
+            } else {
+                let q = l2_normalize(&q)?; // F32
+                let k = l2_normalize(&k)?; // F32
+                let q = (q * scale)?.to_dtype(input_dtype)?;
+                let k = k.to_dtype(input_dtype)?;
+                (q, k)
+            }
+        }
+
+        #[cfg(not(feature = "cuda"))]
+        {
+            let q = l2_normalize(&q)?; // F32
+            let k = l2_normalize(&k)?; // F32
+            let q = (q * scale)?.to_dtype(input_dtype)?;
+            let k = k.to_dtype(input_dtype)?;
+            (q, k)
+        }
     };
 
     // --- Step 6: Compute gates ---

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1399,24 +1399,36 @@ pub fn gated_deltanet_forward(
 
     // --- Step 5: L2 normalize Q, K; scale Q by 1/sqrt(dk) ---
     //
-    // Two paths: a fused CUDA kernel
-    // (`kiln_rmsnorm_kernel::fused_l2_qk_norm`) that collapses the
+    // Two paths: the candle-op reference path (default) and a fused CUDA
+    // kernel (`kiln_rmsnorm_kernel::fused_l2_qk_norm`) that collapses the
     // l2-normalize(Q) + scale(Q) + l2-normalize(K) + dtype-cast chain
     // (~11 candle launches on tiny per-row tensors at decode shape) into a
-    // single launch, and the candle-op reference path that runs whenever the
-    // kernel is unavailable (CPU, non-bf16, out-of-envelope) or disabled
-    // via `KILN_DISABLE_FUSED_L2_QK_NORM=1`. Both produce bf16 outputs in
-    // `input_dtype`; only the kernel path skips the F32 round-trip through
-    // HBM. The candle path is the parity oracle exercised by
-    // `kiln-rmsnorm-kernel`'s `parity_l2_qk_norm_*` tests.
+    // single launch.
+    //
+    // The fused kernel is **opt-in via `KILN_ENABLE_FUSED_L2_QK_NORM=1`**.
+    // Phase 6 wallclock validation on Arm B (RTX A6000, KILN_W4A16=1
+    // KILN_CUDA_GRAPHS=true, paged 512/128, 3 paired runs) measured a
+    // median speedup of 1.0093x — well below the task's 1.05x abort floor.
+    // Mean ITL improved by 0.18ms (0.92%); only p99 ITL showed a
+    // meaningful win (24.78ms -> 20.25ms, -18% tail latency) and the
+    // run-to-run variance tightened. The kernel is correct (parity tests
+    // and the full nextest suite pass) but the wallclock impact at the
+    // Qwen3.5-4B GDN decode shape (rows = 16, hidden = 128) does not meet
+    // the bar to engage by default. See PROFILING.md "Phase 6 fused
+    // qk_norm null result" for the full numbers and analysis.
+    //
+    // Both paths produce bf16 outputs in `input_dtype`; only the kernel
+    // path skips the F32 round-trip through HBM. The candle path is the
+    // parity oracle exercised by `kiln-rmsnorm-kernel`'s
+    // `parity_l2_qk_norm_*` tests.
     let (q, k) = {
         kiln_nvtx::range!(c"kiln/gdn/qk_norm");
         let scale = 1.0 / (dk as f64).sqrt();
 
         #[cfg(feature = "cuda")]
         {
-            let disabled = std::env::var("KILN_DISABLE_FUSED_L2_QK_NORM").is_ok();
-            if !disabled
+            let enabled = std::env::var("KILN_ENABLE_FUSED_L2_QK_NORM").is_ok();
+            if enabled
                 && input_dtype == DType::BF16
                 && kiln_rmsnorm_kernel::supports_l2_qk_norm(&q, &k)
             {

--- a/crates/kiln-rmsnorm-kernel/build.rs
+++ b/crates/kiln-rmsnorm-kernel/build.rs
@@ -41,6 +41,7 @@ fn main() {
     }
 
     build.file(csrc_dir.join("fused_rmsnorm.cu"));
+    build.file(csrc_dir.join("fused_l2_qk_norm.cu"));
 
     build.compile("kiln_rmsnorm_kernel");
 

--- a/crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.cu
+++ b/crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.cu
@@ -1,0 +1,174 @@
+// Kiln fused L2-norm(Q) + scale(Q) + L2-norm(K) kernel — single launch,
+// bf16 in/out, F32 reductions.
+//
+// Algorithm (matches `kiln-model::forward::l2_normalize` + the
+// `kiln/gdn/qk_norm` block in forward.rs:
+//
+//   inv_q = q_scale * rsqrt(sum_j(q[r,:]^2) + eps)        (F32)
+//   inv_k =          rsqrt(sum_j(k[r,:]^2) + eps)         (F32)
+//   q_out[r, j] = bf16(q[r, j] * inv_q)
+//   k_out[r, j] = bf16(k[r, j] * inv_k)
+//
+// Launch: one block per row, blockDim.x = 256. Each thread strides over the
+// hidden axis (`dk`) with stride == blockDim.x and accumulates per-thread
+// sum-of-squares for both Q and K in F32. Two warp-shuffle reductions share
+// the same shared-memory scratch (one barrier between them); the resulting
+// `inv_q` and `inv_k` are broadcast to all threads via shared memory before
+// the bf16 epilogue.
+//
+// Why fuse Q and K together: Q and K have identical layout and identical
+// sequencing — the candle path already runs both back-to-back, and at decode
+// shape (rows = 16, hidden = 128) the per-block work is tiny enough that the
+// dominant cost is launch overhead and HBM round-trips, not compute. Folding
+// both into one launch halves the launch count and reuses the same loaded
+// row data twice (once for sum-of-squares, once for the apply pass).
+//
+// Kept intentionally simple — no vectorised bf16 loads, no cp.async, no
+// tensor cores — for the same reason as fused_rmsnorm.cu: the goal is to
+// collapse ~11 candle launches into one, and the arithmetic is memory-bound.
+// Any row width up to 8192 is supported; Qwen3.5-4B uses dk = 128 here.
+
+#include "fused_l2_qk_norm.h"
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+namespace {
+
+constexpr int kThreadsPerBlock = 256;
+constexpr int kMaxWarps = kThreadsPerBlock / 32;  // 8
+
+__device__ __forceinline__ float warp_reduce_sum(float v) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset /= 2) {
+        v += __shfl_xor_sync(0xffffffffu, v, offset);
+    }
+    return v;
+}
+
+__device__ __forceinline__ float block_reduce_sum(float v, float *smem) {
+    int lane = threadIdx.x & 31;
+    int warp = threadIdx.x >> 5;
+
+    v = warp_reduce_sum(v);
+    if (lane == 0) {
+        smem[warp] = v;
+    }
+    __syncthreads();
+
+    // First warp reduces the per-warp partial sums.
+    if (warp == 0) {
+        int num_warps = blockDim.x >> 5;
+        float w = (lane < num_warps) ? smem[lane] : 0.0f;
+        w = warp_reduce_sum(w);
+        if (lane == 0) {
+            smem[0] = w;
+        }
+    }
+    __syncthreads();
+    return smem[0];
+}
+
+__global__ void fused_l2_qk_norm_kernel(
+    const __nv_bfloat16 *__restrict__ q_in,
+    const __nv_bfloat16 *__restrict__ k_in,
+    __nv_bfloat16 *__restrict__ q_out,
+    __nv_bfloat16 *__restrict__ k_out,
+    int hidden,
+    float q_scale,
+    float eps
+) {
+    int row = blockIdx.x;
+    const __nv_bfloat16 *q_row = q_in + static_cast<size_t>(row) * hidden;
+    const __nv_bfloat16 *k_row = k_in + static_cast<size_t>(row) * hidden;
+    __nv_bfloat16 *q_out_row = q_out + static_cast<size_t>(row) * hidden;
+    __nv_bfloat16 *k_out_row = k_out + static_cast<size_t>(row) * hidden;
+
+    __shared__ float smem[kMaxWarps];
+    __shared__ float s_inv_q;
+    __shared__ float s_inv_k;
+
+    // Pass 1: per-thread partial sums of squares for Q and K (F32 accumulators).
+    float q_sum_sq = 0.0f;
+    float k_sum_sq = 0.0f;
+    for (int j = threadIdx.x; j < hidden; j += blockDim.x) {
+        float qj = __bfloat162float(q_row[j]);
+        float kj = __bfloat162float(k_row[j]);
+        q_sum_sq += qj * qj;
+        k_sum_sq += kj * kj;
+    }
+
+    // Reduce Q sum-of-squares; broadcast `inv_q` (already premultiplied by
+    // `q_scale`) to every thread.
+    float q_total = block_reduce_sum(q_sum_sq, smem);
+    if (threadIdx.x == 0) {
+        s_inv_q = q_scale * rsqrtf(q_total + eps);
+    }
+    __syncthreads();
+
+    // Reduce K sum-of-squares; broadcast `inv_k` to every thread.
+    // `block_reduce_sum` overwrites `smem[*]` but `s_inv_q` lives in a
+    // separate shared-memory slot and survives the second reduction.
+    float k_total = block_reduce_sum(k_sum_sq, smem);
+    if (threadIdx.x == 0) {
+        s_inv_k = rsqrtf(k_total + eps);
+    }
+    __syncthreads();
+
+    float inv_q = s_inv_q;
+    float inv_k = s_inv_k;
+
+    // Pass 2: apply the scale + cast back to bf16 in one fused epilogue.
+    // Re-reading q_row / k_row is cheap (the L1/L2 caches still hold them
+    // from pass 1) and lets us avoid a second tensor allocation.
+    for (int j = threadIdx.x; j < hidden; j += blockDim.x) {
+        float qj = __bfloat162float(q_row[j]) * inv_q;
+        float kj = __bfloat162float(k_row[j]) * inv_k;
+        q_out_row[j] = __float2bfloat16(qj);
+        k_out_row[j] = __float2bfloat16(kj);
+    }
+}
+
+}  // namespace
+
+extern "C" kiln_l2_qk_norm_status_t kiln_fused_l2_qk_norm(
+    const void *q_in,
+    const void *k_in,
+    void *q_out,
+    void *k_out,
+    int rows,
+    int hidden,
+    float q_scale,
+    float eps,
+    void *stream
+) {
+    if (rows <= 0 || hidden <= 0) {
+        // No-op; nothing to compute. Treat as success so callers on zero-row
+        // inputs (e.g. empty prefill chunks) don't need to special-case.
+        return 0;
+    }
+    if (hidden > 8192) {
+        return 2;  // out-of-envelope; caller should fall back.
+    }
+
+    dim3 grid(rows);
+    dim3 block(kThreadsPerBlock);
+
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+
+    fused_l2_qk_norm_kernel<<<grid, block, 0, s>>>(
+        reinterpret_cast<const __nv_bfloat16 *>(q_in),
+        reinterpret_cast<const __nv_bfloat16 *>(k_in),
+        reinterpret_cast<__nv_bfloat16 *>(q_out),
+        reinterpret_cast<__nv_bfloat16 *>(k_out),
+        hidden,
+        q_scale,
+        eps
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 1;
+    }
+    return 0;
+}

--- a/crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.h
+++ b/crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.h
@@ -1,0 +1,76 @@
+// Kiln fused L2-norm(Q) + scale(Q) + L2-norm(K) C-ABI wrapper.
+//
+// Replaces the candle op chain used by `kiln-model::forward::l2_normalize`
+// at the GDN `kiln/gdn/qk_norm` step (forward.rs ~line 1402-1411):
+//
+//   q = to_dtype(F32) → sqr → sum_keepdim → +1e-6 → sqrt → broadcast_div
+//   q = q * (1/sqrt(dk)) → to_dtype(bf16)
+//   k = to_dtype(F32) → sqr → sum_keepdim → +1e-6 → sqrt → broadcast_div
+//   k = k.to_dtype(bf16)
+//
+// That is ~11 CUDA kernel launches on tiny per-row tensors during decode
+// (Qwen3.5-4B GDN decode shape: rows = batch * seq_len * Nv = 1*1*16,
+// hidden = dk = 128). Per PROFILING.md (post-PR #166), `:kiln/gdn/qk_norm`
+// is 14.9% of decode wallclock — the largest *unfused* GDN region.
+//
+// This kernel collapses the entire chain into one launch:
+//
+//   inv_q   = q_scale * rsqrt(sum(q^2) + eps)
+//   inv_k   =          rsqrt(sum(k^2) + eps)
+//   q_out   = bf16(q * inv_q)
+//   k_out   = bf16(k * inv_k)
+//
+// One block per row processes both Q and K (same shape, contiguous, bf16).
+// Two warp-shuffle reductions per block — one for Q sum-of-squares, one for
+// K — share the same shared-memory scratch and broadcast `inv_q` / `inv_k`
+// to all threads before the bf16 epilogue.
+//
+// Pointer layout (all bf16, all CUDA, all contiguous):
+//   q_in, k_in, q_out, k_out : [rows, hidden]
+//
+// Scope — forward-only, decode-first, minimal:
+//   - bf16 activations; F32 reductions and accumulators.
+//   - `hidden` <= 8192 (Qwen3.5-4B uses 128 here).
+//   - Any number of rows; blocks tile over rows, threads tile within a row.
+//   - `eps` passed as F32 — kiln uses 1e-6.
+//   - `q_scale` premultiplied into `inv_q` (kiln uses 1/sqrt(dk)).
+//
+// Not in scope:
+//   - Backward pass (decode/inference is forward-only).
+//   - Non-bf16 dtypes, non-contiguous layouts.
+//   - Mismatched Q/K shape (caller validates).
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int kiln_l2_qk_norm_status_t;
+
+// Fused L2-norm(Q) + scale(Q) + L2-norm(K) — single CUDA launch, bf16 in/out.
+//
+//   q_out[r, j] = bf16( q_in[r, j] * q_scale * rsqrt(sum_j(q_in[r,:]^2) + eps) )
+//   k_out[r, j] = bf16( k_in[r, j]           * rsqrt(sum_j(k_in[r,:]^2) + eps) )
+//
+// All pointers are bf16, contiguous, CUDA device memory.
+//
+// Returns 0 on success, 2 if `hidden` exceeds the kernel envelope (caller
+// should fall back), 1 on a CUDA launch error.
+kiln_l2_qk_norm_status_t kiln_fused_l2_qk_norm(
+    const void *q_in,
+    const void *k_in,
+    void *q_out,
+    void *k_out,
+    int rows,
+    int hidden,
+    float q_scale,
+    float eps,
+    void *stream
+);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/kiln-rmsnorm-kernel/src/lib.rs
+++ b/crates/kiln-rmsnorm-kernel/src/lib.rs
@@ -1,51 +1,52 @@
-//! Vendored fused RMSNorm CUDA kernel (Liger-style).
+//! Vendored fused norm CUDA kernels (Liger-style).
+//!
+//! This crate hosts decode-critical Liger-style fused norm kernels for kiln:
+//!
+//! 1. [`fused_rmsnorm`] — Qwen3.5-style RMSNorm `(1 + w) * x * rsqrt(mean(x^2) + eps)`.
+//!    Replaces the ~11 candle ops behind `kiln-model::forward::rms_norm`.
+//!    Used by `kiln/norm/pre_attn` and `kiln/norm/pre_mlp`.
+//! 2. [`fused_l2_qk_norm`] — fused L2-norm(Q) + scale(Q) + L2-norm(K) used by
+//!    GDN linear attention. Replaces the ~11 candle ops behind the
+//!    `kiln/gdn/qk_norm` block in `forward.rs`.
 //!
 //! # Why
 //!
-//! `kiln-model::forward::rms_norm` currently expresses Qwen3.5-style
-//! RMSNorm as a chain of candle ops:
-//!
-//! ```text
-//! to_dtype(F32) → sqr → mean_keepdim → + eps → sqrt → recip →
-//! broadcast_mul → to_dtype(F32 weight) → ones_like + w →
-//! broadcast_mul → to_dtype(bf16)
-//! ```
-//!
-//! That is ~11 CUDA kernel launches per RMSNorm. At decode time each
-//! launch has ~10 µs of per-launch overhead, and the intermediate F32
-//! tensors round-trip through HBM on every step. Per PROFILING.md
-//! (post-PR #130), the two RMSNorm NVTX ranges `kiln/norm/pre_attn`
-//! (11.1 %) and `kiln/norm/pre_mlp` (11.0 %) combine for ~22 % of
-//! decode wallclock and are the #1 hotspot of the current profile.
-//!
-//! This crate collapses those ~11 launches into a single fused kernel
-//! (`fused_rmsnorm_kernel` in `csrc/fused_rmsnorm.cu`): one block per
-//! row, 256 threads per block, F32 reduction + F32 epilogue accumulator,
-//! bf16 load/store.
+//! Both norm chains expand into ~11 CUDA kernel launches per call when
+//! expressed as candle ops. At decode time each launch has ~10 µs of
+//! per-launch overhead, and the intermediate F32 tensors round-trip through
+//! HBM on every step. Per PROFILING.md, the two RMSNorm NVTX ranges combined
+//! for ~22% of decode wallclock pre-fusion (PR #130 era), and `kiln/gdn/qk_norm`
+//! is 14.9% of decode wallclock post-PR #166 — the largest *unfused* GDN
+//! region. Fusing each chain into a single kernel collapses launch overhead
+//! and HBM traffic into one launch + one round-trip per call.
 //!
 //! # Provenance
 //!
-//! Algorithm modelled after LinkedIn's Liger-Kernel `fused_rmsnorm`
+//! Algorithm modelled after LinkedIn's Liger-Kernel
 //! (<https://github.com/linkedin/Liger-Kernel>, `src/liger_kernel/ops/rms_norm.py`),
 //! reimplemented in raw CUDA C so kiln doesn't add a Triton runtime
 //! dependency. Matches kiln's Qwen3.5 convention of `(1 + w) * x * rms_inv`
-//! (weights are centred on 0, not on 1).
+//! (weights centred on 0, not on 1) for RMSNorm; matches the
+//! `kiln-model::forward::l2_normalize` contract `x / sqrt(sum(x^2) + eps)`
+//! for the QK fused norm.
 //!
-//! # API
+//! # APIs
 //!
-//! - [`fused_rmsnorm`] — candle-compatible wrapper. Accepts any bf16 input
-//!   whose last dim is the normalised axis; flattens leading dims, runs
-//!   the kernel, and reshapes back. Only forward pass.
+//! - [`fused_rmsnorm`] — candle-compatible wrapper around the RMSNorm kernel.
+//! - [`supports`] — `(x, weight)` capability check for the RMSNorm kernel.
+//! - [`fused_l2_qk_norm`] — candle-compatible wrapper around the GDN QK
+//!   fused-norm kernel. Returns `(q_out, k_out)`.
+//! - [`supports_l2_qk_norm`] — capability check for the QK kernel.
 //!
 //! # Envelope
 //!
-//! - bf16 activations, bf16 weights.
+//! - bf16 activations, bf16 weights, bf16 outputs.
 //! - Contiguous CUDA tensors only.
-//! - Last dim (`hidden`) must be <= 8192. Qwen3.5-4B uses 2560.
-//! - `eps` is F32 — kiln uses 1e-6 for Qwen3.5.
+//! - Last dim (`hidden`) must be <= 8192.
+//! - `eps` is F32 — kiln uses 1e-6 for both kernels.
 //!
 //! Out of scope: backward pass, fused GEMM prologue, non-bf16 dtypes,
-//! non-contiguous input, unpaired cast (`weight` of a different dtype).
+//! non-contiguous input.
 
 use candle_core::{
     backend::BackendStorage,
@@ -61,6 +62,18 @@ unsafe extern "C" {
         out: *mut core::ffi::c_void,
         rows: i32,
         hidden: i32,
+        eps: f32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
+    fn kiln_fused_l2_qk_norm(
+        q_in: *const core::ffi::c_void,
+        k_in: *const core::ffi::c_void,
+        q_out: *mut core::ffi::c_void,
+        k_out: *mut core::ffi::c_void,
+        rows: i32,
+        hidden: i32,
+        q_scale: f32,
         eps: f32,
         stream: *mut core::ffi::c_void,
     ) -> i32;
@@ -187,6 +200,151 @@ pub fn fused_rmsnorm(x: &Tensor, weight: &Tensor, eps: f32) -> Result<Tensor> {
     }
 
     Ok(out)
+}
+
+/// Whether the fused L2 QK-norm kernel is available for the given Q, K tensors.
+///
+/// Both must be CUDA + bf16 + contiguous, with identical shape, last dim <= 8192.
+/// Decode shape on Qwen3.5-4B is `[batch, seq, nv, dk]` with `dk = 128`.
+pub fn supports_l2_qk_norm(q: &Tensor, k: &Tensor) -> bool {
+    matches!(q.device(), Device::Cuda(_))
+        && matches!(k.device(), Device::Cuda(_))
+        && q.dtype() == DType::BF16
+        && k.dtype() == DType::BF16
+        && q.is_contiguous()
+        && k.is_contiguous()
+        && q.dims() == k.dims()
+        && q.rank() >= 1
+        && q.dims().last().copied().unwrap_or(0) <= 8192
+}
+
+/// Run the fused L2 QK-norm kernel.
+///
+/// Inputs:
+///   - `q`, `k`: bf16, CUDA, contiguous, identical shape; last dim is the
+///     normalised axis (`dk`). Decode shape: `[batch=1, seq=1, nv, dk]`.
+///   - `q_scale`: scalar applied to Q after L2-normalisation. kiln uses
+///     `1 / sqrt(dk)`.
+///   - `eps`: epsilon inside the rsqrt. kiln uses 1e-6.
+///
+/// Returns `(q_out, k_out)`, freshly allocated bf16 tensors with the same
+/// shape as the inputs.
+///
+/// Semantics — matches `kiln-model::forward::l2_normalize` + the
+/// `kiln/gdn/qk_norm` block in forward.rs exactly:
+///
+///   q_out = (q / sqrt(sum(q^2, dim=-1) + eps)) * q_scale, cast to bf16
+///   k_out =  k / sqrt(sum(k^2, dim=-1) + eps),            cast to bf16
+pub fn fused_l2_qk_norm(
+    q: &Tensor,
+    k: &Tensor,
+    q_scale: f32,
+    eps: f32,
+) -> Result<(Tensor, Tensor)> {
+    let device = q.device();
+
+    if q.dtype() != DType::BF16 || k.dtype() != DType::BF16 {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: l2_qk_norm requires bf16 inputs (got {:?}, {:?})",
+            q.dtype(),
+            k.dtype()
+        );
+    }
+    if q.dims() != k.dims() {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: l2_qk_norm requires q.dims == k.dims (got {:?}, {:?})",
+            q.dims(),
+            k.dims()
+        );
+    }
+
+    let dims = q.dims().to_vec();
+    let hidden = *dims.last().ok_or_else(|| {
+        candle_core::Error::Msg("kiln-rmsnorm-kernel: q must have rank >= 1".to_string())
+    })?;
+
+    if hidden > 8192 {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: l2_qk_norm hidden dim {hidden} exceeds envelope (<= 8192)"
+        );
+    }
+
+    let rows: usize = dims[..dims.len() - 1].iter().product();
+
+    let q_out = Tensor::zeros(dims.as_slice(), DType::BF16, device)?;
+    let k_out = Tensor::zeros(dims.as_slice(), DType::BF16, device)?;
+
+    if rows == 0 {
+        return Ok((q_out, k_out));
+    }
+
+    let q = q.contiguous()?;
+    let k = k.contiguous()?;
+
+    {
+        let (q_storage, q_layout) = q.storage_and_layout();
+        let (k_storage, k_layout) = k.storage_and_layout();
+        let (qo_storage, qo_layout) = q_out.storage_and_layout();
+        let (ko_storage, ko_layout) = k_out.storage_and_layout();
+
+        let q_cuda = match &*q_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: q must be on CUDA"),
+        };
+        let k_cuda = match &*k_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: k must be on CUDA"),
+        };
+        let qo_cuda = match &*qo_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: q_out must be on CUDA"),
+        };
+        let ko_cuda = match &*ko_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: k_out must be on CUDA"),
+        };
+
+        let stream = q_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let q_slice = q_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(q_layout.start_offset()..);
+        let k_slice = k_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(k_layout.start_offset()..);
+        let qo_slice = qo_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(qo_layout.start_offset()..);
+        let ko_slice = ko_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(ko_layout.start_offset()..);
+
+        unsafe {
+            let (q_ptr, _g1) = q_slice.device_ptr(&stream);
+            let (k_ptr, _g2) = k_slice.device_ptr(&stream);
+            let (qo_ptr, _g3) = qo_slice.device_ptr(&stream);
+            let (ko_ptr, _g4) = ko_slice.device_ptr(&stream);
+
+            let status = kiln_fused_l2_qk_norm(
+                q_ptr as *const _,
+                k_ptr as *const _,
+                qo_ptr as *mut _,
+                ko_ptr as *mut _,
+                rows as i32,
+                hidden as i32,
+                q_scale,
+                eps,
+                raw_stream,
+            );
+
+            if status != 0 {
+                candle_core::bail!("kiln_fused_l2_qk_norm failed with status {status}");
+            }
+        }
+    }
+
+    Ok((q_out, k_out))
 }
 
 #[cfg(test)]
@@ -367,6 +525,194 @@ mod tests {
         assert!(
             diff < 1e-2,
             "parity failed: max_abs_diff={diff} exceeds 1e-2 tolerance"
+        );
+    }
+
+    // ----- L2 QK-norm parity (matches `kiln-model::forward::l2_normalize`
+    // followed by the `q * scale` + `to_dtype(bf16)` epilogue used in the
+    // `kiln/gdn/qk_norm` block). -----
+
+    fn reference_l2_qk_norm(
+        q: &Tensor,
+        k: &Tensor,
+        q_scale: f64,
+        eps: f64,
+    ) -> Result<(Tensor, Tensor)> {
+        let dtype = q.dtype();
+
+        let q_f32 = q.to_dtype(DType::F32)?;
+        let q_sq = q_f32.sqr()?.sum_keepdim(candle_core::D::Minus1)?;
+        let q_norm = (q_sq + eps)?.sqrt()?;
+        let q_normed = q_f32.broadcast_div(&q_norm)?;
+        let q_out = (q_normed * q_scale)?.to_dtype(dtype)?;
+
+        let k_f32 = k.to_dtype(DType::F32)?;
+        let k_sq = k_f32.sqr()?.sum_keepdim(candle_core::D::Minus1)?;
+        let k_norm = (k_sq + eps)?.sqrt()?;
+        let k_normed = k_f32.broadcast_div(&k_norm)?;
+        let k_out = k_normed.to_dtype(dtype)?;
+
+        Ok((q_out, k_out))
+    }
+
+    fn max_abs_diff(a: &Tensor, b: &Tensor) -> f32 {
+        (a - b)
+            .unwrap()
+            .to_dtype(DType::F32)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap()
+    }
+
+    fn fill_pseudo_random(buf: &mut Vec<f32>, n: usize, seed: u32, scale: f32) {
+        let mut state = seed;
+        for _ in 0..n {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            let f = ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0;
+            buf.push(f * scale);
+        }
+    }
+
+    #[test]
+    fn parity_l2_qk_norm_decode_shape() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        // Qwen3.5-4B GDN decode shape: [batch=1, seq=1, nv=16, dk=128]
+        let batch = 1usize;
+        let seq = 1usize;
+        let nv = 16usize;
+        let dk = 128usize;
+        let total = batch * seq * nv * dk;
+        let q_scale = 1.0 / (dk as f64).sqrt();
+        let eps = 1e-6;
+
+        let mut q_raw = Vec::with_capacity(total);
+        let mut k_raw = Vec::with_capacity(total);
+        fill_pseudo_random(&mut q_raw, total, 0x1357_9bdf, 0.5);
+        fill_pseudo_random(&mut k_raw, total, 0x2468_ace0, 0.5);
+
+        let q_f32 = Tensor::from_vec(q_raw, (batch, seq, nv, dk), &device).unwrap();
+        let k_f32 = Tensor::from_vec(k_raw, (batch, seq, nv, dk), &device).unwrap();
+        let q = q_f32.to_dtype(DType::BF16).unwrap();
+        let k = k_f32.to_dtype(DType::BF16).unwrap();
+
+        let (q_ref, k_ref) = reference_l2_qk_norm(&q, &k, q_scale, eps).unwrap();
+        let (q_fused, k_fused) =
+            fused_l2_qk_norm(&q, &k, q_scale as f32, eps as f32).unwrap();
+
+        assert_eq!(q_fused.dims(), &[batch, seq, nv, dk]);
+        assert_eq!(k_fused.dims(), &[batch, seq, nv, dk]);
+
+        let q_diff = max_abs_diff(&q_ref, &q_fused);
+        let k_diff = max_abs_diff(&k_ref, &k_fused);
+
+        // bf16 tolerance: 1e-2 matches the existing rmsnorm tests. Both
+        // outputs are bf16, both reductions are F32, so this is the right
+        // bar.
+        assert!(
+            q_diff < 1e-2,
+            "Q parity failed: max_abs_diff={q_diff} exceeds 1e-2 tolerance"
+        );
+        assert!(
+            k_diff < 1e-2,
+            "K parity failed: max_abs_diff={k_diff} exceeds 1e-2 tolerance"
+        );
+    }
+
+    #[test]
+    fn parity_l2_qk_norm_prefill_shape() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        // Prefill-like shape with Qwen3.5-4B GDN dims:
+        // [batch=1, seq=512, nv=16, dk=128] — 8192 rows.
+        let batch = 1usize;
+        let seq = 512usize;
+        let nv = 16usize;
+        let dk = 128usize;
+        let total = batch * seq * nv * dk;
+        let q_scale = 1.0 / (dk as f64).sqrt();
+        let eps = 1e-6;
+
+        let mut q_raw = Vec::with_capacity(total);
+        let mut k_raw = Vec::with_capacity(total);
+        fill_pseudo_random(&mut q_raw, total, 0xdead_beef, 0.7);
+        fill_pseudo_random(&mut k_raw, total, 0xfeed_face, 0.7);
+
+        let q_f32 = Tensor::from_vec(q_raw, (batch, seq, nv, dk), &device).unwrap();
+        let k_f32 = Tensor::from_vec(k_raw, (batch, seq, nv, dk), &device).unwrap();
+        let q = q_f32.to_dtype(DType::BF16).unwrap();
+        let k = k_f32.to_dtype(DType::BF16).unwrap();
+
+        let (q_ref, k_ref) = reference_l2_qk_norm(&q, &k, q_scale, eps).unwrap();
+        let (q_fused, k_fused) =
+            fused_l2_qk_norm(&q, &k, q_scale as f32, eps as f32).unwrap();
+
+        assert_eq!(q_fused.dims(), &[batch, seq, nv, dk]);
+        assert_eq!(k_fused.dims(), &[batch, seq, nv, dk]);
+
+        let q_diff = max_abs_diff(&q_ref, &q_fused);
+        let k_diff = max_abs_diff(&k_ref, &k_fused);
+
+        assert!(
+            q_diff < 1e-2,
+            "Q parity failed: max_abs_diff={q_diff} exceeds 1e-2 tolerance"
+        );
+        assert!(
+            k_diff < 1e-2,
+            "K parity failed: max_abs_diff={k_diff} exceeds 1e-2 tolerance"
+        );
+    }
+
+    #[test]
+    fn parity_l2_qk_norm_batch_two() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        // [batch=2, seq=1, nv=16, dk=128] — exercises the multi-batch path.
+        let batch = 2usize;
+        let seq = 1usize;
+        let nv = 16usize;
+        let dk = 128usize;
+        let total = batch * seq * nv * dk;
+        let q_scale = 1.0 / (dk as f64).sqrt();
+        let eps = 1e-6;
+
+        let mut q_raw = Vec::with_capacity(total);
+        let mut k_raw = Vec::with_capacity(total);
+        fill_pseudo_random(&mut q_raw, total, 0x1234_5678, 0.4);
+        fill_pseudo_random(&mut k_raw, total, 0xaaaa_5555, 0.4);
+
+        let q_f32 = Tensor::from_vec(q_raw, (batch, seq, nv, dk), &device).unwrap();
+        let k_f32 = Tensor::from_vec(k_raw, (batch, seq, nv, dk), &device).unwrap();
+        let q = q_f32.to_dtype(DType::BF16).unwrap();
+        let k = k_f32.to_dtype(DType::BF16).unwrap();
+
+        let (q_ref, k_ref) = reference_l2_qk_norm(&q, &k, q_scale, eps).unwrap();
+        let (q_fused, k_fused) =
+            fused_l2_qk_norm(&q, &k, q_scale as f32, eps as f32).unwrap();
+
+        let q_diff = max_abs_diff(&q_ref, &q_fused);
+        let k_diff = max_abs_diff(&k_ref, &k_fused);
+
+        assert!(
+            q_diff < 1e-2,
+            "Q parity failed: max_abs_diff={q_diff} exceeds 1e-2 tolerance"
+        );
+        assert!(
+            k_diff < 1e-2,
+            "K parity failed: max_abs_diff={k_diff} exceeds 1e-2 tolerance"
         );
     }
 }


### PR DESCRIPTION
## Summary

Phase 6 task: collapse the `:kiln/gdn/qk_norm` decode region (14.9% of decode wallclock per the post-PR #166 profile) into a single fused CUDA kernel. The kernel is **correct** but **misses the task's 1.05× decode tok/s abort floor**, so it is shipped **opt-in only** via `KILN_ENABLE_FUSED_L2_QK_NORM=1`. The candle reference path remains the production default.

## Bench result (Arm B, RTX A6000, 3 paired runs)

`KILN_W4A16=1 KILN_CUDA_GRAPHS=true`, paged 512/128. Same binary; baseline disables the kernel via env var, fused enables it.

| Metric                 | Baseline (median) | Fused (median) | Delta                |
| ---------------------- | ----------------: | -------------: | :------------------- |
| **decode tok/s**       |             50.81 |          51.28 | **+0.93% (1.0093×)** |
| mean ITL               |          19.68 ms |       19.50 ms | -0.18 ms (-0.92%)    |
| p50 ITL                |          19.63 ms |       19.47 ms | -0.16 ms (-0.81%)    |
| **p99 ITL**            |          24.78 ms |       20.25 ms | **-4.54 ms (-18.3%)** |
| best-of-3 decode tok/s |             51.67 |          51.63 | -0.07% (0.9994×)     |
| run-to-run range       |     11.48 (40-52) |     1.00 (50-52) | **-10.5 (10× tighter)** |

**Median speedup = 1.0093× — well below the task's 1.05× hard abort floor.**

The only clearly positive signals are p99 ITL (-18% tail latency) and run-to-run variance (10× tighter), suggesting the fused launch removes a small but real source of dispatch jitter. That is not enough to clear the bar.

## Why the kernel won the math but lost the wallclock

`:kiln/gdn/qk_norm` is 14.9% of decode = ~2.93 ms of the median 19.68 ms ITL. The math ceiling for fully eliminating it is **1.175× decode speedup**. The actual 0.18 ms median ITL improvement implies the kernel only shaved ~6% of the qk_norm region.

The dominant explanation: under `KILN_CUDA_GRAPHS=true` the qk_norm chain is captured once and replayed every decode step, so the per-step "11 launches → 1" benefit at host code already mostly collapses to a no-op at replay time. That is also why p99 (which correlates with off-graph dispatch jitter) shows a clear win while mean tok/s does not.

## Why ship the kernel at all (opt-in)

1. **It is correct** — 3 parity tests at decode/prefill/batch shapes pass; the full 128-test `kiln-model` nextest suite passes. No regression.
2. **Tail-latency improvement is real** — workloads sensitive to ITL tail variance (live token streaming, latency-SLO serving) may want it.
3. **Future re-evaluation is cheap** — if a later optimization shifts the dispatch-overhead balance, the kernel is already wired and tested.

The kernel sits behind `KILN_ENABLE_FUSED_L2_QK_NORM=1` (note: enable, not disable). Default decode behavior is unchanged from PR #166.

## What changed

- **`crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.{h,cu}`** — single-block per-row CUDA kernel, two warp-shuffle reductions sharing scratch shmem, bf16 in/out, F32 reductions, hidden ≤ 8192 envelope.
- **`crates/kiln-rmsnorm-kernel/build.rs`** — adds the new `.cu` to the cc build.
- **`crates/kiln-rmsnorm-kernel/src/lib.rs`** — `kiln_fused_l2_qk_norm` FFI decl, `supports_l2_qk_norm` capability gate, `fused_l2_qk_norm` candle wrapper, `reference_l2_qk_norm` parity oracle, 3 `parity_l2_qk_norm_*` unit tests.
- **`crates/kiln-model/src/forward.rs`** — step-5 region updated with the **opt-in** dispatch (`KILN_ENABLE_FUSED_L2_QK_NORM`) and an in-tree comment pointing to the PROFILING.md null-result section.
- **`PROFILING.md`** — new "Phase 6 — fused L2-norm Q+K decode kernel (NULL RESULT, 2026-04-19)" section with bench table, math ceiling analysis, dispatch-amortization explanation, and re-visit triggers. The post-PR #166 "Recommended next optimization target" block also gets a do-not-retry note for standalone qk_norm fusion.

## Re-visit triggers

A future PR can re-default this kernel to ON only if **all three** hold on a fresh `nsys` profile of current `main`:

1. `:kiln/gdn/qk_norm` NVTX region ≥ **10%** of decode wall-clock (it is 14.9% today; may be lower after graph-replay amortization).
2. The fused kernel produces a median **≥ 1.03×** decode tok/s speedup on a 3-run paired bench (currently 1.0093×).
3. There is a documented reason the dispatch-overhead amortization no longer dominates (e.g. CUDA graphs disabled at this region for a different reason, or a much wider fused region that includes the upstream `q = a.broadcast_mul(...)` step).

## Test plan

- [x] `cargo nextest run -p kiln-rmsnorm-kernel` on Arm B — all 6 tests pass (3 existing rmsnorm + 3 new l2_qk_norm parity at decode/prefill/batch shapes, tolerance < 1e-2).
- [x] `cargo nextest run -p kiln-model --features cuda` on Arm B — all 128 tests pass (no regression in the candle default path or in any kernel-enabled test).
- [x] 3 paired baseline + fused `kiln-bench --paged --prompt-tokens 512 --max-output-tokens 128` runs on Arm B with `KILN_W4A16=1 KILN_CUDA_GRAPHS=true` — see bench table above.
- [x] `cargo check -p kiln-model` (CPU-only) — clean (pre-existing warnings only).

## Cost

Pod `7s9x0e53pjoglc` (RTX A6000, on-demand, $0.79/hr) — total ~75 min uptime, ~\$1.00.

## Note on diagnostic capture

`nsys 2023.4.4` (baked in `ghcr.io/ericflo/kiln-runpod:latest`) hits the `EventCollection::CheckOrder` finalization bug on this workload (same bug noted in earlier post-#158 / post-#166 sections). Both nsys captures generated valid `.qdstrm` traces but `QdstrmImporter` exited non-zero before producing `.nsys-rep`. Bench data alone is the abort criterion per the task brief, so the missing NVTX share confirmation does not change the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)