### PR TITLE
desktop: replace stale Scaffold-only placeholder in ui/index.html

### DIFF
--- a/desktop/ui/index.html
+++ b/desktop/ui/index.html
@@ -23,15 +23,15 @@
         box-sizing: border-box;
       }
       h1 { font-size: 22px; margin: 0 0 8px 0; font-weight: 600; }
-      p  { margin: 4px 0; color: #a8aeb8; font-size: 14px; }
-      code { background: #1b1e24; padding: 2px 6px; border-radius: 4px; font-size: 13px; }
+      p  { margin: 8px 0; color: #a8aeb8; font-size: 14px; max-width: 560px; }
+      p.hint { color: #6b7280; font-size: 12px; }
     </style>
   </head>
   <body>
     <div class="wrap">
       <h1>Kiln Desktop</h1>
-      <p>Scaffold only. Tray, server supervision, and dashboard coming soon.</p>
-      <p>Build locally with <code>cd desktop &amp;&amp; cargo check</code>.</p>
+      <p>Running in the system tray. Click the Kiln icon in your menu bar or system tray to open the dashboard, change settings, view logs, or quit.</p>
+      <p class="hint">If you do not see the tray icon, check that the app is running and that your OS is showing tray icons.</p>
     </div>
   </body>
 </html>


### PR DESCRIPTION
## What
Replace the original scaffold placeholder in desktop/ui/index.html ("Scaffold only. Tray, server supervision, and dashboard coming soon.") with accurate copy describing the tray-only UX.

## Why
All scaffold-era features (tray, supervisor, dashboard, settings, logs, about, notifications, keyboard shortcuts) have shipped. The placeholder text is misleading. The file itself must remain because tauri.conf.json sets frontendDist: "ui" and Tauri requires an index.html at the dist root, even though no window currently loads it (tray.rs creates dashboard/settings/logs/about windows with explicit URLs).

## Test plan
- [x] HTML-only change; cargo check skipped per known Cloud Eric limitation (no GTK/webkit2gtk)
- [ ] CI matrix (windows-latest, ubuntu-22.04, macos-14) builds green