### PR TITLE
desktop: dashboard toolbar wraps gracefully at narrow widths

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -73,9 +73,17 @@
         position: absolute;
         top: 8px;
         right: 12px;
+        left: 12px;
+        max-width: calc(100vw - 24px);
         display: flex;
+        flex-wrap: wrap;
+        justify-content: flex-end;
         gap: 8px;
         z-index: 10;
+        background: rgba(15, 17, 21, 0.85);
+        backdrop-filter: blur(4px);
+        padding: 6px 8px;
+        border-radius: 8px;
       }
       #toolbar button {
         margin-top: 0;


### PR DESCRIPTION
## What
The dashboard toolbar packs 6 status pills + 6 action buttons into a single non-wrapping flex row pinned `right: 12px`, with natural width ~1500px. The default dashboard window is 1024x768, so the toolbar overflows leftward off-screen on first launch.

## Change
- Add `flex-wrap: wrap;`, `justify-content: flex-end;`, `left: 12px;`, and `max-width: calc(100vw - 24px);` to `#toolbar` so items wrap into multiple right-aligned rows when the window is narrow.
- Add a translucent backdrop (`rgba(15, 17, 21, 0.85)` with `backdrop-filter: blur(4px)`) plus small padding + rounded corners so wrapped rows do not visually clash with the iframe behind.

## Why
World-class polish: nothing should overflow off-screen at the app's own default window size.