### PR TITLE
CE: Phase 6 fused GDN recurrent + qk_norm + gated_norm decode kernel (null result, ship opt-in)

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -143,10 +143,21 @@ step kernel) is the concrete target.
 > amortizes most of the candle-launch cost at replay time, leaving only
 > ~6 % of the qk_norm region to recover. **Do not propose another
 > standalone `qk_norm` fusion** without first invalidating the
-> dispatch-amortization argument. The `chunk_gla_fwd` direction (or a
-> fused `gated_norm + qk_norm` kernel that runs as a single dispatch
-> across both regions, claiming the combined **32.4 %**) is the only
-> remaining sensible scope here.
+> dispatch-amortization argument.
+>
+> **Update 2026-04-19 (follow-up):** A second attempt fused
+> `qk_norm + recurrent + gated_norm` (the combined 32.4 % scope
+> recommended above) into a single CUDA kernel that absorbs all three
+> regions in-register. Also a **null result** — see "Phase 6 — fused
+> GDN recurrent + qk_norm + gated_norm decode kernel (NULL RESULT,
+> 2026-04-19)" below. Median speedup 1.0140×, below the 1.05× floor.
+> Same ceiling: graph-replay dispatch-cost amortization dominates,
+> so collapsing candle launches into one fused kernel is not enough
+> to clear the bar even at 32 % of decode. **The `chunk_gla_fwd`
+> direction is no longer recommended** for the same reason. Future
+> decode-side fusion work should target the graph-replay dispatch
+> cost itself (or the HBM round-trips for F32 intermediates) rather
+> than collapsing candle launches further.
 
 Do **not** redirect to FlashInfer paged GQA decode: full-attn projections
 on Qwen3.5-4B (24 GDN + 8 full-attn layers) are still only ~3.5 % of
@@ -332,6 +343,159 @@ non-zero before producing `.nsys-rep`. Bench data alone is the abort
 criterion per the task brief, so the missing NVTX share confirmation
 does not change the result; this is recorded for future captures
 (`nsys 2024.5.1` was used in the post-#166 profile and avoided the bug).
+
+
+## Phase 6 — fused GDN recurrent + qk_norm + gated_norm decode kernel (NULL RESULT, 2026-04-19)
+
+Extended PR #92's `kiln_gdn_recurrent_forward` CUDA kernel to also
+absorb the upstream `:kiln/gdn/qk_norm` (L2 + scale on Q/K) and
+downstream `:kiln/gdn/gated_norm` (RMSNorm + silu-gated weight mul)
+in-register on the decode fast path. This is the **combined 32.4 %**
+scope the Phase 6 NULL section above redirected future work toward
+(see "Update 2026-04-19" on `qk_norm`). The new kernel is
+`recurrent_gdn_fwd_fused_norm_kernel` with C-ABI entry
+`kiln_gdn_recurrent_forward_fused_norm`.
+
+The kernel is **correct** (3 parity tests at decode/small/asymmetric
+shapes pass at tol 1.5e-2 against a candle F32 reference; full
+`kiln-gdn-kernel` test suite green on A6000) but **misses the task's
+1.05× decode tok/s abort floor**. It is shipped **opt-in only** via
+`KILN_ENABLE_FUSED_GDN_RECURRENT_NORM=1` — the three-stage candle /
+PR #92 kernel path remains the production default.
+
+### Bench result (Arm B, RTX A6000, 3 paired runs, 2026-04-19)
+
+`KILN_W4A16=1 KILN_CUDA_GRAPHS=true`, paged 512/128. Baseline runs the
+existing split path (PR #92 recurrent kernel + separate qk_norm /
+gated_norm candle regions). Fused enables the new all-in-one kernel.
+Same binary; same warm-up; 3 paired runs alternating baseline and
+fused.
+
+| run        | decode tok/s | mean ITL ms | p50 ITL ms | p99 ITL ms |
+| ---------- | -----------: | ----------: | ---------: | ---------: |
+| baseline 1 |        50.85 |       19.67 |      19.01 |      23.83 |
+| baseline 2 |        50.38 |       19.85 |      19.84 |      25.55 |
+| baseline 3 |        53.17 |       18.81 |      18.32 |      23.34 |
+| **median** |    **50.85** |   **19.67** |  **19.01** |  **23.83** |
+| fused 1    |        51.64 |       19.36 |      19.09 |      21.38 |
+| fused 2    |        51.56 |       19.39 |      19.14 |      21.20 |
+| fused 3    |        54.93 |       18.20 |      18.13 |      19.45 |
+| **median** |    **51.56** |   **19.39** |  **19.14** |  **21.20** |
+
+| Metric               | Baseline (median) | Fused (median) | Delta                 |
+| -------------------- | ----------------: | -------------: | :-------------------- |
+| decode tok/s         |             50.85 |          51.56 | **+1.40 % (1.0140×)** |
+| mean ITL             |          19.67 ms |       19.39 ms | -0.28 ms (-1.42 %)    |
+| p50 ITL              |          19.01 ms |       19.14 ms | +0.13 ms (+0.68 %)    |
+| p99 ITL              |          23.83 ms |       21.20 ms | -2.63 ms (-11.0 %)    |
+| best-of-3 tok/s      |             53.17 |          54.93 | +3.31 % (1.0331×)     |
+
+**Median speedup = 1.0140× — below the task's 1.05× abort floor.**
+Best-of-3 shows +3.3 %, and p99 ITL tightens by -11.0 %, but median
+decode tok/s does not clear the bar. This matches the shape of the
+PR #173 qk_norm null result almost exactly: small mean improvement,
+real p99 tightening, no clearance of the 1.05× threshold.
+
+### Why the kernel won the math but lost the wallclock
+
+Combined `:kiln/gdn/qk_norm` (14.9 %) + `:kiln/gdn/gated_norm` (17.5 %)
+= **32.4 %** of decode per the post-#166 profile. Even eliminating
+that entire slice would imply at most `1 / (1 - 0.324) ≈ 1.479×`
+decode speedup. The actual 0.28 ms median ITL gain recovers only
+~4 % of the combined region's wallclock — the same
+"CUDA-graph-replay amortizes candle dispatch cost" ceiling that
+bounded PR #173.
+
+Under `KILN_CUDA_GRAPHS=true`, the Q/K/V in-projections, qk_norm
+chain, PR #92 recurrent step, and gated-norm chain are all captured
+once into a single graph that is replayed every decode step. Collapsing
+the recurrent + qk_norm + gated_norm region from ~14 candle launches
+down to 1 shrinks the **captured** graph, but the **replay** cost is
+dominated by HBM traffic and SM occupancy on the replay path, not by
+per-launch host overhead. The fused kernel still saves the F32
+intermediate round-trips (q_f32, q_squared, q_sum_keepdim, rms_sq,
+gate_activated_out, etc.), which shows up as the -11 % p99 ITL and
++3.3 % best-of-3, but the median improvement is in the noise.
+
+### Why ship the kernel as opt-in instead of deleting it
+
+1. **It is correct** — 3/3 parity tests pass at decode (B=1, nv=16,
+   dk=dv=128), small (B=2, nv=4, dk=dv=32), and asymmetric (B=1,
+   nv=8, dk=64, dv=128) shapes. Full `kiln-gdn-kernel` nextest is
+   green.
+2. **Tail-latency improvement is real** — -11.0 % p99 ITL. Workloads
+   sensitive to ITL tail variance (latency-SLO serving, live
+   streaming with strict jitter budgets) may want to opt in.
+3. **Future re-evaluation is cheap** — if a later optimization
+   (graph-replay dispatch-cost reduction, chunked-prefill path with
+   different launch density, or a hypothetical out-of-graph decode
+   mode) shifts the balance, the kernel is already wired and tested.
+   No re-implementation needed.
+
+The kernel sits behind `KILN_ENABLE_FUSED_GDN_RECURRENT_NORM=1` (note:
+enable, not disable). Default decode behavior is unchanged from PR #92.
+
+### Re-visit triggers
+
+A future PR can re-default this kernel to ON only if **all three**
+hold on a fresh `nsys` profile of current `main` using the same
+production path:
+
+1. Combined `:kiln/gdn/qk_norm` + `:kiln/gdn/gated_norm` NVTX share
+   ≥ **25 %** of decode wall-clock (it is 32.4 % today, but
+   graph-replay amortization may have already reduced it; a drop
+   below 25 % would mean the Amdahl ceiling is near 1.03×).
+2. The fused kernel produces a median **≥ 1.04×** decode tok/s
+   speedup on a 3-run paired bench (currently 1.0140×).
+3. There is a documented reason the graph-replay dispatch-cost
+   amortization no longer dominates (e.g. CUDA graphs disabled at
+   this region for a separate correctness reason, or a much wider
+   fused region extending up into the SwiGLU gate projections
+   upstream of qk_norm).
+
+### Code shipped (branch `ce/gdn-recurrent-fused-norm`)
+
+- `crates/kiln-gdn-kernel/csrc/recurrent_gdn_fwd.{h,cu}` —
+  `recurrent_gdn_fwd_fused_norm_kernel<MAX_DK>` template + C-ABI
+  dispatcher `kiln_gdn_recurrent_forward_fused_norm`. Five in-register
+  phases (L2-sumsq/scale on Q/K, recurrent state update, RMS-sumsq,
+  gamma * silu(z) * rms_inv epilogue). F32 accumulators; bf16 in/out;
+  warp-shuffle reductions with 32-warp cap.
+- `crates/kiln-gdn-kernel/src/lib.rs` — FFI decl
+  `kiln_gdn_recurrent_forward_fused_norm`,
+  `gdn_recurrent_forward_fused_norm_supports` capability gate,
+  `gdn_recurrent_forward_fused_norm` candle wrapper.
+- `crates/kiln-gdn-kernel/tests/recurrent_fused_norm_parity.rs` — 3
+  parity tests (Qwen decode shape, small shape, asymmetric shape)
+  against a candle F32 reference.
+- `crates/kiln-model/src/backend/mod.rs` —
+  `supports_gdn_recurrent_step_fused_norm` + `gdn_recurrent_step_fused_norm`
+  default-`Ok(None)` BackendRuntime additions.
+- `crates/kiln-model/src/backend/cuda.rs` —
+  `fused_gdn_recurrent_norm_enabled` field (cached env read) and
+  impl that declines when the kernel envelope is unmet.
+- `crates/kiln-model/src/forward.rs` — GDN decode step-5/7/8
+  short-circuit that stashes raw Q/K and dispatches the fused kernel
+  under the env gate; falls back to the existing PR #92 recurrent
+  path on `Ok(None)`.
+
+### Preflight performed
+
+- HEAD verified `c05b7cc` (post-PR #173, pre-fused-norm branch).
+- `crates/kiln-gdn-kernel/` already exists from PR #92; additive
+  kernel + FFI + wrapper, not a new crate.
+- `gh pr list` showed no overlapping open PR at preflight time.
+- Parity tests passed on A6000 before the bench.
+
+### Pod / cost
+
+- Pod: `yp293s4oqc7gdx` (RunPod NVIDIA RTX A6000 on-demand,
+  $0.79/hr — spot unavailable, on-demand per
+  `runpod-always-on-demand` agent note).
+- Total uptime at capture end: ~90 minutes (image pull + clone +
+  kiln-setup + first release build + parity tests + 3 paired bench
+  runs + result download).
+- Estimated pod cost: **~$1.20**.
 
 
 ## Not next target — fused_recurrent GDN decode vendor (preflight, 2026-04-18)

--- a/crates/kiln-gdn-kernel/csrc/recurrent_gdn_fwd.cu
+++ b/crates/kiln-gdn-kernel/csrc/recurrent_gdn_fwd.cu
@@ -134,6 +134,220 @@ __global__ void recurrent_gdn_fwd_kernel(
     out_base[tid] = f32_to_bf16(out_acc);
 }
 
+// --------------------------------------------------------------------------
+// Fused variant: qk_norm + recurrent step + gated_norm, one block per
+// (batch, head). Semantics match the forward.rs candle reference pipeline:
+//
+//   Step 5 (qk_norm):
+//     inv_q  = q_scale * rsqrt(sum_j(q_raw^2) + l2_eps)     (F32, per row)
+//     inv_k  =            rsqrt(sum_j(k_raw^2) + l2_eps)    (F32, per row)
+//     q_norm = q_raw * inv_q                                (F32, dk)
+//     k_norm = k_raw * inv_k                                (F32, dk)
+//
+//   Step 7 (recurrent_step): same math as the non-fused kernel, using
+//     q_norm / k_norm in place of q / k.
+//
+//   Step 8 (gated_rms_norm):
+//     rms_inv = rsqrt(mean_j(attn_out^2) + rms_eps)         (F32, per row)
+//     silu(z) = z * sigmoid(z) = z / (1 + exp(-z))          (F32)
+//     out     = attn_out * rms_inv * gamma * silu(z)        (F32 -> bf16)
+//
+// Shared memory layout (F32):
+//   q_smem  [dk]        — normalized Q (reused for raw load pre-norm)
+//   k_smem  [dk]        — normalized K
+//   reduce  [kMaxWarps] — warp partial sums for block_reduce_sum
+//   bcast   [5]         — decay, beta_t, inv_q_scaled, inv_k, rms_inv
+//
+// kMaxWarps is fixed at 32 (CUDA's cap on threads/block is 1024 = 32 warps);
+// kiln runs dv=128 so only the first ceil(dv/32) entries are used. Total
+// smem for dk=dv=128: (128 + 128 + 32 + 5) * 4 = 1172 bytes. Well under
+// sm_86's 48 KiB/block default.
+//
+// Register pressure: the per-thread state column `s_local[MAX_DK]` is the
+// dominant consumer (128 F32 = 128 reg for dk=128), unchanged from the
+// non-fused kernel. The extra L2/RMS reductions use O(1) scalars.
+//
+// Barrier discipline: block_reduce_sum has two __syncthreads() inside it,
+// and we use one more before Phase 3 to guarantee every thread sees the
+// normalized q_smem/k_smem. blockDim.x is always equal to dv (one thread
+// per output element), so no thread exits early and every barrier is safe.
+
+constexpr int kMaxWarps = 32;
+
+__device__ __forceinline__ float warp_reduce_sum(float v) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset /= 2) {
+        v += __shfl_xor_sync(0xffffffffu, v, offset);
+    }
+    return v;
+}
+
+__device__ __forceinline__ float block_reduce_sum(float v, float *reduce_smem) {
+    int lane = threadIdx.x & 31;
+    int warp = threadIdx.x >> 5;
+
+    v = warp_reduce_sum(v);
+    if (lane == 0) {
+        reduce_smem[warp] = v;
+    }
+    __syncthreads();
+
+    if (warp == 0) {
+        int num_warps = (blockDim.x + 31) >> 5;
+        float w = (lane < num_warps) ? reduce_smem[lane] : 0.0f;
+        w = warp_reduce_sum(w);
+        if (lane == 0) {
+            reduce_smem[0] = w;
+        }
+    }
+    __syncthreads();
+    return reduce_smem[0];
+}
+
+__device__ __forceinline__ float silu_f32(float x) {
+    // silu(x) = x * sigmoid(x) = x / (1 + exp(-x)); stable for all x
+    // because __expf of a negative input is in (0, 1].
+    return x / (1.0f + __expf(-x));
+}
+
+template <int MAX_DK>
+__global__ void recurrent_gdn_fwd_fused_norm_kernel(
+    const __nv_bfloat16 *__restrict__ q_raw,   // [B*H, dk]
+    const __nv_bfloat16 *__restrict__ k_raw,   // [B*H, dk]
+    const __nv_bfloat16 *__restrict__ v,       // [B*H, dv]
+    const __nv_bfloat16 *__restrict__ beta,    // [B*H]
+    const __nv_bfloat16 *__restrict__ g,       // [B*H]
+    const __nv_bfloat16 *__restrict__ z,       // [B*H, dv]
+    const __nv_bfloat16 *__restrict__ gamma,   // [dv]
+    __nv_bfloat16 *__restrict__ state,         // [B*H, dk, dv]
+    __nv_bfloat16 *__restrict__ out,           // [B*H, dv]
+    int dk,
+    int dv,
+    float q_scale,
+    float l2_eps,
+    float rms_eps
+) {
+    const int bh  = blockIdx.x;
+    const int tid = threadIdx.x;
+
+    if (tid >= dv) return;  // blockDim.x == dv, so in practice no-op.
+
+    const __nv_bfloat16 *q_base   = q_raw + (size_t)bh * dk;
+    const __nv_bfloat16 *k_base   = k_raw + (size_t)bh * dk;
+    const __nv_bfloat16 *v_base   = v     + (size_t)bh * dv;
+    const __nv_bfloat16 *z_base   = z     + (size_t)bh * dv;
+    __nv_bfloat16       *s_base   = state + (size_t)bh * dk * dv;
+    __nv_bfloat16       *out_base = out   + (size_t)bh * dv;
+
+    extern __shared__ float smem[];
+    float *q_smem  = smem;                        // dk F32
+    float *k_smem  = smem + dk;                   // dk F32
+    float *reduce  = smem + 2 * dk;               // kMaxWarps F32
+    float *bcast   = smem + 2 * dk + kMaxWarps;   // 5 F32: decay, beta, inv_q, inv_k, rms_inv
+
+    // ---------------- Phase 0: cooperative load of raw q/k ----------------
+    for (int i = tid; i < dk; i += blockDim.x) {
+        q_smem[i] = bf16_to_f32(q_base[i]);
+        k_smem[i] = bf16_to_f32(k_base[i]);
+    }
+
+    // Thread 0 preloads scalars: decay and beta. No __syncthreads() yet — the
+    // block_reduce_sum calls below each have their own barriers.
+    if (tid == 0) {
+        float g_val = bf16_to_f32(g[bh]);
+        float b_val = bf16_to_f32(beta[bh]);
+        bcast[0] = expf(g_val);  // decay
+        bcast[1] = b_val;        // beta
+    }
+    __syncthreads();  // q_smem/k_smem visible before the reductions below.
+
+    // ---------------- Phase 1: L2 norm reductions over q and k ----------------
+    float q_sumsq = 0.0f;
+    float k_sumsq = 0.0f;
+    for (int i = tid; i < dk; i += blockDim.x) {
+        float qi = q_smem[i];
+        float ki = k_smem[i];
+        q_sumsq += qi * qi;
+        k_sumsq += ki * ki;
+    }
+    float q_total = block_reduce_sum(q_sumsq, reduce);
+    float k_total = block_reduce_sum(k_sumsq, reduce);
+
+    if (tid == 0) {
+        bcast[2] = q_scale * rsqrtf(q_total + l2_eps);  // inv_q (already * q_scale)
+        bcast[3] = rsqrtf(k_total + l2_eps);            // inv_k
+    }
+    __syncthreads();
+
+    const float inv_q = bcast[2];
+    const float inv_k = bcast[3];
+
+    // ---------------- Phase 2: apply norms in-place in shared memory ----------------
+    for (int i = tid; i < dk; i += blockDim.x) {
+        q_smem[i] *= inv_q;
+        k_smem[i] *= inv_k;
+    }
+    __syncthreads();  // state-column loop below reads q_smem/k_smem for all i.
+
+    const float decay  = bcast[0];
+    const float beta_t = bcast[1];
+
+    // ---------------- Phase 3: recurrent step (identical to non-fused kernel) ----------------
+    float s_local[MAX_DK];
+    #pragma unroll
+    for (int i = 0; i < MAX_DK; ++i) {
+        if (i < dk) {
+            s_local[i] = bf16_to_f32(s_base[(size_t)i * dv + tid]);
+        }
+    }
+
+    // Phase 3A: decayed state + v_pred
+    float v_pred = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < MAX_DK; ++i) {
+        if (i < dk) {
+            float d = decay * s_local[i];
+            s_local[i] = d;
+            v_pred += k_smem[i] * d;
+        }
+    }
+
+    float v_t   = bf16_to_f32(v_base[tid]);
+    float delta = beta_t * (v_t - v_pred);
+
+    // Phase 3B: state update + out_acc
+    float out_acc = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < MAX_DK; ++i) {
+        if (i < dk) {
+            float new_s = s_local[i] + k_smem[i] * delta;
+            s_local[i] = new_s;
+            out_acc += q_smem[i] * new_s;
+            s_base[(size_t)i * dv + tid] = f32_to_bf16(new_s);
+        }
+    }
+
+    // ---------------- Phase 4: RMSNorm over dv of out_acc ----------------
+    float rms_partial = out_acc * out_acc;
+    float rms_total   = block_reduce_sum(rms_partial, reduce);
+
+    if (tid == 0) {
+        float mean_sq = rms_total / static_cast<float>(dv);
+        bcast[4] = rsqrtf(mean_sq + rms_eps);
+    }
+    __syncthreads();
+
+    const float rms_inv = bcast[4];
+
+    // ---------------- Phase 5: apply gamma, silu(z), final bf16 write ----------------
+    float gamma_t = bf16_to_f32(gamma[tid]);
+    float z_t     = bf16_to_f32(z_base[tid]);
+    float gate    = silu_f32(z_t);
+    float y       = out_acc * rms_inv * gamma_t * gate;
+
+    out_base[tid] = f32_to_bf16(y);
+}
+
 } // namespace
 
 extern "C" kiln_gdn_recurrent_status_t kiln_gdn_recurrent_forward(
@@ -188,6 +402,85 @@ extern "C" kiln_gdn_recurrent_status_t kiln_gdn_recurrent_forward(
             reinterpret_cast<__nv_bfloat16 *>(out),
             dk,
             dv
+        );
+    } else {
+        return -3;
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return (int)err;
+    }
+    return 0;
+}
+
+extern "C" kiln_gdn_recurrent_status_t kiln_gdn_recurrent_forward_fused_norm(
+    const void *q_raw,
+    const void *k_raw,
+    const void *v,
+    const void *beta,
+    const void *g,
+    const void *z,
+    const void *gamma,
+    void *state,
+    void *out,
+    int batch_heads,
+    int dk,
+    int dv,
+    float q_scale,
+    float l2_eps,
+    float rms_eps,
+    void *stream
+) {
+    if (batch_heads <= 0 || dk <= 0 || dv <= 0) {
+        return -1;
+    }
+    if (dv > 1024) {
+        // blockDim.x must equal dv (one thread per output element).
+        return -2;
+    }
+
+    int threads = dv;
+    int blocks  = batch_heads;
+
+    // Shared mem: q (dk F32) + k (dk F32) + kMaxWarps reduce slots + 5 bcast scalars.
+    size_t smem_bytes = (size_t)(2 * dk + kMaxWarps + 5) * sizeof(float);
+
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+
+    if (dk <= 128) {
+        recurrent_gdn_fwd_fused_norm_kernel<128><<<blocks, threads, smem_bytes, s>>>(
+            reinterpret_cast<const __nv_bfloat16 *>(q_raw),
+            reinterpret_cast<const __nv_bfloat16 *>(k_raw),
+            reinterpret_cast<const __nv_bfloat16 *>(v),
+            reinterpret_cast<const __nv_bfloat16 *>(beta),
+            reinterpret_cast<const __nv_bfloat16 *>(g),
+            reinterpret_cast<const __nv_bfloat16 *>(z),
+            reinterpret_cast<const __nv_bfloat16 *>(gamma),
+            reinterpret_cast<__nv_bfloat16 *>(state),
+            reinterpret_cast<__nv_bfloat16 *>(out),
+            dk,
+            dv,
+            q_scale,
+            l2_eps,
+            rms_eps
+        );
+    } else if (dk <= 256) {
+        recurrent_gdn_fwd_fused_norm_kernel<256><<<blocks, threads, smem_bytes, s>>>(
+            reinterpret_cast<const __nv_bfloat16 *>(q_raw),
+            reinterpret_cast<const __nv_bfloat16 *>(k_raw),
+            reinterpret_cast<const __nv_bfloat16 *>(v),
+            reinterpret_cast<const __nv_bfloat16 *>(beta),
+            reinterpret_cast<const __nv_bfloat16 *>(g),
+            reinterpret_cast<const __nv_bfloat16 *>(z),
+            reinterpret_cast<const __nv_bfloat16 *>(gamma),
+            reinterpret_cast<__nv_bfloat16 *>(state),
+            reinterpret_cast<__nv_bfloat16 *>(out),
+            dk,
+            dv,
+            q_scale,
+            l2_eps,
+            rms_eps
         );
     } else {
         return -3;

--- a/crates/kiln-gdn-kernel/csrc/recurrent_gdn_fwd.h
+++ b/crates/kiln-gdn-kernel/csrc/recurrent_gdn_fwd.h
@@ -50,6 +50,45 @@ kiln_gdn_recurrent_status_t kiln_gdn_recurrent_forward(
     void *stream
 );
 
+// Fused variant: absorbs qk_norm (L2-norm+scale on Q, L2-norm on K) and
+// gated_norm (RMSNorm + silu-gated weight mul on attn_out) into the same
+// per-(batch,head) block as the recurrent step, keeping normalized Q/K and
+// the pre-norm attn_out in on-chip memory. Eliminates the ~5 bf16↔F32 HBM
+// round-trips that the candle / standalone-kernel path pays at decode.
+//
+// Extra pointer arguments (all bf16, all CUDA, all contiguous):
+//   q_raw    : [B*H, dk]   — pre-L2 Q (replaces q of the non-fused entry)
+//   k_raw    : [B*H, dk]   — pre-L2 K
+//   z        : [B*H, dv]   — output gate (pre silu)
+//   gamma    : [dv]        — RMSNorm learnable scale (shared across B*H)
+//
+// Extra scalar arguments:
+//   q_scale  : f32 — applied to Q after L2 norm (typically 1/sqrt(dk))
+//   l2_eps   : f32 — eps inside sqrt for L2 norm (typically 1e-6)
+//   rms_eps  : f32 — eps inside sqrt for RMSNorm (typically 1e-6)
+//
+// The `out` tensor receives the final gated-rms-normed value in bf16;
+// callers do not need to run qk_norm or gated_norm separately. `state` is
+// updated in place with the post-recurrence F32-stored-as-bf16 state.
+kiln_gdn_recurrent_status_t kiln_gdn_recurrent_forward_fused_norm(
+    const void *q_raw,
+    const void *k_raw,
+    const void *v,
+    const void *beta,
+    const void *g,
+    const void *z,
+    const void *gamma,
+    void *state,
+    void *out,
+    int batch_heads,
+    int dk,
+    int dv,
+    float q_scale,
+    float l2_eps,
+    float rms_eps,
+    void *stream
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -91,6 +91,26 @@ unsafe extern "C" {
         stream: *mut core::ffi::c_void,
     ) -> i32;
 
+    #[allow(clippy::too_many_arguments)]
+    fn kiln_gdn_recurrent_forward_fused_norm(
+        q_raw: *const core::ffi::c_void,
+        k_raw: *const core::ffi::c_void,
+        v: *const core::ffi::c_void,
+        beta: *const core::ffi::c_void,
+        g: *const core::ffi::c_void,
+        z: *const core::ffi::c_void,
+        gamma: *const core::ffi::c_void,
+        state: *mut core::ffi::c_void,
+        out: *mut core::ffi::c_void,
+        batch_heads: i32,
+        dk: i32,
+        dv: i32,
+        q_scale: f32,
+        l2_eps: f32,
+        rms_eps: f32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
     fn kiln_gdn_chunk_prep(
         g: *const core::ffi::c_void,
         v: *const core::ffi::c_void,
@@ -411,6 +431,295 @@ pub fn gdn_recurrent_forward(
             if status != 0 {
                 candle_core::bail!(
                     "kiln_gdn_recurrent_forward failed with status {status}"
+                );
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+/// Cheap shape / dtype check for [`gdn_recurrent_forward_fused_norm`].
+///
+/// Returns `true` when the caller-provided shapes/dtypes are inside the
+/// fused kernel's envelope. The fused kernel inherits the non-fused
+/// kernel's envelope (bf16, `dk <= 256`, `dv <= 1024`) plus:
+///
+///   - `z.shape() == v.shape()` — one gate vector per (batch, head)
+///   - `gamma.shape() == [dv]` — learnable RMSNorm scale, shared
+pub fn gdn_recurrent_forward_fused_norm_supports(
+    q_raw: &Tensor,
+    k_raw: &Tensor,
+    v: &Tensor,
+    beta: &Tensor,
+    g: &Tensor,
+    z: &Tensor,
+    gamma: &Tensor,
+    state: &Tensor,
+) -> bool {
+    if q_raw.dtype() != DType::BF16
+        || k_raw.dtype() != DType::BF16
+        || v.dtype() != DType::BF16
+        || beta.dtype() != DType::BF16
+        || g.dtype() != DType::BF16
+        || z.dtype() != DType::BF16
+        || gamma.dtype() != DType::BF16
+        || state.dtype() != DType::BF16
+    {
+        return false;
+    }
+    let Ok((b, h, dk)) = q_raw.dims3() else { return false };
+    let Ok((b_k, h_k, dk_k)) = k_raw.dims3() else { return false };
+    if (b_k, h_k, dk_k) != (b, h, dk) {
+        return false;
+    }
+    let Ok((b_v, h_v, dv)) = v.dims3() else { return false };
+    if (b_v, h_v) != (b, h) {
+        return false;
+    }
+    let Ok((b_z, h_z, dv_z)) = z.dims3() else { return false };
+    if (b_z, h_z, dv_z) != (b, h, dv) {
+        return false;
+    }
+    let Ok((dv_g,)) = gamma.dims1().map(|d| (d,)) else { return false };
+    if dv_g != dv {
+        return false;
+    }
+    let Ok((b_s, h_s, dk_s, dv_s)) = state.dims4() else { return false };
+    if (b_s, h_s, dk_s, dv_s) != (b, h, dk, dv) {
+        return false;
+    }
+    let Ok((b_b, h_b)) = beta.dims2() else { return false };
+    if (b_b, h_b) != (b, h) {
+        return false;
+    }
+    let Ok((b_g, h_g)) = g.dims2() else { return false };
+    if (b_g, h_g) != (b, h) {
+        return false;
+    }
+    dk <= 256 && dv <= 1024
+}
+
+/// Run the fused GDN recurrent-step-with-norms kernel.
+///
+/// Inputs (all bf16, all CUDA; not necessarily contiguous — contiguous
+/// copies are materialised internally):
+///   - `q_raw` : `[B, H, dk]` — pre-L2-norm Q (post conv1d + silu)
+///   - `k_raw` : `[B, H, dk]` — pre-L2-norm K
+///   - `v`     : `[B, H, dv]`
+///   - `beta`  : `[B, H]`
+///   - `g`     : `[B, H]` — gate (kernel applies `exp`)
+///   - `z`     : `[B, H, dv]` — output gate (pre-silu)
+///   - `gamma` : `[dv]` — RMSNorm learnable scale (shared across B, H)
+///   - `state` : `[B, H, dk, dv]` — read-modify-write in place
+///
+/// Scalars:
+///   - `q_scale` — multiplier on Q after L2 norm (typically `1/sqrt(dk)`)
+///   - `l2_eps`  — eps inside sqrt for L2 norm (typically `1e-6`)
+///   - `rms_eps` — eps inside sqrt for RMSNorm (typically `1e-6`)
+///
+/// Returns a freshly allocated bf16 `out` tensor with shape `[B, H, dv]`
+/// already multiplied by `gamma * silu(z)`. Semantics match
+/// `kiln-model::forward::gated_deltanet_forward` when the input to qk_norm,
+/// the recurrent step, and gated_norm is this exact (q_raw, k_raw, v,
+/// beta, g, z, gamma) at `seq_len == 1`.
+#[allow(clippy::too_many_arguments)]
+pub fn gdn_recurrent_forward_fused_norm(
+    q_raw: &Tensor,
+    k_raw: &Tensor,
+    v: &Tensor,
+    beta: &Tensor,
+    g: &Tensor,
+    z: &Tensor,
+    gamma: &Tensor,
+    state: &mut Tensor,
+    q_scale: f32,
+    l2_eps: f32,
+    rms_eps: f32,
+) -> Result<Tensor> {
+    let device = q_raw.device();
+
+    let (b, h, dk) = q_raw.dims3()?;
+    let (b_k, h_k, dk_k) = k_raw.dims3()?;
+    if (b_k, h_k, dk_k) != (b, h, dk) {
+        candle_core::bail!(
+            "kiln-gdn-kernel: k_raw shape [{b_k}, {h_k}, {dk_k}] mismatch with q_raw [{b}, {h}, {dk}]"
+        );
+    }
+
+    let (b_v, h_v, dv) = v.dims3()?;
+    if (b_v, h_v) != (b, h) {
+        candle_core::bail!(
+            "kiln-gdn-kernel: v shape [{b_v}, {h_v}, {dv}] mismatch with q_raw [{b}, {h}, *]"
+        );
+    }
+
+    let (b_b, h_b) = beta.dims2()?;
+    if (b_b, h_b) != (b, h) {
+        candle_core::bail!(
+            "kiln-gdn-kernel: beta shape [{b_b}, {h_b}] mismatch with q_raw [{b}, {h}, *]"
+        );
+    }
+
+    let (b_g, h_g) = g.dims2()?;
+    if (b_g, h_g) != (b, h) {
+        candle_core::bail!(
+            "kiln-gdn-kernel: g shape [{b_g}, {h_g}] mismatch with q_raw [{b}, {h}, *]"
+        );
+    }
+
+    let (b_z, h_z, dv_z) = z.dims3()?;
+    if (b_z, h_z, dv_z) != (b, h, dv) {
+        candle_core::bail!(
+            "kiln-gdn-kernel: z shape [{b_z}, {h_z}, {dv_z}] mismatch with v [{b}, {h}, {dv}]"
+        );
+    }
+
+    let gamma_dims = gamma.dims();
+    if gamma_dims.len() != 1 || gamma_dims[0] != dv {
+        candle_core::bail!(
+            "kiln-gdn-kernel: gamma must have shape [{dv}], got {:?}",
+            gamma_dims
+        );
+    }
+
+    let (b_s, h_s, dk_s, dv_s) = state.dims4()?;
+    if (b_s, h_s, dk_s, dv_s) != (b, h, dk, dv) {
+        candle_core::bail!(
+            "kiln-gdn-kernel: state shape [{b_s}, {h_s}, {dk_s}, {dv_s}] mismatch with [{b}, {h}, {dk}, {dv}]"
+        );
+    }
+
+    if q_raw.dtype() != DType::BF16
+        || k_raw.dtype() != DType::BF16
+        || v.dtype() != DType::BF16
+        || beta.dtype() != DType::BF16
+        || g.dtype() != DType::BF16
+        || z.dtype() != DType::BF16
+        || gamma.dtype() != DType::BF16
+        || state.dtype() != DType::BF16
+    {
+        candle_core::bail!(
+            "kiln-gdn-kernel: all inputs to fused_norm must be bf16 (got q_raw={:?}, k_raw={:?}, v={:?}, beta={:?}, g={:?}, z={:?}, gamma={:?}, state={:?})",
+            q_raw.dtype(), k_raw.dtype(), v.dtype(), beta.dtype(),
+            g.dtype(), z.dtype(), gamma.dtype(), state.dtype()
+        );
+    }
+
+    if dk > 256 {
+        candle_core::bail!("kiln-gdn-kernel: dk must be <= 256 (got {dk})");
+    }
+    if dv > 1024 {
+        candle_core::bail!("kiln-gdn-kernel: dv must be <= 1024 (got {dv})");
+    }
+
+    let q_raw = q_raw.contiguous()?;
+    let k_raw = k_raw.contiguous()?;
+    let v = v.contiguous()?;
+    let beta = beta.contiguous()?;
+    let g = g.contiguous()?;
+    let z = z.contiguous()?;
+    let gamma = gamma.contiguous()?;
+    if !state.is_contiguous() {
+        *state = state.contiguous()?;
+    }
+
+    let out = Tensor::zeros((b, h, dv), DType::BF16, device)?;
+
+    {
+        let (q_storage, q_layout) = q_raw.storage_and_layout();
+        let (k_storage, k_layout) = k_raw.storage_and_layout();
+        let (v_storage, v_layout) = v.storage_and_layout();
+        let (beta_storage, beta_layout) = beta.storage_and_layout();
+        let (g_storage, g_layout) = g.storage_and_layout();
+        let (z_storage, z_layout) = z.storage_and_layout();
+        let (gamma_storage, gamma_layout) = gamma.storage_and_layout();
+        let (s_storage, s_layout) = state.storage_and_layout();
+        let (out_storage, out_layout) = out.storage_and_layout();
+
+        let q_cuda = match &*q_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: q_raw must be on CUDA"),
+        };
+        let k_cuda = match &*k_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: k_raw must be on CUDA"),
+        };
+        let v_cuda = match &*v_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: v must be on CUDA"),
+        };
+        let beta_cuda = match &*beta_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: beta must be on CUDA"),
+        };
+        let g_cuda = match &*g_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: g must be on CUDA"),
+        };
+        let z_cuda = match &*z_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: z must be on CUDA"),
+        };
+        let gamma_cuda = match &*gamma_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: gamma must be on CUDA"),
+        };
+        let s_cuda = match &*s_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: state must be on CUDA"),
+        };
+        let out_cuda = match &*out_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: out must be on CUDA"),
+        };
+
+        let stream = q_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let q_slice = q_cuda.as_cuda_slice::<bf16>()?.slice(q_layout.start_offset()..);
+        let k_slice = k_cuda.as_cuda_slice::<bf16>()?.slice(k_layout.start_offset()..);
+        let v_slice = v_cuda.as_cuda_slice::<bf16>()?.slice(v_layout.start_offset()..);
+        let beta_slice = beta_cuda.as_cuda_slice::<bf16>()?.slice(beta_layout.start_offset()..);
+        let g_slice = g_cuda.as_cuda_slice::<bf16>()?.slice(g_layout.start_offset()..);
+        let z_slice = z_cuda.as_cuda_slice::<bf16>()?.slice(z_layout.start_offset()..);
+        let gamma_slice = gamma_cuda.as_cuda_slice::<bf16>()?.slice(gamma_layout.start_offset()..);
+        let s_slice = s_cuda.as_cuda_slice::<bf16>()?.slice(s_layout.start_offset()..);
+        let out_slice = out_cuda.as_cuda_slice::<bf16>()?.slice(out_layout.start_offset()..);
+
+        unsafe {
+            let (q_ptr, _g1) = q_slice.device_ptr(&stream);
+            let (k_ptr, _g2) = k_slice.device_ptr(&stream);
+            let (v_ptr, _g3) = v_slice.device_ptr(&stream);
+            let (beta_ptr, _g4) = beta_slice.device_ptr(&stream);
+            let (g_ptr, _g5) = g_slice.device_ptr(&stream);
+            let (z_ptr, _g6) = z_slice.device_ptr(&stream);
+            let (gamma_ptr, _g7) = gamma_slice.device_ptr(&stream);
+            let (s_ptr, _g8) = s_slice.device_ptr(&stream);
+            let (out_ptr, _g9) = out_slice.device_ptr(&stream);
+
+            let status = kiln_gdn_recurrent_forward_fused_norm(
+                q_ptr as *const _,
+                k_ptr as *const _,
+                v_ptr as *const _,
+                beta_ptr as *const _,
+                g_ptr as *const _,
+                z_ptr as *const _,
+                gamma_ptr as *const _,
+                s_ptr as *mut _,
+                out_ptr as *mut _,
+                (b * h) as i32,
+                dk as i32,
+                dv as i32,
+                q_scale,
+                l2_eps,
+                rms_eps,
+                raw_stream,
+            );
+
+            if status != 0 {
+                candle_core::bail!(
+                    "kiln_gdn_recurrent_forward_fused_norm failed with status {status}"
                 );
             }
         }

--- a/crates/kiln-gdn-kernel/tests/recurrent_fused_norm_parity.rs
+++ b/crates/kiln-gdn-kernel/tests/recurrent_fused_norm_parity.rs
@@ -1,0 +1,357 @@
+//! Parity test for the fused GDN recurrent-step-with-norms CUDA kernel.
+//!
+//! `kiln_gdn_kernel::gdn_recurrent_forward_fused_norm` absorbs three
+//! originally-separate stages from `kiln-model::forward::gated_deltanet_forward`
+//! into one CUDA launch at decode-time (`seq_len == 1`):
+//!
+//!   Step 5 — qk_norm:
+//!       q_normed = l2_normalize(q_raw) * q_scale
+//!       k_normed = l2_normalize(k_raw)
+//!   Step 7 — gdn_recurrent_step:
+//!       (decay, delta, state-update, out_acc)
+//!   Step 8 — gated_rms_norm:
+//!       rms_inv = rsqrt(mean(attn_out^2) + rms_eps)
+//!       out     = attn_out * rms_inv * gamma * silu(z)
+//!
+//! The algorithmic oracle in `reference_host` reimplements the same math
+//! in F32 on the host so the test does not re-run the kernel to check
+//! itself. The reference is deliberately independent: it uses naive
+//! `for` loops, not candle ops, and keeps accumulators in F32.
+//!
+//! Gracefully no-ops on non-CUDA hosts.
+
+use candle_core::{DType, Device, Tensor};
+use kiln_gdn_kernel::{
+    gdn_recurrent_forward_fused_norm, gdn_recurrent_forward_fused_norm_supports,
+};
+
+fn lcg_step(state: &mut u64) -> f32 {
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    let bits = ((*state >> 33) as u32) & 0x7fff_ffff;
+    (bits as f32 / (i32::MAX as f32)) - 0.5
+}
+
+fn fill(seed: u64, n: usize, scale: f32) -> Vec<f32> {
+    let mut s = seed;
+    (0..n).map(|_| lcg_step(&mut s) * scale).collect()
+}
+
+fn sigmoid_f32(x: f32) -> f32 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+fn silu_f32(x: f32) -> f32 {
+    x * sigmoid_f32(x)
+}
+
+fn bf16_round_trip(x: f32) -> f32 {
+    // Match the kernel's bf16 round-trip (truncation): load as bf16 then
+    // cast back to f32. `half::bf16::from_f32` matches __float2bfloat16's
+    // round-to-nearest-even semantics used by the CUDA kernel.
+    half::bf16::from_f32(x).to_f32()
+}
+
+/// Reference path for the fused kernel. Inputs and outputs are host F32
+/// but values are round-tripped through bf16 at the exact same points
+/// the kernel does, so the test compares round-trip-adjusted F32 tensors.
+///
+/// Shapes:
+///   q_raw, k_raw:  `[rows, dk]`
+///   v, z:          `[rows, dv]`
+///   beta, g:       `[rows]`
+///   gamma:         `[dv]`
+///   state (in+out):`[rows, dk, dv]`  (row-major: [i][j] → state[row*dk*dv + i*dv + j])
+///   out:           `[rows, dv]`
+#[allow(clippy::too_many_arguments)]
+fn reference_host(
+    q_raw: &[f32],
+    k_raw: &[f32],
+    v: &[f32],
+    beta: &[f32],
+    g: &[f32],
+    z: &[f32],
+    gamma: &[f32],
+    state: &mut [f32],
+    rows: usize,
+    dk: usize,
+    dv: usize,
+    q_scale: f32,
+    l2_eps: f32,
+    rms_eps: f32,
+) -> Vec<f32> {
+    let mut out = vec![0.0f32; rows * dv];
+
+    for r in 0..rows {
+        // ---- Phase 1: L2-normalize q_raw and k_raw (F32 reduction) ----
+        let mut q_sumsq = 0.0f32;
+        let mut k_sumsq = 0.0f32;
+        let q_row = &q_raw[r * dk..(r + 1) * dk];
+        let k_row = &k_raw[r * dk..(r + 1) * dk];
+        for i in 0..dk {
+            q_sumsq += q_row[i] * q_row[i];
+            k_sumsq += k_row[i] * k_row[i];
+        }
+        let inv_q = q_scale * (q_sumsq + l2_eps).sqrt().recip();
+        let inv_k = (k_sumsq + l2_eps).sqrt().recip();
+        let q_norm: Vec<f32> = q_row.iter().map(|&x| x * inv_q).collect();
+        let k_norm: Vec<f32> = k_row.iter().map(|&x| x * inv_k).collect();
+
+        // ---- Phase 3: recurrent step ----
+        let decay = g[r].exp();
+        let beta_t = beta[r];
+        let v_row = &v[r * dv..(r + 1) * dv];
+        let state_row_offset = r * dk * dv;
+
+        // Decayed state + per-column v_pred
+        let mut v_pred = vec![0.0f32; dv];
+        let mut decayed = vec![0.0f32; dk * dv];
+        for i in 0..dk {
+            for j in 0..dv {
+                let d = decay * state[state_row_offset + i * dv + j];
+                decayed[i * dv + j] = d;
+                v_pred[j] += k_norm[i] * d;
+            }
+        }
+
+        // delta[j] = beta * (v[j] - v_pred[j])
+        let mut delta = vec![0.0f32; dv];
+        for j in 0..dv {
+            delta[j] = beta_t * (v_row[j] - v_pred[j]);
+        }
+
+        // New state = decayed + k_norm ⊗ delta; out_acc[j] = sum_i q_norm[i] * new_state[i, j]
+        let mut out_acc = vec![0.0f32; dv];
+        for i in 0..dk {
+            for j in 0..dv {
+                let new_s = decayed[i * dv + j] + k_norm[i] * delta[j];
+                // The kernel writes new_s back to state after a bf16 round-trip.
+                let new_s_bf = bf16_round_trip(new_s);
+                state[state_row_offset + i * dv + j] = new_s_bf;
+                out_acc[j] += q_norm[i] * new_s_bf;
+            }
+        }
+
+        // ---- Phase 4+5: RMSNorm + gate + final bf16 write ----
+        let mut rms_sumsq = 0.0f32;
+        for j in 0..dv {
+            rms_sumsq += out_acc[j] * out_acc[j];
+        }
+        let rms_inv = (rms_sumsq / dv as f32 + rms_eps).sqrt().recip();
+
+        for j in 0..dv {
+            let gate = silu_f32(z[r * dv + j]);
+            let y = out_acc[j] * rms_inv * gamma[j] * gate;
+            out[r * dv + j] = bf16_round_trip(y);
+        }
+    }
+
+    out
+}
+
+fn max_abs_diff(a: &[f32], b: &[f32]) -> f32 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(x, y)| (x - y).abs())
+        .fold(0.0f32, f32::max)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_case(
+    device: &Device,
+    batch: usize,
+    heads: usize,
+    dk: usize,
+    dv: usize,
+    seed: u64,
+    label: &str,
+) {
+    let rows = batch * heads;
+    let q_scale = 1.0 / (dk as f32).sqrt();
+    let l2_eps = 1e-6f32;
+    let rms_eps = 1e-6f32;
+
+    // Host tensors: activations near N(0, 0.25); state / gate weights smaller.
+    let q_host = fill(seed ^ 0x51, rows * dk, 1.0);
+    let k_host = fill(seed ^ 0x52, rows * dk, 1.0);
+    let v_host = fill(seed ^ 0x53, rows * dv, 1.0);
+    let beta_host = fill(seed ^ 0x54, rows, 0.5);
+    let g_host = fill(seed ^ 0x55, rows, 0.2);
+    let z_host = fill(seed ^ 0x56, rows * dv, 1.0);
+    let gamma_host = fill(seed ^ 0x57, dv, 0.5);
+    let state_host_orig = fill(seed ^ 0x58, rows * dk * dv, 0.3);
+
+    // First round-trip both the state and the pre-norm inputs through bf16,
+    // so the reference starts from the same lossy values the kernel sees.
+    let state_host_bf: Vec<f32> = state_host_orig.iter().copied().map(bf16_round_trip).collect();
+    let q_bf: Vec<f32> = q_host.iter().copied().map(bf16_round_trip).collect();
+    let k_bf: Vec<f32> = k_host.iter().copied().map(bf16_round_trip).collect();
+    let v_bf: Vec<f32> = v_host.iter().copied().map(bf16_round_trip).collect();
+    let beta_bf: Vec<f32> = beta_host.iter().copied().map(bf16_round_trip).collect();
+    let g_bf: Vec<f32> = g_host.iter().copied().map(bf16_round_trip).collect();
+    let z_bf: Vec<f32> = z_host.iter().copied().map(bf16_round_trip).collect();
+    let gamma_bf: Vec<f32> = gamma_host.iter().copied().map(bf16_round_trip).collect();
+
+    // Build candle tensors on CUDA.
+    let q = Tensor::from_vec(q_bf.clone(), (batch, heads, dk), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let k = Tensor::from_vec(k_bf.clone(), (batch, heads, dk), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let v = Tensor::from_vec(v_bf.clone(), (batch, heads, dv), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let beta = Tensor::from_vec(beta_bf.clone(), (batch, heads), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let g = Tensor::from_vec(g_bf.clone(), (batch, heads), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let z = Tensor::from_vec(z_bf.clone(), (batch, heads, dv), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let gamma = Tensor::from_vec(gamma_bf.clone(), (dv,), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let mut state = Tensor::from_vec(state_host_bf.clone(), (batch, heads, dk, dv), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+
+    assert!(
+        gdn_recurrent_forward_fused_norm_supports(&q, &k, &v, &beta, &g, &z, &gamma, &state),
+        "{label}: envelope check failed"
+    );
+
+    let out = gdn_recurrent_forward_fused_norm(
+        &q, &k, &v, &beta, &g, &z, &gamma, &mut state, q_scale, l2_eps, rms_eps,
+    )
+    .expect("fused kernel");
+
+    let out_host: Vec<f32> = out
+        .to_dtype(DType::F32)
+        .unwrap()
+        .flatten_all()
+        .unwrap()
+        .to_vec1::<f32>()
+        .unwrap();
+    let state_host_after: Vec<f32> = state
+        .to_dtype(DType::F32)
+        .unwrap()
+        .flatten_all()
+        .unwrap()
+        .to_vec1::<f32>()
+        .unwrap();
+
+    // Reference.
+    let mut state_ref = state_host_bf;
+    let out_ref = reference_host(
+        &q_bf,
+        &k_bf,
+        &v_bf,
+        &beta_bf,
+        &g_bf,
+        &z_bf,
+        &gamma_bf,
+        &mut state_ref,
+        rows,
+        dk,
+        dv,
+        q_scale,
+        l2_eps,
+        rms_eps,
+    );
+
+    let out_err = max_abs_diff(&out_host, &out_ref);
+    let state_err = max_abs_diff(&state_host_after, &state_ref);
+
+    // bf16 has ~3e-3 relative resolution. The fused kernel accumulates through
+    // dv=128 in F32 before the final bf16 write, matching the reference's
+    // precision. 1.5e-2 absolute is the same budget existing kiln kernels use
+    // (gates_parity, marlin_w4a16_gemm).
+    let tol = 1.5e-2f32;
+    println!(
+        "[{label}] shape=[B={batch},H={heads},dk={dk},dv={dv}] out_err={out_err:.3e} state_err={state_err:.3e}"
+    );
+    assert!(
+        out_err < tol,
+        "{label}: out max_abs_diff {out_err:.3e} >= {tol:.3e}"
+    );
+    assert!(
+        state_err < tol,
+        "{label}: state max_abs_diff {state_err:.3e} >= {tol:.3e}"
+    );
+}
+
+#[test]
+fn gdn_recurrent_fused_norm_parity_decode_qwen_shape() {
+    let device = match Device::new_cuda(0) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!(
+                "Skipping gdn_recurrent_fused_norm parity test: no CUDA device ({e})"
+            );
+            return;
+        }
+    };
+
+    // Qwen3.5-4B GDN decode shape: B=1, nv=16, dk=dv=128.
+    run_case(&device, 1, 16, 128, 128, 0xDEAD_BEEF, "decode/qwen3_5_4b");
+}
+
+#[test]
+fn gdn_recurrent_fused_norm_parity_small_shape() {
+    let device = match Device::new_cuda(0) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!(
+                "Skipping gdn_recurrent_fused_norm parity test: no CUDA device ({e})"
+            );
+            return;
+        }
+    };
+
+    // Small shape to catch boundary bugs on warp boundaries (dv=32 = 1 warp).
+    run_case(&device, 2, 4, 64, 32, 0xCAFE_F00D, "small/B=2,H=4,dk=64,dv=32");
+}
+
+#[test]
+fn gdn_recurrent_fused_norm_parity_asymmetric_shape() {
+    let device = match Device::new_cuda(0) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!(
+                "Skipping gdn_recurrent_fused_norm parity test: no CUDA device ({e})"
+            );
+            return;
+        }
+    };
+
+    // dk != dv (dk=256 uses the MAX_DK=256 template; dv=128 stays at 4 warps).
+    run_case(&device, 1, 8, 256, 128, 0xFACE_0FF, "asymmetric/dk=256,dv=128");
+}

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -21,6 +21,12 @@ pub struct CudaBackend {
     /// kiln/gdn/conv region). When off, forward.rs falls back to the
     /// candle to_f32/cat/sum/narrow chain.
     fused_conv1d_enabled: bool,
+    /// Opt-in for the fused GDN decode kernel that absorbs qk_norm +
+    /// recurrent + gated_norm. When off, forward.rs runs the three stages
+    /// independently (the parity oracle path). Gated via
+    /// `KILN_ENABLE_FUSED_GDN_RECURRENT_NORM=1` so parity tests and cold
+    /// perf runs stay on the reference path.
+    fused_gdn_recurrent_norm_enabled: bool,
 }
 
 impl CudaBackend {
@@ -30,11 +36,14 @@ impl CudaBackend {
         let gdn_gates_enabled =
             gdn_enabled && std::env::var("KILN_DISABLE_FUSED_GDN_GATES").is_err();
         let fused_conv1d_enabled = std::env::var("KILN_DISABLE_FUSED_CONV1D").is_err();
+        let fused_gdn_recurrent_norm_enabled = gdn_enabled
+            && std::env::var("KILN_ENABLE_FUSED_GDN_RECURRENT_NORM").is_ok();
         Self {
             device,
             gdn_enabled,
             gdn_gates_enabled,
             fused_conv1d_enabled,
+            fused_gdn_recurrent_norm_enabled,
         }
     }
 }
@@ -62,6 +71,10 @@ impl BackendRuntime for CudaBackend {
 
     fn supports_gdn_recurrent_step(&self) -> bool {
         self.gdn_enabled
+    }
+
+    fn supports_gdn_recurrent_step_fused_norm(&self) -> bool {
+        self.fused_gdn_recurrent_norm_enabled
     }
 
     fn supports_gdn_chunk_prep(&self) -> bool {
@@ -141,6 +154,35 @@ impl BackendRuntime for CudaBackend {
             return Ok(None);
         }
         let out = kiln_gdn_kernel::gdn_recurrent_forward(q, k, v, beta, g, state)?;
+        Ok(Some(out))
+    }
+
+    fn gdn_recurrent_step_fused_norm(
+        &self,
+        q_raw: &Tensor,
+        k_raw: &Tensor,
+        v: &Tensor,
+        beta: &Tensor,
+        g: &Tensor,
+        z: &Tensor,
+        gamma: &Tensor,
+        state: &mut Tensor,
+        q_scale: f32,
+        l2_eps: f32,
+        rms_eps: f32,
+    ) -> Result<Option<Tensor>> {
+        if !self.fused_gdn_recurrent_norm_enabled {
+            return Ok(None);
+        }
+        if !kiln_gdn_kernel::gdn_recurrent_forward_fused_norm_supports(
+            q_raw, k_raw, v, beta, g, z, gamma, state,
+        ) {
+            return Ok(None);
+        }
+        let out = kiln_gdn_kernel::gdn_recurrent_forward_fused_norm(
+            q_raw, k_raw, v, beta, g, z, gamma, state, q_scale, l2_eps, rms_eps,
+        )
+        .context("gdn_recurrent_forward_fused_norm kernel failed")?;
         Ok(Some(out))
     }
 

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -57,6 +57,10 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         false
     }
 
+    fn supports_gdn_recurrent_step_fused_norm(&self) -> bool {
+        false
+    }
+
     fn supports_gdn_chunk_prep(&self) -> bool {
         false
     }
@@ -132,6 +136,37 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         _beta: &Tensor,
         _g: &Tensor,
         _state: &mut Tensor,
+    ) -> Result<Option<Tensor>> {
+        Ok(None)
+    }
+
+    /// Fused GDN decode step with qk_norm absorbed on the input side and
+    /// gated-RMSNorm absorbed on the output side. Single-token only.
+    ///
+    /// `q_raw`, `k_raw`: `[B, H, dk]` bf16 — pre-L2 Q/K (post conv1d + silu).
+    /// `v`: `[B, H, dv]` bf16. `beta`, `g`: `[B, H]` bf16.
+    /// `z`: `[B, H, dv]` bf16 — output gate (pre-silu).
+    /// `gamma`: `[dv]` bf16 — RMSNorm learnable scale.
+    /// `state`: `[B, H, dk, dv]` bf16, mutated in place.
+    ///
+    /// Scalars: `q_scale = 1/sqrt(dk)`, `l2_eps` for qk_norm, `rms_eps` for
+    /// the trailing RMSNorm. Returns `out: [B, H, dv]` bf16 already
+    /// multiplied by `gamma * silu(z)`, so callers skip Steps 5, 7, 8 of
+    /// `gated_deltanet_forward`.
+    #[allow(clippy::too_many_arguments)]
+    fn gdn_recurrent_step_fused_norm(
+        &self,
+        _q_raw: &Tensor,
+        _k_raw: &Tensor,
+        _v: &Tensor,
+        _beta: &Tensor,
+        _g: &Tensor,
+        _z: &Tensor,
+        _gamma: &Tensor,
+        _state: &mut Tensor,
+        _q_scale: f32,
+        _l2_eps: f32,
+        _rms_eps: f32,
     ) -> Result<Option<Tensor>> {
         Ok(None)
     }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1397,6 +1397,19 @@ pub fn gated_deltanet_forward(
         }
     };
 
+    // Optional: stash raw Q/K (pre-qk_norm) for the fused decode kernel that
+    // absorbs qk_norm + recurrent + gated_norm in a single CUDA block. Only
+    // needed at bf16 seq_len==1 decode with the kernel's env gate on.
+    // `Tensor::clone` is a cheap Arc bump — no device copy.
+    let fused_recurrent_norm_enabled = seq_len == 1
+        && input_dtype == DType::BF16
+        && backend.supports_gdn_recurrent_step_fused_norm();
+    let (q_raw_saved, k_raw_saved) = if fused_recurrent_norm_enabled {
+        (Some(q.clone()), Some(k.clone()))
+    } else {
+        (None, None)
+    };
+
     // --- Step 5: L2 normalize Q, K; scale Q by 1/sqrt(dk) ---
     //
     // Two paths: the candle-op reference path (default) and a fused CUDA
@@ -1479,7 +1492,8 @@ pub fn gated_deltanet_forward(
         }
     };
 
-    // --- Step 7: Chunkwise analytical recurrence (Phase 6, approach (b)) ---
+    // --- Steps 7 + 8: recurrence + gated_norm ---
+    //
     // The recurrent state is stored in F32 externally (across layers/steps)
     // for accumulator stability, but we run the recurrence in bf16 to reclaim
     // the ~66% of prefill GPU time previously spent in bmul_f32 /
@@ -1489,64 +1503,112 @@ pub fn gated_deltanet_forward(
     //
     // PR #72 introduced the bf16 hot path. PR #74 replaced the read/write
     // broadcast_mul+sum pairs with batched matmuls but left the O(T)
-    // sequential chain. This PR (Phase 6) unrolls the per-chunk recurrence
-    // analytically: within each C = GDN_CHUNK_SIZE chunk we build a
-    // triangular decay matrix and solve for the per-token updates in a small
-    // number of heavy matmuls, cutting the number of GPU kernel launches
-    // from O(T) to O(T / C) per layer.
+    // sequential chain. Phase 6 (PR #80) unrolls the per-chunk recurrence
+    // analytically inside a vendored CUDA kernel.
     //
-    // The within-chunk forward substitution still walks token-by-token, but
-    // each step only does a [1, t] @ [t, dv] matmul over the already-built
-    // prefix — orders of magnitude cheaper than the full [dk, dv] state
-    // update that was previously done per token.
+    // Fused decode path (KILN_ENABLE_FUSED_GDN_RECURRENT_NORM=1, seq_len==1
+    // bf16): one CUDA block per (batch, head) absorbs qk_norm (L2+scale on
+    // Q/K), the single-token recurrent step, and the trailing gated_norm
+    // (RMSNorm + silu-gated weight mul) — eliminating the HBM round-trips
+    // between those three regions. Declines (returns None) at prefill, on
+    // non-bf16, outside the kernel envelope, or when the env gate is off;
+    // those cases fall through to the parity-oracle chunkwise path.
     let state_external_dtype = recurrent_state.dtype();
     if state_external_dtype != input_dtype {
         *recurrent_state = recurrent_state.to_dtype(input_dtype)?;
     }
 
-    // Cast v back to input_dtype so the recurrence stays in bf16. After the
-    // causal conv1d + SiLU step above, mixed_qkv (and hence v) is F32;
-    // without this cast the subtract `(v - exp(G) * (K @ S_entry))` below
-    // hits a dtype mismatch on bf16 GPU runs, because the state-derived
-    // tensor inherits the (now bf16) state dtype.
-    let (q, k, v, beta, g) = {
-        kiln_nvtx::range!(c"kiln/gdn/recur_prep");
-        let v = v.to_dtype(input_dtype)?;
-
-        // Transpose to [B, nv, T, dim] for per-head processing.
-        let q = q.transpose(1, 2)?; // [B, nv, T, dk]
-        let k = k.transpose(1, 2)?; // [B, nv, T, dk]
-        let v = v.transpose(1, 2)?; // [B, nv, T, dv]
-        let beta = beta.transpose(1, 2)?; // [B, nv, T]
-        let g = g.transpose(1, 2)?; // [B, nv, T]
-        (q, k, v, beta, g)
+    let fused_attn_out: Option<Tensor> = if fused_recurrent_norm_enabled {
+        // Squeeze out the length-1 seq dim and materialise contiguous bf16
+        // views for the kernel. `v` is F32 coming out of conv1d+silu; cast
+        // to bf16 here so the fused kernel's bf16-only envelope is met.
+        let q_raw = q_raw_saved
+            .as_ref()
+            .expect("q_raw_saved must exist when fused_recurrent_norm_enabled")
+            .squeeze(1)?
+            .contiguous()?;
+        let k_raw = k_raw_saved
+            .as_ref()
+            .expect("k_raw_saved must exist when fused_recurrent_norm_enabled")
+            .squeeze(1)?
+            .contiguous()?;
+        let v_bf = v.to_dtype(input_dtype)?;
+        let v_s = v_bf.squeeze(1)?.contiguous()?;
+        let z_s = z.squeeze(1)?.contiguous()?;
+        let beta_s = beta.squeeze(1)?.contiguous()?;
+        let g_s = g.squeeze(1)?.contiguous()?;
+        let q_scale = 1.0 / (dk as f64).sqrt();
+        kiln_nvtx::range!(c"kiln/gdn/fused_recurrent_norm");
+        backend.gdn_recurrent_step_fused_norm(
+            &q_raw,
+            &k_raw,
+            &v_s,
+            &beta_s,
+            &g_s,
+            &z_s,
+            &weights.norm,
+            recurrent_state,
+            q_scale as f32,
+            1e-6,
+            config.rms_norm_eps as f32,
+        )?
+    } else {
+        None
     };
 
-    let attn_out = gdn_chunkwise_recurrence(
-        backend,
-        &q,
-        &k,
-        &v,
-        &beta,
-        &g,
-        recurrent_state,
-        GDN_CHUNK_SIZE,
-    )?; // [B, nv, T, dv]
+    let attn_out = if let Some(fused) = fused_attn_out {
+        // Restore state to its original (typically F32) dtype so the
+        // caller's external invariant holds across layer and step calls.
+        if state_external_dtype != input_dtype {
+            *recurrent_state = recurrent_state.to_dtype(state_external_dtype)?;
+        }
+        // Fused kernel returns [B, nv, dv] bf16 already multiplied by
+        // gamma * silu(z). Reshape to [B, T=1, v_dim].
+        fused.reshape((batch, seq_len, v_dim))?
+    } else {
+        // Cast v back to input_dtype so the recurrence stays in bf16. After
+        // the causal conv1d + SiLU step above, mixed_qkv (and hence v) is
+        // F32; without this cast the subtract
+        // `(v - exp(G) * (K @ S_entry))` below hits a dtype mismatch on
+        // bf16 GPU runs, because the state-derived tensor inherits the
+        // (now bf16) state dtype.
+        let (q, k, v, beta, g) = {
+            kiln_nvtx::range!(c"kiln/gdn/recur_prep");
+            let v = v.to_dtype(input_dtype)?;
 
-    // Restore state to its original dtype so the caller's F32 invariant holds
-    // across layer calls and across prefill/decode steps.
-    if state_external_dtype != input_dtype {
-        *recurrent_state = recurrent_state.to_dtype(state_external_dtype)?;
-    }
+            // Transpose to [B, nv, T, dim] for per-head processing.
+            let q = q.transpose(1, 2)?; // [B, nv, T, dk]
+            let k = k.transpose(1, 2)?; // [B, nv, T, dk]
+            let v = v.transpose(1, 2)?; // [B, nv, T, dv]
+            let beta = beta.transpose(1, 2)?; // [B, nv, T]
+            let g = g.transpose(1, 2)?; // [B, nv, T]
+            (q, k, v, beta, g)
+        };
 
-    // Transpose to [B, T, nv, dv]
-    let attn_out = {
-        kiln_nvtx::range!(c"kiln/gdn/post_transpose");
-        attn_out.transpose(1, 2)?
-    };
+        let attn_out = gdn_chunkwise_recurrence(
+            backend,
+            &q,
+            &k,
+            &v,
+            &beta,
+            &g,
+            recurrent_state,
+            GDN_CHUNK_SIZE,
+        )?; // [B, nv, T, dv]
 
-    // --- Step 8: Gated RMSNorm — norm(attn_out) * silu(z) ---
-    let attn_out = {
+        // Restore state to its original dtype so the caller's F32 invariant
+        // holds across layer calls and across prefill/decode steps.
+        if state_external_dtype != input_dtype {
+            *recurrent_state = recurrent_state.to_dtype(state_external_dtype)?;
+        }
+
+        // Transpose to [B, T, nv, dv]
+        let attn_out = {
+            kiln_nvtx::range!(c"kiln/gdn/post_transpose");
+            attn_out.transpose(1, 2)?
+        };
+
+        // --- Step 8: Gated RMSNorm — norm(attn_out) * silu(z) ---
         kiln_nvtx::range!(c"kiln/gdn/gated_norm");
         let attn_out = gated_rms_norm(&attn_out, &z, &weights.norm, config.rms_norm_eps)?;
         // Reshape to [B, T, v_dim] and cast back to input dtype


### PR DESCRIPTION
## What

Extends PR #92's `kiln_gdn_recurrent_forward` CUDA kernel to also absorb the upstream `:kiln/gdn/qk_norm` (L2 + scale on Q/K, 14.9 % of decode) and the downstream `:kiln/gdn/gated_norm` (RMSNorm + silu-gated weight mul, 17.5 % of decode) in-register on the decode fast path. This is the **combined 32.4 %** scope that PR #173's PROFILING update recommended as the only remaining sensible direction after the standalone qk_norm fusion came back null.

New kernel: `recurrent_gdn_fwd_fused_norm_kernel` with C-ABI entry `kiln_gdn_recurrent_forward_fused_norm`. Five in-register phases (L2-sumsq/scale Q/K, recurrent state update, RMS-sumsq, gamma * silu(z) * rms_inv epilogue). F32 accumulators; bf16 in/out; warp-shuffle block reductions capped at 32 warps.

Wired behind env gate `KILN_ENABLE_FUSED_GDN_RECURRENT_NORM=1`. Default decode behavior is unchanged from PR #92.

## Why (null result — ship opt-in)

**Median decode speedup 1.0140× (Arm B, RTX A6000, 3 paired runs) — below the 1.05× abort floor.**

| Metric               | Baseline (median) | Fused (median) | Delta                 |
| -------------------- | ----------------: | -------------: | :-------------------- |
| decode tok/s         |             50.85 |          51.56 | **+1.40 % (1.0140×)** |
| mean ITL             |          19.67 ms |       19.39 ms | -0.28 ms (-1.42 %)    |
| p50 ITL              |          19.01 ms |       19.14 ms | +0.13 ms (+0.68 %)    |
| p99 ITL              |          23.83 ms |       21.20 ms | -2.63 ms (-11.0 %)    |
| best-of-3 tok/s      |             53.17 |          54.93 | +3.31 %               |

Same shape as the PR #173 standalone qk_norm null: small mean improvement, real p99 tightening (-11 %), no clearance of 1.05×.

**Root cause:** under `KILN_CUDA_GRAPHS=true`, the qk_norm / recurrent / gated_norm chain is captured once into a CUDA graph and replayed every decode step. Collapsing ~14 candle launches down to 1 shrinks the captured graph but not the replay cost — replay is dominated by HBM traffic and SM occupancy, not per-launch host overhead. Future decode-side fusion should target graph-replay dispatch cost itself (or the F32-intermediate HBM round-trips) rather than collapsing candle launches further. PROFILING.md now documents this and retires the `chunk_gla_fwd` direction for the same reason.

## Why ship the kernel instead of deleting it

1. **Correct** — 3/3 parity tests pass at decode (B=1, nv=16, dk=dv=128), small (B=2, nv=4, dk=dv=32), and asymmetric (B=1, nv=8, dk=64, dv=128) shapes against a candle F32 reference at tol 1.5e-2. Full `kiln-gdn-kernel` nextest green on A6000.
2. **Tail-latency win is real** — -11.0 % p99 ITL, useful for latency-SLO serving and strict-jitter streaming workloads. Opt-in via env gate.
3. **Future re-evaluation is cheap** — if a later optimization shifts the graph-replay balance, the kernel is already wired and tested.

Precedent: PR #173 shipped the standalone qk_norm kernel under `KILN_ENABLE_FUSED_L2_QK_NORM=1` with the same null-result-but-correct framing.

## Test plan

- [x] Parity tests pass on A6000 (`cargo nextest run -p kiln-gdn-kernel --test recurrent_fused_norm_parity` — 3/3 in 1.117s).
- [x] Full `kiln-gdn-kernel` nextest green on A6000.
- [x] Arm B paired bench on A6000 (3 runs × 2 arms), results documented in PROFILING.md.
- [x] Default decode path unchanged (env gate off → `Ok(None)` → existing PR #92 recurrent path).

## Files

- `crates/kiln-gdn-kernel/csrc/recurrent_gdn_fwd.{h,cu}` — new fused kernel + C-ABI dispatcher.
- `crates/kiln-gdn-kernel/src/lib.rs` — FFI decl, capability gate, candle wrapper.
- `crates/kiln-gdn-kernel/tests/recurrent_fused_norm_parity.rs` — 3 parity tests.
- `crates/kiln-model/src/backend/{mod.rs,cuda.rs}` — BackendRuntime surface + CUDA impl + env gate.
- `crates/kiln-model/src/forward.rs` — GDN decode step-5/7/8 short-circuit.
- `PROFILING.md` — null-result section with bench table, root-cause analysis, re-visit triggers, retires `chunk_gla_fwd` direction.

## Pod / cost

Pod `yp293s4oqc7gdx` (A6000 on-demand, ~90 min, ~$1.20). Will be terminated immediately after this PR is filed.