### PR TITLE
desktop: Cmd/Ctrl+W + Esc close shortcuts on settings and logs

### DIFF
--- a/desktop/ui/logs.html
+++ b/desktop/ui/logs.html
@@ -253,6 +253,24 @@
         render([]);
       });
 
+      function closeWindow() {
+        // Tauri v2: webview windows expose close() via getCurrentWebviewWindow.
+        // Fall back across a couple of namespace shapes since different
+        // tauri versions / withGlobalTauri flags expose different globals.
+        const webview = window.__TAURI__ && window.__TAURI__.webviewWindow;
+        const windowNs = window.__TAURI__ && window.__TAURI__.window;
+        const getter =
+          (webview && typeof webview.getCurrentWebviewWindow === "function" && webview.getCurrentWebviewWindow) ||
+          (windowNs && typeof windowNs.getCurrentWindow === "function" && windowNs.getCurrentWindow) ||
+          null;
+        const cur = getter ? getter() : null;
+        if (cur && typeof cur.close === "function") {
+          cur.close();
+        } else {
+          window.close();
+        }
+      }
+
       document.addEventListener("keydown", (e) => {
         if (e.key === "Escape" && document.activeElement === filterEl) {
           if (filterEl.value.length > 0) {
@@ -267,7 +285,10 @@
         if (!mod) return;
         const shift = e.shiftKey;
         const lower = typeof e.key === "string" ? e.key.toLowerCase() : "";
-        if (!shift && lower === "f") {
+        if (!shift && lower === "w") {
+          e.preventDefault();
+          closeWindow();
+        } else if (!shift && lower === "f") {
           e.preventDefault();
           filterEl.focus();
           filterEl.select();

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -284,12 +284,41 @@
       saveBtn.addEventListener("click", save);
       restartBtn.addEventListener("click", restart);
 
+      function closeWindow() {
+        // Tauri v2: webview windows expose close() via getCurrentWebviewWindow.
+        // Fall back across a couple of namespace shapes since different
+        // tauri versions / withGlobalTauri flags expose different globals.
+        const webview = window.__TAURI__ && window.__TAURI__.webviewWindow;
+        const windowNs = window.__TAURI__ && window.__TAURI__.window;
+        const getter =
+          (webview && typeof webview.getCurrentWebviewWindow === "function" && webview.getCurrentWebviewWindow) ||
+          (windowNs && typeof windowNs.getCurrentWindow === "function" && windowNs.getCurrentWindow) ||
+          null;
+        const cur = getter ? getter() : null;
+        if (cur && typeof cur.close === "function") {
+          cur.close();
+        } else {
+          window.close();
+        }
+      }
+
       document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") {
+          const tag = e.target && e.target.tagName;
+          if (tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "SELECT") {
+            e.preventDefault();
+            closeWindow();
+            return;
+          }
+        }
         const mod = e.metaKey || e.ctrlKey;
         if (!mod) return;
         const shift = e.shiftKey;
         const lower = typeof e.key === "string" ? e.key.toLowerCase() : "";
-        if (!shift && lower === "s") {
+        if (!shift && lower === "w") {
+          e.preventDefault();
+          closeWindow();
+        } else if (!shift && lower === "s") {
           e.preventDefault();
           if (!saveBtn.disabled) saveBtn.click();
         } else if (!shift && lower === "r") {


### PR DESCRIPTION
## What
Adds a closeWindow() helper and keydown branches so the Settings and Logs windows can be dismissed with Cmd/Ctrl+W (both) and Escape (settings only).

## Why
About window already supports Escape and Cmd/Ctrl+W to close. Settings and Logs did not, forcing mouse use. This makes window dismissal consistent across all desktop windows.

## Scope
- settings.html: adds closeWindow() helper (copied from about.html pattern) + Escape (when not focused on an input/textarea/select) and Cmd/Ctrl+W close handlers.
- logs.html: adds closeWindow() helper + Cmd/Ctrl+W close handler. Existing Escape-for-filter behavior is preserved.

## Tests
HTML/JS only. Tauri cargo check is not runnable in Cloud Eric (no GTK). CI matrix (Ubuntu/Windows/macOS) validates the full build.