### PR TITLE
desktop: keyboard shortcut help modal on logs window

### DIFF
--- a/desktop/ui/logs.html
+++ b/desktop/ui/logs.html
@@ -99,6 +99,96 @@
         color: #6c7280;
         font-style: italic;
       }
+      .modal-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.55);
+        backdrop-filter: blur(4px);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+      }
+      .modal-overlay.hidden {
+        display: none !important;
+      }
+      .modal-card {
+        background: #1b1e24;
+        border: 1px solid #2a2f3a;
+        border-radius: 8px;
+        padding: 20px 24px;
+        max-width: 420px;
+        width: 90%;
+        max-height: 80vh;
+        overflow-y: auto;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6);
+      }
+      .modal-card header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin: 0 0 14px 0;
+        padding: 0;
+        background: transparent;
+        border: 0;
+      }
+      .modal-card header h2 {
+        margin: 0;
+        font-size: 15px;
+        font-weight: 600;
+        color: #e6e6e6;
+        flex: 0 0 auto;
+      }
+      .modal-card header button#shortcuts-close {
+        margin: 0;
+        background: transparent;
+        color: #a8aeb8;
+        border: 0;
+        padding: 0 4px;
+        font-size: 22px;
+        line-height: 1;
+        cursor: pointer;
+      }
+      .modal-card header button#shortcuts-close:hover {
+        color: #e6e6e6;
+        background: transparent;
+      }
+      .modal-card dl {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        column-gap: 16px;
+        row-gap: 10px;
+        margin: 0;
+        align-items: center;
+      }
+      .modal-card dt {
+        color: #d8dbe2;
+        font-size: 13px;
+      }
+      .modal-card dd {
+        margin: 0;
+        display: flex;
+        gap: 4px;
+        align-items: center;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+      }
+      .modal-card kbd {
+        display: inline-block;
+        background: #0f1115;
+        border: 1px solid #2a2f3a;
+        border-radius: 4px;
+        padding: 2px 6px;
+        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 11px;
+        color: #e6e6e6;
+        line-height: 1;
+      }
+      .modal-card p.hint {
+        margin: 14px 0 0 0;
+        color: #6c7280;
+        font-size: 11px;
+      }
     </style>
   </head>
   <body>
@@ -112,6 +202,29 @@
       <button id="clear" type="button" title="Clear view (Ctrl/Cmd+Shift+K)">Clear view</button>
     </header>
     <div id="log" class="empty">(no log lines yet)</div>
+    <div id="shortcuts-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="shortcuts-title">
+      <div class="modal-card">
+        <header>
+          <h2 id="shortcuts-title">Keyboard Shortcuts</h2>
+          <button id="shortcuts-close" aria-label="Close">×</button>
+        </header>
+        <dl>
+          <dt>Show this help</dt>
+          <dd><kbd>?</kbd> or <kbd>Ctrl</kbd>+<kbd>/</kbd></dd>
+          <dt>Close window</dt>
+          <dd><kbd>Ctrl</kbd>+<kbd>W</kbd></dd>
+          <dt>Focus filter</dt>
+          <dd><kbd>Ctrl</kbd>+<kbd>F</kbd></dd>
+          <dt>Save logs to file</dt>
+          <dd><kbd>Ctrl</kbd>+<kbd>S</kbd></dd>
+          <dt>Clear view</dt>
+          <dd><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>K</kbd></dd>
+          <dt>Clear filter (when focused)</dt>
+          <dd><kbd>Esc</kbd></dd>
+        </dl>
+        <p class="hint">Use Cmd in place of Ctrl on macOS. (Windows/Linux builds only today.)</p>
+      </div>
+    </div>
     <script defer>
       const invoke = (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
         || (window.__TAURI__ && window.__TAURI__.invoke);
@@ -271,7 +384,30 @@
         }
       }
 
+      const shortcutsModal = document.getElementById("shortcuts-modal");
+      const shortcutsCloseBtn = document.getElementById("shortcuts-close");
+      function openShortcutsModal() {
+        shortcutsModal.classList.remove("hidden");
+      }
+      function closeShortcutsModal() {
+        shortcutsModal.classList.add("hidden");
+      }
+      shortcutsCloseBtn.addEventListener("click", closeShortcutsModal);
+      shortcutsModal.addEventListener("click", (e) => {
+        if (e.target === shortcutsModal) closeShortcutsModal();
+      });
+
       document.addEventListener("keydown", (e) => {
+        const modalOpen = !shortcutsModal.classList.contains("hidden");
+        if (modalOpen) {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            closeShortcutsModal();
+          }
+          return;
+        }
+        const target = e.target;
+        const inInput = target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable);
         if (e.key === "Escape" && document.activeElement === filterEl) {
           if (filterEl.value.length > 0) {
             filterEl.value = "";
@@ -282,9 +418,20 @@
           return;
         }
         const mod = e.metaKey || e.ctrlKey;
-        if (!mod) return;
         const shift = e.shiftKey;
-        const lower = typeof e.key === "string" ? e.key.toLowerCase() : "";
+        const key = e.key;
+        const lower = typeof key === "string" ? key.toLowerCase() : "";
+        if (!inInput && !mod && (key === "?" || (shift && key === "/"))) {
+          e.preventDefault();
+          openShortcutsModal();
+          return;
+        }
+        if (!inInput && mod && !shift && key === "/") {
+          e.preventDefault();
+          openShortcutsModal();
+          return;
+        }
+        if (!mod) return;
         if (!shift && lower === "w") {
           e.preventDefault();
           closeWindow();


### PR DESCRIPTION
## What
Adds the same `?`/`Cmd+Ctrl+/` keyboard shortcut help modal to the logs window that PR #179 added to the dashboard. Lists all logs-window shortcuts in one discoverable place.

## Why
The logs window has 4 keyboard shortcuts (close, focus filter, save, clear view) plus Esc-to-clear-filter, but no in-app cheatsheet. Tooltips on buttons are not obvious. This mirrors the dashboard pattern for consistency.

## Shortcuts listed
- `?` or `Ctrl/Cmd+/` — Show this help
- `Ctrl/Cmd+W` — Close window
- `Ctrl/Cmd+F` — Focus filter
- `Ctrl/Cmd+S` — Save logs to file
- `Ctrl/Cmd+Shift+K` — Clear view
- `Esc` (in filter) — Clear filter text

## Test
- Open logs window; press `?` → modal appears
- Press `Esc` → modal closes
- Press `Cmd/Ctrl+/` → modal appears
- Click outside card or X button → modal closes
- Verify existing shortcuts still work: `Cmd+F` focuses filter, `Cmd+S` saves, `Cmd+Shift+K` clears view, `Cmd+W` closes
- Verify typing `?` in the filter input does NOT trigger the modal
- Verify `Esc` in filter (with modal closed) still clears filter text

## Notes
- Modal CSS, structure, and behavior mirror `desktop/ui/dashboard.html` (PR #179)
- Modal-open state takes priority over filter-Esc handling so Esc closes the modal first
- `?` and `Cmd/Ctrl+/` are gated on \`!inInput\` so they do not fire while typing in the filter