### PR TITLE
desktop: keyboard shortcut help modal on settings window

### DIFF
--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -81,6 +81,96 @@
       .status.error { color: #f08080; }
       .todo { color: #a8aeb8; font-size: 11px; margin-top: 4px; }
       .version-footer { margin-top: 16px; color: #6c7280; font-size: 11px; text-align: right; }
+      .modal-overlay {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.55);
+        backdrop-filter: blur(4px);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+      }
+      .modal-overlay.hidden {
+        display: none !important;
+      }
+      .modal-card {
+        background: #1b1e24;
+        border: 1px solid #2a2f3a;
+        border-radius: 8px;
+        padding: 20px 24px;
+        max-width: 420px;
+        width: 90%;
+        max-height: 80vh;
+        overflow-y: auto;
+        box-shadow: 0 10px 40px rgba(0, 0, 0, 0.6);
+      }
+      .modal-card header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        margin: 0 0 14px 0;
+        padding: 0;
+        background: transparent;
+        border: 0;
+      }
+      .modal-card header h2 {
+        margin: 0;
+        font-size: 15px;
+        font-weight: 600;
+        color: #e6e6e6;
+        flex: 0 0 auto;
+      }
+      .modal-card header button#shortcuts-close {
+        margin: 0;
+        background: transparent;
+        color: #a8aeb8;
+        border: 0;
+        padding: 0 4px;
+        font-size: 22px;
+        line-height: 1;
+        cursor: pointer;
+      }
+      .modal-card header button#shortcuts-close:hover {
+        color: #e6e6e6;
+        background: transparent;
+      }
+      .modal-card dl {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        column-gap: 16px;
+        row-gap: 10px;
+        margin: 0;
+        align-items: center;
+      }
+      .modal-card dt {
+        color: #d8dbe2;
+        font-size: 13px;
+      }
+      .modal-card dd {
+        margin: 0;
+        display: flex;
+        gap: 4px;
+        align-items: center;
+        justify-content: flex-end;
+        flex-wrap: wrap;
+      }
+      .modal-card kbd {
+        display: inline-block;
+        background: #0f1115;
+        border: 1px solid #2a2f3a;
+        border-radius: 4px;
+        padding: 2px 6px;
+        font-family: "SF Mono", Menlo, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: 11px;
+        color: #e6e6e6;
+        line-height: 1;
+      }
+      .modal-card p.hint {
+        margin: 14px 0 0 0;
+        color: #6c7280;
+        font-size: 11px;
+      }
     </style>
   </head>
   <body>
@@ -154,6 +244,26 @@
       </div>
       <div class="status" id="status"></div>
       <div class="version-footer">Kiln Desktop v<span id="app-version">—</span></div>
+    </div>
+
+    <div id="shortcuts-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="shortcuts-title">
+      <div class="modal-card">
+        <header>
+          <h2 id="shortcuts-title">Keyboard Shortcuts</h2>
+          <button id="shortcuts-close" aria-label="Close">×</button>
+        </header>
+        <dl>
+          <dt>Show this help</dt>
+          <dd><kbd>?</kbd> or <kbd>Ctrl</kbd>+<kbd>/</kbd></dd>
+          <dt>Close window</dt>
+          <dd><kbd>Esc</kbd> or <kbd>Ctrl</kbd>+<kbd>W</kbd></dd>
+          <dt>Save settings</dt>
+          <dd><kbd>Ctrl</kbd>+<kbd>S</kbd></dd>
+          <dt>Reload settings</dt>
+          <dd><kbd>Ctrl</kbd>+<kbd>R</kbd></dd>
+        </dl>
+        <p class="hint">Use Cmd in place of Ctrl on macOS. (Windows/Linux builds only today.)</p>
+      </div>
     </div>
 
     <script>
@@ -302,19 +412,53 @@
         }
       }
 
+      const shortcutsModal = document.getElementById("shortcuts-modal");
+      const shortcutsCloseBtn = document.getElementById("shortcuts-close");
+      function openShortcutsModal() {
+        shortcutsModal.classList.remove("hidden");
+      }
+      function closeShortcutsModal() {
+        shortcutsModal.classList.add("hidden");
+      }
+      shortcutsCloseBtn.addEventListener("click", closeShortcutsModal);
+      shortcutsModal.addEventListener("click", (e) => {
+        if (e.target === shortcutsModal) closeShortcutsModal();
+      });
+
       document.addEventListener("keydown", (e) => {
+        const modalOpen = !shortcutsModal.classList.contains("hidden");
+        if (modalOpen) {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            closeShortcutsModal();
+          }
+          return;
+        }
+        const target = e.target;
+        const inInput = target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable || target.tagName === "SELECT");
+        const mod = e.metaKey || e.ctrlKey;
+        const shift = e.shiftKey;
+        const key = e.key;
+        const lower = typeof key === "string" ? key.toLowerCase() : "";
+        if (!inInput && !mod && (key === "?" || (shift && key === "/"))) {
+          e.preventDefault();
+          openShortcutsModal();
+          return;
+        }
+        if (!inInput && mod && !shift && key === "/") {
+          e.preventDefault();
+          openShortcutsModal();
+          return;
+        }
         if (e.key === "Escape") {
-          const tag = e.target && e.target.tagName;
+          const tag = target && target.tagName;
           if (tag !== "INPUT" && tag !== "TEXTAREA" && tag !== "SELECT") {
             e.preventDefault();
             closeWindow();
             return;
           }
         }
-        const mod = e.metaKey || e.ctrlKey;
         if (!mod) return;
-        const shift = e.shiftKey;
-        const lower = typeof e.key === "string" ? e.key.toLowerCase() : "";
         if (!shift && lower === "w") {
           e.preventDefault();
           closeWindow();


### PR DESCRIPTION
## What
Adds a help modal listing keyboard shortcuts to the settings window (? or Cmd/Ctrl+/ to open, Esc/backdrop to close).

## Why
Mirrors the dashboard (PR #179) and logs (PR #180) help modals so settings shortcuts are discoverable without reading the source. Completes the in-app shortcut discovery across all three windows with keyboard-driven UX.

## Test plan
- [ ] CI passes on Linux + Windows + macOS builds
- [ ] Manual: open settings window, press ?, verify modal lists Esc / Cmd+W / Cmd+S / Cmd+R
- [ ] Manual: Esc closes modal first, then second Esc closes window