### PR TITLE
desktop: dirty-state indicator on Settings Save button

### DIFF
--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -77,6 +77,7 @@
       }
       button.secondary { background: #2a2f3a; }
       button:disabled { opacity: 0.5; cursor: default; }
+      button#save:disabled { opacity: 0.55; cursor: default; background: #1f3a78; }
       .status { margin-top: 8px; font-size: 12px; color: #7fbf7f; min-height: 16px; }
       .status.error { color: #f08080; }
       .todo { color: #a8aeb8; font-size: 11px; margin-top: 4px; }
@@ -271,6 +272,7 @@
       const dialog = window.__TAURI__.dialog;
       const statusEl = document.getElementById("status");
       const restartBtn = document.getElementById("restart");
+      let lastSavedSnapshot = null;
 
       const fields = [
         "kiln_binary", "model_path", "host", "port",
@@ -324,10 +326,23 @@
           const result = await dialog.open(opts);
           if (typeof result === "string" && result.length) {
             document.getElementById(inputId).value = result;
+            updateDirtyIndicator();
           }
         } catch (e) {
           setStatus("Pick failed: " + e, true);
         }
+      }
+
+      function isDirty() {
+        if (lastSavedSnapshot === null) return false;
+        return JSON.stringify(readForm()) !== lastSavedSnapshot;
+      }
+
+      function updateDirtyIndicator() {
+        const dirty = isDirty();
+        const btn = document.getElementById("save");
+        btn.classList.toggle("dirty", dirty);
+        btn.disabled = !dirty;
       }
 
       function setStatus(msg, err) {
@@ -344,6 +359,8 @@
         try {
           const s = await invoke("get_settings");
           writeForm(s);
+          lastSavedSnapshot = JSON.stringify(readForm());
+          updateDirtyIndicator();
           hideRestart();
           setStatus("Loaded.");
         } catch (e) {
@@ -354,6 +371,8 @@
       async function save() {
         try {
           await invoke("set_settings", { new: readForm() });
+          lastSavedSnapshot = JSON.stringify(readForm());
+          updateDirtyIndicator();
           let running = false;
           try {
             const state = await invoke("server_state");
@@ -393,6 +412,10 @@
       reloadBtn.addEventListener("click", load);
       saveBtn.addEventListener("click", save);
       restartBtn.addEventListener("click", restart);
+
+      const formContainer = document.querySelector(".wrap");
+      formContainer.addEventListener("input", updateDirtyIndicator);
+      formContainer.addEventListener("change", updateDirtyIndicator);
 
       function closeWindow() {
         // Tauri v2: webview windows expose close() via getCurrentWebviewWindow.


### PR DESCRIPTION
Polish: Save button is now disabled until the form has unsaved changes, and re-disables after a successful save.

## What
- Capture a JSON snapshot of form values after `load()` and after a successful `save()`.
- Add `isDirty()` comparing current form to `lastSavedSnapshot`.
- Add `updateDirtyIndicator()` that toggles `.dirty` class and `disabled` on `#save`.
- Delegated `input`/`change` listener on `.wrap` triggers re-evaluation.
- `pickPath()` calls `updateDirtyIndicator()` after programmatic value change (inputs don't auto-fire `input`).
- CSS: `#save:disabled` gets muted tone (opacity 0.55, background `#1f3a78`).

## UX outcome
- On load: Save is disabled (muted).
- Any edit (text, number, checkbox, path picker): Save becomes enabled.
- After Save succeeds: Save returns to disabled until the next edit.
- Reverting an edit back to saved value: Save returns to disabled.