### PR TITLE
CE: desktop: settings unsaved-changes guard on close

### DIFF
--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -257,7 +257,7 @@
           <dt>Show this help</dt>
           <dd><kbd>?</kbd> or <kbd>Ctrl</kbd>+<kbd>/</kbd></dd>
           <dt>Close window</dt>
-          <dd><kbd>Esc</kbd> or <kbd>Ctrl</kbd>+<kbd>W</kbd></dd>
+          <dd><kbd>Esc</kbd> or <kbd>Ctrl</kbd>+<kbd>W</kbd> (prompts if unsaved changes)</dd>
           <dt>Save settings</dt>
           <dd><kbd>Ctrl</kbd>+<kbd>S</kbd></dd>
           <dt>Reload settings</dt>
@@ -418,6 +418,9 @@
       formContainer.addEventListener("change", updateDirtyIndicator);
 
       function closeWindow() {
+        if (isDirty() && !window.confirm("You have unsaved changes. Discard them and close?")) {
+          return;
+        }
         // Tauri v2: webview windows expose close() via getCurrentWebviewWindow.
         // Fall back across a couple of namespace shapes since different
         // tauri versions / withGlobalTauri flags expose different globals.


### PR DESCRIPTION
## What
Close paths on the settings window (Escape, Cmd/Ctrl+W) now prompt "You have unsaved changes. Discard them and close?" via `window.confirm()` when `isDirty()` returns true. Closing is aborted on Cancel.

## Why
Follow-on to #182 (dirty-state indicator on Save). Users can already see that edits are pending, but nothing stops accidental close from discarding them. A single `confirm()` at the top of `closeWindow()` is enough — no new modal needed, and all close paths that route through `closeWindow()` (Escape, Cmd/Ctrl+W) inherit the guard.

## Test plan
- Open Settings, edit a field, press Esc → confirm prompt appears, Cancel keeps window open with dirty state intact.
- Same flow with Cmd/Ctrl+W.
- Open Settings, do nothing, press Esc → closes immediately (no prompt).
- Save, then Esc → closes immediately.

## Notes
- `cargo check` was run locally under `desktop/` and fails in Cloud Eric due to missing GTK/webkit2gtk system libs (`gobject-2.0 was not found in the pkg-config search path`); CI matrix (ubuntu-22.04 + windows-latest + macos-14) validates full build.
- Shortcuts help modal updated to note that close prompts when unsaved changes exist.