### PR TITLE
CE: desktop: Restore defaults button in Settings

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -111,6 +111,11 @@ async fn get_settings(state: State<'_, SettingsState>) -> Result<Settings, Strin
     Ok(state.read().await.clone())
 }
 
+#[tauri::command]
+async fn default_settings() -> Result<Settings, String> {
+    Ok(Settings::default())
+}
+
 #[derive(serde::Serialize)]
 struct BinaryStatus {
     installed: bool,
@@ -578,6 +583,7 @@ fn main() {
             copy_logs,
             save_logs_to_file,
             get_settings,
+            default_settings,
             set_settings,
             get_kiln_url,
             get_openai_base_url,

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -263,6 +263,7 @@
 
       <div class="actions">
         <button class="secondary" id="reload" title="Reload (Cmd/Ctrl+R)">Reload</button>
+        <button class="secondary" id="restore-defaults" title="Reset all fields to defaults">Restore defaults</button>
         <button class="secondary" id="restart" hidden>Restart now</button>
         <button id="save" title="Save (Cmd/Ctrl+S)">Save</button>
       </div>
@@ -430,10 +431,26 @@
         }
       }
 
+      async function restoreDefaults() {
+        if (!window.confirm("Reset all settings to defaults? You'll need to click Save to persist.")) {
+          return;
+        }
+        try {
+          const d = await invoke("default_settings");
+          writeForm(d);
+          updateDirtyIndicator();
+          setStatus("Defaults loaded. Click Save to persist.");
+        } catch (e) {
+          setStatus("Restore failed: " + e, true);
+        }
+      }
+
       const reloadBtn = document.getElementById("reload");
       const saveBtn = document.getElementById("save");
+      const restoreBtn = document.getElementById("restore-defaults");
       reloadBtn.addEventListener("click", load);
       saveBtn.addEventListener("click", save);
+      restoreBtn.addEventListener("click", restoreDefaults);
       restartBtn.addEventListener("click", restart);
 
       const formContainer = document.querySelector(".wrap");


### PR DESCRIPTION
## What
Add a Restore defaults button in the Settings window that resets form fields to `Settings::default()` values. User must explicitly Save to persist (no silent overwrite).

## Why
Polish gap: 13-field settings window with non-obvious perf toggles (FP8 KV cache, CUDA graphs, speculative decoding) offered no way to recover sane defaults after experimentation.

## Changes
- New `default_settings` Tauri command in `desktop/src/main.rs` returning `Settings::default()`.
- New "Restore defaults" secondary button in `desktop/ui/settings.html` that confirms, populates the form via existing `writeForm`, marks the form dirty, and requires explicit Save.

## Test plan
- CI matrix builds Windows MSI + Linux AppImage/deb cleanly
- Manual: open Settings, toggle several fields, click Restore defaults, confirm dialog, verify form resets but Save still required