### PR TITLE
CE: desktop: persist window size/position across launches

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2163,6 +2163,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-updater",
+ "tauri-plugin-window-state",
  "tokio",
 ]
 
@@ -4671,6 +4672,21 @@ dependencies = [
  "url",
  "windows-sys 0.60.2",
  "zip",
+]
+
+[[package]]
+name = "tauri-plugin-window-state"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73736611e14142408d15353e21e3cca2f12a3cfb523ad0ce85999b6d2ef1a704"
+dependencies = [
+ "bitflags 2.11.1",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -22,6 +22,7 @@ tauri-plugin-clipboard-manager = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
 tauri-plugin-notification = "2"
+tauri-plugin-window-state = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "sync", "time", "io-util"] }

--- a/desktop/capabilities/default.json
+++ b/desktop/capabilities/default.json
@@ -10,6 +10,7 @@
     "updater:default",
     "process:default",
     "notification:default",
-    "shell:allow-open"
+    "shell:allow-open",
+    "window-state:default"
   ]
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -560,6 +560,7 @@ fn main() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_notification::init())
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,
             None,


### PR DESCRIPTION
## What
Adds `tauri-plugin-window-state` so Dashboard, Settings, Logs, and About windows remember their size and position between launches.

## Why
Every window currently reopens at its hardcoded default size/position from `tauri.conf.json`. Users expect desktop apps to remember where they left a window — resizing Settings or Logs every time you reopen them is a friction point this plugin eliminates in one line.

## How
- Adds `tauri-plugin-window-state = "2"` to `desktop/Cargo.toml`.
- Registers the plugin via `.plugin(tauri_plugin_window_state::Builder::default().build())` in `main.rs` (immediately before `tauri_plugin_autostart::init` to keep autostart last).
- Grants `window-state:default` permission in `desktop/capabilities/default.json` since the existing capability uses an explicit allowlist.
- Plugin auto-applies to all webview windows; no per-window config required.

## Validation
`cargo check` under `desktop/` fails locally in Cloud Eric due to missing GTK/webkit2gtk system libs (known env limitation — see agent note `tauri-cargo-check-gtk-missing`). CI will validate full build on Windows + Linux.