### PR TITLE
desktop: Download from HuggingFace button in Settings

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -21,6 +21,10 @@ in a VM.
 
 The desktop installer bundles only the wrapper — the `kiln` server binary and model weights must be installed separately. See the root [QUICKSTART.md](../QUICKSTART.md) and point the app at the binary and model path from Settings on first launch.
 
+## Model weights
+
+Settings has a **Download from HuggingFace…** button next to the Model Path picker. Enter a repo id (e.g. `Qwen/Qwen3-4B`), optionally a revision and a token for gated repos, and the app will stream the safetensors shards, tokenizer, and config into `app_data_dir/models/<repo>/` and auto-fill the Model Path field. You still need to click Save to apply it. Users who prefer the CLI can keep using `huggingface-cli download …` and point the Model Path picker at the result.
+
 macOS `.dmg` releases are signed with a Developer ID certificate and notarized by Apple. See [docs/desktop/signing.md](../docs/desktop/signing.md) for the CI setup and required secrets.
 
 ## What ships in v0.1.0

--- a/desktop/src/hf_download.rs
+++ b/desktop/src/hf_download.rs
@@ -1,0 +1,505 @@
+//! One-shot HuggingFace model download for the Settings window.
+//!
+//! The desktop app otherwise requires users to shell out to
+//! `huggingface-cli download ...` before the model path setting has
+//! anything useful to point at. This module lets the frontend pass a
+//! `repo_id` (and optional revision / token for gated models), list the
+//! relevant files via the public HF tree API, and stream each file into
+//! `app_data_dir()/models/<sanitized_repo>/` while emitting progress
+//! events the settings modal renders as a progress bar.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+
+pub const HF_DOWNLOAD_PROGRESS_EVENT: &str = "hf-download-progress";
+pub const HF_DOWNLOAD_DONE_EVENT: &str = "hf-download-done";
+pub const HF_DOWNLOAD_ERROR_EVENT: &str = "hf-download-error";
+
+const HF_API_BASE: &str = "https://huggingface.co";
+const USER_AGENT: &str = concat!("kiln-desktop/", env!("CARGO_PKG_VERSION"));
+
+/// File suffixes / exact names we download. Anything else in the repo
+/// (READMEs, .gitattributes, *.bin when safetensors exist, onnx, etc.)
+/// is skipped — kiln only needs the weights, tokenizer, and config.
+const WEIGHT_SUFFIXES: &[&str] = &[".safetensors"];
+const TOKENIZER_EXACT: &[&str] = &[
+    "tokenizer.json",
+    "tokenizer.model",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "config.json",
+    "generation_config.json",
+    "chat_template.jinja",
+];
+
+/// Per-file IPC throttle: report no more than once every 250ms or once
+/// per 64KB of bytes (whichever fires first). Matches the cadence the
+/// installer module uses so both progress bars feel similar.
+const PROGRESS_BYTES_INTERVAL: u64 = 64 * 1024;
+const PROGRESS_TIME_INTERVAL_MS: u64 = 250;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HfDownloadRequest {
+    pub repo_id: String,
+    #[serde(default)]
+    pub revision: Option<String>,
+    #[serde(default)]
+    pub token: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
+pub enum HfDownloadProgress {
+    Listing,
+    Downloading {
+        file: String,
+        received: u64,
+        total: u64,
+        overall_received: u64,
+        overall_total: u64,
+        file_index: usize,
+        file_count: usize,
+    },
+    Verifying,
+    Done {
+        path: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HfDownloadDone {
+    pub path: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HfDownloadError {
+    pub error: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TreeEntry {
+    #[serde(rename = "type")]
+    entry_type: String,
+    path: String,
+    #[serde(default)]
+    size: u64,
+    #[serde(default)]
+    lfs: Option<LfsMeta>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LfsMeta {
+    #[serde(default)]
+    size: u64,
+}
+
+/// Replace `/` with `__` so the repo id is safe as a single directory
+/// name on every supported OS. Everything else is kept verbatim; HF repo
+/// ids are ASCII-safe already (letters, digits, `-`, `_`, `.`).
+fn sanitize_repo_id(repo_id: &str) -> String {
+    repo_id.replace('/', "__")
+}
+
+/// Target directory for a given repo id, rooted at `app_data_dir()`.
+fn target_dir(app: &AppHandle, repo_id: &str) -> Result<PathBuf, String> {
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app_data_dir unavailable: {}", e))?;
+    Ok(base.join("models").join(sanitize_repo_id(repo_id)))
+}
+
+/// Quick "is this repo already here?" check: the directory exists and
+/// contains the tokenizer plus at least one safetensors shard. We
+/// intentionally do NOT auto-resume for MVP — the error message tells
+/// the user to delete the folder to re-download.
+async fn looks_already_downloaded(dir: &Path) -> bool {
+    if !fs::try_exists(dir).await.unwrap_or(false) {
+        return false;
+    }
+    let tokenizer = dir.join("tokenizer.json");
+    if !fs::try_exists(&tokenizer).await.unwrap_or(false) {
+        return false;
+    }
+    let mut rd = match fs::read_dir(dir).await {
+        Ok(r) => r,
+        Err(_) => return false,
+    };
+    while let Ok(Some(entry)) = rd.next_entry().await {
+        if entry
+            .file_name()
+            .to_str()
+            .map(|s| s.ends_with(".safetensors"))
+            .unwrap_or(false)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// Decide whether a file path returned by the HF tree API is something
+/// kiln needs. Keeps only weights + tokenizer/config. The subdir logic
+/// (basename match) lets us still pick up files inside vendor subdirs
+/// if the repo layout ever ships that way.
+fn should_keep(path: &str) -> bool {
+    let basename = Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    if TOKENIZER_EXACT.iter().any(|t| *t == basename) {
+        return true;
+    }
+    if WEIGHT_SUFFIXES.iter().any(|suffix| basename.ends_with(suffix)) {
+        return true;
+    }
+    false
+}
+
+fn build_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .connect_timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("build reqwest client: {}", e))
+}
+
+fn bearer(token: &Option<String>) -> Option<String> {
+    token
+        .as_ref()
+        .map(|t| t.trim())
+        .filter(|t| !t.is_empty())
+        .map(|t| format!("Bearer {}", t))
+}
+
+/// List the files in `{repo_id}` at `{revision}`. Filter to the ones
+/// kiln actually needs and drop `*.bin` if any `*.safetensors` are
+/// present (repos often ship both). Returns `(path, size)` pairs.
+async fn list_files(
+    client: &reqwest::Client,
+    repo_id: &str,
+    revision: &str,
+    token: &Option<String>,
+) -> Result<Vec<(String, u64)>, String> {
+    let url = format!(
+        "{}/api/models/{}/tree/{}?recursive=true",
+        HF_API_BASE, repo_id, revision
+    );
+    let mut req = client
+        .get(&url)
+        .header("Accept", "application/json");
+    if let Some(auth) = bearer(token) {
+        req = req.header("Authorization", auth);
+    }
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| format!("list request failed: {}", e))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if status.as_u16() == 401 || status.as_u16() == 403 {
+            return Err(format!(
+                "HF API returned {} — the repo may be gated or the token is invalid.",
+                status
+            ));
+        }
+        if status.as_u16() == 404 {
+            return Err(format!(
+                "HF API returned 404 — repo '{}' at revision '{}' not found.",
+                repo_id, revision
+            ));
+        }
+        return Err(format!(
+            "HF API returned HTTP {}: {}",
+            status,
+            body.chars().take(200).collect::<String>()
+        ));
+    }
+    let entries: Vec<TreeEntry> = resp
+        .json()
+        .await
+        .map_err(|e| format!("parse tree listing: {}", e))?;
+
+    let mut kept: Vec<(String, u64)> = entries
+        .into_iter()
+        .filter(|e| e.entry_type == "file")
+        .filter(|e| should_keep(&e.path))
+        .map(|e| {
+            let size = e.lfs.as_ref().map(|l| l.size).unwrap_or(0);
+            let size = if size > 0 { size } else { e.size };
+            (e.path, size)
+        })
+        .collect();
+
+    // If both *.bin and *.safetensors exist, drop the *.bin shards.
+    // (We currently only list safetensors so this is a no-op, but it's
+    // a cheap guard for forward compatibility if we ever widen
+    // WEIGHT_SUFFIXES.)
+    let has_safetensors = kept.iter().any(|(p, _)| p.ends_with(".safetensors"));
+    if has_safetensors {
+        kept.retain(|(p, _)| !p.ends_with(".bin"));
+    }
+
+    if !kept.iter().any(|(p, _)| p.ends_with(".safetensors")) {
+        return Err(format!(
+            "No *.safetensors files found in '{}' at revision '{}'. kiln requires safetensors weights.",
+            repo_id, revision
+        ));
+    }
+
+    Ok(kept)
+}
+
+fn emit_progress(app: &AppHandle, p: HfDownloadProgress) {
+    let _ = app.emit(HF_DOWNLOAD_PROGRESS_EVENT, p);
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn download_file(
+    app: &AppHandle,
+    client: &reqwest::Client,
+    repo_id: &str,
+    revision: &str,
+    token: &Option<String>,
+    rel_path: &str,
+    file_size: u64,
+    dest: &Path,
+    file_index: usize,
+    file_count: usize,
+    overall_received_before: u64,
+    overall_total: u64,
+) -> Result<u64, String> {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("mkdir {}: {}", parent.display(), e))?;
+    }
+
+    let url = format!(
+        "{}/{}/resolve/{}/{}",
+        HF_API_BASE, repo_id, revision, rel_path
+    );
+    let mut req = client.get(&url);
+    if let Some(auth) = bearer(token) {
+        req = req.header("Authorization", auth);
+    }
+    let mut resp = req
+        .send()
+        .await
+        .map_err(|e| format!("download {} failed: {}", rel_path, e))?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "download {} returned HTTP {}",
+            rel_path,
+            resp.status()
+        ));
+    }
+
+    let total_from_header = resp.content_length();
+    // Prefer the listing-reported size when the HTTP header is missing
+    // (the HF CDN sometimes omits Content-Length on redirects).
+    let file_total = total_from_header.unwrap_or(file_size);
+
+    let mut file = fs::File::create(dest)
+        .await
+        .map_err(|e| format!("create {}: {}", dest.display(), e))?;
+
+    let mut received: u64 = 0;
+    let mut last_reported_bytes: u64 = 0;
+    let mut last_emit = Instant::now();
+
+    // Emit an initial 0/total sample so the progress bar paints before
+    // the first chunk arrives on slow links.
+    emit_progress(
+        app,
+        HfDownloadProgress::Downloading {
+            file: rel_path.to_string(),
+            received: 0,
+            total: file_total,
+            overall_received: overall_received_before,
+            overall_total,
+            file_index,
+            file_count,
+        },
+    );
+
+    loop {
+        let chunk = resp
+            .chunk()
+            .await
+            .map_err(|e| format!("chunk read failed on {}: {}", rel_path, e))?;
+        let Some(bytes) = chunk else { break };
+        received = received.saturating_add(bytes.len() as u64);
+        file.write_all(&bytes)
+            .await
+            .map_err(|e| format!("write {}: {}", dest.display(), e))?;
+
+        let time_ok = last_emit.elapsed().as_millis() as u64 >= PROGRESS_TIME_INTERVAL_MS;
+        let bytes_ok = received.saturating_sub(last_reported_bytes) >= PROGRESS_BYTES_INTERVAL;
+        if time_ok || bytes_ok {
+            last_reported_bytes = received;
+            last_emit = Instant::now();
+            emit_progress(
+                app,
+                HfDownloadProgress::Downloading {
+                    file: rel_path.to_string(),
+                    received,
+                    total: file_total.max(received),
+                    overall_received: overall_received_before.saturating_add(received),
+                    overall_total: overall_total.max(overall_received_before.saturating_add(received)),
+                    file_index,
+                    file_count,
+                },
+            );
+        }
+    }
+
+    file.flush()
+        .await
+        .map_err(|e| format!("flush {}: {}", dest.display(), e))?;
+
+    emit_progress(
+        app,
+        HfDownloadProgress::Downloading {
+            file: rel_path.to_string(),
+            received,
+            total: file_total.max(received),
+            overall_received: overall_received_before.saturating_add(received),
+            overall_total: overall_total.max(overall_received_before.saturating_add(received)),
+            file_index,
+            file_count,
+        },
+    );
+
+    Ok(received)
+}
+
+/// Full download pipeline for one HF repo. Emits progress events and
+/// returns the final target directory. Callers wire the result into
+/// `settings.model_path` and surface the `Done` event to the modal.
+pub async fn download_hf_model(
+    app: AppHandle,
+    req: HfDownloadRequest,
+) -> Result<PathBuf, String> {
+    let repo_id = req.repo_id.trim().to_string();
+    if repo_id.is_empty() {
+        return Err("Repo id is required (e.g. Qwen/Qwen3-4B).".into());
+    }
+    let revision = req
+        .revision
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "main".to_string());
+
+    let dir = target_dir(&app, &repo_id)?;
+    if looks_already_downloaded(&dir).await {
+        return Err(format!(
+            "Model already downloaded at {}. Delete the folder to re-download.",
+            dir.display()
+        ));
+    }
+    fs::create_dir_all(&dir)
+        .await
+        .map_err(|e| format!("mkdir {}: {}", dir.display(), e))?;
+
+    emit_progress(&app, HfDownloadProgress::Listing);
+
+    let client = build_client()?;
+    let files = list_files(&client, &repo_id, &revision, &req.token).await?;
+
+    let overall_total: u64 = files.iter().map(|(_, s)| *s).sum();
+    let file_count = files.len();
+    let mut overall_received: u64 = 0;
+
+    for (idx, (rel, size)) in files.iter().enumerate() {
+        let dest = dir.join(rel);
+        let got = download_file(
+            &app,
+            &client,
+            &repo_id,
+            &revision,
+            &req.token,
+            rel,
+            *size,
+            &dest,
+            idx + 1,
+            file_count,
+            overall_received,
+            overall_total,
+        )
+        .await?;
+        overall_received = overall_received.saturating_add(got);
+    }
+
+    emit_progress(&app, HfDownloadProgress::Verifying);
+
+    // Basic post-check: the usual kiln-required trio landed.
+    let tokenizer_ok = fs::try_exists(dir.join("tokenizer.json"))
+        .await
+        .unwrap_or(false);
+    if !tokenizer_ok {
+        return Err("Download completed but tokenizer.json is missing.".into());
+    }
+
+    emit_progress(
+        &app,
+        HfDownloadProgress::Done {
+            path: dir.display().to_string(),
+        },
+    );
+
+    Ok(dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_repo_id_replaces_slash() {
+        assert_eq!(sanitize_repo_id("Qwen/Qwen3-4B"), "Qwen__Qwen3-4B");
+        assert_eq!(sanitize_repo_id("no-slash"), "no-slash");
+        assert_eq!(
+            sanitize_repo_id("org/sub/name"),
+            "org__sub__name"
+        );
+    }
+
+    #[test]
+    fn should_keep_filters_tokenizer_and_weights() {
+        assert!(should_keep("model-00001-of-00002.safetensors"));
+        assert!(should_keep("tokenizer.json"));
+        assert!(should_keep("config.json"));
+        assert!(should_keep("generation_config.json"));
+        assert!(should_keep("chat_template.jinja"));
+        assert!(should_keep("special_tokens_map.json"));
+        assert!(should_keep("subdir/tokenizer.json"));
+
+        assert!(!should_keep("README.md"));
+        assert!(!should_keep(".gitattributes"));
+        assert!(!should_keep("model.onnx"));
+        assert!(!should_keep("pytorch_model.bin"));
+    }
+
+    #[test]
+    fn bearer_normalizes_empty_tokens() {
+        assert_eq!(bearer(&None), None);
+        assert_eq!(bearer(&Some("".to_string())), None);
+        assert_eq!(bearer(&Some("   ".to_string())), None);
+        assert_eq!(
+            bearer(&Some("hf_abc".to_string())),
+            Some("Bearer hf_abc".to_string())
+        );
+        assert_eq!(
+            bearer(&Some("  hf_abc ".to_string())),
+            Some("Bearer hf_abc".to_string())
+        );
+    }
+}

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1,5 +1,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+mod hf_download;
 mod installer;
 mod poller;
 mod settings;
@@ -227,6 +228,46 @@ async fn download_kiln_server(
 #[tauri::command]
 async fn cancel_kiln_download(inst: State<'_, InstallerHandle>) -> Result<(), String> {
     inst.cancel.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
+/// Kick off a HuggingFace model download into
+/// `app_data_dir()/models/<sanitized_repo>/`. Progress is streamed via
+/// the `hf-download-progress` event; terminal success / failure arrive as
+/// `hf-download-done` / `hf-download-error`. The returned `Result` only
+/// indicates whether the background task was spawned; the caller should
+/// wait on events for actual completion.
+#[tauri::command]
+async fn download_hf_model(
+    app: AppHandle,
+    repo_id: String,
+    revision: Option<String>,
+    token: Option<String>,
+) -> Result<(), String> {
+    let req = hf_download::HfDownloadRequest {
+        repo_id,
+        revision,
+        token,
+    };
+    let app_for_task = app.clone();
+    tauri::async_runtime::spawn(async move {
+        match hf_download::download_hf_model(app_for_task.clone(), req).await {
+            Ok(path) => {
+                let _ = app_for_task.emit(
+                    hf_download::HF_DOWNLOAD_DONE_EVENT,
+                    hf_download::HfDownloadDone {
+                        path: path.display().to_string(),
+                    },
+                );
+            }
+            Err(err) => {
+                let _ = app_for_task.emit(
+                    hf_download::HF_DOWNLOAD_ERROR_EVENT,
+                    hf_download::HfDownloadError { error: err },
+                );
+            }
+        }
+    });
     Ok(())
 }
 
@@ -617,6 +658,7 @@ fn main() {
             get_binary_status,
             download_kiln_server,
             cancel_kiln_download,
+            download_hf_model,
             path_info
         ])
         .run(tauri::generate_context!())

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -192,6 +192,66 @@
         color: #6c7280;
         font-size: 11px;
       }
+      .hf-form label {
+        display: block;
+        margin: 10px 0 4px 0;
+        font-size: 12px;
+        color: #cfd3da;
+      }
+      .hf-form input[type="text"],
+      .hf-form input[type="password"] {
+        width: 100%;
+        box-sizing: border-box;
+        background: #0f1115;
+        color: #e6e6e6;
+        border: 1px solid #2a2f3a;
+        border-radius: 4px;
+        padding: 6px 8px;
+        font-size: 13px;
+      }
+      .hf-form .hint {
+        margin: 4px 0 0 0;
+        color: #6c7280;
+        font-size: 11px;
+      }
+      .hf-progress {
+        margin-top: 14px;
+      }
+      .hf-progress.hidden {
+        display: none;
+      }
+      .hf-progress-bar {
+        height: 6px;
+        background: #0f1115;
+        border: 1px solid #2a2f3a;
+        border-radius: 3px;
+        overflow: hidden;
+        margin: 6px 0;
+      }
+      .hf-progress-fill {
+        height: 100%;
+        width: 0%;
+        background: #2f66f0;
+        transition: width 120ms linear;
+      }
+      .hf-progress-line {
+        font-size: 11px;
+        color: #a8aeb8;
+        line-height: 1.4;
+        word-break: break-all;
+      }
+      .hf-progress-line.error {
+        color: #f08080;
+      }
+      .hf-progress-line.success {
+        color: #7fbf7f;
+      }
+      .hf-actions {
+        display: flex;
+        gap: 8px;
+        justify-content: flex-end;
+        margin-top: 16px;
+      }
     </style>
   </head>
   <body>
@@ -212,6 +272,7 @@
           <span class="path-row">
             <input type="text" id="model_path" placeholder="/path/to/model" />
             <button type="button" class="browse" id="pick_model_path">Browse</button>
+            <button type="button" class="browse" id="download_hf_model" title="Download model weights from HuggingFace">Download from HuggingFace…</button>
           </span>
           <span class="hint">Directory containing the Qwen3.5-4B weights.</span>
           <span class="path-warning" id="warn_model_path"></span>
@@ -282,6 +343,36 @@
       </div>
       <div class="status" id="status"></div>
       <div class="version-footer">Kiln Desktop v<span id="app-version">—</span></div>
+    </div>
+
+    <div id="hf-download-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="hf-download-title">
+      <div class="modal-card">
+        <header>
+          <h2 id="hf-download-title">Download from HuggingFace</h2>
+          <button id="hf-close" aria-label="Close">×</button>
+        </header>
+        <div class="hf-form">
+          <label for="hf_repo_id">Repo ID</label>
+          <input type="text" id="hf_repo_id" placeholder="Qwen/Qwen3-4B" autocomplete="off" spellcheck="false" />
+          <p class="hint">HuggingFace repo id, e.g. Qwen/Qwen3-4B. kiln requires a repo with safetensors weights.</p>
+
+          <label for="hf_revision">Revision <span style="color:#6c7280;font-weight:normal;">(optional)</span></label>
+          <input type="text" id="hf_revision" placeholder="main" autocomplete="off" spellcheck="false" />
+
+          <label for="hf_token">HuggingFace token <span style="color:#6c7280;font-weight:normal;">(optional, for gated repos)</span></label>
+          <input type="password" id="hf_token" placeholder="hf_…" autocomplete="off" spellcheck="false" />
+          <p class="hint">Not saved — used only for this download.</p>
+        </div>
+        <div id="hf-progress" class="hf-progress hidden">
+          <div class="hf-progress-line" id="hf-progress-summary">Preparing…</div>
+          <div class="hf-progress-bar"><div class="hf-progress-fill" id="hf-progress-fill"></div></div>
+          <div class="hf-progress-line" id="hf-progress-detail"></div>
+        </div>
+        <div class="hf-actions">
+          <button class="secondary" id="hf-cancel">Cancel</button>
+          <button id="hf-start">Download</button>
+        </div>
+      </div>
     </div>
 
     <div id="shortcuts-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="shortcuts-title">
@@ -559,12 +650,217 @@
         if (e.target === shortcutsModal) closeShortcutsModal();
       });
 
+      // ---------- HuggingFace download modal ----------
+      const hfModal = document.getElementById("hf-download-modal");
+      const hfCloseBtn = document.getElementById("hf-close");
+      const hfCancelBtn = document.getElementById("hf-cancel");
+      const hfStartBtn = document.getElementById("hf-start");
+      const hfRepoInput = document.getElementById("hf_repo_id");
+      const hfRevisionInput = document.getElementById("hf_revision");
+      const hfTokenInput = document.getElementById("hf_token");
+      const hfProgressWrap = document.getElementById("hf-progress");
+      const hfProgressFill = document.getElementById("hf-progress-fill");
+      const hfProgressSummary = document.getElementById("hf-progress-summary");
+      const hfProgressDetail = document.getElementById("hf-progress-detail");
+      const hfOpenBtn = document.getElementById("download_hf_model");
+
+      let hfDownloading = false;
+      let hfUnlistenFns = [];
+
+      function formatBytes(n) {
+        if (!n || n <= 0) return "0 B";
+        const units = ["B", "KB", "MB", "GB", "TB"];
+        let i = 0;
+        let v = n;
+        while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
+        return (i === 0 ? v.toFixed(0) : v.toFixed(1)) + " " + units[i];
+      }
+
+      function resetHfModal() {
+        hfProgressWrap.classList.add("hidden");
+        hfProgressFill.style.width = "0%";
+        hfProgressFill.style.background = "#2f66f0";
+        hfProgressSummary.className = "hf-progress-line";
+        hfProgressSummary.textContent = "Preparing…";
+        hfProgressDetail.className = "hf-progress-line";
+        hfProgressDetail.textContent = "";
+        hfStartBtn.disabled = false;
+        hfStartBtn.textContent = "Download";
+        hfCancelBtn.textContent = "Cancel";
+        hfRepoInput.disabled = false;
+        hfRevisionInput.disabled = false;
+        hfTokenInput.disabled = false;
+      }
+
+      function openHfModal() {
+        resetHfModal();
+        if (!hfRepoInput.value) {
+          hfRepoInput.placeholder = "Qwen/Qwen3-4B";
+        }
+        hfModal.classList.remove("hidden");
+        setTimeout(() => hfRepoInput.focus(), 0);
+      }
+
+      async function teardownHfListeners() {
+        for (const fn of hfUnlistenFns) {
+          try { fn(); } catch (_) {}
+        }
+        hfUnlistenFns = [];
+      }
+
+      async function closeHfModal() {
+        if (hfDownloading) return; // Cancel handler handles in-flight closes.
+        await teardownHfListeners();
+        hfModal.classList.add("hidden");
+        // Clear the token field so it never lingers across opens.
+        hfTokenInput.value = "";
+      }
+
+      async function startHfDownload() {
+        const repoId = (hfRepoInput.value || "").trim();
+        if (!repoId) {
+          hfProgressWrap.classList.remove("hidden");
+          hfProgressSummary.className = "hf-progress-line error";
+          hfProgressSummary.textContent = "Repo id is required (e.g. Qwen/Qwen3-4B).";
+          hfProgressDetail.textContent = "";
+          return;
+        }
+        const revision = (hfRevisionInput.value || "").trim() || null;
+        const token = (hfTokenInput.value || "").trim() || null;
+
+        hfProgressWrap.classList.remove("hidden");
+        hfProgressFill.style.width = "0%";
+        hfProgressFill.style.background = "#2f66f0";
+        hfProgressSummary.className = "hf-progress-line";
+        hfProgressSummary.textContent = "Listing repository files…";
+        hfProgressDetail.textContent = "";
+        hfStartBtn.disabled = true;
+        hfCancelBtn.textContent = "Close";
+        hfRepoInput.disabled = true;
+        hfRevisionInput.disabled = true;
+        hfTokenInput.disabled = true;
+        hfDownloading = true;
+
+        // Listen for events for this download. Unlisten on completion/cancel.
+        const event = window.__TAURI__ && window.__TAURI__.event;
+        if (!event || typeof event.listen !== "function") {
+          hfProgressSummary.className = "hf-progress-line error";
+          hfProgressSummary.textContent = "Tauri event API unavailable.";
+          hfDownloading = false;
+          hfStartBtn.disabled = false;
+          hfCancelBtn.textContent = "Close";
+          return;
+        }
+
+        const unProgress = await event.listen("hf-download-progress", (e) => {
+          const p = e && e.payload;
+          if (!p || !p.phase) return;
+          if (p.phase === "listing") {
+            hfProgressSummary.textContent = "Listing repository files…";
+          } else if (p.phase === "downloading") {
+            const pct = p.overall_total > 0
+              ? Math.max(0, Math.min(100, (p.overall_received / p.overall_total) * 100))
+              : 0;
+            hfProgressFill.style.width = pct.toFixed(1) + "%";
+            hfProgressSummary.textContent =
+              "Downloading " + p.file_index + " of " + p.file_count +
+              ": " + (p.file || "");
+            hfProgressDetail.textContent =
+              formatBytes(p.overall_received) + " / " + formatBytes(p.overall_total) +
+              " (" + formatBytes(p.received) + " / " + formatBytes(p.total) + " current)";
+          } else if (p.phase === "verifying") {
+            hfProgressSummary.textContent = "Verifying download…";
+          } else if (p.phase === "done") {
+            hfProgressFill.style.width = "100%";
+            hfProgressSummary.className = "hf-progress-line success";
+            hfProgressSummary.textContent = "Downloaded to " + (p.path || "");
+          }
+        });
+        const unDone = await event.listen("hf-download-done", (e) => {
+          const payload = e && e.payload;
+          const path = payload && payload.path;
+          hfProgressFill.style.width = "100%";
+          hfProgressSummary.className = "hf-progress-line success";
+          hfProgressSummary.textContent = "Downloaded to " + (path || "(unknown)");
+          hfProgressDetail.textContent = "";
+          hfDownloading = false;
+          if (path) {
+            const modelInput = document.getElementById("model_path");
+            modelInput.value = path;
+            modelInput.dispatchEvent(new Event("input", { bubbles: true }));
+            modelInput.dispatchEvent(new Event("change", { bubbles: true }));
+            validatePath("model_path");
+          }
+          hfStartBtn.disabled = true;
+          hfStartBtn.textContent = "Done";
+          hfCancelBtn.textContent = "Close";
+          // Auto-close after a short delay so the success state is legible.
+          setTimeout(() => {
+            if (!hfModal.classList.contains("hidden")) {
+              closeHfModal();
+            }
+          }, 1400);
+        });
+        const unError = await event.listen("hf-download-error", (e) => {
+          const payload = e && e.payload;
+          const err = (payload && payload.error) || "Unknown error";
+          hfProgressSummary.className = "hf-progress-line error";
+          hfProgressSummary.textContent = "Download failed: " + err;
+          hfProgressDetail.textContent = "";
+          hfProgressFill.style.background = "#3a2a2a";
+          hfDownloading = false;
+          hfStartBtn.disabled = false;
+          hfStartBtn.textContent = "Retry";
+          hfCancelBtn.textContent = "Close";
+          hfRepoInput.disabled = false;
+          hfRevisionInput.disabled = false;
+          hfTokenInput.disabled = false;
+        });
+        hfUnlistenFns = [unProgress, unDone, unError];
+
+        try {
+          await invoke("download_hf_model", {
+            repoId: repoId,
+            revision: revision,
+            token: token,
+          });
+        } catch (err) {
+          hfProgressSummary.className = "hf-progress-line error";
+          hfProgressSummary.textContent = "Failed to start download: " + err;
+          hfProgressDetail.textContent = "";
+          hfDownloading = false;
+          hfStartBtn.disabled = false;
+          hfStartBtn.textContent = "Retry";
+          hfCancelBtn.textContent = "Close";
+          hfRepoInput.disabled = false;
+          hfRevisionInput.disabled = false;
+          hfTokenInput.disabled = false;
+          await teardownHfListeners();
+        }
+      }
+
+      hfOpenBtn.addEventListener("click", openHfModal);
+      hfCloseBtn.addEventListener("click", closeHfModal);
+      hfCancelBtn.addEventListener("click", closeHfModal);
+      hfStartBtn.addEventListener("click", startHfDownload);
+      hfModal.addEventListener("click", (e) => {
+        if (e.target === hfModal && !hfDownloading) closeHfModal();
+      });
+
       document.addEventListener("keydown", (e) => {
-        const modalOpen = !shortcutsModal.classList.contains("hidden");
-        if (modalOpen) {
+        const shortcutsOpen = !shortcutsModal.classList.contains("hidden");
+        const hfOpen = !hfModal.classList.contains("hidden");
+        if (shortcutsOpen) {
           if (e.key === "Escape") {
             e.preventDefault();
             closeShortcutsModal();
+          }
+          return;
+        }
+        if (hfOpen) {
+          if (e.key === "Escape" && !hfDownloading) {
+            e.preventDefault();
+            closeHfModal();
           }
           return;
         }


### PR DESCRIPTION
## What

Adds a one-click **Download from HuggingFace…** button to the Settings window that downloads a HuggingFace model (safetensors shards + tokenizer/config) into \`app_data_dir/models/<repo>/\` and auto-fills the Model Path field. Users can go from fresh install to a working kiln server without ever shelling out to \`huggingface-cli\`.

## Why

Project vision calls for an in-app model fetch path (\"Model path picker (with HF download helper later)\"). Today users must run \`huggingface-cli download …\` in a terminal before the app is useful, which breaks the \"no terminal\" promise for consumer users.

## Changes

- \`desktop/src/hf_download.rs\` (new): async streaming download module with
  - HF tree-API listing (\`GET /api/models/{repo}/tree/{revision}?recursive=true\`) + filter to safetensors + tokenizer/config files
  - Per-file streaming via \`reqwest\` + \`Response::chunk()\` (same pattern as \`installer.rs\`; no new crates)
  - Progress events throttled to one emit per 64KB or 250ms (matches installer)
  - \`HfDownloadProgress\` enum with \`Listing\` / \`Downloading\` / \`Verifying\` / \`Done\` phases
  - Target dir: \`app_data_dir()/models/<sanitized_repo>/\` (slashes → \`__\`)
  - Refuses to clobber an already-downloaded repo; tells the user to delete the folder to re-download
- \`desktop/src/main.rs\`: register \`mod hf_download\` + new \`download_hf_model\` Tauri command; wires through \`async_runtime::spawn\` + emits \`hf-download-done\`/\`hf-download-error\` on termination
- \`desktop/ui/settings.html\`: new button next to Browse, new modal with repo id / revision / token fields, progress bar, success/error states. Reuses existing dirty-state + save flow — success sets \`#model_path\` and dispatches \`input\`/\`change\` so the existing validation + save button light up. Escape / backdrop-close disabled mid-download.
- \`desktop/README.md\`: brief \"Model weights\" paragraph describing the new flow.

## Dependencies

No new crates. \`reqwest\` already has \`stream\` + \`rustls-tls\` features enabled.

## Out of scope (follow-ups)

- Abort mid-download (Cancel currently just closes the modal; background task finishes silently)
- Download resume after interruption
- Recommended-models dropdown / curated list
- Persistent HF token in settings
- Auto-detect disk space before download
- Delete / re-download controls for existing models

## Test notes

- Unit tests for \`sanitize_repo_id\`, \`should_keep\`, and \`bearer\` added in \`hf_download.rs\`.
- \`cargo check\` was attempted locally but GTK/WebKit sys libs aren't installed in the Cloud Eric build sessions (known limitation — see \`desktop-kiln-cargo-check-syslibs\` note). CI will gate the Rust compile.
- End-to-end test plan: open Settings → click Download from HuggingFace → enter \`Qwen/Qwen3-4B\` → watch progress → confirm \`model_path\` auto-fills → Save.

## Rough edges worth reviewer attention

1. **No abort mid-download for MVP.** Clicking Cancel during a download just closes the modal; the background task keeps running to completion in \`app_data_dir/models/…\`. An explicit abort flag would follow the installer's \`AtomicBool\` cancel pattern; deferred to a follow-up to keep this PR focused.
2. **Pre-existing-folder handling is blunt.** If \`tokenizer.json\` + any \`*.safetensors\` exist, we refuse to download and tell the user to delete the folder. A resumable / smarter \"already there\" path is explicitly out of scope.
3. **Token input is session-only**, never persisted — matches the task spec.