### PR TITLE
desktop: color stderr lines in log viewer

### DIFF
--- a/desktop/ui/logs.html
+++ b/desktop/ui/logs.html
@@ -99,6 +99,15 @@
         color: #6c7280;
         font-style: italic;
       }
+      #log .line {
+        white-space: pre-wrap;
+      }
+      #log .line-stderr {
+        color: #f0a04a;
+      }
+      #log .line-stdout {
+        color: inherit;
+      }
       .modal-overlay {
         position: fixed;
         inset: 0;
@@ -323,7 +332,20 @@
           return;
         }
         logEl.classList.remove("empty");
-        logEl.textContent = visible.join("\n");
+        logEl.innerHTML = "";
+        const frag = document.createDocumentFragment();
+        for (const line of visible) {
+          const div = document.createElement("div");
+          div.className = "line";
+          if (line.startsWith("[stderr] ")) {
+            div.classList.add("line-stderr");
+          } else if (line.startsWith("[stdout] ")) {
+            div.classList.add("line-stdout");
+          }
+          div.textContent = line;
+          frag.appendChild(div);
+        }
+        logEl.appendChild(frag);
         if (autoscrollEl.checked) {
           logEl.scrollTop = logEl.scrollHeight;
         }


### PR DESCRIPTION
## What
Visually distinguish stderr vs stdout lines in the desktop log viewer so errors are spottable at a glance.

- Each line now renders as its own `<div class=\"line\">` with an added `line-stderr` or `line-stdout` class based on the `[stdout] ` / `[stderr] ` prefix from `supervisor.rs`.
- Stderr lines are colored amber (`#f0a04a`); stdout keeps default.
- Filter/copy/save/clear still operate on the raw `lines` array, so behavior is unchanged.

## Why
Previously all lines joined into a single `textContent` blob — impossible to spot crashes, CUDA warnings, or panics in a flood of normal startup logs.

## Validation
- Local `cargo check` in `desktop/` fails with missing GTK/webkit2gtk libs — Cloud Eric env limitation. CI matrix validates real builds.
- Frontend-only HTML/CSS/JS change; no Rust touched.