### PR TITLE
desktop: click model-path pill to copy

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -191,6 +191,11 @@
       #check-updates-btn.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
       #check-updates-btn.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
       #check-updates-btn:disabled { background: #2a2f3a; color: #6c7280; cursor: default; }
+      #model-path-pill.copyable { cursor: pointer; }
+      #model-path-pill.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
+      #model-path-pill.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
+      #model-path-pill.flash #model-path,
+      #model-path-pill.flash-warn #model-path { color: inherit; }
       #status-badge {
         display: inline-flex;
         align-items: center;
@@ -1494,10 +1499,12 @@
           if (settings && settings.model_path) {
             modelPathEl.textContent = settings.model_path;
             modelPathEl.classList.remove("empty");
-            modelPathPill.title = `Configured model path: ${settings.model_path}`;
+            modelPathPill.classList.add("copyable");
+            modelPathPill.title = `Configured model path: ${settings.model_path} (click to copy)`;
           } else {
             modelPathEl.textContent = MODEL_EMPTY_LABEL;
             modelPathEl.classList.add("empty");
+            modelPathPill.classList.remove("copyable");
             modelPathPill.title = MODEL_EMPTY_TITLE;
           }
         } catch (err) {
@@ -1506,6 +1513,48 @@
       }
 
       window.addEventListener("focus", refreshModelPath);
+
+      let modelPathPillResetTimer = null;
+      function flashModelPathPill(cls) {
+        if (modelPathPillResetTimer) {
+          clearTimeout(modelPathPillResetTimer);
+          modelPathPillResetTimer = null;
+        }
+        modelPathPill.classList.remove("flash", "flash-warn");
+        if (cls) modelPathPill.classList.add(cls);
+        modelPathPillResetTimer = setTimeout(() => {
+          modelPathPill.classList.remove("flash", "flash-warn");
+          modelPathPillResetTimer = null;
+        }, 1200);
+      }
+
+      async function copyModelPath() {
+        if (modelPathEl.classList.contains("empty")) return;
+        if (!invoke) {
+          flashModelPathPill("flash-warn");
+          return;
+        }
+        try {
+          const settings = await invoke("get_settings");
+          const path = settings && settings.model_path;
+          if (!path) {
+            flashModelPathPill("flash-warn");
+            return;
+          }
+          try {
+            await navigator.clipboard.writeText(path);
+            flashModelPathPill("flash");
+          } catch (err) {
+            flashModelPathPill("flash-warn");
+            console.error("clipboard.writeText failed", err);
+          }
+        } catch (err) {
+          flashModelPathPill("flash-warn");
+          console.error("get_settings failed", err);
+        }
+      }
+
+      modelPathPill.addEventListener("click", copyModelPath);
 
       const checkUpdatesBtn = document.getElementById("check-updates-btn");
       const CHECK_UPDATES_LABEL = "Check for Updates";


### PR DESCRIPTION
## What
Make the dashboard toolbar's model-path pill click-to-copy when a path is configured, matching the existing Copy OpenAI Base URL pattern (flash green on success, red on failure).

## Why
Users currently have no quick way to grab the configured model path from the dashboard — they need to open Settings and select the text. One-click copy is a natural polish after PR #190.

## How
- Add `.copyable` class + `flash`/`flash-warn` CSS to `#model-path-pill`
- `refreshModelPath()` toggles `.copyable` based on whether a path is set
- Click handler reads path via `get_settings`, writes to clipboard, flashes status
- No new keyboard shortcut