### PR TITLE
desktop: click #base-url pill to copy

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -196,6 +196,9 @@
       #model-path-pill.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
       #model-path-pill.flash #model-path,
       #model-path-pill.flash-warn #model-path { color: inherit; }
+      #base-url.copyable { cursor: pointer; }
+      #base-url.flash { background: #245a32; border-color: #2f7a43; color: #d6f2dd; }
+      #base-url.flash-warn { background: #5a3324; border-color: #7a432f; color: #f2ddd6; }
       #status-badge {
         display: inline-flex;
         align-items: center;
@@ -1160,14 +1163,57 @@
       function setBaseUrl(url) {
         if (url) {
           baseUrlEl.textContent = url;
-          baseUrlEl.title = url;
+          baseUrlEl.title = `${url} (click to copy)`;
           baseUrlEl.classList.remove("empty");
+          baseUrlEl.classList.add("copyable");
         } else {
           baseUrlEl.textContent = BASE_URL_EMPTY_LABEL;
           baseUrlEl.title = BASE_URL_EMPTY_TITLE;
           baseUrlEl.classList.add("empty");
+          baseUrlEl.classList.remove("copyable");
         }
       }
+
+      let baseUrlResetTimer = null;
+      function flashBaseUrl(cls) {
+        if (baseUrlResetTimer) {
+          clearTimeout(baseUrlResetTimer);
+          baseUrlResetTimer = null;
+        }
+        baseUrlEl.classList.remove("flash", "flash-warn");
+        if (cls) baseUrlEl.classList.add(cls);
+        baseUrlResetTimer = setTimeout(() => {
+          baseUrlEl.classList.remove("flash", "flash-warn");
+          baseUrlResetTimer = null;
+        }, 1200);
+      }
+
+      async function copyBaseUrl() {
+        if (baseUrlEl.classList.contains("empty")) return;
+        if (!invoke) {
+          flashBaseUrl("flash-warn");
+          return;
+        }
+        try {
+          const url = await invoke("get_openai_base_url");
+          if (!url) {
+            flashBaseUrl("flash-warn");
+            return;
+          }
+          try {
+            await navigator.clipboard.writeText(url);
+            flashBaseUrl("flash");
+          } catch (err) {
+            flashBaseUrl("flash-warn");
+            console.error("clipboard.writeText failed", err);
+          }
+        } catch (err) {
+          flashBaseUrl("flash-warn");
+          console.error("get_openai_base_url failed", err);
+        }
+      }
+
+      baseUrlEl.addEventListener("click", copyBaseUrl);
 
       async function refreshBaseUrl(kind) {
         if (!invoke || kind !== "Running") {


### PR DESCRIPTION
## What
Makes the `#base-url` code element in the dashboard toolbar clickable to copy the OpenAI base URL, matching PR #191's model-path pill pattern.

## Why
Two UI elements next to each other (model-path pill + base-url pill) were inconsistent — model-path copied on click, base-url did not. A separate `Copy OpenAI base URL` button already exists and stays; this just adds the same one-click shortcut for parity.

## Changes (`desktop/ui/dashboard.html`)
- CSS: add `.copyable` and `.flash`/`.flash-warn` rules for `#base-url` (mirrors `#model-path-pill` styles)
- `setBaseUrl()`: toggle `.copyable` class and append `(click to copy)` to the title when a URL is set; remove `.copyable` and restore the empty title otherwise
- Add `flashBaseUrl()` and `copyBaseUrl()` helpers reusing the existing `get_openai_base_url` invoke
- Wire `click` listener on the `#base-url` element

## Notes
- The standalone `#copy-url` button is intentionally untouched — it remains the explicit action; the pill click is a convenience shortcut.
- Cloud Eric cannot run `cargo check` on the Tauri crate (GTK/webkit2gtk missing), but this change is pure HTML/JS/CSS in `desktop/ui/dashboard.html` with no Rust touched. CI's Windows + Ubuntu matrix validates the full build.

## Test plan
- Manual: start kiln server, click the URL pill, confirm green flash and URL lands in clipboard
- Before server runs (pill has `.empty`), click is a no-op
- Tooltip shows `<url> (click to copy)` while running, default empty title while stopped