### PR TITLE
desktop: fix HF download placeholder to Qwen/Qwen3.5-4B

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -23,7 +23,7 @@ The desktop installer bundles only the wrapper — the `kiln` server binary and 
 
 ## Model weights
 
-Settings has a **Download from HuggingFace…** button next to the Model Path picker. Enter a repo id (e.g. `Qwen/Qwen3-4B`), optionally a revision and a token for gated repos, and the app will stream the safetensors shards, tokenizer, and config into `app_data_dir/models/<repo>/` and auto-fill the Model Path field. You still need to click Save to apply it. Users who prefer the CLI can keep using `huggingface-cli download …` and point the Model Path picker at the result.
+Settings has a **Download from HuggingFace…** button next to the Model Path picker. Enter a repo id (e.g. `Qwen/Qwen3.5-4B`), optionally a revision and a token for gated repos, and the app will stream the safetensors shards, tokenizer, and config into `app_data_dir/models/<repo>/` and auto-fill the Model Path field. You still need to click Save to apply it. Users who prefer the CLI can keep using `huggingface-cli download …` and point the Model Path picker at the result.
 
 macOS `.dmg` releases are signed with a Developer ID certificate and notarized by Apple. See [docs/desktop/signing.md](../docs/desktop/signing.md) for the CI setup and required secrets.
 

--- a/desktop/src/hf_download.rs
+++ b/desktop/src/hf_download.rs
@@ -389,7 +389,7 @@ pub async fn download_hf_model(
 ) -> Result<PathBuf, String> {
     let repo_id = req.repo_id.trim().to_string();
     if repo_id.is_empty() {
-        return Err("Repo id is required (e.g. Qwen/Qwen3-4B).".into());
+        return Err("Repo id is required (e.g. Qwen/Qwen3.5-4B).".into());
     }
     let revision = req
         .revision
@@ -464,7 +464,7 @@ mod tests {
 
     #[test]
     fn sanitize_repo_id_replaces_slash() {
-        assert_eq!(sanitize_repo_id("Qwen/Qwen3-4B"), "Qwen__Qwen3-4B");
+        assert_eq!(sanitize_repo_id("Qwen/Qwen3.5-4B"), "Qwen__Qwen3.5-4B");
         assert_eq!(sanitize_repo_id("no-slash"), "no-slash");
         assert_eq!(
             sanitize_repo_id("org/sub/name"),

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -353,8 +353,8 @@
         </header>
         <div class="hf-form">
           <label for="hf_repo_id">Repo ID</label>
-          <input type="text" id="hf_repo_id" placeholder="Qwen/Qwen3-4B" autocomplete="off" spellcheck="false" />
-          <p class="hint">HuggingFace repo id, e.g. Qwen/Qwen3-4B. kiln requires a repo with safetensors weights.</p>
+          <input type="text" id="hf_repo_id" placeholder="Qwen/Qwen3.5-4B" autocomplete="off" spellcheck="false" />
+          <p class="hint">HuggingFace repo id, e.g. Qwen/Qwen3.5-4B. kiln requires a repo with safetensors weights.</p>
 
           <label for="hf_revision">Revision <span style="color:#6c7280;font-weight:normal;">(optional)</span></label>
           <input type="text" id="hf_revision" placeholder="main" autocomplete="off" spellcheck="false" />
@@ -695,7 +695,7 @@
       function openHfModal() {
         resetHfModal();
         if (!hfRepoInput.value) {
-          hfRepoInput.placeholder = "Qwen/Qwen3-4B";
+          hfRepoInput.placeholder = "Qwen/Qwen3.5-4B";
         }
         hfModal.classList.remove("hidden");
         setTimeout(() => hfRepoInput.focus(), 0);
@@ -721,7 +721,7 @@
         if (!repoId) {
           hfProgressWrap.classList.remove("hidden");
           hfProgressSummary.className = "hf-progress-line error";
-          hfProgressSummary.textContent = "Repo id is required (e.g. Qwen/Qwen3-4B).";
+          hfProgressSummary.textContent = "Repo id is required (e.g. Qwen/Qwen3.5-4B).";
           hfProgressDetail.textContent = "";
           return;
         }


### PR DESCRIPTION
## What

Corrects the HuggingFace download placeholder and related hint/error strings in the Settings window from Qwen/Qwen3-4B to Qwen/Qwen3.5-4B — the canonical model kiln actually targets.

## Why