### PR TITLE
kiln-core: clarify ChatML fallback is not Qwen3.5's full template

### DIFF
--- a/crates/kiln-core/src/tokenizer.rs
+++ b/crates/kiln-core/src/tokenizer.rs
@@ -91,7 +91,10 @@ impl KilnTokenizer {
     /// Apply the chat template to format messages into a prompt string.
     ///
     /// If a Jinja2 template was set via [`with_chat_template`], renders it with
-    /// minijinja. Otherwise uses Qwen3's ChatML format as the default.
+    /// minijinja. Otherwise falls back to plain ChatML framing — a minimal
+    /// subset that omits Qwen3.5's XML `<function=...>` tool calls, `<think>`
+    /// reasoning, and `<tool_response>` handling. Load the model's real
+    /// `chat_template` via `with_chat_template` for production use.
     pub fn apply_chat_template(&self, messages: &[ChatMessage]) -> Result<String, TokenizerError> {
         match &self.chat_template {
             Some(template) => self.render_jinja_template(template, messages),
@@ -142,7 +145,10 @@ impl KilnTokenizer {
         .map_err(|e| TokenizerError::ChatTemplate(e.to_string()))
     }
 
-    /// Format messages using ChatML (the format used by Qwen3 and many other models).
+    /// Plain ChatML framing fallback: `<|im_start|>role\n...<|im_end|>\n`.
+    /// Qwen3.5's real template adds XML `<function=...>` tool calls, `<think>`
+    /// reasoning, and `<tool_response>` wrapping on top of this — none of
+    /// which is implemented here.
     fn apply_chatml(messages: &[ChatMessage]) -> String {
         let mut prompt = String::new();
         for msg in messages {


### PR DESCRIPTION
## What

Fix two misleading doc comments in `crates/kiln-core/src/tokenizer.rs` that described the `apply_chatml` fallback as \"Qwen3's ChatML format.\" Qwen3.5 (kiln's canonical target) uses a full Jinja template with XML tool calls (`<function=...>`), `<think>` reasoning, and `<tool_response>` wrapping — none of which the fallback implements.

## Why

Calling the fallback \"Qwen3's ChatML format\" implies it is sufficient for Qwen3 / Qwen3.5 inference. It is not. Readers who trust the comment may ship bugs by relying on the fallback instead of loading the model's real `chat_template` via `with_chat_template`. This PR makes the limitation explicit so the minijinja path is the obvious correct choice for real usage.

See Qwen/Qwen3.5-4B `tokenizer_config.json` on HF and the dspy-qwen-adapter README (https://github.com/cmpnd-ai/dspy-qwen-adapter) for the format divergence from plain ChatML.

## Changes

- `crates/kiln-core/src/tokenizer.rs` — doc comments only on `apply_chat_template` and `apply_chatml`. No logic changes.

Validated with `cargo check -p kiln-core` (clean, only pre-existing warnings in prefix_cache.rs).