### PR TITLE
desktop: bump version to 0.1.7

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-desktop"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kiln-desktop"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Kiln Desktop — system tray app for the kiln local LLM server"
 authors = ["Eric Florenzano <eric@eflorenzano.com>"]

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kiln Desktop",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "com.eflorenzano.kiln.desktop",
   "build": {
     "frontendDist": "ui",


### PR DESCRIPTION
Cuts kiln desktop v0.1.7. Ships PRs #192, #193, #194, #197, #198 (copy pills + HF placeholder fix + auto-update design).