### PR TITLE
desktop: check for kiln binary updates (detection only)

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2150,6 +2150,7 @@ dependencies = [
  "dirs 5.0.1",
  "flate2",
  "reqwest 0.12.28",
+ "semver",
  "serde",
  "serde_json",
  "sha2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -31,6 +31,7 @@ dirs = "5"
 sha2 = "0.10"
 flate2 = "1"
 tar = "0.4"
+semver = "1"
 
 [features]
 default = ["custom-protocol"]

--- a/desktop/src/installer.rs
+++ b/desktop/src/installer.rs
@@ -393,6 +393,57 @@ fn clear_quarantine(path: &Path) {
 #[cfg(not(target_os = "macos"))]
 fn clear_quarantine(_path: &Path) {}
 
+/// Parse the second whitespace-separated token from `kiln --version`
+/// output. Returns `None` when the output is empty or has only one token.
+/// `kiln --version` prints either `kiln <semver>` or
+/// `kiln <semver> (<git-sha>)`; we take the `<semver>` token.
+fn parse_kiln_version_output(stdout: &str) -> Option<String> {
+    stdout.split_whitespace().nth(1).map(|s| s.to_string())
+}
+
+/// Run `bin --version` and return the reported semver, or `None` if the
+/// command fails, exits non-zero, or produces unparseable output.
+pub async fn current_kiln_version(bin: &Path) -> Option<String> {
+    let out = tokio::process::Command::new(bin)
+        .arg("--version")
+        .output()
+        .await
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    parse_kiln_version_output(&stdout)
+}
+
+/// Fetch the newest release version for the current target. Returns
+/// `None` when the platform has no prebuilt asset or when the GitHub
+/// releases listing fails. Callers should separately check
+/// [`supports_auto_install`] to distinguish those two cases.
+pub async fn discover_latest_version(client: &reqwest::Client) -> Option<String> {
+    let target = current_target()?;
+    discover_asset(client, target).await.ok().map(|p| p.version)
+}
+
+/// Decide whether `latest` is newer than `current` using semver.
+///
+/// Per design doc (`desktop/docs/binary-update.md`): fall back to string
+/// inequality when either side fails to parse as semver, never suggest a
+/// downgrade, and treat "unknown current version" as "offer latest".
+pub fn is_update_available(current: Option<&str>, latest: &str) -> bool {
+    let Some(current) = current else { return true; };
+    match (
+        semver::Version::parse(current),
+        semver::Version::parse(latest),
+    ) {
+        (Ok(c), Ok(l)) => c < l,
+        // One side isn't valid semver — best we can do is say "offer when
+        // strings differ" so a genuine mismatch surfaces without claiming
+        // a downgrade-as-update when parsing succeeds on both sides.
+        _ => current != latest,
+    }
+}
+
 /// Full install pipeline: discover latest asset, download, verify sha256,
 /// extract, chmod, clear quarantine. Returns the installed binary path.
 pub async fn install_latest_server(
@@ -469,4 +520,60 @@ pub async fn install_latest_server(
     clear_quarantine(&installed);
 
     Ok((installed, pair.version))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_update_available, parse_kiln_version_output};
+
+    #[test]
+    fn parse_version_plain() {
+        assert_eq!(
+            parse_kiln_version_output("kiln 0.1.7\n"),
+            Some("0.1.7".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_version_with_git_sha() {
+        assert_eq!(
+            parse_kiln_version_output("kiln 0.2.0 (abc1234)\n"),
+            Some("0.2.0".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_version_handles_empty_and_single_token() {
+        assert_eq!(parse_kiln_version_output(""), None);
+        assert_eq!(parse_kiln_version_output("kiln"), None);
+        assert_eq!(parse_kiln_version_output("\n"), None);
+    }
+
+    #[test]
+    fn update_available_when_current_unknown() {
+        assert!(is_update_available(None, "0.2.0"));
+    }
+
+    #[test]
+    fn update_available_for_newer_semver() {
+        assert!(is_update_available(Some("0.1.7"), "0.2.0"));
+        assert!(is_update_available(Some("0.1.7"), "0.1.8"));
+        assert!(is_update_available(Some("0.1.0-rc.1"), "0.1.0"));
+    }
+
+    #[test]
+    fn no_update_when_equal_or_newer() {
+        assert!(!is_update_available(Some("0.2.0"), "0.2.0"));
+        assert!(!is_update_available(Some("0.3.0"), "0.2.0"));
+        assert!(!is_update_available(Some("0.1.0"), "0.1.0-rc.1"));
+    }
+
+    #[test]
+    fn non_semver_falls_back_to_string_inequality() {
+        // Only current is unparseable: offer when strings differ.
+        assert!(is_update_available(Some("not-semver"), "0.2.0"));
+        assert!(!is_update_available(Some("not-semver"), "not-semver"));
+        // Only latest is unparseable: same rule.
+        assert!(is_update_available(Some("0.1.0"), "not-semver"));
+    }
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -350,6 +350,58 @@ async fn check_for_updates(app: AppHandle) -> Result<UpdateCheckResult, String> 
     }
 }
 
+#[derive(serde::Serialize)]
+struct KilnUpdateCheckResult {
+    current: Option<String>,
+    latest: Option<String>,
+    update_available: bool,
+    platform_supported: bool,
+}
+
+/// Detection-only check for a newer kiln binary release. Looks up the
+/// currently-installed version by invoking `kiln --version`, queries the
+/// latest `kiln-v*` GitHub release for this platform, and compares via
+/// semver. No download or swap here — that lands in slice 2 of
+/// `desktop/docs/binary-update.md`.
+#[tauri::command]
+async fn check_for_kiln_update(
+    state: State<'_, SettingsState>,
+) -> Result<KilnUpdateCheckResult, String> {
+    let configured = {
+        let s = state.read().await;
+        s.kiln_binary
+            .clone()
+            .unwrap_or_else(|| std::path::PathBuf::from("kiln"))
+    };
+    let current = match installer::resolve_binary(&configured) {
+        Some(p) => installer::current_kiln_version(&p).await,
+        None => None,
+    };
+
+    let platform_supported = installer::supports_auto_install();
+    let latest = if platform_supported {
+        let client = reqwest::Client::builder()
+            .user_agent(concat!("kiln-desktop/", env!("CARGO_PKG_VERSION")))
+            .connect_timeout(std::time::Duration::from_secs(15))
+            .build()
+            .map_err(|e| format!("build reqwest client: {}", e))?;
+        installer::discover_latest_version(&client).await
+    } else {
+        None
+    };
+
+    let update_available = match &latest {
+        Some(l) => installer::is_update_available(current.as_deref(), l),
+        None => false,
+    };
+    Ok(KilnUpdateCheckResult {
+        current,
+        latest,
+        update_available,
+        platform_supported,
+    })
+}
+
 /// Re-check, then download and install the available update, then restart the
 /// app. We re-check rather than caching an `Update` handle because Tauri
 /// commands are stateless and the small race window is acceptable.
@@ -655,6 +707,7 @@ fn main() {
             get_diagnostic_info,
             check_for_updates,
             install_update,
+            check_for_kiln_update,
             get_binary_status,
             download_kiln_server,
             cancel_kiln_download,

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -80,6 +80,33 @@
         cursor: pointer;
       }
       button.browse:hover { background: #343a46; }
+      .update-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 6px 0 2px 0;
+        flex-wrap: wrap;
+      }
+      .update-status {
+        font-size: 12px;
+        color: #a8aeb8;
+        line-height: 1.35;
+      }
+      .update-status.checking { color: #a8aeb8; }
+      .update-status.up-to-date { color: #7fbf7f; }
+      .update-status.available { color: #f0b080; }
+      .update-status.error { color: #f08080; }
+      .update-status .badge {
+        display: inline-block;
+        padding: 1px 6px;
+        border-radius: 3px;
+        background: #2a2f3a;
+        color: #e6e6e6;
+        font-size: 11px;
+        margin-left: 4px;
+      }
+      .update-status.available .badge { background: #5a3f1a; color: #f6d3a6; }
+      .update-status.up-to-date .badge { background: #1f3a22; color: #b7e3b9; }
       .actions {
         display: flex;
         gap: 8px;
@@ -268,6 +295,10 @@
           <span class="hint">Leave blank to use kiln on PATH. Otherwise pick the kiln executable.</span>
           <span class="path-warning" id="warn_kiln_binary"></span>
         </label>
+        <div class="update-row">
+          <button type="button" class="browse" id="check_for_kiln_update">Check for Updates</button>
+          <span class="update-status" id="kiln_update_status"></span>
+        </div>
         <label class="row"><span class="name">Model path</span>
           <span class="path-row">
             <input type="text" id="model_path" placeholder="/path/to/model" />
@@ -918,6 +949,64 @@
       invoke("get_app_version").then(v => {
         document.getElementById("app-version").textContent = v;
       }).catch(() => {});
+
+      // ---------- Check for kiln binary updates (detection only) ----------
+      const kilnUpdateBtn = document.getElementById("check_for_kiln_update");
+      const kilnUpdateStatusEl = document.getElementById("kiln_update_status");
+      let kilnUpdateChecking = false;
+
+      function setKilnUpdateStatus(kind, html) {
+        kilnUpdateStatusEl.className = "update-status" + (kind ? " " + kind : "");
+        kilnUpdateStatusEl.innerHTML = html;
+      }
+
+      function escapeHtml(s) {
+        return String(s).replace(/[&<>"']/g, (c) => ({
+          "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+        }[c]));
+      }
+
+      async function checkForKilnUpdate() {
+        if (kilnUpdateChecking) return;
+        kilnUpdateChecking = true;
+        kilnUpdateBtn.disabled = true;
+        setKilnUpdateStatus("checking", "Checking…");
+        try {
+          const r = await invoke("check_for_kiln_update");
+          if (!r.platform_supported) {
+            setKilnUpdateStatus("", "Not available on this platform");
+            return;
+          }
+          const current = r.current ? escapeHtml(r.current) : "unknown";
+          if (!r.latest) {
+            setKilnUpdateStatus(
+              "error",
+              "Could not reach GitHub releases. Current: " + current + "."
+            );
+            return;
+          }
+          const latest = escapeHtml(r.latest);
+          if (r.update_available) {
+            setKilnUpdateStatus(
+              "available",
+              "Current " + current + " → latest " + latest +
+                ' <span class="badge">Update available</span>'
+            );
+          } else {
+            setKilnUpdateStatus(
+              "up-to-date",
+              "Current " + current + " <span class=\"badge\">Up to date</span>"
+            );
+          }
+        } catch (e) {
+          setKilnUpdateStatus("error", "Check failed: " + escapeHtml(e));
+        } finally {
+          kilnUpdateChecking = false;
+          kilnUpdateBtn.disabled = false;
+        }
+      }
+      kilnUpdateBtn.addEventListener("click", checkForKilnUpdate);
+
       load();
     </script>
   </body>


### PR DESCRIPTION
## What

Slice 1 of the kiln binary auto-updater pipeline (designed in #198, `desktop/docs/binary-update.md`). **Detection + display only** — no download, no swap (slice 2).

- New `current_kiln_version(bin)` helper: runs `bin --version`, parses the 2nd whitespace token
- New `check_for_kiln_update` Tauri command: returns `{ current, latest, update_available, platform_supported }`
- New "Check for Updates" row in Settings with status badge ("Up to date" / "Update available" / error)
- Uses `semver::Version` for comparison — never suggests a downgrade, falls back to string inequality for non-semver

## Why

Users currently have no in-app signal that a newer kiln binary exists. This ships the visibility half so slice 2 can wire the actual install flow.

## Scope

- ~251 net LOC (under 300 budget)
- 7 unit tests covering version parsing and comparison edge cases (plain, git-sha suffix, empty, newer semver, equal, downgrade-suppression, non-semver fallback)
- Reuses existing `discover_asset` + `current_target` + `supports_auto_install` from `installer.rs`

## Test plan

- [ ] CI passes (if any)
- [x] Unit tests: `cargo test -p kiln-desktop --lib installer` (validated in scratch crate — Cloud Eric pods lack GTK for full Tauri build)
- [x] `cargo metadata` succeeds on desktop crate
- [ ] Manual: launch desktop, open Settings, click "Check for Updates" — verify badge state

## Follow-up (slice 2)

- Add `install_kiln_update` command that downloads + atomically swaps the binary
- Wire "Install Update" CTA into the same Settings row