### PR TITLE
desktop: updater slice 2 — download to staging

### DIFF
--- a/desktop/src/installer.rs
+++ b/desktop/src/installer.rs
@@ -25,6 +25,14 @@ pub const INSTALL_PROGRESS_EVENT: &str = "kiln-install-progress";
 pub const INSTALL_DONE_EVENT: &str = "kiln-install-done";
 pub const INSTALL_FAILED_EVENT: &str = "kiln-install-failed";
 
+pub const UPDATE_DOWNLOAD_PROGRESS_EVENT: &str = "download_update_progress";
+pub const UPDATE_DOWNLOAD_DONE_EVENT: &str = "download_update_done";
+pub const UPDATE_DOWNLOAD_FAILED_EVENT: &str = "download_update_failed";
+
+/// Subdirectory under `app_data_dir` where update tarballs are staged
+/// before the slice-3 atomic-swap step promotes them.
+pub const UPDATE_STAGING_DIR: &str = "kiln-updates";
+
 const RELEASES_URL: &str = "https://api.github.com/repos/ericflo/kiln/releases";
 const USER_AGENT: &str = concat!("kiln-desktop/", env!("CARGO_PKG_VERSION"));
 /// Upper bound on release-asset size we're willing to stream. A macOS Metal
@@ -53,6 +61,31 @@ pub struct InstallDone {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct InstallFailed {
+    pub error: String,
+    pub cancelled: bool,
+}
+
+/// Progress payload for the slice-2 "download update tarball to staging"
+/// pipeline. Separate from [`InstallProgress`] because the update flow
+/// is simpler (download-only, no extract/verify yet) and the UI wants to
+/// key progress bars by `version`.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateDownloadProgress {
+    pub version: String,
+    pub downloaded_bytes: u64,
+    pub total_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateDownloadDone {
+    pub version: String,
+    pub path: String,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UpdateDownloadFailed {
+    pub version: String,
     pub error: String,
     pub cancelled: bool,
 }
@@ -109,6 +142,54 @@ pub fn install_dir(app: &AppHandle) -> Result<PathBuf, String> {
         .app_data_dir()
         .map_err(|e| format!("app_data_dir unavailable: {}", e))?;
     Ok(base.join("bin"))
+}
+
+/// File-extension convention for the release tarball/zip for `target`.
+/// Windows releases ship as `.zip`; all other targets ship as `.tar.gz`.
+/// Detected purely by substring match on the target triple to keep this
+/// helper testable without platform cfg gates.
+fn release_archive_ext(target: &str) -> &'static str {
+    if target.contains("windows") {
+        "zip"
+    } else {
+        "tar.gz"
+    }
+}
+
+/// Asset filename for a given kiln release, matching the naming convention
+/// in `.github/workflows/server-release.yml`:
+///     `kiln-<version>-<target>.<ext>`
+///
+/// Pure helper — exposed for unit tests and reused by
+/// [`release_download_url`] and [`staging_tarball_path`].
+pub fn release_asset_name(version: &str, target: &str) -> String {
+    format!(
+        "kiln-{}-{}.{}",
+        version,
+        target,
+        release_archive_ext(target)
+    )
+}
+
+/// Full GitHub Releases download URL for the kiln binary at `version` for
+/// `target`. Uses the existing `kiln-v*` tag convention
+/// (see `.github/workflows/server-release.yml`).
+pub fn release_download_url(version: &str, target: &str) -> String {
+    format!(
+        "https://github.com/ericflo/kiln/releases/download/kiln-v{}/{}",
+        version,
+        release_asset_name(version, target)
+    )
+}
+
+/// Staging path inside `app_data_dir` where the downloaded update tarball
+/// is written before slice 3's atomic-swap step promotes it. Files land
+/// under `<app_data_dir>/kiln-updates/kiln-v<version>.<ext>` so multiple
+/// staged updates can coexist without colliding on filename.
+pub fn staging_tarball_path(app_data_dir: &Path, version: &str, target: &str) -> PathBuf {
+    app_data_dir
+        .join(UPDATE_STAGING_DIR)
+        .join(format!("kiln-v{}.{}", version, release_archive_ext(target)))
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -444,6 +525,129 @@ pub fn is_update_available(current: Option<&str>, latest: &str) -> bool {
     }
 }
 
+/// Download the release tarball for `version` to the staging path under
+/// `<app_data_dir>/kiln-updates/`. Does NOT extract, verify sha256, or
+/// touch the running kiln binary — that is slice 3 of
+/// `desktop/docs/binary-update.md`.
+///
+/// Emits [`UPDATE_DOWNLOAD_PROGRESS_EVENT`] with a
+/// [`UpdateDownloadProgress`] payload during streaming. Returns the full
+/// staging file path on success.
+pub async fn download_release_binary(
+    app: &AppHandle,
+    version: &str,
+    cancel: Arc<AtomicBool>,
+) -> Result<(PathBuf, u64), String> {
+    let target = current_target().ok_or_else(|| {
+        "No prebuilt kiln release exists for this platform (Windows + Linux \
+         release assets land in a separate build task)."
+            .to_string()
+    })?;
+
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app_data_dir unavailable: {}", e))?;
+    let dest = staging_tarball_path(&base, version, target);
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)
+            .await
+            .map_err(|e| format!("mkdir {}: {}", parent.display(), e))?;
+    }
+
+    let url = release_download_url(version, target);
+    let client = reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .connect_timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("build reqwest client: {}", e))?;
+
+    let mut resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("download request failed: {}", e))?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "download from {} returned HTTP {}",
+            url,
+            resp.status()
+        ));
+    }
+    let total_bytes = resp.content_length();
+    if let Some(t) = total_bytes {
+        if t > MAX_ASSET_BYTES {
+            return Err(format!(
+                "asset claims {} bytes, over {}-byte safety limit",
+                t, MAX_ASSET_BYTES
+            ));
+        }
+    }
+
+    let mut file = fs::File::create(&dest)
+        .await
+        .map_err(|e| format!("create {}: {}", dest.display(), e))?;
+    let mut downloaded: u64 = 0;
+    let mut last_reported: u64 = 0;
+
+    let _ = app.emit(
+        UPDATE_DOWNLOAD_PROGRESS_EVENT,
+        UpdateDownloadProgress {
+            version: version.to_string(),
+            downloaded_bytes: 0,
+            total_bytes,
+        },
+    );
+
+    loop {
+        if cancel.load(Ordering::SeqCst) {
+            // Best-effort cleanup of partial file on cancel.
+            drop(file);
+            let _ = fs::remove_file(&dest).await;
+            return Err("download cancelled".to_string());
+        }
+        let chunk = resp
+            .chunk()
+            .await
+            .map_err(|e| format!("chunk read failed: {}", e))?;
+        let Some(bytes) = chunk else { break };
+        downloaded = downloaded.saturating_add(bytes.len() as u64);
+        if downloaded > MAX_ASSET_BYTES {
+            return Err(format!(
+                "aborted — received {} bytes past {}-byte safety limit",
+                downloaded, MAX_ASSET_BYTES
+            ));
+        }
+        file.write_all(&bytes)
+            .await
+            .map_err(|e| format!("write chunk: {}", e))?;
+        // Keep IPC cost down — emit at 64KB granularity.
+        if downloaded.saturating_sub(last_reported) >= 64 * 1024 {
+            last_reported = downloaded;
+            let _ = app.emit(
+                UPDATE_DOWNLOAD_PROGRESS_EVENT,
+                UpdateDownloadProgress {
+                    version: version.to_string(),
+                    downloaded_bytes: downloaded,
+                    total_bytes,
+                },
+            );
+        }
+    }
+    file.flush()
+        .await
+        .map_err(|e| format!("flush: {}", e))?;
+    let _ = app.emit(
+        UPDATE_DOWNLOAD_PROGRESS_EVENT,
+        UpdateDownloadProgress {
+            version: version.to_string(),
+            downloaded_bytes: downloaded,
+            total_bytes,
+        },
+    );
+    Ok((dest, downloaded))
+}
+
 /// Full install pipeline: discover latest asset, download, verify sha256,
 /// extract, chmod, clear quarantine. Returns the installed binary path.
 pub async fn install_latest_server(
@@ -524,7 +728,106 @@ pub async fn install_latest_server(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_update_available, parse_kiln_version_output};
+    use super::{
+        is_update_available, parse_kiln_version_output, release_archive_ext,
+        release_asset_name, release_download_url, staging_tarball_path, UPDATE_STAGING_DIR,
+    };
+    use std::path::PathBuf;
+
+    #[test]
+    fn archive_ext_windows_is_zip() {
+        assert_eq!(release_archive_ext("x86_64-pc-windows-msvc-cuda124"), "zip");
+        assert_eq!(release_archive_ext("x86_64-pc-windows-gnu"), "zip");
+    }
+
+    #[test]
+    fn archive_ext_unix_is_tar_gz() {
+        assert_eq!(
+            release_archive_ext("aarch64-apple-darwin-metal"),
+            "tar.gz"
+        );
+        assert_eq!(
+            release_archive_ext("x86_64-unknown-linux-gnu-cuda124"),
+            "tar.gz"
+        );
+        assert_eq!(release_archive_ext("x86_64-apple-darwin"), "tar.gz");
+    }
+
+    #[test]
+    fn asset_name_matches_release_workflow_macos() {
+        assert_eq!(
+            release_asset_name("0.2.0", "aarch64-apple-darwin-metal"),
+            "kiln-0.2.0-aarch64-apple-darwin-metal.tar.gz"
+        );
+    }
+
+    #[test]
+    fn asset_name_matches_release_workflow_linux() {
+        assert_eq!(
+            release_asset_name("0.2.0", "x86_64-unknown-linux-gnu-cuda124"),
+            "kiln-0.2.0-x86_64-unknown-linux-gnu-cuda124.tar.gz"
+        );
+    }
+
+    #[test]
+    fn asset_name_windows_uses_zip() {
+        assert_eq!(
+            release_asset_name("0.2.0", "x86_64-pc-windows-msvc-cuda124"),
+            "kiln-0.2.0-x86_64-pc-windows-msvc-cuda124.zip"
+        );
+    }
+
+    #[test]
+    fn download_url_uses_kiln_v_tag_and_matching_asset() {
+        assert_eq!(
+            release_download_url("0.2.0", "aarch64-apple-darwin-metal"),
+            "https://github.com/ericflo/kiln/releases/download/kiln-v0.2.0/\
+             kiln-0.2.0-aarch64-apple-darwin-metal.tar.gz"
+                .replace(' ', "")
+        );
+        assert_eq!(
+            release_download_url("1.2.3", "x86_64-pc-windows-msvc-cuda124"),
+            "https://github.com/ericflo/kiln/releases/download/kiln-v1.2.3/\
+             kiln-1.2.3-x86_64-pc-windows-msvc-cuda124.zip"
+                .replace(' ', "")
+        );
+        assert_eq!(
+            release_download_url("1.0.0", "x86_64-unknown-linux-gnu-cuda124"),
+            "https://github.com/ericflo/kiln/releases/download/kiln-v1.0.0/\
+             kiln-1.0.0-x86_64-unknown-linux-gnu-cuda124.tar.gz"
+                .replace(' ', "")
+        );
+    }
+
+    #[test]
+    fn staging_path_nests_under_update_staging_dir() {
+        let base = PathBuf::from("/tmp/fake-app-data");
+        let p = staging_tarball_path(&base, "0.2.0", "aarch64-apple-darwin-metal");
+        assert!(
+            p.starts_with(base.join(UPDATE_STAGING_DIR)),
+            "staging path {} should be under {}",
+            p.display(),
+            base.join(UPDATE_STAGING_DIR).display()
+        );
+        assert_eq!(p.file_name().unwrap(), "kiln-v0.2.0.tar.gz");
+    }
+
+    #[test]
+    fn staging_path_windows_uses_zip_extension() {
+        let base = PathBuf::from("C:/fake/AppData");
+        let p = staging_tarball_path(&base, "0.2.0", "x86_64-pc-windows-msvc-cuda124");
+        assert_eq!(p.file_name().unwrap(), "kiln-v0.2.0.zip");
+    }
+
+    #[test]
+    fn staging_path_version_is_embedded_verbatim() {
+        // Version strings are injected from GitHub release tags, so they can
+        // include pre-release / build metadata. The staging helper must not
+        // drop or rewrite them.
+        let base = PathBuf::from("/tmp/x");
+        let p = staging_tarball_path(&base, "0.3.0-rc.1", "aarch64-apple-darwin-metal");
+        assert_eq!(p.file_name().unwrap(), "kiln-v0.3.0-rc.1.tar.gz");
+    }
 
     #[test]
     fn parse_version_plain() {

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -231,6 +231,66 @@ async fn cancel_kiln_download(inst: State<'_, InstallerHandle>) -> Result<(), St
     Ok(())
 }
 
+/// Updater slice 2: download a newer kiln release tarball into the staging
+/// directory under `app_data_dir/kiln-updates/`. **Does not** extract, swap
+/// the live binary, or restart the supervisor — those steps land in slice 3
+/// (see `desktop/docs/binary-update.md`).
+///
+/// Progress is streamed as `download_update_progress`; terminal events are
+/// `download_update_done` (success) and `download_update_failed` (error or
+/// cancelled). Reuses [`InstallerState`] so a fresh-install and an update
+/// download can't race the same on-disk file or cancel flag.
+#[tauri::command]
+async fn download_kiln_update(
+    app: AppHandle,
+    version: String,
+    inst: State<'_, InstallerHandle>,
+) -> Result<(), String> {
+    if inst.in_progress.swap(true, Ordering::SeqCst) {
+        return Err("an install or update download is already in progress".into());
+    }
+    inst.cancel.store(false, Ordering::SeqCst);
+
+    let app_for_task = app.clone();
+    let inst_for_task = (*inst).clone();
+    let version_for_task = version.clone();
+
+    tauri::async_runtime::spawn(async move {
+        let result = installer::download_release_binary(
+            &app_for_task,
+            &version_for_task,
+            Arc::clone(&inst_for_task.cancel),
+        )
+        .await;
+        match result {
+            Ok((path, bytes)) => {
+                let _ = app_for_task.emit(
+                    installer::UPDATE_DOWNLOAD_DONE_EVENT,
+                    installer::UpdateDownloadDone {
+                        version: version_for_task,
+                        path: path.display().to_string(),
+                        bytes,
+                    },
+                );
+            }
+            Err(err) => {
+                let cancelled = inst_for_task.cancel.load(Ordering::SeqCst);
+                let _ = app_for_task.emit(
+                    installer::UPDATE_DOWNLOAD_FAILED_EVENT,
+                    installer::UpdateDownloadFailed {
+                        version: version_for_task,
+                        error: err,
+                        cancelled,
+                    },
+                );
+            }
+        }
+        inst_for_task.in_progress.store(false, Ordering::SeqCst);
+    });
+
+    Ok(())
+}
+
 /// Kick off a HuggingFace model download into
 /// `app_data_dir()/models/<sanitized_repo>/`. Progress is streamed via
 /// the `hf-download-progress` event; terminal success / failure arrive as
@@ -711,6 +771,7 @@ fn main() {
             get_binary_status,
             download_kiln_server,
             cancel_kiln_download,
+            download_kiln_update,
             download_hf_model,
             path_info
         ])

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -107,6 +107,36 @@
       }
       .update-status.available .badge { background: #5a3f1a; color: #f6d3a6; }
       .update-status.up-to-date .badge { background: #1f3a22; color: #b7e3b9; }
+      .update-download {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        flex-basis: 100%;
+        margin-top: 2px;
+      }
+      .update-download.hidden { display: none; }
+      button.browse.hidden { display: none; }
+      .update-download-bar {
+        height: 6px;
+        background: #0f1115;
+        border: 1px solid #2a2f3a;
+        border-radius: 3px;
+        overflow: hidden;
+      }
+      .update-download-fill {
+        height: 100%;
+        width: 0%;
+        background: #2f66f0;
+        transition: width 120ms linear;
+      }
+      .update-download-line {
+        font-size: 11px;
+        color: #a8aeb8;
+        line-height: 1.4;
+        word-break: break-all;
+      }
+      .update-download-line.error { color: #f08080; }
+      .update-download-line.success { color: #7fbf7f; }
       .actions {
         display: flex;
         gap: 8px;
@@ -298,6 +328,12 @@
         <div class="update-row">
           <button type="button" class="browse" id="check_for_kiln_update">Check for Updates</button>
           <span class="update-status" id="kiln_update_status"></span>
+          <button type="button" class="browse hidden" id="download_kiln_update">Download Update</button>
+          <button type="button" class="browse hidden" id="install_kiln_update" disabled title="Install lands in updater slice 3">Install</button>
+          <div class="update-download hidden" id="kiln_update_download">
+            <div class="update-download-bar"><div class="update-download-fill" id="kiln_update_download_fill"></div></div>
+            <div class="update-download-line" id="kiln_update_download_line"></div>
+          </div>
         </div>
         <label class="row"><span class="name">Model path</span>
           <span class="path-row">
@@ -953,7 +989,15 @@
       // ---------- Check for kiln binary updates (detection only) ----------
       const kilnUpdateBtn = document.getElementById("check_for_kiln_update");
       const kilnUpdateStatusEl = document.getElementById("kiln_update_status");
+      const kilnUpdateDownloadBtn = document.getElementById("download_kiln_update");
+      const kilnUpdateInstallBtn = document.getElementById("install_kiln_update");
+      const kilnUpdateProgressWrap = document.getElementById("kiln_update_download");
+      const kilnUpdateProgressFill = document.getElementById("kiln_update_download_fill");
+      const kilnUpdateProgressLine = document.getElementById("kiln_update_download_line");
       let kilnUpdateChecking = false;
+      let kilnUpdateDownloading = false;
+      let kilnUpdateLatest = null;
+      let kilnUpdateUnlistenFns = [];
 
       function setKilnUpdateStatus(kind, html) {
         kilnUpdateStatusEl.className = "update-status" + (kind ? " " + kind : "");
@@ -966,11 +1010,38 @@
         }[c]));
       }
 
+      function setKilnUpdateProgressLine(kind, text) {
+        kilnUpdateProgressLine.className =
+          "update-download-line" + (kind ? " " + kind : "");
+        kilnUpdateProgressLine.textContent = text;
+      }
+
+      function showKilnUpdateActions(latest) {
+        kilnUpdateLatest = latest || null;
+        if (latest) {
+          kilnUpdateDownloadBtn.classList.remove("hidden");
+          kilnUpdateInstallBtn.classList.add("hidden");
+        } else {
+          kilnUpdateDownloadBtn.classList.add("hidden");
+          kilnUpdateInstallBtn.classList.add("hidden");
+          kilnUpdateProgressWrap.classList.add("hidden");
+        }
+      }
+
+      async function teardownKilnUpdateListeners() {
+        const fns = kilnUpdateUnlistenFns;
+        kilnUpdateUnlistenFns = [];
+        for (const fn of fns) {
+          try { await fn(); } catch (_) {}
+        }
+      }
+
       async function checkForKilnUpdate() {
         if (kilnUpdateChecking) return;
         kilnUpdateChecking = true;
         kilnUpdateBtn.disabled = true;
         setKilnUpdateStatus("checking", "Checking…");
+        showKilnUpdateActions(null);
         try {
           const r = await invoke("check_for_kiln_update");
           if (!r.platform_supported) {
@@ -992,6 +1063,7 @@
               "Current " + current + " → latest " + latest +
                 ' <span class="badge">Update available</span>'
             );
+            showKilnUpdateActions(r.latest);
           } else {
             setKilnUpdateStatus(
               "up-to-date",
@@ -1006,6 +1078,100 @@
         }
       }
       kilnUpdateBtn.addEventListener("click", checkForKilnUpdate);
+
+      // ---------- Download an available kiln update (slice 2) ----------
+      // Streams the release tarball to <app_data_dir>/kiln-updates/. Does NOT
+      // extract or swap the running binary — the Install button is left
+      // disabled until updater slice 3 lands the atomic-swap pipeline.
+      async function startKilnUpdateDownload() {
+        if (kilnUpdateDownloading || !kilnUpdateLatest) return;
+        const version = kilnUpdateLatest;
+        kilnUpdateDownloading = true;
+        kilnUpdateDownloadBtn.disabled = true;
+        kilnUpdateInstallBtn.classList.add("hidden");
+        kilnUpdateInstallBtn.disabled = true;
+        kilnUpdateProgressWrap.classList.remove("hidden");
+        kilnUpdateProgressFill.style.background = "#2f66f0";
+        kilnUpdateProgressFill.style.width = "0%";
+        setKilnUpdateProgressLine("", "Starting download for v" + version + "…");
+
+        const event = window.__TAURI__ && window.__TAURI__.event;
+        if (!event || typeof event.listen !== "function") {
+          setKilnUpdateProgressLine("error", "Tauri event API unavailable.");
+          kilnUpdateDownloading = false;
+          kilnUpdateDownloadBtn.disabled = false;
+          return;
+        }
+
+        await teardownKilnUpdateListeners();
+
+        const unProgress = await event.listen("download_update_progress", (e) => {
+          const p = e && e.payload;
+          if (!p || p.version !== version) return;
+          const total = p.total_bytes;
+          const got = p.downloaded_bytes || 0;
+          if (total && total > 0) {
+            const pct = Math.max(0, Math.min(100, (got / total) * 100));
+            kilnUpdateProgressFill.style.width = pct.toFixed(1) + "%";
+            setKilnUpdateProgressLine(
+              "",
+              formatBytes(got) + " / " + formatBytes(total) +
+                " (" + pct.toFixed(0) + "%) — v" + version
+            );
+          } else {
+            // Server didn't report Content-Length; show indeterminate text.
+            setKilnUpdateProgressLine(
+              "",
+              "Downloaded " + formatBytes(got) + " — v" + version
+            );
+          }
+        });
+        const unDone = await event.listen("download_update_done", (e) => {
+          const p = e && e.payload;
+          if (!p || p.version !== version) return;
+          kilnUpdateProgressFill.style.width = "100%";
+          setKilnUpdateProgressLine(
+            "success",
+            "Downloaded v" + version + " (" + formatBytes(p.bytes || 0) +
+              ") to " + (p.path || "(unknown)") + ". Install lands in updater slice 3."
+          );
+          kilnUpdateDownloading = false;
+          kilnUpdateDownloadBtn.disabled = true;
+          kilnUpdateDownloadBtn.textContent = "Downloaded";
+          // Surface the Install button as a slice-3 placeholder so the user
+          // sees the next step exists; it stays disabled until slice 3.
+          kilnUpdateInstallBtn.classList.remove("hidden");
+          kilnUpdateInstallBtn.disabled = true;
+          teardownKilnUpdateListeners();
+        });
+        const unFailed = await event.listen("download_update_failed", (e) => {
+          const p = e && e.payload;
+          if (!p || p.version !== version) return;
+          const err = p.error || "Unknown error";
+          const cancelled = !!p.cancelled;
+          kilnUpdateProgressFill.style.background = cancelled ? "#3a3a2a" : "#3a2a2a";
+          setKilnUpdateProgressLine(
+            "error",
+            (cancelled ? "Cancelled: " : "Download failed: ") + err
+          );
+          kilnUpdateDownloading = false;
+          kilnUpdateDownloadBtn.disabled = false;
+          kilnUpdateDownloadBtn.textContent = "Retry Download";
+          teardownKilnUpdateListeners();
+        });
+        kilnUpdateUnlistenFns = [unProgress, unDone, unFailed];
+
+        try {
+          await invoke("download_kiln_update", { version: version });
+        } catch (err) {
+          setKilnUpdateProgressLine("error", "Failed to start download: " + err);
+          kilnUpdateDownloading = false;
+          kilnUpdateDownloadBtn.disabled = false;
+          kilnUpdateDownloadBtn.textContent = "Retry Download";
+          await teardownKilnUpdateListeners();
+        }
+      }
+      kilnUpdateDownloadBtn.addEventListener("click", startKilnUpdateDownload);
 
       load();
     </script>


### PR DESCRIPTION
## What

Updater slice 2: download a newer kiln release tarball into a staging path. Builds on slice 1 (PR #200, detection only). Slice 3 (extract + atomic swap + restart) is explicitly out of scope.

### New surface

- `installer::download_release_binary(app, version, cancel) -> Result<(PathBuf, u64), String>` — pure download helper, streams release tarball to `<app_data_dir>/kiln-updates/kiln-v<version>.<ext>`, polls a shared cancel flag, enforces a 2 GB safety cap.
- `download_kiln_update(version: String)` Tauri command, registered in `invoke_handler!`. Reuses `InstallerState` so an in-flight install and an update download can't race the same on-disk file or cancel flag.
- Settings UI: "Download Update" button (only visible after a successful "Check for Updates" reports `update_available`), inline progress bar, and a slice-3 placeholder "Install" button left disabled with `title="Install lands in updater slice 3"`.

### Events

- `download_update_progress` → `{ version, downloaded_bytes, total_bytes }`, emitted at 64 KB granularity to keep IPC cost flat.
- `download_update_done` → `{ version, path, bytes }`.
- `download_update_failed` → `{ version, error, cancelled }`.

### Pure helpers (unit-tested)

- `release_archive_ext(target)` — `.zip` for `*-windows-*`, `.tar.gz` otherwise.
- `release_asset_name(version, target)` — matches `.github/workflows/server-release.yml` (`kiln-<version>-<target>.<ext>`).
- `release_download_url(version, target)` — uses the existing `kiln-v*` tag convention.
- `staging_tarball_path(app_data_dir, version, target)` — nests under `app_data_dir/kiln-updates/`.

### Slice-3 deliberately NOT included

- No tarball extraction.
- No atomic swap of the running `kiln` binary.
- No supervisor restart, health check, or rollback.
- The slice-3 design is captured in `desktop/docs/binary-update.md` (PR #198).

## Why

Splitting the updater into reviewable slices keeps each PR small and reversible. Slice 1 (detection) gives the user visibility; slice 2 gives them the ability to stage the new binary; slice 3 will perform the destructive swap behind a separate review.

## Tests

- 9 new unit tests on the pure helpers (URL construction per platform, archive extension detection, staging path computation), validated end-to-end in a scratch crate because Cloud Eric lacks GTK/webkit2gtk to build the full Tauri crate locally.
- `cargo metadata --format-version 1 --manifest-path desktop/Cargo.toml > /dev/null` passes (structural check).
- Existing `installer.rs` tests still pass (version parsing + update-available logic).

## Test plan

- [ ] On macOS aarch64: bump local kiln to an older version, click "Check for Updates", confirm "Update available" badge.
- [ ] Click "Download Update", observe progress bar fill.
- [ ] Confirm tarball lands at `~/Library/Application Support/com.eflorenzano.kiln-desktop/kiln-updates/kiln-v<version>.tar.gz` and is the same size GitHub reports.
- [ ] Confirm "Install" button is visible but disabled with the slice-3 hint.
- [ ] Cancel mid-download via the existing `cancel_kiln_download` command and confirm the partial file is removed and the UI reports a cancelled state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)