### PR TITLE
server+desktop: configurable served model ID

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -24,8 +24,9 @@ use crate::state::{AppState, ModelBackend};
 /// OpenAI-compatible chat completion request.
 #[derive(Debug, Deserialize)]
 pub struct ChatCompletionRequest {
-    #[serde(default = "default_model")]
-    pub model: String,
+    /// When omitted, the server falls back to its configured `served_model_id`.
+    #[serde(default)]
+    pub model: Option<String>,
     pub messages: Vec<Message>,
     #[serde(default)]
     pub temperature: Option<f32>,
@@ -44,10 +45,6 @@ pub struct ChatCompletionRequest {
     /// Kiln extension: which LoRA adapter to use for this request.
     #[serde(default)]
     pub adapter: Option<String>,
-}
-
-fn default_model() -> String {
-    "qwen3.5-4b".to_string()
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -382,7 +379,10 @@ async fn generate_real(
         id: format!("chatcmpl-{}", Uuid::new_v4()),
         object: "chat.completion",
         created: now,
-        model: req.model.clone(),
+        model: req
+            .model
+            .clone()
+            .unwrap_or_else(|| state.served_model_id.clone()),
         choices: vec![Choice {
             index: 0,
             message: Message {
@@ -409,7 +409,7 @@ async fn generate_real(
 ///    forwarding loop. On timeout, the task drops `sync_rx`, stopping generation,
 ///    and sends an error event to the client.
 async fn generate_real_streaming(
-    _state: &AppState,
+    state: &AppState,
     runner: &std::sync::Arc<std::sync::RwLock<kiln_model::ModelRunner>>,
     block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
     paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
@@ -422,11 +422,14 @@ async fn generate_real_streaming(
     let pc = paged_cache.clone();
     let prompt = prompt_text.to_owned();
     let params = sampling.clone();
-    let model = req.model.clone();
+    let model = req
+        .model
+        .clone()
+        .unwrap_or_else(|| state.served_model_id.clone());
     let completion_id = format!("chatcmpl-{}", Uuid::new_v4());
     let created = now_epoch();
-    let gpu_lock = _state.gpu_lock.clone();
-    let timeout = _state.request_timeout;
+    let gpu_lock = state.gpu_lock.clone();
+    let timeout = state.request_timeout;
 
     // Use a tokio mpsc channel to bridge sync generation -> async SSE stream.
     let (tx, rx) = tokio::sync::mpsc::channel::<Event>(32);
@@ -716,7 +719,10 @@ async fn generate_mock(
         id: format!("chatcmpl-{}", Uuid::new_v4()),
         object: "chat.completion",
         created: now,
-        model: req.model.clone(),
+        model: req
+            .model
+            .clone()
+            .unwrap_or_else(|| state.served_model_id.clone()),
         choices: vec![Choice {
             index: 0,
             message: Message {

--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -165,7 +165,8 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
         version: env!("CARGO_PKG_VERSION"),
         uptime_seconds,
         model: format!(
-            "qwen3.5-4b ({}L, {}H, {}KV)",
+            "{} ({}L, {}H, {}KV)",
+            state.served_model_id,
             state.model_config.num_layers,
             state.model_config.num_attention_heads,
             state.model_config.num_kv_heads,
@@ -217,7 +218,14 @@ mod tests {
         let engine = MockEngine::new(config.clone());
         let tokenizer =
             kiln_core::tokenizer::KilnTokenizer::from_pretrained("Qwen/Qwen3.5-4B").unwrap();
-        AppState::new_mock(config, scheduler, Arc::new(engine), tokenizer, 300)
+        AppState::new_mock(
+            config,
+            scheduler,
+            Arc::new(engine),
+            tokenizer,
+            300,
+            "qwen3.5-4b-kiln".to_string(),
+        )
     }
 
     #[tokio::test]
@@ -239,7 +247,7 @@ mod tests {
 
         assert_eq!(json["status"], "ok");
         assert!(json["uptime_seconds"].is_number());
-        assert!(json["model"].as_str().unwrap().contains("qwen3.5-4b"));
+        assert!(json["model"].as_str().unwrap().contains("qwen3.5-4b-kiln"));
         assert_eq!(json["backend"], "mock");
         assert!(json["active_adapter"].is_null());
         assert_eq!(json["adapters_loaded"], 0);

--- a/crates/kiln-server/src/api/models.rs
+++ b/crates/kiln-server/src/api/models.rs
@@ -17,11 +17,10 @@ struct ModelInfo {
 }
 
 async fn list_models(State(state): State<AppState>) -> Json<ModelsResponse> {
-    let _ = state; // Will use config for model name later
     Json(ModelsResponse {
         object: "list",
         data: vec![ModelInfo {
-            id: "qwen3.5-4b".to_string(),
+            id: state.served_model_id.clone(),
             object: "model",
             owned_by: "kiln",
         }],
@@ -30,4 +29,67 @@ async fn list_models(State(state): State<AppState>) -> Json<ModelsResponse> {
 
 pub fn routes() -> Router<AppState> {
     Router::new().route("/v1/models", get(list_models))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use kiln_core::config::ModelConfig;
+    use kiln_model::engine::MockEngine;
+    use kiln_scheduler::{Scheduler, SchedulerConfig};
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    fn make_test_state(served_model_id: &str) -> AppState {
+        let config = ModelConfig::qwen3_5_4b();
+        let sched_config = SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        };
+        let scheduler = Scheduler::new(sched_config, 256);
+        let engine = MockEngine::new(config.clone());
+        let tokenizer =
+            kiln_core::tokenizer::KilnTokenizer::from_pretrained("Qwen/Qwen3.5-4B").unwrap();
+        AppState::new_mock(
+            config,
+            scheduler,
+            Arc::new(engine),
+            tokenizer,
+            300,
+            served_model_id.to_string(),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_models_returns_served_model_id() {
+        let state = make_test_state("custom-served-id");
+        let app = routes().with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/models")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["object"], "list");
+        assert_eq!(json["data"][0]["id"], "custom-served-id");
+        assert_eq!(json["data"][0]["object"], "model");
+        assert_eq!(json["data"][0]["owned_by"], "kiln");
+    }
 }

--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -25,7 +25,12 @@ pub struct Cli {
 #[derive(Subcommand)]
 pub enum Commands {
     /// Start the inference server (default when no subcommand given)
-    Serve,
+    Serve {
+        /// Override the served model identifier exposed at /v1/models.
+        /// Wins over KILN_SERVED_MODEL_ID env and TOML `model.served_model_id`.
+        #[arg(long, value_name = "ID")]
+        served_model_id: Option<String>,
+    },
 
     /// Submit training data to a running server
     #[command(subcommand)]
@@ -252,6 +257,11 @@ pub fn run_config_check(file: Option<&str>) -> anyhow::Result<()> {
                 "  {} {}",
                 style("Model ID:").dim(),
                 config.model.model_id
+            );
+            println!(
+                "  {} {}",
+                style("Served as:").dim(),
+                config.model.effective_served_model_id()
             );
             if let Some(ref p) = config.model.path {
                 println!("  {} {}", style("Model path:").dim(), p);

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -47,6 +47,24 @@ pub struct ModelConfig {
     pub model_id: String,
     pub tokenizer_path: Option<String>,
     pub adapter_dir: Option<String>,
+    /// Override the string exposed at `/v1/models` and echoed in chat completion responses.
+    /// When `None`, derived from `model_id` (strip up to last `/`, lowercase, append `-kiln`).
+    pub served_model_id: Option<String>,
+}
+
+impl ModelConfig {
+    /// Resolve the served model identifier.
+    ///
+    /// Returns the explicit `served_model_id` override when set; otherwise derives
+    /// it from `model_id` by stripping everything up to and including the last `/`,
+    /// lowercasing the remainder, and appending `-kiln`.
+    pub fn effective_served_model_id(&self) -> String {
+        if let Some(ref id) = self.served_model_id {
+            return id.clone();
+        }
+        let base = self.model_id.rsplit('/').next().unwrap_or(&self.model_id);
+        format!("{}-kiln", base.to_lowercase())
+    }
 }
 
 /// GPU memory allocation settings.
@@ -148,6 +166,7 @@ impl Default for ModelConfig {
             model_id: "Qwen/Qwen3.5-4B".into(),
             tokenizer_path: None,
             adapter_dir: None,
+            served_model_id: None,
         }
     }
 }
@@ -270,6 +289,9 @@ impl KilnConfig {
         }
         if let Ok(v) = std::env::var("KILN_ADAPTER_DIR") {
             self.model.adapter_dir = Some(v);
+        }
+        if let Ok(v) = std::env::var("KILN_SERVED_MODEL_ID") {
+            self.model.served_model_id = Some(v);
         }
 
         // Memory
@@ -667,5 +689,62 @@ level = "warn"
     fn test_load_nonexistent_explicit_path_errors() {
         let result = KilnConfig::load(Some("/no/such/file.toml"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_served_model_id_default_derivation() {
+        let config = ModelConfig::default();
+        assert_eq!(config.effective_served_model_id(), "qwen3.5-4b-kiln");
+    }
+
+    #[test]
+    fn test_served_model_id_derives_from_lowercase_no_slash() {
+        let config = ModelConfig {
+            model_id: "qwen3.5-4b".into(),
+            ..ModelConfig::default()
+        };
+        assert_eq!(config.effective_served_model_id(), "qwen3.5-4b-kiln");
+    }
+
+    #[test]
+    fn test_served_model_id_derives_from_nested_path() {
+        let config = ModelConfig {
+            model_id: "Org/Subdir/Model-Foo_7B".into(),
+            ..ModelConfig::default()
+        };
+        assert_eq!(config.effective_served_model_id(), "model-foo_7b-kiln");
+    }
+
+    #[test]
+    fn test_served_model_id_explicit_override_passes_through() {
+        let config = ModelConfig {
+            model_id: "Qwen/Qwen3.5-4B".into(),
+            served_model_id: Some("My-Custom_Name".into()),
+            ..ModelConfig::default()
+        };
+        assert_eq!(config.effective_served_model_id(), "My-Custom_Name");
+    }
+
+    #[test]
+    fn test_served_model_id_env_var_overrides_toml() {
+        let toml_str = r#"
+[model]
+served_model_id = "from-toml"
+"#;
+        let mut config: KilnConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.model.served_model_id.as_deref(), Some("from-toml"));
+
+        unsafe {
+            std::env::set_var("KILN_SERVED_MODEL_ID", "from-env");
+        }
+        config.apply_env_overrides();
+        assert_eq!(
+            config.model.effective_served_model_id(),
+            "from-env",
+            "env var should override TOML value"
+        );
+        unsafe {
+            std::env::remove_var("KILN_SERVED_MODEL_ID");
+        }
     }
 }

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -61,7 +61,17 @@ async fn main() -> Result<()> {
             }
         },
         // Serve mode (default)
-        Some(Commands::Serve) | None => {}
+        Some(Commands::Serve { ref served_model_id }) => {
+            // CLI flag wins over env/TOML; surface it via env var so the
+            // config loader picks it up uniformly.
+            if let Some(v) = served_model_id {
+                // Safety: argv parsing happens before any threads are spawned.
+                unsafe {
+                    std::env::set_var("KILN_SERVED_MODEL_ID", v);
+                }
+            }
+        }
+        None => {}
     }
 
     // --- Server startup ---
@@ -74,6 +84,8 @@ async fn main() -> Result<()> {
 
     let model_config = ModelConfig::qwen3_5_4b();
     let model_path = config.model.path.as_deref();
+    let served_model_id = config.model.effective_served_model_id();
+    tracing::info!(served_model_id = %served_model_id, "served model identifier");
 
     // Print startup banner to stderr (doesn't interfere with structured logs)
     cli::print_banner(host, port, model_path, args.config.as_deref());
@@ -153,6 +165,7 @@ async fn main() -> Result<()> {
             adapter_dir,
             &config.memory,
             config.server.request_timeout_secs,
+            served_model_id,
         )
     } else {
         // Mock mode: use scheduler + mock engine.
@@ -174,6 +187,7 @@ async fn main() -> Result<()> {
             Arc::new(engine),
             tokenizer,
             config.server.request_timeout_secs,
+            served_model_id,
         )
     };
 

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -187,6 +187,8 @@ pub struct AppState {
     /// Server-level default for adapter checkpoint interval during training.
     /// Per-job config overrides this. None = only save at the end.
     pub checkpoint_interval: Option<usize>,
+    /// Identifier exposed at `/v1/models` and echoed in chat completion responses.
+    pub served_model_id: String,
 }
 
 impl AppState {
@@ -197,6 +199,7 @@ impl AppState {
         engine: Arc<dyn Engine>,
         tokenizer: KilnTokenizer,
         request_timeout_secs: u64,
+        served_model_id: String,
     ) -> Self {
         Self {
             model_config,
@@ -220,6 +223,7 @@ impl AppState {
             metrics: Arc::new(Metrics::new()),
             started_at: std::time::Instant::now(),
             checkpoint_interval: None,
+            served_model_id,
         }
     }
 
@@ -240,6 +244,7 @@ impl AppState {
         adapter_dir: PathBuf,
         memory_cfg: &crate::config::MemoryConfig,
         request_timeout_secs: u64,
+        served_model_id: String,
     ) -> Self {
         let block_size = 16;
 
@@ -385,6 +390,7 @@ impl AppState {
             metrics: Arc::new(Metrics::new()),
             started_at: std::time::Instant::now(),
             checkpoint_interval: None,
+            served_model_id,
         }
     }
 }

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -879,6 +879,17 @@ document.getElementById('grpo-form').addEventListener('submit', async (e) => {
 // --- Chat ---
 const chatMessages = [];
 let chatAbort = null;
+let servedModelId = null;
+
+async function loadServedModelId() {
+  try {
+    const res = await fetch('/v1/models');
+    if (!res.ok) return;
+    const data = await res.json();
+    servedModelId = data?.data?.[0]?.id || null;
+  } catch {}
+}
+loadServedModelId();
 
 function renderChat() {
   const el = document.getElementById('chat-messages');
@@ -913,12 +924,12 @@ async function sendChat() {
   const temp = parseFloat(document.getElementById('chat-temp').value) || 0.7;
 
   const body = {
-    model: 'qwen3.5-4b',
     messages: chatMessages.filter(m => m.content).map(m => ({ role: m.role, content: m.content })),
     stream: true,
     temperature: temp,
     max_tokens: 1024,
   };
+  if (servedModelId) body.model = servedModelId;
   if (adapter) body.adapter = adapter;
 
   try {

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -192,7 +192,7 @@ async fn test_real_model_chat_completion() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300);
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300, "qwen3.5-4b-kiln".to_string());
 
     let app = api::router(state);
 
@@ -257,7 +257,7 @@ async fn test_real_model_streaming_chat_completion() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300);
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300, "qwen3.5-4b-kiln".to_string());
 
     let app = api::router(state);
 
@@ -372,6 +372,7 @@ async fn test_request_timeout_configurable() {
         std::path::PathBuf::from("/tmp/kiln-test-adapters"),
         &kiln_server::config::MemoryConfig::default(),
         42,
+        "qwen3.5-4b-kiln".to_string(),
     );
 
     assert_eq!(state.request_timeout.as_secs(), 42);
@@ -396,6 +397,7 @@ async fn test_default_request_timeout() {
         std::path::PathBuf::from("/tmp/kiln-test-adapters"),
         &kiln_server::config::MemoryConfig::default(),
         300,
+        "qwen3.5-4b-kiln".to_string(),
     );
 
     assert_eq!(state.request_timeout.as_secs(), 300);
@@ -411,7 +413,7 @@ async fn test_health_with_real_backend() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300);
+    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300, "qwen3.5-4b-kiln".to_string());
 
     let app = api::router(state);
 
@@ -465,6 +467,7 @@ async fn test_real_model_chat_completion_metal() {
         std::path::PathBuf::from("/tmp/kiln-test-adapters"),
         &kiln_server::config::MemoryConfig::default(),
         300,
+        "qwen3.5-4b-kiln".to_string(),
     );
 
     let app = api::router(state);

--- a/desktop/src/settings.rs
+++ b/desktop/src/settings.rs
@@ -18,6 +18,7 @@ pub struct Settings {
     pub prefix_cache: bool,
     pub speculative_decoding: bool,
     pub adapter_dir: Option<PathBuf>,
+    pub served_model_id: Option<String>,
     pub auto_start: bool,
     pub auto_restart: bool,
     pub launch_at_login: bool,
@@ -36,6 +37,7 @@ impl Default for Settings {
             prefix_cache: true,
             speculative_decoding: false,
             adapter_dir: None,
+            served_model_id: None,
             auto_start: true,
             auto_restart: true,
             launch_at_login: false,
@@ -113,6 +115,12 @@ pub fn apply_to_supervisor_config(s: &Settings, cfg: &mut SupervisorConfig) {
     if let Some(model) = &s.model_path {
         envs.push(("KILN_MODEL_PATH".to_string(), model.display().to_string()));
     }
+    if let Some(id) = &s.served_model_id {
+        let trimmed = id.trim();
+        if !trimmed.is_empty() {
+            envs.push(("KILN_SERVED_MODEL_ID".to_string(), trimmed.to_string()));
+        }
+    }
 
     cfg.args = Vec::new();
     cfg.envs = envs;
@@ -156,6 +164,7 @@ mod tests {
         s.fp8_kv_cache = true;
         s.model_path = Some(PathBuf::from("/models/foo"));
         s.adapter_dir = Some(PathBuf::from("/adapters"));
+        s.served_model_id = Some("custom-id".to_string());
         s.auto_restart = false;
 
         let mut cfg = SupervisorConfig::default();
@@ -176,6 +185,7 @@ mod tests {
         assert_eq!(env_get("KILN_SPEC_ENABLED"), Some("0")); // default false
         assert_eq!(env_get("KILN_MODEL_PATH"), Some("/models/foo"));
         assert_eq!(env_get("KILN_ADAPTER_DIR"), Some("/adapters"));
+        assert_eq!(env_get("KILN_SERVED_MODEL_ID"), Some("custom-id"));
 
         // Host/port also propagated as structured fields for the poller.
         assert_eq!(cfg.host, "0.0.0.0");

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -324,6 +324,10 @@
           <span class="hint">Where LoRA adapters are saved and loaded from.</span>
           <span class="path-warning" id="warn_adapter_dir"></span>
         </label>
+        <label class="row"><span class="name">Served model ID</span>
+          <input type="text" id="served_model_id" placeholder="(auto-derived from model_id)" />
+          <span class="hint">Identifier returned by /v1/models and echoed in chat completion responses. Leave blank to use the kiln default (model_id stripped to its last path segment, lowercased, with "-kiln" appended).</span>
+        </label>
       </fieldset>
 
       <fieldset>
@@ -437,6 +441,7 @@
         "kiln_binary", "model_path", "host", "port",
         "inference_fraction", "fp8_kv_cache", "cuda_graphs",
         "prefix_cache", "speculative_decoding", "adapter_dir",
+        "served_model_id",
         "auto_start", "auto_restart", "launch_at_login",
       ];
 
@@ -457,6 +462,7 @@
           prefix_cache: n("prefix_cache").checked,
           speculative_decoding: n("speculative_decoding").checked,
           adapter_dir: strOrNull("adapter_dir"),
+          served_model_id: strOrNull("served_model_id"),
           auto_start: n("auto_start").checked,
           auto_restart: n("auto_restart").checked,
           launch_at_login: n("launch_at_login").checked,
@@ -475,6 +481,7 @@
         n("prefix_cache").checked = !!s.prefix_cache;
         n("speculative_decoding").checked = !!s.speculative_decoding;
         n("adapter_dir").value = s.adapter_dir || "";
+        n("served_model_id").value = s.served_model_id || "";
         n("auto_start").checked = !!s.auto_start;
         n("auto_restart").checked = !!s.auto_restart;
         n("launch_at_login").checked = !!s.launch_at_login;

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -18,6 +18,13 @@ shutdown_timeout_secs = 30
 model_id = "Qwen/Qwen3.5-4B"
 # tokenizer_path = "/path/to/tokenizer.json"
 # adapter_dir = "/path/to/adapters"  # Default: <model_path>/adapters
+# served_model_id = "qwen3.5-4b-kiln" # ID exposed at /v1/models and echoed in chat completion
+                                      # responses. Default: derived from `model_id` by stripping
+                                      # everything up to and including the last "/", lowercasing,
+                                      # and appending "-kiln" (so "Qwen/Qwen3.5-4B" becomes
+                                      # "qwen3.5-4b-kiln"). Override precedence:
+                                      #   --served-model-id flag > KILN_SERVED_MODEL_ID env >
+                                      #   this TOML value > derived default.
                                       #
                                       # GPTQ INT4 quantization: point `path` at a GPTQ model directory
                                       # containing quantize_config.json. Kiln auto-detects GPTQ and


### PR DESCRIPTION
## What

Adds a single source of truth for the identifier exposed at `/v1/models` and echoed in chat completion responses. Default is derived from `model.model_id` (strip up to last `/`, lowercase, append `-kiln`) so `Qwen/Qwen3.5-4B` becomes `qwen3.5-4b-kiln`.

## Override precedence (highest wins)

1. `--served-model-id` CLI flag on `kiln serve`
2. `KILN_SERVED_MODEL_ID` env var
3. `model.served_model_id` in TOML
4. Derived default

## Changes

### Server (`crates/kiln-server`)

- `ModelConfig.served_model_id: Option<String>` + `effective_served_model_id()` with derivation logic
- `KILN_SERVED_MODEL_ID` env override in `apply_env_overrides`
- `Serve` subcommand gains `--served-model-id` flag (sets env before config load so the existing precedence path resolves it)
- `AppState` carries the resolved string; `/v1/models`, `/v1/chat/completions`, and `/health` all use it instead of a hardcoded `qwen3.5-4b` / `qwen-4b`
- `ChatCompletionRequest.model` is now optional and falls back to the served ID when omitted
- `run_config_check` prints the effective served-as identifier alongside model id
- `ui.html` fetches `/v1/models` on load and uses that ID in completion requests
- 5 new unit tests (default derivation, lowercase-no-slash, nested path, explicit override, env-overrides-TOML)
- Integration tests updated for the new `AppState::new_real` signature (6 call sites in `tests/real_model_integration.rs`)

### Desktop (`desktop/`)

- `Settings.served_model_id: Option<String>` with empty-string trimming so a blank field falls back to the kiln default
- `KILN_SERVED_MODEL_ID` emitted to the supervisor only when non-empty
- Settings UI input row with placeholder + hint explaining the default
- `apply_populates_env_vars_for_kiln_server` test extended to assert the new env var

### Docs

- `kiln.example.toml` documents `served_model_id` under `[model]` with the derivation rule and the full precedence order

## Local validation

`cargo test -p kiln-server` could not run in the authoring sandbox because `openssl-sys` (transitive via `reqwest`) needs `libssl-dev` and root is unavailable here. The changes are mechanical struct/field/signature additions plus pure derivation logic — please run `cargo test -p kiln-server` before merge to confirm. The new tests live in `crates/kiln-server/src/config.rs` (5 tests) and `crates/kiln-server/src/api/models.rs` (1 test) and `desktop/src/settings.rs` (extended existing test).

## Why

So users can set a custom identifier (e.g. matching what their existing OpenAI-API client expects) without forking, and so the hardcoded `"qwen3.5-4b"` literal is no longer scattered across the server.