### PR TITLE
desktop: updater slice 3a — extract staged tarball to bin/kiln.new + verify sha256

### DIFF
--- a/desktop/src/installer.rs
+++ b/desktop/src/installer.rs
@@ -29,9 +29,20 @@ pub const UPDATE_DOWNLOAD_PROGRESS_EVENT: &str = "download_update_progress";
 pub const UPDATE_DOWNLOAD_DONE_EVENT: &str = "download_update_done";
 pub const UPDATE_DOWNLOAD_FAILED_EVENT: &str = "download_update_failed";
 
+pub const EXTRACT_UPDATE_PROGRESS_EVENT: &str = "extract_update_progress";
+pub const EXTRACT_UPDATE_DONE_EVENT: &str = "extract_update_done";
+pub const EXTRACT_UPDATE_FAILED_EVENT: &str = "extract_update_failed";
+
 /// Subdirectory under `app_data_dir` where update tarballs are staged
 /// before the slice-3 atomic-swap step promotes them.
 pub const UPDATE_STAGING_DIR: &str = "kiln-updates";
+
+/// Filename of the staged extracted binary produced by slice 3a. Lives
+/// next to `bin/kiln` so slice 3b's atomic rename stays inside the same
+/// filesystem. Platform-independent on purpose: the atomic-swap step
+/// targets `bin/kiln` on unix and `bin/kiln.exe` on Windows, but the
+/// sibling staging file is always `bin/kiln.new`.
+pub const NEW_BINARY_NAME: &str = "kiln.new";
 
 const RELEASES_URL: &str = "https://api.github.com/repos/ericflo/kiln/releases";
 const USER_AGENT: &str = concat!("kiln-desktop/", env!("CARGO_PKG_VERSION"));
@@ -85,6 +96,33 @@ pub struct UpdateDownloadDone {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct UpdateDownloadFailed {
+    pub version: String,
+    pub error: String,
+    pub cancelled: bool,
+}
+
+/// Progress payload for the slice-3a "extract + verify" pipeline. The
+/// `total_bytes` field is `None` until extraction completes because the
+/// tar entry's header-declared size is read lazily; a later slice may
+/// pre-scan the archive to report total up front if the UX wants a smooth
+/// progress bar instead of a two-step animation.
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtractUpdateProgress {
+    pub version: String,
+    pub extracted_bytes: u64,
+    pub total_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtractUpdateDone {
+    pub version: String,
+    pub path: String,
+    pub bytes: u64,
+    pub sha256_ok: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExtractUpdateFailed {
     pub version: String,
     pub error: String,
     pub cancelled: bool,
@@ -190,6 +228,137 @@ pub fn staging_tarball_path(app_data_dir: &Path, version: &str, target: &str) ->
     app_data_dir
         .join(UPDATE_STAGING_DIR)
         .join(format!("kiln-v{}.{}", version, release_archive_ext(target)))
+}
+
+/// Path where slice 3a writes the extracted `kiln` binary before the
+/// slice-3b atomic rename promotes it to `bin/kiln` (or `bin/kiln.exe`
+/// on Windows). See `desktop/docs/binary-update.md` "Storage layout".
+pub fn extracted_new_binary_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join("bin").join(NEW_BINARY_NAME)
+}
+
+/// Verify that the file at `path` matches `expected` (64-char lowercase
+/// hex sha256). Streams the file in 64 KiB chunks so large tarballs and
+/// extracted binaries don't balloon memory.
+pub fn verify_sha256(path: &Path, expected: &str) -> Result<(), String> {
+    use std::io::Read;
+    let expected = expected.trim().to_lowercase();
+    if expected.len() != 64 || !expected.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(format!("expected sha256 is not 64-char hex: {}", expected));
+    }
+    let mut file = std::fs::File::open(path)
+        .map_err(|e| format!("open {}: {}", path.display(), e))?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file
+            .read(&mut buf)
+            .map_err(|e| format!("read {}: {}", path.display(), e))?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    let actual = hex_lower(hasher.finalize().as_slice());
+    if actual != expected {
+        return Err(format!(
+            "sha256 mismatch: expected {}, got {}",
+            expected, actual
+        ));
+    }
+    Ok(())
+}
+
+/// Extract the `kiln` (or `kiln.exe`) binary from a release archive into
+/// `target_binary_path`, overwriting any existing file at that path.
+/// Returns the number of bytes written.
+///
+/// tar.gz only today — Windows `.zip` support lands alongside the Windows
+/// release asset build. Detection is purely on the archive filename so
+/// this helper stays testable without platform cfg gates.
+pub fn extract_tarball_to(
+    tarball: &Path,
+    target_binary_path: &Path,
+) -> Result<u64, String> {
+    let fname = tarball
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("");
+    if fname.ends_with(".zip") {
+        return Err(
+            "windows .zip extraction lands alongside Windows release asset support"
+                .to_string(),
+        );
+    }
+    if !(fname.ends_with(".tar.gz") || fname.ends_with(".tgz")) {
+        return Err(format!(
+            "unsupported archive extension for {} — expected .tar.gz or .zip",
+            tarball.display()
+        ));
+    }
+
+    if let Some(parent) = target_binary_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("mkdir {}: {}", parent.display(), e))?;
+    }
+    if target_binary_path.exists() {
+        std::fs::remove_file(target_binary_path).map_err(|e| {
+            format!(
+                "remove stale {}: {}",
+                target_binary_path.display(),
+                e
+            )
+        })?;
+    }
+
+    let file = std::fs::File::open(tarball)
+        .map_err(|e| format!("open {}: {}", tarball.display(), e))?;
+    let gz = flate2::read::GzDecoder::new(file);
+    let mut archive = tar::Archive::new(gz);
+
+    let entries = archive
+        .entries()
+        .map_err(|e| format!("read tar entries: {}", e))?;
+    for entry in entries {
+        let mut entry = entry.map_err(|e| format!("tar entry: {}", e))?;
+        let rel = entry
+            .path()
+            .map_err(|e| format!("tar entry path: {}", e))?
+            .into_owned();
+        // Reject absolute paths and `..` traversal the same way the
+        // first-install extractor does (installer.rs `extract_tarball`).
+        if rel.is_absolute()
+            || rel
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir))
+        {
+            return Err(format!(
+                "tar entry {} escapes archive root",
+                rel.display()
+            ));
+        }
+        let name = match rel.file_name().and_then(|s| s.to_str()) {
+            Some(n) => n,
+            None => continue,
+        };
+        if name != "kiln" && name != "kiln.exe" {
+            continue;
+        }
+        entry.unpack(target_binary_path).map_err(|e| {
+            format!("unpack {}: {}", target_binary_path.display(), e)
+        })?;
+        let size = std::fs::metadata(target_binary_path)
+            .map(|m| m.len())
+            .map_err(|e| {
+                format!("stat {}: {}", target_binary_path.display(), e)
+            })?;
+        return Ok(size);
+    }
+
+    Err(format!(
+        "tarball {} did not contain a `kiln` (or `kiln.exe`) binary",
+        tarball.display()
+    ))
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -648,6 +817,122 @@ pub async fn download_release_binary(
     Ok((dest, downloaded))
 }
 
+/// Fetch the sha256 digest for the tarball published alongside `version`
+/// on the current target, by re-discovering the release asset pair and
+/// downloading the companion `.sha256` file. Returned as a 64-char
+/// lowercase hex digest.
+///
+/// Exposed as its own helper (vs. baking it into
+/// [`extract_and_verify_update`]) so the UI can fetch the digest once
+/// when the user clicks "Extract & Verify" and hand it to the
+/// orchestrator — keeping slice 3a self-contained without forcing slice
+/// 2's download step to persist the digest to disk.
+pub async fn fetch_release_sha256(version: &str) -> Result<String, String> {
+    let target = current_target().ok_or_else(|| {
+        "No prebuilt kiln release exists for this platform.".to_string()
+    })?;
+    let client = reqwest::Client::builder()
+        .user_agent(USER_AGENT)
+        .connect_timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("build reqwest client: {}", e))?;
+    let pair = discover_asset(&client, target).await?;
+    if pair.version != version {
+        return Err(format!(
+            "latest published release is {}, not {} — asset discovery drift",
+            pair.version, version
+        ));
+    }
+    let sha_asset = pair.sha256.ok_or_else(|| {
+        format!(
+            "release {} has no {}.sha256 asset — cannot verify",
+            pair.version, pair.tarball.name
+        )
+    })?;
+    fetch_expected_sha256(&client, &sha_asset).await
+}
+
+/// Slice 3a orchestrator: verify the staged tarball written by slice 2 at
+/// [`staging_tarball_path`] against `expected_sha256`, then extract the
+/// `kiln` binary to `<app_data_dir>/bin/kiln.new`. Does NOT swap
+/// `bin/kiln`, stop the supervisor, or restart — that is slice 3b.
+///
+/// Sha256 verification runs BEFORE extraction so a corrupted download
+/// never produces a garbage `kiln.new` on disk. Both the verify and the
+/// extract run inside [`tokio::task::spawn_blocking`] so the reads don't
+/// block the runtime. Emits [`EXTRACT_UPDATE_PROGRESS_EVENT`] at start
+/// and finish with [`ExtractUpdateProgress`]; terminal `done`/`failed`
+/// events are emitted by the Tauri command layer so cancellation state
+/// lives with the cancel flag there.
+pub async fn extract_and_verify_update(
+    app: &AppHandle,
+    version: &str,
+    expected_sha256: &str,
+    cancel: Arc<AtomicBool>,
+) -> Result<(PathBuf, u64), String> {
+    let target = current_target().ok_or_else(|| {
+        "No prebuilt kiln release exists for this platform.".to_string()
+    })?;
+    let base = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("app_data_dir unavailable: {}", e))?;
+    let tarball = staging_tarball_path(&base, version, target);
+    if !tarball.is_file() {
+        return Err(format!(
+            "no staged update tarball at {} — run the download step first",
+            tarball.display()
+        ));
+    }
+    let new_path = extracted_new_binary_path(&base);
+
+    let _ = app.emit(
+        EXTRACT_UPDATE_PROGRESS_EVENT,
+        ExtractUpdateProgress {
+            version: version.to_string(),
+            extracted_bytes: 0,
+            total_bytes: None,
+        },
+    );
+
+    if cancel.load(Ordering::SeqCst) {
+        return Err("extract cancelled".to_string());
+    }
+
+    let tarball_for_verify = tarball.clone();
+    let expected = expected_sha256.to_string();
+    tokio::task::spawn_blocking(move || verify_sha256(&tarball_for_verify, &expected))
+        .await
+        .map_err(|e| format!("verify task join: {}", e))??;
+
+    if cancel.load(Ordering::SeqCst) {
+        return Err("extract cancelled".to_string());
+    }
+
+    let tarball_for_extract = tarball.clone();
+    let new_path_for_extract = new_path.clone();
+    let bytes = tokio::task::spawn_blocking(move || {
+        extract_tarball_to(&tarball_for_extract, &new_path_for_extract)
+    })
+    .await
+    .map_err(|e| format!("extract task join: {}", e))??;
+
+    // Unix: chmod 0755 so slice 3b's atomic rename hands the supervisor a
+    // runnable file without a follow-up chmod. No-op on Windows.
+    make_executable(&new_path)?;
+
+    let _ = app.emit(
+        EXTRACT_UPDATE_PROGRESS_EVENT,
+        ExtractUpdateProgress {
+            version: version.to_string(),
+            extracted_bytes: bytes,
+            total_bytes: Some(bytes),
+        },
+    );
+
+    Ok((new_path, bytes))
+}
+
 /// Full install pipeline: discover latest asset, download, verify sha256,
 /// extract, chmod, clear quarantine. Returns the installed binary path.
 pub async fn install_latest_server(
@@ -729,9 +1014,12 @@ pub async fn install_latest_server(
 #[cfg(test)]
 mod tests {
     use super::{
-        is_update_available, parse_kiln_version_output, release_archive_ext,
-        release_asset_name, release_download_url, staging_tarball_path, UPDATE_STAGING_DIR,
+        extract_tarball_to, extracted_new_binary_path, is_update_available,
+        parse_kiln_version_output, release_archive_ext, release_asset_name,
+        release_download_url, staging_tarball_path, verify_sha256, NEW_BINARY_NAME,
+        UPDATE_STAGING_DIR,
     };
+    use std::io::Write;
     use std::path::PathBuf;
 
     #[test]
@@ -878,5 +1166,174 @@ mod tests {
         assert!(!is_update_available(Some("not-semver"), "not-semver"));
         // Only latest is unparseable: same rule.
         assert!(is_update_available(Some("0.1.0"), "not-semver"));
+    }
+
+    // ---- Slice 3a: extracted_new_binary_path / verify_sha256 / extract_tarball_to ----
+
+    #[test]
+    fn new_binary_path_is_bin_kiln_new() {
+        let base = PathBuf::from("/tmp/fake-app-data");
+        let p = extracted_new_binary_path(&base);
+        assert_eq!(p, base.join("bin").join(NEW_BINARY_NAME));
+        assert_eq!(p.file_name().unwrap(), "kiln.new");
+        assert!(p.starts_with(base.join("bin")));
+    }
+
+    fn tmp_dir(tag: &str) -> PathBuf {
+        let mut p = std::env::temp_dir();
+        p.push(format!(
+            "kiln-installer-test-{}-{}-{}",
+            tag,
+            std::process::id(),
+            // nanos since UNIX_EPOCH; good enough to avoid collisions
+            // across parallel tests inside the same process.
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn verify_sha256_matches_known_digest() {
+        // sha256("hello world") = b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9
+        let dir = tmp_dir("verify-match");
+        let path = dir.join("hello.txt");
+        std::fs::write(&path, b"hello world").unwrap();
+        verify_sha256(
+            &path,
+            "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+        )
+        .expect("sha256 should match");
+        // Also accepts uppercase + surrounding whitespace.
+        verify_sha256(
+            &path,
+            "  B94D27B9934D3E08A52E52D7DA7DABFAC484EFE37A5380EE9088F7ACE2EFCDE9  ",
+        )
+        .expect("sha256 should be case/whitespace tolerant");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_sha256_rejects_mismatch() {
+        let dir = tmp_dir("verify-mismatch");
+        let path = dir.join("hello.txt");
+        std::fs::write(&path, b"hello world").unwrap();
+        let err = verify_sha256(&path, &"0".repeat(64)).unwrap_err();
+        assert!(err.contains("sha256 mismatch"), "got {}", err);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn verify_sha256_rejects_non_hex_expected() {
+        let dir = tmp_dir("verify-nonhex");
+        let path = dir.join("hello.txt");
+        std::fs::write(&path, b"hello world").unwrap();
+        // Wrong length.
+        let err = verify_sha256(&path, "abc123").unwrap_err();
+        assert!(err.contains("64-char hex"), "got {}", err);
+        // Right length but contains a non-hex char.
+        let mut bad = "a".repeat(63);
+        bad.push('z');
+        let err = verify_sha256(&path, &bad).unwrap_err();
+        assert!(err.contains("64-char hex"), "got {}", err);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Build a gzipped tar archive containing a single `kiln` entry with
+    /// `contents`, returning the tarball path.
+    fn write_fake_tarball(dir: &std::path::Path, contents: &[u8]) -> PathBuf {
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+
+        let tar_path = dir.join("kiln-fake.tar.gz");
+        let file = std::fs::File::create(&tar_path).unwrap();
+        let gz = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(gz);
+        let mut header = tar::Header::new_gnu();
+        header.set_size(contents.len() as u64);
+        header.set_mode(0o755);
+        header.set_cksum();
+        builder
+            .append_data(&mut header, "kiln", contents)
+            .unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+        tar_path
+    }
+
+    #[test]
+    fn extract_tarball_to_writes_kiln_binary() {
+        let dir = tmp_dir("extract-happy");
+        let tar_path = write_fake_tarball(&dir, b"fake-kiln-binary-contents");
+        let target = dir.join("bin").join("kiln.new");
+        let bytes = extract_tarball_to(&tar_path, &target)
+            .expect("extract should succeed");
+        assert!(target.is_file(), "target binary should exist");
+        assert_eq!(bytes, std::fs::metadata(&target).unwrap().len());
+        let got = std::fs::read(&target).unwrap();
+        assert_eq!(got, b"fake-kiln-binary-contents");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn extract_tarball_to_overwrites_existing_target() {
+        let dir = tmp_dir("extract-overwrite");
+        let tar_path = write_fake_tarball(&dir, b"new-contents");
+        let target = dir.join("bin").join("kiln.new");
+        std::fs::create_dir_all(target.parent().unwrap()).unwrap();
+        let mut stale = std::fs::File::create(&target).unwrap();
+        stale.write_all(b"OLD-CONTENTS-that-should-be-replaced").unwrap();
+        drop(stale);
+
+        extract_tarball_to(&tar_path, &target).expect("extract should succeed");
+        let got = std::fs::read(&target).unwrap();
+        assert_eq!(got, b"new-contents");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn extract_tarball_to_rejects_zip_archive() {
+        let dir = tmp_dir("extract-zip");
+        let zip_path = dir.join("kiln-fake.zip");
+        std::fs::write(&zip_path, b"PK\x03\x04-not-a-real-zip").unwrap();
+        let target = dir.join("bin").join("kiln.new");
+        let err = extract_tarball_to(&zip_path, &target).unwrap_err();
+        assert!(
+            err.contains("windows .zip extraction"),
+            "expected zip-not-supported error, got {}",
+            err
+        );
+        assert!(!target.exists(), "no binary should be written on error");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn extract_tarball_to_rejects_archive_without_kiln_entry() {
+        let dir = tmp_dir("extract-missing-kiln");
+        // Build a tar.gz that contains a `README` entry but no `kiln` entry.
+        use flate2::write::GzEncoder;
+        use flate2::Compression;
+        let tar_path = dir.join("kiln-nokiln.tar.gz");
+        let file = std::fs::File::create(&tar_path).unwrap();
+        let gz = GzEncoder::new(file, Compression::default());
+        let mut builder = tar::Builder::new(gz);
+        let body = b"just a readme";
+        let mut header = tar::Header::new_gnu();
+        header.set_size(body.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        builder.append_data(&mut header, "README", &body[..]).unwrap();
+        builder.into_inner().unwrap().finish().unwrap();
+
+        let target = dir.join("bin").join("kiln.new");
+        let err = extract_tarball_to(&tar_path, &target).unwrap_err();
+        assert!(
+            err.contains("did not contain a `kiln`"),
+            "expected missing-kiln error, got {}",
+            err
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -291,6 +291,83 @@ async fn download_kiln_update(
     Ok(())
 }
 
+/// Fetch the sha256 digest for the tarball published alongside `version`
+/// on the current target. The settings UI calls this right before
+/// [`extract_update`] so it can hand the expected digest to the
+/// orchestrator. Kept as a separate command (rather than baked into
+/// `extract_update`) so slice 3a stays self-contained without forcing
+/// slice 2's download step to persist the digest to disk.
+#[tauri::command]
+async fn fetch_update_sha256(version: String) -> Result<String, String> {
+    installer::fetch_release_sha256(&version).await
+}
+
+/// Updater slice 3a: verify the staged tarball and extract the kiln
+/// binary to `<app_data_dir>/bin/kiln.new`. **Does not** swap
+/// `bin/kiln`, stop the supervisor, or restart — atomic swap + restart
+/// land in slice 3b (see `desktop/docs/binary-update.md`).
+///
+/// Progress is streamed as `extract_update_progress`; terminal events are
+/// `extract_update_done` (success) and `extract_update_failed` (error or
+/// cancelled). Reuses [`InstallerState`] so a fresh-install, slice-2
+/// download, and slice-3a extract can't race the same on-disk file or
+/// cancel flag.
+#[tauri::command]
+async fn extract_update(
+    app: AppHandle,
+    version: String,
+    expected_sha256: String,
+    inst: State<'_, InstallerHandle>,
+) -> Result<(), String> {
+    if inst.in_progress.swap(true, Ordering::SeqCst) {
+        return Err(
+            "an install, update download, or extract is already in progress".into(),
+        );
+    }
+    inst.cancel.store(false, Ordering::SeqCst);
+
+    let app_for_task = app.clone();
+    let inst_for_task = (*inst).clone();
+    let version_for_task = version.clone();
+
+    tauri::async_runtime::spawn(async move {
+        let result = installer::extract_and_verify_update(
+            &app_for_task,
+            &version_for_task,
+            &expected_sha256,
+            Arc::clone(&inst_for_task.cancel),
+        )
+        .await;
+        match result {
+            Ok((path, bytes)) => {
+                let _ = app_for_task.emit(
+                    installer::EXTRACT_UPDATE_DONE_EVENT,
+                    installer::ExtractUpdateDone {
+                        version: version_for_task,
+                        path: path.display().to_string(),
+                        bytes,
+                        sha256_ok: true,
+                    },
+                );
+            }
+            Err(err) => {
+                let cancelled = inst_for_task.cancel.load(Ordering::SeqCst);
+                let _ = app_for_task.emit(
+                    installer::EXTRACT_UPDATE_FAILED_EVENT,
+                    installer::ExtractUpdateFailed {
+                        version: version_for_task,
+                        error: err,
+                        cancelled,
+                    },
+                );
+            }
+        }
+        inst_for_task.in_progress.store(false, Ordering::SeqCst);
+    });
+
+    Ok(())
+}
+
 /// Kick off a HuggingFace model download into
 /// `app_data_dir()/models/<sanitized_repo>/`. Progress is streamed via
 /// the `hf-download-progress` event; terminal success / failure arrive as
@@ -772,6 +849,8 @@ fn main() {
             download_kiln_server,
             cancel_kiln_download,
             download_kiln_update,
+            fetch_update_sha256,
+            extract_update,
             download_hf_model,
             path_info
         ])

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -329,7 +329,8 @@
           <button type="button" class="browse" id="check_for_kiln_update">Check for Updates</button>
           <span class="update-status" id="kiln_update_status"></span>
           <button type="button" class="browse hidden" id="download_kiln_update">Download Update</button>
-          <button type="button" class="browse hidden" id="install_kiln_update" disabled title="Install lands in updater slice 3">Install</button>
+          <button type="button" class="browse hidden" id="extract_kiln_update">Extract &amp; Verify</button>
+          <button type="button" class="browse hidden" id="install_kiln_update" disabled title="Atomic swap lands in updater slice 3b">Install</button>
           <div class="update-download hidden" id="kiln_update_download">
             <div class="update-download-bar"><div class="update-download-fill" id="kiln_update_download_fill"></div></div>
             <div class="update-download-line" id="kiln_update_download_line"></div>
@@ -997,12 +998,14 @@
       const kilnUpdateBtn = document.getElementById("check_for_kiln_update");
       const kilnUpdateStatusEl = document.getElementById("kiln_update_status");
       const kilnUpdateDownloadBtn = document.getElementById("download_kiln_update");
+      const kilnUpdateExtractBtn = document.getElementById("extract_kiln_update");
       const kilnUpdateInstallBtn = document.getElementById("install_kiln_update");
       const kilnUpdateProgressWrap = document.getElementById("kiln_update_download");
       const kilnUpdateProgressFill = document.getElementById("kiln_update_download_fill");
       const kilnUpdateProgressLine = document.getElementById("kiln_update_download_line");
       let kilnUpdateChecking = false;
       let kilnUpdateDownloading = false;
+      let kilnUpdateExtracting = false;
       let kilnUpdateLatest = null;
       let kilnUpdateUnlistenFns = [];
 
@@ -1027,9 +1030,11 @@
         kilnUpdateLatest = latest || null;
         if (latest) {
           kilnUpdateDownloadBtn.classList.remove("hidden");
+          kilnUpdateExtractBtn.classList.add("hidden");
           kilnUpdateInstallBtn.classList.add("hidden");
         } else {
           kilnUpdateDownloadBtn.classList.add("hidden");
+          kilnUpdateExtractBtn.classList.add("hidden");
           kilnUpdateInstallBtn.classList.add("hidden");
           kilnUpdateProgressWrap.classList.add("hidden");
         }
@@ -1140,13 +1145,16 @@
           setKilnUpdateProgressLine(
             "success",
             "Downloaded v" + version + " (" + formatBytes(p.bytes || 0) +
-              ") to " + (p.path || "(unknown)") + ". Install lands in updater slice 3."
+              ") to " + (p.path || "(unknown)") + ". Next: Extract & Verify."
           );
           kilnUpdateDownloading = false;
           kilnUpdateDownloadBtn.disabled = true;
           kilnUpdateDownloadBtn.textContent = "Downloaded";
-          // Surface the Install button as a slice-3 placeholder so the user
-          // sees the next step exists; it stays disabled until slice 3.
+          // Slice 3a: offer Extract & Verify. The Install button stays
+          // disabled — atomic swap lands in updater slice 3b.
+          kilnUpdateExtractBtn.classList.remove("hidden");
+          kilnUpdateExtractBtn.disabled = false;
+          kilnUpdateExtractBtn.textContent = "Extract & Verify";
           kilnUpdateInstallBtn.classList.remove("hidden");
           kilnUpdateInstallBtn.disabled = true;
           teardownKilnUpdateListeners();
@@ -1179,6 +1187,113 @@
         }
       }
       kilnUpdateDownloadBtn.addEventListener("click", startKilnUpdateDownload);
+
+      // ---------- Extract & verify the staged update tarball (slice 3a) ----------
+      // Verifies the staged tarball's sha256 against the release manifest,
+      // then extracts the `kiln` binary to <app_data_dir>/bin/kiln.new. Does
+      // NOT swap bin/kiln, stop the supervisor, or restart — atomic swap
+      // lands in updater slice 3b.
+      async function startKilnUpdateExtract() {
+        if (kilnUpdateExtracting || !kilnUpdateLatest) return;
+        const version = kilnUpdateLatest;
+        kilnUpdateExtracting = true;
+        kilnUpdateExtractBtn.disabled = true;
+        kilnUpdateExtractBtn.textContent = "Extracting…";
+        kilnUpdateInstallBtn.classList.add("hidden");
+        kilnUpdateInstallBtn.disabled = true;
+        kilnUpdateProgressWrap.classList.remove("hidden");
+        kilnUpdateProgressFill.style.background = "#2f66f0";
+        kilnUpdateProgressFill.style.width = "0%";
+        setKilnUpdateProgressLine(
+          "",
+          "Verifying sha256 for v" + version + "…"
+        );
+
+        const event = window.__TAURI__ && window.__TAURI__.event;
+        if (!event || typeof event.listen !== "function") {
+          setKilnUpdateProgressLine("error", "Tauri event API unavailable.");
+          kilnUpdateExtracting = false;
+          kilnUpdateExtractBtn.disabled = false;
+          kilnUpdateExtractBtn.textContent = "Extract & Verify";
+          return;
+        }
+
+        await teardownKilnUpdateListeners();
+
+        const unProgress = await event.listen("extract_update_progress", (e) => {
+          const p = e && e.payload;
+          if (!p || p.version !== version) return;
+          const total = p.total_bytes;
+          const got = p.extracted_bytes || 0;
+          if (total && total > 0) {
+            const pct = Math.max(0, Math.min(100, (got / total) * 100));
+            kilnUpdateProgressFill.style.width = pct.toFixed(1) + "%";
+            setKilnUpdateProgressLine(
+              "",
+              "Extracted " + formatBytes(got) + " / " + formatBytes(total) +
+                " (" + pct.toFixed(0) + "%) — v" + version
+            );
+          } else {
+            setKilnUpdateProgressLine(
+              "",
+              "Extracting v" + version + "… " + formatBytes(got)
+            );
+          }
+        });
+        const unDone = await event.listen("extract_update_done", (e) => {
+          const p = e && e.payload;
+          if (!p || p.version !== version) return;
+          kilnUpdateProgressFill.style.width = "100%";
+          setKilnUpdateProgressLine(
+            "success",
+            "Extracted v" + version + " (" + formatBytes(p.bytes || 0) +
+              ", sha256 OK) to " + (p.path || "(unknown)") +
+              ". Atomic swap lands in updater slice 3b."
+          );
+          kilnUpdateExtracting = false;
+          kilnUpdateExtractBtn.disabled = true;
+          kilnUpdateExtractBtn.textContent = "Extracted";
+          kilnUpdateInstallBtn.classList.remove("hidden");
+          kilnUpdateInstallBtn.disabled = true;
+          teardownKilnUpdateListeners();
+        });
+        const unFailed = await event.listen("extract_update_failed", (e) => {
+          const p = e && e.payload;
+          if (!p || p.version !== version) return;
+          const err = p.error || "Unknown error";
+          const cancelled = !!p.cancelled;
+          kilnUpdateProgressFill.style.background = cancelled ? "#3a3a2a" : "#3a2a2a";
+          setKilnUpdateProgressLine(
+            "error",
+            (cancelled ? "Cancelled: " : "Extract failed: ") + err
+          );
+          kilnUpdateExtracting = false;
+          kilnUpdateExtractBtn.disabled = false;
+          kilnUpdateExtractBtn.textContent = "Retry Extract & Verify";
+          teardownKilnUpdateListeners();
+        });
+        kilnUpdateUnlistenFns = [unProgress, unDone, unFailed];
+
+        try {
+          const expectedSha256 = await invoke("fetch_update_sha256", {
+            version: version,
+          });
+          await invoke("extract_update", {
+            version: version,
+            expectedSha256: expectedSha256,
+          });
+        } catch (err) {
+          setKilnUpdateProgressLine(
+            "error",
+            "Failed to start extract: " + escapeHtml(String(err))
+          );
+          kilnUpdateExtracting = false;
+          kilnUpdateExtractBtn.disabled = false;
+          kilnUpdateExtractBtn.textContent = "Retry Extract & Verify";
+          await teardownKilnUpdateListeners();
+        }
+      }
+      kilnUpdateExtractBtn.addEventListener("click", startKilnUpdateExtract);
 
       load();
     </script>


### PR DESCRIPTION
## What

Slice 3a of the kiln binary auto-update pipeline. Verifies the staged
tarball written by slice 2 (PR #201) and extracts the `kiln` binary to
`<app_data_dir>/bin/kiln.new`.

New pure helpers in `desktop/src/installer.rs`:

- `extracted_new_binary_path(app_data_dir)` — returns `<app_data_dir>/bin/kiln.new`.
- `verify_sha256(path, expected)` — streams the file in 64 KiB chunks and
  rejects non-hex / wrong-length expected digests up front.
- `extract_tarball_to(tarball, target_binary_path)` — reads the `.tar.gz`,
  finds the `kiln` (or `kiln.exe`) entry, rejects absolute paths and `..`
  traversal, overwrites any stale target, returns bytes written. Emits a
  clear "zip not yet supported" error for Windows archives so the
  filename check stays testable without platform cfg gates.
- `fetch_release_sha256(version)` — re-discovers the release asset pair
  and returns the published tarball digest as a 64-char lowercase hex
  string.
- `extract_and_verify_update(app, version, expected_sha256, cancel)` —
  resolves the staging path, verifies sha256 BEFORE extraction (so
  corruption never produces a garbage `kiln.new`), then extracts inside
  `spawn_blocking`. Checks the cancel flag between phases. Emits
  `extract_update_progress` at start (0 bytes, unknown total) and at
  finish (bytes, bytes). `make_executable` chmods the new binary 0755
  on unix so slice 3b's atomic rename hands the supervisor a runnable
  file.

New Tauri commands in `desktop/src/main.rs`, both registered in
`invoke_handler!`:

- `fetch_update_sha256(version) -> String`
- `extract_update(version, expected_sha256)` — mirrors the
  `download_kiln_update` pattern: swaps `InstallerState.in_progress`
  atomically, spawns the background task, emits
  `extract_update_done { version, path, bytes, sha256_ok: true }` on
  success or `extract_update_failed { version, error, cancelled }` on
  error.

Settings UI (`desktop/ui/settings.html`):

- New "Extract &amp; Verify" button between Download and Install, surfaced
  only after download completes.
- Install button title updated to "Atomic swap lands in updater slice 3b".
- JS listeners for `extract_update_progress` / `_done` / `_failed` reuse
  the existing progress bar; the click handler calls
  `fetch_update_sha256` then `extract_update`.

## Why

Slice 3a is the first half of the in-place upgrade step. Keeping extract
+ verify separate from the atomic-swap + restart is deliberate: this
slice is idempotent, runnable while the supervisor is live, and leaves
`bin/kiln` untouched so a verify failure never damages a working
install.

## Slice 3b deliberately NOT included

This PR intentionally does NOT:

- swap `bin/kiln` for `bin/kiln.new`
- stop the supervisor or restart the server
- enable the Install button (stays disabled with a slice-3b hint)
- record an install manifest / rollback breadcrumb

Those belong in the atomic-swap slice.

## Tests

Ran inside a scratch cargo crate at `/tmp/kiln-updater-slice3a-check`
that copies the pure helpers verbatim (Cloud Eric can't `cargo check`
the full Tauri crate because system GTK libs aren't installed locally):

```
running 8 tests
........
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured
```

Covers:

- `extracted_new_binary_path` returns `<base>/bin/kiln.new`.
- `verify_sha256` matches a known "hello world" digest, tolerates
  whitespace + mixed case, rejects sha256 mismatch, rejects non-hex and
  wrong-length expected strings.
- `extract_tarball_to` writes a synthetic kiln tarball to disk,
  overwrites a stale target, rejects `.zip` archives with a clear error
  message, and errors cleanly when the archive lacks a `kiln` entry.

Also mirrored as `#[cfg(test)]` tests in `desktop/src/installer.rs` so
they run under the real crate once a Tauri-capable host is available.

`cargo metadata --format-version 1 --manifest-path desktop/Cargo.toml`
passes.

## Test plan

- [ ] macOS aarch64 dev build: `cargo test -p kiln-desktop`
- [ ] macOS aarch64 dev run: Download Update, then Extract & Verify;
      confirm `bin/kiln.new` appears next to `bin/kiln` and is chmod 0755.
- [ ] Inject a bit-flipped byte into the staged tarball on disk and
      confirm extract fails with `sha256 mismatch` and leaves `bin/kiln.new`
      absent.
- [ ] Confirm the Install button still surfaces as disabled with the
      "slice 3b" hint after Extract succeeds.
- [ ] Re-run Extract & Verify after success to confirm it overwrites
      the stale `kiln.new` cleanly.