### PR TITLE
marlin: drop BF16 *_proj_t after Marlin pack (-4.4 GB VRAM, parity)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -282,6 +282,33 @@ fn weight_to_tensor(w: &WeightTensor, device: &Device) -> Result<Tensor> {
     Ok(t)
 }
 
+/// Tiny BF16 placeholder that replaces a projection's pre-transposed
+/// contiguous copy (`*_proj_t`) once Marlin has absorbed it. Dropping the
+/// original `Tensor` field releases the underlying CUDA buffer (the
+/// refcounted `Arc<Storage>` hits zero), reclaiming the per-layer BF16
+/// residency. The struct layout is preserved so every existing construction
+/// site (tests, loaders) continues to compile unchanged.
+fn dropped_bf16_stub(device: &Device) -> Result<Tensor> {
+    Ok(Tensor::zeros((1usize,), DType::BF16, device)?)
+}
+
+/// Kill switch for the Marlin BF16 residency cleanup. Setting
+/// `KILN_DISABLE_MARLIN_BF16_DROP=1` keeps the full-size `*_proj_t`
+/// contiguous copies resident alongside the packed Marlin weights so the
+/// previous behaviour can be reproduced for A/B measurements or parity
+/// debugging. Any unset value leaves the drop enabled.
+fn marlin_bf16_drop_disabled() -> bool {
+    matches!(
+        std::env::var("KILN_DISABLE_MARLIN_BF16_DROP")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+
 impl GpuWeights {
     /// Convert `ModelWeights` (CPU bytes) into candle tensors on the given device.
     ///
@@ -336,6 +363,17 @@ impl GpuWeights {
                             .context(ctx("q_proj marlin pack"))?
                     } else {
                         None
+                    };
+                    // When Marlin has absorbed q_proj, the BF16 `q_proj_t`
+                    // contiguous copy is no longer touched by the forward
+                    // path (`q_proj_forward` dispatches on `q_proj_marlin`).
+                    // Drop it to reclaim the per-layer BF16 residency.
+                    // `KILN_DISABLE_MARLIN_BF16_DROP=1` preserves the old
+                    // behaviour for A/B measurements.
+                    let q_proj_t = if q_proj_marlin.is_some() && !marlin_bf16_drop_disabled() {
+                        dropped_bf16_stub(device).context(ctx("q_proj_t stub"))?
+                    } else {
+                        q_proj_t
                     };
                     GpuAttentionWeights::Full(GpuFullAttentionWeights {
                         q_proj,
@@ -418,6 +456,28 @@ impl GpuWeights {
                 } else {
                     (None, None, None)
                 };
+            // Per-projection drop of the BF16 contiguous pre-transpose once
+            // Marlin has absorbed it. `mlp_proj_forward` dispatches on the
+            // per-projection `*_marlin` option; when packing succeeds the
+            // corresponding `*_proj_t` is never read again.
+            // `KILN_DISABLE_MARLIN_BF16_DROP=1` preserves the old behaviour
+            // for A/B measurements.
+            let drop_disabled = marlin_bf16_drop_disabled();
+            let gate_proj_t = if gate_proj_marlin.is_some() && !drop_disabled {
+                dropped_bf16_stub(device).context(ctx("gate_proj_t stub"))?
+            } else {
+                gate_proj_t
+            };
+            let up_proj_t = if up_proj_marlin.is_some() && !drop_disabled {
+                dropped_bf16_stub(device).context(ctx("up_proj_t stub"))?
+            } else {
+                up_proj_t
+            };
+            let down_proj_t = if down_proj_marlin.is_some() && !drop_disabled {
+                dropped_bf16_stub(device).context(ctx("down_proj_t stub"))?
+            } else {
+                down_proj_t
+            };
             let mlp = GpuFfnWeights {
                 gate_proj,
                 up_proj,


### PR DESCRIPTION
## What

Drop the BF16 pre-transposed projection copies (`q_proj_t`, `gate_proj_t`,
`up_proj_t`, `down_proj_t`) once Marlin W4A16 has absorbed the corresponding
BF16 projection. The forward hot path already dispatches on the per-layer
`*_marlin` option — `q_proj_forward` and `mlp_proj_forward` never touch the
BF16 `*_proj_t` when the packed Marlin weight is present — so the BF16
contiguous copies sit unused in VRAM for the entire life of the process.

After load, each absorbed `*_proj_t` field is replaced with a 1-element
BF16 stub. That drops the original tensor's `Arc<Storage>` refcount to zero
and frees the CUDA buffer. The struct layout is preserved so every
existing construction site compiles unchanged.

Only the **transposed** copies are dropped. The non-transposed `*_proj`
fields are preserved because `kiln-train/src/trainer.rs:102-115` reads
`.dims()` on them during LoRA init, so dropping them would break the
training path.

## Kill switch

`KILN_DISABLE_MARLIN_BF16_DROP=1` (also accepts `true` / `yes`) preserves
the prior behaviour, keeping the full-size `*_proj_t` contiguous copies
resident alongside the packed Marlin weights. Matches the kiln convention
for kernel kill switches (PRs #92, #133, #158, #166).

## Measurement

A6000, `KILN_W4A16=1`, CUDA graphs on, `kiln-bench --paged --prompt-tokens
512 --max-output-tokens 128 --skip-training`, median of 3 back-to-back runs
per arm (6 runs total, A/B interleaved into two arms). Max VRAM sampled
per run via `nvidia-smi --query-gpu=memory.used` at 1s intervals.

|                 | max VRAM (MiB) | decode tok/s | mean ITL ms | p99 ITL ms |
|-----------------|---------------:|-------------:|------------:|-----------:|
| drop-disabled   |         18058  |        45.7  |       21.9  |     26.04  |
| drop-enabled    |         13514  |        50.1  |       20.0  |     24.16  |
| delta           |    **-4544**   |   within noise | within noise | within noise |
|                 |   **(-25.2%)** |    (parity)  |   (parity)  |  (parity)  |

Per-run numbers (unsorted, drop-disabled / drop-enabled):
- decode tok/s: `[45.7, 45.2, 50.5]` / `[50.6, 44.3, 50.1]`
- mean ITL ms:  `[21.9, 22.1, 19.8]` / `[19.7, 22.6, 20.0]`
- p99 ITL ms:   `[27.10, 26.04, 23.77]` / `[22.52, 33.83, 24.16]`
- max VRAM:     `[18058, 18058, 18058]` / `[13779, 13514, 13514]`

The observed 4.4 GB VRAM reduction aligns with the theoretical ceiling
(32 layers × 3 MLP proj × ~47 MB + 8 full-attn × q_proj × ~40 MB ≈ 4.7 GB).
The ~0.3 GB residual is the non-transposed `*_proj` tensors kept resident
for trainer compatibility.

Decode throughput, mean ITL, and p99 ITL all sit inside the established
run-to-run variance for A6000 `KILN_W4A16=1` paged decode, so this is a
zero-regression VRAM reclaim.

## Why scope to `*_proj_t` only

`kiln-train/src/trainer.rs:102-115` constructs LoRA init tensors by
reading `.dims()` on the non-transposed projection fields. Replacing
those with a 1-element stub would crash LoRA bootstrap. The transposed
copies (`*_proj_t`) were added in PR #128 purely to avoid a per-step
`.t()` copy in the BF16 forward path; under Marlin they are dead weight
and can be freed.

## Notes

- No kernel changes; no scheduler changes; purely residency/lifetime
  cleanup on the loader side.
- When `KILN_W4A16=0`, no code path changes at all — the drop is gated on
  `*_marlin.is_some()` so BF16-only builds retain full `*_proj_t` as
  before.
