### PR TITLE
desktop: release v0.1.8

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-desktop"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kiln-desktop"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Kiln Desktop — system tray app for the kiln local LLM server"
 authors = ["Eric Florenzano <eric@eflorenzano.com>"]

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kiln Desktop",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "com.eflorenzano.kiln.desktop",
   "build": {
     "frontendDist": "ui",


### PR DESCRIPTION
Bumps `kiln-desktop` from `0.1.7` → `0.1.8`.

## Changes since desktop-v0.1.7

- #207 desktop: health-gate updater install with rollback to kiln.bak
- #205 desktop: updater slice 3b — atomic swap bin/kiln.new into bin/kiln
- #203 desktop: updater slice 3a — extract staged tarball to bin/kiln.new + verify sha256
- #202 server+desktop: configurable served model ID
- #201 desktop: updater slice 2 — download new kiln binary to staging path
- #200 desktop: add check-for-updates command and Settings UI (detection only)

## Files

- `desktop/Cargo.toml`
- `desktop/Cargo.lock`
- `desktop/tauri.conf.json`

After merge, push tag `desktop-v0.1.8` to trigger the Tauri release workflow.