### PR TITLE
marlin: parallelize W4A16 projection packing at model load

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "memmap2",
  "mlx-rs",
  "rand 0.8.6",
+ "rayon",
  "safetensors 0.5.3",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ mlx-rs = { version = "0.25", default-features = false }
 # Random number generation
 rand = "0.8"
 
+# Data-parallel iteration
+rayon = "1"
+
 # Testing
 tempfile = "3"
 

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -30,7 +30,7 @@ mlx-rs = { workspace = true, optional = true }
 half = { version = "2", optional = true }
 
 [features]
-cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-conv1d-kernel", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel", "dep:kiln-marlin-gemm", "dep:kiln-rmsnorm-kernel"]
+cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-conv1d-kernel", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel", "dep:kiln-marlin-gemm", "dep:kiln-rmsnorm-kernel", "dep:half"]
 # Enable candle's Metal backend on Apple Silicon. Pulls in candle-metal-kernels
 # (JIT-compiled MSL shaders cached in the MetalDevice); no Xcode required.
 metal = ["candle-core/metal", "candle-nn/metal"]

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -23,6 +23,7 @@ kiln-marlin-gemm = { workspace = true, optional = true }
 kiln-rmsnorm-kernel = { workspace = true, optional = true }
 kiln-nvtx = { workspace = true }
 rand = { workspace = true }
+rayon = { workspace = true }
 mlx-rs = { workspace = true, optional = true }
 # Pin to the same major as candle-core and mlx-rs. Only pulled in by the
 # mlx backend for native bf16/f16 conversion at the candle↔mlx boundary.

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -309,6 +309,65 @@ fn marlin_bf16_drop_disabled() -> bool {
     )
 }
 
+/// Sidecar record: which slot in `layers[layer_idx]` a queued Marlin pack
+/// job belongs to. Populated inline with `pack_from_bf16_batch`'s input vec
+/// during the per-layer build loop, then replayed after the batch pack
+/// finishes so the packed `MarlinPackedProj` lands in the right field.
+#[derive(Clone, Copy, Debug)]
+enum MarlinPackKind {
+    QProj,
+    GateProj,
+    UpProj,
+    DownProj,
+}
+
+#[derive(Debug)]
+struct MarlinPackEntry {
+    layer_idx: usize,
+    kind: MarlinPackKind,
+}
+
+/// Install a successfully packed projection into its target layer slot,
+/// and drop the corresponding pre-transposed BF16 copy unless
+/// `KILN_DISABLE_MARLIN_BF16_DROP=1` has preserved it.
+fn install_marlin_packed(
+    layer: &mut GpuLayerWeights,
+    kind: MarlinPackKind,
+    packed: crate::marlin_proj::MarlinPackedProj,
+    device: &Device,
+    drop_disabled: bool,
+) -> Result<()> {
+    match kind {
+        MarlinPackKind::QProj => {
+            if let GpuAttentionWeights::Full(ref mut full) = layer.attention {
+                full.q_proj_marlin = Some(packed);
+                if !drop_disabled {
+                    full.q_proj_t = dropped_bf16_stub(device)?;
+                }
+            }
+        }
+        MarlinPackKind::GateProj => {
+            layer.mlp.gate_proj_marlin = Some(packed);
+            if !drop_disabled {
+                layer.mlp.gate_proj_t = dropped_bf16_stub(device)?;
+            }
+        }
+        MarlinPackKind::UpProj => {
+            layer.mlp.up_proj_marlin = Some(packed);
+            if !drop_disabled {
+                layer.mlp.up_proj_t = dropped_bf16_stub(device)?;
+            }
+        }
+        MarlinPackKind::DownProj => {
+            layer.mlp.down_proj_marlin = Some(packed);
+            if !drop_disabled {
+                layer.mlp.down_proj_t = dropped_bf16_stub(device)?;
+            }
+        }
+    }
+    Ok(())
+}
+
 impl GpuWeights {
     /// Convert `ModelWeights` (CPU bytes) into candle tensors on the given device.
     ///
@@ -330,6 +389,16 @@ impl GpuWeights {
         let rotary_inv_freq =
             compute_rotary_inv_freq(config.rotary_dim(), config.rope_theta, device)
                 .context("rotary_inv_freq")?;
+
+        // Per-layer `pack_from_bf16` used to run inline during weight load,
+        // serializing ~104 calls (8 × q_proj + 96 × MLP gate/up/down) behind
+        // a single thread. At ~58s cold load on the Qwen3.5-4B A6000 build
+        // this is a significant fraction of server startup. Sidecar the
+        // pack inputs here, batch-pack via rayon after the layer loop, and
+        // install results into the per-layer slots.
+        let w4a16_enabled = crate::marlin_proj::env_enabled();
+        let mut marlin_pack_inputs: Vec<(Tensor, i32)> = Vec::new();
+        let mut marlin_pack_meta: Vec<MarlinPackEntry> = Vec::new();
 
         let mut layers = Vec::with_capacity(weights.layers.len());
         for (i, lw) in weights.layers.iter().enumerate() {
@@ -354,27 +423,18 @@ impl GpuWeights {
                         .contiguous().context(ctx("v_proj.t contiguous"))?;
                     let o_proj_t = o_proj.t().context(ctx("o_proj.t"))?
                         .contiguous().context(ctx("o_proj.t contiguous"))?;
-                    // KILN_W4A16=1 opt-in: pack q_proj into Marlin W4A16 layout
-                    // once, and let the forward path route through the Marlin
-                    // kernel. Skip gracefully if the shape doesn't fit Marlin's
-                    // tile constraints — the forward path will fall back.
-                    let q_proj_marlin = if crate::marlin_proj::env_enabled() {
-                        crate::marlin_proj::pack_from_bf16(&q_proj_t, 128)
-                            .context(ctx("q_proj marlin pack"))?
-                    } else {
-                        None
-                    };
-                    // When Marlin has absorbed q_proj, the BF16 `q_proj_t`
-                    // contiguous copy is no longer touched by the forward
-                    // path (`q_proj_forward` dispatches on `q_proj_marlin`).
-                    // Drop it to reclaim the per-layer BF16 residency.
-                    // `KILN_DISABLE_MARLIN_BF16_DROP=1` preserves the old
-                    // behaviour for A/B measurements.
-                    let q_proj_t = if q_proj_marlin.is_some() && !marlin_bf16_drop_disabled() {
-                        dropped_bf16_stub(device).context(ctx("q_proj_t stub"))?
-                    } else {
-                        q_proj_t
-                    };
+                    // KILN_W4A16=1 opt-in: queue q_proj for the post-loop
+                    // Marlin batch pack. The packed weight (and the BF16
+                    // drop) are installed after the layer loop via
+                    // `install_marlin_packed`, so `q_proj_marlin` starts as
+                    // None and `q_proj_t` keeps the BF16 copy until then.
+                    if w4a16_enabled {
+                        marlin_pack_inputs.push((q_proj_t.clone(), 128));
+                        marlin_pack_meta.push(MarlinPackEntry {
+                            layer_idx: i,
+                            kind: MarlinPackKind::QProj,
+                        });
+                    }
                     GpuAttentionWeights::Full(GpuFullAttentionWeights {
                         q_proj,
                         k_proj,
@@ -386,7 +446,7 @@ impl GpuWeights {
                         k_proj_t,
                         v_proj_t,
                         o_proj_t,
-                        q_proj_marlin,
+                        q_proj_marlin: None,
                     })
                 }
                 crate::weights::AttentionWeights::Linear(attn) => {
@@ -438,46 +498,28 @@ impl GpuWeights {
                 .contiguous().context(ctx("up_proj.t contiguous"))?;
             let down_proj_t = down_proj.t().context(ctx("down_proj.t"))?
                 .contiguous().context(ctx("down_proj.t contiguous"))?;
-            // KILN_W4A16=1 opt-in: pack each MLP projection into Marlin W4A16
-            // layout once, and let the forward path route through the Marlin
-            // kernel. Skip gracefully per-projection if the shape doesn't fit
-            // Marlin's tile constraints — the forward path falls back to the
-            // BF16 `broadcast_matmul(*_t)` for any projection that returns
-            // None.
-            let (gate_proj_marlin, up_proj_marlin, down_proj_marlin) =
-                if crate::marlin_proj::env_enabled() {
-                    let g = crate::marlin_proj::pack_from_bf16(&gate_proj_t, 128)
-                        .context(ctx("gate_proj marlin pack"))?;
-                    let u = crate::marlin_proj::pack_from_bf16(&up_proj_t, 128)
-                        .context(ctx("up_proj marlin pack"))?;
-                    let d = crate::marlin_proj::pack_from_bf16(&down_proj_t, 128)
-                        .context(ctx("down_proj marlin pack"))?;
-                    (g, u, d)
-                } else {
-                    (None, None, None)
-                };
-            // Per-projection drop of the BF16 contiguous pre-transpose once
-            // Marlin has absorbed it. `mlp_proj_forward` dispatches on the
-            // per-projection `*_marlin` option; when packing succeeds the
-            // corresponding `*_proj_t` is never read again.
-            // `KILN_DISABLE_MARLIN_BF16_DROP=1` preserves the old behaviour
-            // for A/B measurements.
-            let drop_disabled = marlin_bf16_drop_disabled();
-            let gate_proj_t = if gate_proj_marlin.is_some() && !drop_disabled {
-                dropped_bf16_stub(device).context(ctx("gate_proj_t stub"))?
-            } else {
-                gate_proj_t
-            };
-            let up_proj_t = if up_proj_marlin.is_some() && !drop_disabled {
-                dropped_bf16_stub(device).context(ctx("up_proj_t stub"))?
-            } else {
-                up_proj_t
-            };
-            let down_proj_t = if down_proj_marlin.is_some() && !drop_disabled {
-                dropped_bf16_stub(device).context(ctx("down_proj_t stub"))?
-            } else {
-                down_proj_t
-            };
+            // KILN_W4A16=1 opt-in: queue each MLP projection for the
+            // post-loop Marlin batch pack. See the q_proj comment above —
+            // the `*_proj_marlin` fields start as None, and
+            // `install_marlin_packed` drops `*_proj_t` after the batch runs
+            // (unless `KILN_DISABLE_MARLIN_BF16_DROP=1`).
+            if w4a16_enabled {
+                marlin_pack_inputs.push((gate_proj_t.clone(), 128));
+                marlin_pack_meta.push(MarlinPackEntry {
+                    layer_idx: i,
+                    kind: MarlinPackKind::GateProj,
+                });
+                marlin_pack_inputs.push((up_proj_t.clone(), 128));
+                marlin_pack_meta.push(MarlinPackEntry {
+                    layer_idx: i,
+                    kind: MarlinPackKind::UpProj,
+                });
+                marlin_pack_inputs.push((down_proj_t.clone(), 128));
+                marlin_pack_meta.push(MarlinPackEntry {
+                    layer_idx: i,
+                    kind: MarlinPackKind::DownProj,
+                });
+            }
             let mlp = GpuFfnWeights {
                 gate_proj,
                 up_proj,
@@ -485,9 +527,9 @@ impl GpuWeights {
                 gate_proj_t,
                 up_proj_t,
                 down_proj_t,
-                gate_proj_marlin,
-                up_proj_marlin,
-                down_proj_marlin,
+                gate_proj_marlin: None,
+                up_proj_marlin: None,
+                down_proj_marlin: None,
             };
 
             layers.push(GpuLayerWeights {
@@ -496,6 +538,42 @@ impl GpuWeights {
                 attention,
                 mlp,
             });
+        }
+
+        // Batch-pack the queued Marlin projections in parallel. On
+        // Qwen3.5-4B this is 8 × q_proj + 96 × MLP = 104 projections. The
+        // CPU-bound `quantize_and_pack` work now runs across every
+        // available worker thread (rayon's default pool) while the
+        // GPU↔CPU copies stay sequential inside
+        // `pack_from_bf16_batch`. Set `KILN_DISABLE_PARALLEL_PACK=1` to
+        // force the legacy serial pack for A/B measurements or rollback.
+        if w4a16_enabled && !marlin_pack_inputs.is_empty() {
+            let pack_start = std::time::Instant::now();
+            let packed = crate::marlin_proj::pack_from_bf16_batch(&marlin_pack_inputs)
+                .context("marlin batch pack")?;
+            let pack_elapsed_ms = pack_start.elapsed().as_millis();
+            let parallel = !crate::marlin_proj::parallel_pack_disabled();
+            let n_inputs = marlin_pack_inputs.len();
+            let n_packed = packed.iter().filter(|p| p.is_some()).count();
+            tracing::info!(
+                n_inputs,
+                n_packed,
+                pack_elapsed_ms = pack_elapsed_ms as u64,
+                parallel,
+                "marlin batch pack complete"
+            );
+            eprintln!(
+                "[kiln] marlin batch pack: {n_packed}/{n_inputs} projections in {pack_elapsed_ms} ms ({})",
+                if parallel { "parallel" } else { "serial" }
+            );
+
+            let drop_disabled = marlin_bf16_drop_disabled();
+            for (entry, maybe_packed) in marlin_pack_meta.into_iter().zip(packed.into_iter()) {
+                if let Some(p) = maybe_packed {
+                    install_marlin_packed(&mut layers[entry.layer_idx], entry.kind, p, device, drop_disabled)
+                        .with_context(|| format!("install marlin {:?} on layer {}", entry.kind, entry.layer_idx))?;
+                }
+            }
         }
 
         Ok(Self {

--- a/crates/kiln-model/src/marlin_proj.rs
+++ b/crates/kiln-model/src/marlin_proj.rs
@@ -24,7 +24,11 @@ use anyhow::Result;
 use anyhow::Context;
 #[cfg(feature = "cuda")]
 use candle_core::DType;
+#[cfg(feature = "cuda")]
+use candle_core::Device;
 use candle_core::Tensor;
+#[cfg(feature = "cuda")]
+use half::f16;
 
 /// A q_proj / projection weight packed into Marlin's W4A16 layout.
 ///
@@ -50,17 +54,37 @@ pub fn shape_is_supported(k: usize, n: usize) -> bool {
     k % 128 == 0 && n % 256 == 0
 }
 
-/// Pack a BF16 projection weight into Marlin's W4A16 layout.
-///
-/// `weight_t` is the pre-transposed projection tensor (the same `q_proj_t`
-/// the BF16 forward path already uses), i.e. shape `[k, n] = [in, out]`. We
-/// download it to CPU, run the pure-Rust packer, then upload the packed
-/// int32 tensor and permuted f16 scales back to the source device.
-///
-/// On non-CUDA builds this returns `Ok(None)` so the caller can keep the
-/// same control flow. The kernel itself only exists when `cuda` is on.
+/// Intermediate host-side representation of a weight ready to run through
+/// Marlin's pure-Rust packer. Produced by [`prepare_pack_job`]; consumed by
+/// [`pack_host`]. Splitting the download, pack, and upload phases lets
+/// [`pack_from_bf16_batch`] run the CPU-bound pack step for many projections
+/// in parallel via rayon while keeping the GPU↔CPU copies sequential.
 #[cfg(feature = "cuda")]
-pub fn pack_from_bf16(weight_t: &Tensor, groupsize: i32) -> Result<Option<MarlinPackedProj>> {
+pub struct PackJobHost {
+    /// `[k, n]` row-major f32 view of the pre-transposed weight.
+    pub host_weight: Vec<f32>,
+    pub k: usize,
+    pub n: usize,
+    pub groupsize: i32,
+}
+
+/// Marlin-packed buffers sitting on the host, ready for upload via
+/// [`upload_packed`].
+#[cfg(feature = "cuda")]
+pub struct PackedHost {
+    pub b_packed_vec: Vec<i32>,
+    pub scales_vec: Vec<f16>,
+    pub k: usize,
+    pub n: usize,
+    pub groupsize: i32,
+}
+
+/// Phase 1 of Marlin packing: validate shape, cast BF16→F32 on-device, then
+/// download to a host f32 buffer. Returns `Ok(None)` if the projection's
+/// shape doesn't fit Marlin's tile constraints (same semantics as
+/// [`pack_from_bf16`]) or the tensor doesn't live on a CUDA device.
+#[cfg(feature = "cuda")]
+pub fn prepare_pack_job(weight_t: &Tensor, groupsize: i32) -> Result<Option<PackJobHost>> {
     let device = weight_t.device();
     if !device.is_cuda() {
         return Ok(None);
@@ -69,17 +93,13 @@ pub fn pack_from_bf16(weight_t: &Tensor, groupsize: i32) -> Result<Option<Marlin
         .dims2()
         .context("marlin_proj: weight_t must be a 2D [k, n] tensor")?;
     if !shape_is_supported(k, n) {
-        // Caller logs; skipping is not an error. Marlin only supports
-        // k%128 && n%256 for its instantiated tile shapes.
         return Ok(None);
     }
     if !(groupsize == -1 || groupsize == 128) {
         anyhow::bail!("marlin_proj: groupsize must be -1 or 128 (got {groupsize})");
     }
     if groupsize == 128 && k % 128 != 0 {
-        anyhow::bail!(
-            "marlin_proj: k={k} not divisible by groupsize=128"
-        );
+        anyhow::bail!("marlin_proj: k={k} not divisible by groupsize=128");
     }
 
     // The Marlin packer needs f32 on host. Go through a cast on-device (to
@@ -95,11 +115,47 @@ pub fn pack_from_bf16(weight_t: &Tensor, groupsize: i32) -> Result<Option<Marlin
         .context("marlin_proj: download weight to host")?;
     debug_assert_eq!(host_weight.len(), k * n);
 
-    let (b_packed_vec, scales_vec, _dequant) =
-        kiln_marlin_gemm::pack::quantize_and_pack(&host_weight, k, n, groupsize as i64);
+    Ok(Some(PackJobHost {
+        host_weight,
+        k,
+        n,
+        groupsize,
+    }))
+}
 
+/// Phase 2 of Marlin packing: run the pure-Rust `quantize_and_pack` against
+/// a host weight buffer. Pure CPU, no GPU state, no I/O — safe to call from
+/// any rayon worker thread in parallel with other `pack_host` calls.
+#[cfg(feature = "cuda")]
+pub fn pack_host(job: &PackJobHost) -> PackedHost {
+    let (b_packed_vec, scales_vec, _dequant) = kiln_marlin_gemm::pack::quantize_and_pack(
+        &job.host_weight,
+        job.k,
+        job.n,
+        job.groupsize as i64,
+    );
+    PackedHost {
+        b_packed_vec,
+        scales_vec,
+        k: job.k,
+        n: job.n,
+        groupsize: job.groupsize,
+    }
+}
+
+/// Phase 3 of Marlin packing: upload the packed i32 weight tensor and
+/// permuted f16 scales to `device` and assemble the final
+/// [`MarlinPackedProj`].
+#[cfg(feature = "cuda")]
+pub fn upload_packed(packed: PackedHost, device: &Device) -> Result<MarlinPackedProj> {
+    let PackedHost {
+        b_packed_vec,
+        scales_vec,
+        k,
+        n,
+        groupsize,
+    } = packed;
     let num_groups = if groupsize == -1 { 1 } else { k / groupsize as usize };
-
     let b_packed = Tensor::from_vec(b_packed_vec, (k / 16, n * 16 / 8), &candle_core::Device::Cpu)
         .context("marlin_proj: build host b_packed tensor")?
         .to_device(device)
@@ -108,14 +164,99 @@ pub fn pack_from_bf16(weight_t: &Tensor, groupsize: i32) -> Result<Option<Marlin
         .context("marlin_proj: build host scales tensor")?
         .to_device(device)
         .context("marlin_proj: upload scales to device")?;
-
-    Ok(Some(MarlinPackedProj {
+    Ok(MarlinPackedProj {
         b_packed,
         scales,
         groupsize,
         k,
         n,
-    }))
+    })
+}
+
+/// Pack a BF16 projection weight into Marlin's W4A16 layout.
+///
+/// `weight_t` is the pre-transposed projection tensor (the same `q_proj_t`
+/// the BF16 forward path already uses), i.e. shape `[k, n] = [in, out]`. We
+/// download it to CPU, run the pure-Rust packer, then upload the packed
+/// int32 tensor and permuted f16 scales back to the source device.
+///
+/// On non-CUDA builds this returns `Ok(None)` so the caller can keep the
+/// same control flow. The kernel itself only exists when `cuda` is on.
+///
+/// For packing many projections at model load, prefer
+/// [`pack_from_bf16_batch`] which runs the CPU-bound pack step for every
+/// projection in parallel via rayon.
+#[cfg(feature = "cuda")]
+pub fn pack_from_bf16(weight_t: &Tensor, groupsize: i32) -> Result<Option<MarlinPackedProj>> {
+    let device = weight_t.device().clone();
+    let job = match prepare_pack_job(weight_t, groupsize)? {
+        Some(j) => j,
+        None => return Ok(None),
+    };
+    let packed = pack_host(&job);
+    let out = upload_packed(packed, &device)?;
+    Ok(Some(out))
+}
+
+/// Batch-pack several projection weights, running the CPU-bound
+/// `quantize_and_pack` step in parallel via rayon.
+///
+/// Each input is a pre-transposed `[k, n]` weight plus its Marlin groupsize
+/// (`-1` or `128`). The result preserves input order: entry `i` in the
+/// returned vec is the packed projection for input `i`. Entries whose
+/// shape didn't fit Marlin's tile constraints (or that live on a non-CUDA
+/// device) are `Ok(None)`, matching the single-weight
+/// [`pack_from_bf16`] contract so the caller can fall back to the BF16
+/// path on a per-projection basis.
+///
+/// Phases:
+/// 1. Serial GPU→CPU download of each weight into a host f32 buffer.
+/// 2. Parallel CPU pack across all queued jobs (rayon `par_iter`).
+/// 3. Serial CPU→GPU upload of the packed buffers.
+///
+/// Setting `KILN_DISABLE_PARALLEL_PACK=1` forces phase 2 to run
+/// sequentially, reproducing the pre-change wall-clock (useful for A/B
+/// measurements or rollback).
+#[cfg(feature = "cuda")]
+pub fn pack_from_bf16_batch(
+    inputs: &[(Tensor, i32)],
+) -> Result<Vec<Option<MarlinPackedProj>>> {
+    if inputs.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Device must be consistent across inputs. The call sites in
+    // `forward.rs` build every weight on the same `device`, so this is a
+    // sanity check rather than a real runtime constraint.
+    let device = inputs[0].0.device().clone();
+
+    // Phase 1: serial GPU→CPU download.
+    let jobs: Vec<Option<PackJobHost>> = inputs
+        .iter()
+        .map(|(t, gs)| prepare_pack_job(t, *gs))
+        .collect::<Result<Vec<_>>>()?;
+
+    // Phase 2: parallel CPU pack. Rayon `par_iter` over `Option` skips
+    // None entries cheaply and preserves input order in the output.
+    let packed: Vec<Option<PackedHost>> = if parallel_pack_disabled() {
+        jobs.iter()
+            .map(|j| j.as_ref().map(pack_host))
+            .collect()
+    } else {
+        use rayon::prelude::*;
+        jobs.par_iter()
+            .map(|j| j.as_ref().map(pack_host))
+            .collect()
+    };
+
+    // Phase 3: serial CPU→GPU upload.
+    let mut out = Vec::with_capacity(packed.len());
+    for p in packed {
+        match p {
+            Some(p) => out.push(Some(upload_packed(p, &device)?)),
+            None => out.push(None),
+        }
+    }
+    Ok(out)
 }
 
 /// Non-CUDA stub: Marlin kernel is CUDA-only, so packing always returns
@@ -124,6 +265,15 @@ pub fn pack_from_bf16(weight_t: &Tensor, groupsize: i32) -> Result<Option<Marlin
 #[cfg(not(feature = "cuda"))]
 pub fn pack_from_bf16(_weight_t: &Tensor, _groupsize: i32) -> Result<Option<MarlinPackedProj>> {
     Ok(None)
+}
+
+/// Non-CUDA stub for [`pack_from_bf16_batch`]: the kernel is CUDA-only, so
+/// every entry is skipped.
+#[cfg(not(feature = "cuda"))]
+pub fn pack_from_bf16_batch(
+    inputs: &[(Tensor, i32)],
+) -> Result<Vec<Option<MarlinPackedProj>>> {
+    Ok((0..inputs.len()).map(|_| None).collect())
 }
 
 /// Run `x @ W` against a Marlin-packed projection.
@@ -192,4 +342,22 @@ pub fn env_enabled() -> bool {
         }
         Err(_) => false,
     }
+}
+
+/// Check the `KILN_DISABLE_PARALLEL_PACK` env var.
+///
+/// `KILN_DISABLE_PARALLEL_PACK=1` (or `true`/`yes`, case-insensitive) forces
+/// [`pack_from_bf16_batch`] to run the CPU pack phase sequentially, matching
+/// the pre-parallelisation wall-clock. Intended for A/B measurements and as
+/// a rollback in case the parallel path ever disagrees with the serial one.
+pub fn parallel_pack_disabled() -> bool {
+    matches!(
+        std::env::var("KILN_DISABLE_PARALLEL_PACK")
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
 }


### PR DESCRIPTION
## What

Parallelize the 104 Marlin `quantize_and_pack` jobs (8 × `q_proj` + 32 × 3 MLP proj) that run during `GpuWeights::from_model_weights` when `KILN_W4A16=1`. These are pure-Rust CPU work behind `kiln_marlin_gemm::pack::quantize_and_pack`, so the serial wait isn't a CUDA synchronization constraint — it's a scheduling one.

Split pack into three explicit phases in `marlin_proj`:

1. `prepare_pack_job`   — GPU→CPU download (BF16 weight → host `Vec<f32>`)
2. `pack_host`          — CPU-bound `quantize_and_pack` (pure Rust)
3. `upload_packed`      — CPU→GPU upload (packed `i32` + `f16` scales)

`pack_from_bf16_batch` composes them. Phase 1 and phase 3 stay on one thread so the CUDA context doesn't have to deal with multi-thread uploads; only phase 2 (pure CPU) fans out via `rayon::par_iter`. `KILN_DISABLE_PARALLEL_PACK=1` forces phase 2 serial for A/B measurements and as a rollback switch (precedent: `KILN_DISABLE_RMSNORM_KERNEL`, `KILN_DISABLE_FUSED_CONV1D`, `KILN_DISABLE_MARLIN_BF16_DROP`).

`forward.rs` collects a sidecar `(Tensor, groupsize)` + `MarlinPackEntry { layer_idx, kind }` record for every projection that would have been packed inline (q_proj on full-attn layers; gate/up/down on every layer). After the layer loop finishes, `pack_from_bf16_batch` runs once, and `install_marlin_packed` places each `MarlinPackedProj` into its owning slot plus drops the BF16 `*_proj_t` residency when `KILN_DISABLE_MARLIN_BF16_DROP` is unset (preserves PR #206's behavior). The public `pack_from_bf16` entry point is preserved so the existing `marlin_qproj_parity` test keeps working.

Pack wall-clock is logged via `tracing::info!` + `eprintln!` at the batch call site.

## Bench (A6000, Qwen3.5-4B, `KILN_W4A16=1`, paged, 512-prompt × 128-decode)

### Pack wall-clock

| Mode | Jobs | Pack time | Speedup |
| --- | --- | --- | --- |
| Serial (`KILN_DISABLE_PARALLEL_PACK=1`) | 104/104 | **42,822 ms** | 1.00× |
| Parallel (run 1) | 104/104 | 16,892 ms | 2.53× |
| Parallel (run 2) | 104/104 | 16,867 ms | 2.54× |
| Parallel (run 3) | 104/104 | 16,610 ms | 2.58× |
| **Parallel (median)** | 104/104 | **16,867 ms** | **2.54×** |

**~26 s wall-clock saved at model load** (60.6% reduction).

### Decode steady-state (parity check — pack only runs at load, so decode shouldn't move)

| Mode | Decode tok/s | Mean ITL | vs post-#206 (~51 tok/s) |
| --- | --- | --- | --- |
| Serial | 53.0 | 18.9 ms | +3.9% |
| Parallel run 1 | 51.5 | 19.4 ms | +1.0% |
| Parallel run 2 | 51.6 | 19.4 ms | +1.2% |
| Parallel run 3 | 52.2 | 19.2 ms | +2.4% |
| **Parallel median** | **51.6** | **19.4 ms** | **+1.2%** (within ±2%) |

Prefill holds: 320.9 ms serial → 328.6 ms parallel run 1 (~same).

## Parity

`cargo test --release --features cuda -p kiln-model --test marlin_qproj_parity -- --nocapture`:

```
m=1 k=2560 n=8192 cosine_similarity=0.999997 max_abs_diff=0.00391
m=128 k=2560 n=8192 cosine_similarity=0.999997 max_abs_diff=0.00781
test q_proj_marlin_parity_qwen35_4b ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.45s
```

Matches the post-#206 parity numbers — batching doesn't change the per-projection pack output, only the scheduling around it.

## Kill switch

```bash
# Force serial pack (legacy behavior, for A/B or rollback):
KILN_W4A16=1 KILN_DISABLE_PARALLEL_PACK=1 ./kiln serve
```

## Files

- `crates/kiln-model/src/marlin_proj.rs` — 3-phase helpers + `pack_from_bf16_batch` + `parallel_pack_disabled()`. `pack_from_bf16` rewritten to compose the phases (API preserved).
- `crates/kiln-model/src/forward.rs` — sidecar queue + post-loop batch call + `install_marlin_packed` + timing log.
- `crates/kiln-model/Cargo.toml` — `rayon` dep; `half` moved into the `cuda` feature (packed scales are `Vec<f16>` on host between phases 2 and 3).
- `Cargo.toml` (workspace) — `rayon` workspace dep.

Phase 1 and phase 3 stay single-threaded — Tensor `.clone()` is Arc-based so the sidecar clones are cheap and don't double VRAM. Only phase 2 fans out across the rayon default pool.