### PR TITLE
release: kiln-v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "candle-core",
  "cc",
@@ -1821,7 +1821,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "candle-core",
  "cc",
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "candle-core",
  "cc",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1890,11 +1890,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.1.0"
+version = "0.1.1"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "candle-core",
  "cc",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1944,7 +1944,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## Summary

Bump kiln workspace version from 0.1.0 to 0.1.1 to cut a new server release.

## Changes since kiln-v0.1.0

Non-desktop changes totaling ~768 lines across kiln-server, kiln-model, and kiln-core since 2026-04-18:

- `crates/kiln-model/src/forward.rs` — 202 line delta (GDN/kernel work)
- `crates/kiln-model/src/marlin_proj.rs` — 210 line delta (Marlin W4A16 improvements)
- `crates/kiln-server/src/api/completions.rs` — 113 line delta
- `crates/kiln-server/src/api/models.rs` — 66 line delta
- `crates/kiln-server/src/config.rs` — 79 line delta
- Plus kiln-core tokenizer fixes, kiln-server CLI/state/main/ui/health updates, PROFILING.md, and kiln.example.toml.

38 commits total on main since the previous server tag.

## Release artifacts

The `server-release.yml` workflow (triggered on `kiln-v*` tags) builds a signed + notarized macOS aarch64 Metal binary (`kiln-0.1.1-aarch64-apple-darwin-metal.tar.gz` + `.sha256`) and uploads it to a draft GitHub Release. Linux/Windows CUDA builds are not yet covered by the workflow.

## Test plan

- [x] Workspace version bumped in `Cargo.toml`
- [x] `Cargo.lock` regenerated (`cargo update --workspace --offline`)
- [ ] CI green on this PR
- [ ] Merge, tag `kiln-v0.1.1` on main, push tag
- [ ] server-release workflow produces the macOS Metal artifact
- [ ] Draft release published