### PR TITLE
desktop: updater slice 5 — auto-check on launch

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -539,6 +539,73 @@ async fn check_for_kiln_update(
     })
 }
 
+/// Event emitted when the launch-time check discovers a newer kiln binary.
+/// Payload matches `KilnUpdateAvailablePayload` (current + latest version).
+const KILN_UPDATE_AVAILABLE_EVENT: &str = "kiln-update-available";
+
+#[derive(serde::Serialize, Clone)]
+struct KilnUpdateAvailablePayload {
+    current: Option<String>,
+    latest: String,
+}
+
+/// Launch-time auto-check for a newer kiln binary. Non-blocking, fails
+/// silently on any error, never panics. Runs once per launch: no periodic
+/// polling (per `desktop/docs/binary-update.md` open question #4 — stay
+/// within the 60/hr anonymous GitHub rate limit). Emits
+/// `kiln-update-available` so the dashboard can surface a banner and
+/// settings can pre-populate the status pill.
+async fn check_kiln_update_on_launch(app: AppHandle, settings: SettingsState) {
+    // Give the supervisor ~10s to stabilize before we make a network call.
+    // Keeps the launch path fast and avoids racing with auto_start.
+    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
+    if !installer::supports_auto_install() {
+        return;
+    }
+
+    let configured = {
+        let s = settings.read().await;
+        s.kiln_binary
+            .clone()
+            .unwrap_or_else(|| std::path::PathBuf::from("kiln"))
+    };
+    let current = match installer::resolve_binary(&configured) {
+        Some(p) => installer::current_kiln_version(&p).await,
+        None => None,
+    };
+
+    let client = match reqwest::Client::builder()
+        .user_agent(concat!("kiln-desktop/", env!("CARGO_PKG_VERSION")))
+        .connect_timeout(std::time::Duration::from_secs(15))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[main] auto_update check: build reqwest client failed: {}", e);
+            return;
+        }
+    };
+
+    let Some(latest) = installer::discover_latest_version(&client).await else {
+        return;
+    };
+
+    if !installer::is_update_available(current.as_deref(), &latest) {
+        return;
+    }
+
+    if let Err(e) = app.emit(
+        KILN_UPDATE_AVAILABLE_EVENT,
+        KilnUpdateAvailablePayload {
+            current: current.clone(),
+            latest: latest.clone(),
+        },
+    ) {
+        eprintln!("[main] emit kiln-update-available failed: {}", e);
+    }
+}
+
 /// Re-check, then download and install the available update, then restart the
 /// app. We re-check rather than caching an `Update` handle because Tauri
 /// commands are stateless and the small race window is acceptable.
@@ -820,6 +887,19 @@ fn main() {
                     }
                 });
             }
+
+            // Non-blocking auto-check for a newer kiln binary. Runs once per
+            // launch after a short delay so the supervisor can stabilize.
+            // Emits `kiln-update-available` on success; failures are logged
+            // and swallowed so a flaky GitHub API call never blocks startup.
+            // Per `desktop/docs/binary-update.md` this is launch-only — no
+            // periodic polling, to stay under the anonymous GitHub rate limit.
+            let app_for_update = handle.clone();
+            let settings_for_update: SettingsState = Arc::clone(&settings_state);
+            tauri::async_runtime::spawn(async move {
+                check_kiln_update_on_launch(app_for_update, settings_for_update).await;
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -174,6 +174,42 @@
         font-size: 12px;
       }
       #toolbar button:hover { background: #232831; }
+      #update-banner {
+        position: absolute;
+        top: 58px;
+        left: 12px;
+        right: 12px;
+        max-width: calc(100vw - 24px);
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        z-index: 9;
+        background: rgba(90, 51, 36, 0.95);
+        border: 1px solid #7a432f;
+        color: #f2ddd6;
+        padding: 8px 12px;
+        border-radius: 8px;
+        font-size: 13px;
+      }
+      #update-banner-text { flex: 1; }
+      #update-banner button {
+        margin-top: 0;
+        background: #7a432f;
+        color: #f2ddd6;
+        border: 1px solid #a05a3f;
+        padding: 4px 10px;
+        font-size: 12px;
+      }
+      #update-banner button:hover { background: #a05a3f; }
+      #update-banner button.secondary {
+        background: transparent;
+        color: #f2ddd6;
+        border: 1px solid transparent;
+        padding: 2px 8px;
+        font-size: 16px;
+        line-height: 1;
+      }
+      #update-banner button.secondary:hover { background: rgba(255, 255, 255, 0.08); }
       #toolbar button#stop-server:hover { background: #5a2424; border-color: #7a3232; color: #f2d6d6; }
       #toolbar button#stop-server:disabled { background: #2a2f3a; color: #6c7280; cursor: default; }
       #toolbar button#restart-server:hover { background: #3a4a6a; border-color: #4a5a7a; color: #d6e0f2; }
@@ -521,6 +557,11 @@
       <button id="open-settings" title="Open the settings window (Ctrl/Cmd+,)">Settings</button>
       <button id="check-updates-btn" title="Check for an updated version of Kiln Desktop">Check for Updates</button>
     </div>
+    <div id="update-banner" class="hidden" role="status" aria-live="polite">
+      <span id="update-banner-text">A newer kiln server is available.</span>
+      <button id="update-banner-open-settings" title="Open settings to review and install">Open Settings</button>
+      <button id="update-banner-dismiss" class="secondary" title="Dismiss this banner for this session" aria-label="Dismiss">×</button>
+    </div>
     <iframe id="frame" class="hidden" title="Kiln UI"></iframe>
     <div id="status">
       <h1 id="status-title">Connecting to Kiln server…</h1>
@@ -787,6 +828,32 @@
             installProgressLabel.textContent = `Install failed: ${msg}`;
           }
         }).catch((err) => console.error("listen kiln-install-failed:", err));
+
+        tauriEventApi.listen("kiln-update-available", (evt) => {
+          const p = (evt && evt.payload) || {};
+          const latest = p.latest || "";
+          const banner = document.getElementById("update-banner");
+          const text = document.getElementById("update-banner-text");
+          if (!banner || !text) return;
+          text.textContent = latest
+            ? `Kiln ${latest} is available. Open Settings to install.`
+            : "A newer kiln server is available. Open Settings to install.";
+          banner.classList.remove("hidden");
+        }).catch((err) => console.error("listen kiln-update-available:", err));
+      }
+
+      const updateBannerOpenSettings = document.getElementById("update-banner-open-settings");
+      const updateBannerDismiss = document.getElementById("update-banner-dismiss");
+      const updateBanner = document.getElementById("update-banner");
+      if (updateBannerOpenSettings) {
+        updateBannerOpenSettings.addEventListener("click", async () => {
+          try { await invoke("open_settings"); } catch (e) { console.error(e); }
+        });
+      }
+      if (updateBannerDismiss && updateBanner) {
+        updateBannerDismiss.addEventListener("click", () => {
+          updateBanner.classList.add("hidden");
+        });
       }
 
       async function load() {

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -1092,6 +1092,29 @@
       }
       kilnUpdateBtn.addEventListener("click", checkForKilnUpdate);
 
+      // Pre-populate the status pill when the launch-time auto-check
+      // discovers an update before the user clicks the button. We surface
+      // the result and wire up the Download action so the user can install
+      // without triggering a second network call. Clicking the button
+      // afterwards still runs a fresh check.
+      (() => {
+        const event = window.__TAURI__ && window.__TAURI__.event;
+        if (!event || typeof event.listen !== "function") return;
+        event.listen("kiln-update-available", (evt) => {
+          if (kilnUpdateChecking || kilnUpdateDownloading) return;
+          const p = (evt && evt.payload) || {};
+          if (!p.latest) return;
+          const current = p.current ? escapeHtml(p.current) : "unknown";
+          const latest = escapeHtml(p.latest);
+          setKilnUpdateStatus(
+            "available",
+            "Current " + current + " → latest " + latest +
+              ' <span class="badge">Update available</span>'
+          );
+          showKilnUpdateActions(p.latest);
+        }).catch((err) => console.error("listen kiln-update-available:", err));
+      })();
+
       // ---------- Download an available kiln update (slice 2) ----------
       // Streams the release tarball to <app_data_dir>/kiln-updates/. Does NOT
       // extract or swap the running binary — that is the Extract & Verify


### PR DESCRIPTION
## What

Slice 5 of the manual v1 updater flow (`desktop/docs/binary-update.md` v2).

Adds a non-blocking, launch-time check for a newer kiln binary. Runs once per launch (no periodic polling). When a newer release is available, emits a `kiln-update-available` event; the dashboard shows an amber banner and the settings page pre-populates its status pill with the available-update state. Install still requires an explicit click through the existing slices 1–4 flow.

## Changes

### `desktop/src/main.rs`
- New `check_kiln_update_on_launch(AppHandle, SettingsState)` helper. Sleeps ~10s so the supervisor stabilizes, then reuses the same pipeline as the manual `check_for_kiln_update` command: `installer::supports_auto_install` → `resolve_binary` → `current_kiln_version` → `discover_latest_version` → `is_update_available`. Failures log to stderr and return silently — never panic, never block startup.
- New `KILN_UPDATE_AVAILABLE_EVENT` constant (`"kiln-update-available"`) and a serde-serializable `KilnUpdateAvailablePayload { current, latest }` payload.
- Spawned from `setup()` after the existing `auto_start` block with `tauri::async_runtime::spawn`.

### `desktop/ui/dashboard.html`
- New `#update-banner` element pinned under the toolbar (amber/#5a3324 palette, matching existing `flash-warn` styling). Hidden by default; revealed when `kiln-update-available` fires with a `{ current, latest }` payload.
- **Open Settings** button calls the existing `open_settings` Tauri command.
- **×** dismiss button hides the banner for the remainder of the session (no persisted state — re-fires on next launch if still applicable).

### `desktop/ui/settings.html`
- Event listener that piggybacks on `check_for_kiln_update`'s existing status-pill rendering. When auto-check fires first, the status pill + Download button populate without a second network call. Manual `Check for Updates` click still performs a fresh check.
- Guarded by `kilnUpdateChecking || kilnUpdateDownloading` so an in-flight operation isn't clobbered.

## Design-doc alignment

- **Open question #3** → no tray badge, surface in dashboard + settings only ✅
- **Open question #4** → on launch + manual button only, no periodic polling ✅
- Rate-limit-safe: one GitHub API call per launch.

## Validation

`cd desktop && cargo check` fails in the Cloud Eric sandbox due to missing GTK/webkit2gtk/atk system libraries (`glib-sys`, `atk-sys`, etc. build-scripts fail at `pkg-config`). This is a known environment limitation — see the `tauri-cargo-check-gtk-missing` agent note. CI (ubuntu/macOS/windows via tauri-action) validates the full build.

Logic review: the new helper is a trimmed-down clone of the existing `check_for_kiln_update` command and reuses the same `installer::*` helpers, so any regression would already break the manual flow.

## Risk

Low — one extra `tauri::async_runtime::spawn`, one extra HTTP GET per launch, and ~50 lines of UI wiring. Failures swallowed. Dismiss is session-scoped so a restart re-surfaces the banner if the update is still outstanding.