### PR TITLE
docs: desktop app auto-downloads prebuilt kiln on Linux + Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ Kiln Desktop is a system-tray app that wraps the `kiln` server for people who do
 | Linux | [Kiln.Desktop_0.1.0_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.0/Kiln.Desktop_0.1.0_amd64.deb) | 5.5 MB |
 | Linux | [Kiln.Desktop_0.1.0_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.0/Kiln.Desktop_0.1.0_amd64.AppImage) | 79 MB |
 
-The installer bundles the desktop wrapper only. You still need to install the `kiln` server binary and download model weights separately — see [QUICKSTART.md](QUICKSTART.md). Point the app at the `kiln` binary and model path from Settings on first launch.
+The installer bundles the desktop wrapper only. On first launch the app offers to auto-download the matching prebuilt `kiln` server binary for your platform (macOS aarch64 / Metal, Linux x86_64 / CUDA 12.4, Windows x86_64 / CUDA 12.4) from the latest `kiln-v*` GitHub release and verify it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be downloaded separately — the Settings window has a HuggingFace downloader, or you can use the CLI path in [QUICKSTART.md](QUICKSTART.md).
 
 **Dashboard** — toolbar shows server state, model path, VRAM budget, active LoRA adapter, training status, and the OpenAI base URL with a one-click copy. The kiln server's `/ui` is embedded below.
 

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -19,7 +19,7 @@ in a VM.
 - `Kiln.Desktop_0.1.0_amd64.deb` (Debian/Ubuntu, 5.5 MB)
 - `Kiln.Desktop_0.1.0_amd64.AppImage` (portable Linux, 79 MB)
 
-The desktop installer bundles only the wrapper — the `kiln` server binary and model weights must be installed separately. See the root [QUICKSTART.md](../QUICKSTART.md) and point the app at the binary and model path from Settings on first launch.
+The desktop installer bundles only the wrapper. On first launch the app offers to auto-download the prebuilt `kiln` server binary from the latest `kiln-v*` GitHub release — `aarch64-apple-darwin-metal` on macOS, `x86_64-unknown-linux-gnu-cuda124` on Linux x86_64, `x86_64-pc-windows-msvc-cuda124` on Windows x86_64 — and verifies it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be installed separately; see the root [QUICKSTART.md](../QUICKSTART.md) or use the HuggingFace downloader in Settings.
 
 ## Model weights
 


### PR DESCRIPTION
Slice 4 (final) of the Linux/Windows CUDA server-release rollout.

## What

Two README paragraphs that predated slices 1-3 said users still had to install the `kiln` server binary separately on Linux/Windows. That's no longer true — with #213, #214, #215 merged, the desktop app's installer resolves a prebuilt asset URL on all three supported platforms and fetches+verifies it on first launch.

Updated text:

- `README.md` §Desktop App — platform-scoped auto-download callout, keeps the 'manual path / Settings' escape hatch and the QUICKSTART.md link for the weights workflow.
- `desktop/README.md` §Releases — same rewording, spells out the exact three target suffixes (`aarch64-apple-darwin-metal`, `x86_64-unknown-linux-gnu-cuda124`, `x86_64-pc-windows-msvc-cuda124`) so anyone grepping for them from a downloader bug can trace the naming.

## Why this shape

The task description said "update the Prebuilt binaries table if one exists; skip otherwise." There isn't one — the README only documents the *desktop installer* download list, not a prebuilt *server binary* list. But the two existing prose sentences were actively misleading now that slices 1-3 shipped, so updating them is the minimal-diff correction that keeps docs honest without introducing a net-new table we don't otherwise maintain.

## Scope

Docs-only — no code paths change.