### PR TITLE
phase6: nsys post-#210 decode profile

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,6 +1,233 @@
 # Kiln Profiling Report
 
 
+## Phase 6 — Post-PR #210 decode profile (2026-04-20)
+
+Fresh nsys capture on current `main` after the post-#166 cluster of Marlin /
+load-time / VRAM / bench-infra changes. Supersedes the post-#166 breakdown as
+the canonical "next target" reference. This is the first profile since #173
+(opt-in fused L2-QK norm, null median) and #176 (closed-null big-fusion) were
+resolved, so it is also the first profile that lets us re-check whether any
+GDN gate-path fusion has meaningfully shifted proportions at the
+graph-replay layer.
+
+**Preflight** (kernel-vendor-precondition-check, before pod $):
+
+- Recent PRs reviewed:
+  - #204 bench-only pool verification (no code delta vs #166 NVTX snapshot)
+  - #206 drop BF16 MLP weights when Marlin is resident (VRAM cleanup; no
+    decode-path compute delta)
+  - #210 parallelize Marlin pack loop (load-time only; no forward-path
+    compute delta)
+  - #211–#215 desktop / CI / docs (no runtime impact)
+- Net: no forward-path code deltas since the post-#166 NVTX snapshot. The
+  NVTX composition is expected to be within run-to-run variance of post-#166,
+  and this capture confirms that — top-3 region ordering is unchanged
+  (gates → gated_norm → qk_norm) and their summed share moves from 50.4% →
+  50.8% (within noise). **The profile's job is not to find a shifted
+  hotspot — it is to rule out new candidates before we consider re-opening
+  any closed-null kernel work.**
+- Not-a-target list (verified against `gh pr list --repo ericflo/kiln
+  --state all`): qk_norm standalone (#173 null 1.0093×), gated_norm
+  standalone (#141 null), big-fusion qk_norm+gated_norm+recurrent (#176
+  null, $14.99 burn), FlashInfer paged GQA decode (#163 math-ceiling
+  ≤1.005×), gate-path fusion across Step 7 recurrence (#164 architecturally
+  infeasible — two halves already shipped/closed independently).
+
+**Hardware:** Pool-acquired RunPod NVIDIA RTX A6000 on-demand (pod
+`t0vmof6qkwostu`, $0.49/hr), Driver 580.95.05, CUDA 12.8,
+`ghcr.io/ericflo/kiln-runpod:latest`.
+
+**Build:** release, `--features cuda,nvtx`, `KILN_CUDA_ARCHS=86`,
+`KILN_W4A16=1 KILN_CUDA_GRAPHS=true`, sccache ON (Backblaze B2 bucket).
+
+**Bench & profile:** `kiln-bench --model-path /workspace/qwen3.5-4b --paged
+--prompt-tokens 512 --max-output-tokens 128 --skip-training`, 3 back-to-back
+clean bench runs (no nsys) followed by a single nsys capture run. nsys
+2024.6.2 with `--trace=cuda,nvtx` (NO `--cuda-graph-trace=node` — that flag
+previously corrupted event ordering and produced an
+`EventCollection::CheckOrder` finalization failure; CUDA-graph attribution
+is intentionally sacrificed so we get a valid trace at all).
+
+### Decode bench — 512-prompt × 128-decode (Arm B, 3 clean runs)
+
+| run    | decode tok/s | mean ITL ms | prefill (ms) | model load (s) |
+| ------ | -----------: | ----------: | -----------: | -------------: |
+| 1      |        52.29 |       19.13 |        324.3 |          23.76 |
+| 2      |        50.92 |       19.65 |        329.6 |          22.75 |
+| 3      |        52.88 |       18.90 |        327.7 |          22.90 |
+| median |    **52.29** |   **19.13** |    **327.7** |      **22.90** |
+
+Resident VRAM: 17528 MB (post-#206 drop; matches the expected −1.3 GB vs
+pre-#206). Marlin pack latency at load: ~22.9 s (post-#210 parallelized;
+was ~58 s on the pre-#210 baseline — confirms the load-time win landed).
+
+### Δ vs post-#166 direct-RunPod baseline (median)
+
+| metric            | post-#166 direct | 2026-04-20 post-#210 | Δ         |
+| ----------------- | ---------------: | -------------------: | --------: |
+| decode tok/s      |            49.76 |                52.29 |    +5.1 % |
+| mean ITL ms       |            20.10 |                19.13 |    −4.8 % |
+| model load s      |             ~50+ |                22.90 | ~ −54 %   |
+| resident VRAM MB  |           ~18800 |                17528 |    −6.8 % |
+
+The decode tok/s uplift is within run-to-run variance (post-#204 pool re-run
+also saw a median of 51.37 tok/s on identical code — variance band is ~±3%
+across sessions). Model-load and VRAM deltas are real and attributable to
+#210 and #206 respectively. **Decode hotspots are materially unchanged.**
+
+### NVTX region top-10 (decode, wall-clock %, post-#210 nsys capture)
+
+Source: `profiling-artifacts/post210_nvtx.csv` (130 decode iterations
+captured, 3120 GDN instances = 130 × 24 GDN layers, 4160 MLP instances =
+130 × 32 MLP layers, 1041 full-attn `qkv` instances ≈ 130 × 8 GQA layers +
+1 prefill).
+
+| %        | region                          | med (ns) | notes                      |
+| -------: | ------------------------------- | -------: | -------------------------- |
+| **18.5** | `:kiln/gdn/gates`               |  198,347 | GDN Step 6 (fused in #158) |
+| **17.6** | `:kiln/gdn/gated_norm`          |  188,730 | #141 closed null           |
+| **14.7** | `:kiln/gdn/qk_norm`             |  157,995 | #173 opt-in only (null)    |
+|      7.7 | `:kiln/gdn/in_proj`             |   81,101 | Marlin GEMM                |
+|      6.6 | `:kiln/mlp/gate`                |   52,591 | Marlin GEMM                |
+|      6.2 | `:kiln/mlp/up`                  |   50,035 | Marlin GEMM                |
+|      6.0 | `:kiln/mlp/down`                |   47,815 | Marlin GEMM                |
+|      3.4 | `:kiln/gdn/head_expand`         |   36,927 | reshape/broadcast          |
+|      3.4 | `:kiln/residual`                |   13,636 | 8321 instances             |
+|      3.0 | `:kiln/proj/qkv`                |   97,379 | full-attn Marlin (8 lyrs)  |
+
+Sub-10 regions worth noting: `gdn/out_proj` 2.8%, `norm/pre_mlp` 2.2%,
+`attn/gdn/recurrent` 2.0%, `norm/pre_attn` 1.9%, `gdn/conv` 1.8%,
+`proj/o` 0.8%, `gdn/recur_prep` 0.8%.
+
+**Aggregates:**
+- **GDN total:** ~68.5% (`gates` 18.5 + `gated_norm` 17.6 + `qk_norm` 14.7
+  + `in_proj` 7.7 + `head_expand` 3.4 + `out_proj` 2.8 + `recurrent` 2.0 +
+  `conv` 1.8 + `recur_prep` 0.8)
+- **MLP trio:** 18.8% (`gate` 6.6 + `up` 6.2 + `down` 6.0)
+- **Full-attn projections:** ~3.8% (`qkv` 3.0 + `o` 0.8) — **still below
+  the 10% FlashInfer threshold** (this re-confirms the #163 preflight).
+
+### CUDA kernel top-10 (`--trace=cuda,nvtx`, post-#210)
+
+Source: `profiling-artifacts/post210_kern.csv` (nsys `cuda_gpu_kern_sum`).
+
+| %        | kernel                                                           | med (ns) | notes                                |
+| -------: | ---------------------------------------------------------------- | -------: | ------------------------------------ |
+| **15.7** | `Marlin<256,1,8,8,4,8>`                                          |   20,288 | 13527 invocations                    |
+| **12.6** | `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_256x64_32x4_nn`   | 1,715,259 | 130 invocations = **lm_head** |
+|     10.5 | `ampere_bf16_s16816gemm_bf16_128x64_ldg8_f2f_stages_64x3_nn`     |   60,000 | 3121 invocations                     |
+|      9.8 | `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_64x64_32x6_nn`    |   36,208 | 6244 invocations                     |
+|  **8.6** | `ucopy_bf16`                                                     |   32,897 | 4164 invocations — cross-cutting     |
+|      5.7 | `ampere_bf16_s16816gemm_bf16_64x64_sliced1x2_ldg8_f2f_stages_64x5_nn` | 32,480 | 3121 invocations                 |
+|      3.4 | `bmul_f32`                                                       |    2,784 | 24979 invocations (elementwise zoo)  |
+|      3.2 | `fused_rmsnorm_kernel`                                           |    6,176 | 10536 invocations (PR #133 kernel)   |
+|      2.7 | `recurrent_gdn_fwd_kernel<128>`                                  |   15,360 | 3122 invocations (PR #80 kernel)     |
+|      2.5 | `cast_f32_bf16`                                                  |    1,312 | 20814 invocations                    |
+
+Sub-top-10 notable: `ucopy_f32` 2.1%, `cast_bf16_f32` 1.8%, `affine_f32`
+1.6%, `fast_sum_f32` 1.3%, `bmul_bf16` 0.8%, `badd_bf16` 0.8%. Together the
+elementwise zoo (casts + ucopy + affine + sum + mul) accounts for ~20% of
+kernel time, scattered across the GDN + norm + residual paths.
+
+### Graph-replay-aware analysis (per region)
+
+The dispatch-amortization lesson from #141, #173, #176, and #164 applies
+with full force: under CUDA graph replay the per-iteration kernel-launch
+cost goes to near-zero, so a fusion that only collapses launches shows up
+as a null delta. **For a fusion to clear the 1.05× decode floor, it must
+reduce real compute or memory traffic, not just dispatch cost.** The
+math-ceiling check below uses the decode-level Amdahl bound: a fusion
+eliminating fraction *p* of decode time at speedup *s* yields a total
+speedup of `1 / (1 - p·(1 - 1/s))`, and the win-contribution is
+`p · (1 - 1/s)`. We require that contribution ≥ 0.05 (i.e. ≥5% decode
+speedup) to even queue a pod-$ attempt.
+
+| region                           | % | already attempted?                   | realistic compute-reducing fusion? | win contribution if 1.10× | queue?     |
+| -------------------------------- | -: | ------------------------------------ | :--------------------------------: | ------------------------: | ---------- |
+| `:kiln/gdn/gates`                | 18.5 | fused in #158 (merged)             | already fused                      |                         — | **no**     |
+| `:kiln/gdn/gated_norm`           | 17.6 | #141 closed null                   | would need new memory-reducing approach | 0.016                | **no** (re-visit needs new idea, not new attempt) |
+| `:kiln/gdn/qk_norm`              | 14.7 | #173 opt-in, null median           | already tried and null             |                     0.013 | **no** |
+| `:kiln/gdn/in_proj`              |  7.7 | Marlin GEMM (already quantized)    | GEMM shape change, not fusion      |                     0.007 | **no**     |
+| MLP trio (gate+up+down)          | 18.8 | none                               | partial fusion (swiglu gate/up merge into a single Marlin call) plausible | 0.017 | **no** (sub-floor) |
+| `:kiln/gdn/in_proj` + `out_proj` | 10.5 | none                               | share layout work, potential combined load  | 0.009        | **no** (sub-floor) |
+| `ucopy_bf16` (kernel-level)      |  8.6 kernel-% | none                    | many sites (residual, reshape, cast-adjacent); consolidation could pay if source sites are identified | depends on which sites | **investigate** |
+| elementwise zoo (aggregate)      | ~20 kernel-% | none                     | cross-cutting; no single natural fusion site | depends on grouping | **investigate** |
+| `:kiln/residual`                 |  3.4 | none                               | potential in-place ADD into RMSNorm epilogue | 0.003            | **no**     |
+| full-attn `:kiln/proj/qkv`       |  3.0 | FlashInfer #163 ruled null         | already quantized (Marlin)         |                     0.003 | **no**     |
+
+None of the "queue?" column says **yes**. Every standalone region either
+already has a shipped fusion, has a closed-null attempt on record, or sits
+below the 1.10× × region-% floor of 0.05 decode speedup.
+
+### Next target — recommendation
+
+**Do not queue another standalone decode-kernel fusion.** The top three
+GDN regions (gates / gated_norm / qk_norm, summed 50.8%) have all been
+attacked and each either shipped (#158) or closed null (#141, #173, #176).
+The MLP trio is the only sizable region that has not been touched, but at
+18.8% it requires a 1.362× per-region speedup to clear the 5% decode floor,
+and that's the theoretical ceiling — real speedups under graph replay fall
+well below the nominal kernel-level number.
+
+Three qualified candidates for the next Phase 6 slice, in priority order:
+
+1. **`ucopy_bf16` source-site audit (investigate-only, $0 preflight
+   follow-up).** `ucopy_bf16` is 8.6% of kernel time spread across 4164
+   invocations per decode step. If the source sites (candle's transpose /
+   contiguous / cast-adjacent copies) can be identified and consolidated,
+   the math-ceiling case is: 8.6% × (1 − 1/1.5) ≈ 0.029, still sub-floor
+   *if we only save kernel time*, but attacking it means reducing memory
+   traffic which *does* compound under graph replay. This needs an
+   instrumentation pass first — add `NVTX_RANGE!` around each call site —
+   before any kernel work.
+
+2. **KV cache FP8 (`KILN_KV_CACHE_FP8=1`).** Non-kernel axis; not about
+   decode tok/s, about doubling effective context. Already wired
+   (`KILN_KV_CACHE_FP8` in `kiln-server/src/config.rs`). Needs a
+   correctness + quality benchmark, not a fusion. Distinct win category
+   from the decode-kernel work; would not be starved by the math-ceiling
+   floor because context-length is a product feature, not a decode-speed
+   metric.
+
+3. **MLP gate/up Marlin merge (speculative).** `:kiln/mlp/gate` (6.6%) and
+   `:kiln/mlp/up` (6.2%) run on the same input activation and are
+   immediately fused by a SwiGLU elementwise op. A single Marlin call
+   producing both outputs in parallel should halve the activation load
+   cost. Math-ceiling: 12.8% × (1 − 1/1.5) = 0.043 — still sub-floor, so
+   **not a queued task yet**. Flag it as "needs further math" — specifically
+   needs a profile that separates activation-load time from GEMM time on
+   the MLP trio. Do that profiling before committing pod $.
+
+### Do NOT target (restated)
+
+- **`:kiln/gdn/qk_norm`** standalone — PR #173 shipped opt-in, null median
+  (1.0093× point estimate, variance-reducing only). Do not re-queue without
+  new evidence of a memory-reducing approach that wasn't tried in #173.
+- **`:kiln/gdn/gated_norm`** standalone — PR #141 closed null. Do not
+  re-queue.
+- **Big-fusion (`qk_norm` + `gated_norm` + `recurrent`)** — PR #176 closed
+  null, $14.99 burn. Step 7 (recurrent) is architecturally separated from
+  Steps 6 and 8 and cannot be single-kernel fused. Do not re-queue.
+- **FlashInfer paged GQA decode** — PR #163 preflight: full-attn total is
+  3.8% of decode this capture (was 3.5% post-#166), math ceiling ≤1.038×
+  even at infinite speedup on that region. Not viable on Qwen3.5-4B's
+  24 GDN + 8 GQA architecture.
+- **Gate-path fusion across Step 7 recurrence** — PR #164 preflight
+  concluded architecturally infeasible; the two halves (Step 6 gates, Step
+  8 gated_norm) are separated by the recurrent scan and cannot share a
+  kernel. Both halves are already addressed independently (#158 merged,
+  #141 closed null). Do not re-queue as a combined task.
+
+### Artifacts
+
+- `profiling-artifacts/post210_nvtx.csv` — full NVTX region table
+  (24 rows).
+- `profiling-artifacts/post210_kern.csv` — full CUDA kernel table
+  (52 rows).
+- Raw `.nsys-rep` (112 MB) retained on pod only (too large to commit).
+
+
 ## Re-profile 2026-04-20 (pool-verification baseline)
 
 Bench-only re-run on a fresh pod acquired through the new Cloud Eric kiln pod

--- a/profiling-artifacts/post210_kern.csv
+++ b/profiling-artifacts/post210_kern.csv
@@ -1,0 +1,59 @@
+
+NOTICE: Existing SQLite export found: kiln-decode5.sqlite
+        It is assumed file was previously exported from: kiln-decode5.nsys-rep
+        Consider using --force-export=true if needed.
+
+Processing [kiln-decode5.sqlite] with [/opt/nvidia/nsight-systems/2024.6.2/host-linux-x64/reports/cuda_gpu_kern_sum.py]... 
+Time (%),Total Time (ns),Instances,Avg (ns),Med (ns),Min (ns),Max (ns),StdDev (ns),Name
+15.7,279139141,13527,20635.7,20288.0,17985,22912,1126.0,"void Marlin<(int)256, (int)1, (int)8, (int)8, (int)4, (int)8>(const int4 *, const int4 *, int4 *, const int4 *, int, int, int, int *)"
+12.6,222980430,130,1715234.1,1715258.5,1713226,1717674,906.2,void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_256x64_32x4_nn_align8>(T1::Params)
+10.5,187381797,3121,60039.0,60000.0,59680,60832,178.0,ampere_bf16_s16816gemm_bf16_128x64_ldg8_f2f_stages_64x3_nn
+9.8,174596605,6244,27962.3,36208.0,10016,38240,12553.5,void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_64x64_32x6_nn_align8>(T1::Params)
+8.6,153041632,4164,36753.5,32896.5,3008,78081,33781.5,ucopy_bf16
+5.7,101479517,3121,32515.1,32480.0,31840,33472,235.8,ampere_bf16_s16816gemm_bf16_64x64_sliced1x2_ldg8_f2f_stages_64x5_nn
+3.4,61102302,24979,2446.1,2784.0,1376,3648,806.0,bmul_f32
+3.2,56015221,10536,5316.6,6176.0,1632,6560,1784.8,"<unnamed>::fused_rmsnorm_kernel(const __nv_bfloat16 *, const __nv_bfloat16 *, __nv_bfloat16 *, int, float)"
+2.7,47962443,3122,15362.7,15360.0,15200,15489,47.2,"void <unnamed>::recurrent_gdn_fwd_kernel<(int)128>(const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, __nv_bfloat16 *, __nv_bfloat16 *, int, int)"
+2.5,43924083,20814,2110.3,1312.0,1184,6080,1635.7,cast_f32_bf16
+2.1,36940288,12489,2957.8,3008.0,2272,3616,413.1,ucopy_f32
+1.8,31318911,17692,1770.2,1249.0,1216,4320,1072.1,cast_bf16_f32
+1.6,28729263,21854,1314.6,1312.0,1216,1441,70.8,affine_f32
+1.3,22871364,9366,2442.0,2432.0,2368,2560,29.0,fast_sum_f32
+1.2,21668842,6244,3470.3,3456.0,3232,3904,169.9,bdiv_f32
+1.1,19348987,6242,3099.8,3024.0,2656,3745,395.1,void cutlass::Kernel2<cutlass_80_wmma_tensorop_s161616gemm_bf16_16x16_128x1_nn_align8>(T1::Params)
+1.0,17877596,13527,1321.6,1312.0,1280,1377,26.2,cast_bf16_f16
+1.0,17695841,13527,1308.2,1280.0,1248,1409,45.1,cast_f16_bf16
+1.0,17412009,130,133938.5,133761.0,132481,136865,900.5,fast_argmax_bf16
+0.9,16234313,12488,1300.0,1280.0,1216,1441,71.2,uneg_f32
+0.9,15576181,11448,1360.6,1312.0,992,1633,156.5,badd_f32
+0.8,14182880,9364,1514.6,1568.0,1376,1665,115.5,bmul_bf16
+0.8,13709417,8324,1647.0,1568.5,1344,2112,261.1,badd_bf16
+0.7,13206383,9364,1410.3,1440.0,1312,1504,50.2,uexp_bf16
+0.7,13176906,9366,1406.9,1408.0,1312,1600,44.5,uexp_f32
+0.7,12985933,9364,1386.8,1408.0,1280,1824,84.7,affine_bf16
+0.7,12901321,9366,1377.5,1376.0,1312,1409,31.6,usqr_f32
+0.7,12426604,9366,1326.8,1344.0,1248,1377,30.9,usqrt_f32
+0.7,11787470,8324,1416.1,1440.0,1312,1504,55.7,urecip_bf16
+0.7,11684655,8324,1403.7,1408.0,1280,1696,82.1,uneg_bf16
+0.6,11242431,6242,1801.1,1792.5,1600,2113,183.9,"void cublasLt::splitKreduce_kernel<(int)32, (int)16, int, float, __nv_bfloat16, float, __nv_bfloat16, (bool)1, (bool)0, (bool)0>(cublasLt::cublasSplitKParams<T6>, const T4 *, const T5 *, T5 *, const T6 *, const T6 *, const T7 *, const T4 *, T7 *, void *, long, T6 *, int *)"
+0.5,8682619,6244,1390.6,1360.5,1248,1568,128.8,bmaximum_f32
+0.5,8622800,6244,1381.0,1377.0,1312,1441,41.9,urecip_f32
+0.5,8458924,912,9275.1,9280.0,7648,11296,671.0,"std::enable_if<!T7, void>::type internal::gemvx::kernel<int, int, __nv_bfloat16, __nv_bfloat16, __nv_bfloat16, float, (bool)0, (bool)1, (bool)0, (bool)0, (int)7, (bool)0, cublasGemvParamsEx<int, cublasGemvTensorStridedBatched<const __nv_bfloat16>, cublasGemvTensorStridedBatched<const __nv_bfloat16>, cublasGemvTensorStridedBatched<__nv_bfloat16>, float>>(T13)"
+0.3,5461985,520,10503.8,10464.0,9280,12128,709.2,"void gemv2T_kernel_val<int, int, __nv_bfloat16, __nv_bfloat16, __nv_bfloat16, float, (int)128, (int)16, (int)4, (int)4, (bool)0, (bool)0, cublasGemvParamsEx<int, cublasGemvTensorStridedBatched<const __nv_bfloat16>, cublasGemvTensorStridedBatched<const __nv_bfloat16>, cublasGemvTensorStridedBatched<__nv_bfloat16>, float>>(T13, T6, T6)"
+0.3,5396417,3121,1729.1,1728.0,1600,1984,70.0,"void <unnamed>::kiln_conv1d_update_k4_kernel<(bool)1>(const __nv_bfloat16 *, const __nv_bfloat16 *, float *, float *, int, int)"
+0.3,4647443,392,11855.7,11840.0,10592,13408,639.9,void cutlass::Kernel2<cutlass_80_wmma_tensorop_bf16_s161616gemm_bf16_16x16_128x1_tn_align2>(T1::Params)
+0.2,4219480,1040,4057.2,4064.0,3776,4256,55.9,fast_max_bf16
+0.2,4197278,3122,1344.4,1344.0,1312,1376,16.0,ulog_f32
+0.2,3967229,1040,3814.6,3808.0,3776,3936,25.6,fast_sum_bf16
+0.2,3730389,1040,3586.9,3584.0,3424,3680,36.3,bdiv_bf16
+0.2,3630224,1040,3490.6,3488.0,3360,3584,43.2,bsub_bf16
+0.2,3055659,2082,1467.7,1456.5,1376,1569,69.7,"void cublasLt::splitKreduce_kernel<(int)32, (int)16, int, __nv_bfloat16, __nv_bfloat16, float, __nv_bfloat16, (bool)1, (bool)0, (bool)0>(cublasLt::cublasSplitKParams<T6>, const T4 *, const T5 *, T5 *, const T6 *, const T6 *, const T7 *, const T4 *, T7 *, void *, long, T6 *, int *)"
+0.2,2998449,2082,1440.2,1392.5,1280,1633,142.8,bsub_f32
+0.2,2821038,2082,1355.0,1344.0,1312,1408,21.2,copy2d_bf16
+0.1,1507300,1041,1447.9,1440.0,1408,1473,16.2,ucos_f32
+0.1,1497093,1041,1438.1,1440.0,1408,1472,13.3,usin_f32
+0.1,1184840,128,9256.6,9280.0,8096,10272,451.4,"std::enable_if<!T7, void>::type internal::gemvx::kernel<int, int, __nv_bfloat16, __nv_bfloat16, __nv_bfloat16, float, (bool)0, (bool)1, (bool)0, (bool)0, (int)9, (bool)0, cublasGemvParamsEx<int, cublasGemvTensorStridedBatched<const __nv_bfloat16>, cublasGemvTensorStridedBatched<const __nv_bfloat16>, cublasGemvTensorStridedBatched<__nv_bfloat16>, float>>(T13)"
+0.1,1042180,88,11843.0,11808.0,10976,12896,505.1,void cutlass::Kernel2<cutlass_80_wmma_tensorop_bf16_s161616gemm_bf16_16x16_128x1_tn_align8>(T1::Params)
+0.0,475362,40,11884.0,11824.0,11328,12576,306.8,void cutlass::Kernel2<cutlass_80_wmma_tensorop_bf16_s161616gemm_bf16_16x16_128x2_tn_align8>(T1::Params)
+0.0,388001,130,2984.6,2976.0,2912,3136,41.6,is_u32_bf16
+

--- a/profiling-artifacts/post210_nvtx.csv
+++ b/profiling-artifacts/post210_nvtx.csv
@@ -1,0 +1,25 @@
+Generating SQLite file kiln-decode5.sqlite from kiln-decode5.nsys-rep
+Processing [kiln-decode5.sqlite] with [/opt/nvidia/nsight-systems/2024.6.2/host-linux-x64/reports/nvtx_sum.py]... 
+Time (%),Total Time (ns),Instances,Avg (ns),Med (ns),Min (ns),Max (ns),StdDev (ns),Style,Range
+18.5,624723075,3120,200231.8,198347.0,184678,658745,17148.5,PushPop,:kiln/gdn/gates
+17.6,594606390,3120,190579.0,188730.0,177631,649793,16757.4,PushPop,:kiln/gdn/gated_norm
+14.7,496610183,3120,159169.9,157994.5,147813,395041,8329.7,PushPop,:kiln/gdn/qk_norm
+7.7,259444843,3120,83155.4,81101.0,74308,2288330,50225.8,PushPop,:kiln/gdn/in_proj
+6.6,224613669,4160,53993.7,52591.0,48626,3100830,47931.7,PushPop,:kiln/mlp/gate
+6.2,211024353,4161,50714.8,50035.0,44996,488744,7277.0,PushPop,:kiln/mlp/up
+6.0,202086909,4161,48566.9,47815.0,43664,436534,8999.8,PushPop,:kiln/mlp/down
+3.4,116427829,3120,37316.6,36926.5,33463,67546,2224.8,PushPop,:kiln/gdn/head_expand
+3.4,114074246,8321,13709.2,13636.0,10168,117470,2050.2,PushPop,:kiln/residual
+3.0,102696170,1041,98651.5,97379.0,92805,332199,8497.6,PushPop,:kiln/proj/qkv
+2.8,94945599,3120,30431.3,29791.0,26613,438090,9755.4,PushPop,:kiln/gdn/out_proj
+2.2,72766276,4160,17491.9,16943.5,14900,622357,11546.6,PushPop,:kiln/norm/pre_mlp
+2.0,68534571,3120,21966.2,20382.5,17882,3780420,67591.0,PushPop,:kiln/attn/gdn/recurrent
+1.9,64350200,4161,15465.1,14976.0,13443,547544,8364.7,PushPop,:kiln/norm/pre_attn
+1.8,59667443,3120,19124.2,18450.5,15928,346071,10122.8,PushPop,:kiln/gdn/conv
+0.8,28381539,1040,27289.9,26314.0,23841,656152,19598.7,PushPop,:kiln/proj/o
+0.8,28233000,3120,9049.0,8625.0,7892,371665,6557.1,PushPop,:kiln/gdn/recur_prep
+0.2,6225837,130,47891.1,47230.5,41500,84421,3979.3,PushPop,:kiln/lm_head
+0.2,5815418,3120,1863.9,1747.0,1506,7918,566.3,PushPop,:kiln/gdn/qkv_split
+0.1,4576171,3120,1466.7,1363.0,933,9623,587.6,PushPop,:kiln/attn/gdn/precopy
+0.0,1609792,3120,516.0,446.0,260,6377,445.2,PushPop,:kiln/gdn/post_transpose
+


### PR DESCRIPTION
## What

Fresh nsys decode profile on current `main` after the post-#166 cluster
(#206 BF16 drop, #210 Marlin pack parallelization, #173/#176 closed-null
fusion attempts). Updates `kiln/PROFILING.md` with:

- 3-run bench: median **52.3 tok/s** / ITL **19.1 ms** / prefill 327 ms
  (Arm B paged 512/128, `KILN_W4A16=1 KILN_CUDA_GRAPHS=true`)
- **NVTX region top-10** (wall-clock %) — top-3 unchanged: `gates` 18.5%,
  `gated_norm` 17.6%, `qk_norm` 14.7% (GDN share ~68.5%, MLP trio 18.8%,
  full-attn projections 3.8%)
- **CUDA kernel top-10** — Marlin 15.7%, lm_head cutlass 12.6%,
  ampere_bf16_s16816gemm family 10.5+9.8+5.7%, **ucopy_bf16 8.6%**
  (cross-cutting), fused_rmsnorm_kernel 3.2%, recurrent_gdn_fwd_kernel 2.7%
- **Graph-replay-aware** per-region analysis with math-ceiling check
  (`region_pct × (1 − 1/speedup) ≥ 5%` floor)
- **Next target** recommendation (priority order):
  1. `ucopy_bf16` source-site audit — instrumentation-only preflight, $0
  2. KV cache FP8 (non-kernel, context-length axis — already wired)
  3. Speculative MLP gate/up Marlin merge (needs more profiling before
     committing pod $)
- **Do NOT target** list restating #141 (gated_norm null), #163 (FlashInfer
  math-ceiling ≤1.038×), #164 (Step 7 recurrence separates halves),
  #173 (qk_norm opt-in null 1.0093×), #176 (big-fusion null, \$14.99 burn)

## Why

The job of this profile is not to find a shifted hotspot — it is to **rule
out** new candidates before considering any re-opening of closed-null
fusion work. Decode composition is materially unchanged vs post-#166
(within run-to-run variance), which confirms #173 + #176 + #206 + #210 did
not shift the decode-path balance. **None of the standalone regions clears
the 1.05× decode floor under graph-replay amortization** — we need either
cross-cutting consolidation (ucopy_bf16 audit) or a pivot to non-kernel
axes (KV cache FP8), not another single-kernel fusion attempt.

## Artifacts

- `profiling-artifacts/post210_nvtx.csv` (24 NVTX regions)
- `profiling-artifacts/post210_kern.csv` (52 CUDA kernels)

## Preflight record

PRs #204 (pool bench-only), #206 (VRAM cleanup), #210 (load-time only),
#211–#215 (desktop/CI/docs) all verified as non-forward-path changes.
NVTX delta from post-#166 top-3 (gates 18.0%, gated_norm 17.5%, qk_norm
14.9%) to post-#210 top-3 (18.5%, 17.6%, 14.7%) is within noise, as
expected.