### PR TITLE
desktop: updater slice 6 — GPU arch compat gate

### DIFF
--- a/desktop/src/installer.rs
+++ b/desktop/src/installer.rs
@@ -756,6 +756,109 @@ pub fn is_update_available(current: Option<&str>, latest: &str) -> bool {
     }
 }
 
+// ---------- GPU arch compat gate (slice 6) ----------
+//
+// Before offering a kiln update on Linux/Windows, the desktop app detects
+// the local GPU's SM arch via `nvidia-smi --query-gpu=compute_cap` and
+// refuses to suggest a binary compiled for an unsupported arch. macOS
+// has no SM arch concept (single release target), so the check
+// short-circuits to `Supported`. Detection failure (no nvidia-smi,
+// non-zero exit, timeout, unparseable output) is reported as `Unknown`
+// and is treated as "don't block" by callers — preserving existing
+// behavior on systems without nvidia-smi.
+//
+// See `desktop/docs/binary-update.md` (CUDA / GPU compat, lines 260-280).
+
+/// SM arches that the current kiln release series supports. Hardcoded
+/// here until a later slice parses `supported_sm` out of the GitHub
+/// release notes (design doc lines 266-268).
+pub const SUPPORTED_SM_ARCHS: &[u32] = &[80, 86, 89, 90];
+
+/// Outcome of the local GPU arch compatibility check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GpuCompat {
+    /// The detected SM arch is in [`SUPPORTED_SM_ARCHS`].
+    Supported(u32),
+    /// The detected SM arch is NOT in [`SUPPORTED_SM_ARCHS`]. Callers
+    /// should refuse to offer an update and surface the SM number to the
+    /// user.
+    Unsupported(u32),
+    /// Detection failed (no nvidia-smi, non-zero exit, timeout, or
+    /// unparseable output). Callers should NOT block the update offer —
+    /// this preserves existing behavior on systems without nvidia-smi,
+    /// which includes macOS and any non-CUDA host.
+    Unknown,
+}
+
+/// Whether `arch` is in [`SUPPORTED_SM_ARCHS`].
+pub fn is_supported_sm(arch: u32) -> bool {
+    SUPPORTED_SM_ARCHS.contains(&arch)
+}
+
+/// Parse the first non-empty line of `nvidia-smi --query-gpu=compute_cap
+/// --format=csv,noheader` output into an integer SM arch number (e.g.
+/// `"8.6"` -> `Some(86)`, `"12.0"` -> `Some(120)`). Ignores trailing
+/// whitespace and subsequent GPU lines (take the first GPU). Returns
+/// `None` when the input is empty, unparseable, or has an unexpected
+/// shape.
+pub fn parse_compute_cap(output: &str) -> Option<u32> {
+    let first = output.lines().find(|line| !line.trim().is_empty())?;
+    let trimmed = first.trim();
+    let (major_s, minor_s) = trimmed.split_once('.')?;
+    let major: u32 = major_s.trim().parse().ok()?;
+    let minor: u32 = minor_s.trim().parse().ok()?;
+    // `compute_cap` minor digit is always a single decimal; multiplying
+    // the major by 10 matches the SM arch numbering used elsewhere in
+    // this file (sm_86, sm_120, etc.).
+    Some(major * 10 + minor)
+}
+
+/// Invoke `nvidia-smi --query-gpu=compute_cap --format=csv,noheader` and
+/// parse the first GPU's compute capability. Returns `None` when the
+/// command fails to spawn, exits non-zero, times out (5s), or produces
+/// unparseable output.
+#[cfg(not(target_os = "macos"))]
+pub async fn detect_gpu_compute_cap() -> Option<u32> {
+    let fut = tokio::process::Command::new("nvidia-smi")
+        .args(["--query-gpu=compute_cap", "--format=csv,noheader"])
+        .output();
+    let out = tokio::time::timeout(std::time::Duration::from_secs(5), fut)
+        .await
+        .ok()?
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    parse_compute_cap(&stdout)
+}
+
+/// macOS has no SM arch concept — detection is never attempted.
+#[cfg(target_os = "macos")]
+pub async fn detect_gpu_compute_cap() -> Option<u32> {
+    None
+}
+
+/// GPU arch compatibility check for the current host. On macOS this
+/// always returns [`GpuCompat::Supported`] with a sentinel arch of `0`
+/// (macOS has a single release target — SM arch doesn't apply). On
+/// Linux/Windows this shells out to `nvidia-smi`; detection failure is
+/// reported as [`GpuCompat::Unknown`] so callers don't block the update
+/// on systems without nvidia-smi.
+#[cfg(target_os = "macos")]
+pub async fn gpu_compat() -> GpuCompat {
+    GpuCompat::Supported(0)
+}
+
+#[cfg(not(target_os = "macos"))]
+pub async fn gpu_compat() -> GpuCompat {
+    match detect_gpu_compute_cap().await {
+        Some(arch) if is_supported_sm(arch) => GpuCompat::Supported(arch),
+        Some(arch) => GpuCompat::Unsupported(arch),
+        None => GpuCompat::Unknown,
+    }
+}
+
 /// Download the release tarball for `version` to the staging path under
 /// `<app_data_dir>/kiln-updates/`. Does NOT extract, verify sha256, or
 /// touch the running kiln binary — that is slice 3 of
@@ -1376,11 +1479,12 @@ pub async fn install_staged_update(
 mod tests {
     use super::{
         backup_binary_path, cleanup_bak, current_target, extract_tarball_to,
-        extracted_new_binary_path, installed_binary_path, is_update_available,
-        parse_kiln_version_output, release_archive_ext, release_asset_name,
-        release_download_url, rollback_to_bak, staging_tarball_path,
-        supports_auto_install, swap_new_binary_into_place, verify_sha256,
-        BACKUP_BINARY_NAME, NEW_BINARY_NAME, UPDATE_STAGING_DIR,
+        extracted_new_binary_path, installed_binary_path, is_supported_sm,
+        is_update_available, parse_compute_cap, parse_kiln_version_output,
+        release_archive_ext, release_asset_name, release_download_url,
+        rollback_to_bak, staging_tarball_path, supports_auto_install,
+        swap_new_binary_into_place, verify_sha256, BACKUP_BINARY_NAME,
+        NEW_BINARY_NAME, SUPPORTED_SM_ARCHS, UPDATE_STAGING_DIR,
     };
     use std::io::Write;
     use std::path::PathBuf;
@@ -1958,5 +2062,72 @@ mod tests {
         assert!(!backup.exists(), "backup should have been removed");
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // ---------- GPU arch compat gate (slice 6) ----------
+
+    #[test]
+    fn parse_compute_cap_ampere() {
+        assert_eq!(parse_compute_cap("8.6\n"), Some(86));
+    }
+
+    #[test]
+    fn parse_compute_cap_blackwell() {
+        assert_eq!(parse_compute_cap("12.0\n"), Some(120));
+    }
+
+    #[test]
+    fn parse_compute_cap_first_of_multiple() {
+        // Multi-GPU hosts emit one line per GPU; take the first.
+        assert_eq!(parse_compute_cap("8.0\n9.0\n"), Some(80));
+    }
+
+    #[test]
+    fn parse_compute_cap_empty_is_none() {
+        assert_eq!(parse_compute_cap(""), None);
+    }
+
+    #[test]
+    fn parse_compute_cap_whitespace_only_is_none() {
+        assert_eq!(parse_compute_cap("   \n\n"), None);
+    }
+
+    #[test]
+    fn parse_compute_cap_garbage_is_none() {
+        assert_eq!(parse_compute_cap("bad"), None);
+    }
+
+    #[test]
+    fn parse_compute_cap_no_trailing_newline() {
+        assert_eq!(parse_compute_cap("7.5"), Some(75));
+    }
+
+    #[test]
+    fn parse_compute_cap_missing_minor_is_none() {
+        // `compute_cap` always emits `major.minor`; anything else is a
+        // shape we don't know how to interpret.
+        assert_eq!(parse_compute_cap("8\n"), None);
+    }
+
+    #[test]
+    fn is_supported_sm_table() {
+        // SUPPORTED list from the design doc.
+        for &arch in SUPPORTED_SM_ARCHS {
+            assert!(is_supported_sm(arch), "SM {} should be supported", arch);
+        }
+        // Blackwell (SM 120) is NOT supported under CUDA 12.4.
+        assert!(!is_supported_sm(120));
+        // Older Turing / Volta are out of scope for kiln releases.
+        assert!(!is_supported_sm(75));
+        assert!(!is_supported_sm(70));
+    }
+
+    #[test]
+    fn parse_compute_cap_supported_check_is_separate() {
+        // parse_compute_cap should succeed on ANY `major.minor` input —
+        // the SUPPORTED_SM_ARCHS check lives in is_supported_sm so an
+        // unknown-but-parseable arch still surfaces to the caller.
+        assert_eq!(parse_compute_cap("7.5\n"), Some(75));
+        assert!(!is_supported_sm(75));
     }
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -493,6 +493,12 @@ struct KilnUpdateCheckResult {
     latest: Option<String>,
     update_available: bool,
     platform_supported: bool,
+    /// `Some(sm)` when the local GPU's SM arch is NOT in
+    /// `installer::SUPPORTED_SM_ARCHS` — the UI should surface a warn
+    /// pill and disable the Download button. `None` when supported,
+    /// unknown (no nvidia-smi, detection failed), or irrelevant (macOS).
+    /// See `desktop/docs/binary-update.md` (CUDA / GPU compat).
+    gpu_unsupported: Option<u32>,
 }
 
 /// Detection-only check for a newer kiln binary release. Looks up the
@@ -527,15 +533,30 @@ async fn check_for_kiln_update(
         None
     };
 
-    let update_available = match &latest {
+    let mut update_available = match &latest {
         Some(l) => installer::is_update_available(current.as_deref(), l),
         None => false,
     };
+
+    // GPU arch compat gate (slice 6): if nvidia-smi reports a compute
+    // capability outside `installer::SUPPORTED_SM_ARCHS`, refuse to offer
+    // the update. Unknown detection (no nvidia-smi, timeout, etc.) is
+    // NOT a block — preserve existing behavior on systems without
+    // nvidia-smi. See `desktop/docs/binary-update.md` (CUDA / GPU compat).
+    let gpu_unsupported = match installer::gpu_compat().await {
+        installer::GpuCompat::Unsupported(sm) => {
+            update_available = false;
+            Some(sm)
+        }
+        installer::GpuCompat::Supported(_) | installer::GpuCompat::Unknown => None,
+    };
+
     Ok(KilnUpdateCheckResult {
         current,
         latest,
         update_available,
         platform_supported,
+        gpu_unsupported,
     })
 }
 
@@ -592,6 +613,19 @@ async fn check_kiln_update_on_launch(app: AppHandle, settings: SettingsState) {
     };
 
     if !installer::is_update_available(current.as_deref(), &latest) {
+        return;
+    }
+
+    // GPU arch compat gate (slice 6): silently skip the banner when the
+    // local GPU's SM arch is outside `installer::SUPPORTED_SM_ARCHS`.
+    // Unknown detection is treated as supported — the check_for_kiln_update
+    // command path still surfaces the compat state to the settings UI when
+    // the user clicks "Check for Updates".
+    if let installer::GpuCompat::Unsupported(sm) = installer::gpu_compat().await {
+        eprintln!(
+            "[main] auto_update: skipping — GPU SM {} not supported",
+            sm
+        );
         return;
     }
 

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -95,6 +95,7 @@
       .update-status.checking { color: #a8aeb8; }
       .update-status.up-to-date { color: #7fbf7f; }
       .update-status.available { color: #f0b080; }
+      .update-status.warn { color: #e6c070; }
       .update-status.error { color: #f08080; }
       .update-status .badge {
         display: inline-block;
@@ -107,6 +108,7 @@
       }
       .update-status.available .badge { background: #5a3f1a; color: #f6d3a6; }
       .update-status.up-to-date .badge { background: #1f3a22; color: #b7e3b9; }
+      .update-status.warn .badge { background: #4a3a1a; color: #f0d98a; }
       .update-download {
         display: flex;
         flex-direction: column;
@@ -1062,6 +1064,19 @@
             return;
           }
           const current = r.current ? escapeHtml(r.current) : "unknown";
+          if (r.gpu_unsupported != null) {
+            // GPU arch compat gate (slice 6): the local GPU's SM arch
+            // isn't in kiln's SUPPORTED_SM_ARCHS — refuse to offer the
+            // update. Keep Download hidden; user sees why.
+            const sm = escapeHtml(String(r.gpu_unsupported));
+            setKilnUpdateStatus(
+              "warn",
+              "GPU not supported (SM " + sm + "). Kiln releases require SM 80, 86, 89, or 90. " +
+                '<span class="badge">Update blocked</span>'
+            );
+            showKilnUpdateActions(null);
+            return;
+          }
           if (!r.latest) {
             setKilnUpdateStatus(
               "error",


### PR DESCRIPTION
## What

Add GPU arch compatibility gate to the updater. Before offering a kiln update on Linux/Windows, detect the local GPU's SM arch via `nvidia-smi --query-gpu=compute_cap --format=csv,noheader` and refuse the offer if the arch isn't in `SUPPORTED_SM_ARCHS` (80, 86, 89, 90). macOS short-circuits to `Supported(0)` — the single release target makes SM arch a non-concept there.

Detection failure (no nvidia-smi, non-zero exit, timeout, unparseable output) is reported as `GpuCompat::Unknown` and does NOT block the update offer — preserves existing behavior on systems without nvidia-smi.

## Changes

- `desktop/src/installer.rs`: `SUPPORTED_SM_ARCHS`, `GpuCompat` enum, `parse_compute_cap`, `detect_gpu_compute_cap` (with 5s `tokio::time::timeout`), `gpu_compat` (macOS short-circuit), `is_supported_sm`, unit tests.
- `desktop/src/main.rs`: Gate `check_for_kiln_update` (sets `update_available = false`, populates new `gpu_unsupported: Option<u32>` field on `KilnUpdateCheckResult`) and `check_kiln_update_on_launch` (silently skips the banner with a stderr log when unsupported).
- `desktop/ui/settings.html`: Render GPU-unsupported state as a warn-pill "GPU not supported (SM N). Kiln releases require SM 80, 86, 89, or 90." with the Download button hidden. New `.update-status.warn` CSS class.

## Design-doc alignment

- `desktop/docs/binary-update.md` lines 260-280 (CUDA / GPU compat).
- Treats Unknown as Supported so the check is additive, not a regression on nvidia-smi-less hosts.
- Open question #6 (version pinning / "skip this version") NOT addressed — still deferred.

## Tests

Pure `parse_compute_cap` + `is_supported_sm` covered by unit tests:

- `parse_compute_cap("8.6\n") == Some(86)` (Ampere)
- `parse_compute_cap("12.0\n") == Some(120)` (Blackwell)
- `parse_compute_cap("8.0\n9.0\n") == Some(80)` (first of multiple GPUs)
- `parse_compute_cap("") == None`
- `parse_compute_cap("   \n\n") == None`
- `parse_compute_cap("bad") == None`
- `parse_compute_cap("7.5") == Some(75)` (no trailing newline)
- `parse_compute_cap("8\n") == None` (missing minor)
- `is_supported_sm_table` — every arch in SUPPORTED_SM_ARCHS passes; 120, 75, 70 do not
- `parse_compute_cap_supported_check_is_separate` — unsupported-but-parseable arch still surfaces

Full `cargo test --package kiln-desktop` skipped in Cloud Eric per agent note `tauri-cargo-check-gtk-missing` (glib-sys/webkit2gtk build deps not installed, cannot install system packages in the sandbox). Per agent note `tauri-pure-helper-testing`, validated the pure helpers in a scratch crate (`/tmp/parse-cc-test`) mirroring `parse_compute_cap` + `is_supported_sm` + `SUPPORTED_SM_ARCHS`:

```
running 10 tests
test tests::is_supported_sm_table ... ok
test tests::parse_compute_cap_ampere ... ok
test tests::parse_compute_cap_blackwell ... ok
test tests::parse_compute_cap_empty_is_none ... ok
test tests::parse_compute_cap_first_of_multiple ... ok
test tests::parse_compute_cap_garbage_is_none ... ok
test tests::parse_compute_cap_missing_minor_is_none ... ok
test tests::parse_compute_cap_no_trailing_newline ... ok
test tests::parse_compute_cap_supported_check_is_separate ... ok
test tests::parse_compute_cap_whitespace_only_is_none ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

CI matrix validates the full Linux/Windows/macOS builds.

## Non-goals (next slices)

- Parse `supported_sm` from release notes (design doc lines 266-268).
- CUDA runtime version detection (design doc line 278).
- Multi-GPU support beyond first GPU.
- Version pinning / skip-this-version (open question #6).
