### PR TITLE
desktop: updater slice 7 — parse supported_sm from release notes

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -137,7 +137,7 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --draft \
               --title "Kiln server $TAG" \
-              --notes "Prebuilt \`kiln\` server binaries for $TAG. See the repository README for supported platforms."
+              --notes "Prebuilt \`kiln\` server binaries for $TAG. See the repository README for supported platforms.\n\nsupported_sm: [80, 86, 89, 90]"
           fi
           gh release upload "$TAG" "$ARTIFACT" "$ARTIFACT.sha256" \
             --repo "$GITHUB_REPOSITORY" --clobber
@@ -235,7 +235,7 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --draft \
               --title "Kiln server $TAG" \
-              --notes "Prebuilt \`kiln\` server binaries for $TAG. See the repository README for supported platforms."
+              --notes "Prebuilt \`kiln\` server binaries for $TAG. See the repository README for supported platforms.\n\nsupported_sm: [80, 86, 89, 90]"
           fi
           gh release upload "$TAG" "$ARTIFACT" "$ARTIFACT.sha256" \
             --repo "$GITHUB_REPOSITORY" --clobber
@@ -323,7 +323,7 @@ jobs:
               --repo "$env:GITHUB_REPOSITORY" `
               --draft `
               --title "Kiln server $env:TAG" `
-              --notes "Prebuilt ``kiln`` server binaries for $env:TAG. See the repository README for supported platforms."
+              --notes "Prebuilt ``kiln`` server binaries for $env:TAG. See the repository README for supported platforms.\n\nsupported_sm: [80, 86, 89, 90]"
           }
           gh release upload "$env:TAG" "$env:ARTIFACT" "$env:ARTIFACT.sha256" `
             --repo "$env:GITHUB_REPOSITORY" --clobber

--- a/desktop/src/installer.rs
+++ b/desktop/src/installer.rs
@@ -437,12 +437,22 @@ struct Release {
     tag_name: String,
     #[serde(default)]
     assets: Vec<ReleaseAsset>,
+    /// Full release-notes body (markdown). Parsed by
+    /// [`parse_supported_sm`] so the per-release supported-SM list can
+    /// move with the release rather than being hardcoded in the desktop
+    /// app. `None` when the field is absent (older releases predating the
+    /// `supported_sm:` convention).
+    #[serde(default)]
+    body: Option<String>,
 }
 
 struct AssetPair {
     version: String,
     tarball: ReleaseAsset,
     sha256: Option<ReleaseAsset>,
+    /// Release-notes body carried forward so callers can feed it to
+    /// [`is_supported_sm_for_release`] / [`supported_sm_for_release`].
+    release_body: Option<String>,
 }
 
 /// Fetch the newest `kiln-v*` release and find the asset pair matching
@@ -495,6 +505,7 @@ async fn discover_asset(
             version,
             tarball: tar,
             sha256: sha,
+            release_body: release.body.clone(),
         });
     }
     Err(format!(
@@ -737,6 +748,20 @@ pub async fn discover_latest_version(client: &reqwest::Client) -> Option<String>
     discover_asset(client, target).await.ok().map(|p| p.version)
 }
 
+/// Fetch the newest release's version + notes body for the current
+/// target. Feeds [`is_supported_sm_for_release`] so callers can apply the
+/// per-release supported-SM list. Returns `None` under the same
+/// conditions as [`discover_latest_version`].
+pub async fn discover_latest_version_and_body(
+    client: &reqwest::Client,
+) -> Option<(String, Option<String>)> {
+    let target = current_target()?;
+    discover_asset(client, target)
+        .await
+        .ok()
+        .map(|p| (p.version, p.release_body))
+}
+
 /// Decide whether `latest` is newer than `current` using semver.
 ///
 /// Per design doc (`desktop/docs/binary-update.md`): fall back to string
@@ -793,6 +818,71 @@ pub enum GpuCompat {
 /// Whether `arch` is in [`SUPPORTED_SM_ARCHS`].
 pub fn is_supported_sm(arch: u32) -> bool {
     SUPPORTED_SM_ARCHS.contains(&arch)
+}
+
+/// Parse `supported_sm: [80, 86, 89, 90]` (or `supported_sm: 80, 86, 89, 90`)
+/// from release-notes body. Returns `None` when the line is absent or
+/// unparseable so callers fall back to [`SUPPORTED_SM_ARCHS`].
+///
+/// The key match is strict (lowercase `supported_sm`). Brackets are
+/// optional; whitespace inside the list is tolerated. Any unparseable
+/// element or an empty list returns `None` so the caller falls back to
+/// the compiled-in default rather than silently locking out every arch.
+///
+/// Note on line terminators: `gh release create --notes "..."` passes
+/// the string verbatim (no escape-sequence processing), so release
+/// bodies emitted by the CI workflow may contain literal `\n` (two
+/// characters) between fields rather than real newlines. We normalize
+/// both forms before scanning for the key so either style works.
+pub fn parse_supported_sm(body: &str) -> Option<Vec<u32>> {
+    let normalized = body.replace("\\n", "\n");
+    for line in normalized.lines() {
+        let trimmed = line.trim();
+        let Some(rest) = trimmed.strip_prefix("supported_sm:") else {
+            continue;
+        };
+        let rest = rest.trim();
+        let inner = rest
+            .strip_prefix('[')
+            .and_then(|s| s.strip_suffix(']'))
+            .unwrap_or(rest);
+        let parts: Vec<&str> = inner
+            .split(',')
+            .map(|s| s.trim())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if parts.is_empty() {
+            return None;
+        }
+        let mut out = Vec::with_capacity(parts.len());
+        for p in parts {
+            let n: u32 = p.parse().ok()?;
+            out.push(n);
+        }
+        if out.is_empty() {
+            return None;
+        }
+        return Some(out);
+    }
+    None
+}
+
+/// Pick the supported-SM list for a release: prefer the parsed list from
+/// its notes body, fall back to [`SUPPORTED_SM_ARCHS`] when the body is
+/// missing, malformed, or empty.
+pub fn supported_sm_for_release(body: Option<&str>) -> Vec<u32> {
+    body.and_then(parse_supported_sm)
+        .filter(|v| !v.is_empty())
+        .unwrap_or_else(|| SUPPORTED_SM_ARCHS.to_vec())
+}
+
+/// Whether `arch` is supported by the release whose notes body is
+/// `body`. Per-release list takes precedence over [`SUPPORTED_SM_ARCHS`]
+/// so a newer release can widen support (e.g. add Blackwell SM 120) by
+/// publishing `supported_sm: [80, 86, 89, 90, 120]` in its notes without
+/// waiting for a desktop update.
+pub fn is_supported_sm_for_release(arch: u32, body: Option<&str>) -> bool {
+    supported_sm_for_release(body).contains(&arch)
 }
 
 /// Parse the first non-empty line of `nvidia-smi --query-gpu=compute_cap
@@ -1480,11 +1570,12 @@ mod tests {
     use super::{
         backup_binary_path, cleanup_bak, current_target, extract_tarball_to,
         extracted_new_binary_path, installed_binary_path, is_supported_sm,
-        is_update_available, parse_compute_cap, parse_kiln_version_output,
-        release_archive_ext, release_asset_name, release_download_url,
-        rollback_to_bak, staging_tarball_path, supports_auto_install,
-        swap_new_binary_into_place, verify_sha256, BACKUP_BINARY_NAME,
-        NEW_BINARY_NAME, SUPPORTED_SM_ARCHS, UPDATE_STAGING_DIR,
+        is_supported_sm_for_release, is_update_available, parse_compute_cap,
+        parse_kiln_version_output, parse_supported_sm, release_archive_ext,
+        release_asset_name, release_download_url, rollback_to_bak,
+        staging_tarball_path, supports_auto_install, swap_new_binary_into_place,
+        verify_sha256, BACKUP_BINARY_NAME, NEW_BINARY_NAME, SUPPORTED_SM_ARCHS,
+        UPDATE_STAGING_DIR,
     };
     use std::io::Write;
     use std::path::PathBuf;
@@ -2129,5 +2220,71 @@ mod tests {
         // unknown-but-parseable arch still surfaces to the caller.
         assert_eq!(parse_compute_cap("7.5\n"), Some(75));
         assert!(!is_supported_sm(75));
+    }
+
+    #[test]
+    fn parse_supported_sm_bracketed() {
+        assert_eq!(
+            parse_supported_sm("foo\nsupported_sm: [80, 86, 89, 90]\nbar"),
+            Some(vec![80, 86, 89, 90]),
+        );
+    }
+
+    #[test]
+    fn parse_supported_sm_unbracketed() {
+        assert_eq!(
+            parse_supported_sm("supported_sm: 80, 86"),
+            Some(vec![80, 86]),
+        );
+    }
+
+    #[test]
+    fn parse_supported_sm_literal_backslash_n() {
+        // `gh release create --notes "..."` passes its argument verbatim,
+        // so workflow-emitted bodies may contain literal `\n` (two
+        // characters: backslash + n) between fields instead of real
+        // newlines. Normalization must handle that form too.
+        let body =
+            "Prebuilt kiln binaries for kiln-v1.0.0. See README for platforms.\\n\\nsupported_sm: [80, 86, 89, 90]";
+        assert_eq!(
+            parse_supported_sm(body),
+            Some(vec![80, 86, 89, 90]),
+        );
+    }
+
+    #[test]
+    fn parse_supported_sm_extra_whitespace() {
+        assert_eq!(
+            parse_supported_sm("  supported_sm:   [ 80 , 89 ]  "),
+            Some(vec![80, 89]),
+        );
+    }
+
+    #[test]
+    fn parse_supported_sm_missing_returns_none() {
+        assert_eq!(parse_supported_sm("any text"), None);
+    }
+
+    #[test]
+    fn parse_supported_sm_unparseable_element_returns_none() {
+        assert_eq!(parse_supported_sm("supported_sm: [80, abc]"), None);
+    }
+
+    #[test]
+    fn parse_supported_sm_empty_list_returns_none() {
+        assert_eq!(parse_supported_sm("supported_sm: []"), None);
+    }
+
+    #[test]
+    fn is_supported_sm_for_release_uses_parsed() {
+        let body = "notes\nsupported_sm: [120]\n";
+        assert!(is_supported_sm_for_release(120, Some(body)));
+        assert!(!is_supported_sm_for_release(86, Some(body)));
+    }
+
+    #[test]
+    fn is_supported_sm_for_release_falls_back() {
+        assert!(is_supported_sm_for_release(86, None));
+        assert!(!is_supported_sm_for_release(75, None));
     }
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -522,15 +522,18 @@ async fn check_for_kiln_update(
     };
 
     let platform_supported = installer::supports_auto_install();
-    let latest = if platform_supported {
+    let (latest, release_body) = if platform_supported {
         let client = reqwest::Client::builder()
             .user_agent(concat!("kiln-desktop/", env!("CARGO_PKG_VERSION")))
             .connect_timeout(std::time::Duration::from_secs(15))
             .build()
             .map_err(|e| format!("build reqwest client: {}", e))?;
-        installer::discover_latest_version(&client).await
+        match installer::discover_latest_version_and_body(&client).await {
+            Some((v, b)) => (Some(v), b),
+            None => (None, None),
+        }
     } else {
-        None
+        (None, None)
     };
 
     let mut update_available = match &latest {
@@ -538,15 +541,23 @@ async fn check_for_kiln_update(
         None => false,
     };
 
-    // GPU arch compat gate (slice 6): if nvidia-smi reports a compute
-    // capability outside `installer::SUPPORTED_SM_ARCHS`, refuse to offer
-    // the update. Unknown detection (no nvidia-smi, timeout, etc.) is
-    // NOT a block — preserve existing behavior on systems without
-    // nvidia-smi. See `desktop/docs/binary-update.md` (CUDA / GPU compat).
+    // GPU arch compat gate (slices 6 + 7): `gpu_compat` rejects arches
+    // outside the compiled-in `SUPPORTED_SM_ARCHS`, but slice 7 lets
+    // each release widen that list via a machine-readable
+    // `supported_sm: [...]` line in its notes. Reclassify an
+    // `Unsupported` verdict to `Supported` when the release-specific
+    // list includes the detected arch. Unknown detection (no nvidia-smi,
+    // timeout, etc.) is NOT a block — preserve existing behavior on
+    // systems without nvidia-smi. See
+    // `desktop/docs/binary-update.md` (CUDA / GPU compat).
     let gpu_unsupported = match installer::gpu_compat().await {
         installer::GpuCompat::Unsupported(sm) => {
-            update_available = false;
-            Some(sm)
+            if installer::is_supported_sm_for_release(sm, release_body.as_deref()) {
+                None
+            } else {
+                update_available = false;
+                Some(sm)
+            }
         }
         installer::GpuCompat::Supported(_) | installer::GpuCompat::Unknown => None,
     };
@@ -608,7 +619,9 @@ async fn check_kiln_update_on_launch(app: AppHandle, settings: SettingsState) {
         }
     };
 
-    let Some(latest) = installer::discover_latest_version(&client).await else {
+    let Some((latest, release_body)) =
+        installer::discover_latest_version_and_body(&client).await
+    else {
         return;
     };
 
@@ -616,17 +629,22 @@ async fn check_kiln_update_on_launch(app: AppHandle, settings: SettingsState) {
         return;
     }
 
-    // GPU arch compat gate (slice 6): silently skip the banner when the
-    // local GPU's SM arch is outside `installer::SUPPORTED_SM_ARCHS`.
-    // Unknown detection is treated as supported — the check_for_kiln_update
-    // command path still surfaces the compat state to the settings UI when
-    // the user clicks "Check for Updates".
+    // GPU arch compat gate (slices 6 + 7): silently skip the banner when
+    // the local GPU's SM arch is outside the supported list for this
+    // release. The list comes from the release-notes `supported_sm:`
+    // line when present, otherwise falls back to
+    // `installer::SUPPORTED_SM_ARCHS`. Unknown detection is treated as
+    // supported — the check_for_kiln_update command path still surfaces
+    // the compat state to the settings UI when the user clicks "Check
+    // for Updates".
     if let installer::GpuCompat::Unsupported(sm) = installer::gpu_compat().await {
-        eprintln!(
-            "[main] auto_update: skipping — GPU SM {} not supported",
-            sm
-        );
-        return;
+        if !installer::is_supported_sm_for_release(sm, release_body.as_deref()) {
+            eprintln!(
+                "[main] auto_update: skipping — GPU SM {} not supported",
+                sm
+            );
+            return;
+        }
     }
 
     if let Err(e) = app.emit(


### PR DESCRIPTION
## Summary

Slice 7 of the kiln binary updater per `desktop/docs/binary-update.md`
(lines 260-280). Slice 6 (#218) shipped a hardcoded `SUPPORTED_SM_ARCHS`
gate; this slice lets each release widen or narrow the supported-SM
list via a machine-readable `supported_sm:` line in its notes, so the
list moves with the release rather than being pinned to the desktop
app version.

- `installer::Release` now deserializes `body: Option<String>` from
  the GitHub releases API and carries it forward on `AssetPair.release_body`.
- `installer::parse_supported_sm(body)` parses the `supported_sm: [...]`
  convention (bracketed or unbracketed, whitespace-tolerant, strict
  lowercase key). Returns `None` on missing key, unparseable element,
  or empty list so callers fall back to the compiled-in default.
- `installer::supported_sm_for_release(body)` picks parsed-or-fallback.
  `installer::is_supported_sm_for_release(arch, body)` is the thin
  wrapper used by the gate.
- `installer::discover_latest_version_and_body(client)` returns the
  latest `(version, Option<body>)` for the current target so callers
  don't need a second `discover_asset` call.
- `main::check_for_kiln_update` and `main::check_kiln_update_on_launch`
  now reclassify a `GpuCompat::Unsupported(sm)` verdict to supported
  when the release-specific list includes the detected arch — so a
  release whose notes say `supported_sm: [120]` will pass on a
  Blackwell host even though the compiled-in list still rejects SM 120.
- `.github/workflows/server-release.yml` appends
  `\n\nsupported_sm: [80, 86, 89, 90]` to the three `--notes` strings
  (Linux + macOS bash, Windows PowerShell) so future releases advertise
  the list in a machine-readable form.

### Note on line terminators

`gh release create --notes "..."` passes the string verbatim (no
escape-sequence processing), so CI-emitted bodies contain literal
`\n` (two characters) rather than real newlines. The parser
normalizes `\\n` → `\n` before scanning, which lets it handle both
CI-emitted bodies and hand-written release notes. There is a dedicated
test (`parse_supported_sm_literal_backslash_n`) covering the CI shape.

## Validation

Pure-helper tests validated via scratch cargo crate (Cloud Eric
sandbox can't `cargo check` Tauri crates — GTK/webkit2gtk missing,
per agent note `tauri-cargo-check-gtk-missing`). Same approach slice 6
used.

```
running 9 tests
test tests::is_supported_sm_for_release_falls_back ... ok
test tests::is_supported_sm_for_release_uses_parsed ... ok
test tests::parse_supported_sm_bracketed ... ok
test tests::parse_supported_sm_empty_list_returns_none ... ok
test tests::parse_supported_sm_extra_whitespace ... ok
test tests::parse_supported_sm_literal_backslash_n ... ok
test tests::parse_supported_sm_missing_returns_none ... ok
test tests::parse_supported_sm_unbracketed ... ok
test tests::parse_supported_sm_unparseable_element_returns_none ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

Full `cargo check` of the desktop crate skipped per sandbox limitation.

## Files

- `desktop/src/installer.rs` — add `Release.body` / `AssetPair.release_body`,
  `parse_supported_sm`, `supported_sm_for_release`,
  `is_supported_sm_for_release`, `discover_latest_version_and_body`, and
  8 new unit tests.
- `desktop/src/main.rs` — pipe `release_body` through
  `check_for_kiln_update` and `check_kiln_update_on_launch`; reclassify
  `Unsupported` to supported when the per-release list covers the arch.
- `.github/workflows/server-release.yml` — append
  `supported_sm: [80, 86, 89, 90]` to all three `--notes` strings.

The GPU-compat gate now consults per-release `supported_sm` with the
hardcoded `SUPPORTED_SM_ARCHS` as fallback.
