### PR TITLE
desktop: updater slice 8 — min_cuda gate

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -137,7 +137,7 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --draft \
               --title "Kiln server $TAG" \
-              --notes "Prebuilt \`kiln\` server binaries for $TAG. See the repository README for supported platforms.\n\nsupported_sm: [80, 86, 89, 90]"
+              --notes "Prebuilt \`kiln\` server binaries for $TAG. See the repository README for supported platforms.\n\nsupported_sm: [80, 86, 89, 90]\nmin_cuda: 12.4"
           fi
           gh release upload "$TAG" "$ARTIFACT" "$ARTIFACT.sha256" \
             --repo "$GITHUB_REPOSITORY" --clobber
@@ -235,7 +235,7 @@ jobs:
               --repo "$GITHUB_REPOSITORY" \
               --draft \
               --title "Kiln server $TAG" \
-              --notes "Prebuilt \`kiln\` server binaries for $TAG. See the repository README for supported platforms.\n\nsupported_sm: [80, 86, 89, 90]"
+              --notes "Prebuilt \`kiln\` server binaries for $TAG. See the repository README for supported platforms.\n\nsupported_sm: [80, 86, 89, 90]\nmin_cuda: 12.4"
           fi
           gh release upload "$TAG" "$ARTIFACT" "$ARTIFACT.sha256" \
             --repo "$GITHUB_REPOSITORY" --clobber
@@ -323,7 +323,7 @@ jobs:
               --repo "$env:GITHUB_REPOSITORY" `
               --draft `
               --title "Kiln server $env:TAG" `
-              --notes "Prebuilt ``kiln`` server binaries for $env:TAG. See the repository README for supported platforms.\n\nsupported_sm: [80, 86, 89, 90]"
+              --notes "Prebuilt ``kiln`` server binaries for $env:TAG. See the repository README for supported platforms.\n\nsupported_sm: [80, 86, 89, 90]\nmin_cuda: 12.4"
           }
           gh release upload "$env:TAG" "$env:ARTIFACT" "$env:ARTIFACT.sha256" `
             --repo "$env:GITHUB_REPOSITORY" --clobber

--- a/desktop/src/installer.rs
+++ b/desktop/src/installer.rs
@@ -949,6 +949,135 @@ pub async fn gpu_compat() -> GpuCompat {
     }
 }
 
+/// Parse `min_cuda: 12.4` (or `min_cuda: 12`) from release-notes body.
+/// Returns `Some((major, minor))` when the key is present and parseable,
+/// `None` when the key is absent, empty, or unparseable. A bare major
+/// (`min_cuda: 12`) is normalized to `(12, 0)`.
+///
+/// Mirrors [`parse_supported_sm`] for line-terminator handling: `gh
+/// release create --notes "..."` passes the string verbatim without
+/// escape-sequence processing, so bodies emitted by CI may contain
+/// literal `\n` (two characters) between fields rather than real
+/// newlines. Both forms are normalized before key scanning.
+pub fn parse_min_cuda(body: &str) -> Option<(u32, u32)> {
+    let normalized = body.replace("\\n", "\n");
+    for line in normalized.lines() {
+        let trimmed = line.trim();
+        let Some(rest) = trimmed.strip_prefix("min_cuda:") else {
+            continue;
+        };
+        let token = rest.trim();
+        if token.is_empty() {
+            return None;
+        }
+        return match token.split_once('.') {
+            Some((major_s, minor_s)) => {
+                let major: u32 = major_s.trim().parse().ok()?;
+                let minor: u32 = minor_s.trim().parse().ok()?;
+                Some((major, minor))
+            }
+            None => {
+                let major: u32 = token.parse().ok()?;
+                Some((major, 0))
+            }
+        };
+    }
+    None
+}
+
+/// Pick the minimum-CUDA requirement for a release from its notes body.
+/// Passes through to [`parse_min_cuda`]; returns `None` when no
+/// `min_cuda:` line is present so callers treat the release as
+/// CUDA-agnostic (no gate).
+pub fn min_cuda_for_release(body: Option<&str>) -> Option<(u32, u32)> {
+    body.and_then(parse_min_cuda)
+}
+
+/// Whether the local CUDA driver version `local` satisfies the release's
+/// `min_cuda:` requirement parsed from `body`. Returns `true` when:
+/// - `body` has no `min_cuda:` line (CUDA-agnostic release, no gate), or
+/// - `local` is `None` (detection failed — preserve the no-block policy
+///   applied to [`GpuCompat::Unknown`] so systems without `nvidia-smi`
+///   are not locked out), or
+/// - `local >= required` by lexicographic `(major, minor)` comparison.
+///
+/// Returns `false` only when the release advertises a `min_cuda:` AND
+/// the local driver was detected AND the local version is strictly
+/// older.
+pub fn is_cuda_compatible_for_release(
+    local: Option<(u32, u32)>,
+    body: Option<&str>,
+) -> bool {
+    let Some(required) = min_cuda_for_release(body) else {
+        return true;
+    };
+    let Some(local) = local else {
+        return true;
+    };
+    local >= required
+}
+
+/// Parse `nvidia-smi` stdout (plain invocation, no args) for the
+/// "CUDA Version: X.Y" token in the header line. Returns
+/// `Some((major, minor))` on success, `None` when the line is absent or
+/// unparseable. Tolerates arbitrary whitespace around the token.
+///
+/// Typical header shape:
+/// `| NVIDIA-SMI 535.86.10   Driver Version: 535.86.10   CUDA Version: 12.2     |`
+pub fn parse_cuda_driver_version(stdout: &str) -> Option<(u32, u32)> {
+    for line in stdout.lines() {
+        let Some(idx) = line.find("CUDA Version:") else {
+            continue;
+        };
+        let after = &line[idx + "CUDA Version:".len()..];
+        // The next whitespace-delimited token is the version. Strip any
+        // trailing `|` or other table-border punctuation before parsing.
+        let token = after.split_whitespace().next()?;
+        let cleaned: String = token
+            .chars()
+            .take_while(|c| c.is_ascii_digit() || *c == '.')
+            .collect();
+        if cleaned.is_empty() {
+            return None;
+        }
+        return match cleaned.split_once('.') {
+            Some((major_s, minor_s)) => {
+                let major: u32 = major_s.parse().ok()?;
+                let minor: u32 = minor_s.parse().ok()?;
+                Some((major, minor))
+            }
+            None => {
+                let major: u32 = cleaned.parse().ok()?;
+                Some((major, 0))
+            }
+        };
+    }
+    None
+}
+
+/// Invoke plain `nvidia-smi` (no args) and parse the CUDA driver version
+/// from its header. Returns `None` when the command fails to spawn,
+/// exits non-zero, times out (5s), or produces unparseable output. On
+/// macOS this always returns `None` — no nvidia-smi, no CUDA.
+#[cfg(not(target_os = "macos"))]
+pub async fn detect_cuda_driver_version() -> Option<(u32, u32)> {
+    let fut = tokio::process::Command::new("nvidia-smi").output();
+    let out = tokio::time::timeout(std::time::Duration::from_secs(5), fut)
+        .await
+        .ok()?
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    parse_cuda_driver_version(&stdout)
+}
+
+#[cfg(target_os = "macos")]
+pub async fn detect_cuda_driver_version() -> Option<(u32, u32)> {
+    None
+}
+
 /// Download the release tarball for `version` to the staging path under
 /// `<app_data_dir>/kiln-updates/`. Does NOT extract, verify sha256, or
 /// touch the running kiln binary — that is slice 3 of
@@ -1569,9 +1698,11 @@ pub async fn install_staged_update(
 mod tests {
     use super::{
         backup_binary_path, cleanup_bak, current_target, extract_tarball_to,
-        extracted_new_binary_path, installed_binary_path, is_supported_sm,
-        is_supported_sm_for_release, is_update_available, parse_compute_cap,
-        parse_kiln_version_output, parse_supported_sm, release_archive_ext,
+        extracted_new_binary_path, installed_binary_path,
+        is_cuda_compatible_for_release, is_supported_sm,
+        is_supported_sm_for_release, is_update_available, min_cuda_for_release,
+        parse_compute_cap, parse_cuda_driver_version, parse_kiln_version_output,
+        parse_min_cuda, parse_supported_sm, release_archive_ext,
         release_asset_name, release_download_url, rollback_to_bak,
         staging_tarball_path, supports_auto_install, swap_new_binary_into_place,
         verify_sha256, BACKUP_BINARY_NAME, NEW_BINARY_NAME, SUPPORTED_SM_ARCHS,
@@ -2286,5 +2417,131 @@ mod tests {
     fn is_supported_sm_for_release_falls_back() {
         assert!(is_supported_sm_for_release(86, None));
         assert!(!is_supported_sm_for_release(75, None));
+    }
+
+    #[test]
+    fn parse_min_cuda_basic() {
+        assert_eq!(parse_min_cuda("min_cuda: 12.4"), Some((12, 4)));
+    }
+
+    #[test]
+    fn parse_min_cuda_bare_major() {
+        assert_eq!(parse_min_cuda("min_cuda: 12"), Some((12, 0)));
+    }
+
+    #[test]
+    fn parse_min_cuda_literal_backslash_n() {
+        let body =
+            "Prebuilt kiln binaries for kiln-v1.0.0. See README.\\n\\nsupported_sm: [80, 86, 89, 90]\\nmin_cuda: 12.4";
+        assert_eq!(parse_min_cuda(body), Some((12, 4)));
+    }
+
+    #[test]
+    fn parse_min_cuda_absent() {
+        assert_eq!(parse_min_cuda("any text without the key"), None);
+    }
+
+    #[test]
+    fn parse_min_cuda_malformed() {
+        assert_eq!(parse_min_cuda("min_cuda: abc"), None);
+        assert_eq!(parse_min_cuda("min_cuda: 12.abc"), None);
+        assert_eq!(parse_min_cuda("min_cuda:"), None);
+    }
+
+    #[test]
+    fn parse_min_cuda_extra_whitespace() {
+        assert_eq!(parse_min_cuda("  min_cuda:   12.4  "), Some((12, 4)));
+    }
+
+    #[test]
+    fn min_cuda_for_release_passthrough() {
+        assert_eq!(
+            min_cuda_for_release(Some("notes\nmin_cuda: 12.4\n")),
+            Some((12, 4))
+        );
+        assert_eq!(min_cuda_for_release(Some("no key")), None);
+        assert_eq!(min_cuda_for_release(None), None);
+    }
+
+    #[test]
+    fn parse_cuda_driver_version_smi_header() {
+        let out = "+-----------------------------------------------------------------------------------------+\n\
+                   | NVIDIA-SMI 535.86.10   Driver Version: 535.86.10   CUDA Version: 12.2     |\n\
+                   |-----------------------------------------+------------------------+----------------------+";
+        assert_eq!(parse_cuda_driver_version(out), Some((12, 2)));
+    }
+
+    #[test]
+    fn parse_cuda_driver_version_bare_major() {
+        let out = "| Driver Version: 550.00   CUDA Version: 12     |";
+        assert_eq!(parse_cuda_driver_version(out), Some((12, 0)));
+    }
+
+    #[test]
+    fn parse_cuda_driver_version_missing() {
+        let out = "+---------+\n| no cuda token here |\n+---------+";
+        assert_eq!(parse_cuda_driver_version(out), None);
+    }
+
+    #[test]
+    fn parse_cuda_driver_version_malformed() {
+        let out = "| CUDA Version: abc |";
+        assert_eq!(parse_cuda_driver_version(out), None);
+    }
+
+    #[test]
+    fn is_cuda_compatible_for_release_no_body() {
+        assert!(is_cuda_compatible_for_release(Some((11, 8)), None));
+        assert!(is_cuda_compatible_for_release(None, None));
+    }
+
+    #[test]
+    fn is_cuda_compatible_for_release_no_local() {
+        // Detection failed → do not block the update.
+        assert!(is_cuda_compatible_for_release(
+            None,
+            Some("min_cuda: 12.4"),
+        ));
+    }
+
+    #[test]
+    fn is_cuda_compatible_for_release_older_local() {
+        assert!(!is_cuda_compatible_for_release(
+            Some((11, 8)),
+            Some("min_cuda: 12.4"),
+        ));
+        assert!(!is_cuda_compatible_for_release(
+            Some((12, 3)),
+            Some("min_cuda: 12.4"),
+        ));
+    }
+
+    #[test]
+    fn is_cuda_compatible_for_release_newer_local() {
+        assert!(is_cuda_compatible_for_release(
+            Some((12, 6)),
+            Some("min_cuda: 12.4"),
+        ));
+        assert!(is_cuda_compatible_for_release(
+            Some((13, 0)),
+            Some("min_cuda: 12.4"),
+        ));
+    }
+
+    #[test]
+    fn is_cuda_compatible_for_release_equal() {
+        assert!(is_cuda_compatible_for_release(
+            Some((12, 4)),
+            Some("min_cuda: 12.4"),
+        ));
+    }
+
+    #[test]
+    fn is_cuda_compatible_for_release_body_without_key() {
+        // Release without a min_cuda: line is treated as CUDA-agnostic.
+        assert!(is_cuda_compatible_for_release(
+            Some((11, 0)),
+            Some("supported_sm: [80, 86]"),
+        ));
     }
 }

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -499,6 +499,13 @@ struct KilnUpdateCheckResult {
     /// unknown (no nvidia-smi, detection failed), or irrelevant (macOS).
     /// See `desktop/docs/binary-update.md` (CUDA / GPU compat).
     gpu_unsupported: Option<u32>,
+    /// `Some(reason)` when the release advertises a `min_cuda:` that
+    /// the local CUDA driver (from `nvidia-smi` header) is older than.
+    /// `None` when the release is CUDA-agnostic, detection failed, or
+    /// the local driver meets the minimum. Mirrors `gpu_unsupported`:
+    /// the UI should surface a warn pill and disable the Download
+    /// button. See `desktop/docs/binary-update.md` (CUDA / GPU compat).
+    cuda_driver_too_old: Option<String>,
 }
 
 /// Detection-only check for a newer kiln binary release. Looks up the
@@ -562,12 +569,39 @@ async fn check_for_kiln_update(
         installer::GpuCompat::Supported(_) | installer::GpuCompat::Unknown => None,
     };
 
+    // CUDA driver compat gate (slice 8): if the release advertises a
+    // `min_cuda:` line in its notes AND we can detect the local driver's
+    // CUDA version via `nvidia-smi`, refuse the update when local < min.
+    // Missing `min_cuda:` (CUDA-agnostic release) or failed detection
+    // (no nvidia-smi, timeout) preserves the no-block policy applied to
+    // `GpuCompat::Unknown`. See `desktop/docs/binary-update.md` (CUDA /
+    // GPU compat).
+    let cuda_driver_too_old = if gpu_unsupported.is_none() && update_available {
+        let local = installer::detect_cuda_driver_version().await;
+        if !installer::is_cuda_compatible_for_release(local, release_body.as_deref()) {
+            let req = installer::min_cuda_for_release(release_body.as_deref())
+                .expect("min_cuda must be Some when compat check failed");
+            let local =
+                local.expect("local driver must be Some when compat check failed");
+            update_available = false;
+            Some(format!(
+                "This kiln release requires CUDA >= {}.{}; local driver supports CUDA {}.{}.",
+                req.0, req.1, local.0, local.1
+            ))
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
     Ok(KilnUpdateCheckResult {
         current,
         latest,
         update_available,
         platform_supported,
         gpu_unsupported,
+        cuda_driver_too_old,
     })
 }
 
@@ -645,6 +679,23 @@ async fn check_kiln_update_on_launch(app: AppHandle, settings: SettingsState) {
             );
             return;
         }
+    }
+
+    // CUDA driver compat gate (slice 8): mirror check_for_kiln_update —
+    // skip the banner when the release advertises a `min_cuda:` newer
+    // than the local driver. Missing `min_cuda:` or failed detection
+    // does not block, matching the SM-gate policy on unknown state.
+    let local_cuda = installer::detect_cuda_driver_version().await;
+    if !installer::is_cuda_compatible_for_release(local_cuda, release_body.as_deref()) {
+        let req = installer::min_cuda_for_release(release_body.as_deref())
+            .expect("min_cuda must be Some when compat check failed");
+        let local =
+            local_cuda.expect("local driver must be Some when compat check failed");
+        eprintln!(
+            "[main] auto_update: skipping — release requires CUDA >= {}.{}, local {}.{}",
+            req.0, req.1, local.0, local.1
+        );
+        return;
     }
 
     if let Err(e) = app.emit(


### PR DESCRIPTION
## Slice 8: `min_cuda` gate

Parses `min_cuda:` from release-notes body and refuses updates when the local CUDA driver (from `nvidia-smi` header) is older than the release's minimum. Companion to slice 7 (SM arch gate, #220).

Per `desktop/docs/binary-update.md` lines 262-274.

### Changes

**`desktop/src/installer.rs`**
- `parse_min_cuda(body) -> Option<(u32, u32)>` — parses `min_cuda: 12.4` or bare `min_cuda: 12` (→ `(12, 0)`); normalizes literal `\n` → `\n` like `parse_supported_sm`.
- `parse_cuda_driver_version(stdout) -> Option<(u32, u32)>` — scans `nvidia-smi` header for `CUDA Version: X.Y`.
- `detect_cuda_driver_version()` (async) — runs plain `nvidia-smi` with 5s timeout; macOS stub returns `None`.
- `min_cuda_for_release(body)` — passthrough to `parse_min_cuda`.
- `is_cuda_compatible_for_release(local, body)` — `true` when release is CUDA-agnostic, detection failed, or `local >= required`; `false` only when both parse AND `local < required`.

**`desktop/src/main.rs`**
- `KilnUpdateCheckResult.cuda_driver_too_old: Option<String>` — reason text when gate fires.
- `check_for_kiln_update` now runs the CUDA gate after the SM gate; sets `update_available = false` and populates the reason on mismatch.
- `check_kiln_update_on_launch` mirrors the gate — silently skips the banner emit.

**`.github/workflows/server-release.yml`**
- All three `--notes` sites (macOS aarch64, Linux x86_64 CUDA, Windows x86_64 CUDA) now append `\nmin_cuda: 12.4`.

### Policy preserved

- No-block on unknown detection: `local = None` (no `nvidia-smi`, timeout, non-zero exit) is treated as compatible — mirrors `GpuCompat::Unknown` policy from the SM gate.
- CUDA-agnostic releases (no `min_cuda:` line) are never blocked.

### Tests

Added 16 unit tests in `installer.rs` covering basic parse, bare major, literal `\n` normalization, absent/malformed inputs, whitespace tolerance, passthrough, `nvidia-smi` header parsing (full table header + bare major + missing + malformed), and the full compat matrix (no body, no local, older/newer/equal, body without key).

Validated via scratch crate (Tauri + GTK libs are unavailable in the sandbox, so `cargo check` in `desktop/` fails on system deps — this is the documented workflow from slices 1-7). All 17 scratch-crate tests pass.