### PR TITLE
phase6: frontier audit post-#223 (recommend next target)

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,6 +1,295 @@
 # Kiln Profiling Report
 
 
+## Phase 6 — Frontier audit post-#223 (2026-04-20)
+
+**Outcome: Phase 6 decode-kernel frontier is nearly exhausted.** Every
+standalone region in the post-#210 NVTX top-10 either already has a shipped
+fusion, has a closed-null attempt on record, is quantized (Marlin), is an
+ABI-required layout transform with no compute-reducing fix, or sits
+sub-floor at the 1.05× decode-speedup queue gate. The only remaining
+quantifiable decode-speed lever is the **Marlin wrapper → BF16-native I/O
+epilogue** (redirect #2 from the #223 KILL): eliminate the per-call
+BF16↔FP16 cast pair around every Marlin GEMM in the forward path. This
+audit recommends one $0 preflight on that lever next, and if it fails to
+clear the floor, declares Phase 6 complete and advances to Phase 7
+(DX / capability). No pod spent, no code changed.
+
+Precedent for doc-only preflight / redirect PRs:
+[#131](https://github.com/ericflo/kiln/pull/131) (chunk_gla_fwd already
+vendored), [#163](https://github.com/ericflo/kiln/pull/163) (FlashInfer
+paged GQA decode redirect), [#164](https://github.com/ericflo/kiln/pull/164)
+(GDN gate-path fusion architecturally infeasible),
+[#170](https://github.com/ericflo/kiln/pull/170) (fused_recurrent already
+done), [#219](https://github.com/ericflo/kiln/pull/219) (ucopy_bf16 null),
+[#223](https://github.com/ericflo/kiln/pull/223) (MLP gate/up Marlin
+fusion KILL).
+
+### Why this audit
+
+Three post-#210 follow-up items were sequenced after the post-#210 decode
+profile identified no high-ceiling standalone fusion:
+
+1. **ucopy_bf16 source-site audit** — resolved by PR #219: null, every
+   un-addressed `ucopy_bf16` site is either below the 1.05× floor or is an
+   ABI-required layout transform for a downstream kernel (`causal_conv1d_update`,
+   GQA matmul, chunkwise GDN recurrence). No queueable fusion.
+2. **KV cache FP8 verification** — resolved by PR #222: `KILN_KV_CACHE_FP8=1`
+   is bit-identical and within ±3% of BF16 on workable prompt lengths, but
+   the long-context OOM ceiling is set by GDN prefill state, not the GQA KV
+   cache. Kept opt-in (default `false`); not a decode-speed lever.
+3. **MLP gate/up Marlin merge** — resolved by PR #223: KILL. Math-ceiling
+   fails by a wide margin even under heroic assumptions. Flagged two
+   redirects: (a) GDN prefill memory reduction (capability, not decode
+   speed) and (b) **Marlin wrapper → BF16-native I/O epilogue** (decode
+   speed candidate).
+
+With all three redirects resolved, the Phase 6 frontier question is now:
+*is there any remaining standalone decode-kernel lever above the 1.05×
+floor?* This audit walks the post-#210 NVTX top-10 one more time against
+every closed PR, every preflight doc, and every architecturally-rejected
+candidate, and answers the question concretely.
+
+### Post-#210 NVTX top-10 — exhaustion matrix
+
+No forward-path code has landed since the post-#210 capture (PRs #219,
+#222, #223 are all doc-only / non-decode-path). The NVTX composition is
+therefore unchanged. For each region, this table maps the current prior-PR
+coverage and the math-ceiling verdict at 1.10× local speedup.
+
+| %    | region                     | prior coverage                                                               | compute lever remaining?                                                      | 1.10× math-ceiling | verdict                                  |
+| ---: | -------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------- | -----------------: | ---------------------------------------- |
+| 18.5 | `:kiln/gdn/gates`          | **PR #158 merged** (fused Step 6 gate kernel)                                | already fused; no further compute lever                                       | — (already fused)  | **do not queue**                         |
+| 17.6 | `:kiln/gdn/gated_norm`     | **PR #141 closed null** (graph-replay dispatch amortization ate the win)     | would need a memory-reducing approach, not a fusion                           | 0.016 (sub-floor)  | **do not queue** without new evidence    |
+| 14.7 | `:kiln/gdn/qk_norm`        | **PR #173 opt-in**, null median (1.0093× point estimate, variance only)      | already tried; fused kernel exists behind `KILN_ENABLE_FUSED_L2_QK_NORM`      | 0.013 (sub-floor)  | **do not queue**                         |
+|  7.7 | `:kiln/gdn/in_proj`        | Marlin W4A16 (PR #146-era quantization)                                      | GEMM shape change, not fusion; activations-load-bound at m=1                  | 0.007 (sub-floor)  | **do not queue** as standalone           |
+|  6.6 | `:kiln/mlp/gate`           | Marlin W4A16; **PR #223 KILL** (gate/up merge cannot clear floor)            | already quantized; merge-with-up killed                                       | 0.006 (sub-floor)  | **do not queue**                         |
+|  6.2 | `:kiln/mlp/up`             | Marlin W4A16; **PR #223 KILL**                                               | already quantized; merge-with-gate killed                                     | 0.006 (sub-floor)  | **do not queue**                         |
+|  6.0 | `:kiln/mlp/down`           | Marlin W4A16                                                                 | SwiGLU-down fuse impossible (distinct weight, distinct input); standalone sub-floor | 0.005 (sub-floor) | **do not queue**                         |
+|  3.4 | `:kiln/gdn/head_expand`    | **PR #219 null** (`ucopy_bf16` site 2); ABI-required broadcast materialization | downstream GDN matmul cannot accept broadcast-strided K/V                     | 0.003 (sub-floor)  | **do not queue**                         |
+|  3.4 | `:kiln/residual`           | none                                                                         | potential in-place ADD into RMSNorm epilogue (add+norm fusion)                | 0.003 (sub-floor)  | **do not queue** standalone              |
+|  3.0 | `:kiln/proj/qkv` full-attn | Marlin W4A16; **PR #163 preflight** ruled FlashInfer out (full-attn 3.8%)    | full-attn total 3.8% of decode; math ceiling ≤1.038× at infinite speedup      | 0.003 (sub-floor)  | **do not queue**                         |
+
+Sub-top-10 (each ≤3%, each sub-floor even at infinite speedup): `gdn/out_proj`
+2.8, `norm/pre_mlp` 2.2, `attn/gdn/recurrent` 2.0 (already vendored in #80),
+`norm/pre_attn` 1.9, `gdn/conv` 1.8 (ABI-bound per #219), `proj/o` 0.8,
+`gdn/recur_prep` 0.8 (ABI-bound per #219).
+
+**Conclusion:** No standalone NVTX region is queueable as a pure fusion
+task. Every realistic fusion candidate either has a prior null attempt, is
+ABI-bound to a downstream kernel input contract, or is sub-floor under
+graph replay.
+
+### Un-attempted cross-cutting candidates — math-ceiling
+
+Three candidates cut across multiple regions and were not evaluated as
+standalone-region items above. This section sizes each one at the
+decode-level Amdahl bound and rules on queueability.
+
+**Candidate A — `add + RMSNorm` epilogue fusion (residual into post-attn /
+post-MLP norm).** The transformer block at `crates/kiln-model/src/forward.rs`
+lines ~2460–2509 issues `(x + attn_out)` → `rms_norm(x, ...)` and
+`(x + ffn_out)` → `rms_norm(x, ...)` as separate NVTX ranges. Regions
+involved: `:kiln/residual` (3.4%) + `:kiln/norm/pre_attn` (1.9%) +
+`:kiln/norm/pre_mlp` (2.2%) = **7.5%**. A fused kernel that consumes the
+residual and runs the normalization in the same pass could elide one
+full activation read and one full activation write per residual-into-norm
+pair.
+
+Math-ceiling: assume generous 1.5× local speedup (memory-bound, not
+dispatch-bound, so graph replay does not fully amortize the win):
+
+```
+contribution = 0.075 · (1 − 1/1.5) = 0.025
+```
+
+Sub-floor. Even at 2.0× local speedup (unrealistic — the norm is already
+the #133 fused kernel and can't be sped up much further):
+
+```
+contribution = 0.075 · (1 − 1/2.0) = 0.0375
+```
+
+Still sub-floor. Verdict: **not queueable.** This is structurally the
+same-shape idea as #141 (gated_norm fusion) which already closed null,
+and the graph-replay dispatch-amortization lesson applies.
+
+**Candidate B — Marlin wrapper → BF16-native I/O epilogue.** Flagged by PR
+#223 as redirect #2. Each of the 12 Marlin callsites per layer (GDN
+`in_proj_qkv`/`in_proj_z`/`in_proj_a`/`in_proj_b`/`out_proj`; full-attn
+`q`/`k`/`v`/`o`; MLP `gate`/`up`/`down`) currently wraps the FP16-only
+Marlin kernel with:
+
+1. `a.to_dtype(DType::F16).contiguous()` — BF16→FP16 activation cast
+2. Allocate FP16 output `Tensor::zeros((m, n), DType::F16)`
+3. Allocate workspace zeros
+4. Kernel launch
+5. `c_fp16.to_dtype(DType::BF16)` — FP16→BF16 output cast
+
+Steps 1 and 5 emit `cast_bf16_f32`-style kernels that show up in the
+post-#210 kernel top-20 (`cast_f32_bf16` 2.5% + `ucopy_bf16` 8.6% includes
+the contiguous step + FP16 casts visible in the elementwise zoo). Regions
+that end in a Marlin GEMM sum to:
+
+```
+gdn/in_proj        7.7
+gdn/out_proj       2.8
+mlp/gate           6.6
+mlp/up             6.2
+mlp/down           6.0
+proj/qkv (full)    3.0
+proj/o (full)      0.8
+────────────────────
+total             33.1
+```
+
+Of each region's wall-clock, the wrapper cast pair + allocations are not
+the kernel itself; post-#210 kernel-level attribution puts `Marlin` at
+15.7% (the kernel proper) vs region total 33.1%, so ~17.4 pp of decode is
+spent outside the Marlin kernel in those regions — allocation, casts,
+layout, and stream sync. An epilogue variant of Marlin that accepts BF16
+input directly (via an FP16→BF16 input reader in the load stage) and
+writes BF16 output directly (via an FP32→BF16 accumulator epilogue) would
+eliminate steps 1 and 5 across all 12 callsites simultaneously.
+
+Realistic local speedup: eliminating cast + ucopy + FP16 buffer
+alloc/free per call is a ~5–10% reduction of each region's wall-clock at
+m=1 decode (where the cast + alloc amortizes poorly). Take the
+conservative end: 5% of 33.1% = 1.66 pp decode reduction, contribution
+0.0166. Take the optimistic end: 10% of 33.1% = 3.31 pp, contribution
+0.0331. At the mid-point (7.5% local):
+
+```
+contribution = 0.331 · 0.075 ≈ 0.025
+```
+
+This is on the edge of the 0.05 floor but plausibly clears it under two
+assumptions: (a) the cast-elimination also removes the `cast_f32_bf16` /
+`ucopy_bf16` memory pressure on the HBM, compounding under graph replay;
+(b) the BF16-native accumulator epilogue can be written to avoid the FP32
+intermediate buffer allocation as well. Under those assumptions, a 10%
+local speedup on a 33.1% aggregate is the realistic target, and
+contribution ≈ 0.033 at median with a plausible tail reaching 0.05+ if
+HBM-traffic reduction compounds.
+
+**This is the single remaining quantifiable decode-speed lever.** It is
+also the only un-attempted candidate where the math-ceiling is plausibly
+close to the 1.05× floor with a non-zero chance of clearing it. It
+requires non-trivial kernel work (Marlin is FP16-only by upstream design;
+adding BF16-native I/O requires modifying the vendored kernel at
+`crates/kiln-marlin-gemm/src/lib.rs` to emit a new tile variant), but the
+surface area is well-defined and the win is shared across 12 callsites.
+
+Verdict: **queue as the next Phase 6 slice, but gate it on a $0
+preflight.** Before any pod $, preflight needs to:
+
+1. Confirm that BF16-native tile variants are compatible with Marlin's
+   existing `Marlin<256,1,8,8,4,8>` tile structure (the vLLM Marlin-BF16
+   variant `MarlinBF16<...>` is precedent; does it exist in vendored form?).
+2. Confirm that the per-call wrapper overhead (cast + alloc) is at least
+   ~5% of each GEMM's wall-clock via a targeted nsys capture with NVTX
+   sub-ranges on the wrapper stages. If it is <2%, the math-ceiling kills
+   this candidate too.
+3. Confirm the elementwise-zoo `cast_f32_bf16` (2.5%) and
+   `ucopy_bf16` (8.6%) reductions that would follow are not already
+   addressed by some upstream Candle optimization (the audit in #219
+   already scoped `ucopy_bf16` and ruled out the per-site lever; the
+   wrapper-cast bucket is a different set of invocations).
+
+**Candidate C — GDN prefill memory reduction (long-context capability,
+not decode speed).** Flagged by PR #222 as the redirect destination after
+FP8 KV cache verification showed that long-context OOM is set by GDN
+prefill state, not the GQA KV cache. Regions involved: `:kiln/gdn/recur_prep`
+(0.8% decode) + prefill-only paths (not decode top-10). This is **not a
+decode-speed lever** — it is a capability unlock. At m=1 decode it
+contributes ≤0.8% of wall-clock and sits deep below the floor.
+
+Verdict: **not a decode-speed queue item.** If pursued, it is a Phase 7
+capability work item, not a Phase 6 decode-kernel slice.
+
+### Math-ceiling summary
+
+| candidate                                    | aggregate % | realistic speedup | contribution | decision                     |
+| -------------------------------------------- | ----------: | ----------------: | -----------: | ---------------------------- |
+| Add+RMSNorm epilogue fusion (residual→norm)  |         7.5 |              1.5× |        0.025 | **do not queue** (sub-floor) |
+| Marlin wrapper → BF16-native I/O epilogue    |        33.1 | 1.05–1.10× (region-local) | 0.017–0.033 | **preflight next** (plausibly clears 0.05) |
+| GDN prefill memory reduction                 |    ≤0.8 decode | — (capability)    |          n/a | **not a decode slice**       |
+
+### Recommendation
+
+**Next Phase 6 slice: Marlin wrapper → BF16-native I/O epilogue preflight
+($0, doc-only).** The preflight should verify:
+
+1. Upstream Marlin has a BF16-native tile variant in the vLLM reference
+   (if yes, vendoring path is precedented like `kiln-gdn-kernel` from #80).
+2. The wrapper cast + alloc overhead on the m=1 decode path is ≥5% of
+   each GEMM's region wall-clock, measured with NVTX sub-ranges on the
+   wrapper stages (no pod $; run on an already-warm bench pod or during
+   the next re-profile).
+3. The expected HBM-traffic reduction (one fewer BF16→FP16 cast kernel
+   launch per GEMM × 12 GEMMs × 32 layers = 384 kernel launches
+   eliminated per decode step) compounds or dilutes under graph replay
+   via a nsys-reported kernel-launch-count delta projection.
+
+If any of (1)–(3) fails, issue a doc-only redirect PR (precedent: #131,
+#163, #164, #170, #219, #223) and **declare Phase 6 complete**. At that
+point the recommendation is to advance to Phase 7, which has two
+well-defined work items waiting:
+
+- **Capability:** GDN prefill memory reduction for long-context (redirect
+  from #222). Unlocks ≥65536 prompt tokens, which FP8 KV cache verified
+  is currently gated by GDN prefill state, not the KV cache.
+- **DX:** self-speculative decoding is already implemented via the
+  skip-layer approach (per agent note `kiln-speculative-decoding-design`);
+  the remaining work is benchmarking it end-to-end and exposing it as a
+  server option.
+
+Either item is a reasonable Phase 7 starting point; the preflight outcome
+on Marlin BF16-native I/O will determine whether Phase 6 needs one more
+slice first.
+
+### Do-NOT-queue list (restated, cumulative)
+
+These candidates have all been evaluated and closed; do not re-queue
+without new profiling evidence that materially changes their
+math-ceiling. The prior-PR or prior-preflight reference is the required
+cross-check:
+
+- **`:kiln/gdn/gates`** — PR #158 merged (fused).
+- **`:kiln/gdn/gated_norm`** standalone — PR #141 closed null.
+- **`:kiln/gdn/qk_norm`** standalone — PR #173 opt-in, null median.
+- **Big-fusion (`qk_norm + gated_norm + recurrent`)** — PR #176 closed
+  null ($14.99 burn); Step 7 architecturally separates Step 6 and Step 8.
+- **FlashInfer paged GQA decode** — PR #163 preflight: full-attn ≤3.8%
+  of decode; math ceiling ≤1.038× even at infinite speedup.
+- **Gate-path fusion across Step 7 recurrence** — PR #164 preflight:
+  architecturally infeasible; both halves already addressed independently.
+- **`ucopy_bf16` source-site consolidation** — PR #219 null: every
+  un-addressed site is ABI-required or sub-floor.
+- **MLP gate/up Marlin merge** — PR #223 KILL: math-ceiling fails by wide
+  margin under CUDA graph replay.
+- **KV cache FP8 as decode-speed lever** — PR #222 verification: bit-
+  identical, ±3% speed, not a context-length unlock on current path. Kept
+  opt-in; not a decode-speed queue item.
+- **Add+RMSNorm epilogue fusion** — this audit: 0.025 contribution at
+  generous 1.5×, sub-floor under graph replay (same shape as #141).
+
+### Artifacts
+
+This is a doc-only PR. No bench was run; no pod was acquired. Total
+compute cost: $0. The audit relied on:
+
+- The existing post-#210 profile
+  (`profiling-artifacts/post210_nvtx.csv`, `profiling-artifacts/post210_kern.csv`).
+- The post-#222 FP8 KV cache verification raw data
+  (`profiling-artifacts/fp8_kv_verify_2026-04-20.csv`).
+- Source reads of `crates/kiln-model/src/forward.rs`,
+  `crates/kiln-model/src/marlin_proj.rs`, and
+  `crates/kiln-marlin-gemm/src/lib.rs` at the current `main` HEAD.
+- PR history cross-check via `gh pr list --repo ericflo/kiln --state all`
+  through PR #223.
+
+
 ## Phase 6 — Post-#222 preflight: MLP gate/up Marlin fusion math-ceiling audit (2026-04-20)
 
 **Outcome: KILL.** Fusing the MLP `gate_proj` and `up_proj` Marlin W4A16


### PR DESCRIPTION
## Summary

Doc-only PR. Appends a **Phase 6 frontier audit 2026-04-20** section to `PROFILING.md`. No code changed; no pod acquired; total compute cost: **$0**.

This is the follow-up audit after the three post-#210 redirect items resolved:
- #219 (ucopy_bf16 source-site audit) → null
- #222 (KV cache FP8 verification) → kept opt-in, not a decode-speed lever
- #223 (MLP gate/up Marlin fusion) → KILL

## Finding

**Phase 6 decode-kernel frontier is nearly exhausted.** Every standalone NVTX region in the post-#210 top-10 is already fused (#158), closed null (#141, #173, #176), Marlin-quantized, ABI-bound (#219), or sub-floor under graph replay.

Three un-attempted cross-cutting candidates evaluated with math-ceiling analysis:

| candidate                                    | aggregate % | realistic speedup         | contribution | decision                     |
| -------------------------------------------- | ----------: | ------------------------: | -----------: | ---------------------------- |
| Add+RMSNorm epilogue fusion (residual→norm)  |         7.5 |                      1.5× |        0.025 | **do not queue** (sub-floor; same shape as #141 null) |
| Marlin wrapper → BF16-native I/O epilogue    |        33.1 | 1.05–1.10× (region-local) | 0.017–0.033 | **preflight next** (plausibly clears 0.05) |
| GDN prefill memory reduction                 | ≤0.8 decode | — (capability)            |          n/a | **not a decode slice** (Phase 7 item) |

## Recommendation

**Next Phase 6 slice: Marlin wrapper → BF16-native I/O epilogue preflight ($0, doc-only).**

This is the only remaining quantifiable decode-speed lever. The wrapper overhead (BF16↔FP16 cast pair + FP16 buffer alloc) runs on every Marlin callsite — 12 per layer × 32 layers = 384 kernel launches per decode step — and contributes ~17.4 pp of decode wall-clock outside the Marlin kernel proper. A BF16-native tile variant (vLLM precedent) would eliminate steps 1 and 5 of the current wrapper simultaneously.

Preflight gates on three checks before any pod $:
1. Confirm vLLM Marlin-BF16 tile variant exists in vendored form.
2. Confirm wrapper cast + alloc is ≥5% of each GEMM's region wall-clock via NVTX sub-range capture.
3. Confirm HBM-traffic reduction (384 kernel launches eliminated) compounds under graph replay.

**If preflight fails, declare Phase 6 complete** and advance to Phase 7:
- **Capability:** GDN prefill memory reduction for long-context (redirect from #222).
- **DX:** self-speculative decoding end-to-end benchmarking + server option (skip-layer already implemented per `kiln-speculative-decoding-design`).

## Do-not-queue list (restated cumulatively)

Adds "Add+RMSNorm epilogue fusion" to the existing list of closed candidates across #141, #158, #163, #164, #173, #176, #219, #222, #223.

## Test plan

- [x] No code changed; `PROFILING.md` renders cleanly (verified via `head -20` at insertion point).
- [x] Single-file diff (+289 lines to `PROFILING.md`).
- [x] No new references to closed/null PRs without cross-reference.
- [x] Math-ceiling calculations use the same Amdahl bound as prior audits (#219, #223).