### PR TITLE
desktop: updater slice 8 UI — surface cuda_driver_too_old in Settings

### DIFF
--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -1077,6 +1077,18 @@
             showKilnUpdateActions(null);
             return;
           }
+          if (r.cuda_driver_too_old != null) {
+            // CUDA driver compat gate (slice 8): the release requires a
+            // newer CUDA driver than the local machine has. Refuse the
+            // offer and explain why. Mirrors gpu_unsupported handling.
+            const reason = escapeHtml(String(r.cuda_driver_too_old));
+            setKilnUpdateStatus(
+              "warn",
+              "CUDA driver too old: " + reason + " <span class=\"badge\">Update blocked</span>"
+            );
+            showKilnUpdateActions(null);
+            return;
+          }
           if (!r.latest) {
             setKilnUpdateStatus(
               "error",


### PR DESCRIPTION
## What

Parallel UI branch for slice 8 backend. desktop/src/main.rs already emits `cuda_driver_too_old` from `check_for_kiln_update` (PR #221), but desktop/ui/settings.html silently ignored the field — a user with an outdated CUDA driver saw "Update available" and could click Download. This adds a warn pill + hides the Download button, mirroring the existing `gpu_unsupported` handling.

## Files
- desktop/ui/settings.html — new `if (r.cuda_driver_too_old != null)` branch after the `gpu_unsupported` branch and before `!r.latest`

## Validation
HTML-only change. Cloud Eric sandbox has no GTK/webkit2gtk libs for `cargo check` (see agent note `tauri-cargo-check-gtk-missing`). No CI runs on desktop/ui/*.html either. Visual verification via the built desktop app is the real gate; code review covers this patch.

## Design ref
desktop/docs/binary-update.md §CUDA / GPU compat (lines 254–277).

🤖 Generated with [Claude Code](https://claude.com/claude-code)