### PR TITLE
desktop: release v0.1.10

### DIFF
--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-desktop"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kiln-desktop"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "Kiln Desktop — system tray app for the kiln local LLM server"
 authors = ["Eric Florenzano <eric@eflorenzano.com>"]

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kiln Desktop",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "identifier": "com.eflorenzano.kiln.desktop",
   "build": {
     "frontendDist": "ui",


### PR DESCRIPTION
## Summary

Bumps kiln-desktop from 0.1.9 to 0.1.10 to ship updater improvements that landed after the v0.1.9 tag.

## Changes since v0.1.9

- #220 updater slice 7 — parse supported_sm from release notes
- #221 updater slice 8 — min_cuda gate + cuda_driver_too_old field
- #227 updater slice 8 UI — surface cuda_driver_too_old reason in Settings

## Validation

- Local cargo check skipped (GTK/webkit2gtk missing in Cloud Eric sessions; see agent note tauri-cargo-check-gtk-missing)
- CI matrix (Linux AppImage/deb + Windows MSI) validates full build

## Release

After merge, tag-triggered workflow builds artifacts. Run `gh release edit desktop-v0.1.10 --repo ericflo/kiln --draft=false` to publish (see note kiln-desktop-release-draft-publish).