### PR TITLE
desktop: refresh README download links to v0.1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,14 +237,14 @@ Kiln Desktop is a system-tray app that wraps the `kiln` server for people who do
 
 **Windows, Linux, and macOS (Apple Silicon).** The Windows and Linux installers drive the CUDA build of `kiln`; the macOS installer drives the candle-metal build on M-series hardware. Intel Macs are not supported. A signed + notarized `.dmg` will ship alongside the existing installers once the macOS port lands — see [MACOS_MLX_PLAN.md](MACOS_MLX_PLAN.md), Phase 7.
 
-**Download — [Kiln Desktop v0.1.0](https://github.com/ericflo/kiln/releases/tag/desktop-v0.1.0):**
+**Download — [Kiln Desktop v0.1.10](https://github.com/ericflo/kiln/releases/tag/desktop-v0.1.10):**
 
 | Platform | Installer | Size |
 |---|---|---|
-| Windows | [Kiln.Desktop_0.1.0_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.0/Kiln.Desktop_0.1.0_x64-setup.exe) (NSIS) | 3.4 MB |
-| Windows | [Kiln.Desktop_0.1.0_x64_en-US.msi](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.0/Kiln.Desktop_0.1.0_x64_en-US.msi) (MSI) | 5.0 MB |
-| Linux | [Kiln.Desktop_0.1.0_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.0/Kiln.Desktop_0.1.0_amd64.deb) | 5.5 MB |
-| Linux | [Kiln.Desktop_0.1.0_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.0/Kiln.Desktop_0.1.0_amd64.AppImage) | 79 MB |
+| Windows | [Kiln.Desktop_0.1.10_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.10/Kiln.Desktop_0.1.10_x64-setup.exe) (NSIS) | 4.3 MB |
+| Windows | [Kiln.Desktop_0.1.10_x64_en-US.msi](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.10/Kiln.Desktop_0.1.10_x64_en-US.msi) (MSI) | 6.5 MB |
+| Linux | [Kiln.Desktop_0.1.10_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.10/Kiln.Desktop_0.1.10_amd64.deb) | 8.3 MB |
+| Linux | [Kiln.Desktop_0.1.10_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.10/Kiln.Desktop_0.1.10_amd64.AppImage) | 82 MB |
 
 The installer bundles the desktop wrapper only. On first launch the app offers to auto-download the matching prebuilt `kiln` server binary for your platform (macOS aarch64 / Metal, Linux x86_64 / CUDA 12.4, Windows x86_64 / CUDA 12.4) from the latest `kiln-v*` GitHub release and verify it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be downloaded separately — the Settings window has a HuggingFace downloader, or you can use the CLI path in [QUICKSTART.md](QUICKSTART.md).
 


### PR DESCRIPTION
## What
Bump README Download table from desktop-v0.1.0 to desktop-v0.1.10.

## Why
README has been pinned to v0.1.0 since the first release; we are now on v0.1.10 with 10 published desktop releases. Users clicking the first Download link get a 10-version-old installer.

## Sizes verified
gh release view desktop-v0.1.10 --json assets (bytes: exe 4524851, msi 6819840, deb 8751670, AppImage 85694968).