### PR TITLE
desktop: refresh desktop/README.md to v0.1.10

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -12,12 +12,12 @@ in a VM.
 
 ## Releases
 
-[Kiln Desktop v0.1.0](https://github.com/ericflo/kiln/releases/tag/desktop-v0.1.0) ships four installers:
+[Kiln Desktop v0.1.10](https://github.com/ericflo/kiln/releases/tag/desktop-v0.1.10) ships four installers:
 
-- `Kiln.Desktop_0.1.0_x64-setup.exe` (Windows NSIS, 3.4 MB)
-- `Kiln.Desktop_0.1.0_x64_en-US.msi` (Windows MSI, 5.0 MB)
-- `Kiln.Desktop_0.1.0_amd64.deb` (Debian/Ubuntu, 5.5 MB)
-- `Kiln.Desktop_0.1.0_amd64.AppImage` (portable Linux, 79 MB)
+- `Kiln.Desktop_0.1.10_x64-setup.exe` (Windows NSIS, 4.3 MB)
+- `Kiln.Desktop_0.1.10_x64_en-US.msi` (Windows MSI, 6.5 MB)
+- `Kiln.Desktop_0.1.10_amd64.deb` (Debian/Ubuntu, 8.3 MB)
+- `Kiln.Desktop_0.1.10_amd64.AppImage` (portable Linux, 82 MB)
 
 The desktop installer bundles only the wrapper. On first launch the app offers to auto-download the prebuilt `kiln` server binary from the latest `kiln-v*` GitHub release — `aarch64-apple-darwin-metal` on macOS, `x86_64-unknown-linux-gnu-cuda124` on Linux x86_64, `x86_64-pc-windows-msvc-cuda124` on Windows x86_64 — and verifies it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be installed separately; see the root [QUICKSTART.md](../QUICKSTART.md) or use the HuggingFace downloader in Settings.
 
@@ -27,7 +27,7 @@ Settings has a **Download from HuggingFace…** button next to the Model Path pi
 
 macOS `.dmg` releases are signed with a Developer ID certificate and notarized by Apple. See [docs/desktop/signing.md](../docs/desktop/signing.md) for the CI setup and required secrets.
 
-## What ships in v0.1.0
+## What ships in v0.1.10
 
 - **Subprocess supervisor** — Tokio child process driving the `kiln` binary, with stdout/stderr captured into an in-process ring buffer.
 - **Crash restart** with exponential backoff, and a clear error state surfaced in the tray.


### PR DESCRIPTION
## What
Bump the desktop/README.md release references from v0.1.0 to v0.1.10, matching the top-level README refresh in #232.

## Why
Sibling doc was 10 versions behind. First thing contributors see when they cd into desktop/.

## Scope
Version strings + asset sizes only. macOS scope language intentionally untouched — that is a separate project-description conflict.