### PR TITLE
docs: surface Desktop App in QUICKSTART

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -11,6 +11,21 @@ Either an NVIDIA GPU **or** an Apple Silicon Mac.
 - **Rust**: Stable toolchain (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`)
 - **Disk**: ~20GB free (model weights + build artifacts)
 
+## Quick path: Desktop App (recommended for most users)
+
+Kiln Desktop ships prebuilt installers for Windows, Linux, and macOS. The installer bundles only the GUI wrapper — on first launch it auto-downloads the matching prebuilt `kiln` server binary for your platform and verifies it against the published SHA-256. **No Rust toolchain or CUDA build required for the GUI itself.**
+
+**Download — [Kiln Desktop v0.1.10](https://github.com/ericflo/kiln/releases/tag/desktop-v0.1.10):**
+
+| Platform | Installer | Size |
+|----------|-----------|------|
+| Windows | [Kiln.Desktop_0.1.10_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.10/Kiln.Desktop_0.1.10_x64-setup.exe) (NSIS) | 4.3 MB |
+| Windows | [Kiln.Desktop_0.1.10_x64_en-US.msi](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.10/Kiln.Desktop_0.1.10_x64_en-US.msi) (MSI) | 6.5 MB |
+| Linux | [Kiln.Desktop_0.1.10_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.10/Kiln.Desktop_0.1.10_amd64.deb) | 8.3 MB |
+| Linux | [Kiln.Desktop_0.1.10_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.10/Kiln.Desktop_0.1.10_amd64.AppImage) | 82 MB |
+
+Continue with section 1 (Build Kiln) only if you want to build from source, contribute, or use the CLI directly. Otherwise, install the desktop app, let it finish its first-launch downloads, then skip ahead to section 4 (Test Inference) once the server is running.
+
 ## 1. Build Kiln
 
 ```bash


### PR DESCRIPTION
## What
Add a 'Quick path: Desktop App' section near the top of QUICKSTART.md so non-technical readers see the prebuilt installer path before the 15-30 min CUDA cargo build.

## Why
QUICKSTART currently sends every reader through `cargo build --release --features cuda`. The Desktop App ships ready-to-run installers (Win/Linux/macOS) that auto-download the prebuilt kiln server binary on first launch. Users who don't need a source build should see that path first. README.md mentions Desktop already; this brings QUICKSTART into parity.

## Test
- Local grep checks for installer link sync with README
- Heading order verified