### PR TITLE
desktop: refresh README Dashboard & Settings descriptions to current feature set

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,11 +248,11 @@ Kiln Desktop is a system-tray app that wraps the `kiln` server for people who do
 
 The installer bundles the desktop wrapper only. On first launch the app offers to auto-download the matching prebuilt `kiln` server binary for your platform (macOS aarch64 / Metal, Linux x86_64 / CUDA 12.4, Windows x86_64 / CUDA 12.4) from the latest `kiln-v*` GitHub release and verify it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be downloaded separately — the Settings window has a HuggingFace downloader, or you can use the CLI path in [QUICKSTART.md](QUICKSTART.md).
 
-**Dashboard** — toolbar shows server state, model path, VRAM budget, active LoRA adapter, training status, and the OpenAI base URL with a one-click copy. The kiln server's `/ui` is embedded below.
+**Dashboard** — a toolbar across the top surfaces server state, model path, VRAM usage, active LoRA adapter, training status, and the OpenAI base URL as click-to-copy pills, alongside Start / Stop / Restart Server, View Logs, and Settings buttons. A first-run empty state walks you through setting a model path, and if the kiln server crashes while the dashboard is open an error screen surfaces it with a one-click recovery path. Keyboard shortcuts cover the common actions — <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>S</kbd> to start, <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>.</kbd> to stop, <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>R</kbd> to restart, <kbd>Ctrl/Cmd</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> to copy the base URL, <kbd>Ctrl/Cmd</kbd>+<kbd>L</kbd> for logs, <kbd>Ctrl/Cmd</kbd>+<kbd>,</kbd> for settings, and <kbd>?</kbd> for the full cheatsheet modal. The toolbar wraps gracefully at narrow window widths, and the kiln server's `/ui` is embedded below.
 
 ![Dashboard](docs/desktop/dashboard.png)
 
-**Settings** — model path, port, memory budget, FP8/CUDA graphs/prefix cache toggles, and startup options.
+**Settings** — pick a model path (or pull weights with the built-in HuggingFace downloader), configure the listening host and port, and tune the runtime: inference VRAM fraction, FP8 KV cache, CUDA graphs, prefix cache, and adapter directory. Startup options cover auto-start kiln on app launch, auto-restart on crash, and launch-at-login. A Check for Updates button (with the same check running automatically on launch) surfaces new `kiln-v*` releases and explains when an update is held back for CUDA driver or GPU SM-arch compatibility reasons.
 
 ![Settings](docs/desktop/settings.png)
 


### PR DESCRIPTION
## What

Refreshes the Dashboard and Settings descriptive paragraphs in the **Desktop App** section of README.md to reflect ~13 UI features that have shipped since PR #138 (the last screenshot/description refresh). Text-only — screenshots are unchanged this cycle.

## Dashboard paragraph now covers

- Click-to-copy pills for model path, VRAM, adapter, and OpenAI base URL
- Start / Stop / Restart Server, View Logs, Settings action buttons
- First-run empty state guiding the user to set a model path
- Error screen auto-recovery when the kiln server crashes while the dashboard is open
- Keyboard shortcuts: `Ctrl/Cmd+Shift+S` start, `Ctrl/Cmd+Shift+.` stop, `Ctrl/Cmd+Shift+R` restart, `Ctrl/Cmd+Shift+C` copy base URL, `Ctrl/Cmd+L` logs, `Ctrl/Cmd+,` settings, `?` for the cheatsheet modal
- Toolbar wraps gracefully at narrow widths
- Embedded kiln `/ui` below the toolbar

## Settings paragraph now covers

- Model path picker + HuggingFace downloader
- Host bind + port
- Memory budget (inference fraction), FP8 KV cache, CUDA graphs, prefix cache
- Adapter directory
- Auto-start kiln on app launch, auto-restart on crash, launch-at-login
- Check for Updates (auto on launch + manual button) with CUDA driver / GPU SM-arch compatibility messaging

## Shipped PRs this refresh covers

Roughly #155, #157, #178, #179, #191, #192, #194, #197, #200, #212, #221, #227 — click-to-copy pills, keyboard shortcuts modal, Restart Server button, first-run empty state, crash-recovery error screen, toolbar wrap, HuggingFace download modal, launch-at-login, auto-restart, update checker with compat gating.

## Verification

- `grep -n "toolbar shows" README.md` returns nothing (old text gone)
- Dashboard paragraph mentions click-to-copy, keyboard shortcuts, Restart
- Settings paragraph mentions HuggingFace, launch-at-login, auto-restart
- Each feature was cross-checked against `desktop/ui/dashboard.html` and `desktop/ui/settings.html` in current `main` before describing it

No code changed; README-only.