### PR TITLE
desktop: CHANGELOG.md + auto-populate release notes

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -59,6 +59,26 @@ jobs:
         with:
           workspaces: './desktop -> target'
 
+      - name: Extract release notes from CHANGELOG.md
+        if: startsWith(github.ref, 'refs/tags/desktop-v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          NOTES=$(awk -v tag="## ${TAG} " '
+            index($0, tag) == 1 { found = 1; print; next }
+            found && /^## desktop-v/ { exit }
+            found { print }
+          ' desktop/CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            NOTES="See desktop/CHANGELOG.md for changes."
+          fi
+          {
+            echo "RELEASE_BODY<<KILN_EOF"
+            echo "$NOTES"
+            echo "KILN_EOF"
+          } >> "$GITHUB_ENV"
+
       - name: Write App Store Connect API key to disk (macOS)
         if: runner.os == 'macOS' && startsWith(github.ref, 'refs/tags/desktop-v')
         env:
@@ -93,6 +113,7 @@ jobs:
           projectPath: desktop
           tagName: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && github.ref_name || '' }}
           releaseName: 'Kiln Desktop ${{ startsWith(github.ref, ''refs/tags/desktop-v'') && github.ref_name || '''' }}'
+          releaseBody: ${{ env.RELEASE_BODY }}
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,0 +1,97 @@
+# Kiln Desktop Changelog
+
+## desktop-v0.1.10 — 2026-04-20
+- Updater parses `supported_sm` from kiln release notes
+- Updater parses `min_cuda` and refuses to install when the local CUDA driver is too old
+- Surface `cuda_driver_too_old` error in the Settings updater UI
+
+## desktop-v0.1.9 — 2026-04-20
+- Picks up the kiln-v0.1.2 server fix
+- Updater GPU arch compatibility gate via `nvidia-smi compute_cap`
+- `current_target()` extended to Linux + Windows CUDA 12.4
+- Auto-check for a new kiln binary on launch
+- Wire the Install button to `install_staged_update`
+- Docs: desktop app auto-downloads a prebuilt kiln on Linux + Windows
+
+## desktop-v0.1.8 — 2026-04-19
+- Updater slice 2: download the new kiln binary to a staging path
+- Updater slice 3a: extract the staged tarball to `bin/kiln.new` + verify sha256
+- Updater slice 3b: atomic swap of `bin/kiln.new` into `bin/kiln`
+- Health-gated updater install with rollback to `kiln.bak`
+- Check-for-updates command and Settings UI (detection only)
+- Server + desktop: configurable served model ID
+
+## desktop-v0.1.7 — 2026-04-19
+- Click the base-URL pill to copy the OpenAI base URL
+- Click the model-path pill to copy the model path
+- Click the VRAM pill to copy the VRAM value
+- Click the adapter pill to copy the active LoRA name
+- Log viewer: stdout/stderr stream filter checkboxes
+- Fix HuggingFace download placeholder to `Qwen/Qwen3.5-4B`
+- Design doc for kiln binary auto-update
+
+## desktop-v0.1.6 — 2026-04-19
+- Supersedes the broken v0.1.5 draft
+- Fix v0.1.4 crashloop by passing kiln server settings as `KILN_*` env vars
+- Color stderr lines amber in the log viewer
+- "Download from HuggingFace" button in Settings
+- Persist window size and position across launches
+
+## desktop-v0.1.4 — 2026-04-19
+- Warn on non-existent paths in Settings
+- "Restore defaults" button in the Settings window
+- Inline help text for advanced settings
+- Dirty-state indicator on the Settings Save button
+- Confirm discard when closing Settings with unsaved changes
+- Keyboard shortcut help modals (dashboard, settings, logs)
+- Dashboard start/stop shortcuts (`Ctrl/Cmd+Shift+S`, `Ctrl/Cmd+Shift+.`)
+- `Cmd/Ctrl+W` and `Esc` close shortcuts for settings and logs windows
+- Auto-download the signed kiln server on first run
+- Wrap the dashboard toolbar gracefully at narrow widths
+
+## desktop-v0.1.2 — 2026-04-18
+- Replace the stale "Scaffold only" placeholder in `ui/index.html`
+- Notify on server-ready and server-stopped transitions
+- Fix silent button no-ops (set `withGlobalTauri` + About close)
+- Sync `Cargo.lock` with the `tauri-plugin-notification` dependency
+
+## desktop-v0.1.1 — 2026-04-18
+- Sign and notarize the macOS `.dmg` for Gatekeeper
+- Gracefully stop the kiln server on tray Quit
+- About window with version, repo link, and license
+- About window: show OS/arch + Copy diagnostic button
+- Dashboard first-run empty state when `model_path` is unset
+- Dashboard toolbar: live server state badge, server uptime, OpenAI base URL, Stop/Restart Server buttons, configured model path, VRAM budget, active adapter, training status pill
+- Dashboard toolbar regrouped into status (left) and actions (right)
+- Dashboard Start Server button for the not-running state
+- Auto-show the error screen when kiln crashes while the dashboard is open
+- Native notification when the server enters Error state
+- Include kiln port in the tray tooltip when running
+- Per-state tray icons (stopped/starting/running/training/error)
+- Open Kiln UI in an external browser from the tray
+- Restart Server tray menu item + status indicator row at the top of the tray menu
+- View Logs / Settings buttons in the dashboard toolbar
+- Log viewer: filter input, copy button, Save-to-file button
+- Keyboard shortcuts for the dashboard (Logs, Settings, Copy, Restart)
+- Keyboard shortcuts for the settings window (`Cmd/Ctrl+S`, `Cmd/Ctrl+R`)
+- Keyboard shortcuts for the logs window (Filter, Save, Clear)
+- Copy OpenAI base URL quick action in the tray
+- Native file pickers for kiln binary, model path, and adapter directory
+- "Restart now" button in Settings after save
+- Tauri auto-updater plumbing + Check-for-Updates flow (tray + dashboard)
+- Show app version in the settings window footer
+- Refreshed README screenshots and dashboard description
+- macOS support via candle-metal (Wave 1) + mlx-rs (Wave 2)
+
+## desktop-v0.1.0 — 2026-04-17
+- Initial release
+- Tauri v2 `desktop/` project scaffold (not a Cargo workspace member)
+- Subprocess supervisor for the kiln server
+- System tray with status icon and right-click menu
+- Settings window with persistence and Supervisor wiring
+- Dashboard window embedding kiln's `/ui` via webview
+- Launch-at-login via `tauri-plugin-autostart`
+- Poll `/v1/health` and `/v1/train/status` to drive tray state
+- Log viewer window tailing supervisor stdout/stderr
+- CI building Windows MSI/NSIS and Linux `.deb`/AppImage packages
+- Kiln logo desktop icons


### PR DESCRIPTION
## What
Adds `desktop/CHANGELOG.md` (covering `desktop-v0.1.0` — `desktop-v0.1.10`) and patches `.github/workflows/desktop-build.yml` so future tag-triggered releases automatically get release notes from the matching CHANGELOG.md section.

## Why
`desktop-v0.1.5` through `desktop-v0.1.10` all shipped with empty GitHub release pages — anyone following the README download link sees a binary list with no context about what's new. This PR fixes both the backlog (one-time: `gh release edit` to backfill v0.1.10) and prevents recurrence (every future tag picks up its CHANGELOG.md section as the release body).

## How
- New `desktop/CHANGELOG.md` with one section per shipped tag. Content pulled from merged PR titles + commit log for each adjacent tag pair (`git log desktop-vA..desktop-vB -- desktop/`). Factual bullets only.
- New workflow step ("Extract release notes from CHANGELOG.md") that runs on tag pushes (`refs/tags/desktop-v*`). It `awk`-extracts the matching `## desktop-vX.Y.Z —` section into a multi-line env var `RELEASE_BODY`. The trailing space in the tag match (`"## ${TAG} "`) prevents the `v0.1.0` section from greedily matching `v0.1.10`.
- Added `releaseBody: ${{ env.RELEASE_BODY }}` to the `tauri-action@v0` block. Falls back to "See desktop/CHANGELOG.md for changes." when no matching section exists (e.g. a tag cut before CHANGELOG.md was updated).

## Validation
- `python3 -c 'import yaml; yaml.safe_load(open(".github/workflows/desktop-build.yml"))'` — YAML parses cleanly
- `awk` extraction verified for both `desktop-v0.1.10` (returns only its 4 lines) and `desktop-v0.1.0` (does not match `v0.1.10`)
- `desktop/cargo metadata` unaffected; no Rust code changed