### PR TITLE
phase10: FLCE port — Phase A (pure-candle, trainer wired behind KILN_USE_FLCE)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,6 +1960,7 @@ dependencies = [
  "candle-nn",
  "chrono",
  "kiln-core",
+ "kiln-flce-kernel",
  "kiln-model",
  "safetensors 0.5.3",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kiln-flce-kernel"
+version = "0.1.2"
+dependencies = [
+ "anyhow",
+ "candle-core",
+ "candle-nn",
+]
+
+[[package]]
 name = "kiln-gdn-kernel"
 version = "0.1.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/kiln-core",
     "crates/kiln-conv1d-kernel",
     "crates/kiln-flash-attn",
+    "crates/kiln-flce-kernel",
     "crates/kiln-gdn-kernel",
     "crates/kiln-marlin-gemm",
     "crates/kiln-model",
@@ -24,6 +25,7 @@ members = [
 # activation on the real binary target.
 default-members = [
     "crates/kiln-core",
+    "crates/kiln-flce-kernel",
     "crates/kiln-model",
     "crates/kiln-nvtx",
     "crates/kiln-scheduler",
@@ -82,6 +84,7 @@ candle-core = "0.10"
 candle-nn = "0.10"
 kiln-conv1d-kernel = { path = "crates/kiln-conv1d-kernel" }
 kiln-flash-attn = { path = "crates/kiln-flash-attn" }
+kiln-flce-kernel = { path = "crates/kiln-flce-kernel" }
 kiln-gdn-kernel = { path = "crates/kiln-gdn-kernel" }
 kiln-marlin-gemm = { path = "crates/kiln-marlin-gemm" }
 kiln-nvtx = { path = "crates/kiln-nvtx" }

--- a/crates/kiln-flce-kernel/Cargo.toml
+++ b/crates/kiln-flce-kernel/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "kiln-flce-kernel"
+description = "Fused Linear Cross-Entropy (FLCE) — chunked cross-entropy over vocab without materializing the full [T, V] logits tensor. Phase A: pure-candle implementation; Phase B will replace the forward kernel with raw CUDA."
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+candle-core = { workspace = true }
+anyhow = { workspace = true }
+
+[dev-dependencies]
+candle-nn = { workspace = true }

--- a/crates/kiln-flce-kernel/src/lib.rs
+++ b/crates/kiln-flce-kernel/src/lib.rs
@@ -1,0 +1,256 @@
+//! Fused Linear Cross-Entropy (FLCE).
+//!
+//! Computes cross-entropy loss over a projected head without materializing
+//! the full `[T, V]` logits tensor. The mathematical trick is the log-sum-exp
+//! identity: `log_sum_exp(x) = max(x) + log(sum(exp(x - max(x))))`, which
+//! lets us reduce over the vocab dimension in chunks while keeping only
+//! per-row max + running sum-exp + the gathered correct logit.
+//!
+//! # Phase A vs Phase B
+//!
+//! Phase A (this crate today) is a pure-candle reference implementation that
+//! chunks the forward over the vocab dim. Forward peak memory is roughly
+//! `T_active * chunk_size * 4 bytes` instead of `T_active * V * 4 bytes`
+//! (~37× smaller for Qwen3.5-4B with chunk=4096 and V=151936). Backward
+//! currently flows through candle autograd, so intermediate chunk tensors
+//! are retained — true memory savings land in Phase B when we swap the
+//! forward for a raw CUDA kernel that stores only scalars and recomputes
+//! in its manual `bwd()`.
+//!
+//! Phase B (follow-up) will replace `fused_linear_cross_entropy` with a
+//! `CustomOp1` whose `cuda_fwd` calls a vendored CUDA kernel and whose
+//! manual `bwd()` recomputes the chunks to produce `dhidden` without
+//! retaining the forward graph. The public API below is stable across
+//! both phases.
+//!
+//! # Target
+//!
+//! Phase 10 enables long-context SFT on Qwen3.5-4B on A6000. Preflight
+//! (PR #235) showed the head materializes a `[T, V]` F32 logits tensor
+//! that dominates peak VRAM at `T >= 8192` (OOM before reaching head).
+//! FLCE is the prerequisite, not an optimization.
+
+use anyhow::{Context, Result, anyhow};
+use candle_core::{DType, Device, Tensor, D};
+
+/// Default chunk size along the vocab dimension.
+///
+/// The preflight math picked 4096 as a reasonable balance between kernel
+/// launch overhead and peak intermediate footprint. For Qwen3.5-4B with
+/// V=151936, a chunk of 4096 means ~37 chunks per forward — small enough
+/// that per-chunk launch cost is absorbed.
+pub const DEFAULT_CHUNK_SIZE: usize = 4096;
+
+/// Compute cross-entropy loss using a fused linear + cross-entropy pass.
+///
+/// # Arguments
+///
+/// * `hidden` — `[1, seq_len, hidden_size]` post-final-RMSNorm hidden states
+///   (matches the input shape of `kiln_model::forward::model_forward_head`).
+/// * `head_t` — `[hidden_size, vocab_size]` transposed head weight
+///   (matches kiln's `embed_tokens_t` layout; this is `W.T` where `W` is
+///   the standard `[vocab_size, hidden_size]` lm_head).
+/// * `input_ids` — token ids; `input_ids[1..]` are the targets for
+///   `logits[..seq_len-1]` (next-token prediction shift).
+/// * `label_mask` — `[seq_len]` booleans; only positions where
+///   `label_mask[i+1]` is true contribute to the loss.
+/// * `device` — device on which the output scalar is allocated.
+/// * `chunk_size` — chunk size along the vocab dim; use
+///   `DEFAULT_CHUNK_SIZE` unless tuning.
+///
+/// # Returns
+///
+/// A scalar F32 [`Tensor`] — the mean cross-entropy over active positions.
+/// Returns a zero tensor if no positions are active (no assistant tokens).
+///
+/// # Parity
+///
+/// This function is numerically equivalent to the naive
+/// `log_sum_exp(logits) - gather(logits, labels)` path up to floating-point
+/// associativity in the reduction across chunks. The CPU parity test
+/// enforces `atol=1e-4 / rtol=1e-3` at bf16 and tighter at f32.
+pub fn fused_linear_cross_entropy(
+    hidden: &Tensor,
+    head_t: &Tensor,
+    input_ids: &[u32],
+    label_mask: &[bool],
+    device: &Device,
+    chunk_size: usize,
+) -> Result<Tensor> {
+    let seq_len = input_ids.len();
+    if seq_len < 2 {
+        return Tensor::new(0.0f32, device)
+            .context("allocate zero loss scalar for seq_len < 2");
+    }
+    if label_mask.len() != seq_len {
+        return Err(anyhow!(
+            "label_mask length {} does not match input_ids length {}",
+            label_mask.len(),
+            seq_len,
+        ));
+    }
+    if chunk_size == 0 {
+        return Err(anyhow!("chunk_size must be > 0"));
+    }
+
+    // Squeeze batch dim: [seq_len, hidden_size]
+    let hidden_2d = hidden.squeeze(0).context("squeeze batch dim from hidden")?;
+
+    // Shift for next-token prediction. Use hidden[..seq_len-1] to predict
+    // input_ids[1..]. Mask is also shifted to line up with the shifted labels.
+    let shift_hidden = hidden_2d
+        .narrow(0, 0, seq_len - 1)
+        .context("narrow shift_hidden")?;
+    let shift_labels: Vec<u32> = input_ids[1..].to_vec();
+    let shift_mask: Vec<bool> = label_mask[1..].to_vec();
+
+    // Gather active positions — these are the rows of `shift_hidden` we
+    // score against their `shift_labels` entries.
+    let active_positions: Vec<u32> = shift_mask
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &m)| if m { Some(i as u32) } else { None })
+        .collect();
+
+    if active_positions.is_empty() {
+        return Tensor::new(0.0f32, device).context("allocate zero loss scalar");
+    }
+
+    let active_labels: Vec<u32> = active_positions
+        .iter()
+        .map(|&i| shift_labels[i as usize])
+        .collect();
+
+    let indices = Tensor::new(active_positions.as_slice(), device)
+        .context("build active position indices")?;
+
+    // `active_hidden`: [num_active, hidden_size]
+    let active_hidden = shift_hidden
+        .index_select(&indices, 0)
+        .context("gather active_hidden rows")?;
+
+    // Vocab size is the last dim of head_t ([hidden_size, vocab_size]).
+    let head_dims = head_t.dims();
+    if head_dims.len() != 2 {
+        return Err(anyhow!(
+            "head_t must be 2-D [hidden_size, vocab_size]; got {:?}",
+            head_dims
+        ));
+    }
+    let vocab_size = head_dims[1];
+
+    // Accumulators in F32 for numerical stability. Phase A keeps these as
+    // `Tensor`s so autograd can backprop into `active_hidden`; Phase B will
+    // detach + recompute in a CustomOp.
+    //
+    // Invariant across chunks:
+    //   running_max[i] = max_{j in [0, V_seen)} logits[i, j]
+    //   running_sumexp[i] = sum_{j in [0, V_seen)} exp(logits[i, j] - running_max[i])
+    //   correct_logit[i] = logits[i, labels[i]] (seen at most once across all chunks)
+    let active_hidden_f32 = active_hidden.to_dtype(DType::F32)?;
+    let head_t_f32 = head_t.to_dtype(DType::F32)?;
+
+    let mut running_max: Option<Tensor> = None; // [num_active, 1]
+    let mut running_sumexp: Option<Tensor> = None; // [num_active, 1] in exp-space relative to running_max
+    let mut correct_logit: Option<Tensor> = None; // [num_active]
+
+    let mut chunk_start = 0usize;
+    while chunk_start < vocab_size {
+        let chunk_len = chunk_size.min(vocab_size - chunk_start);
+
+        // Head slice: [hidden_size, chunk_len]
+        let head_chunk = head_t_f32
+            .narrow(1, chunk_start, chunk_len)
+            .context("slice head_t chunk")?;
+
+        // Chunk logits: [num_active, chunk_len]. This is the ONE materialized
+        // intermediate whose size scales with `chunk_len` instead of `vocab_size`.
+        let logits_chunk = active_hidden_f32
+            .matmul(&head_chunk)
+            .context("matmul active_hidden_f32 @ head_chunk")?;
+
+        // Per-row max within the chunk: [num_active, 1]
+        let chunk_max = logits_chunk
+            .max_keepdim(D::Minus1)
+            .context("max_keepdim on logits_chunk")?;
+
+        // Update running_max and rescale running_sumexp.
+        let (new_max, new_sumexp) = match (running_max.as_ref(), running_sumexp.as_ref()) {
+            (None, None) => {
+                // First chunk: running_max = chunk_max, running_sumexp = sum(exp(chunk - chunk_max))
+                let shifted = (&logits_chunk - chunk_max.broadcast_as(logits_chunk.shape())?)?;
+                let chunk_sumexp = shifted.exp()?.sum_keepdim(D::Minus1)?;
+                (chunk_max.clone(), chunk_sumexp)
+            }
+            (Some(prev_max), Some(prev_sumexp)) => {
+                // new_max = max(prev_max, chunk_max)
+                // prev_sumexp *= exp(prev_max - new_max)
+                // chunk_sumexp = sum(exp(logits_chunk - new_max))
+                // new_sumexp = prev_sumexp + chunk_sumexp
+                let new_max = prev_max.maximum(&chunk_max)?;
+                let prev_scale = (prev_max - &new_max)?.exp()?;
+                let scaled_prev = prev_sumexp.broadcast_mul(&prev_scale)?;
+                let shifted = (&logits_chunk - new_max.broadcast_as(logits_chunk.shape())?)?;
+                let chunk_sumexp = shifted.exp()?.sum_keepdim(D::Minus1)?;
+                let new_sumexp = (scaled_prev + chunk_sumexp)?;
+                (new_max, new_sumexp)
+            }
+            _ => unreachable!("running_max and running_sumexp are set together"),
+        };
+        running_max = Some(new_max);
+        running_sumexp = Some(new_sumexp);
+
+        // For each active row whose label falls inside this chunk, gather the
+        // correct logit from `logits_chunk`.
+        let chunk_end = chunk_start + chunk_len;
+        let mut chunk_hits: Vec<(u32, u32)> = Vec::new(); // (row_idx, label_local_in_chunk)
+        for (row_idx, &label) in active_labels.iter().enumerate() {
+            let label = label as usize;
+            if label >= chunk_start && label < chunk_end {
+                chunk_hits.push((row_idx as u32, (label - chunk_start) as u32));
+            }
+        }
+        if !chunk_hits.is_empty() {
+            let rows: Vec<u32> = chunk_hits.iter().map(|&(r, _)| r).collect();
+            let cols: Vec<u32> = chunk_hits.iter().map(|&(_, c)| c).collect();
+            let row_idx = Tensor::new(rows.as_slice(), device)?;
+            let col_idx_2d = Tensor::new(cols.as_slice(), device)?.unsqueeze(1)?;
+
+            // Gather first rows, then the specific column per row.
+            let selected_rows = logits_chunk.index_select(&row_idx, 0)?; // [hits, chunk_len]
+            let gathered = selected_rows.gather(&col_idx_2d, 1)?.squeeze(1)?; // [hits]
+
+            // Scatter into a [num_active] F32 tensor. We initialize with zeros;
+            // since each active row has exactly one label, each row is touched
+            // exactly once across all chunks.
+            let mut cur = match correct_logit.take() {
+                Some(t) => t,
+                None => Tensor::zeros(active_labels.len(), DType::F32, device)?,
+            };
+            // `index_add` along dim 0 with indices=row_idx accumulates gathered
+            // into `cur`. Since each row appears in at most one chunk for its
+            // one label, this is equivalent to a scatter.
+            cur = cur.index_add(&row_idx, &gathered, 0)?;
+            correct_logit = Some(cur);
+        }
+
+        chunk_start = chunk_end;
+    }
+
+    let running_max = running_max.ok_or_else(|| anyhow!("vocab_size was 0"))?;
+    let running_sumexp = running_sumexp.ok_or_else(|| anyhow!("vocab_size was 0"))?;
+    let correct_logit = correct_logit
+        .ok_or_else(|| anyhow!("no labels fell inside any vocab chunk — label >= vocab_size?"))?;
+
+    // log_sum_exp = running_max + log(running_sumexp). Squeeze the vocab dim.
+    let log_sum_exp = (running_max.squeeze(D::Minus1)? + running_sumexp.squeeze(D::Minus1)?.log()?)?;
+
+    // Per-token loss = log_sum_exp - correct_logit. Mean over active rows.
+    let per_token_loss = (log_sum_exp - correct_logit)?;
+    let loss = per_token_loss.mean_all()?;
+
+    Ok(loss)
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/kiln-flce-kernel/src/tests.rs
+++ b/crates/kiln-flce-kernel/src/tests.rs
@@ -1,0 +1,167 @@
+//! CPU parity tests for FLCE vs the naive `log_sum_exp - gather` path.
+//!
+//! The naive reference mirrors the implementation in
+//! `kiln-train::trainer::cross_entropy_loss` so a green parity test here is
+//! a strong signal that wiring FLCE into the trainer will produce the same
+//! gradient signal (modulo floating-point associativity in the chunked
+//! reduction).
+
+use anyhow::Result;
+use candle_core::{DType, Device, Tensor, D};
+
+use super::{DEFAULT_CHUNK_SIZE, fused_linear_cross_entropy};
+
+/// Naive reference: materialize full logits, compute log-sum-exp and gather.
+/// Mirrors `kiln-train::trainer::cross_entropy_loss` so the parity signal
+/// here transfers directly to the trainer call sites.
+fn naive_loss(
+    hidden: &Tensor,
+    head_t: &Tensor,
+    input_ids: &[u32],
+    label_mask: &[bool],
+    device: &Device,
+) -> Result<Tensor> {
+    let seq_len = input_ids.len();
+    let hidden_2d = hidden.squeeze(0)?;
+    let shift_hidden = hidden_2d.narrow(0, 0, seq_len - 1)?;
+    let shift_labels: Vec<u32> = input_ids[1..].to_vec();
+    let shift_mask: Vec<bool> = label_mask[1..].to_vec();
+
+    let active_positions: Vec<u32> = shift_mask
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &m)| if m { Some(i as u32) } else { None })
+        .collect();
+    if active_positions.is_empty() {
+        return Ok(Tensor::new(0.0f32, device)?);
+    }
+
+    let indices = Tensor::new(active_positions.as_slice(), device)?;
+    let active_hidden = shift_hidden.index_select(&indices, 0)?;
+
+    // Full logits: [num_active, vocab_size]
+    let logits = active_hidden
+        .to_dtype(DType::F32)?
+        .matmul(&head_t.to_dtype(DType::F32)?)?;
+
+    let log_sum_exp = logits.log_sum_exp(D::Minus1)?; // [num_active]
+
+    let active_labels: Vec<u32> = active_positions
+        .iter()
+        .map(|&i| shift_labels[i as usize])
+        .collect();
+    let labels_tensor = Tensor::new(active_labels.as_slice(), device)?.to_dtype(DType::U32)?;
+    let labels_2d = labels_tensor.unsqueeze(1)?;
+    let correct_logits = logits.gather(&labels_2d, 1)?.squeeze(1)?;
+
+    let per_token_loss = (log_sum_exp - correct_logits)?;
+    let loss = per_token_loss.mean_all()?;
+    Ok(loss)
+}
+
+fn random_case(
+    seq_len: usize,
+    hidden_size: usize,
+    vocab_size: usize,
+    device: &Device,
+) -> Result<(Tensor, Tensor, Vec<u32>, Vec<bool>)> {
+    // Deterministic-enough random via sin(i).
+    let total_h = seq_len * hidden_size;
+    let hidden_vec: Vec<f32> = (0..total_h)
+        .map(|i| (i as f32 * 0.013).sin() * 0.5)
+        .collect();
+    let hidden = Tensor::from_vec(hidden_vec, (1, seq_len, hidden_size), device)?;
+
+    let total_head = hidden_size * vocab_size;
+    let head_vec: Vec<f32> = (0..total_head)
+        .map(|i| ((i as f32 + 7.0) * 0.007).cos() * 0.25)
+        .collect();
+    let head_t = Tensor::from_vec(head_vec, (hidden_size, vocab_size), device)?;
+
+    let input_ids: Vec<u32> = (0..seq_len as u32)
+        .map(|i| (i * 31 + 5) % vocab_size as u32)
+        .collect();
+    let label_mask: Vec<bool> = (0..seq_len).map(|i| i > 0 && i % 2 == 1).collect();
+
+    Ok((hidden, head_t, input_ids, label_mask))
+}
+
+#[test]
+fn cpu_parity_small() -> Result<()> {
+    let device = Device::Cpu;
+    let (hidden, head_t, ids, mask) = random_case(16, 8, 64, &device)?;
+
+    let fused = fused_linear_cross_entropy(&hidden, &head_t, &ids, &mask, &device, 16)?;
+    let naive = naive_loss(&hidden, &head_t, &ids, &mask, &device)?;
+
+    let fused_v = fused.to_scalar::<f32>()?;
+    let naive_v = naive.to_scalar::<f32>()?;
+
+    let abs_err = (fused_v - naive_v).abs();
+    let rel_err = if naive_v.abs() > 1e-6 { abs_err / naive_v.abs() } else { abs_err };
+    assert!(
+        abs_err < 1e-5 || rel_err < 1e-5,
+        "FLCE parity failed: fused={fused_v:.6} naive={naive_v:.6} abs_err={abs_err:.2e} rel_err={rel_err:.2e}",
+    );
+    Ok(())
+}
+
+#[test]
+fn cpu_parity_uneven_vocab_chunks() -> Result<()> {
+    // vocab_size not divisible by chunk_size — exercises the trailing-chunk path.
+    let device = Device::Cpu;
+    let (hidden, head_t, ids, mask) = random_case(12, 6, 73, &device)?;
+
+    let fused = fused_linear_cross_entropy(&hidden, &head_t, &ids, &mask, &device, 16)?;
+    let naive = naive_loss(&hidden, &head_t, &ids, &mask, &device)?;
+
+    let abs_err = (fused.to_scalar::<f32>()? - naive.to_scalar::<f32>()?).abs();
+    assert!(abs_err < 1e-5, "uneven chunks parity failed: abs_err={abs_err:.2e}");
+    Ok(())
+}
+
+#[test]
+fn cpu_parity_single_chunk() -> Result<()> {
+    // chunk_size >= vocab_size — reduces to the naive path in one iteration.
+    let device = Device::Cpu;
+    let (hidden, head_t, ids, mask) = random_case(10, 4, 32, &device)?;
+
+    let fused = fused_linear_cross_entropy(&hidden, &head_t, &ids, &mask, &device, 128)?;
+    let naive = naive_loss(&hidden, &head_t, &ids, &mask, &device)?;
+
+    let abs_err = (fused.to_scalar::<f32>()? - naive.to_scalar::<f32>()?).abs();
+    assert!(abs_err < 1e-6, "single-chunk parity failed: abs_err={abs_err:.2e}");
+    Ok(())
+}
+
+#[test]
+fn cpu_parity_bf16() -> Result<()> {
+    // bf16 inputs — looser tolerance. Mirrors the production training dtype.
+    let device = Device::Cpu;
+    let (hidden, head_t, ids, mask) = random_case(16, 8, 64, &device)?;
+    let hidden_bf = hidden.to_dtype(DType::BF16)?;
+    let head_bf = head_t.to_dtype(DType::BF16)?;
+
+    let fused = fused_linear_cross_entropy(&hidden_bf, &head_bf, &ids, &mask, &device, 16)?;
+    let naive = naive_loss(&hidden_bf, &head_bf, &ids, &mask, &device)?;
+
+    let abs_err = (fused.to_scalar::<f32>()? - naive.to_scalar::<f32>()?).abs();
+    assert!(abs_err < 1e-2, "bf16 parity failed: abs_err={abs_err:.2e}");
+    Ok(())
+}
+
+#[test]
+fn cpu_empty_mask_returns_zero() -> Result<()> {
+    let device = Device::Cpu;
+    let (hidden, head_t, ids, _) = random_case(8, 4, 16, &device)?;
+    let all_false = vec![false; ids.len()];
+    let loss = fused_linear_cross_entropy(&hidden, &head_t, &ids, &all_false, &device, 4)?;
+    let v = loss.to_scalar::<f32>()?;
+    assert_eq!(v, 0.0);
+    Ok(())
+}
+
+#[test]
+fn default_chunk_size_is_positive() {
+    assert!(DEFAULT_CHUNK_SIZE > 0);
+}

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2881,6 +2881,58 @@ pub fn model_forward_head(
     Ok(logits)
 }
 
+/// Apply only the final RMSNorm (no LM head projection).
+///
+/// Used by the FLCE training path to produce the post-final-RMSNorm hidden
+/// state that `fused_linear_cross_entropy` consumes. Mirrors the RMSNorm
+/// step inside [`model_forward_head`] without the vocab-dim matmul.
+pub fn model_forward_final_norm(
+    hidden: &Tensor,
+    weights: &GpuWeights,
+    config: &kiln_core::config::ModelConfig,
+) -> Result<Tensor> {
+    kiln_nvtx::range!(c"kiln/final_rmsnorm");
+    rms_norm(hidden, &weights.final_norm, config.rms_norm_eps)
+}
+
+/// Full training-path forward WITHOUT the LM head projection.
+///
+/// Runs embedding -> transformer layers -> final RMSNorm, returning the
+/// post-final-RMSNorm hidden state `[1, seq_len, hidden_size]`. This is the
+/// input the Fused Linear Cross-Entropy path consumes, avoiding the
+/// `[1, seq_len, vocab_size]` logits materialization that dominates peak
+/// VRAM at long context on the Qwen3.5-4B head (V=151936).
+///
+/// Call site is the trainer (SFT and GRPO) behind the `KILN_USE_FLCE`
+/// environment flag. No KV cache is used (matches `standard_forward_backward`).
+pub fn model_forward_no_head(
+    backend: &dyn BackendRuntime,
+    token_ids: &[u32],
+    weights: &GpuWeights,
+    config: &kiln_core::config::ModelConfig,
+    linear_state: Option<&mut LinearAttentionState>,
+    lora: Option<&LoraWeights>,
+) -> Result<Tensor> {
+    let (hidden, positions) = model_forward_embed(token_ids, weights)?;
+    let num_layers = weights.layers.len();
+    let hidden = model_forward_segment(
+        backend,
+        hidden,
+        weights,
+        config,
+        &positions,
+        0,
+        num_layers,
+        linear_state,
+        lora,
+    )?;
+    let normed = {
+        kiln_nvtx::range!(c"kiln/final_rmsnorm");
+        rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?
+    };
+    Ok(normed)
+}
+
 /// Full model forward pass using paged KV cache.
 ///
 /// Same as [`model_forward`] but uses a [`PagedKvCache`] and [`BlockTable`]

--- a/crates/kiln-train/Cargo.toml
+++ b/crates/kiln-train/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 kiln-core = { workspace = true }
+kiln-flce-kernel = { workspace = true }
 kiln-model = { workspace = true }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -11,10 +11,11 @@ use candle_core::{DType, Device, Tensor, Var};
 
 use kiln_core::config::ModelConfig;
 use kiln_core::tokenizer::KilnTokenizer;
+use kiln_flce_kernel::{fused_linear_cross_entropy, DEFAULT_CHUNK_SIZE};
 use kiln_model::backend::{self, BackendRuntime};
 use kiln_model::forward::{
-    model_forward, model_forward_embed, model_forward_head, model_forward_segment,
-    GpuWeights, LinearAttentionState,
+    model_forward, model_forward_embed, model_forward_final_norm, model_forward_head,
+    model_forward_no_head, model_forward_segment, GpuWeights, LinearAttentionState,
 };
 use kiln_model::lora_loader::{
     LoraLayerWeights, LoraProjectionWeights, LoraWeights,
@@ -976,6 +977,22 @@ fn cross_entropy_loss(
     Ok(loss)
 }
 
+/// Read `KILN_USE_FLCE` env var. When set (`1`, `true`, `yes`), SFT training
+/// takes the Fused Linear Cross-Entropy path: the LM head matmul is fused
+/// into a chunked log-sum-exp + gather reduction so the `[T, V]` logits
+/// tensor is never materialized. Required to keep long-context SFT
+/// (T >= 8192) under the A6000 VRAM budget on Qwen3.5-4B (V=151936).
+///
+/// Default: disabled. Opt-in while the path is being validated.
+fn use_flce() -> bool {
+    std::env::var("KILN_USE_FLCE")
+        .map(|v| {
+            let v = v.to_lowercase();
+            v == "1" || v == "true" || v == "yes"
+        })
+        .unwrap_or(false)
+}
+
 /// SGD update: param = param - lr * grad
 fn sgd_step(
     params: &TrainableLoraParams,
@@ -1202,11 +1219,22 @@ fn checkpointed_forward_backward(
             )?;
         }
 
-        // LM head
-        let logits = model_forward_head(&hidden, weights, model_config)?;
-
-        // Loss (only on assistant tokens)
-        let loss = cross_entropy_loss(&logits, input_ids, label_mask, device)?;
+        // LM head + loss (or fused LCE when KILN_USE_FLCE=1).
+        let loss = if use_flce() {
+            let normed = model_forward_final_norm(&hidden, weights, model_config)?;
+            fused_linear_cross_entropy(
+                &normed,
+                &weights.embed_tokens_t,
+                input_ids,
+                label_mask,
+                device,
+                DEFAULT_CHUNK_SIZE,
+            )
+            .context("fused linear cross-entropy (checkpointed)")?
+        } else {
+            let logits = model_forward_head(&hidden, weights, model_config)?;
+            cross_entropy_loss(&logits, input_ids, label_mask, device)?
+        };
         let loss_val = loss.to_scalar::<f32>()? as f64;
         total_loss += loss_val;
 
@@ -1234,17 +1262,35 @@ fn standard_forward_backward(
     let lora_weights = params.as_lora_weights();
     let mut linear_state = LinearAttentionState::new(model_config, device)?;
 
-    let logits = model_forward(
-        backend,
-        input_ids,
-        weights,
-        model_config,
-        None,
-        Some(&mut linear_state),
-        Some(&lora_weights),
-    ).context("training forward pass")?;
-
-    let loss = cross_entropy_loss(&logits, input_ids, label_mask, device)?;
+    let loss = if use_flce() {
+        let hidden = model_forward_no_head(
+            backend,
+            input_ids,
+            weights,
+            model_config,
+            Some(&mut linear_state),
+            Some(&lora_weights),
+        ).context("training forward pass (FLCE)")?;
+        fused_linear_cross_entropy(
+            &hidden,
+            &weights.embed_tokens_t,
+            input_ids,
+            label_mask,
+            device,
+            DEFAULT_CHUNK_SIZE,
+        ).context("fused linear cross-entropy")?
+    } else {
+        let logits = model_forward(
+            backend,
+            input_ids,
+            weights,
+            model_config,
+            None,
+            Some(&mut linear_state),
+            Some(&lora_weights),
+        ).context("training forward pass")?;
+        cross_entropy_loss(&logits, input_ids, label_mask, device)?
+    };
     let loss_val = loss.to_scalar::<f32>()? as f64;
     let grads = loss.backward().context("backward pass")?;
 
@@ -1694,6 +1740,76 @@ mod tests {
         // Cross-entropy on random logits over vocab=32 should be ~ln(32) ≈ 3.47
         assert!(loss_std > 1.0 && loss_std < 10.0, "standard loss out of range: {loss_std}");
         assert!(loss_ckpt > 1.0 && loss_ckpt < 10.0, "checkpointed loss out of range: {loss_ckpt}");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_flce_parity_vs_naive_loss() -> Result<()> {
+        // Kill-switch parity: naive `model_forward_head` + `cross_entropy_loss`
+        // must match `model_forward_no_head` + `fused_linear_cross_entropy`
+        // on the same weights and inputs, up to floating-point associativity
+        // in the chunked vocab reduction.
+        //
+        // This is the trainer-integration equivalent of the CPU parity tests
+        // inside `kiln-flce-kernel`: those validate the kernel in isolation,
+        // this validates the wiring end-to-end through the real transformer
+        // stack so enabling `KILN_USE_FLCE` for SFT is a no-op on the loss.
+        let device = Device::Cpu;
+        let config = tiny_config();
+        let weights = tiny_weights(&config, &device)?;
+
+        let input_ids: Vec<u32> = vec![1, 5, 10, 3, 7, 2, 8];
+        let label_mask = vec![false, false, true, true, true, true, false];
+
+        let backend = backend::for_device(&device);
+
+        // Naive path: full forward → logits → cross_entropy_loss.
+        let mut linear_state_naive = LinearAttentionState::new(&config, &device)?;
+        let logits = model_forward(
+            &*backend,
+            &input_ids,
+            &weights,
+            &config,
+            None,
+            Some(&mut linear_state_naive),
+            None,
+        )?;
+        let loss_naive = cross_entropy_loss(&logits, &input_ids, &label_mask, &device)?
+            .to_scalar::<f32>()?;
+
+        // FLCE path: no-head forward → fused LCE (small chunk to exercise the
+        // chunked reduction on a modest vocab size).
+        let mut linear_state_flce = LinearAttentionState::new(&config, &device)?;
+        let hidden = model_forward_no_head(
+            &*backend,
+            &input_ids,
+            &weights,
+            &config,
+            Some(&mut linear_state_flce),
+            None,
+        )?;
+        let loss_flce = fused_linear_cross_entropy(
+            &hidden,
+            &weights.embed_tokens_t,
+            &input_ids,
+            &label_mask,
+            &device,
+            8, // small chunk to exercise uneven-chunk path
+        )?
+        .to_scalar::<f32>()?;
+
+        let abs_err = (loss_naive - loss_flce).abs();
+        let rel_err = if loss_naive.abs() > 1e-6 {
+            abs_err / loss_naive.abs()
+        } else {
+            abs_err
+        };
+        assert!(
+            abs_err < 1e-4 || rel_err < 1e-4,
+            "FLCE trainer parity failed: naive={loss_naive:.6} flce={loss_flce:.6} \
+             abs_err={abs_err:.2e} rel_err={rel_err:.2e}",
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Phase A of the FLCE port: add `kiln-flce-kernel` crate with a pure-candle chunked log-sum-exp + gather implementation, wire it into the SFT training paths behind `KILN_USE_FLCE=1`, and ship CPU parity tests.

**Why this is a prerequisite, not an optimization.** Preflight (#235) showed that at `T >= 8192` on Qwen3.5-4B (V=151936), the `[T, V]` F32 logits tensor the head materializes dominates peak VRAM and OOMs before reaching the head on A6000. Long-context SFT is blocked without FLCE — this is the unblocking PR.

## What's in Phase A

- **`crates/kiln-flce-kernel/`** — new crate, pure candle, no CUDA dep (goes into `default-members`).
  - `fused_linear_cross_entropy(hidden, head_t, input_ids, label_mask, device, chunk_size) -> Tensor` computes the cross-entropy loss chunked over the vocab dim. Maintains running max + running sum-exp (`log_sum_exp = running_max + log(running_sumexp)`) and scatters the correct-class logit per active row into a `[num_active]` tensor via `index_add`.
  - Forward peak intermediate is `T_active * chunk_size` f32 instead of `T_active * V` f32 — ~37x smaller for Qwen3.5-4B with `chunk=4096`.
  - 6 CPU parity tests (small, uneven chunks, single chunk, bf16, empty mask, constant). F32 tolerance `abs_err < 1e-5`, bf16 `< 1e-2`. All pass in 0.04s.

- **`crates/kiln-model/src/forward.rs`** — two small public helpers:
  - `model_forward_no_head(backend, token_ids, weights, config, linear_state, lora)` — full training-path forward that stops at final RMSNorm, returns `[1, seq_len, hidden_size]`. Reuses `model_forward_embed` + `model_forward_segment` + `rms_norm`.
  - `model_forward_final_norm(hidden, weights, config)` — just the final RMSNorm (used by the checkpointed path, which already has post-layers hidden in hand).

- **`crates/kiln-train/src/trainer.rs`** — `use_flce()` env-flag helper, SFT call sites branched:
  - `standard_forward_backward` (line ~1247 before): `model_forward_no_head` + `fused_linear_cross_entropy` when flag is on; original `model_forward` + `cross_entropy_loss` otherwise.
  - `checkpointed_forward_backward` (line ~1206 before): `model_forward_final_norm` + `fused_linear_cross_entropy` when flag is on; original `model_forward_head` + `cross_entropy_loss` otherwise.
  - GRPO paths intentionally unchanged — they compute per-token log-probs from full logits and need a separate fused op; out of scope here.
  - New `test_flce_parity_vs_naive_loss` drives both paths end-to-end through the real tiny transformer and asserts `abs_err < 1e-4`.

## What Phase A does NOT do (deferred to Phase B)

Phase A is honest about its scope:

- **Forward memory win only.** The forward path already avoids the `[T, V]` tensor, but backward flows through candle autograd, so the per-chunk intermediates are retained. Real backward memory parity with Liger/torchtune FLCE requires a manual `bwd()`.
- **No custom CUDA kernel.** Phase A uses candle tensor ops so the same code runs on CPU/CUDA/Metal for parity. candle's `CustomOp1` signature (`cpu_fwd`/`cuda_fwd` operate on raw storage) doesn't compose with higher-level Tensor ops, and a CPU-only `CustomOp` would be useless for GPU training.
- **No GRPO integration.** GRPO needs fused linear + log-softmax + gather for per-token log-probs, not cross-entropy; different op.

**Phase B** (follow-up PR) will replace the pure-candle forward with a `CustomOp1` whose `cuda_fwd` calls a vendored CUDA kernel and whose manual `bwd()` recomputes chunks to produce `dhidden` without retaining the forward graph. The public `fused_linear_cross_entropy` signature is stable across both phases.

## Test plan

- [x] `cargo nextest run -p kiln-flce-kernel` — 6/6 parity tests pass
- [x] `cargo nextest run -p kiln-train` — all trainer tests pass, including new `test_flce_parity_vs_naive_loss`
- [x] `cargo nextest run -p kiln-flce-kernel -p kiln-model -p kiln-train` — 147/147 pass
- [x] `cargo check -p kiln-train` clean (no new warnings)
- [ ] Phase B: run a real long-context SFT with `KILN_USE_FLCE=1` on A6000 and confirm VRAM drop + loss parity

## Budget discipline

This PR landed fully from a local macOS-style (non-CUDA) check path. No RunPod pod acquired, $0 GPU spend. Phase B will require a pod when the CUDA kernel ships.