### PR TITLE
docs: link CHANGELOG.md from root + desktop READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ Kiln Desktop is a system-tray app that wraps the `kiln` server for people who do
 
 **Download — [Kiln Desktop v0.1.10](https://github.com/ericflo/kiln/releases/tag/desktop-v0.1.10):**
 
+See **[desktop/CHANGELOG.md](desktop/CHANGELOG.md)** for the full version history.
+
 | Platform | Installer | Size |
 |---|---|---|
 | Windows | [Kiln.Desktop_0.1.10_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.1.10/Kiln.Desktop_0.1.10_x64-setup.exe) (NSIS) | 4.3 MB |

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -42,6 +42,8 @@ macOS `.dmg` releases are signed with a Developer ID certificate and notarized b
 - **Real Kiln logo icons** — PNG/ICO/ICNS baked into all platform bundles.
 - **GitHub Actions CI** — builds Windows MSI and NSIS installers and Linux `.deb` / `.AppImage`, attaches artifacts to tag releases.
 
+See **[CHANGELOG.md](CHANGELOG.md)** for older versions and full release history.
+
 ## Architecture
 
 The app is a [Tauri v2](https://v2.tauri.app/) project (Rust backend, HTML/JS frontend) that spawns and supervises the `kiln` binary as a **child process**. Kiln is NOT embedded as a library — it is a heavyweight GPU server (CUDA on Linux/Windows, Metal on macOS), and keeping it as a separate binary preserves headless usage and avoids dragging candle/CUDA/Metal into the Tauri build.


### PR DESCRIPTION
## What
Links the new desktop/CHANGELOG.md from both the root README and desktop/README so readers can scan full version history in one click.

## Why
PR #239 shipped desktop/CHANGELOG.md and the auto-release-notes workflow, but neither README surfaces it. Currently users see one current-release blurb plus a tag link; full history requires clicking through each release.

## How
- Root README: one new line in the Desktop App section above the installer table.
- desktop/README.md: one new line at the end of the v0.1.10 features section.
- No code or workflow changes.