### PR TITLE
mtp: scaffolding for native MTP speculative decoding (WIP)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -129,6 +129,45 @@ pub struct GpuWeights {
     /// so the RoPE hot path can reuse it instead of rebuilding a fresh `Vec<f32>` +
     /// HtoD upload on every layer's attention call (~8 × per token in prefill).
     pub rotary_inv_freq: Tensor,
+    /// Native MTP (Multi-Token Prediction) head tensors on device, when the
+    /// checkpoint shipped them and the loader surfaced a `ModelWeights.mtp`.
+    /// `None` for checkpoints without MTP support; the `KILN_SPEC_METHOD=mtp`
+    /// code path must bail with an error and fall back to `SkipLayer` or
+    /// single-token decode when this is `None`.
+    pub mtp: Option<MtpGpuWeights>,
+}
+
+/// GPU-ready native MTP head tensors.
+///
+/// Mirrors [`crate::weights::MtpWeights`] after upload. The `lm_head` is tied
+/// to the base model's token embedding, so this struct intentionally does NOT
+/// carry its own `lm_head` tensor — the spec-decode forward pass reuses
+/// [`GpuWeights::embed_tokens_t`] for the final projection.
+///
+/// The inner [`GpuLayerWeights`] is re-used for the MTP transformer layer so
+/// the forward pass can dispatch through the same full-attention kernels
+/// (q/k/v/o_proj, q_norm, k_norm, input/post_attention_layernorm, SwiGLU MLP)
+/// that it uses for the base model's eight full-attention layers. The loader
+/// already rejects any MTP checkpoint that resolves as linear attention, so
+/// the inner `attention` field is always `GpuAttentionWeights::Full(_)`.
+pub struct MtpGpuWeights {
+    /// Concat-then-project: `[hidden_size, 2 * hidden_size]`, BF16 on device.
+    /// Ingests `concat(norm_embed, norm_hidden)` → produces `[seq, hidden_size]`.
+    pub fc: Tensor,
+    /// Pre-transposed `fc` for the forward hot path: `[2 * hidden_size, hidden_size]`, contiguous.
+    /// Same transpose-caching pattern as the base model's `*_proj_t` fields
+    /// (PRs #117/#124/#128) — eliminates a per-draft-step `.t().contiguous()`
+    /// on a 26 MiB bf16 matrix when drafting.
+    pub fc_t: Tensor,
+    /// RMSNorm weight for the draft-candidate's token embedding. `[hidden_size]`.
+    pub pre_fc_norm_embedding: Tensor,
+    /// RMSNorm weight for the base model's last hidden state. `[hidden_size]`.
+    pub pre_fc_norm_hidden: Tensor,
+    /// Single MTP transformer layer. The loader validates this is always a
+    /// full-attention layer, so `layer.attention` is `Full(...)` at runtime.
+    pub layer: GpuLayerWeights,
+    /// Final RMSNorm weight before the tied lm_head. `[hidden_size]`.
+    pub final_layernorm: Tensor,
 }
 
 /// Compute the rotary-embedding `inv_freq` tensor once and upload it to `device`.
@@ -267,6 +306,69 @@ impl LinearAttentionState {
             recurrent_states,
             conv_states,
         })
+    }
+
+    /// Capture the current GDN recurrent + conv state into a fresh shadow
+    /// `LinearAttentionState`. Used by speculative decoding to preserve the
+    /// base model's O(1) GDN state before advancing into a draft: if any
+    /// proposed token is rejected, [`Self::restore_from`] puts it back.
+    ///
+    /// This snapshot allocates new device tensors and issues a
+    /// `cudaMemcpyDeviceToDevice` per layer. For Qwen3.5-4B that is
+    /// 24 × (recurrent ≈ 2 MiB + conv ≈ 24 KiB) ≈ 49 MiB per snapshot, which
+    /// is acceptable for WIP scaffolding. The follow-up PR replaces this with
+    /// the ping-pong shadow-slot pattern from the existing KV-cache draft
+    /// code path (no per-step alloc, two pre-allocated slots swapped via
+    /// index) to bring overhead to zero.
+    pub fn snapshot(&self) -> Result<Self> {
+        let mut recurrent_states = Vec::with_capacity(self.recurrent_states.len());
+        for t in &self.recurrent_states {
+            recurrent_states.push(t.copy().context("snapshot recurrent state")?);
+        }
+        let mut conv_states = Vec::with_capacity(self.conv_states.len());
+        for t in &self.conv_states {
+            conv_states.push(t.copy().context("snapshot conv state")?);
+        }
+        Ok(Self {
+            recurrent_states,
+            conv_states,
+        })
+    }
+
+    /// Restore this state from a previously captured [`Self::snapshot`].
+    ///
+    /// Checks that the shapes/counts match — a mismatch indicates the caller
+    /// mixed up snapshots from different sessions, which would be a logic bug
+    /// in the spec-decode loop. Overwrites the current tensors in place so
+    /// downstream GPU pointers (e.g. those captured inside a CUDA graph) stay
+    /// valid. The follow-up ping-pong rewrite folds this into a zero-copy
+    /// slot swap; this correctness-first copy implementation is the scaffold.
+    pub fn restore_from(&mut self, snapshot: &Self) -> Result<()> {
+        if self.recurrent_states.len() != snapshot.recurrent_states.len() {
+            anyhow::bail!(
+                "LinearAttentionState::restore_from: recurrent_states len mismatch ({} vs {})",
+                self.recurrent_states.len(),
+                snapshot.recurrent_states.len()
+            );
+        }
+        if self.conv_states.len() != snapshot.conv_states.len() {
+            anyhow::bail!(
+                "LinearAttentionState::restore_from: conv_states len mismatch ({} vs {})",
+                self.conv_states.len(),
+                snapshot.conv_states.len()
+            );
+        }
+        for (dst, src) in self
+            .recurrent_states
+            .iter_mut()
+            .zip(snapshot.recurrent_states.iter())
+        {
+            *dst = src.copy().context("restore recurrent state")?;
+        }
+        for (dst, src) in self.conv_states.iter_mut().zip(snapshot.conv_states.iter()) {
+            *dst = src.copy().context("restore conv state")?;
+        }
+        Ok(())
     }
 }
 
@@ -628,12 +730,146 @@ impl GpuWeights {
             }
         }
 
+        // Upload native MTP head tensors when the checkpoint shipped them.
+        // For WIP scaffolding the MTP transformer layer is kept in BF16 and
+        // is NOT queued for Marlin batch packing: the MTP layer is a single
+        // layer whose projections account for ~3% of total model memory, so
+        // deferring W4A16 coverage costs little and keeps the scaffold
+        // simple. The follow-up PR extends `marlin_pack_inputs` to include
+        // the MTP layer's q_proj + MLP trio.
+        let mtp = if let Some(mtp_w) = &weights.mtp {
+            let fc = weight_to_tensor(&mtp_w.fc, device).context("mtp.fc")?;
+            let fc_t = fc
+                .t()
+                .context("mtp.fc.t")?
+                .contiguous()
+                .context("mtp.fc.t contiguous")?;
+            let pre_fc_norm_embedding = weight_to_tensor(&mtp_w.pre_fc_norm_embedding, device)
+                .context("mtp.pre_fc_norm_embedding")?;
+            let pre_fc_norm_hidden = weight_to_tensor(&mtp_w.pre_fc_norm_hidden, device)
+                .context("mtp.pre_fc_norm_hidden")?;
+            let final_layernorm = weight_to_tensor(&mtp_w.final_layernorm, device)
+                .context("mtp.final_layernorm")?;
+
+            // The MTP inner transformer layer. Loader guarantees this is a
+            // full-attention layer (bails otherwise). Keep the upload inline
+            // — duplicating the ~70-line layer-upload block here is a
+            // deliberate scaffolding shortcut; the follow-up PR factors this
+            // and the main per-layer upload into a shared helper.
+            let mtp_layer = {
+                let lw = &mtp_w.layer;
+                let ctx = |name: &str| format!("mtp.layer {name}");
+
+                let input_layernorm =
+                    weight_to_tensor(&lw.input_layernorm, device).context(ctx("input_layernorm"))?;
+                let post_attention_layernorm = weight_to_tensor(&lw.post_attention_layernorm, device)
+                    .context(ctx("post_attention_layernorm"))?;
+
+                let attention = match &lw.attention {
+                    crate::weights::AttentionWeights::Full(attn) => {
+                        let q_proj = weight_to_tensor(&attn.q_proj, device).context(ctx("q_proj"))?;
+                        let k_proj = weight_to_tensor(&attn.k_proj, device).context(ctx("k_proj"))?;
+                        let v_proj = weight_to_tensor(&attn.v_proj, device).context(ctx("v_proj"))?;
+                        let o_proj = weight_to_tensor(&attn.o_proj, device).context(ctx("o_proj"))?;
+                        let q_proj_t = q_proj
+                            .t()
+                            .context(ctx("q_proj.t"))?
+                            .contiguous()
+                            .context(ctx("q_proj.t contiguous"))?;
+                        let k_proj_t = k_proj
+                            .t()
+                            .context(ctx("k_proj.t"))?
+                            .contiguous()
+                            .context(ctx("k_proj.t contiguous"))?;
+                        let v_proj_t = v_proj
+                            .t()
+                            .context(ctx("v_proj.t"))?
+                            .contiguous()
+                            .context(ctx("v_proj.t contiguous"))?;
+                        let o_proj_t = o_proj
+                            .t()
+                            .context(ctx("o_proj.t"))?
+                            .contiguous()
+                            .context(ctx("o_proj.t contiguous"))?;
+                        GpuAttentionWeights::Full(GpuFullAttentionWeights {
+                            q_proj,
+                            k_proj,
+                            v_proj,
+                            o_proj,
+                            q_norm: weight_to_tensor(&attn.q_norm, device).context(ctx("q_norm"))?,
+                            k_norm: weight_to_tensor(&attn.k_norm, device).context(ctx("k_norm"))?,
+                            q_proj_t,
+                            k_proj_t,
+                            v_proj_t,
+                            o_proj_t,
+                            q_proj_marlin: None,
+                        })
+                    }
+                    crate::weights::AttentionWeights::Linear(_) => {
+                        anyhow::bail!(
+                            "MTP layer resolved as linear attention — loader should have caught this"
+                        );
+                    }
+                };
+
+                let gate_proj =
+                    weight_to_tensor(&lw.mlp.gate_proj, device).context(ctx("gate_proj"))?;
+                let up_proj = weight_to_tensor(&lw.mlp.up_proj, device).context(ctx("up_proj"))?;
+                let down_proj =
+                    weight_to_tensor(&lw.mlp.down_proj, device).context(ctx("down_proj"))?;
+                let gate_proj_t = gate_proj
+                    .t()
+                    .context(ctx("gate_proj.t"))?
+                    .contiguous()
+                    .context(ctx("gate_proj.t contiguous"))?;
+                let up_proj_t = up_proj
+                    .t()
+                    .context(ctx("up_proj.t"))?
+                    .contiguous()
+                    .context(ctx("up_proj.t contiguous"))?;
+                let down_proj_t = down_proj
+                    .t()
+                    .context(ctx("down_proj.t"))?
+                    .contiguous()
+                    .context(ctx("down_proj.t contiguous"))?;
+
+                GpuLayerWeights {
+                    input_layernorm,
+                    post_attention_layernorm,
+                    attention,
+                    mlp: GpuFfnWeights {
+                        gate_proj,
+                        up_proj,
+                        down_proj,
+                        gate_proj_t,
+                        up_proj_t,
+                        down_proj_t,
+                        gate_proj_marlin: None,
+                        up_proj_marlin: None,
+                        down_proj_marlin: None,
+                    },
+                }
+            };
+
+            Some(MtpGpuWeights {
+                fc,
+                fc_t,
+                pre_fc_norm_embedding,
+                pre_fc_norm_hidden,
+                layer: mtp_layer,
+                final_layernorm,
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
             embed_tokens,
             embed_tokens_t,
             layers,
             final_norm,
             rotary_inv_freq,
+            mtp,
         })
     }
 }
@@ -3893,6 +4129,7 @@ mod tests {
             layers,
             final_norm,
             rotary_inv_freq,
+            mtp: None,
         })
     }
 
@@ -4290,6 +4527,7 @@ mod tests {
             layers,
             final_norm,
             rotary_inv_freq,
+            mtp: None,
         })
     }
 

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1167,6 +1167,7 @@ mod tests {
             layers: vec![layer],
             final_norm,
             rotary_inv_freq,
+            mtp: None,
         }
     }
 

--- a/crates/kiln-model/src/loader.rs
+++ b/crates/kiln-model/src/loader.rs
@@ -94,10 +94,21 @@ fn load_model_dense(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeigh
     let final_norm = extract_tensor(&tensor_map, &format!("{prefix}norm.weight"))?;
     validate_shape(&final_norm, &[config.hidden_size], "final_norm")?;
 
+    // Optional: load native MTP head when the checkpoint ships it.
+    // Qwen3.5-4B has `num_nextn_predict_layers = 1` (k=1 draft depth) and
+    // stores 15 `mtp.*` tensors. We detect purely by tensor presence rather
+    // than adding a new config field — if the checkpoint has MTP tensors,
+    // load them; if not, leave `ModelWeights.mtp` as None.
+    let mtp = load_mtp_if_present(&tensor_map, &prefix, config)?;
+    if mtp.is_some() {
+        tracing::info!("Native MTP head detected and loaded (k=1 draft depth)");
+    }
+
     let weights = ModelWeights {
         embedding: EmbeddingWeights { embed_tokens },
         layers,
         final_norm,
+        mtp,
     };
 
     let total_mb = weights.total_bytes() as f64 / (1024.0 * 1024.0);
@@ -172,10 +183,21 @@ fn load_model_gptq(
     let final_norm = extract_tensor(&tensor_map, &format!("{prefix}norm.weight"))?;
     validate_shape(&final_norm, &[config.hidden_size], "final_norm")?;
 
+    // GPTQ MTP is not yet supported — the MTP layer projections would need
+    // a separate GPTQ dequant path. For now we simply log and skip.
+    if tensor_map.contains_key("mtp.fc.weight")
+        || tensor_map.contains_key(&format!("{prefix}mtp.fc.weight") as &str)
+    {
+        tracing::warn!(
+            "MTP tensors present in GPTQ checkpoint but GPTQ MTP loading is not yet implemented — skipping"
+        );
+    }
+
     let weights = ModelWeights {
         embedding: EmbeddingWeights { embed_tokens },
         layers,
         final_norm,
+        mtp: None,
     };
 
     let total_mb = weights.total_bytes() as f64 / (1024.0 * 1024.0);
@@ -463,6 +485,100 @@ fn load_ffn(
         up_proj,
         down_proj,
     })
+}
+
+/// Detect and load the native MTP head if present in the checkpoint.
+///
+/// Qwen3.5-4B ships 15 MTP-prefixed tensors under `<prefix>mtp.*`:
+/// - `mtp.fc.weight` `[hidden, 2*hidden]`
+/// - `mtp.pre_fc_norm_embedding.weight` `[hidden]`
+/// - `mtp.pre_fc_norm_hidden.weight` `[hidden]`
+/// - `mtp.layers.0.*` — one full GQA transformer layer (shape identical to a
+///   main-model full-attention layer including `attn_output_gate`)
+/// - `mtp.final_layernorm.weight` `[hidden]`
+///
+/// The MTP head ties its `lm_head` to the base model's `embed_tokens`, so we
+/// do NOT load a separate `mtp.lm_head` tensor. The spec-decode forward
+/// path reuses `GpuWeights::embed_tokens_t`.
+///
+/// Returns `Ok(Some(..))` when detected, `Ok(None)` when absent (so older
+/// or MTP-less checkpoints continue to load unchanged).
+fn load_mtp_if_present(
+    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    prefix: &str,
+    config: &ModelConfig,
+) -> Result<Option<MtpWeights>> {
+    // Probe: is the MTP fc projection present? (Single-file and VL-prefixed
+    // checkpoints both land at `{prefix}mtp.fc.weight`.)
+    let mtp_prefix = format!("{prefix}mtp.");
+    let fc_key = format!("{mtp_prefix}fc.weight");
+    if !tensor_map.contains_key(fc_key.as_str()) {
+        return Ok(None);
+    }
+
+    let ctx = |name: &str| format!("mtp.{name}");
+
+    let fc = extract_tensor(tensor_map, &fc_key)?;
+    // fc maps concat(embed, hidden) → hidden, so shape is [hidden, 2*hidden].
+    validate_shape(&fc, &[config.hidden_size, 2 * config.hidden_size], &ctx("fc"))?;
+
+    let pre_fc_norm_embedding = extract_tensor(
+        tensor_map,
+        &format!("{mtp_prefix}pre_fc_norm_embedding.weight"),
+    )?;
+    validate_shape(
+        &pre_fc_norm_embedding,
+        &[config.hidden_size],
+        &ctx("pre_fc_norm_embedding"),
+    )?;
+
+    let pre_fc_norm_hidden = extract_tensor(
+        tensor_map,
+        &format!("{mtp_prefix}pre_fc_norm_hidden.weight"),
+    )?;
+    validate_shape(
+        &pre_fc_norm_hidden,
+        &[config.hidden_size],
+        &ctx("pre_fc_norm_hidden"),
+    )?;
+
+    let final_layernorm =
+        extract_tensor(tensor_map, &format!("{mtp_prefix}final_layernorm.weight"))?;
+    validate_shape(
+        &final_layernorm,
+        &[config.hidden_size],
+        &ctx("final_layernorm"),
+    )?;
+
+    // The MTP layer uses the same full-attention shape as the main-model
+    // full-attention layers (GQA + output gate + SwiGLU MLP). We reuse
+    // `load_layer` with a synthetic prefix that points at `mtp.layers.0.`
+    // and an index (3) whose residue class `(i + 1) % 4 == 0` makes
+    // `is_full_attention_layer` return true. The layer_idx argument is only
+    // used for error context strings, not for dispatch.
+    let mtp_layer_prefix = format!("{mtp_prefix}layers.0.");
+    let layer = load_layer(tensor_map, &mtp_layer_prefix, 3, config)
+        .context("mtp layer 0")?;
+    // Defensive: MTP layer must be full attention. If this ever fires the
+    // checkpoint is shipping a linear-attention MTP head and the forward
+    // pass below won't match.
+    match &layer.attention {
+        AttentionWeights::Full(_) => {}
+        AttentionWeights::Linear(_) => {
+            bail!(
+                "MTP layer loaded as linear attention — expected full GQA attention. \
+                 Checkpoint schema change?"
+            );
+        }
+    }
+
+    Ok(Some(MtpWeights {
+        fc,
+        pre_fc_norm_embedding,
+        pre_fc_norm_hidden,
+        layer,
+        final_layernorm,
+    }))
 }
 
 /// Extract a tensor by name from the unified tensor map.

--- a/crates/kiln-model/src/weights.rs
+++ b/crates/kiln-model/src/weights.rs
@@ -147,6 +147,108 @@ pub struct LayerWeights {
     pub mlp: FfnWeights,
 }
 
+/// Native MTP (Multi-Token Prediction) head weights for Qwen3.5-4B.
+///
+/// The pretrained Qwen3.5-4B checkpoint ships 15 MTP-prefixed tensors
+/// (`num_nextn_predict_layers = 1` → `k=1` draft depth). The MTP head
+/// lets us draft one token per decode step using the model's own
+/// distilled head instead of a skip-layer self-spec approximation.
+///
+/// Forward shape (vLLM `qwen3_next_mtp.py` reference):
+/// `concat(pre_fc_norm_embedding(embed(t)), pre_fc_norm_hidden(h)) → fc (2H→H)
+///  → layer (GQA + SwiGLU MLP) → final_layernorm → tied lm_head (= embed_tokens.t())`
+///
+/// `lm_head` is tied to the base model's `embed_tokens`, so we do NOT
+/// store a separate `lm_head` tensor — the spec-decode forward path
+/// reuses `GpuWeights::embed_tokens_t`.
+#[derive(Debug)]
+pub struct MtpWeights {
+    /// Concat-then-project: `[hidden_size, 2 * hidden_size]`.
+    /// Ingests `concat(norm_embed, norm_hidden)` and produces `[seq, hidden_size]`.
+    pub fc: WeightTensor,
+    /// RMSNorm applied to the draft-candidate's token embedding before concat. `[hidden_size]`.
+    pub pre_fc_norm_embedding: WeightTensor,
+    /// RMSNorm applied to the base model's last hidden state before concat. `[hidden_size]`.
+    pub pre_fc_norm_hidden: WeightTensor,
+    /// Single MTP transformer layer (full GQA attention + SwiGLU MLP + input/post
+    /// layernorms). Shape matches the main model's full-attention layer.
+    pub layer: LayerWeights,
+    /// Final RMSNorm before the tied lm_head. `[hidden_size]`.
+    pub final_layernorm: WeightTensor,
+}
+
+impl MtpWeights {
+    /// Total size of all MTP tensors in bytes.
+    pub fn total_bytes(&self) -> usize {
+        let mut total = self.fc.size_bytes();
+        total += self.pre_fc_norm_embedding.size_bytes();
+        total += self.pre_fc_norm_hidden.size_bytes();
+        total += self.final_layernorm.size_bytes();
+        total += self.layer.input_layernorm.size_bytes();
+        total += self.layer.post_attention_layernorm.size_bytes();
+        total += self.layer.mlp.gate_proj.size_bytes();
+        total += self.layer.mlp.up_proj.size_bytes();
+        total += self.layer.mlp.down_proj.size_bytes();
+        match &self.layer.attention {
+            AttentionWeights::Full(attn) => {
+                total += attn.q_proj.size_bytes();
+                total += attn.k_proj.size_bytes();
+                total += attn.v_proj.size_bytes();
+                total += attn.o_proj.size_bytes();
+                total += attn.q_norm.size_bytes();
+                total += attn.k_norm.size_bytes();
+            }
+            AttentionWeights::Linear(attn) => {
+                total += attn.in_proj_qkv.size_bytes();
+                total += attn.in_proj_z.size_bytes();
+                total += attn.out_proj.size_bytes();
+                total += attn.in_proj_a.size_bytes();
+                total += attn.in_proj_b.size_bytes();
+                total += attn.conv1d.size_bytes();
+                total += attn.norm.size_bytes();
+                total += attn.a_log.size_bytes();
+                total += attn.dt_bias.size_bytes();
+            }
+        }
+        total
+    }
+
+    /// Total parameter count across all MTP tensors.
+    pub fn total_params(&self) -> usize {
+        let mut total = self.fc.numel();
+        total += self.pre_fc_norm_embedding.numel();
+        total += self.pre_fc_norm_hidden.numel();
+        total += self.final_layernorm.numel();
+        total += self.layer.input_layernorm.numel();
+        total += self.layer.post_attention_layernorm.numel();
+        total += self.layer.mlp.gate_proj.numel();
+        total += self.layer.mlp.up_proj.numel();
+        total += self.layer.mlp.down_proj.numel();
+        match &self.layer.attention {
+            AttentionWeights::Full(attn) => {
+                total += attn.q_proj.numel();
+                total += attn.k_proj.numel();
+                total += attn.v_proj.numel();
+                total += attn.o_proj.numel();
+                total += attn.q_norm.numel();
+                total += attn.k_norm.numel();
+            }
+            AttentionWeights::Linear(attn) => {
+                total += attn.in_proj_qkv.numel();
+                total += attn.in_proj_z.numel();
+                total += attn.out_proj.numel();
+                total += attn.in_proj_a.numel();
+                total += attn.in_proj_b.numel();
+                total += attn.conv1d.numel();
+                total += attn.norm.numel();
+                total += attn.a_log.numel();
+                total += attn.dt_bias.numel();
+            }
+        }
+        total
+    }
+}
+
 /// Complete Qwen3.5-4B language model weights.
 ///
 /// Note: lm_head is tied to embed_tokens (shared weight matrix),
@@ -157,6 +259,11 @@ pub struct ModelWeights {
     pub layers: Vec<LayerWeights>,
     /// Final RMSNorm. [hidden_size]
     pub final_norm: WeightTensor,
+    /// Optional native MTP head (Qwen3.5-4B ships one, other variants may not).
+    /// Populated when `num_nextn_predict_layers > 0` in the model config AND the
+    /// `mtp.*` tensors are present in the checkpoint. Consumed by
+    /// `KILN_SPEC_METHOD=mtp` at serve time.
+    pub mtp: Option<MtpWeights>,
 }
 
 impl ModelWeights {
@@ -164,6 +271,9 @@ impl ModelWeights {
     pub fn total_bytes(&self) -> usize {
         let mut total = self.embedding.embed_tokens.size_bytes();
         total += self.final_norm.size_bytes();
+        if let Some(mtp) = &self.mtp {
+            total += mtp.total_bytes();
+        }
         for layer in &self.layers {
             total += layer.input_layernorm.size_bytes();
             total += layer.post_attention_layernorm.size_bytes();
@@ -199,6 +309,9 @@ impl ModelWeights {
     pub fn total_params(&self) -> usize {
         let mut total = self.embedding.embed_tokens.numel();
         total += self.final_norm.numel();
+        if let Some(mtp) = &self.mtp {
+            total += mtp.total_params();
+        }
         for layer in &self.layers {
             total += layer.input_layernorm.numel();
             total += layer.post_attention_layernorm.numel();

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -118,18 +118,64 @@ pub struct PrefixCacheConfig {
     pub max_blocks: Option<usize>,
 }
 
+/// Which speculative-decoding method to use when `enabled = true`.
+///
+/// - `Off` — no spec decoding, one token per step.
+/// - `SkipLayer` — self-speculative using the first `draft_layers` of the main
+///   model as a lightweight draft. Works on any checkpoint; kept as fallback
+///   and A/B baseline.
+/// - `Mtp` — native Multi-Token Prediction using the model's pretrained MTP
+///   heads. Requires the checkpoint to contain `mtp.*` tensors (Qwen3.5-4B
+///   has one MTP layer, k=1).
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SpecMethod {
+    Off,
+    SkipLayer,
+    Mtp,
+}
+
+impl Default for SpecMethod {
+    fn default() -> Self {
+        Self::Off
+    }
+}
+
+impl SpecMethod {
+    /// Parse from an env-var string. Case-insensitive; accepts common aliases.
+    /// Returns `None` for unknown values so the caller can warn and fall back.
+    pub fn parse_env(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "off" | "none" | "0" | "false" => Some(Self::Off),
+            "skip_layer" | "skiplayer" | "skip-layer" | "self" => Some(Self::SkipLayer),
+            "mtp" | "native_mtp" | "native-mtp" => Some(Self::Mtp),
+            _ => None,
+        }
+    }
+}
+
 /// Speculative decoding settings.
-/// Uses self-speculative (skip-layer) approach: the first N layers of the main
-/// model act as a lightweight draft, avoiding the need to load a second model.
+///
+/// Two implementations coexist:
+///   * `SkipLayer` — the first `draft_layers` of the main model act as the
+///     draft. Works on any checkpoint.
+///   * `Mtp` — native MTP heads shipped with the checkpoint (Qwen3.5-4B k=1).
+///     Requires `mtp.*` tensors in the weights.
+///
+/// `method` selects which path is active when `enabled = true`. For backward
+/// compatibility, setting `enabled = true` with `method = Off` falls back to
+/// `SkipLayer`.
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct SpeculativeDecodingConfig {
     /// Enable speculative decoding (default: false).
     pub enabled: bool,
+    /// Which speculative-decoding method to use. Default: `Off`.
+    pub method: SpecMethod,
     /// Number of tokens the draft proposes per step (default: 4).
+    /// Ignored by `Mtp` when the checkpoint has fewer MTP layers than this.
     pub num_speculative_tokens: usize,
-    /// Number of layers to use for the draft model (default: 8).
-    /// Uses the first N layers of the main model as the draft.
+    /// Number of layers to use for the `SkipLayer` draft (default: 8).
     pub draft_layers: usize,
 }
 
@@ -244,8 +290,27 @@ impl Default for SpeculativeDecodingConfig {
     fn default() -> Self {
         Self {
             enabled: false,
+            method: SpecMethod::Off,
             num_speculative_tokens: 4,
             draft_layers: 8,
+        }
+    }
+}
+
+impl SpeculativeDecodingConfig {
+    /// Resolve the effective speculative-decoding method.
+    ///
+    /// Returns `Off` if the feature is disabled; otherwise returns the
+    /// configured `method`, falling back to `SkipLayer` for backward
+    /// compatibility when `enabled = true` but `method = Off` (older configs
+    /// and older env-var usage that predate `KILN_SPEC_METHOD`).
+    pub fn effective_method(&self) -> SpecMethod {
+        if !self.enabled {
+            return SpecMethod::Off;
+        }
+        match self.method {
+            SpecMethod::Off => SpecMethod::SkipLayer,
+            m => m,
         }
     }
 }
@@ -396,6 +461,16 @@ impl KilnConfig {
         // Speculative decoding
         if let Ok(v) = std::env::var("KILN_SPEC_ENABLED") {
             self.speculative.enabled = v == "1" || v.eq_ignore_ascii_case("true");
+        }
+        if let Ok(v) = std::env::var("KILN_SPEC_METHOD") {
+            if let Some(m) = SpecMethod::parse_env(&v) {
+                self.speculative.method = m;
+            } else {
+                tracing::warn!(
+                    "ignoring unknown KILN_SPEC_METHOD='{}' (expected off|skip_layer|mtp)",
+                    v
+                );
+            }
         }
         if let Ok(v) = std::env::var("KILN_SPEC_NUM_TOKENS") {
             if let Ok(n) = v.parse() {

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -115,6 +115,7 @@ fn tiny_weights(config: &ModelConfig, device: &Device) -> GpuWeights {
         layers: vec![layer],
         final_norm,
         rotary_inv_freq,
+        mtp: None,
     }
 }
 

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -1544,6 +1544,7 @@ mod tests {
             layers,
             final_norm,
             rotary_inv_freq,
+            mtp: None,
         })
     }
 


### PR DESCRIPTION
## WIP foundation PR — native MTP speculative decoding

Lays the structural groundwork for **Phase X native MTP spec-decode on Qwen3.5-4B** (ref: preflight PR #240). Deliberately scaffolding-only so the shape is reviewable before the forward-path wiring and A6000 benchmark land in a follow-up PR.

### What's in this PR (~550 LOC)

**weights.rs**
- `MtpWeights` struct holding all 15 MTP tensors:
  `fc`, `pre_fc_norm_embedding`, `pre_fc_norm_hidden`, `mtp.layers.0.*` (full GQA layer), `final_layernorm`
- `ModelWeights.mtp: Option<MtpWeights>` — model with native MTP or without
- `total_bytes` / `total_params` include MTP tensors so CLI and bookkeeping stay honest

**loader.rs**
- `load_mtp_if_present` probes for `mtp.fc.weight` and loads all 15 tensors
- Reuses the existing `load_layer` helper with synthetic `layer_idx=3` so `(3+1)%4 == 0` dispatches to full-attention (matches Qwen3.5-4B MTP layer shape); defensive `bail!` if it ever resolves linear
- GPTQ path currently sets `mtp: None` with a warning

**config.rs**
- `SpecMethod` enum: `Off` / `SkipLayer` / `Mtp` (serde snake_case, `Default = Off`, env aliases like `off/none/0/false`, `skip_layer/self`, `mtp/native_mtp`)
- New `method: SpecMethod` field on `SpeculativeDecodingConfig`
- `KILN_SPEC_METHOD` env parsing — unknown values warn and fall back (no hard fail)
- `effective_method()` helper: maps `enabled=true && method=Off` → `SkipLayer` for back-compat with existing `KILN_SPEC_ENABLED=1` usage

**forward.rs**
- `MtpGpuWeights` struct mirroring `MtpWeights` on device; `GpuWeights.mtp: Option<MtpGpuWeights>`
- Full MTP GPU upload path in `GpuWeights::from_model_weights`: fc (+ transpose), both pre_fc norms, the MTP layer (inlined — skips Marlin for now, ~1 layer / ~3% of model memory; see follow-up), `final_layernorm`
- `LinearAttentionState::snapshot` / `restore_from` for GDN-state rollback on rejected draft tokens
  - First pass uses `tensor.copy()` (~49 MiB per snapshot on Qwen3.5-4B)
  - Follow-up replaces with ping-pong shadow-slot pattern for zero per-step overhead
- Four call-site updates with `mtp: None` so `GpuWeights { ... }` still constructs (tests + trainer + generate helpers)

### Deferred to follow-up PR

- `mtp_forward_step` — concat(pre_fc_norm_embedding(embed(t)), pre_fc_norm_hidden(h_prev)) → fc (2H→H) → MTP layer → final_layernorm → tied lm_head
- `speculative_mtp_decode_step` — draft proposal + target verification loop with GDN-state rollback + rejection sampling
- `generate_mtp_speculative` in generate.rs
- `SpecMethod` dispatch in bench.rs and generate.rs
- Marlin packing for the MTP layer
- A6000 3-arm median-of-3 benchmark (Off / SkipLayer / Mtp) with the hard abort criteria from the task spec (α < 0.65 or Arm C < Arm A → ship negative-result PR)

### Verification

- `cargo check -p kiln-model` ✅ clean (only pre-existing warnings)
- `cargo check -p kiln-train` ✅ clean
- `cargo check --workspace` blocked in the Cloud Eric sandbox by a pre-existing missing libssl-dev (not touched by this change); A6000 pods pick up the full dep graph
- No runtime behavior changes for existing code paths — `mtp: None` everywhere means the SkipLayer and non-spec paths are bit-identical to `main`

### Why land as a WIP scaffold

Task spec explicitly permits WIP landing if budget/context runs out. Splitting the structural shape (safe, reviewable, no runtime effect) from the forward-path wiring (needs GPU iteration) keeps each review focused and avoids a 1500+ LOC mega-PR landing untested on hardware we can't check locally.