### PR TITLE
runpod: kiln-heartbeat — Phase A pod-wedge watchdog

### DIFF
--- a/.github/workflows/runpod-image.yml
+++ b/.github/workflows/runpod-image.yml
@@ -58,7 +58,67 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha,prefix=sha-
 
-      - name: Build and push
+      - name: Build (load locally, no push) — smoke-test stage
+        # First build pass: load the image into the local docker daemon so we
+        # can `docker run` it for runtime checks BEFORE publishing. The second
+        # pass (below) reuses the GHA cache and pushes — near-instant because
+        # every layer is cache-hit.
+        id: build_local
+        uses: docker/build-push-action@v5
+        with:
+          context: deploy/runpod
+          load: true
+          push: false
+          tags: kiln-runpod-smoketest:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: false
+          sbom: false
+
+      - name: Runtime smoke test — kiln-heartbeat must appear within 60s
+        # Phase A pod-wedge watchdog: launch the freshly-built image, wait
+        # ~40s for the first heartbeat write, and assert the file exists with
+        # a fresh `timestamp_iso:` value. If this fails the publish step is
+        # skipped — protects RunPod pods from a broken heartbeat regression.
+        run: |
+          set -euo pipefail
+          CID=$(docker run -d --rm kiln-runpod-smoketest:latest)
+          trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+          # Heartbeat writes every 30s; wait 40s for the first cycle.
+          sleep 40
+          if ! docker exec "$CID" test -f /workspace/heartbeat.txt; then
+              echo "FAIL: /workspace/heartbeat.txt missing after 40s" >&2
+              echo "--- /tmp/kiln-heartbeat.stderr (if any) ---" >&2
+              docker exec "$CID" sh -c 'cat /tmp/kiln-heartbeat.stderr 2>/dev/null || echo "(no stderr file)"' >&2
+              echo "--- container processes ---" >&2
+              docker exec "$CID" ps -ef >&2 || true
+              exit 1
+          fi
+          HB="$(docker exec "$CID" cat /workspace/heartbeat.txt)"
+          echo "--- heartbeat.txt ---"
+          echo "$HB"
+          echo "---"
+          if ! echo "$HB" | grep -q '^timestamp_iso:'; then
+              echo "FAIL: heartbeat missing 'timestamp_iso:' line" >&2
+              exit 1
+          fi
+          # Verify the timestamp is fresh (within 60s of now).
+          TS="$(echo "$HB" | awk -F': ' '/^timestamp_iso:/ {print $2; exit}')"
+          HB_EPOCH="$(date -u -d "$TS" +%s 2>/dev/null || echo 0)"
+          NOW_EPOCH="$(date -u +%s)"
+          AGE=$(( NOW_EPOCH - HB_EPOCH ))
+          if [ "$HB_EPOCH" -le 0 ] || [ "$AGE" -lt 0 ] || [ "$AGE" -gt 60 ]; then
+              echo "FAIL: heartbeat timestamp age ${AGE}s outside 0-60s window (parsed=${HB_EPOCH}, now=${NOW_EPOCH})" >&2
+              exit 1
+          fi
+          # Spot-check the contract keys Phase B parsers depend on.
+          for key in uptime_s load_1m gpu0_util_pct workspace_target_mtime build_logs; do
+              echo "$HB" | grep -q "^${key}:" \
+                  || { echo "FAIL: heartbeat missing required key '${key}:'" >&2; exit 1; }
+          done
+          echo "OK: kiln-heartbeat live; timestamp ${AGE}s fresh; all contract keys present"
+
+      - name: Build and push (uses cache from smoke-test stage)
         id: build
         uses: docker/build-push-action@v5
         with:

--- a/deploy/runpod/Dockerfile
+++ b/deploy/runpod/Dockerfile
@@ -123,6 +123,15 @@ RUN chmod +x /etc/profile.d/kiln-motd.sh
 COPY kiln-setup.sh /usr/local/bin/kiln-setup
 RUN chmod +x /usr/local/bin/kiln-setup
 
+# --- kiln-heartbeat: pod-wedge watchdog (Phase A) ---
+# Writes /workspace/heartbeat.txt atomically every 30s with GPU util, load,
+# top procs, build-tree mtime, and build log sizes. Started by entrypoint.sh
+# before the sshd exec; orchestrator-side watchdog (Phase B) parses the file
+# to distinguish wedged sshd from genuinely-working workload. Output schema
+# is an API contract — see deploy/runpod/kiln-heartbeat.sh for the keys.
+COPY kiln-heartbeat.sh /usr/local/bin/kiln-heartbeat
+RUN chmod +x /usr/local/bin/kiln-heartbeat
+
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
@@ -136,7 +145,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 #      missing PATH, missing RUSTUP_HOME/CARGO_HOME (rustup default won't
 #      resolve), etc.
 RUN set -e; \
-    TOOLS="nvcc rustc cargo cargo-nextest sccache nsys gh git curl jq cmake ninja protoc clang rg tmux b2 huggingface-cli python3"; \
+    TOOLS="nvcc rustc cargo cargo-nextest sccache nsys gh git curl jq cmake ninja protoc clang rg tmux b2 huggingface-cli python3 kiln-heartbeat"; \
     for bin in $TOOLS; do \
         if ! command -v "$bin" >/dev/null 2>&1; then \
             echo "FAIL (interactive env): '$bin' not on PATH" >&2; exit 1; \

--- a/deploy/runpod/entrypoint.sh
+++ b/deploy/runpod/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# entrypoint.sh — install RunPod $PUBLIC_KEY, start sshd.
+# entrypoint.sh — install RunPod $PUBLIC_KEY, start kiln-heartbeat, start sshd.
 set -euo pipefail
 
 if [ -n "${PUBLIC_KEY:-}" ]; then
@@ -12,6 +12,15 @@ fi
 # Generate host keys on first boot
 if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
     ssh-keygen -A
+fi
+
+# Phase A pod-wedge watchdog: write /workspace/heartbeat.txt every 30s.
+# Backgrounded BEFORE the sshd exec so the heartbeat lives on as a child of
+# PID 1 (the replacing sshd). The Phase B orchestrator-side watchdog uses
+# this file as the ground-truth liveness signal — if the file stops updating
+# while the SSH connection still answers TCP, the pod has wedged.
+if [ -x /usr/local/bin/kiln-heartbeat ]; then
+    /usr/local/bin/kiln-heartbeat > /tmp/kiln-heartbeat.stderr 2>&1 &
 fi
 
 exec "$@"

--- a/deploy/runpod/kiln-heartbeat.sh
+++ b/deploy/runpod/kiln-heartbeat.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# kiln-heartbeat — Phase A of the pod-wedge watchdog system.
+#
+# Writes /workspace/heartbeat.txt atomically every 30s with ground-truth
+# liveness signals (GPU util, load, top procs, build-tree mtime, build log
+# sizes). The orchestrator-side watchdog (Phase B) parses this file to
+# distinguish a genuinely working pod from one whose sshd has wedged but
+# whose actual workload is dead.
+#
+# The output schema is an API contract — Phase B parsers depend on these
+# exact key names. Add new keys at the end; do not rename or reorder.
+#
+# Robustness rules:
+#   - Atomic write: render to .new, then `mv` (rename(2) is atomic on Linux).
+#   - Self-healing: every iteration is wrapped in a subshell + `|| true`,
+#     so a single bad command never stops the heartbeat.
+#   - Silent: all output goes to the file; nothing on stdout/stderr.
+
+set -u  # not -e: a failed sub-command must not kill the loop
+
+HEARTBEAT_FILE="${KILN_HEARTBEAT_FILE:-/workspace/heartbeat.txt}"
+HEARTBEAT_INTERVAL="${KILN_HEARTBEAT_INTERVAL:-30}"
+TARGET_DIR="${KILN_HEARTBEAT_TARGET_DIR:-/workspace/kiln/target}"
+BUILD_LOGS=(${KILN_HEARTBEAT_BUILD_LOGS:-/tmp/build.log /tmp/bench.log})
+
+mkdir -p "$(dirname "$HEARTBEAT_FILE")" 2>/dev/null || true
+
+write_heartbeat() {
+    local tmp="${HEARTBEAT_FILE}.new"
+    {
+        printf 'timestamp_iso: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%S+00:00)"
+        printf 'uptime_s: %s\n' "$(awk '{printf "%d", $1}' /proc/uptime 2>/dev/null || echo 0)"
+
+        # Load average — /proc/loadavg is "1m 5m 15m running/total lastpid"
+        if read -r l1 l5 l15 _ < /proc/loadavg 2>/dev/null; then
+            printf 'load_1m: %s\n' "$l1"
+            printf 'load_5m: %s\n' "$l5"
+            printf 'load_15m: %s\n' "$l15"
+        else
+            printf 'load_1m: none\nload_5m: none\nload_15m: none\n'
+        fi
+
+        # GPU 0 — nvidia-smi may be absent (CPU-only pod) or fail (no driver).
+        if command -v nvidia-smi >/dev/null 2>&1; then
+            local gpu
+            gpu="$(nvidia-smi --query-gpu=utilization.gpu,utilization.memory,memory.used,memory.total \
+                              --format=csv,noheader,nounits -i 0 2>/dev/null | head -1)"
+            if [ -n "$gpu" ]; then
+                local util mem_util mem_used mem_total
+                util="$(echo "$gpu"      | awk -F, '{gsub(/ /,""); print $1}')"
+                mem_util="$(echo "$gpu"  | awk -F, '{gsub(/ /,""); print $2}')"
+                mem_used="$(echo "$gpu"  | awk -F, '{gsub(/ /,""); print $3}')"
+                mem_total="$(echo "$gpu" | awk -F, '{gsub(/ /,""); print $4}')"
+                printf 'gpu0_util_pct: %s\n' "${util:-none}"
+                printf 'gpu0_mem_util_pct: %s\n' "${mem_util:-none}"
+                printf 'gpu0_mem_used_mib: %s\n' "${mem_used:-none}"
+                printf 'gpu0_mem_total_mib: %s\n' "${mem_total:-none}"
+            else
+                printf 'gpu0_util_pct: none\ngpu0_mem_util_pct: none\ngpu0_mem_used_mib: none\ngpu0_mem_total_mib: none\n'
+            fi
+        else
+            printf 'gpu0_util_pct: none\ngpu0_mem_util_pct: none\ngpu0_mem_used_mib: none\ngpu0_mem_total_mib: none\n'
+        fi
+
+        # Top 3 procs by CPU%. Columns: comm %cpu %mem. `ps -e --sort` is
+        # procps-only (Ubuntu 22.04 image); on busybox / minimal images the
+        # awk pipe yields no rows and we fall through to `none 0.0 0.0` so
+        # the section always has at least one parseable line.
+        printf 'top_procs:\n'
+        local procs
+        procs="$(ps -eo comm=,pcpu=,pmem= --sort=-pcpu 2>/dev/null \
+                 | awk 'NF>=3 {printf "  %s %s %s\n", $1, $2, $3}' \
+                 | head -3)"
+        if [ -n "$procs" ]; then
+            printf '%s\n' "$procs"
+        else
+            printf '  none 0.0 0.0\n'
+        fi
+
+        # Build-tree freshness — the canonical "are we still compiling" signal.
+        if [ -e "$TARGET_DIR" ]; then
+            local mtime_epoch now_epoch age
+            mtime_epoch="$(stat -c %Y "$TARGET_DIR" 2>/dev/null || echo 0)"
+            now_epoch="$(date -u +%s)"
+            age=$(( now_epoch - mtime_epoch ))
+            printf 'workspace_target_mtime: %s\n' \
+                "$(date -u -d "@${mtime_epoch}" +%Y-%m-%dT%H:%M:%S+00:00 2>/dev/null || echo none)"
+            printf 'workspace_target_mtime_age_s: %s\n' "$age"
+        else
+            printf 'workspace_target_mtime: absent\n'
+            printf 'workspace_target_mtime_age_s: none\n'
+        fi
+
+        # Build log sizes — Phase B watches for log growth as a liveness signal.
+        printf 'build_logs:\n'
+        local any_log=0
+        for log in "${BUILD_LOGS[@]}"; do
+            if [ -f "$log" ]; then
+                local sz
+                sz="$(stat -c %s "$log" 2>/dev/null || echo 0)"
+                printf '  %s %s\n' "$log" "$sz"
+                any_log=1
+            fi
+        done
+        [ $any_log -eq 0 ] && printf '  none 0\n'
+    } > "$tmp" 2>/dev/null
+
+    mv -f "$tmp" "$HEARTBEAT_FILE" 2>/dev/null || true
+}
+
+# Outer loop: every iteration is wrapped so any single-cycle failure is
+# absorbed and the next cycle still runs. `sleep` itself is outside the
+# subshell so an interrupted iteration doesn't cause a tight CPU spin.
+while true; do
+    ( write_heartbeat ) >/dev/null 2>&1 || true
+    sleep "$HEARTBEAT_INTERVAL"
+done


### PR DESCRIPTION
## Summary

Phase A of the pod-wedge watchdog system. Bake `/usr/local/bin/kiln-heartbeat` into the `kiln-runpod` image and start it from `entrypoint.sh` before the sshd `exec`. The script writes `/workspace/heartbeat.txt` atomically every 30 seconds with ground-truth liveness signals — GPU util, load average, top procs by CPU, build-tree mtime, and build log sizes — that the orchestrator-side **Phase B** watchdog (separate clouderic task, not in this PR) will use to distinguish a wedged sshd from a genuinely-working workload.

Motivation: 2026-04-20 incidents `c8a185469bcd372de6718b75` (\$13.76, 1h40m) and `dd4948c46c35c942d374f45f` (\$99.76, 3h40m) both burned hours polling wedged RunPod sshds. The prevention layers so far (SKILL.md anti-pattern section, project description ban, agent notes) are paperwork. This PR + Phase B are the structural fix.

## What's in this PR

- **`deploy/runpod/kiln-heartbeat.sh`** — ~95 lines of bash. Atomic writes (render to `.new`, `mv` to final). Outer loop wraps each iteration in a subshell + `|| true`, so a single bad command can't stop the heartbeat. Silent on stdout. Robust to missing `nvidia-smi` (CPU-only pod), absent `/workspace/kiln/target` (no build yet), and absent build logs (emits `none` placeholders).
- **`deploy/runpod/Dockerfile`** — `COPY` + `chmod +x` + adds `kiln-heartbeat` to the build-time `TOOLS` smoke-test list.
- **`deploy/runpod/entrypoint.sh`** — backgrounds `/usr/local/bin/kiln-heartbeat` before `exec "$@"` so the heartbeat lives on as a child of PID 1 (the replacing sshd).
- **`.github/workflows/runpod-image.yml`** — restructured to **build-load → runtime smoke test → build-push**. The smoke test launches the freshly-built image, sleeps 40s (one heartbeat cycle), then asserts `/workspace/heartbeat.txt` exists, `timestamp_iso:` is fresh within 60s, and every contract key (`uptime_s`, `load_1m`, `gpu0_util_pct`, `workspace_target_mtime`, `build_logs`) is present. A broken heartbeat regression now blocks publish. Both build passes share the GHA cache; the second is near-instant.

## Heartbeat schema (API contract for Phase B)

```
timestamp_iso: 2026-04-20T18:15:03+00:00
uptime_s: 4823
load_1m: 8.20
load_5m: 4.10
load_15m: 1.80
gpu0_util_pct: 94
gpu0_mem_util_pct: 72
gpu0_mem_used_mib: 18432
gpu0_mem_total_mib: 49140
top_procs:
  cargo 78.3 2.1
  rustc 12.4 8.9
  nvcc   5.2 1.3
workspace_target_mtime: 2026-04-20T18:14:51+00:00
workspace_target_mtime_age_s: 12
build_logs:
  /tmp/build.log 2456789
  /tmp/bench.log 128934
```

Add new keys at the end; do not rename or reorder.

## Test plan

- [x] Local syntax check (`bash -n`)
- [x] Local end-to-end run with `KILN_HEARTBEAT_FILE=/tmp/heartbeat-test.txt` produces all required keys
- [x] Robust to missing `nvidia-smi` (Cloud Eric env has none — emits `gpu0_util_pct: none`)
- [x] Robust to absent `/workspace/kiln/target` (emits `workspace_target_mtime: absent`)
- [x] Robust to absent build logs (emits `build_logs:\n  none 0`)
- [ ] CI runtime smoke test: GHA workflow launches built image, asserts `heartbeat.txt` written within 60s
- [ ] Pod verification on real A6000 after merge: `cat /workspace/heartbeat.txt` shows live GPU util while a CUDA workload runs

## Phase B (next, separate task — do NOT bundle here)

Orchestrator-side watchdog in clouderic that calls `runpod_api.py download $POD_ID /workspace/heartbeat.txt /tmp/hb.txt` on a poll interval, parses the schema above, and terminates pods whose heartbeat hasn't updated in N×30s OR whose `workspace_target_mtime_age_s` exceeds a configurable threshold while the SSH connection still answers TCP.