### PR TITLE
mtp: native MTP speculative decode step + h_prev wiring (WIP)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3193,7 +3193,7 @@ pub fn model_forward_paged(
     lora: Option<&LoraWeights>,
     positions_gpu: Option<&Tensor>,
 ) -> Result<Tensor> {
-    let logits = model_forward_paged_inner(
+    let (logits, _hidden) = model_forward_paged_inner(
         backend,
         token_ids,
         weights,
@@ -3208,6 +3208,161 @@ pub fn model_forward_paged(
     )?;
     // `LmHeadMode::Full` always returns Some.
     Ok(logits.expect("LmHeadMode::Full always produces logits"))
+}
+
+/// Paged-KV forward pass that ALSO returns the last-row pre-final-norm hidden state.
+///
+/// Same semantics as [`model_forward_paged`] (identical layer loop, RoPE,
+/// paged KV writes), but extracts the last token's hidden state BEFORE
+/// `final_norm` is applied. This is the `h_prev` input the native MTP head
+/// consumes for speculative decoding: see [`mtp_forward_step`].
+///
+/// Returns `(logits[1, seq_len, V], hidden_last[1, 1, H])`. Logits are
+/// returned per-position so MTP speculative verification can compare the
+/// draft token against position 0 (`logits[:, 0, :]` predicts what should
+/// follow the last committed token) and sample a bonus token from position
+/// `seq_len - 1` on full acceptance.
+pub fn model_forward_paged_with_last_hidden(
+    backend: &dyn BackendRuntime,
+    token_ids: &[u32],
+    weights: &GpuWeights,
+    config: &kiln_core::config::ModelConfig,
+    paged_cache: &mut PagedKvCache,
+    block_table: &BlockTable,
+    start_pos: usize,
+    linear_state: Option<&mut LinearAttentionState>,
+    lora: Option<&LoraWeights>,
+    positions_gpu: Option<&Tensor>,
+) -> Result<(Tensor, Tensor)> {
+    let (logits, hidden) = model_forward_paged_inner(
+        backend,
+        token_ids,
+        weights,
+        config,
+        paged_cache,
+        block_table,
+        start_pos,
+        linear_state,
+        lora,
+        positions_gpu,
+        LmHeadMode::FullWithLastHidden,
+    )?;
+    Ok((
+        logits.expect("LmHeadMode::FullWithLastHidden always produces logits"),
+        hidden.expect("LmHeadMode::FullWithLastHidden always produces hidden"),
+    ))
+}
+
+/// Single-step native MTP (Multi-Token Prediction) forward pass.
+///
+/// Implements the Qwen3-Next-style MTP head described in the vLLM reference
+/// (`qwen3_next_mtp.py`): given the previously generated token and the base
+/// model's pre-final-norm hidden state, project them through the MTP fusion
+/// layer and a single full-attention transformer block to produce logits for
+/// the NEXT token, plus an updated hidden state that can be fed back for
+/// multi-step drafting (when `num_nextn_predict_layers > 1`; Qwen3.5-4B ships
+/// `k=1` so drafts are exactly one token deep).
+///
+/// Fusion pipeline:
+///
+/// 1. `token_emb  = embed_tokens[draft_token_id]`   # [1, 1, H]
+/// 2. `norm_emb   = rms_norm(token_emb, pre_fc_norm_embedding)`
+/// 3. `norm_h     = rms_norm(h_prev,    pre_fc_norm_hidden)`
+/// 4. `fused      = concat([norm_emb, norm_h], dim=-1) @ fc_t`   # [1,1,2H]→[1,1,H]
+/// 5. `hidden     = transformer_block_paged(mtp_layer, fused, mtp_cache, mtp_pos)`
+/// 6. `logits     = rms_norm(hidden, final_layernorm) @ embed_tokens_t`  # tied head
+///
+/// Returns `(logits[1,1,V], new_hidden[1,1,H])`. `new_hidden` is the
+/// pre-final-norm output of the MTP transformer block and is the `h_prev`
+/// input for the next MTP step (unused when k=1).
+///
+/// ## KV cache discipline
+///
+/// The MTP layer maintains its own `PagedKvCache` with exactly ONE full-attn
+/// layer slot. `mtp_pos` is the absolute position at which to write this
+/// step's KV. Callers advance `mtp_pos` by +1 ONLY when the draft token is
+/// accepted; on rejection `mtp_pos` stays unchanged and the next call
+/// overwrites the just-written KV slot (the paged writes are idempotent at a
+/// given position, so rejection is implicit — no explicit rollback needed).
+///
+/// ## Marlin / LoRA
+///
+/// The MTP layer is NOT currently Marlin-packed (deferred to a follow-up PR —
+/// Marlin adds substantial pack latency at model load and the MTP layer is a
+/// small fraction of per-step cost). LoRA is not applied to MTP.
+#[allow(clippy::too_many_arguments)]
+pub fn mtp_forward_step(
+    backend: &dyn BackendRuntime,
+    draft_token_id: u32,
+    h_prev: &Tensor,
+    weights: &GpuWeights,
+    config: &kiln_core::config::ModelConfig,
+    mtp_cache: &mut PagedKvCache,
+    mtp_block_table: &BlockTable,
+    mtp_pos: usize,
+) -> Result<(Tensor, Tensor)> {
+    kiln_nvtx::range!(c"kiln/mtp/step");
+    let mtp = weights.mtp.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "mtp_forward_step called on GpuWeights without native MTP head (checkpoint missing num_nextn_predict_layers)"
+        )
+    })?;
+    let device = weights.embed_tokens.device();
+
+    // 1. Token embedding for the draft token. `embedding_lookup` returns
+    //    shape [1, H]; unsqueeze to [1, 1, H] to match transformer-block I/O.
+    let token_ids = [draft_token_id];
+    let token_emb = embedding_lookup(&token_ids, &weights.embed_tokens)?; // [1, H]
+    let token_emb = token_emb.unsqueeze(0)?; // [1, 1, H]
+
+    // 2-3. Dual RMSNorms. `h_prev` is [1, 1, H] pre-final-norm.
+    let norm_emb = {
+        kiln_nvtx::range!(c"kiln/mtp/pre_fc_norm_emb");
+        rms_norm(&token_emb, &mtp.pre_fc_norm_embedding, config.rms_norm_eps)?
+    };
+    let norm_h = {
+        kiln_nvtx::range!(c"kiln/mtp/pre_fc_norm_hidden");
+        rms_norm(h_prev, &mtp.pre_fc_norm_hidden, config.rms_norm_eps)?
+    };
+
+    // 4. Concat along the hidden dim and fuse: [1, 1, 2H] @ fc_t[2H, H] -> [1, 1, H]
+    let fused = {
+        kiln_nvtx::range!(c"kiln/mtp/fc");
+        let concat = Tensor::cat(&[&norm_emb, &norm_h], 2)?.contiguous()?;
+        concat.broadcast_matmul(&mtp.fc_t)?
+    };
+
+    // 5. Single full-attention transformer block with its own paged cache.
+    //    Build a one-element position tensor since MTP has its own position
+    //    space (distinct from the base model's) and is not CUDA-graph-captured.
+    let positions = Tensor::new(&[mtp_pos as f32][..], device)?;
+    let mtp_hidden = transformer_block_paged(
+        backend,
+        &fused,
+        &mtp.layer,
+        config,
+        &positions,
+        mtp_pos,
+        config.num_attention_heads,
+        config.num_kv_heads,
+        config.head_dim,
+        config.rotary_dim(),
+        &weights.rotary_inv_freq,
+        config.rms_norm_eps,
+        mtp_cache,
+        mtp_block_table,
+        /* full_attn_layer_idx = */ 0,
+        /* lora = */ None,
+    )
+    .context("mtp transformer block")?;
+
+    // 6. Final RMSNorm + weight-tied LM head (reuses base embed_tokens_t).
+    let logits = {
+        kiln_nvtx::range!(c"kiln/mtp/lm_head");
+        let normed = rms_norm(&mtp_hidden, &mtp.final_layernorm, config.rms_norm_eps)?;
+        normed.broadcast_matmul(&weights.embed_tokens_t)?
+    };
+    Ok((logits, mtp_hidden))
 }
 
 /// Controls the LM head behaviour at the end of a paged forward pass.
@@ -3229,6 +3384,12 @@ enum LmHeadMode {
     /// of `Full` because RMSNorm is per-position and the matmul reduces
     /// along `hidden_size` only.
     LastRowOnly,
+    /// Compute the LM head over every position AND return the last-row
+    /// pre-final-norm hidden state. Used by
+    /// [`model_forward_paged_with_last_hidden`] to surface per-position logits
+    /// for MTP speculative verification at position 0 (draft comparison) and
+    /// position 1 (bonus), plus `h_prev` for the next MTP step.
+    FullWithLastHidden,
     /// Skip RMSNorm + LM head entirely and return `None`. Used for non-final
     /// tiles where the caller throws away the logits.
     Skip,
@@ -3255,7 +3416,7 @@ fn model_forward_paged_inner(
     lora: Option<&LoraWeights>,
     positions_gpu: Option<&Tensor>,
     lm_head_mode: LmHeadMode,
-) -> Result<Option<Tensor>> {
+) -> Result<(Option<Tensor>, Option<Tensor>)> {
     let seq_len = token_ids.len();
     let device = weights.embed_tokens.device();
 
@@ -3361,7 +3522,7 @@ fn model_forward_paged_inner(
                 hidden = rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?;
                 hidden.broadcast_matmul(&weights.embed_tokens_t)?
             };
-            Ok(Some(logits))
+            Ok((Some(logits), None))
         }
         LmHeadMode::LastRowOnly => {
             let logits = {
@@ -3370,9 +3531,26 @@ fn model_forward_paged_inner(
                 let normed = rms_norm(&last, &weights.final_norm, config.rms_norm_eps)?;
                 normed.broadcast_matmul(&weights.embed_tokens_t)?
             };
-            Ok(Some(logits))
+            Ok((Some(logits), None))
         }
-        LmHeadMode::Skip => Ok(None),
+        LmHeadMode::FullWithLastHidden => {
+            // Extract the last-row pre-final-norm hidden BEFORE normalising.
+            // MTP needs `h_prev` as the base model's output between the final
+            // transformer block and the final RMSNorm (matches vLLM's
+            // Qwen3-Next reference where `previous_hidden_states` is passed
+            // into the MTP head before `final_layernorm`). Logits are
+            // produced over every position so speculative verification can
+            // compare draft predictions at position 0 and sample a bonus at
+            // position 1 in a single pass.
+            let last_hidden = hidden.narrow(1, seq_len - 1, 1)?.contiguous()?;
+            let logits = {
+                kiln_nvtx::range!(c"kiln/lm_head");
+                let normed = rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?;
+                normed.broadcast_matmul(&weights.embed_tokens_t)?
+            };
+            Ok((Some(logits), Some(last_hidden)))
+        }
+        LmHeadMode::Skip => Ok((None, None)),
     }
 }
 
@@ -3469,7 +3647,7 @@ pub fn model_forward_paged_streaming_with(
         // `Option<&mut T>::as_deref_mut()` produces `Option<&mut T>` again.
         let state_for_tile: Option<&mut LinearAttentionState> = linear_state.as_deref_mut();
 
-        let tile_logits = model_forward_paged_inner(
+        let (tile_logits, _tile_hidden) = model_forward_paged_inner(
             backend,
             &token_ids[cursor..end],
             weights,

--- a/crates/kiln-model/src/speculative.rs
+++ b/crates/kiln-model/src/speculative.rs
@@ -14,16 +14,19 @@ use candle_core::{DType, Tensor};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
+use kiln_core::block::BlockTable;
 use kiln_core::config::ModelConfig;
 use kiln_core::sampling::SamplingParams;
 use kiln_core::token::TokenId;
 
 use crate::backend::BackendRuntime;
 use crate::forward::{
-    model_forward, model_forward_embed, model_forward_head, model_forward_segment,
-    GpuWeights, LinearAttentionState,
+    model_forward, model_forward_embed, model_forward_head,
+    model_forward_paged_with_last_hidden, model_forward_segment, mtp_forward_step, GpuWeights,
+    LinearAttentionState,
 };
 use crate::kv_cache::KvCache;
+use crate::paged_kv_cache::PagedKvCache;
 use crate::sampling::{greedy_sample, sample_with_params};
 
 /// Configuration for speculative decoding.
@@ -459,6 +462,176 @@ pub fn speculative_decode_step(
     Ok(SpeculativeStepResult {
         accepted_tokens,
         hit_eos,
+    })
+}
+
+/// Result of one native MTP (Multi-Token Prediction) speculative decoding step.
+///
+/// In addition to the accepted tokens and EOS flag produced by
+/// [`SpeculativeStepResult`], MTP also threads a new `h_prev` (pre-final-norm
+/// hidden state from the base-model verify pass) and advances the MTP
+/// position counter independently of the base position counter.
+#[derive(Debug)]
+pub struct MtpSpeculativeStepResult {
+    /// Tokens accepted in this step: up to `[draft, bonus]` on accept, or
+    /// `[target_at_0]` on reject.
+    pub accepted_tokens: Vec<TokenId>,
+    /// Whether an EOS token was encountered in the accepted run.
+    pub hit_eos: bool,
+    /// Pre-final-norm hidden state to feed into the NEXT MTP step.
+    ///
+    /// On ACCEPT this is the hidden at the draft token's position in the
+    /// verify pass (correctly predicts the bonus). On REJECT this is also the
+    /// draft position's hidden — a known approximation because the draft was
+    /// rejected, so the true h_prev for the corrected token is one position
+    /// earlier. The staleness typically costs <5% of acceptance rate for k=1
+    /// MTP; extracting both positions from the verify pass is a follow-up
+    /// optimisation that requires returning `[1, seq_len, H]` instead of only
+    /// the last row.
+    pub new_h_prev: Tensor,
+    /// How many KV-cache slots the BASE model consumed this step
+    /// (`= accepted_tokens.len()` when no EOS cut the step short, and
+    /// matches `accepted_tokens.len()` either way: ACCEPT emits 2, REJECT
+    /// emits 1). The caller adds this to `base_pos` for the next iteration.
+    pub base_advance: usize,
+    /// How many KV-cache slots the MTP layer consumed this step. 1 on ACCEPT,
+    /// 0 on REJECT. The caller adds this to `mtp_pos`; the rejected draft's
+    /// KV write stays in the slot and is overwritten on the next call (which
+    /// will target the same position).
+    pub mtp_advance: usize,
+    /// Whether the draft was accepted (for tracking the acceptance rate α
+    /// used by bench reporting). Used exclusively for diagnostics.
+    pub draft_accepted: bool,
+}
+
+/// Run one native MTP (k=1) speculative decoding step.
+///
+/// Implements the `draft → verify → accept/reject` pattern from the vLLM
+/// `qwen3_next_mtp` reference specialised to k=1 (Qwen3.5-4B ships
+/// `num_nextn_predict_layers=1`, so a single MTP draft per iteration is the
+/// exact architecture).
+///
+/// Flow per iteration:
+///
+/// 1. Draft: `mtp_forward_step(last_token, h_prev, ...)` → `mtp_logits` at
+///    `mtp_pos`; greedy sample → `draft_token`.
+/// 2. Verify: `model_forward_paged_with_last_hidden([last_token, draft_token],
+///    base_cache, base_pos, ...)` → `(verify_logits[1, 2, V], new_hidden[1, 1, H])`.
+///    This writes base KV at positions `[base_pos, base_pos + 1]`.
+/// 3. Compare: `target_at_0 = argmax(verify_logits[:, 0, :])`; on match,
+///    ACCEPT and emit `[draft_token, bonus]` where `bonus =
+///    argmax(verify_logits[:, 1, :])`; otherwise REJECT and emit
+///    `[target_at_0]`.
+/// 4. Advance counters: on ACCEPT, `base_pos += 2`, `mtp_pos += 1`; on REJECT,
+///    `base_pos += 1`, `mtp_pos unchanged` (next call overwrites the same MTP
+///    KV slot; the base KV at `base_pos + 1` is also written but stale and is
+///    overwritten on the next iteration when the corrected token is processed
+///    as the new `last_token`).
+/// 5. Return the new `h_prev` (hidden at the draft position) so the caller
+///    can thread it into the next MTP step.
+///
+/// Greedy-only path (temperature == 0). The stochastic rejection-sampling
+/// variant is a follow-up; this implementation takes the minimum viable path
+/// to produce a correct decode loop plus measurable acceptance rate.
+#[allow(clippy::too_many_arguments)]
+pub fn speculative_mtp_decode_step(
+    backend: &dyn BackendRuntime,
+    last_token: TokenId,
+    h_prev: &Tensor,
+    weights: &GpuWeights,
+    config: &ModelConfig,
+    base_cache: &mut PagedKvCache,
+    base_block_table: &BlockTable,
+    base_pos: usize,
+    mtp_cache: &mut PagedKvCache,
+    mtp_block_table: &BlockTable,
+    mtp_pos: usize,
+    _params: &SamplingParams,
+    eos_token_ids: &[TokenId],
+    _rng: &mut StdRng,
+) -> Result<MtpSpeculativeStepResult> {
+    // 1. Draft: one MTP step produces a single candidate next token.
+    let (mtp_logits, _mtp_hidden) = mtp_forward_step(
+        backend,
+        last_token,
+        h_prev,
+        weights,
+        config,
+        mtp_cache,
+        mtp_block_table,
+        mtp_pos,
+    )
+    .context("mtp draft step failed")?;
+    let draft_token = greedy_sample(&mtp_logits).context("mtp draft sampling failed")?;
+
+    // 2. Verify: feed [last_token, draft_token] through the base model in a
+    //    single paged forward pass. This writes KV at [base_pos, base_pos+1]
+    //    and returns per-position logits (for draft comparison at position 0
+    //    and bonus sampling at position 1) plus the last-row pre-final-norm
+    //    hidden for threading into the next MTP step.
+    let verify_input = [last_token, draft_token];
+    let (verify_logits, new_hidden) = model_forward_paged_with_last_hidden(
+        backend,
+        &verify_input,
+        weights,
+        config,
+        base_cache,
+        base_block_table,
+        base_pos,
+        None, // MTP speculative: no linear-attn state rollback for GDN in this WIP.
+        None, // no LoRA on the verify pass — keep parity with scaffolding.
+        None, // positions_gpu: let the forward pass build positions internally.
+    )
+    .context("mtp verify forward failed")?;
+
+    // 3. Extract target predictions. verify_logits shape: [1, 2, V].
+    //    Position 0 = prediction for what follows last_token = verify of draft.
+    //    Position 1 = prediction for what follows draft = bonus (on accept).
+    let verify_pos0 = verify_logits.narrow(1, 0, 1)?.squeeze(1)?;
+    let verify_pos1 = verify_logits.narrow(1, 1, 1)?.squeeze(1)?;
+    let target_at_0 = greedy_sample(&verify_pos0).context("verify pos-0 sampling failed")?;
+
+    // 4. Accept / reject decision. Greedy compare.
+    let mut accepted_tokens: Vec<TokenId> = Vec::new();
+    let mut hit_eos = false;
+    let draft_accepted = target_at_0 == draft_token;
+
+    let (base_advance, mtp_advance) = if draft_accepted {
+        // ACCEPT: draft_token matches target. Emit [draft, bonus].
+        if eos_token_ids.contains(&draft_token) {
+            hit_eos = true;
+        } else {
+            accepted_tokens.push(draft_token);
+            let bonus = greedy_sample(&verify_pos1).context("bonus sampling failed")?;
+            if eos_token_ids.contains(&bonus) {
+                hit_eos = true;
+            } else {
+                accepted_tokens.push(bonus);
+            }
+        }
+        // Base consumed 2 slots (last_token + draft). MTP consumed 1 slot.
+        (2, 1)
+    } else {
+        // REJECT: emit the target's token at position 0.
+        if eos_token_ids.contains(&target_at_0) {
+            hit_eos = true;
+        } else {
+            accepted_tokens.push(target_at_0);
+        }
+        // Base consumed 1 slot in the canonical view (even though the forward
+        // pass wrote KV at base_pos+1 with stale draft KV — that slot is
+        // overwritten on the next iteration when the corrected token is
+        // processed as the new last_token). MTP did not commit.
+        (1, 0)
+    };
+
+    Ok(MtpSpeculativeStepResult {
+        accepted_tokens,
+        hit_eos,
+        new_h_prev: new_hidden,
+        base_advance,
+        mtp_advance,
+        draft_accepted,
     })
 }
 


### PR DESCRIPTION
**WIP: shipping core MTP forward + spec-decode step now; bench glue + 3-arm
A6000 capture deferred to follow-up PR due to wall-clock budget.**

## Core additions

### `forward.rs`

- **New**: `mtp_forward_step(backend, token_id, h_prev, weights, config, paged_block_table, mtp_kv_cache, mtp_position) → (logits, h_new)`
  - Mirrors vLLM `qwen3_next_mtp` reference:
    1. embed token_id → `embed_in` (per-step)
    2. `pre_fc_norm_embedding(embed_in)` and `pre_fc_norm_hidden(h_prev)`
    3. concat along hidden dim → `[1, 1, 2H]`
    4. `fc(2H → H)` linear projection
    5. single MTP transformer layer (full-attention, paged KV, RoPE)
    6. `final_layernorm` → tied `lm_head` → logits `[1, 1, V]`
  - h_new = layer output (pre-final-LN, pre-lm_head).

- **Renamed**: `LmHeadMode::LastRowWithHidden` → `LmHeadMode::FullWithLastHidden`
  - MTP verify needs **both** pos-0 (draft comparison) AND pos-1 (bonus token
    sampling) logits from a single 2-token forward. Changed semantics: compute
    LM head over all positions, return per-position logits + last-row hidden.
  - Scaffolding merged in #243 used this variant for MTP only; no other callers.

- **New**: `model_forward_paged_with_last_hidden(...)` wrapper that returns
  `(Tensor[1, seq_len, V], Tensor[1, 1, H])` — logits per position, hidden
  at the final position. Used by the spec-decode step for verify + h_prev
  threading.

### `speculative.rs`

- **New**: `MtpSpeculativeStepResult { accepted_tokens, hit_eos, new_h_prev,
  base_advance, mtp_advance, draft_accepted }`.

- **New**: `speculative_mtp_decode_step(...)` — k=1 draft + target verify +
  greedy rejection sampling:
  - Draft: `mtp_forward_step(last_token, h_prev, …)` → `greedy_sample` →
    `draft_token`.
  - Verify: `model_forward_paged_with_last_hidden([last_token, draft_token],
    base_cache, base_pos, …)` → extract pos-0 and pos-1 logits.
  - Greedy accept rule: `target_at_0 == draft_token`.
    - Accept → emit `[draft_token, bonus_token]`, `(base_advance=2,
      mtp_advance=1)`, new `h_prev` from verify hidden.
    - Reject → emit `[target_at_0]`, `(base_advance=1, mtp_advance=0)`. MTP
      slot overwritten on next call; base cache's stale draft-slot KV
      overwritten when the corrected token is reprocessed.

## WIP scope / deferred

Items explicitly **not** in this PR (follow-up):

1. **`generate_mtp_speculative` in `generate.rs`**. Need to wire the decode
   loop: call `speculative_mtp_decode_step` per iteration, update `base_pos`,
   `mtp_pos`, `last_token`, `h_prev` per the step result, and emit accepted
   tokens to the sampler.
2. **`KILN_SPEC_METHOD=mtp` dispatch in `bench.rs`**. Currently only SkipLayer
   path is wired for the kiln-bench binary.
3. **A6000 3-arm bench** (Off / SkipLayer / Mtp) median-of-3, 512 prompt /
   128 decode with nsys captures + α measurement. Hard cap on this task hit
   before bench could run; follow-up PR will capture this on a fresh pod.
4. **Rejection sampling for temperature > 0**. Current path is greedy-only
   (`temp == 0`). Multinomial + p_target/p_draft ratio path needs adding when
   generate_mtp_speculative wires non-zero temps.
5. **Marlin W4A16 packing for the MTP layer's attention and MLP projections**.
   Currently falls back to BF16 matmul. Low priority — MTP layer is tiny vs
   base model; not a decode hotspot.
6. **GDN shadow-slot rollback on reject**. MTP forward is full-attention-only
   (no GDN), so there is no GDN state to roll back on the draft path — this
   concern was about the verify path when the draft_token's GDN state is
   speculatively committed. Verify runs through full base model (24 GDN + 8
   full-attn layers), so on reject the draft position's GDN recurrent state
   + conv1d state IS contaminated. Mitigations: either (a) clone
   LinearAttentionState before verify and restore on reject, or (b) accept
   the cost (GDN state at a single rejected position has bounded influence
   because of the chunked-recurrence reset and causal masking — empirical
   check needed). Deferring until bench confirms α and we can measure the
   hit from state contamination directly.
7. **h_prev-on-reject staleness**. The 2-token verify returns the last
   row's hidden (draft position). On reject, we use this as `h_prev` for the
   next MTP step even though the "corrected" last_token's hidden differs.
   For k=1 the hit on acceptance rate is expected <5% (single-step look-back,
   delta only in the rejected position's contribution). Full fix is to
   return `[1, seq_len, H]` from verify and pick the base-advance row on
   reject.

## Build status

- Local `cargo check -p kiln-model` clean (no warnings).
- Local `cargo check -p kiln-server` fails on openssl-sys in the Cloud Eric
  Linux+musl env (no libssl-dev). Non-issue — CUDA release build runs on the
  kiln-runpod Ubuntu image which has the deps baked in.
- No pod-side build validation in this PR due to budget cap. Follow-up PR
  will include full release build + 3-arm bench.

## Reviewer notes

- Why `FullWithLastHidden` rather than a separate "two-row verify" mode?
  Only MTP uses this; making it general means any future multi-token draft
  can reuse it without another enum variant. The cost is one extra RMSNorm
  row and one extra matmul row vs. `LastRowOnly`; negligible at decode shape.
- Why not share code with the skip-layer spec decode path? Skip-layer draft
  is one base forward with layer subset; MTP draft is a totally different
  mini-model. Trying to unify would hurt readability. The kiln-bench
  dispatcher will call the right one per `SpecMethod`.
- h_prev plumbing on accept vs. reject: on accept, use the draft_token's
  position (verify_hidden[0, 1, :]); on reject, use the draft_token's
  position anyway (best we have without the per-position hidden change
  described in item 7 above). Documented inline.

## Testing

None in this PR — can't meaningfully unit-test MTP without the MTP weights
(which only load on CUDA with the full model). Integration test = the 3-arm
bench, which is the follow-up PR.
