### PR TITLE
desktop: enrich Copy diagnostic info with binary path, model path, server state

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -428,15 +428,58 @@ struct DiagnosticInfo {
     version: String,
     os: String,
     arch: String,
+    kiln_binary: Option<String>,
+    model_path: Option<String>,
+    server_state: String,
 }
 
 #[tauri::command]
-fn get_diagnostic_info() -> DiagnosticInfo {
-    DiagnosticInfo {
+async fn get_diagnostic_info(
+    sup: State<'_, Arc<Supervisor>>,
+    state: State<'_, SettingsState>,
+) -> Result<DiagnosticInfo, String> {
+    let (configured_binary, model_path) = {
+        let s = state.read().await;
+        (s.kiln_binary.clone(), s.model_path.clone())
+    };
+    let kiln_binary = {
+        let configured = configured_binary
+            .clone()
+            .unwrap_or_else(|| std::path::PathBuf::from("kiln"));
+        let resolved = installer::resolve_binary(&configured);
+        let display = resolved
+            .map(|p| p.display().to_string())
+            .unwrap_or_else(|| configured.display().to_string());
+        if display.is_empty() {
+            None
+        } else {
+            Some(display)
+        }
+    };
+    let model_path = model_path.and_then(|p| {
+        let s = p.display().to_string();
+        if s.is_empty() {
+            None
+        } else {
+            Some(s)
+        }
+    });
+    let server_state = match sup.state().await {
+        ServerState::Stopped => "stopped".to_string(),
+        ServerState::Starting => "starting".to_string(),
+        ServerState::Running => "running".to_string(),
+        ServerState::TrainingActive => "training-active".to_string(),
+        ServerState::Error(msg) => format!("error: {}", msg),
+        ServerState::NoBinary(msg) => format!("no-binary: {}", msg),
+    };
+    Ok(DiagnosticInfo {
         version: env!("CARGO_PKG_VERSION").to_string(),
         os: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
-    }
+        kiln_binary,
+        model_path,
+        server_state,
+    })
 }
 
 #[tauri::command]

--- a/desktop/ui/about.html
+++ b/desktop/ui/about.html
@@ -115,7 +115,14 @@
 
       const versionEl = document.getElementById("version");
       const platformEl = document.getElementById("platform");
-      const diag = { version: "unknown", os: "unknown", arch: "unknown" };
+      const diag = {
+        version: "unknown",
+        os: "unknown",
+        arch: "unknown",
+        kiln_binary: "",
+        model_path: "",
+        server_state: "",
+      };
 
       function renderDiag() {
         versionEl.textContent = diag.version;
@@ -128,6 +135,9 @@
             if (d.version) diag.version = d.version;
             if (d.os) diag.os = d.os;
             if (d.arch) diag.arch = d.arch;
+            if (d.kiln_binary) diag.kiln_binary = d.kiln_binary;
+            if (d.model_path) diag.model_path = d.model_path;
+            if (d.server_state) diag.server_state = d.server_state;
           }
           renderDiag();
         }).catch(() => {
@@ -161,7 +171,13 @@
         }, 1200);
       }
       copyBtn.addEventListener("click", async () => {
-        const text = `Kiln Desktop v${diag.version}\nOS: ${diag.os} (${diag.arch})`;
+        const text = [
+          `Kiln Desktop v${diag.version}`,
+          `OS: ${diag.os} (${diag.arch})`,
+          `Server: ${diag.server_state || "unknown"}`,
+          `Kiln binary: ${diag.kiln_binary || "(not resolved)"}`,
+          `Model path: ${diag.model_path || "(not set)"}`,
+        ].join("\n");
         try {
           await navigator.clipboard.writeText(text);
           flashCopy("Copied!");


### PR DESCRIPTION
## What

Extend the About window's "Copy diagnostic info" button to include the resolved kiln binary path, configured model path, and current server state alongside the existing version + OS/arch fields.

Before: clipboard contains `Kiln Desktop v0.1.10\nOS: linux (x86_64)`.
After: clipboard contains the same plus `Server: running`, `Kiln binary: /home/user/.local/share/kiln-desktop/bin/kiln`, `Model path: /home/user/models/Qwen3.5-4B`.

## Why

When a user files a GitHub issue, the maintainer needs to know whether the binary was resolved, what model is configured, and what state the supervisor is in. Today the diagnostic copy provides none of that and a back-and-forth is required to debug almost any user-reported problem.

## Implementation

- `desktop/src/main.rs`: extend `DiagnosticInfo` struct with `kiln_binary`, `model_path`, `server_state`; convert `get_diagnostic_info` to async + `State` injection (same pattern as `get_binary_status`); format `ServerState` via a small match (`stopped`/`starting`/`running`/`training-active`/`error: ...`/`no-binary: ...`).
- `desktop/ui/about.html`: append the new fields to the clipboard text builder and capture them in the `invoke("get_diagnostic_info")` callback. On-screen UI rendering is unchanged, so no screenshot refresh needed.

## Test

- `grep` checks confirm new fields and clipboard lines are present (run before submit).
- `cargo check` not runnable locally (GTK/webkit2gtk missing on Cloud Eric per agent note `tauri-cargo-check-gtk-missing`); GitHub Actions `build (ubuntu-22.04, windows-latest, macos-14)` is the build gate.