### PR TITLE
desktop: run cargo test in CI

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -59,6 +59,11 @@ jobs:
         with:
           workspaces: './desktop -> target'
 
+      - name: Run desktop unit tests (Linux only)
+        if: matrix.platform == 'ubuntu-22.04'
+        working-directory: desktop
+        run: cargo test --locked
+
       - name: Extract release notes from CHANGELOG.md
         if: startsWith(github.ref, 'refs/tags/desktop-v')
         shell: bash


### PR DESCRIPTION
## What
Add `cargo test --locked` step to desktop-build.yml on the ubuntu-22.04 runner only.

## Why
`desktop/src/` has 122 unit tests (is_model_path_set, should_notify_stopped, ready_notification_body, etc.) that compile via tauri-action but never execute. Any regression in pure-helper logic currently ships silently. Ubuntu is the cheapest runner and already installs the GTK/webkit deps needed to link the tauri crate.

## Scope
- Single YAML change, Ubuntu-only, gated by matrix.platform
- No Windows/macOS impact (faster CI)
- Tests run after cache restore so incremental builds apply