### PR TITLE
desktop: preflight tray Restart Server when model_path unset or binary missing

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -152,7 +152,44 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                     });
                 }
                 ITEM_RESTART => {
+                    let app_for_spawn = app_handle.clone();
                     tauri::async_runtime::spawn(async move {
+                        let has_model_path = {
+                            let settings_state = app_for_spawn.state::<Arc<RwLock<Settings>>>();
+                            let s = settings_state.read().await;
+                            is_model_path_set(&s)
+                        };
+                        if !has_model_path {
+                            let _ = app_for_spawn
+                                .notification()
+                                .builder()
+                                .title("Model path not set")
+                                .body(
+                                    "Open Settings and select a model before restarting the Kiln server.",
+                                )
+                                .show();
+                            if let Err(e) = open_settings_window(&app_for_spawn) {
+                                eprintln!("[tray] open_settings_window failed: {}", e);
+                            }
+                            let _ = app_for_spawn.emit("menu://open-settings", ());
+                            return;
+                        }
+                        let binary_path = supervisor.config_snapshot().await.binary_path;
+                        if !is_binary_available(&binary_path) {
+                            let _ = app_for_spawn
+                                .notification()
+                                .builder()
+                                .title("Kiln binary not installed")
+                                .body(
+                                    "Open Dashboard to download and install the kiln server binary.",
+                                )
+                                .show();
+                            if let Err(e) = open_dashboard_window(&app_for_spawn) {
+                                eprintln!("[tray] open_dashboard_window failed: {}", e);
+                            }
+                            let _ = app_for_spawn.emit("menu://open-dashboard", ());
+                            return;
+                        }
                         if let Err(e) = supervisor.restart().await {
                             eprintln!("[tray] restart_server failed: {}", e);
                         }


### PR DESCRIPTION
## What
Mirrors the Start Server preflight added in #250 and #252 to the tray Restart Server menu item. Previously `ITEM_RESTART` called `supervisor.restart()` directly; `restart()` is just `stop() + start()` and neither preflights, so a tray Restart with no model path or no binary silently transitioned to Starting then to NoBinary with zero user feedback.

Now Restart fails loudly with the same notification + window-open behavior as Start:
- model_path unset → notify "Model path not set" and open Settings
- binary missing → notify "Kiln binary not installed" and open Dashboard (which already routes NoBinary to the install pane)

## Why
Mirror gap to #250/#252. Tray entry points should give consistent feedback regardless of which action the user clicks.

## Test plan
- Existing pure-helper tests (`is_model_path_set`, `is_binary_available`) cover the predicates the new arm uses — no new predicate was introduced.
- `cargo test` / `cargo check` not run locally: Cloud Eric sessions lack the GTK/webkit2gtk system libs needed to link the Tauri crate (confirmed: `pkg-config --libs glib-2.0` fails). CI matrix build (which now includes `cargo test` per #251) validates the arm.