### PR TITLE
Speed up the macOS desktop default inference path

### DIFF
--- a/crates/kiln-core/src/tokenizer.rs
+++ b/crates/kiln-core/src/tokenizer.rs
@@ -22,6 +22,7 @@ pub struct ChatMessage {
 }
 
 /// Wraps the HuggingFace tokenizers crate for Kiln's tokenization needs.
+#[derive(Clone)]
 pub struct KilnTokenizer {
     inner: Tokenizer,
     chat_template: Option<String>,
@@ -58,8 +59,7 @@ impl KilnTokenizer {
 
     /// Load a tokenizer from a local tokenizer.json file.
     pub fn from_file(path: &str) -> Result<Self, TokenizerError> {
-        let inner =
-            Tokenizer::from_file(path).map_err(|e| TokenizerError::Load(e.to_string()))?;
+        let inner = Tokenizer::from_file(path).map_err(|e| TokenizerError::Load(e.to_string()))?;
         Ok(Self {
             inner,
             chat_template: None,

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -9,12 +9,12 @@ use candle_core::{DType, Device, Tensor};
 
 use crate::backend::BackendRuntime;
 use crate::kv_cache::KvCache;
-use crate::lora_loader::{
-    linear_with_lora_t, LoraLayerWeights, LoraProjectionWeights, LoraWeights,
-};
 #[cfg(feature = "cuda")]
 use crate::lora_loader::compute_lora_delta;
-use crate::paged_kv_cache::PagedKvCache;
+use crate::lora_loader::{
+    LoraLayerWeights, LoraProjectionWeights, LoraWeights, linear_with_lora_t,
+};
+use crate::paged_kv_cache::{PagedKvCache, contiguous_slot_run_start};
 use crate::weights::{ModelWeights, TensorDType, WeightTensor};
 
 use kiln_core::block::BlockTable;
@@ -445,7 +445,10 @@ pub fn streaming_prefill_enabled() -> bool {
 /// or not a multiple of 64. The fallback path matches the documented default
 /// so misconfiguration cannot silently change the tile boundary.
 pub fn streaming_tile_tokens() -> usize {
-    match std::env::var("KILN_STREAMING_TILE_TOKENS").ok().and_then(|s| s.parse::<usize>().ok()) {
+    match std::env::var("KILN_STREAMING_TILE_TOKENS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+    {
         Some(n) if n > 0 && n % GDN_CHUNK_SIZE == 0 => n,
         _ => STREAMING_PREFILL_DEFAULT_TILE,
     }
@@ -457,7 +460,10 @@ pub fn streaming_tile_tokens() -> usize {
 /// full per-tile logits (still throwing them away for non-final tiles, but
 /// useful for parity tests against the monolithic path).
 pub fn streaming_last_token_lm_head() -> bool {
-    match std::env::var("KILN_STREAMING_LAST_TOKEN_LM_HEAD").ok().as_deref() {
+    match std::env::var("KILN_STREAMING_LAST_TOKEN_LM_HEAD")
+        .ok()
+        .as_deref()
+    {
         Some(v) => !matches!(v.trim().to_ascii_lowercase().as_str(), "0" | "false" | "no"),
         None => true,
     }
@@ -569,14 +575,26 @@ impl GpuWeights {
                     let k_proj = weight_to_tensor(&attn.k_proj, device).context(ctx("k_proj"))?;
                     let v_proj = weight_to_tensor(&attn.v_proj, device).context(ctx("v_proj"))?;
                     let o_proj = weight_to_tensor(&attn.o_proj, device).context(ctx("o_proj"))?;
-                    let q_proj_t = q_proj.t().context(ctx("q_proj.t"))?
-                        .contiguous().context(ctx("q_proj.t contiguous"))?;
-                    let k_proj_t = k_proj.t().context(ctx("k_proj.t"))?
-                        .contiguous().context(ctx("k_proj.t contiguous"))?;
-                    let v_proj_t = v_proj.t().context(ctx("v_proj.t"))?
-                        .contiguous().context(ctx("v_proj.t contiguous"))?;
-                    let o_proj_t = o_proj.t().context(ctx("o_proj.t"))?
-                        .contiguous().context(ctx("o_proj.t contiguous"))?;
+                    let q_proj_t = q_proj
+                        .t()
+                        .context(ctx("q_proj.t"))?
+                        .contiguous()
+                        .context(ctx("q_proj.t contiguous"))?;
+                    let k_proj_t = k_proj
+                        .t()
+                        .context(ctx("k_proj.t"))?
+                        .contiguous()
+                        .context(ctx("k_proj.t contiguous"))?;
+                    let v_proj_t = v_proj
+                        .t()
+                        .context(ctx("v_proj.t"))?
+                        .contiguous()
+                        .context(ctx("v_proj.t contiguous"))?;
+                    let o_proj_t = o_proj
+                        .t()
+                        .context(ctx("o_proj.t"))?
+                        .contiguous()
+                        .context(ctx("o_proj.t contiguous"))?;
                     // KILN_W4A16=1 opt-in: queue q_proj for the post-loop
                     // Marlin batch pack. The packed weight (and the BF16
                     // drop) are installed after the layer loop via
@@ -604,26 +622,41 @@ impl GpuWeights {
                     })
                 }
                 crate::weights::AttentionWeights::Linear(attn) => {
-                    let in_proj_qkv = weight_to_tensor(&attn.in_proj_qkv, device)
-                        .context(ctx("in_proj_qkv"))?;
-                    let in_proj_z = weight_to_tensor(&attn.in_proj_z, device)
-                        .context(ctx("in_proj_z"))?;
-                    let out_proj = weight_to_tensor(&attn.out_proj, device)
-                        .context(ctx("out_proj"))?;
-                    let in_proj_a = weight_to_tensor(&attn.in_proj_a, device)
-                        .context(ctx("in_proj_a"))?;
-                    let in_proj_b = weight_to_tensor(&attn.in_proj_b, device)
-                        .context(ctx("in_proj_b"))?;
-                    let in_proj_qkv_t = in_proj_qkv.t().context(ctx("in_proj_qkv.t"))?
-                        .contiguous().context(ctx("in_proj_qkv.t contiguous"))?;
-                    let in_proj_z_t = in_proj_z.t().context(ctx("in_proj_z.t"))?
-                        .contiguous().context(ctx("in_proj_z.t contiguous"))?;
-                    let in_proj_a_t = in_proj_a.t().context(ctx("in_proj_a.t"))?
-                        .contiguous().context(ctx("in_proj_a.t contiguous"))?;
-                    let in_proj_b_t = in_proj_b.t().context(ctx("in_proj_b.t"))?
-                        .contiguous().context(ctx("in_proj_b.t contiguous"))?;
-                    let out_proj_t = out_proj.t().context(ctx("out_proj.t"))?
-                        .contiguous().context(ctx("out_proj.t contiguous"))?;
+                    let in_proj_qkv =
+                        weight_to_tensor(&attn.in_proj_qkv, device).context(ctx("in_proj_qkv"))?;
+                    let in_proj_z =
+                        weight_to_tensor(&attn.in_proj_z, device).context(ctx("in_proj_z"))?;
+                    let out_proj =
+                        weight_to_tensor(&attn.out_proj, device).context(ctx("out_proj"))?;
+                    let in_proj_a =
+                        weight_to_tensor(&attn.in_proj_a, device).context(ctx("in_proj_a"))?;
+                    let in_proj_b =
+                        weight_to_tensor(&attn.in_proj_b, device).context(ctx("in_proj_b"))?;
+                    let in_proj_qkv_t = in_proj_qkv
+                        .t()
+                        .context(ctx("in_proj_qkv.t"))?
+                        .contiguous()
+                        .context(ctx("in_proj_qkv.t contiguous"))?;
+                    let in_proj_z_t = in_proj_z
+                        .t()
+                        .context(ctx("in_proj_z.t"))?
+                        .contiguous()
+                        .context(ctx("in_proj_z.t contiguous"))?;
+                    let in_proj_a_t = in_proj_a
+                        .t()
+                        .context(ctx("in_proj_a.t"))?
+                        .contiguous()
+                        .context(ctx("in_proj_a.t contiguous"))?;
+                    let in_proj_b_t = in_proj_b
+                        .t()
+                        .context(ctx("in_proj_b.t"))?
+                        .contiguous()
+                        .context(ctx("in_proj_b.t contiguous"))?;
+                    let out_proj_t = out_proj
+                        .t()
+                        .context(ctx("out_proj.t"))?
+                        .contiguous()
+                        .context(ctx("out_proj.t contiguous"))?;
                     GpuAttentionWeights::Linear(GpuLinearAttentionWeights {
                         in_proj_qkv,
                         in_proj_z,
@@ -643,15 +676,26 @@ impl GpuWeights {
                 }
             };
 
-            let gate_proj = weight_to_tensor(&lw.mlp.gate_proj, device).context(ctx("gate_proj"))?;
+            let gate_proj =
+                weight_to_tensor(&lw.mlp.gate_proj, device).context(ctx("gate_proj"))?;
             let up_proj = weight_to_tensor(&lw.mlp.up_proj, device).context(ctx("up_proj"))?;
-            let down_proj = weight_to_tensor(&lw.mlp.down_proj, device).context(ctx("down_proj"))?;
-            let gate_proj_t = gate_proj.t().context(ctx("gate_proj.t"))?
-                .contiguous().context(ctx("gate_proj.t contiguous"))?;
-            let up_proj_t = up_proj.t().context(ctx("up_proj.t"))?
-                .contiguous().context(ctx("up_proj.t contiguous"))?;
-            let down_proj_t = down_proj.t().context(ctx("down_proj.t"))?
-                .contiguous().context(ctx("down_proj.t contiguous"))?;
+            let down_proj =
+                weight_to_tensor(&lw.mlp.down_proj, device).context(ctx("down_proj"))?;
+            let gate_proj_t = gate_proj
+                .t()
+                .context(ctx("gate_proj.t"))?
+                .contiguous()
+                .context(ctx("gate_proj.t contiguous"))?;
+            let up_proj_t = up_proj
+                .t()
+                .context(ctx("up_proj.t"))?
+                .contiguous()
+                .context(ctx("up_proj.t contiguous"))?;
+            let down_proj_t = down_proj
+                .t()
+                .context(ctx("down_proj.t"))?
+                .contiguous()
+                .context(ctx("down_proj.t contiguous"))?;
             // KILN_W4A16=1 opt-in: queue each MLP projection for the
             // post-loop Marlin batch pack. See the q_proj comment above —
             // the `*_proj_marlin` fields start as None, and
@@ -724,8 +768,19 @@ impl GpuWeights {
             let drop_disabled = marlin_bf16_drop_disabled();
             for (entry, maybe_packed) in marlin_pack_meta.into_iter().zip(packed.into_iter()) {
                 if let Some(p) = maybe_packed {
-                    install_marlin_packed(&mut layers[entry.layer_idx], entry.kind, p, device, drop_disabled)
-                        .with_context(|| format!("install marlin {:?} on layer {}", entry.kind, entry.layer_idx))?;
+                    install_marlin_packed(
+                        &mut layers[entry.layer_idx],
+                        entry.kind,
+                        p,
+                        device,
+                        drop_disabled,
+                    )
+                    .with_context(|| {
+                        format!(
+                            "install marlin {:?} on layer {}",
+                            entry.kind, entry.layer_idx
+                        )
+                    })?;
                 }
             }
         }
@@ -748,8 +803,8 @@ impl GpuWeights {
                 .context("mtp.pre_fc_norm_embedding")?;
             let pre_fc_norm_hidden = weight_to_tensor(&mtp_w.pre_fc_norm_hidden, device)
                 .context("mtp.pre_fc_norm_hidden")?;
-            let final_layernorm = weight_to_tensor(&mtp_w.final_layernorm, device)
-                .context("mtp.final_layernorm")?;
+            let final_layernorm =
+                weight_to_tensor(&mtp_w.final_layernorm, device).context("mtp.final_layernorm")?;
 
             // The MTP inner transformer layer. Loader guarantees this is a
             // full-attention layer (bails otherwise). Keep the upload inline
@@ -760,17 +815,22 @@ impl GpuWeights {
                 let lw = &mtp_w.layer;
                 let ctx = |name: &str| format!("mtp.layer {name}");
 
-                let input_layernorm =
-                    weight_to_tensor(&lw.input_layernorm, device).context(ctx("input_layernorm"))?;
-                let post_attention_layernorm = weight_to_tensor(&lw.post_attention_layernorm, device)
-                    .context(ctx("post_attention_layernorm"))?;
+                let input_layernorm = weight_to_tensor(&lw.input_layernorm, device)
+                    .context(ctx("input_layernorm"))?;
+                let post_attention_layernorm =
+                    weight_to_tensor(&lw.post_attention_layernorm, device)
+                        .context(ctx("post_attention_layernorm"))?;
 
                 let attention = match &lw.attention {
                     crate::weights::AttentionWeights::Full(attn) => {
-                        let q_proj = weight_to_tensor(&attn.q_proj, device).context(ctx("q_proj"))?;
-                        let k_proj = weight_to_tensor(&attn.k_proj, device).context(ctx("k_proj"))?;
-                        let v_proj = weight_to_tensor(&attn.v_proj, device).context(ctx("v_proj"))?;
-                        let o_proj = weight_to_tensor(&attn.o_proj, device).context(ctx("o_proj"))?;
+                        let q_proj =
+                            weight_to_tensor(&attn.q_proj, device).context(ctx("q_proj"))?;
+                        let k_proj =
+                            weight_to_tensor(&attn.k_proj, device).context(ctx("k_proj"))?;
+                        let v_proj =
+                            weight_to_tensor(&attn.v_proj, device).context(ctx("v_proj"))?;
+                        let o_proj =
+                            weight_to_tensor(&attn.o_proj, device).context(ctx("o_proj"))?;
                         let q_proj_t = q_proj
                             .t()
                             .context(ctx("q_proj.t"))?
@@ -796,8 +856,10 @@ impl GpuWeights {
                             k_proj,
                             v_proj,
                             o_proj,
-                            q_norm: weight_to_tensor(&attn.q_norm, device).context(ctx("q_norm"))?,
-                            k_norm: weight_to_tensor(&attn.k_norm, device).context(ctx("k_norm"))?,
+                            q_norm: weight_to_tensor(&attn.q_norm, device)
+                                .context(ctx("q_norm"))?,
+                            k_norm: weight_to_tensor(&attn.k_norm, device)
+                                .context(ctx("k_norm"))?,
                             q_proj_t,
                             k_proj_t,
                             v_proj_t,
@@ -1005,7 +1067,13 @@ pub fn rotary_embedding_from_tensor(
 /// `head_dim`: total dimension per head
 /// `rotary_dim`: number of dimensions to rotate (must be even). The first `rotary_dim` dims
 ///   are rotated; the remaining `head_dim - rotary_dim` dims pass through unchanged.
-fn apply_rope(x: &Tensor, cos: &Tensor, sin: &Tensor, head_dim: usize, rotary_dim: usize) -> Result<Tensor> {
+fn apply_rope(
+    x: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    head_dim: usize,
+    rotary_dim: usize,
+) -> Result<Tensor> {
     let half_rotary = rotary_dim / 2;
     let x_dtype = x.dtype();
 
@@ -1119,8 +1187,8 @@ fn mlp_proj_forward(
         let base = crate::marlin_proj::matmul_bf16(x, packed)
             .context("mlp_proj_forward: marlin matmul")?;
         if let Some(proj) = lora {
-            let delta = compute_lora_delta(x, proj, lora_scale)
-                .context("mlp_proj_forward: lora delta")?;
+            let delta =
+                compute_lora_delta(x, proj, lora_scale).context("mlp_proj_forward: lora delta")?;
             return Ok((base + delta).context("mlp_proj_forward: add lora delta")?);
         }
         return Ok(base);
@@ -1202,7 +1270,9 @@ fn causal_conv1d_prefill(
     let _device = x.device();
     let x_f32 = x.to_dtype(DType::F32)?;
     // Squeeze [channels, 1, kernel_size] -> [channels, kernel_size]
-    let w_f32 = weight.to_dtype(DType::F32)?.reshape((channels, kernel_size))?;
+    let w_f32 = weight
+        .to_dtype(DType::F32)?
+        .reshape((channels, kernel_size))?;
     let k_minus_1 = kernel_size - 1;
 
     // Left-pad with conv_state (previous K-1 inputs, or zeros for fresh state)
@@ -1224,9 +1294,7 @@ fn causal_conv1d_prefill(
     } else {
         // Fewer new tokens than buffer size: shift old state and append new
         let keep = k_minus_1 - seq_len;
-        let old_part = conv_state
-            .to_dtype(DType::F32)?
-            .narrow(2, seq_len, keep)?;
+        let old_part = conv_state.to_dtype(DType::F32)?.narrow(2, seq_len, keep)?;
         *conv_state = Tensor::cat(&[&old_part, &x_f32], 2)?.contiguous()?;
     }
 
@@ -1246,7 +1314,9 @@ fn causal_conv1d_decode(
 ) -> Result<Tensor> {
     let (_batch, channels, _one) = x.dims3()?;
     let x_f32 = x.to_dtype(DType::F32)?;
-    let w_f32 = weight.to_dtype(DType::F32)?.reshape((channels, kernel_size))?;
+    let w_f32 = weight
+        .to_dtype(DType::F32)?
+        .reshape((channels, kernel_size))?;
 
     // Full window = [conv_state | x] -> [batch, channels, kernel_size]
     let window = Tensor::cat(&[&conv_state.to_dtype(DType::F32)?, &x_f32], 2)?;
@@ -1729,9 +1799,9 @@ pub fn gated_deltanet_forward(
     let (mixed_qkv, z, a, b) = {
         kiln_nvtx::range!(c"kiln/gdn/in_proj");
         let mixed_qkv = x.broadcast_matmul(&weights.in_proj_qkv_t)?; // [B, T, qkv_dim]
-        let z = x.broadcast_matmul(&weights.in_proj_z_t)?;           // [B, T, v_dim]
-        let a = x.broadcast_matmul(&weights.in_proj_a_t)?;           // [B, T, nv]
-        let b = x.broadcast_matmul(&weights.in_proj_b_t)?;           // [B, T, nv]
+        let z = x.broadcast_matmul(&weights.in_proj_z_t)?; // [B, T, v_dim]
+        let a = x.broadcast_matmul(&weights.in_proj_a_t)?; // [B, T, nv]
+        let b = x.broadcast_matmul(&weights.in_proj_b_t)?; // [B, T, nv]
         (mixed_qkv, z, a, b)
     };
 
@@ -1767,20 +1837,10 @@ pub fn gated_deltanet_forward(
                 }
             }
         } else if seq_len > 1 {
-            let y = causal_conv1d_prefill(
-                &mixed_qkv_ct,
-                &weights.conv1d,
-                conv_state,
-                kernel_size,
-            )?;
+            let y = causal_conv1d_prefill(&mixed_qkv_ct, &weights.conv1d, conv_state, kernel_size)?;
             cuda_silu(&y.to_dtype(DType::F32)?)?
         } else {
-            let y = causal_conv1d_decode(
-                &mixed_qkv_ct,
-                &weights.conv1d,
-                conv_state,
-                kernel_size,
-            )?;
+            let y = causal_conv1d_decode(&mixed_qkv_ct, &weights.conv1d, conv_state, kernel_size)?;
             cuda_silu(&y.to_dtype(DType::F32)?)?
         };
         // Transpose back to [B, T, qkv_dim]
@@ -1893,9 +1953,7 @@ pub fn gated_deltanet_forward(
     let (beta, g) = {
         kiln_nvtx::range!(c"kiln/gdn/gates");
         if backend.supports_gdn_gates() {
-            if let Some((beta, g)) =
-                backend.gdn_gates(&a, &b, &weights.a_log, &weights.dt_bias)?
-            {
+            if let Some((beta, g)) = backend.gdn_gates(&a, &b, &weights.a_log, &weights.dt_bias)? {
                 (beta, g)
             } else {
                 gated_deltanet_gates_fallback(&a, &b, weights, input_dtype)?
@@ -2020,11 +2078,11 @@ pub fn q_proj_forward(
 ) -> Result<Tensor> {
     #[cfg(feature = "cuda")]
     if let Some(ref packed) = attn_weights.q_proj_marlin {
-        let base = crate::marlin_proj::matmul_bf16(x, packed)
-            .context("q_proj_forward: marlin matmul")?;
+        let base =
+            crate::marlin_proj::matmul_bf16(x, packed).context("q_proj_forward: marlin matmul")?;
         if let Some(proj) = lora {
-            let delta = compute_lora_delta(x, proj, lora_scale)
-                .context("q_proj_forward: lora delta")?;
+            let delta =
+                compute_lora_delta(x, proj, lora_scale).context("q_proj_forward: lora delta")?;
             return Ok((base + delta).context("q_proj_forward: add lora delta")?);
         }
         return Ok(base);
@@ -2067,8 +2125,18 @@ pub fn gqa_attention(
             lora_layer.and_then(|l| l.q_proj.as_ref()),
             lora_scale,
         )?;
-        let k = linear_with_lora_t(x, &attn_weights.k_proj_t, lora_layer.and_then(|l| l.k_proj.as_ref()), lora_scale)?;
-        let v = linear_with_lora_t(x, &attn_weights.v_proj_t, lora_layer.and_then(|l| l.v_proj.as_ref()), lora_scale)?;
+        let k = linear_with_lora_t(
+            x,
+            &attn_weights.k_proj_t,
+            lora_layer.and_then(|l| l.k_proj.as_ref()),
+            lora_scale,
+        )?;
+        let v = linear_with_lora_t(
+            x,
+            &attn_weights.v_proj_t,
+            lora_layer.and_then(|l| l.v_proj.as_ref()),
+            lora_scale,
+        )?;
         (q_raw, k, v)
     };
 
@@ -2080,7 +2148,9 @@ pub fn gqa_attention(
         let q = q_raw.narrow(3, 0, head_dim)?;
         let gate = q_raw.narrow(3, head_dim, head_dim)?;
         // gate needs to be [batch, seq_len, num_heads * head_dim] for later
-        let gate = gate.contiguous()?.reshape(((), seq_len, num_heads * head_dim))?;
+        let gate = gate
+            .contiguous()?
+            .reshape(((), seq_len, num_heads * head_dim))?;
         (q.contiguous()?, Some(gate))
     } else {
         let q = q_raw.reshape(((), seq_len, num_heads, head_dim))?;
@@ -2122,7 +2192,12 @@ pub fn gqa_attention(
             };
             let out = {
                 kiln_nvtx::range!(c"kiln/proj/o");
-                linear_with_lora_t(&attn_output, &attn_weights.o_proj_t, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
+                linear_with_lora_t(
+                    &attn_output,
+                    &attn_weights.o_proj_t,
+                    lora_layer.and_then(|l| l.o_proj.as_ref()),
+                    lora_scale,
+                )?
             };
             return Ok(out);
         }
@@ -2180,10 +2255,11 @@ pub fn gqa_attention(
     let attn_output = attn_weights_softmax.broadcast_matmul(&v)?; // [batch, num_heads, seq_len, head_dim]
 
     // Transpose back: [batch, seq_len, num_heads, head_dim] -> [batch, seq_len, hidden]
-    let attn_output = attn_output
-        .transpose(1, 2)?
-        .contiguous()?
-        .reshape(((), seq_len, num_heads * head_dim))?;
+    let attn_output =
+        attn_output
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape(((), seq_len, num_heads * head_dim))?;
 
     // Apply output gate: attn_output * sigmoid(gate)
     let attn_output = if let Some(ref gate) = gate {
@@ -2196,7 +2272,12 @@ pub fn gqa_attention(
     // Output projection
     let out = {
         kiln_nvtx::range!(c"kiln/proj/o");
-        linear_with_lora_t(&attn_output, &attn_weights.o_proj_t, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
+        linear_with_lora_t(
+            &attn_output,
+            &attn_weights.o_proj_t,
+            lora_layer.and_then(|l| l.o_proj.as_ref()),
+            lora_scale,
+        )?
     };
     Ok(out)
 }
@@ -2253,6 +2334,59 @@ fn try_flash_attn_paged_decode(
         return Ok(None);
     }
 
+    // Reshape Q for the fused-attention APIs: [batch, num_heads, 1, head_dim]
+    // -> [batch, 1, num_heads, head_dim].
+    let q_fa = {
+        kiln_nvtx::range!(c"kiln/attn/q_fa_transpose");
+        q.transpose(1, 2)?.contiguous()?
+    };
+
+    let (k_pool, v_pool) = match paged_cache.pool_tensors(full_attn_layer_idx) {
+        Some(p) => p,
+        None => return Ok(None),
+    };
+
+    // Common macOS/desktop case: a single sequence receives freshly-allocated
+    // blocks, so its whole live KV window is already one contiguous run in the
+    // pool. In that case we can bypass the paged gather path entirely and feed
+    // the fused prefill kernel a direct `[1, total_seq_len, kv_heads, head_dim]`
+    // narrow of the live K/V window.
+    if !paged_cache.is_fp8() {
+        if let Some(start_slot) =
+            contiguous_slot_run_start(block_table, block_size, 0, total_seq_len)
+        {
+            let k_live = k_pool.narrow(0, start_slot, total_seq_len)?.unsqueeze(0)?;
+            let v_live = v_pool.narrow(0, start_slot, total_seq_len)?.unsqueeze(0)?;
+            if let Some(attn_output) = flash_attention_forward(
+                backend,
+                &q_fa,
+                &k_live,
+                &v_live,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+            )? {
+                let attn_output = if let Some(gate) = gate {
+                    let sigmoid_gate = cuda_sigmoid(gate)?;
+                    (attn_output * sigmoid_gate)?
+                } else {
+                    attn_output
+                };
+
+                let out = {
+                    kiln_nvtx::range!(c"kiln/proj/o");
+                    linear_with_lora_t(
+                        &attn_output,
+                        &attn_weights.o_proj_t,
+                        lora_layer.and_then(|l| l.o_proj.as_ref()),
+                        lora_scale,
+                    )?
+                };
+                return Ok(Some(out));
+            }
+        }
+    }
+
     // Verify intra-chunk contiguity. The kernel reads block_table[c * 8] only
     // (for block_size=16) and assumes pages [c*8 .. c*8+7] are physically
     // contiguous in the pool. kiln's `BlockManager` allocates blocks
@@ -2262,9 +2396,7 @@ fn try_flash_attn_paged_decode(
     let n_chunks = total_seq_len.div_ceil(K_BLOCK_N);
     let blocks = &block_table.blocks;
     let allocated = blocks.len();
-    if allocated < n_chunks * pages_per_chunk
-        && allocated < total_seq_len.div_ceil(block_size)
-    {
+    if allocated < n_chunks * pages_per_chunk && allocated < total_seq_len.div_ceil(block_size) {
         // Block table too short for the requested seqlen.
         return Ok(None);
     }
@@ -2310,20 +2442,8 @@ fn try_flash_attn_paged_decode(
     }
 
     let device = q.device();
-    let bt_tensor = Tensor::new(padded.as_slice(), device)?
-        .reshape((1usize, max_blocks_per_seq))?;
-
-    // Reshape Q for the flash-attn API: [batch, num_heads, 1, head_dim]
-    // -> [batch, 1, num_heads, head_dim].
-    let q_fa = {
-        kiln_nvtx::range!(c"kiln/attn/q_fa_transpose");
-        q.transpose(1, 2)?.contiguous()?
-    };
-
-    let (k_pool, v_pool) = match paged_cache.pool_tensors(full_attn_layer_idx) {
-        Some(p) => p,
-        None => return Ok(None),
-    };
+    let bt_tensor =
+        Tensor::new(padded.as_slice(), device)?.reshape((1usize, max_blocks_per_seq))?;
 
     let softmax_scale = 1.0f32 / (head_dim as f32).sqrt();
 
@@ -2406,8 +2526,18 @@ pub fn gqa_attention_paged(
             lora_layer.and_then(|l| l.q_proj.as_ref()),
             lora_scale,
         )?;
-        let k = linear_with_lora_t(x, &attn_weights.k_proj_t, lora_layer.and_then(|l| l.k_proj.as_ref()), lora_scale)?;
-        let v = linear_with_lora_t(x, &attn_weights.v_proj_t, lora_layer.and_then(|l| l.v_proj.as_ref()), lora_scale)?;
+        let k = linear_with_lora_t(
+            x,
+            &attn_weights.k_proj_t,
+            lora_layer.and_then(|l| l.k_proj.as_ref()),
+            lora_scale,
+        )?;
+        let v = linear_with_lora_t(
+            x,
+            &attn_weights.v_proj_t,
+            lora_layer.and_then(|l| l.v_proj.as_ref()),
+            lora_scale,
+        )?;
         (q_raw, k, v)
     };
 
@@ -2417,7 +2547,9 @@ pub fn gqa_attention_paged(
             let q_raw = q_raw.reshape(((), seq_len, num_heads, head_dim * 2))?;
             let q = q_raw.narrow(3, 0, head_dim)?;
             let gate = q_raw.narrow(3, head_dim, head_dim)?;
-            let gate = gate.contiguous()?.reshape(((), seq_len, num_heads * head_dim))?;
+            let gate = gate
+                .contiguous()?
+                .reshape(((), seq_len, num_heads * head_dim))?;
             (q.contiguous()?, Some(gate))
         } else {
             let q = q_raw.reshape(((), seq_len, num_heads, head_dim))?;
@@ -2453,15 +2585,61 @@ pub fn gqa_attention_paged(
         (q, k, v)
     };
 
-    // Write new K/V into paged cache
+    let total_seq_len = start_pos + seq_len;
+
+    // Initial prefill fast path: when there is no prefix history yet
+    // (`start_pos == 0`), the current K/V tensors already cover the entire
+    // attention window. Route prefill through the backend flash-attn path
+    // directly and only write K/V into the paged cache once for future decode.
+    // This avoids a pointless write-then-read round-trip through
+    // `PagedKvCache` on the first prompt tile.
+    if seq_len > 1 && start_pos == 0 && backend.supports_flash_attn_prefill() {
+        kiln_nvtx::range!(c"kiln/attn/full/prefill_initial");
+        let q_prefill = q.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_heads, head_dim]
+        let k_prefill = k.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_kv_heads, head_dim]
+        let v_prefill = v.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_kv_heads, head_dim]
+        if let Some(attn_output) = flash_attention_forward(
+            backend,
+            &q_prefill,
+            &k_prefill,
+            &v_prefill,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+        )? {
+            {
+                kiln_nvtx::range!(c"kiln/kv/copy");
+                paged_cache
+                    .write(full_attn_layer_idx, block_table, start_pos, &k, &v)
+                    .context("paged KV cache write failed")?;
+            }
+
+            let attn_output = if let Some(ref gate) = gate {
+                let sigmoid_gate = cuda_sigmoid(gate)?;
+                (attn_output * sigmoid_gate)?
+            } else {
+                attn_output
+            };
+            let out = {
+                kiln_nvtx::range!(c"kiln/proj/o");
+                linear_with_lora_t(
+                    &attn_output,
+                    &attn_weights.o_proj_t,
+                    lora_layer.and_then(|l| l.o_proj.as_ref()),
+                    lora_scale,
+                )?
+            };
+            return Ok(out);
+        }
+    }
+
+    // Write new K/V into paged cache.
     {
         kiln_nvtx::range!(c"kiln/kv/copy");
         paged_cache
             .write(full_attn_layer_idx, block_table, start_pos, &k, &v)
             .context("paged KV cache write failed")?;
     }
-
-    let total_seq_len = start_pos + seq_len;
 
     // Fast path: fused paged-decode flash-attention kernel.
     // Eliminates the materializing `paged_cache.read()` (an `index_select` /
@@ -2525,7 +2703,9 @@ pub fn gqa_attention_paged(
         .context("paged KV cache read failed")?;
     let kv_len = total_seq_len;
 
-    // Fused-attention path for prefill (seq_len > 1).
+    // Fused-attention path for prefill with existing prefix history
+    // (`start_pos > 0`). Initial prefill is special-cased above so we do not
+    // materialize the same K/V we just produced.
     // Paged cache returns [batch, heads, kv_len, head_dim] — transpose to
     // [batch, kv_len, heads, head_dim] for the backend kernel.
     if seq_len > 1 && backend.supports_flash_attn_prefill() {
@@ -2545,7 +2725,12 @@ pub fn gqa_attention_paged(
             };
             let out = {
                 kiln_nvtx::range!(c"kiln/proj/o");
-                linear_with_lora_t(&attn_output, &attn_weights.o_proj_t, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
+                linear_with_lora_t(
+                    &attn_output,
+                    &attn_weights.o_proj_t,
+                    lora_layer.and_then(|l| l.o_proj.as_ref()),
+                    lora_scale,
+                )?
             };
             return Ok(out);
         }
@@ -2612,7 +2797,12 @@ pub fn gqa_attention_paged(
         };
         let out = {
             kiln_nvtx::range!(c"kiln/proj/o");
-            linear_with_lora_t(&attn_output, &attn_weights.o_proj_t, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
+            linear_with_lora_t(
+                &attn_output,
+                &attn_weights.o_proj_t,
+                lora_layer.and_then(|l| l.o_proj.as_ref()),
+                lora_scale,
+            )?
         };
         return Ok(out);
     }
@@ -2646,10 +2836,11 @@ pub fn gqa_attention_paged(
     let attn_output = attn_weights_softmax.broadcast_matmul(&v)?;
 
     // Transpose back and output projection
-    let attn_output = attn_output
-        .transpose(1, 2)?
-        .contiguous()?
-        .reshape(((), seq_len, num_heads * head_dim))?;
+    let attn_output =
+        attn_output
+            .transpose(1, 2)?
+            .contiguous()?
+            .reshape(((), seq_len, num_heads * head_dim))?;
 
     let attn_output = if let Some(ref gate) = gate {
         let sigmoid_gate = cuda_sigmoid(gate)?;
@@ -2660,7 +2851,12 @@ pub fn gqa_attention_paged(
 
     let out = {
         kiln_nvtx::range!(c"kiln/proj/o");
-        linear_with_lora_t(&attn_output, &attn_weights.o_proj_t, lora_layer.and_then(|l| l.o_proj.as_ref()), lora_scale)?
+        linear_with_lora_t(
+            &attn_output,
+            &attn_weights.o_proj_t,
+            lora_layer.and_then(|l| l.o_proj.as_ref()),
+            lora_scale,
+        )?
     };
     Ok(out)
 }
@@ -2821,7 +3017,9 @@ pub fn transformer_block_paged(
     let attn_weights = match &layer.attention {
         GpuAttentionWeights::Full(w) => w,
         GpuAttentionWeights::Linear(_) => {
-            anyhow::bail!("transformer_block_paged only supports full attention layers (not linear/GDN)")
+            anyhow::bail!(
+                "transformer_block_paged only supports full attention layers (not linear/GDN)"
+            )
         }
     };
 
@@ -2918,8 +3116,8 @@ pub fn model_forward(
     let mut linear_attn_idx: usize = 0;
     for (i, layer) in weights.layers.iter().enumerate() {
         // Get LoRA weights for this layer, if available
-        let layer_lora: Option<(&LoraLayerWeights, f32)> = lora
-            .and_then(|lw| lw.layers.get(i).map(|ll| (ll, lw.scale)));
+        let layer_lora: Option<(&LoraLayerWeights, f32)> =
+            lora.and_then(|lw| lw.layers.get(i).map(|ll| (ll, lw.scale)));
 
         match &layer.attention {
             GpuAttentionWeights::Full(_) => {
@@ -2945,8 +3143,9 @@ pub fn model_forward(
                 full_attn_idx += 1;
             }
             GpuAttentionWeights::Linear(lin_weights) => {
-                let state = linear_state.as_mut()
-                    .ok_or_else(|| anyhow::anyhow!("linear attention state required for GDN layers (layer {i})"))?;
+                let state = linear_state.as_mut().ok_or_else(|| {
+                    anyhow::anyhow!("linear attention state required for GDN layers (layer {i})")
+                })?;
                 // Pre-attention RMSNorm
                 let normed = {
                     kiln_nvtx::range!(c"kiln/norm/pre_attn");
@@ -2969,7 +3168,11 @@ pub fn model_forward(
                 // Post-attention RMSNorm + FFN
                 let normed_post = {
                     kiln_nvtx::range!(c"kiln/norm/pre_mlp");
-                    rms_norm(&hidden, &layer.post_attention_layernorm, config.rms_norm_eps)?
+                    rms_norm(
+                        &hidden,
+                        &layer.post_attention_layernorm,
+                        config.rms_norm_eps,
+                    )?
                 };
                 let ffn_out = swiglu_ffn(&normed_post, &layer.mlp, layer_lora)?;
                 hidden = {
@@ -3025,8 +3228,8 @@ pub fn model_forward_segment(
 
     for i in start_layer..end_layer {
         let layer = &weights.layers[i];
-        let layer_lora: Option<(&LoraLayerWeights, f32)> = lora
-            .and_then(|lw| lw.layers.get(i).map(|ll| (ll, lw.scale)));
+        let layer_lora: Option<(&LoraLayerWeights, f32)> =
+            lora.and_then(|lw| lw.layers.get(i).map(|ll| (ll, lw.scale)));
 
         match &layer.attention {
             GpuAttentionWeights::Full(_) => {
@@ -3051,8 +3254,9 @@ pub fn model_forward_segment(
                 full_attn_idx += 1;
             }
             GpuAttentionWeights::Linear(lin_weights) => {
-                let state = linear_state.as_mut()
-                    .ok_or_else(|| anyhow::anyhow!("linear attention state required for GDN layers (layer {i})"))?;
+                let state = linear_state.as_mut().ok_or_else(|| {
+                    anyhow::anyhow!("linear attention state required for GDN layers (layer {i})")
+                })?;
                 let normed = {
                     kiln_nvtx::range!(c"kiln/norm/pre_attn");
                     rms_norm(&hidden, &layer.input_layernorm, config.rms_norm_eps)?
@@ -3072,7 +3276,11 @@ pub fn model_forward_segment(
                 };
                 let normed_post = {
                     kiln_nvtx::range!(c"kiln/norm/pre_mlp");
-                    rms_norm(&hidden, &layer.post_attention_layernorm, config.rms_norm_eps)?
+                    rms_norm(
+                        &hidden,
+                        &layer.post_attention_layernorm,
+                        config.rms_norm_eps,
+                    )?
                 };
                 let ffn_out = swiglu_ffn(&normed_post, &layer.mlp, layer_lora)?;
                 hidden = {
@@ -3091,10 +3299,7 @@ pub fn model_forward_segment(
 ///
 /// Returns `([1, seq_len, hidden_size], positions)` — the initial hidden state
 /// and position indices for RoPE (starting from position 0, no KV cache offset).
-pub fn model_forward_embed(
-    token_ids: &[u32],
-    weights: &GpuWeights,
-) -> Result<(Tensor, Vec<u32>)> {
+pub fn model_forward_embed(token_ids: &[u32], weights: &GpuWeights) -> Result<(Tensor, Vec<u32>)> {
     let seq_len = token_ids.len();
     let mut hidden = embedding_lookup(token_ids, &weights.embed_tokens)?;
     hidden = hidden.unsqueeze(0)?;
@@ -3433,9 +3638,7 @@ fn model_forward_paged_inner(
     let positions: &Tensor = match positions_gpu {
         Some(t) => t,
         None => {
-            let pos_f32: Vec<f32> = (start_pos..start_pos + seq_len)
-                .map(|p| p as f32)
-                .collect();
+            let pos_f32: Vec<f32> = (start_pos..start_pos + seq_len).map(|p| p as f32).collect();
             positions_owned = Tensor::new(pos_f32.as_slice(), device)?;
             &positions_owned
         }
@@ -3446,8 +3649,8 @@ fn model_forward_paged_inner(
     let mut linear_attn_idx: usize = 0;
     for (i, layer) in weights.layers.iter().enumerate() {
         // Get LoRA weights for this layer, if available
-        let layer_lora: Option<(&LoraLayerWeights, f32)> = lora
-            .and_then(|lw| lw.layers.get(i).map(|ll| (ll, lw.scale)));
+        let layer_lora: Option<(&LoraLayerWeights, f32)> =
+            lora.and_then(|lw| lw.layers.get(i).map(|ll| (ll, lw.scale)));
 
         match &layer.attention {
             GpuAttentionWeights::Full(_) => {
@@ -3473,8 +3676,9 @@ fn model_forward_paged_inner(
                 full_attn_idx += 1;
             }
             GpuAttentionWeights::Linear(lin_weights) => {
-                let state = linear_state.as_mut()
-                    .ok_or_else(|| anyhow::anyhow!("linear attention state required for GDN layers (layer {i})"))?;
+                let state = linear_state.as_mut().ok_or_else(|| {
+                    anyhow::anyhow!("linear attention state required for GDN layers (layer {i})")
+                })?;
                 let normed = {
                     kiln_nvtx::range!(c"kiln/norm/pre_attn");
                     rms_norm(&hidden, &layer.input_layernorm, config.rms_norm_eps)?
@@ -3494,7 +3698,11 @@ fn model_forward_paged_inner(
                 };
                 let normed_post = {
                     kiln_nvtx::range!(c"kiln/norm/pre_mlp");
-                    rms_norm(&hidden, &layer.post_attention_layernorm, config.rms_norm_eps)?
+                    rms_norm(
+                        &hidden,
+                        &layer.post_attention_layernorm,
+                        config.rms_norm_eps,
+                    )?
                 };
                 let ffn_out = swiglu_ffn(&normed_post, &layer.mlp, layer_lora)?;
                 hidden = {
@@ -3849,7 +4057,10 @@ mod tests {
 
         // First rotary_dim dims should be different at non-zero position
         let rotary_diff: f32 = (0..rotary_dim).map(|i| (orig[i] - rotated[i]).abs()).sum();
-        assert!(rotary_diff > 0.01, "Rotary dims should change at position 100");
+        assert!(
+            rotary_diff > 0.01,
+            "Rotary dims should change at position 100"
+        );
 
         // Passthrough dims (rotary_dim..head_dim) must be identical
         for i in rotary_dim..head_dim {
@@ -3875,7 +4086,12 @@ mod tests {
         let rotary_dim = 4; // partial rotation
 
         let q = Tensor::randn(0.0_f32, 1.0, (batch, seq_len, num_heads, head_dim), &device)?;
-        let k = Tensor::randn(0.0_f32, 1.0, (batch, seq_len, num_kv_heads, head_dim), &device)?;
+        let k = Tensor::randn(
+            0.0_f32,
+            1.0,
+            (batch, seq_len, num_kv_heads, head_dim),
+            &device,
+        )?;
         let positions: Vec<u32> = (0..seq_len as u32).collect();
 
         let inv_freq = compute_rotary_inv_freq(rotary_dim, 10_000.0, &device)?;
@@ -3960,7 +4176,12 @@ mod tests {
     }
 
     /// Create a minimal config for tests (no output gate, simple dims).
-    fn make_test_config(num_heads: usize, num_kv_heads: usize, head_dim: usize, hidden: usize) -> kiln_core::config::ModelConfig {
+    fn make_test_config(
+        num_heads: usize,
+        num_kv_heads: usize,
+        head_dim: usize,
+        hidden: usize,
+    ) -> kiln_core::config::ModelConfig {
         kiln_core::config::ModelConfig {
             hidden_size: hidden,
             num_layers: 4,
@@ -4031,7 +4252,22 @@ mod tests {
 
         let inv_freq = compute_rotary_inv_freq(head_dim, 10_000.0, &device)?;
         let backend = test_backend(&device);
-        let out = gqa_attention(&backend, &x, &attn, &positions, num_heads, num_kv_heads, head_dim, head_dim, &inv_freq, 1e-6, None, 0, false, None)?;
+        let out = gqa_attention(
+            &backend,
+            &x,
+            &attn,
+            &positions,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            head_dim,
+            &inv_freq,
+            1e-6,
+            None,
+            0,
+            false,
+            None,
+        )?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         Ok(())
@@ -4054,12 +4290,30 @@ mod tests {
 
         let inv_freq = compute_rotary_inv_freq(head_dim, 10_000.0, &device)?;
         let backend = test_backend(&device);
-        let out = gqa_attention(&backend, &x, &attn, &positions, num_heads, num_kv_heads, head_dim, head_dim, &inv_freq, 1e-6, None, 0, false, None)?;
+        let out = gqa_attention(
+            &backend,
+            &x,
+            &attn,
+            &positions,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            head_dim,
+            &inv_freq,
+            1e-6,
+            None,
+            0,
+            false,
+            None,
+        )?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         // Output should be finite and not all zeros
         let vals = out.flatten_all()?.to_vec1::<f32>()?;
-        assert!(vals.iter().all(|v| v.is_finite()), "output should be finite");
+        assert!(
+            vals.iter().all(|v| v.is_finite()),
+            "output should be finite"
+        );
         let sum: f32 = vals.iter().map(|v| v.abs()).sum();
         assert!(sum > 1e-6, "output should not be all zeros");
 
@@ -4080,7 +4334,22 @@ mod tests {
 
         let inv_freq = compute_rotary_inv_freq(head_dim, 10_000.0, &device)?;
         let backend = test_backend(&device);
-        let out = gqa_attention(&backend, &x, &attn, &[0], num_heads, num_kv_heads, head_dim, head_dim, &inv_freq, 1e-6, None, 0, false, None)?;
+        let out = gqa_attention(
+            &backend,
+            &x,
+            &attn,
+            &[0],
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            head_dim,
+            &inv_freq,
+            1e-6,
+            None,
+            0,
+            false,
+            None,
+        )?;
         assert_eq!(out.dims(), &[1, 1, hidden]);
 
         Ok(())
@@ -4133,9 +4402,13 @@ mod tests {
         let layer = GpuLayerWeights {
             input_layernorm: Tensor::zeros(hidden, DType::F32, &device)?,
             post_attention_layernorm: Tensor::zeros(hidden, DType::F32, &device)?,
-            attention: GpuAttentionWeights::Full(
-                make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?,
-            ),
+            attention: GpuAttentionWeights::Full(make_test_attn_weights(
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                hidden,
+                &device,
+            )?),
             mlp: GpuFfnWeights {
                 gate_proj,
                 up_proj,
@@ -4152,7 +4425,22 @@ mod tests {
         let cfg = make_test_config(num_heads, num_kv_heads, head_dim, hidden);
         let inv_freq = compute_rotary_inv_freq(head_dim, 10_000.0, &device)?;
         let backend = test_backend(&device);
-        let out = transformer_block(&backend, &x, &layer, &cfg, &positions, num_heads, num_kv_heads, head_dim, head_dim, &inv_freq, 1e-6, None, 0, None)?;
+        let out = transformer_block(
+            &backend,
+            &x,
+            &layer,
+            &cfg,
+            &positions,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            head_dim,
+            &inv_freq,
+            1e-6,
+            None,
+            0,
+            None,
+        )?;
         assert_eq!(out.dims(), &[batch, seq_len, hidden]);
 
         Ok(())
@@ -4182,9 +4470,13 @@ mod tests {
         let layer = GpuLayerWeights {
             input_layernorm: Tensor::zeros(hidden, DType::F32, &device)?,
             post_attention_layernorm: Tensor::zeros(hidden, DType::F32, &device)?,
-            attention: GpuAttentionWeights::Full(
-                make_test_attn_weights(num_heads, num_kv_heads, head_dim, hidden, &device)?,
-            ),
+            attention: GpuAttentionWeights::Full(make_test_attn_weights(
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                hidden,
+                &device,
+            )?),
             mlp: GpuFfnWeights {
                 gate_proj,
                 up_proj,
@@ -4201,13 +4493,34 @@ mod tests {
         let cfg = make_test_config(num_heads, num_kv_heads, head_dim, hidden);
         let inv_freq = compute_rotary_inv_freq(head_dim, 10_000.0, &device)?;
         let backend = test_backend(&device);
-        let out = transformer_block(&backend, &x, &layer, &cfg, &positions, num_heads, num_kv_heads, head_dim, head_dim, &inv_freq, 1e-6, None, 0, None)?;
+        let out = transformer_block(
+            &backend,
+            &x,
+            &layer,
+            &cfg,
+            &positions,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            head_dim,
+            &inv_freq,
+            1e-6,
+            None,
+            0,
+            None,
+        )?;
 
         // Output should not be zero (residual adds input through)
         let vals = out.flatten_all()?.to_vec1::<f32>()?;
         let sum: f32 = vals.iter().map(|v| v.abs()).sum();
-        assert!(sum > 0.1, "residual connections should keep output non-zero, got sum={sum}");
-        assert!(vals.iter().all(|v| v.is_finite()), "output should be finite");
+        assert!(
+            sum > 0.1,
+            "residual connections should keep output non-zero, got sum={sum}"
+        );
+        assert!(
+            vals.iter().all(|v| v.is_finite()),
+            "output should be finite"
+        );
 
         Ok(())
     }
@@ -4253,7 +4566,22 @@ mod tests {
         let cfg = make_test_config(2, 1, 4, 8);
         let inv_freq = compute_rotary_inv_freq(4, 10_000.0, &device)?;
         let backend = test_backend(&device);
-        let result = transformer_block(&backend, &x, &layer, &cfg, &[0], 2, 1, 4, 4, &inv_freq, 1e-6, None, 0, None);
+        let result = transformer_block(
+            &backend,
+            &x,
+            &layer,
+            &cfg,
+            &[0],
+            2,
+            1,
+            4,
+            4,
+            &inv_freq,
+            1e-6,
+            None,
+            0,
+            None,
+        );
         assert!(result.is_err(), "should reject linear attention layers");
 
         Ok(())
@@ -4468,7 +4796,10 @@ mod tests {
 
         // Logits should be finite
         let vals = logits.flatten_all()?.to_vec1::<f32>()?;
-        assert!(vals.iter().all(|v| v.is_finite()), "all logits should be finite");
+        assert!(
+            vals.iter().all(|v| v.is_finite()),
+            "all logits should be finite"
+        );
 
         Ok(())
     }
@@ -4533,21 +4864,39 @@ mod tests {
         let last_ref_vals = last_ref.flatten_all()?.to_vec1::<f32>()?;
 
         // With KV cache: prefill first 4 tokens, then decode the 5th
-        let mut kv_cache = KvCache::new(
-            num_layers, num_kv_heads, head_dim, 32, DType::F32, &device,
-        )?;
+        let mut kv_cache =
+            KvCache::new(num_layers, num_kv_heads, head_dim, 32, DType::F32, &device)?;
 
         // Prefill
-        let _prefill_logits = model_forward(&backend, &tokens[..4], &weights, &config, Some(&mut kv_cache), None, None)?;
+        let _prefill_logits = model_forward(
+            &backend,
+            &tokens[..4],
+            &weights,
+            &config,
+            Some(&mut kv_cache),
+            None,
+            None,
+        )?;
         kv_cache.advance(4);
         assert_eq!(kv_cache.seq_len(), 4);
 
         // Decode the 5th token
-        let decode_logits = model_forward(&backend, &tokens[4..], &weights, &config, Some(&mut kv_cache), None, None)?;
+        let decode_logits = model_forward(
+            &backend,
+            &tokens[4..],
+            &weights,
+            &config,
+            Some(&mut kv_cache),
+            None,
+            None,
+        )?;
         kv_cache.advance(1);
         assert_eq!(kv_cache.seq_len(), 5);
 
-        let last_cached_vals = decode_logits.narrow(1, 0, 1)?.flatten_all()?.to_vec1::<f32>()?;
+        let last_cached_vals = decode_logits
+            .narrow(1, 0, 1)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
 
         // Compare: should be identical (within floating point tolerance)
         assert_eq!(last_ref_vals.len(), last_cached_vals.len());
@@ -4577,8 +4926,14 @@ mod tests {
         let intermediate_size = 16;
 
         let weights = make_tiny_gpu_weights(
-            &device, vocab_size, hidden_size, num_heads, num_kv_heads,
-            head_dim, intermediate_size, 1,
+            &device,
+            vocab_size,
+            hidden_size,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size,
+            1,
         )?;
 
         let config = kiln_core::config::ModelConfig {
@@ -4609,24 +4964,54 @@ mod tests {
 
         // Reference
         let logits_ref = model_forward(&backend, &tokens, &weights, &config, None, None, None)?;
-        let last_ref = logits_ref.narrow(1, 2, 1)?.flatten_all()?.to_vec1::<f32>()?;
+        let last_ref = logits_ref
+            .narrow(1, 2, 1)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
 
         // KV cache: process token by token
         let mut kv_cache = KvCache::new(1, num_kv_heads, head_dim, 16, DType::F32, &device)?;
 
         // Token 0
-        let _ = model_forward(&backend, &[3], &weights, &config, Some(&mut kv_cache), None, None)?;
+        let _ = model_forward(
+            &backend,
+            &[3],
+            &weights,
+            &config,
+            Some(&mut kv_cache),
+            None,
+            None,
+        )?;
         kv_cache.advance(1);
 
         // Token 1
-        let _ = model_forward(&backend, &[7], &weights, &config, Some(&mut kv_cache), None, None)?;
+        let _ = model_forward(
+            &backend,
+            &[7],
+            &weights,
+            &config,
+            Some(&mut kv_cache),
+            None,
+            None,
+        )?;
         kv_cache.advance(1);
 
         // Token 2
-        let logits_cached = model_forward(&backend, &[1], &weights, &config, Some(&mut kv_cache), None, None)?;
+        let logits_cached = model_forward(
+            &backend,
+            &[1],
+            &weights,
+            &config,
+            Some(&mut kv_cache),
+            None,
+            None,
+        )?;
         kv_cache.advance(1);
 
-        let last_cached = logits_cached.narrow(1, 0, 1)?.flatten_all()?.to_vec1::<f32>()?;
+        let last_cached = logits_cached
+            .narrow(1, 0, 1)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
 
         for (i, (r, c)) in last_ref.iter().zip(&last_cached).enumerate() {
             assert!(
@@ -4775,8 +5160,15 @@ mod tests {
         let full_attention_interval = 4; // layer 3 is full, layers 0,1,2 are linear
 
         let weights = make_hybrid_gpu_weights(
-            &device, vocab_size, hidden_size, num_heads, num_kv_heads,
-            head_dim, intermediate_size, num_layers, full_attention_interval,
+            &device,
+            vocab_size,
+            hidden_size,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size,
+            num_layers,
+            full_attention_interval,
         )?;
 
         let config = kiln_core::config::ModelConfig {
@@ -4807,12 +5199,23 @@ mod tests {
         // Prefill with multiple tokens
         let token_ids: Vec<u32> = vec![1, 5, 3, 10];
         let backend = test_backend(&device);
-        let logits = model_forward(&backend, &token_ids, &weights, &config, None, Some(&mut linear_state), None)?;
+        let logits = model_forward(
+            &backend,
+            &token_ids,
+            &weights,
+            &config,
+            None,
+            Some(&mut linear_state),
+            None,
+        )?;
         assert_eq!(logits.dims(), &[1, 4, vocab_size]);
 
         // All values should be finite (no NaN/Inf)
         let flat = logits.flatten_all()?.to_vec1::<f32>()?;
-        assert!(flat.iter().all(|v| v.is_finite()), "logits contain non-finite values");
+        assert!(
+            flat.iter().all(|v| v.is_finite()),
+            "logits contain non-finite values"
+        );
 
         Ok(())
     }
@@ -4850,16 +5253,24 @@ mod tests {
 
         let weights_cpu = make_hybrid_gpu_weights(
             &cpu_device,
-            scenario.vocab_size, scenario.hidden_size,
-            scenario.num_heads, scenario.num_kv_heads, scenario.head_dim,
-            scenario.intermediate_size, scenario.num_layers,
+            scenario.vocab_size,
+            scenario.hidden_size,
+            scenario.num_heads,
+            scenario.num_kv_heads,
+            scenario.head_dim,
+            scenario.intermediate_size,
+            scenario.num_layers,
             scenario.full_attention_interval,
         )?;
         let weights_metal = make_hybrid_gpu_weights(
             &metal_device,
-            scenario.vocab_size, scenario.hidden_size,
-            scenario.num_heads, scenario.num_kv_heads, scenario.head_dim,
-            scenario.intermediate_size, scenario.num_layers,
+            scenario.vocab_size,
+            scenario.hidden_size,
+            scenario.num_heads,
+            scenario.num_kv_heads,
+            scenario.head_dim,
+            scenario.intermediate_size,
+            scenario.num_layers,
             scenario.full_attention_interval,
         )?;
 
@@ -4867,9 +5278,21 @@ mod tests {
         // GDN layers in the model); otherwise set to head_dim so GDN state
         // is shaped for the fallback path.
         let has_linear_layers = scenario.full_attention_interval > 1;
-        let linear_num_kv_heads = if has_linear_layers { scenario.num_kv_heads } else { 0 };
-        let linear_num_value_heads = if has_linear_layers { scenario.num_heads } else { 0 };
-        let linear_head_dim = if has_linear_layers { scenario.head_dim } else { 0 };
+        let linear_num_kv_heads = if has_linear_layers {
+            scenario.num_kv_heads
+        } else {
+            0
+        };
+        let linear_num_value_heads = if has_linear_layers {
+            scenario.num_heads
+        } else {
+            0
+        };
+        let linear_head_dim = if has_linear_layers {
+            scenario.head_dim
+        } else {
+            0
+        };
         let linear_conv_kernel_dim = if has_linear_layers { 4 } else { 0 };
 
         let config = kiln_core::config::ModelConfig {
@@ -4884,7 +5307,11 @@ mod tests {
             rms_norm_eps: 1e-6,
             rope_theta: 10000.0,
             dtype: kiln_core::config::DType::FP32,
-            num_full_attention_layers: if has_linear_layers { 1 } else { scenario.num_layers },
+            num_full_attention_layers: if has_linear_layers {
+                1
+            } else {
+                scenario.num_layers
+            },
             full_attention_interval: scenario.full_attention_interval,
             attn_output_gate: false,
             linear_num_key_heads: linear_num_kv_heads,
@@ -4898,15 +5325,25 @@ mod tests {
         let cpu_backend = test_backend(&cpu_device);
         let mut cpu_linear = LinearAttentionState::new(&config, &cpu_device)?;
         let logits_cpu = model_forward(
-            &cpu_backend, &scenario.token_ids, &weights_cpu, &config,
-            None, Some(&mut cpu_linear), None,
+            &cpu_backend,
+            &scenario.token_ids,
+            &weights_cpu,
+            &config,
+            None,
+            Some(&mut cpu_linear),
+            None,
         )?;
 
         let metal_backend = crate::backend::for_device(&metal_device);
         let mut metal_linear = LinearAttentionState::new(&config, &metal_device)?;
         let logits_metal = model_forward(
-            &*metal_backend, &scenario.token_ids, &weights_metal, &config,
-            None, Some(&mut metal_linear), None,
+            &*metal_backend,
+            &scenario.token_ids,
+            &weights_metal,
+            &config,
+            None,
+            Some(&mut metal_linear),
+            None,
         )?;
 
         assert_eq!(logits_cpu.dims(), logits_metal.dims());
@@ -4917,16 +5354,27 @@ mod tests {
             .flatten_all()?
             .to_vec1::<f32>()?;
 
-        assert!(cpu_flat.iter().all(|v| v.is_finite()), "{}: CPU logits non-finite", scenario.label);
-        assert!(metal_flat.iter().all(|v| v.is_finite()), "{}: Metal logits non-finite", scenario.label);
+        assert!(
+            cpu_flat.iter().all(|v| v.is_finite()),
+            "{}: CPU logits non-finite",
+            scenario.label
+        );
+        assert!(
+            metal_flat.iter().all(|v| v.is_finite()),
+            "{}: Metal logits non-finite",
+            scenario.label
+        );
 
-        let max_abs_diff = cpu_flat.iter().zip(metal_flat.iter())
+        let max_abs_diff = cpu_flat
+            .iter()
+            .zip(metal_flat.iter())
             .map(|(a, b)| (a - b).abs())
             .fold(0.0f32, f32::max);
         assert!(
             max_abs_diff < scenario.max_abs_diff,
             "{}: CPU vs Metal logits diverge: max abs diff = {max_abs_diff} (bound {})",
-            scenario.label, scenario.max_abs_diff,
+            scenario.label,
+            scenario.max_abs_diff,
         );
         Ok(())
     }
@@ -4992,8 +5440,15 @@ mod tests {
         let full_attention_interval = 4;
 
         let weights = make_hybrid_gpu_weights(
-            &device, vocab_size, hidden_size, num_heads, num_kv_heads,
-            head_dim, intermediate_size, num_layers, full_attention_interval,
+            &device,
+            vocab_size,
+            hidden_size,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            intermediate_size,
+            num_layers,
+            full_attention_interval,
         )?;
 
         let config = kiln_core::config::ModelConfig {
@@ -5024,18 +5479,37 @@ mod tests {
         let backend = test_backend(&device);
 
         // Prefill
-        let prefill_logits = model_forward(&backend, &[1, 5, 3], &weights, &config, Some(&mut kv_cache), Some(&mut linear_state), None)?;
+        let prefill_logits = model_forward(
+            &backend,
+            &[1, 5, 3],
+            &weights,
+            &config,
+            Some(&mut kv_cache),
+            Some(&mut linear_state),
+            None,
+        )?;
         kv_cache.advance(3);
         assert_eq!(prefill_logits.dims(), &[1, 3, vocab_size]);
 
         // Decode: single token should work with persisted linear state
-        let decode_logits = model_forward(&backend, &[10], &weights, &config, Some(&mut kv_cache), Some(&mut linear_state), None)?;
+        let decode_logits = model_forward(
+            &backend,
+            &[10],
+            &weights,
+            &config,
+            Some(&mut kv_cache),
+            Some(&mut linear_state),
+            None,
+        )?;
         kv_cache.advance(1);
         assert_eq!(decode_logits.dims(), &[1, 1, vocab_size]);
 
         // Both should produce finite values
         let flat = decode_logits.flatten_all()?.to_vec1::<f32>()?;
-        assert!(flat.iter().all(|v| v.is_finite()), "decode logits contain non-finite values");
+        assert!(
+            flat.iter().all(|v| v.is_finite()),
+            "decode logits contain non-finite values"
+        );
 
         Ok(())
     }
@@ -5087,8 +5561,10 @@ mod tests {
         let masked = apply_causal_mask_with_offset(&scores, 1, 4, 3)?;
         // Single query should attend to all 4 positions (no masking for q_len=1)
         let vals = masked.flatten_all()?.to_vec1::<f32>()?;
-        assert!(vals.iter().all(|v| (*v - 1.0).abs() < 1e-6),
-            "single query token should attend to all KV positions");
+        assert!(
+            vals.iter().all(|v| (*v - 1.0).abs() < 1e-6),
+            "single query token should attend to all KV positions"
+        );
 
         // Simulate prefill with offset: 2 new queries, 5 total KV (3 cached + 2 new)
         let scores = Tensor::ones((1, 1, 2, 5), DType::F32, &device)?;
@@ -5137,8 +5613,7 @@ mod tests {
             *state = state.broadcast_mul(&g_exp)?;
 
             let kv_mem = k_t.matmul(&*state)?.squeeze(2)?; // [B, nv, dv]
-            let delta: Tensor =
-                (v_t - kv_mem)?.broadcast_mul(&beta_t.unsqueeze(2)?)?; // [B, nv, dv]
+            let delta: Tensor = (v_t - kv_mem)?.broadcast_mul(&beta_t.unsqueeze(2)?)?; // [B, nv, dv]
 
             let k_col = k_t.squeeze(2)?.unsqueeze(3)?; // [B, nv, dk, 1]
             let outer = k_col.broadcast_mul(&delta.unsqueeze(2)?)?; // [B, nv, dk, dv]
@@ -5274,8 +5749,8 @@ mod tests {
     #[cfg(feature = "cuda")]
     #[test]
     fn test_gdn_kernel_matches_fallback() -> Result<()> {
-        use rand::{Rng, SeedableRng};
         use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
 
         let device = match Device::new_cuda(0) {
             Ok(d) => d,
@@ -5345,8 +5820,8 @@ mod tests {
     #[cfg(feature = "cuda")]
     #[test]
     fn test_gdn_recurrent_kernel_matches_reference() -> Result<()> {
-        use rand::{Rng, SeedableRng};
         use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
 
         let device = match Device::new_cuda(0) {
             Ok(d) => d,
@@ -5374,12 +5849,10 @@ mod tests {
         let q_data: Vec<f32> = (0..n_qk).map(|_| rng.gen_range(-0.5f32..0.5f32)).collect();
         let k_data: Vec<f32> = (0..n_qk).map(|_| rng.gen_range(-0.5f32..0.5f32)).collect();
         let v_data: Vec<f32> = (0..n_v).map(|_| rng.gen_range(-1.0f32..1.0f32)).collect();
-        let beta_data: Vec<f32> =
-            (0..n_b).map(|_| rng.gen_range(0.3f32..1.2f32)).collect();
+        let beta_data: Vec<f32> = (0..n_b).map(|_| rng.gen_range(0.3f32..1.2f32)).collect();
         // Small negative gates so exp(g) stays in (~0.8, 1.0).
         let g_data: Vec<f32> = (0..n_b).map(|_| rng.gen_range(-0.2f32..0.0f32)).collect();
-        let s_data: Vec<f32> =
-            (0..n_s).map(|_| rng.gen_range(-0.1f32..0.1f32)).collect();
+        let s_data: Vec<f32> = (0..n_s).map(|_| rng.gen_range(-0.1f32..0.1f32)).collect();
 
         let q_f32 = Tensor::from_slice(&q_data, (b, nv, t, dk), &device)?;
         let k_f32 = Tensor::from_slice(&k_data, (b, nv, t, dk), &device)?;
@@ -5405,9 +5878,8 @@ mod tests {
         let beta_ref = beta.to_dtype(DType::F32)?;
         let g_ref = g.to_dtype(DType::F32)?;
         let mut state_ref = state_bf16.to_dtype(DType::F32)?;
-        let out_ref = gdn_sequential_reference(
-            &q_ref, &k_ref, &v_ref, &beta_ref, &g_ref, &mut state_ref,
-        )?;
+        let out_ref =
+            gdn_sequential_reference(&q_ref, &k_ref, &v_ref, &beta_ref, &g_ref, &mut state_ref)?;
 
         // Kernel path: chunkwise dispatcher with seq_len == 1 routes to
         // the new fused recurrent kernel. Make sure no prior test left the
@@ -5415,12 +5887,13 @@ mod tests {
         // SAFETY: cargo test is single-threaded per test by default and we
         // are only mutating an env var that the dispatcher reads at the top
         // of the same call below. No other thread observes it concurrently.
-        unsafe { std::env::remove_var("KILN_DISABLE_GDN_KERNEL"); }
+        unsafe {
+            std::env::remove_var("KILN_DISABLE_GDN_KERNEL");
+        }
         let backend = crate::backend::for_device(&device);
         let mut state_kernel = state_bf16.clone();
-        let out_kernel = gdn_chunkwise_recurrence(
-            &*backend, &q, &k, &v, &beta, &g, &mut state_kernel, 1,
-        )?;
+        let out_kernel =
+            gdn_chunkwise_recurrence(&*backend, &q, &k, &v, &beta, &g, &mut state_kernel, 1)?;
 
         let out_diff = (out_kernel.to_dtype(DType::F32)? - &out_ref)?;
         let abs = out_diff.abs()?;
@@ -5464,8 +5937,8 @@ mod tests {
     #[cfg(feature = "cuda")]
     #[test]
     fn test_gdn_chunk_prep_matches_fallback() -> Result<()> {
-        use rand::{Rng, SeedableRng};
         use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
 
         let device = match Device::new_cuda(0) {
             Ok(d) => d,
@@ -5505,14 +5978,8 @@ mod tests {
         let q_s = Tensor::from_slice(&qs_data, (b, nv, c, dv), &device)?.to_dtype(DType::BF16)?;
 
         // Kernel path.
-        let (
-            a_strict_k,
-            b_mask_k,
-            v_prime_k,
-            q_s_scaled_k,
-            decay_last_col_k,
-            p_last_k,
-        ) = kiln_gdn_kernel::gdn_chunk_prep(&g, &v, &kkt, &qkt, &ks_entry, &q_s)?;
+        let (a_strict_k, b_mask_k, v_prime_k, q_s_scaled_k, decay_last_col_k, p_last_k) =
+            kiln_gdn_kernel::gdn_chunk_prep(&g, &v, &kkt, &qkt, &ks_entry, &q_s)?;
 
         // Candle reference chain — mirrors the else branch in
         // gdn_chunkwise_recurrence.
@@ -5540,8 +6007,7 @@ mod tests {
         let q_s_scaled_ref = q_s.broadcast_mul(&p_col)?;
 
         let g_last = big_g.narrow(2, c - 1, 1)?; // [B, nv, 1]
-        let decay_last_col_ref =
-            g_last.broadcast_sub(&big_g)?.exp()?.to_dtype(DType::BF16)?; // [B, nv, C]
+        let decay_last_col_ref = g_last.broadcast_sub(&big_g)?.exp()?.to_dtype(DType::BF16)?; // [B, nv, C]
         let p_last_ref = g_last.squeeze(2)?.exp()?.to_dtype(DType::BF16)?; // [B, nv]
 
         let check = |name: &str, k: &Tensor, r: &Tensor| -> Result<()> {
@@ -5609,8 +6075,7 @@ mod tests {
 
         let x_f32 = Tensor::from_slice(&x_data, (batch, channels, 1), &device)?;
         let w_f32 = Tensor::from_slice(&w_data, (channels, 1, kernel_size), &device)?;
-        let s_init =
-            Tensor::from_slice(&s_data, (batch, channels, kernel_size - 1), &device)?;
+        let s_init = Tensor::from_slice(&s_data, (batch, channels, kernel_size - 1), &device)?;
 
         let x = x_f32.to_dtype(DType::BF16)?;
         let w = w_f32.to_dtype(DType::BF16)?;
@@ -5632,9 +6097,7 @@ mod tests {
         let out_k = match backend.causal_conv1d_update(&x, &w, &mut s_k, kernel_size)? {
             Some(t) => t,
             None => {
-                eprintln!(
-                    "backend declined causal_conv1d_update at Qwen3.5 envelope; skipping"
-                );
+                eprintln!("backend declined causal_conv1d_update at Qwen3.5 envelope; skipping");
                 return Ok(());
             }
         };
@@ -5822,7 +6285,11 @@ mod tests {
             .flatten_all()?
             .to_vec1::<f32>()?;
         let stream_slice = stream_logits.flatten_all()?.to_vec1::<f32>()?;
-        assert_eq!(mono_slice.len(), stream_slice.len(), "last tile length mismatch");
+        assert_eq!(
+            mono_slice.len(),
+            stream_slice.len(),
+            "last tile length mismatch"
+        );
         let mut max_abs = 0f32;
         for (a, b) in mono_slice.iter().zip(stream_slice.iter()) {
             let d = (a - b).abs();
@@ -5967,35 +6434,67 @@ mod tests {
         let (mut mono_cache, mono_bt) = make_paged_setup(&config, total + 1, 64, &device)?;
         let mut mono_state = LinearAttentionState::new(&config, &device)?;
         let _ = model_forward_paged(
-            &backend, &tokens, &weights, &config,
-            &mut mono_cache, &mono_bt, 0,
-            Some(&mut mono_state), None, None,
+            &backend,
+            &tokens,
+            &weights,
+            &config,
+            &mut mono_cache,
+            &mono_bt,
+            0,
+            Some(&mut mono_state),
+            None,
+            None,
         )?;
         let mono_decode = model_forward_paged(
-            &backend, &[next_token], &weights, &config,
-            &mut mono_cache, &mono_bt, total,
-            Some(&mut mono_state), None, None,
+            &backend,
+            &[next_token],
+            &weights,
+            &config,
+            &mut mono_cache,
+            &mono_bt,
+            total,
+            Some(&mut mono_state),
+            None,
+            None,
         )?;
 
         // Streaming prefill, then 1 decode step.
         let (mut stream_cache, stream_bt) = make_paged_setup(&config, total + 1, 64, &device)?;
         let mut stream_state = LinearAttentionState::new(&config, &device)?;
         let _ = model_forward_paged_streaming_with(
-            &backend, &tokens, &weights, &config,
-            &mut stream_cache, &stream_bt, 0,
-            Some(&mut stream_state), None,
-            tile, true,
+            &backend,
+            &tokens,
+            &weights,
+            &config,
+            &mut stream_cache,
+            &stream_bt,
+            0,
+            Some(&mut stream_state),
+            None,
+            tile,
+            true,
         )?;
         let stream_decode = model_forward_paged(
-            &backend, &[next_token], &weights, &config,
-            &mut stream_cache, &stream_bt, total,
-            Some(&mut stream_state), None, None,
+            &backend,
+            &[next_token],
+            &weights,
+            &config,
+            &mut stream_cache,
+            &stream_bt,
+            total,
+            Some(&mut stream_state),
+            None,
+            None,
         )?;
 
         let a = mono_decode.flatten_all()?.to_vec1::<f32>()?;
         let b = stream_decode.flatten_all()?.to_vec1::<f32>()?;
         assert_eq!(a.len(), b.len());
-        let max_abs = a.iter().zip(b.iter()).map(|(x, y)| (x - y).abs()).fold(0f32, f32::max);
+        let max_abs = a
+            .iter()
+            .zip(b.iter())
+            .map(|(x, y)| (x - y).abs())
+            .fold(0f32, f32::max);
         assert!(
             max_abs <= 1e-5,
             "decode-after-streaming max_abs_diff={max_abs:e} exceeds 1e-5 \
@@ -6025,9 +6524,7 @@ mod tests {
         let device = match Device::new_cuda(0) {
             Ok(d) => d,
             Err(_) => {
-                eprintln!(
-                    "CUDA not available, skipping test_streaming_matches_monolithic_cuda"
-                );
+                eprintln!("CUDA not available, skipping test_streaming_matches_monolithic_cuda");
                 return Ok(());
             }
         };
@@ -6052,8 +6549,7 @@ mod tests {
         let backend = crate::backend::for_device(&device);
 
         // Monolithic: single forward pass, full LM head.
-        let (mut mono_cache, mono_bt) =
-            make_paged_setup(&config, total, block_size, &device)?;
+        let (mut mono_cache, mono_bt) = make_paged_setup(&config, total, block_size, &device)?;
         let mut mono_state = LinearAttentionState::new(&config, &device)?;
         let mono_logits = model_forward_paged(
             &*backend,
@@ -6070,8 +6566,7 @@ mod tests {
 
         // Streaming: tiled prefill, last_token_only=false so we get a full
         // last-tile logits slice for row-by-row comparison.
-        let (mut stream_cache, stream_bt) =
-            make_paged_setup(&config, total, block_size, &device)?;
+        let (mut stream_cache, stream_bt) = make_paged_setup(&config, total, block_size, &device)?;
         let mut stream_state = LinearAttentionState::new(&config, &device)?;
         let stream_logits = model_forward_paged_streaming_with(
             &*backend,
@@ -6112,7 +6607,11 @@ mod tests {
         {
             let m_v = m.flatten_all()?.to_vec1::<f32>()?;
             let s_v = s.flatten_all()?.to_vec1::<f32>()?;
-            assert_eq!(m_v.len(), s_v.len(), "recurrent_states[{l}] length mismatch");
+            assert_eq!(
+                m_v.len(),
+                s_v.len(),
+                "recurrent_states[{l}] length mismatch"
+            );
             let max_abs = m_v
                 .iter()
                 .zip(s_v.iter())
@@ -6160,20 +6659,30 @@ mod tests {
         assert_eq!(streaming_tile_tokens(), STREAMING_PREFILL_DEFAULT_TILE);
         assert!(streaming_last_token_lm_head(), "default must be true");
 
-        unsafe { std::env::set_var("KILN_STREAMING_PREFILL", "1"); }
+        unsafe {
+            std::env::set_var("KILN_STREAMING_PREFILL", "1");
+        }
         assert!(streaming_prefill_enabled());
 
-        unsafe { std::env::set_var("KILN_STREAMING_PREFILL", "0"); }
+        unsafe {
+            std::env::set_var("KILN_STREAMING_PREFILL", "0");
+        }
         assert!(!streaming_prefill_enabled());
 
-        unsafe { std::env::set_var("KILN_STREAMING_TILE_TOKENS", "256"); }
+        unsafe {
+            std::env::set_var("KILN_STREAMING_TILE_TOKENS", "256");
+        }
         assert_eq!(streaming_tile_tokens(), 256);
 
         // Bad value (not a multiple of GDN_CHUNK_SIZE) falls back to default.
-        unsafe { std::env::set_var("KILN_STREAMING_TILE_TOKENS", "65"); }
+        unsafe {
+            std::env::set_var("KILN_STREAMING_TILE_TOKENS", "65");
+        }
         assert_eq!(streaming_tile_tokens(), STREAMING_PREFILL_DEFAULT_TILE);
 
-        unsafe { std::env::set_var("KILN_STREAMING_LAST_TOKEN_LM_HEAD", "0"); }
+        unsafe {
+            std::env::set_var("KILN_STREAMING_LAST_TOKEN_LM_HEAD", "0");
+        }
         assert!(!streaming_last_token_lm_head());
 
         // Cleanup so this test does not leak state to peers (defensive even

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -16,7 +16,7 @@ pub mod sampling;
 pub mod speculative;
 pub mod weights;
 
-pub use backend::{for_device as backend_for_device, BackendRuntime};
+pub use backend::{BackendRuntime, for_device as backend_for_device};
 pub use engine::Engine;
 pub use forward::LinearAttentionState;
 pub use generate::{
@@ -24,7 +24,7 @@ pub use generate::{
     StreamToken,
 };
 pub use kv_cache::KvCache;
-pub use loader::load_model;
+pub use loader::{LoadModelOptions, load_model, load_model_with_options};
 pub use lora_loader::LoraWeights;
 pub use paged_kv_cache::PagedKvCache;
 pub use speculative::SpeculativeConfig;

--- a/crates/kiln-model/src/loader.rs
+++ b/crates/kiln-model/src/loader.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use memmap2::Mmap;
 use safetensors::SafeTensors;
 
@@ -18,6 +18,23 @@ const LM_PREFIX: &str = "model.language_model.";
 /// Safetensors index file for sharded checkpoints.
 const INDEX_FILENAME: &str = "model.safetensors.index.json";
 
+/// Optional loader toggles for startup-sensitive callers.
+#[derive(Debug, Clone, Copy)]
+pub struct LoadModelOptions {
+    /// Load the checkpoint's native MTP head when present.
+    ///
+    /// Desktop macOS defaults keep speculative decoding off, so skipping this
+    /// avoids extra CPU allocations and GPU upload/transposes for weights that
+    /// the default serve path will never touch.
+    pub load_mtp: bool,
+}
+
+impl Default for LoadModelOptions {
+    fn default() -> Self {
+        Self { load_mtp: true }
+    }
+}
+
 /// Load Qwen3.5-4B language model weights from a directory of safetensors files.
 ///
 /// Handles both single-file (`model.safetensors`) and sharded checkpoints
@@ -27,6 +44,15 @@ const INDEX_FILENAME: &str = "model.safetensors.index.json";
 /// the safetensors files. Only language model weights (prefixed with
 /// `model.language_model.`) are loaded; vision encoder weights are skipped.
 pub fn load_model(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeights> {
+    load_model_with_options(model_dir, config, LoadModelOptions::default())
+}
+
+/// Variant of [`load_model`] with explicit startup-path options.
+pub fn load_model_with_options(
+    model_dir: &Path,
+    config: &ModelConfig,
+    options: LoadModelOptions,
+) -> Result<ModelWeights> {
     // Auto-detect GPTQ quantization.
     if let Some(gptq_config) = quantized::load_gptq_config(model_dir)? {
         tracing::info!(
@@ -35,14 +61,18 @@ pub fn load_model(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeights
             sym = gptq_config.sym,
             "Detected GPTQ quantization — loading quantized weights"
         );
-        return load_model_gptq(model_dir, config, &gptq_config);
+        return load_model_gptq(model_dir, config, &gptq_config, options);
     }
 
-    load_model_dense(model_dir, config)
+    load_model_dense(model_dir, config, options)
 }
 
 /// Load dense (unquantized) BF16/FP16 model weights.
-fn load_model_dense(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeights> {
+fn load_model_dense(
+    model_dir: &Path,
+    config: &ModelConfig,
+    options: LoadModelOptions,
+) -> Result<ModelWeights> {
     let shards = discover_shards(model_dir)?;
     tracing::info!(
         "Loading model from {} ({} shard{})",
@@ -55,10 +85,7 @@ fn load_model_dense(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeigh
     let mmaps = mmap_shards(&shards)?;
     let parsed: Vec<SafeTensors<'_>> = mmaps
         .iter()
-        .map(|mmap| {
-            SafeTensors::deserialize(mmap)
-                .context("Failed to parse safetensors file")
-        })
+        .map(|mmap| SafeTensors::deserialize(mmap).context("Failed to parse safetensors file"))
         .collect::<Result<Vec<_>>>()?;
 
     // Build a unified name -> (shard_idx, tensor_view) lookup.
@@ -69,7 +96,8 @@ fn load_model_dense(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeigh
             all_tensors.push((name, shard_idx, view));
         }
     }
-    let mut tensor_map: HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)> = HashMap::new();
+    let mut tensor_map: HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)> =
+        HashMap::new();
     for (name, shard_idx, view) in &all_tensors {
         tensor_map.insert(name.as_str(), (*shard_idx, view));
     }
@@ -80,7 +108,11 @@ fn load_model_dense(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeigh
 
     // Load embedding.
     let embed_tokens = extract_tensor(&tensor_map, &format!("{prefix}embed_tokens.weight"))?;
-    validate_shape(&embed_tokens, &[config.vocab_size, config.hidden_size], "embed_tokens")?;
+    validate_shape(
+        &embed_tokens,
+        &[config.vocab_size, config.hidden_size],
+        "embed_tokens",
+    )?;
 
     // Load layers.
     let mut layers = Vec::with_capacity(config.num_layers);
@@ -99,9 +131,15 @@ fn load_model_dense(model_dir: &Path, config: &ModelConfig) -> Result<ModelWeigh
     // stores 15 `mtp.*` tensors. We detect purely by tensor presence rather
     // than adding a new config field — if the checkpoint has MTP tensors,
     // load them; if not, leave `ModelWeights.mtp` as None.
-    let mtp = load_mtp_if_present(&tensor_map, &prefix, config)?;
+    let mtp = if options.load_mtp {
+        load_mtp_if_present(&tensor_map, &prefix, config)?
+    } else {
+        None
+    };
     if mtp.is_some() {
         tracing::info!("Native MTP head detected and loaded (k=1 draft depth)");
+    } else if !options.load_mtp {
+        tracing::info!("Skipping native MTP head load");
     }
 
     let weights = ModelWeights {
@@ -135,6 +173,7 @@ fn load_model_gptq(
     model_dir: &Path,
     config: &ModelConfig,
     gptq_config: &GptqConfig,
+    _options: LoadModelOptions,
 ) -> Result<ModelWeights> {
     let shards = discover_shards(model_dir)?;
     tracing::info!(
@@ -147,10 +186,7 @@ fn load_model_gptq(
     let mmaps = mmap_shards(&shards)?;
     let parsed: Vec<SafeTensors<'_>> = mmaps
         .iter()
-        .map(|mmap| {
-            SafeTensors::deserialize(mmap)
-                .context("Failed to parse safetensors file")
-        })
+        .map(|mmap| SafeTensors::deserialize(mmap).context("Failed to parse safetensors file"))
         .collect::<Result<Vec<_>>>()?;
 
     let mut all_tensors: Vec<(String, usize, safetensors::tensor::TensorView<'_>)> = Vec::new();
@@ -159,7 +195,8 @@ fn load_model_gptq(
             all_tensors.push((name, shard_idx, view));
         }
     }
-    let mut tensor_map: HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)> = HashMap::new();
+    let mut tensor_map: HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)> =
+        HashMap::new();
     for (name, shard_idx, view) in &all_tensors {
         tensor_map.insert(name.as_str(), (*shard_idx, view));
     }
@@ -169,7 +206,11 @@ fn load_model_gptq(
 
     // Embedding — stored in original precision even in GPTQ models.
     let embed_tokens = extract_tensor(&tensor_map, &format!("{prefix}embed_tokens.weight"))?;
-    validate_shape(&embed_tokens, &[config.vocab_size, config.hidden_size], "embed_tokens")?;
+    validate_shape(
+        &embed_tokens,
+        &[config.vocab_size, config.hidden_size],
+        "embed_tokens",
+    )?;
 
     // Load layers — linear projections are GPTQ-quantized, norms are dense.
     let mut layers = Vec::with_capacity(config.num_layers);
@@ -263,17 +304,12 @@ fn discover_shards(model_dir: &Path) -> Result<Vec<std::path::PathBuf>> {
             let mut shards: Vec<_> = fs::read_dir(model_dir)?
                 .filter_map(|e| e.ok())
                 .map(|e| e.path())
-                .filter(|p| {
-                    p.extension().is_some_and(|ext| ext == "safetensors")
-                })
+                .filter(|p| p.extension().is_some_and(|ext| ext == "safetensors"))
                 .collect();
             shards.sort();
 
             if shards.is_empty() {
-                bail!(
-                    "No .safetensors files found in {}",
-                    model_dir.display()
-                );
+                bail!("No .safetensors files found in {}", model_dir.display());
             }
             Ok(shards)
         }
@@ -296,7 +332,9 @@ fn mmap_shards(paths: &[std::path::PathBuf]) -> Result<Vec<Mmap>> {
 }
 
 /// Detect the weight name prefix by checking which keys exist.
-fn detect_prefix(tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>) -> String {
+fn detect_prefix(
+    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+) -> String {
     // Try the VL model prefix first (Qwen3.5-4B ships as VL).
     if tensor_map.contains_key(&format!("{LM_PREFIX}embed_tokens.weight") as &str) {
         return LM_PREFIX.to_string();
@@ -321,17 +359,30 @@ fn load_layer(
     config: &ModelConfig,
 ) -> Result<LayerWeights> {
     let input_layernorm = extract_tensor(tensor_map, &format!("{prefix}input_layernorm.weight"))?;
-    validate_shape(&input_layernorm, &[config.hidden_size], &format!("layer {layer_idx} input_layernorm"))?;
+    validate_shape(
+        &input_layernorm,
+        &[config.hidden_size],
+        &format!("layer {layer_idx} input_layernorm"),
+    )?;
 
-    let post_attention_layernorm = extract_tensor(tensor_map, &format!("{prefix}post_attention_layernorm.weight"))?;
-    validate_shape(&post_attention_layernorm, &[config.hidden_size], &format!("layer {layer_idx} post_attn_layernorm"))?;
+    let post_attention_layernorm = extract_tensor(
+        tensor_map,
+        &format!("{prefix}post_attention_layernorm.weight"),
+    )?;
+    validate_shape(
+        &post_attention_layernorm,
+        &[config.hidden_size],
+        &format!("layer {layer_idx} post_attn_layernorm"),
+    )?;
 
     let mlp = load_ffn(tensor_map, prefix, layer_idx, config)?;
 
     let attention = if config.is_full_attention_layer(layer_idx) {
         AttentionWeights::Full(load_full_attention(tensor_map, prefix, layer_idx, config)?)
     } else {
-        AttentionWeights::Linear(load_linear_attention(tensor_map, prefix, layer_idx, config)?)
+        AttentionWeights::Linear(load_linear_attention(
+            tensor_map, prefix, layer_idx, config,
+        )?)
     };
 
     Ok(LayerWeights {
@@ -400,7 +451,11 @@ fn load_linear_attention(
     let num_heads = config.linear_num_value_heads;
 
     let in_proj_qkv = extract_tensor(tensor_map, &format!("{attn}in_proj_qkv.weight"))?;
-    validate_shape(&in_proj_qkv, &[fused_qkv_dim, config.hidden_size], &ctx("in_proj_qkv"))?;
+    validate_shape(
+        &in_proj_qkv,
+        &[fused_qkv_dim, config.hidden_size],
+        &ctx("in_proj_qkv"),
+    )?;
 
     let in_proj_z = extract_tensor(tensor_map, &format!("{attn}in_proj_z.weight"))?;
     validate_shape(&in_proj_z, &[v_dim, config.hidden_size], &ctx("in_proj_z"))?;
@@ -409,10 +464,18 @@ fn load_linear_attention(
     validate_shape(&out_proj, &[config.hidden_size, v_dim], &ctx("out_proj"))?;
 
     let in_proj_a = extract_tensor(tensor_map, &format!("{attn}in_proj_a.weight"))?;
-    validate_shape(&in_proj_a, &[num_heads, config.hidden_size], &ctx("in_proj_a"))?;
+    validate_shape(
+        &in_proj_a,
+        &[num_heads, config.hidden_size],
+        &ctx("in_proj_a"),
+    )?;
 
     let in_proj_b = extract_tensor(tensor_map, &format!("{attn}in_proj_b.weight"))?;
-    validate_shape(&in_proj_b, &[num_heads, config.hidden_size], &ctx("in_proj_b"))?;
+    validate_shape(
+        &in_proj_b,
+        &[num_heads, config.hidden_size],
+        &ctx("in_proj_b"),
+    )?;
 
     // conv1d shape is [channels, 1, kernel_size] — channels = fused QKV dim.
     let conv1d = extract_tensor(tensor_map, &format!("{attn}conv1d.weight"))?;
@@ -472,13 +535,25 @@ fn load_ffn(
     let ctx = |name: &str| format!("layer {layer_idx} mlp.{name}");
 
     let gate_proj = extract_tensor(tensor_map, &format!("{mlp}gate_proj.weight"))?;
-    validate_shape(&gate_proj, &[config.intermediate_size, config.hidden_size], &ctx("gate_proj"))?;
+    validate_shape(
+        &gate_proj,
+        &[config.intermediate_size, config.hidden_size],
+        &ctx("gate_proj"),
+    )?;
 
     let up_proj = extract_tensor(tensor_map, &format!("{mlp}up_proj.weight"))?;
-    validate_shape(&up_proj, &[config.intermediate_size, config.hidden_size], &ctx("up_proj"))?;
+    validate_shape(
+        &up_proj,
+        &[config.intermediate_size, config.hidden_size],
+        &ctx("up_proj"),
+    )?;
 
     let down_proj = extract_tensor(tensor_map, &format!("{mlp}down_proj.weight"))?;
-    validate_shape(&down_proj, &[config.hidden_size, config.intermediate_size], &ctx("down_proj"))?;
+    validate_shape(
+        &down_proj,
+        &[config.hidden_size, config.intermediate_size],
+        &ctx("down_proj"),
+    )?;
 
     Ok(FfnWeights {
         gate_proj,
@@ -520,7 +595,11 @@ fn load_mtp_if_present(
 
     let fc = extract_tensor(tensor_map, &fc_key)?;
     // fc maps concat(embed, hidden) → hidden, so shape is [hidden, 2*hidden].
-    validate_shape(&fc, &[config.hidden_size, 2 * config.hidden_size], &ctx("fc"))?;
+    validate_shape(
+        &fc,
+        &[config.hidden_size, 2 * config.hidden_size],
+        &ctx("fc"),
+    )?;
 
     let pre_fc_norm_embedding = extract_tensor(
         tensor_map,
@@ -557,8 +636,7 @@ fn load_mtp_if_present(
     // `is_full_attention_layer` return true. The layer_idx argument is only
     // used for error context strings, not for dispatch.
     let mtp_layer_prefix = format!("{mtp_prefix}layers.0.");
-    let layer = load_layer(tensor_map, &mtp_layer_prefix, 3, config)
-        .context("mtp layer 0")?;
+    let layer = load_layer(tensor_map, &mtp_layer_prefix, 3, config).context("mtp layer 0")?;
     // Defensive: MTP layer must be full attention. If this ever fires the
     // checkpoint is shipping a linear-attention MTP head and the forward
     // pass below won't match.
@@ -643,8 +721,10 @@ fn load_layer_gptq(
         &format!("layer {layer_idx} input_layernorm"),
     )?;
 
-    let post_attention_layernorm =
-        extract_tensor(tensor_map, &format!("{prefix}post_attention_layernorm.weight"))?;
+    let post_attention_layernorm = extract_tensor(
+        tensor_map,
+        &format!("{prefix}post_attention_layernorm.weight"),
+    )?;
     validate_shape(
         &post_attention_layernorm,
         &[config.hidden_size],
@@ -697,8 +777,8 @@ fn load_gptq_linear(
         .with_context(|| format!("{ctx}: qzeros"))?;
 
     // Convert scales dtype (GPTQ scales are typically F16)
-    let scales_dtype = convert_dtype(scales.2)
-        .with_context(|| format!("{ctx}: scales dtype {:?}", scales.2))?;
+    let scales_dtype =
+        convert_dtype(scales.2).with_context(|| format!("{ctx}: scales dtype {:?}", scales.2))?;
 
     quantized::dequantize_gptq_weight(
         &qweight.0,
@@ -740,16 +820,36 @@ fn load_full_attention_gptq(
     let q_out_dim = config.num_attention_heads * config.head_dim;
     let kv_dim = config.num_kv_heads * config.head_dim;
 
-    let q_proj = load_gptq_linear(tensor_map, &format!("{attn}q_proj"), gptq_config, &ctx("q_proj"))?;
+    let q_proj = load_gptq_linear(
+        tensor_map,
+        &format!("{attn}q_proj"),
+        gptq_config,
+        &ctx("q_proj"),
+    )?;
     validate_shape(&q_proj, &[q_proj_dim, config.hidden_size], &ctx("q_proj"))?;
 
-    let k_proj = load_gptq_linear(tensor_map, &format!("{attn}k_proj"), gptq_config, &ctx("k_proj"))?;
+    let k_proj = load_gptq_linear(
+        tensor_map,
+        &format!("{attn}k_proj"),
+        gptq_config,
+        &ctx("k_proj"),
+    )?;
     validate_shape(&k_proj, &[kv_dim, config.hidden_size], &ctx("k_proj"))?;
 
-    let v_proj = load_gptq_linear(tensor_map, &format!("{attn}v_proj"), gptq_config, &ctx("v_proj"))?;
+    let v_proj = load_gptq_linear(
+        tensor_map,
+        &format!("{attn}v_proj"),
+        gptq_config,
+        &ctx("v_proj"),
+    )?;
     validate_shape(&v_proj, &[kv_dim, config.hidden_size], &ctx("v_proj"))?;
 
-    let o_proj = load_gptq_linear(tensor_map, &format!("{attn}o_proj"), gptq_config, &ctx("o_proj"))?;
+    let o_proj = load_gptq_linear(
+        tensor_map,
+        &format!("{attn}o_proj"),
+        gptq_config,
+        &ctx("o_proj"),
+    )?;
     validate_shape(&o_proj, &[config.hidden_size, q_out_dim], &ctx("o_proj"))?;
 
     // QK norms are stored in original precision (1-D, not quantized).
@@ -791,7 +891,11 @@ fn load_linear_attention_gptq(
         gptq_config,
         &ctx("in_proj_qkv"),
     )?;
-    validate_shape(&in_proj_qkv, &[fused_qkv_dim, config.hidden_size], &ctx("in_proj_qkv"))?;
+    validate_shape(
+        &in_proj_qkv,
+        &[fused_qkv_dim, config.hidden_size],
+        &ctx("in_proj_qkv"),
+    )?;
 
     let in_proj_z = load_gptq_linear(
         tensor_map,
@@ -817,7 +921,11 @@ fn load_linear_attention_gptq(
         gptq_config,
         &ctx("in_proj_a"),
     )?;
-    validate_shape(&in_proj_a, &[num_heads, config.hidden_size], &ctx("in_proj_a"))?;
+    validate_shape(
+        &in_proj_a,
+        &[num_heads, config.hidden_size],
+        &ctx("in_proj_a"),
+    )?;
 
     let in_proj_b = load_gptq_or_dense(
         tensor_map,
@@ -825,7 +933,11 @@ fn load_linear_attention_gptq(
         gptq_config,
         &ctx("in_proj_b"),
     )?;
-    validate_shape(&in_proj_b, &[num_heads, config.hidden_size], &ctx("in_proj_b"))?;
+    validate_shape(
+        &in_proj_b,
+        &[num_heads, config.hidden_size],
+        &ctx("in_proj_b"),
+    )?;
 
     // Non-linear weights: stored in original precision.
     let conv1d = extract_tensor(tensor_map, &format!("{attn}conv1d.weight"))?;
@@ -954,9 +1066,7 @@ mod tests {
     use std::collections::HashMap as StdMap;
 
     /// Create a minimal safetensors file with the given tensors.
-    fn create_test_safetensors(
-        tensors: &[(&str, Vec<usize>, StDtype)],
-    ) -> Vec<u8> {
+    fn create_test_safetensors(tensors: &[(&str, Vec<usize>, StDtype)]) -> Vec<u8> {
         let mut data_map: StdMap<String, Vec<u8>> = StdMap::new();
         let mut views = Vec::new();
 
@@ -1013,37 +1123,117 @@ mod tests {
         let bf16 = StDtype::BF16;
 
         // Embedding + final norm
-        tensors.push((format!("{prefix}embed_tokens.weight"), vec![vocab, hidden], bf16));
+        tensors.push((
+            format!("{prefix}embed_tokens.weight"),
+            vec![vocab, hidden],
+            bf16,
+        ));
         tensors.push((format!("{prefix}norm.weight"), vec![hidden], bf16));
 
         // 4 layers: layers 0,1,2 are linear, layer 3 is full attention
         for i in 0..config.num_layers {
             let lp = format!("{prefix}layers.{i}.");
             tensors.push((format!("{lp}input_layernorm.weight"), vec![hidden], bf16));
-            tensors.push((format!("{lp}post_attention_layernorm.weight"), vec![hidden], bf16));
-            tensors.push((format!("{lp}mlp.gate_proj.weight"), vec![intermediate, hidden], bf16));
-            tensors.push((format!("{lp}mlp.up_proj.weight"), vec![intermediate, hidden], bf16));
-            tensors.push((format!("{lp}mlp.down_proj.weight"), vec![hidden, intermediate], bf16));
+            tensors.push((
+                format!("{lp}post_attention_layernorm.weight"),
+                vec![hidden],
+                bf16,
+            ));
+            tensors.push((
+                format!("{lp}mlp.gate_proj.weight"),
+                vec![intermediate, hidden],
+                bf16,
+            ));
+            tensors.push((
+                format!("{lp}mlp.up_proj.weight"),
+                vec![intermediate, hidden],
+                bf16,
+            ));
+            tensors.push((
+                format!("{lp}mlp.down_proj.weight"),
+                vec![hidden, intermediate],
+                bf16,
+            ));
 
             if config.is_full_attention_layer(i) {
                 // Full attention layer
-                tensors.push((format!("{lp}self_attn.q_proj.weight"), vec![q_proj_dim, hidden], bf16));
-                tensors.push((format!("{lp}self_attn.k_proj.weight"), vec![kv_dim, hidden], bf16));
-                tensors.push((format!("{lp}self_attn.v_proj.weight"), vec![kv_dim, hidden], bf16));
-                tensors.push((format!("{lp}self_attn.o_proj.weight"), vec![hidden, q_out_dim], bf16));
-                tensors.push((format!("{lp}self_attn.q_norm.weight"), vec![config.head_dim], bf16));
-                tensors.push((format!("{lp}self_attn.k_norm.weight"), vec![config.head_dim], bf16));
+                tensors.push((
+                    format!("{lp}self_attn.q_proj.weight"),
+                    vec![q_proj_dim, hidden],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}self_attn.k_proj.weight"),
+                    vec![kv_dim, hidden],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}self_attn.v_proj.weight"),
+                    vec![kv_dim, hidden],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}self_attn.o_proj.weight"),
+                    vec![hidden, q_out_dim],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}self_attn.q_norm.weight"),
+                    vec![config.head_dim],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}self_attn.k_norm.weight"),
+                    vec![config.head_dim],
+                    bf16,
+                ));
             } else {
                 // Linear attention layer
-                tensors.push((format!("{lp}linear_attn.in_proj_qkv.weight"), vec![fused_qkv_dim, hidden], bf16));
-                tensors.push((format!("{lp}linear_attn.in_proj_z.weight"), vec![v_dim, hidden], bf16));
-                tensors.push((format!("{lp}linear_attn.out_proj.weight"), vec![hidden, v_dim], bf16));
-                tensors.push((format!("{lp}linear_attn.in_proj_a.weight"), vec![num_linear_heads, hidden], bf16));
-                tensors.push((format!("{lp}linear_attn.in_proj_b.weight"), vec![num_linear_heads, hidden], bf16));
-                tensors.push((format!("{lp}linear_attn.conv1d.weight"), vec![fused_qkv_dim, 1, conv_size], bf16));
-                tensors.push((format!("{lp}linear_attn.norm.weight"), vec![config.linear_key_head_dim], bf16));
-                tensors.push((format!("{lp}linear_attn.A_log"), vec![num_linear_heads], bf16));
-                tensors.push((format!("{lp}linear_attn.dt_bias"), vec![num_linear_heads], bf16));
+                tensors.push((
+                    format!("{lp}linear_attn.in_proj_qkv.weight"),
+                    vec![fused_qkv_dim, hidden],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}linear_attn.in_proj_z.weight"),
+                    vec![v_dim, hidden],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}linear_attn.out_proj.weight"),
+                    vec![hidden, v_dim],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}linear_attn.in_proj_a.weight"),
+                    vec![num_linear_heads, hidden],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}linear_attn.in_proj_b.weight"),
+                    vec![num_linear_heads, hidden],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}linear_attn.conv1d.weight"),
+                    vec![fused_qkv_dim, 1, conv_size],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}linear_attn.norm.weight"),
+                    vec![config.linear_key_head_dim],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}linear_attn.A_log"),
+                    vec![num_linear_heads],
+                    bf16,
+                ));
+                tensors.push((
+                    format!("{lp}linear_attn.dt_bias"),
+                    vec![num_linear_heads],
+                    bf16,
+                ));
             }
         }
 
@@ -1207,7 +1397,10 @@ mod tests {
         let result = load_model(dir.path(), &config);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("Shape mismatch"), "Error should mention shape mismatch: {err}");
+        assert!(
+            err.contains("Shape mismatch"),
+            "Error should mention shape mismatch: {err}"
+        );
     }
 
     #[test]
@@ -1242,9 +1435,7 @@ mod tests {
     /// Create a safetensors file with custom binary data for each tensor.
     /// Unlike `create_test_safetensors` which fills with zeros, this takes
     /// pre-built byte arrays.
-    fn create_safetensors_with_data(
-        tensors: &[(&str, Vec<usize>, StDtype, Vec<u8>)],
-    ) -> Vec<u8> {
+    fn create_safetensors_with_data(tensors: &[(&str, Vec<usize>, StDtype, Vec<u8>)]) -> Vec<u8> {
         let tensor_views: Vec<(String, safetensors::tensor::TensorView<'_>)> = tensors
             .iter()
             .map(|(name, shape, dtype, data)| {
@@ -1305,7 +1496,10 @@ mod tests {
                 qweight_packed.push(packed);
             }
         }
-        let qweight_bytes: Vec<u8> = qweight_packed.iter().flat_map(|w| w.to_le_bytes()).collect();
+        let qweight_bytes: Vec<u8> = qweight_packed
+            .iter()
+            .flat_map(|w| w.to_le_bytes())
+            .collect();
 
         // qzeros: all 8s (midpoint)
         let mut qzeros_packed = Vec::new();
@@ -1322,9 +1516,10 @@ mod tests {
 
         // scales: all 1.0 in F16
         // F16 1.0 = 0x3C00
-        let scales_bytes: Vec<u8> = std::iter::repeat_n(0x3C00u16.to_le_bytes(), num_groups * out_features)
-            .flatten()
-            .collect();
+        let scales_bytes: Vec<u8> =
+            std::iter::repeat_n(0x3C00u16.to_le_bytes(), num_groups * out_features)
+                .flatten()
+                .collect();
 
         // We leak the name string to get 'static lifetime for the test
         let qweight_name = format!("{name}.qweight");
@@ -1332,9 +1527,27 @@ mod tests {
         let qzeros_name = format!("{name}.qzeros");
 
         vec![
-            ("qweight", qweight_name, vec![in_packed, out_features], StDtype::I32, qweight_bytes),
-            ("scales", scales_name, vec![num_groups, out_features], StDtype::F16, scales_bytes),
-            ("qzeros", qzeros_name, vec![num_groups, out_packed], StDtype::I32, qzeros_bytes),
+            (
+                "qweight",
+                qweight_name,
+                vec![in_packed, out_features],
+                StDtype::I32,
+                qweight_bytes,
+            ),
+            (
+                "scales",
+                scales_name,
+                vec![num_groups, out_features],
+                StDtype::F16,
+                scales_bytes,
+            ),
+            (
+                "qzeros",
+                qzeros_name,
+                vec![num_groups, out_packed],
+                StDtype::I32,
+                qzeros_bytes,
+            ),
         ]
     }
 
@@ -1351,12 +1564,21 @@ mod tests {
         let mut tensors: Vec<(String, Vec<usize>, StDtype, Vec<u8>)> = Vec::new();
 
         // Helper functions (free functions to avoid closure borrow conflicts).
-        fn make_bf16_tensor(name: String, shape: Vec<usize>, bf16: StDtype) -> (String, Vec<usize>, StDtype, Vec<u8>) {
+        fn make_bf16_tensor(
+            name: String,
+            shape: Vec<usize>,
+            bf16: StDtype,
+        ) -> (String, Vec<usize>, StDtype, Vec<u8>) {
             let numel: usize = shape.iter().product();
             (name, shape, bf16, vec![0u8; numel * 2])
         }
 
-        fn make_gptq_tensors(name: &str, out: usize, inp: usize, group_size: usize) -> Vec<(String, Vec<usize>, StDtype, Vec<u8>)> {
+        fn make_gptq_tensors(
+            name: &str,
+            out: usize,
+            inp: usize,
+            group_size: usize,
+        ) -> Vec<(String, Vec<usize>, StDtype, Vec<u8>)> {
             let pack_factor = 8usize;
             let in_packed = inp / pack_factor;
             let num_groups = inp / group_size;
@@ -1371,12 +1593,23 @@ mod tests {
                     qweight_words.push(packed);
                 }
             }
-            let qweight_bytes: Vec<u8> = qweight_words.iter().flat_map(|w| w.to_le_bytes()).collect();
-            result.push((format!("{name}.qweight"), vec![in_packed, out], StDtype::I32, qweight_bytes));
+            let qweight_bytes: Vec<u8> =
+                qweight_words.iter().flat_map(|w| w.to_le_bytes()).collect();
+            result.push((
+                format!("{name}.qweight"),
+                vec![in_packed, out],
+                StDtype::I32,
+                qweight_bytes,
+            ));
 
             // scales: [num_groups, out], all F16 1.0
             let scales_bytes: Vec<u8> = vec![0x00, 0x3C].repeat(num_groups * out);
-            result.push((format!("{name}.scales"), vec![num_groups, out], StDtype::F16, scales_bytes));
+            result.push((
+                format!("{name}.scales"),
+                vec![num_groups, out],
+                StDtype::F16,
+                scales_bytes,
+            ));
 
             // qzeros: [num_groups, out/8], all 8s
             let out_packed_actual = (out + pack_factor - 1) / pack_factor;
@@ -1386,7 +1619,12 @@ mod tests {
                 qzeros_words.push(packed);
             }
             let qzeros_bytes: Vec<u8> = qzeros_words.iter().flat_map(|w| w.to_le_bytes()).collect();
-            result.push((format!("{name}.qzeros"), vec![num_groups, out_packed_actual], StDtype::I32, qzeros_bytes));
+            result.push((
+                format!("{name}.qzeros"),
+                vec![num_groups, out_packed_actual],
+                StDtype::I32,
+                qzeros_bytes,
+            ));
 
             result
         }
@@ -1436,19 +1674,41 @@ mod tests {
                 add_gptq_linear!(&format!("{lp}self_attn.v_proj"), kv_dim, hidden);
                 add_gptq_linear!(&format!("{lp}self_attn.o_proj"), hidden, q_out_dim);
                 // QK norms (not quantized)
-                add_bf16!(format!("{lp}self_attn.q_norm.weight"), vec![config.head_dim]);
-                add_bf16!(format!("{lp}self_attn.k_norm.weight"), vec![config.head_dim]);
+                add_bf16!(
+                    format!("{lp}self_attn.q_norm.weight"),
+                    vec![config.head_dim]
+                );
+                add_bf16!(
+                    format!("{lp}self_attn.k_norm.weight"),
+                    vec![config.head_dim]
+                );
             } else {
                 // Linear attention: large projections quantized
-                add_gptq_linear!(&format!("{lp}linear_attn.in_proj_qkv"), fused_qkv_dim, hidden);
+                add_gptq_linear!(
+                    &format!("{lp}linear_attn.in_proj_qkv"),
+                    fused_qkv_dim,
+                    hidden
+                );
                 add_gptq_linear!(&format!("{lp}linear_attn.in_proj_z"), v_dim, hidden);
                 add_gptq_linear!(&format!("{lp}linear_attn.out_proj"), hidden, v_dim);
                 // Small projections as dense (a, b have small out dim)
-                add_bf16!(format!("{lp}linear_attn.in_proj_a.weight"), vec![num_linear_heads, hidden]);
-                add_bf16!(format!("{lp}linear_attn.in_proj_b.weight"), vec![num_linear_heads, hidden]);
+                add_bf16!(
+                    format!("{lp}linear_attn.in_proj_a.weight"),
+                    vec![num_linear_heads, hidden]
+                );
+                add_bf16!(
+                    format!("{lp}linear_attn.in_proj_b.weight"),
+                    vec![num_linear_heads, hidden]
+                );
                 // Non-linear weights (not quantized)
-                add_bf16!(format!("{lp}linear_attn.conv1d.weight"), vec![fused_qkv_dim, 1, conv_size]);
-                add_bf16!(format!("{lp}linear_attn.norm.weight"), vec![config.linear_key_head_dim]);
+                add_bf16!(
+                    format!("{lp}linear_attn.conv1d.weight"),
+                    vec![fused_qkv_dim, 1, conv_size]
+                );
+                add_bf16!(
+                    format!("{lp}linear_attn.norm.weight"),
+                    vec![config.linear_key_head_dim]
+                );
                 add_bf16!(format!("{lp}linear_attn.A_log"), vec![num_linear_heads]);
                 add_bf16!(format!("{lp}linear_attn.dt_bias"), vec![num_linear_heads]);
             }

--- a/crates/kiln-model/src/paged_kv_cache.rs
+++ b/crates/kiln-model/src/paged_kv_cache.rs
@@ -48,7 +48,16 @@ impl PagedKvCache {
         dtype: DType,
         device: &Device,
     ) -> Result<Self> {
-        Self::new_with_fp8(num_full_attn_layers, num_blocks, block_size, num_kv_heads, head_dim, dtype, device, false)
+        Self::new_with_fp8(
+            num_full_attn_layers,
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_dim,
+            dtype,
+            device,
+            false,
+        )
     }
 
     /// Create a new paged KV cache with optional FP8 quantization.
@@ -120,6 +129,14 @@ impl PagedKvCache {
         let k_flat = k.squeeze(0)?.transpose(0, 1)?.contiguous()?;
         let v_flat = v.squeeze(0)?.transpose(0, 1)?.contiguous()?;
 
+        if let Some(start_slot) =
+            contiguous_slot_run_start(block_table, self.block_size, start_pos, new_len)
+        {
+            k_pool.slice_set(&k_flat, 0, start_slot)?;
+            v_pool.slice_set(&v_flat, 0, start_slot)?;
+            return Ok(());
+        }
+
         for i in 0..new_len {
             let pos = start_pos + i;
             let slot = block_table
@@ -159,6 +176,14 @@ impl PagedKvCache {
 
         let (k_pool, v_pool) = &mut self.layers[layer_idx];
 
+        if let Some(start_slot) =
+            contiguous_slot_run_start(block_table, self.block_size, start_pos, new_len)
+        {
+            k_pool.slice_set(&k_q, 0, start_slot)?;
+            v_pool.slice_set(&v_q, 0, start_slot)?;
+            return Ok(());
+        }
+
         for i in 0..new_len {
             let pos = start_pos + i;
             let slot = block_table
@@ -185,22 +210,33 @@ impl PagedKvCache {
     ) -> Result<(Tensor, Tensor)> {
         let (k_pool, v_pool) = &self.layers[layer_idx];
 
-        // Compute physical slot indices for all positions
-        let slot_indices: Vec<u32> = (0..seq_len)
-            .map(|pos| {
-                block_table
-                    .slot_for(pos, self.block_size)
-                    .map(|s| s as u32)
-                    .ok_or_else(|| anyhow::anyhow!("no slot for position {pos}"))
-            })
-            .collect::<Result<Vec<_>>>()?;
-
         let device = k_pool.device();
-        let indices = Tensor::new(&slot_indices[..], device)?;
+        let (k, v) = if let Some(start_slot) =
+            contiguous_slot_run_start(block_table, self.block_size, 0, seq_len)
+        {
+            (
+                k_pool.narrow(0, start_slot, seq_len)?,
+                v_pool.narrow(0, start_slot, seq_len)?,
+            )
+        } else {
+            // Compute physical slot indices for all positions.
+            let slot_indices: Vec<u32> = (0..seq_len)
+                .map(|pos| {
+                    block_table
+                        .slot_for(pos, self.block_size)
+                        .map(|s| s as u32)
+                        .ok_or_else(|| anyhow::anyhow!("no slot for position {pos}"))
+                })
+                .collect::<Result<Vec<_>>>()?;
 
-        // Gather: [seq_len, num_kv_heads, head_dim]
-        let k = k_pool.index_select(&indices, 0)?;
-        let v = v_pool.index_select(&indices, 0)?;
+            let indices = Tensor::new(&slot_indices[..], device)?;
+
+            // Gather: [seq_len, num_kv_heads, head_dim]
+            (
+                k_pool.index_select(&indices, 0)?,
+                v_pool.index_select(&indices, 0)?,
+            )
+        };
 
         // Dequantize if FP8 (direct, no scaling — values are stored as raw E4M3)
         let (k, v) = if self.fp8 {
@@ -245,16 +281,73 @@ impl PagedKvCache {
     /// For FP8 caches the returned tensors are still U8-encoded — callers must
     /// either dequantize first or use a kernel that supports FP8 inputs.
     pub fn pool_tensors(&self, layer_idx: usize) -> Option<(&Tensor, &Tensor)> {
-        self.layers
-            .get(layer_idx)
-            .map(|(k, v)| (k, v))
+        self.layers.get(layer_idx).map(|(k, v)| (k, v))
     }
+}
+
+pub(crate) fn contiguous_slot_run_start(
+    block_table: &BlockTable,
+    block_size: usize,
+    start_pos: usize,
+    len: usize,
+) -> Option<usize> {
+    if len == 0 {
+        return None;
+    }
+
+    let start_slot = block_table.slot_for(start_pos, block_size)?;
+    if len == 1 {
+        return Some(start_slot);
+    }
+
+    let start_block = start_pos / block_size;
+    let end_pos = start_pos + len - 1;
+    let end_block = end_pos / block_size;
+
+    if start_block == end_block {
+        return Some(start_slot);
+    }
+
+    let first_phys_block = *block_table.blocks.get(start_block)? as usize;
+    for logical_block in (start_block + 1)..=end_block {
+        let expected_phys_block = first_phys_block + (logical_block - start_block);
+        let phys_block = *block_table.blocks.get(logical_block)? as usize;
+        if phys_block != expected_phys_block {
+            return None;
+        }
+    }
+
+    Some(start_slot)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::kv_cache::KvCache;
+
+    #[test]
+    fn test_contiguous_slot_run_start_detection() {
+        let mut contiguous = BlockTable::new();
+        contiguous.push(5);
+        contiguous.push(6);
+        contiguous.push(7);
+
+        assert_eq!(contiguous_slot_run_start(&contiguous, 4, 0, 6), Some(20));
+        assert_eq!(contiguous_slot_run_start(&contiguous, 4, 2, 6), Some(22));
+        assert_eq!(contiguous_slot_run_start(&contiguous, 4, 4, 4), Some(24));
+
+        let mut non_contiguous = BlockTable::new();
+        non_contiguous.push(5);
+        non_contiguous.push(7);
+        non_contiguous.push(8);
+
+        assert_eq!(
+            contiguous_slot_run_start(&non_contiguous, 4, 0, 4),
+            Some(20)
+        );
+        assert_eq!(contiguous_slot_run_start(&non_contiguous, 4, 0, 6), None);
+        assert_eq!(contiguous_slot_run_start(&non_contiguous, 4, 2, 6), None);
+    }
 
     #[test]
     fn test_write_then_read_roundtrip() -> Result<()> {
@@ -264,7 +357,15 @@ mod tests {
         let block_size = 4;
         let num_blocks = 4;
 
-        let mut cache = PagedKvCache::new(1, num_blocks, block_size, num_kv_heads, head_dim, DType::F32, &device)?;
+        let mut cache = PagedKvCache::new(
+            1,
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_dim,
+            DType::F32,
+            &device,
+        )?;
 
         // Set up a block table with 2 blocks (capacity = 8 tokens)
         let mut bt = BlockTable::new();
@@ -274,13 +375,33 @@ mod tests {
         // Write 3 tokens at position 0
         // Shape: [1, num_kv_heads=2, new_len=3, head_dim=4]
         let k = Tensor::new(
-            &[[[[1.0_f32, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
-              [[13.0, 14.0, 15.0, 16.0], [17.0, 18.0, 19.0, 20.0], [21.0, 22.0, 23.0, 24.0]]]],
+            &[[
+                [
+                    [1.0_f32, 2.0, 3.0, 4.0],
+                    [5.0, 6.0, 7.0, 8.0],
+                    [9.0, 10.0, 11.0, 12.0],
+                ],
+                [
+                    [13.0, 14.0, 15.0, 16.0],
+                    [17.0, 18.0, 19.0, 20.0],
+                    [21.0, 22.0, 23.0, 24.0],
+                ],
+            ]],
             &device,
         )?;
         let v = Tensor::new(
-            &[[[[101.0_f32, 102.0, 103.0, 104.0], [105.0, 106.0, 107.0, 108.0], [109.0, 110.0, 111.0, 112.0]],
-              [[113.0, 114.0, 115.0, 116.0], [117.0, 118.0, 119.0, 120.0], [121.0, 122.0, 123.0, 124.0]]]],
+            &[[
+                [
+                    [101.0_f32, 102.0, 103.0, 104.0],
+                    [105.0, 106.0, 107.0, 108.0],
+                    [109.0, 110.0, 111.0, 112.0],
+                ],
+                [
+                    [113.0, 114.0, 115.0, 116.0],
+                    [117.0, 118.0, 119.0, 120.0],
+                    [121.0, 122.0, 123.0, 124.0],
+                ],
+            ]],
             &device,
         )?;
 
@@ -311,7 +432,15 @@ mod tests {
         let block_size = 4;
         let num_blocks = 4;
 
-        let mut cache = PagedKvCache::new(1, num_blocks, block_size, num_kv_heads, head_dim, DType::F32, &device)?;
+        let mut cache = PagedKvCache::new(
+            1,
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_dim,
+            DType::F32,
+            &device,
+        )?;
 
         // Sequence A uses blocks 0 and 2
         let mut bt_a = BlockTable::new();
@@ -336,12 +465,20 @@ mod tests {
         // Read back sequence A — should be all 1.0
         let (k_a_out, _) = cache.read(0, &bt_a, 5)?;
         let vals = k_a_out.flatten_all()?.to_vec1::<f32>()?;
-        assert!(vals.iter().all(|&x| (x - 1.0).abs() < 1e-6), "Sequence A contaminated: {:?}", vals);
+        assert!(
+            vals.iter().all(|&x| (x - 1.0).abs() < 1e-6),
+            "Sequence A contaminated: {:?}",
+            vals
+        );
 
         // Read back sequence B — should be all 2.0
         let (k_b_out, _) = cache.read(0, &bt_b, 5)?;
         let vals = k_b_out.flatten_all()?.to_vec1::<f32>()?;
-        assert!(vals.iter().all(|&x| (x - 2.0).abs() < 1e-6), "Sequence B contaminated: {:?}", vals);
+        assert!(
+            vals.iter().all(|&x| (x - 2.0).abs() < 1e-6),
+            "Sequence B contaminated: {:?}",
+            vals
+        );
 
         Ok(())
     }
@@ -354,7 +491,15 @@ mod tests {
         let block_size = 4;
         let num_blocks = 2;
 
-        let mut cache = PagedKvCache::new(1, num_blocks, block_size, num_kv_heads, head_dim, DType::F32, &device)?;
+        let mut cache = PagedKvCache::new(
+            1,
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_dim,
+            DType::F32,
+            &device,
+        )?;
 
         let mut bt = BlockTable::new();
         bt.push(0); // block 0: slots 0-3
@@ -384,7 +529,15 @@ mod tests {
         let block_size = 4;
         let num_blocks = 2;
 
-        let mut cache = PagedKvCache::new(1, num_blocks, block_size, num_kv_heads, head_dim, DType::F32, &device)?;
+        let mut cache = PagedKvCache::new(
+            1,
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_dim,
+            DType::F32,
+            &device,
+        )?;
 
         let mut bt = BlockTable::new();
         bt.push(0);
@@ -422,8 +575,17 @@ mod tests {
         let num_blocks = 4; // 4 blocks * 4 tokens = 16 slots
 
         // Create both caches
-        let mut contiguous = KvCache::new(1, num_kv_heads, head_dim, max_seq_len, DType::F32, &device)?;
-        let mut paged = PagedKvCache::new(1, num_blocks, block_size, num_kv_heads, head_dim, DType::F32, &device)?;
+        let mut contiguous =
+            KvCache::new(1, num_kv_heads, head_dim, max_seq_len, DType::F32, &device)?;
+        let mut paged = PagedKvCache::new(
+            1,
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_dim,
+            DType::F32,
+            &device,
+        )?;
 
         // Block table with sequential blocks (0, 1, 2, 3) — same layout as contiguous
         let mut bt = BlockTable::new();
@@ -448,13 +610,19 @@ mod tests {
         let p_k_vals = p_k.flatten_all()?.to_vec1::<f32>()?;
         assert_eq!(c_k_vals.len(), p_k_vals.len());
         for (i, (c, p)) in c_k_vals.iter().zip(p_k_vals.iter()).enumerate() {
-            assert!((c - p).abs() < 1e-6, "K mismatch at index {i}: contiguous={c}, paged={p}");
+            assert!(
+                (c - p).abs() < 1e-6,
+                "K mismatch at index {i}: contiguous={c}, paged={p}"
+            );
         }
 
         let c_v_vals = c_v.flatten_all()?.to_vec1::<f32>()?;
         let p_v_vals = p_v.flatten_all()?.to_vec1::<f32>()?;
         for (i, (c, p)) in c_v_vals.iter().zip(p_v_vals.iter()).enumerate() {
-            assert!((c - p).abs() < 1e-6, "V mismatch at index {i}: contiguous={c}, paged={p}");
+            assert!(
+                (c - p).abs() < 1e-6,
+                "V mismatch at index {i}: contiguous={c}, paged={p}"
+            );
         }
 
         // Decode: write 1 more token
@@ -470,13 +638,19 @@ mod tests {
         let c_k_vals = c_k.flatten_all()?.to_vec1::<f32>()?;
         let p_k_vals = p_k.flatten_all()?.to_vec1::<f32>()?;
         for (i, (c, p)) in c_k_vals.iter().zip(p_k_vals.iter()).enumerate() {
-            assert!((c - p).abs() < 1e-6, "K decode mismatch at {i}: contiguous={c}, paged={p}");
+            assert!(
+                (c - p).abs() < 1e-6,
+                "K decode mismatch at {i}: contiguous={c}, paged={p}"
+            );
         }
 
         let c_v_vals = c_v.flatten_all()?.to_vec1::<f32>()?;
         let p_v_vals = p_v.flatten_all()?.to_vec1::<f32>()?;
         for (i, (c, p)) in c_v_vals.iter().zip(p_v_vals.iter()).enumerate() {
-            assert!((c - p).abs() < 1e-6, "V decode mismatch at {i}: contiguous={c}, paged={p}");
+            assert!(
+                (c - p).abs() < 1e-6,
+                "V decode mismatch at {i}: contiguous={c}, paged={p}"
+            );
         }
 
         Ok(())
@@ -506,7 +680,11 @@ mod tests {
             let k_vals = k_out.flatten_all()?.to_vec1::<f32>()?;
             assert_eq!(k_vals, vec![val, val * 10.0], "Layer {layer} K mismatch");
             let v_vals = v_out.flatten_all()?.to_vec1::<f32>()?;
-            assert_eq!(v_vals, vec![val * 100.0, val * 1000.0], "Layer {layer} V mismatch");
+            assert_eq!(
+                v_vals,
+                vec![val * 100.0, val * 1000.0],
+                "Layer {layer} V mismatch"
+            );
         }
 
         Ok(())
@@ -523,8 +701,14 @@ mod tests {
         let num_blocks = 4;
 
         let mut cache = PagedKvCache::new_with_fp8(
-            1, num_blocks, block_size, num_kv_heads, head_dim,
-            DType::F32, &device, true,
+            1,
+            num_blocks,
+            block_size,
+            num_kv_heads,
+            head_dim,
+            DType::F32,
+            &device,
+            true,
         )?;
         assert!(cache.is_fp8());
 
@@ -533,13 +717,33 @@ mod tests {
         bt.push(3);
 
         let k = Tensor::new(
-            &[[[[1.0_f32, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0], [9.0, 10.0, 11.0, 12.0]],
-              [[13.0, 14.0, 15.0, 16.0], [17.0, 18.0, 19.0, 20.0], [21.0, 22.0, 23.0, 24.0]]]],
+            &[[
+                [
+                    [1.0_f32, 2.0, 3.0, 4.0],
+                    [5.0, 6.0, 7.0, 8.0],
+                    [9.0, 10.0, 11.0, 12.0],
+                ],
+                [
+                    [13.0, 14.0, 15.0, 16.0],
+                    [17.0, 18.0, 19.0, 20.0],
+                    [21.0, 22.0, 23.0, 24.0],
+                ],
+            ]],
             &device,
         )?;
         let v = Tensor::new(
-            &[[[[101.0_f32, 102.0, 103.0, 104.0], [105.0, 106.0, 107.0, 108.0], [109.0, 110.0, 111.0, 112.0]],
-              [[113.0, 114.0, 115.0, 116.0], [117.0, 118.0, 119.0, 120.0], [121.0, 122.0, 123.0, 124.0]]]],
+            &[[
+                [
+                    [101.0_f32, 102.0, 103.0, 104.0],
+                    [105.0, 106.0, 107.0, 108.0],
+                    [109.0, 110.0, 111.0, 112.0],
+                ],
+                [
+                    [113.0, 114.0, 115.0, 116.0],
+                    [117.0, 118.0, 119.0, 120.0],
+                    [121.0, 122.0, 123.0, 124.0],
+                ],
+            ]],
             &device,
         )?;
 
@@ -554,7 +758,10 @@ mod tests {
         let k_read = k_out.flatten_all()?.to_vec1::<f32>()?;
         for (i, (o, r)) in k_orig.iter().zip(k_read.iter()).enumerate() {
             let rel_err = (o - r).abs() / o.abs().max(0.01);
-            assert!(rel_err < 0.15, "K index {i}: orig={o}, read={r}, rel_err={rel_err}");
+            assert!(
+                rel_err < 0.15,
+                "K index {i}: orig={o}, read={r}, rel_err={rel_err}"
+            );
         }
 
         Ok(())

--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -47,7 +47,7 @@ rand = { workspace = true }
 [features]
 cuda = ["kiln-model/cuda"]
 metal = ["kiln-model/metal"]
-mlx = ["kiln-model/mlx"]
+mlx = ["metal", "kiln-model/mlx"]
 # Forward kiln-model's NVTX feature so kiln-bench / kiln binaries emit ranges
 # under nsys for per-call-site attribution. No effect without --features cuda.
 nvtx = ["kiln-model/nvtx"]

--- a/crates/kiln-server/examples/flce_preflight_bench.rs
+++ b/crates/kiln-server/examples/flce_preflight_bench.rs
@@ -28,8 +28,8 @@ use kiln_train::trainer::sft_train;
 use kiln_train::{ChatMessage, SftConfig, SftExample};
 use std::path::{Path, PathBuf};
 use std::sync::{
-    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
 use std::thread;
 use std::time::{Duration, Instant};
@@ -49,10 +49,7 @@ struct Row {
 
 fn current_vram_mib() -> u64 {
     std::process::Command::new("nvidia-smi")
-        .args([
-            "--query-gpu=memory.used",
-            "--format=csv,noheader,nounits",
-        ])
+        .args(["--query-gpu=memory.used", "--format=csv,noheader,nounits"])
         .output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
@@ -290,8 +287,12 @@ fn main() -> Result<()> {
         VOCAB_SIZE, HIDDEN
     );
     eprintln!("Loading model from {}", model_path.display());
-    let model_weights =
-        kiln_model::load_model(&model_path, &model_config).context("load_model")?;
+    let model_weights = kiln_model::load_model_with_options(
+        &model_path,
+        &model_config,
+        kiln_model::LoadModelOptions { load_mtp: false },
+    )
+    .context("load_model")?;
     let device = kiln_server::device::select_device()?;
     if matches!(device, Device::Cpu) {
         anyhow::bail!("CUDA device required — preflight measures real VRAM");

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -15,19 +15,18 @@ use kiln_core::config::ModelConfig;
 use kiln_core::sampling::SamplingParams;
 use kiln_core::tokenizer::KilnTokenizer;
 use kiln_core::vram::detect_vram;
+use kiln_model::ModelRunner;
 use kiln_model::backend as runtime_backend;
 use kiln_model::forward::{
-    model_forward, model_forward_paged, model_forward_paged_streaming,
-    model_forward_paged_with_last_hidden, streaming_prefill_enabled, GpuWeights,
-    LinearAttentionState,
+    GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
+    model_forward_paged_streaming, model_forward_paged_with_last_hidden, streaming_prefill_enabled,
 };
 use kiln_model::kv_cache::KvCache;
 use kiln_model::paged_kv_cache::PagedKvCache;
 use kiln_model::sampling::greedy_sample;
 use kiln_model::speculative::{
-    speculative_decode_step, speculative_mtp_decode_step, SpeculativeConfig,
+    SpeculativeConfig, speculative_decode_step, speculative_mtp_decode_step,
 };
-use kiln_model::ModelRunner;
 use kiln_server::config::SpecMethod;
 
 /// Block size used for the paged-path benchmark. Matches the kiln-core default.
@@ -151,12 +150,20 @@ fn parse_args() -> Result<BenchArgs> {
             "--help" | "-h" => {
                 eprintln!("Usage: kiln-bench --model-path <path> [options]");
                 eprintln!("  --model-path <path>       Path to Qwen3.5-4B weights directory");
-                eprintln!("  --max-output-tokens <n>   Max tokens to generate per request (default: 128)");
-                eprintln!("  --prompt-tokens <n>       Approximate prompt length in tokens (default: 512)");
+                eprintln!(
+                    "  --max-output-tokens <n>   Max tokens to generate per request (default: 128)"
+                );
+                eprintln!(
+                    "  --prompt-tokens <n>       Approximate prompt length in tokens (default: 512)"
+                );
                 eprintln!("  --training-steps <n>      Number of SFT training steps (default: 10)");
                 eprintln!("  --skip-training           Skip training benchmarks");
-                eprintln!("  --paged                   Route latency phase through PagedKvCache + model_forward_paged");
-                eprintln!("                            (matches the HTTP/scheduler production path)");
+                eprintln!(
+                    "  --paged                   Route latency phase through PagedKvCache + model_forward_paged"
+                );
+                eprintln!(
+                    "                            (matches the HTTP/scheduler production path)"
+                );
                 std::process::exit(0);
             }
             _ => {}
@@ -588,7 +595,10 @@ fn bench_latency_paged(
             .take(32)
             .map(|t| t.to_string())
             .collect();
-        eprintln!("    Paged decode first 32 token ids: [{}]", first_n.join(","));
+        eprintln!(
+            "    Paged decode first 32 token ids: [{}]",
+            first_n.join(",")
+        );
     }
 
     let mean_itl = if inter_token_ms.is_empty() {
@@ -814,8 +824,7 @@ fn bench_latency_skiplayer(
             break;
         }
 
-        let per_token_ms =
-            (step_time.as_secs_f64() * 1000.0) / step.accepted_tokens.len() as f64;
+        let per_token_ms = (step_time.as_secs_f64() * 1000.0) / step.accepted_tokens.len() as f64;
         for &tok in &step.accepted_tokens {
             inter_token_ms.push(per_token_ms);
             emitted.push(tok);
@@ -1034,8 +1043,7 @@ fn bench_latency_paged_mtp(
             draft_accepted_count += 1;
         }
 
-        let per_token_ms =
-            (step_time.as_secs_f64() * 1000.0) / step.accepted_tokens.len() as f64;
+        let per_token_ms = (step_time.as_secs_f64() * 1000.0) / step.accepted_tokens.len() as f64;
         for &tok in &step.accepted_tokens {
             inter_token_ms.push(per_token_ms);
             num_tokens += 1;
@@ -1155,15 +1163,12 @@ fn bench_training(
     let adapter_dir = std::env::temp_dir().join("kiln-bench-adapters");
     std::fs::create_dir_all(&adapter_dir)?;
 
-    let progress_cb =
-        Some(
-            Box::new(|progress: kiln_train::trainer::TrainingProgress| {
-                eprintln!(
-                    "    Step {}/{}: loss={:.6}",
-                    progress.step, progress.total_steps, progress.loss
-                );
-            }) as kiln_train::trainer::ProgressCallback,
+    let progress_cb = Some(Box::new(|progress: kiln_train::trainer::TrainingProgress| {
+        eprintln!(
+            "    Step {}/{}: loss={:.6}",
+            progress.step, progress.total_steps, progress.loss
         );
+    }) as kiln_train::trainer::ProgressCallback);
 
     let start = Instant::now();
     let result = kiln_train::trainer::sft_train(
@@ -1224,10 +1229,7 @@ fn print_summary(results: &BenchmarkResults) {
     }
 
     eprintln!("\n--- Latency (single request) ---");
-    eprintln!(
-        "Prompt tokens:         {}",
-        results.latency.prompt_tokens
-    );
+    eprintln!("Prompt tokens:         {}", results.latency.prompt_tokens);
     eprintln!(
         "Prefill time:          {:.1} ms ({:.0} tok/s)",
         results.latency.prefill_time_ms, results.latency.prefill_tokens_per_sec
@@ -1252,10 +1254,7 @@ fn print_summary(results: &BenchmarkResults) {
         "Tokens generated:      {}",
         results.latency.num_tokens_generated
     );
-    eprintln!(
-        "Spec method:           {}",
-        results.latency.spec_method
-    );
+    eprintln!("Spec method:           {}", results.latency.spec_method);
     if let Some(alpha) = results.latency.acceptance_rate {
         eprintln!("Draft acceptance α:    {:.3}", alpha);
     }
@@ -1299,8 +1298,15 @@ fn main() -> Result<()> {
     let vram_before = current_vram_used_bytes();
     let load_start = Instant::now();
 
-    let model_weights = kiln_model::load_model(model_path, &model_config)
-        .context("failed to load model weights")?;
+    let spec_method = read_spec_method_from_env();
+    let model_weights = kiln_model::load_model_with_options(
+        model_path,
+        &model_config,
+        kiln_model::LoadModelOptions {
+            load_mtp: matches!(spec_method, SpecMethod::Mtp),
+        },
+    )
+    .context("failed to load model weights")?;
 
     let device = kiln_server::device::select_device()?;
     if matches!(device, candle_core::Device::Cpu) {
@@ -1345,7 +1351,6 @@ fn main() -> Result<()> {
     //   * KILN_SPEC_METHOD=skip_layer → bench_latency_skiplayer (flat KV + skip-layer)
     //   * default / off               → bench_latency_paged (paged Off) when
     //                                   --paged, else bench_latency (flat Off).
-    let spec_method = read_spec_method_from_env();
     let latency = match spec_method {
         SpecMethod::Mtp => {
             eprintln!("--- Latency Benchmark (MTP — native speculative, paged) ---");
@@ -1435,7 +1440,13 @@ fn main() -> Result<()> {
 
     for &n in &run_counts {
         eprintln!("\n{n} sequential runs:");
-        match bench_inference(&runner, &tokenizer, n, args.prompt_tokens, args.max_output_tokens) {
+        match bench_inference(
+            &runner,
+            &tokenizer,
+            n,
+            args.prompt_tokens,
+            args.max_output_tokens,
+        ) {
             Ok(result) => {
                 eprintln!("  => {:.1} tok/s aggregate", result.tokens_per_sec);
                 inference_results.push(result);

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -5,18 +5,16 @@ use anyhow::Result;
 use clap::Parser;
 
 use kiln_server::api;
-use kiln_server::device::select_device;
-use kiln_server::cli::{
-    self, AdapterCommands, Cli, Commands, TrainCommands,
-};
+use kiln_server::cli::{self, AdapterCommands, Cli, Commands, TrainCommands};
 use kiln_server::config::KilnConfig;
+use kiln_server::device::select_device;
 use kiln_server::state;
 
 use kiln_core::config::ModelConfig;
 use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::ModelRunner;
 use kiln_model::engine::MockEngine;
 use kiln_model::forward::GpuWeights;
-use kiln_model::ModelRunner;
 use kiln_scheduler::{Scheduler, SchedulerConfig};
 use state::AppState;
 
@@ -61,7 +59,9 @@ async fn main() -> Result<()> {
             }
         },
         // Serve mode (default)
-        Some(Commands::Serve { ref served_model_id }) => {
+        Some(Commands::Serve {
+            ref served_model_id,
+        }) => {
             // CLI flag wins over env/TOML; surface it via env var so the
             // config loader picks it up uniformly.
             if let Some(v) = served_model_id {
@@ -101,7 +101,10 @@ async fn main() -> Result<()> {
         // Try loading tokenizer from the model directory first
         let tok_file = Path::new(mp).join("tokenizer.json");
         if tok_file.exists() {
-            tracing::info!("loading tokenizer from model directory: {}", tok_file.display());
+            tracing::info!(
+                "loading tokenizer from model directory: {}",
+                tok_file.display()
+            );
             KilnTokenizer::from_file(tok_file.to_str().unwrap())?
         } else {
             tracing::info!("loading tokenizer from HuggingFace Hub: {model_id}");
@@ -120,25 +123,21 @@ async fn main() -> Result<()> {
     let mut state = if let Some(mp) = model_path {
         // Real inference mode: load model weights and create ModelRunner.
         tracing::info!("loading model weights from {mp}");
-        let model_weights = kiln_model::load_model(Path::new(mp), &model_config)?;
+        let load_mtp = matches!(
+            config.speculative.effective_method(),
+            kiln_server::config::SpecMethod::Mtp
+        );
+        let model_weights = kiln_model::load_model_with_options(
+            Path::new(mp),
+            &model_config,
+            kiln_model::LoadModelOptions { load_mtp },
+        )?;
         let device = select_device()?;
         let gpu_weights = GpuWeights::from_model_weights(&model_weights, &model_config, &device)?;
 
-        // ModelRunner takes ownership of a tokenizer, so load a second instance.
-        let runner_tokenizer = if let Some(path) = tokenizer_path {
-            KilnTokenizer::from_file(path)?
-        } else {
-            let tok_file = Path::new(mp).join("tokenizer.json");
-            if tok_file.exists() {
-                KilnTokenizer::from_file(tok_file.to_str().unwrap())?
-            } else {
-                KilnTokenizer::from_pretrained(model_id)?
-            }
-        };
-
         let runner = ModelRunner::new_with_options(
             gpu_weights,
-            runner_tokenizer,
+            tokenizer.clone(),
             model_config.clone(),
             config.memory.cuda_graphs,
         );
@@ -156,7 +155,9 @@ async fn main() -> Result<()> {
         }
 
         tracing::info!(adapter_dir = %adapter_dir.display(), "model loaded — real inference mode");
-        tracing::info!("training endpoints available — in-process LoRA training (no sidecar needed)");
+        tracing::info!(
+            "training endpoints available — in-process LoRA training (no sidecar needed)"
+        );
         AppState::new_real(
             model_config,
             runner,

--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -10,10 +10,12 @@ mod tray;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use settings::{apply_to_supervisor_config, Settings};
+use settings::{
+    apply_desktop_launch_contract, apply_to_supervisor_config, normalize_for_platform, Settings,
+};
 use supervisor::{ServerState, Supervisor, SupervisorConfig};
 use tauri::{AppHandle, Emitter, Manager, State};
-use tauri_plugin_autostart::{ManagerExt, MacosLauncher};
+use tauri_plugin_autostart::{MacosLauncher, ManagerExt};
 use tauri_plugin_updater::UpdaterExt;
 use tokio::sync::RwLock;
 
@@ -38,6 +40,16 @@ fn reconcile_autolaunch(app: &AppHandle, desired: bool) {
             eprintln!("[main] autolaunch disable failed: {}", e);
         }
     }
+}
+
+fn build_supervisor_config(
+    app: &AppHandle,
+    settings: &Settings,
+) -> Result<SupervisorConfig, String> {
+    let mut cfg = SupervisorConfig::default();
+    apply_to_supervisor_config(settings, &mut cfg);
+    apply_desktop_launch_contract(app, &mut cfg)?;
+    Ok(cfg)
 }
 
 type SettingsState = Arc<RwLock<Settings>>;
@@ -96,10 +108,7 @@ async fn copy_logs(
 }
 
 #[tauri::command]
-async fn save_logs_to_file(
-    path: String,
-    sup: State<'_, Arc<Supervisor>>,
-) -> Result<usize, String> {
+async fn save_logs_to_file(path: String, sup: State<'_, Arc<Supervisor>>) -> Result<usize, String> {
     let lines = sup.logs().await;
     let count = lines.len();
     let text = lines.join("\n");
@@ -143,7 +152,9 @@ async fn get_binary_status(
             .unwrap_or_else(|| std::path::PathBuf::from("kiln"))
     };
     let resolved = installer::resolve_binary(&configured);
-    let install_dir = installer::install_dir(&app).ok().map(|p| p.display().to_string());
+    let install_dir = installer::install_dir(&app)
+        .ok()
+        .map(|p| p.display().to_string());
     Ok(BinaryStatus {
         installed: resolved.is_some(),
         resolved_path: resolved.map(|p| p.display().to_string()),
@@ -189,21 +200,35 @@ async fn download_kiln_server(
                 let cfg_update = {
                     let mut s = settings_state.write().await;
                     s.kiln_binary = Some(path.clone());
+                    let normalized = normalize_for_platform(s.clone());
+                    *s = normalized;
                     if let Err(e) = s.save(&app_for_task) {
                         eprintln!("[install] settings.save failed: {}", e);
                     }
-                    let mut cfg = SupervisorConfig::default();
-                    apply_to_supervisor_config(&s, &mut cfg);
-                    cfg
+                    build_supervisor_config(&app_for_task, &s)
                 };
-                supervisor.update_config(cfg_update).await;
-                let _ = app_for_task.emit(
-                    installer::INSTALL_DONE_EVENT,
-                    installer::InstallDone {
-                        path: path.display().to_string(),
-                        version,
-                    },
-                );
+                match cfg_update {
+                    Ok(cfg) => {
+                        supervisor.update_config(cfg).await;
+                        let _ = app_for_task.emit(
+                            installer::INSTALL_DONE_EVENT,
+                            installer::InstallDone {
+                                path: path.display().to_string(),
+                                version,
+                            },
+                        );
+                    }
+                    Err(err) => {
+                        eprintln!("[install] build_supervisor_config failed: {}", err);
+                        let _ = app_for_task.emit(
+                            installer::INSTALL_FAILED_EVENT,
+                            installer::InstallFailed {
+                                error: err,
+                                cancelled: false,
+                            },
+                        );
+                    }
+                }
             }
             Err(err) => {
                 let cancelled = inst_for_task.cancel.load(Ordering::SeqCst);
@@ -320,9 +345,7 @@ async fn extract_update(
     inst: State<'_, InstallerHandle>,
 ) -> Result<(), String> {
     if inst.in_progress.swap(true, Ordering::SeqCst) {
-        return Err(
-            "an install, update download, or extract is already in progress".into(),
-        );
+        return Err("an install, update download, or extract is already in progress".into());
     }
     inst.cancel.store(false, Ordering::SeqCst);
 
@@ -624,8 +647,7 @@ async fn check_for_kiln_update(
         if !installer::is_cuda_compatible_for_release(local, release_body.as_deref()) {
             let req = installer::min_cuda_for_release(release_body.as_deref())
                 .expect("min_cuda must be Some when compat check failed");
-            let local =
-                local.expect("local driver must be Some when compat check failed");
+            let local = local.expect("local driver must be Some when compat check failed");
             update_available = false;
             Some(format!(
                 "This kiln release requires CUDA >= {}.{}; local driver supports CUDA {}.{}.",
@@ -691,13 +713,15 @@ async fn check_kiln_update_on_launch(app: AppHandle, settings: SettingsState) {
     {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("[main] auto_update check: build reqwest client failed: {}", e);
+            eprintln!(
+                "[main] auto_update check: build reqwest client failed: {}",
+                e
+            );
             return;
         }
     };
 
-    let Some((latest, release_body)) =
-        installer::discover_latest_version_and_body(&client).await
+    let Some((latest, release_body)) = installer::discover_latest_version_and_body(&client).await
     else {
         return;
     };
@@ -716,10 +740,7 @@ async fn check_kiln_update_on_launch(app: AppHandle, settings: SettingsState) {
     // for Updates".
     if let installer::GpuCompat::Unsupported(sm) = installer::gpu_compat().await {
         if !installer::is_supported_sm_for_release(sm, release_body.as_deref()) {
-            eprintln!(
-                "[main] auto_update: skipping — GPU SM {} not supported",
-                sm
-            );
+            eprintln!("[main] auto_update: skipping — GPU SM {} not supported", sm);
             return;
         }
     }
@@ -732,8 +753,7 @@ async fn check_kiln_update_on_launch(app: AppHandle, settings: SettingsState) {
     if !installer::is_cuda_compatible_for_release(local_cuda, release_body.as_deref()) {
         let req = installer::min_cuda_for_release(release_body.as_deref())
             .expect("min_cuda must be Some when compat check failed");
-        let local =
-            local_cuda.expect("local driver must be Some when compat check failed");
+        let local = local_cuda.expect("local driver must be Some when compat check failed");
         eprintln!(
             "[main] auto_update: skipping — release requires CUDA >= {}.{}, local {}.{}",
             req.0, req.1, local.0, local.1
@@ -786,7 +806,9 @@ async fn get_kiln_url(
 ) -> Result<String, String> {
     let server_state = sup.state().await;
     match server_state {
-        ServerState::Stopped | ServerState::Error(_) | ServerState::NoBinary(_) => Ok(String::new()),
+        ServerState::Stopped | ServerState::Error(_) | ServerState::NoBinary(_) => {
+            Ok(String::new())
+        }
         ServerState::Starting | ServerState::Running | ServerState::TrainingActive => {
             let s = state.read().await;
             Ok(format!("http://{}:{}/ui", s.host, s.port))
@@ -828,7 +850,9 @@ async fn get_openai_base_url(
 ) -> Result<String, String> {
     let server_state = sup.state().await;
     match server_state {
-        ServerState::Stopped | ServerState::Error(_) | ServerState::NoBinary(_) => Ok(String::new()),
+        ServerState::Stopped | ServerState::Error(_) | ServerState::NoBinary(_) => {
+            Ok(String::new())
+        }
         ServerState::Starting | ServerState::Running | ServerState::TrainingActive => {
             let s = state.read().await;
             Ok(openai_base_url(&s.host, s.port))
@@ -983,13 +1007,13 @@ async fn set_settings(
     state: State<'_, SettingsState>,
     sup: State<'_, Arc<Supervisor>>,
 ) -> Result<(), String> {
+    let new = normalize_for_platform(new);
     new.save(&app)?;
     {
         let mut guard = state.write().await;
         *guard = new.clone();
     }
-    let mut cfg = SupervisorConfig::default();
-    apply_to_supervisor_config(&new, &mut cfg);
+    let cfg = build_supervisor_config(&app, &new)?;
     sup.update_config(cfg).await;
     reconcile_autolaunch(&app, new.launch_at_login);
     Ok(())
@@ -1012,8 +1036,7 @@ fn main() {
             let handle = app.handle().clone();
             let settings = Settings::load(&handle);
 
-            let mut cfg = SupervisorConfig::default();
-            apply_to_supervisor_config(&settings, &mut cfg);
+            let cfg = build_supervisor_config(&handle, &settings)?;
             let supervisor = Arc::new(Supervisor::new(cfg));
             let settings_state: SettingsState = Arc::new(RwLock::new(settings.clone()));
 
@@ -1025,13 +1048,25 @@ fn main() {
 
             reconcile_autolaunch(&handle, settings.launch_at_login);
 
-            if settings.auto_start {
+            let configured_binary = settings
+                .kiln_binary
+                .clone()
+                .unwrap_or_else(|| std::path::PathBuf::from("kiln"));
+            let should_auto_start = settings.auto_start
+                && tray::is_model_path_set(&settings)
+                && tray::is_binary_available(&configured_binary);
+
+            if should_auto_start {
                 let sup = Arc::clone(&supervisor);
                 tauri::async_runtime::spawn(async move {
                     if let Err(e) = sup.start().await {
                         eprintln!("[main] auto_start failed: {}", e);
                     }
                 });
+            } else if settings.auto_start {
+                eprintln!(
+                    "[main] auto_start skipped: waiting for both a model path and an installed kiln binary"
+                );
             }
 
             // Non-blocking auto-check for a newer kiln binary. Runs once per
@@ -1091,7 +1126,10 @@ mod tests {
 
     #[test]
     fn default_loopback() {
-        assert_eq!(openai_base_url("127.0.0.1", 8000), "http://127.0.0.1:8000/v1");
+        assert_eq!(
+            openai_base_url("127.0.0.1", 8000),
+            "http://127.0.0.1:8000/v1"
+        );
     }
 
     #[test]

--- a/desktop/src/settings.rs
+++ b/desktop/src/settings.rs
@@ -5,6 +5,8 @@ use tauri::{AppHandle, Manager};
 
 use crate::supervisor::SupervisorConfig;
 
+const DESKTOP_RUNTIME_CONFIG_NAME: &str = "kiln-desktop-runtime.toml";
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct Settings {
@@ -33,7 +35,7 @@ impl Default for Settings {
             port: 8000,
             inference_fraction: 0.9,
             fp8_kv_cache: false,
-            cuda_graphs: true,
+            cuda_graphs: !cfg!(target_os = "macos"),
             prefix_cache: true,
             speculative_decoding: false,
             adapter_dir: None,
@@ -62,18 +64,73 @@ impl Settings {
         let Ok(data) = std::fs::read_to_string(&path) else {
             return Self::default();
         };
-        serde_json::from_str(&data).unwrap_or_default()
+        normalize_for_platform(serde_json::from_str(&data).unwrap_or_default())
     }
 
     pub fn save(&self, app: &AppHandle) -> Result<(), String> {
         let path = Self::path(app)?;
         if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .map_err(|e| format!("create settings dir: {}", e))?;
+            std::fs::create_dir_all(parent).map_err(|e| format!("create settings dir: {}", e))?;
         }
-        let body =
-            serde_json::to_string_pretty(self).map_err(|e| format!("serialize: {}", e))?;
+        let body = serde_json::to_string_pretty(self).map_err(|e| format!("serialize: {}", e))?;
         std::fs::write(&path, body).map_err(|e| format!("write settings.json: {}", e))
+    }
+}
+
+pub fn normalize_for_platform(mut s: Settings) -> Settings {
+    #[cfg(target_os = "macos")]
+    {
+        // These desktop toggles are CUDA-only today. Keep persisted settings
+        // aligned with the actual macOS launch contract instead of storing
+        // values the child process will ignore or internally override.
+        s.fp8_kv_cache = false;
+        s.cuda_graphs = false;
+    }
+    s
+}
+
+/// Ensure the desktop always launches kiln with a config file under the app's
+/// config directory so ambient `KILN_CONFIG` / `./kiln.toml` never alter the
+/// server's behavior.
+pub fn apply_desktop_launch_contract(
+    app: &AppHandle,
+    cfg: &mut SupervisorConfig,
+) -> Result<(), String> {
+    let path = desktop_runtime_config_path(app)?;
+    ensure_desktop_runtime_config(&path)?;
+    upsert_env(&mut cfg.envs, "KILN_CONFIG", path.display().to_string());
+    Ok(())
+}
+
+fn desktop_runtime_config_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_config_dir()
+        .map_err(|e| format!("app_config_dir unavailable: {}", e))?;
+    Ok(dir.join(DESKTOP_RUNTIME_CONFIG_NAME))
+}
+
+fn ensure_desktop_runtime_config(path: &PathBuf) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("create runtime config dir: {}", e))?;
+    }
+    if path.exists() {
+        return Ok(());
+    }
+    let body = concat!(
+        "# Managed by Kiln Desktop.\n",
+        "# The desktop app injects runtime overrides via KILN_* env vars.\n",
+        "# Keeping this file explicit prevents cwd-local kiln.toml files from\n",
+        "# silently affecting the desktop child process.\n",
+    );
+    std::fs::write(path, body).map_err(|e| format!("write runtime config: {}", e))
+}
+
+fn upsert_env(envs: &mut Vec<(String, String)>, key: &str, value: String) {
+    if let Some((_, existing)) = envs.iter_mut().find(|(name, _)| name == key) {
+        *existing = value;
+    } else {
+        envs.push((key.to_string(), value));
     }
 }
 
@@ -84,6 +141,17 @@ impl Settings {
 /// passed CLI flags that the server didn't accept, which made the supervisor
 /// crashloop with "unexpected argument '--host'".
 pub fn apply_to_supervisor_config(s: &Settings, cfg: &mut SupervisorConfig) {
+    let fp8_kv_cache = if cfg!(target_os = "macos") {
+        false
+    } else {
+        s.fp8_kv_cache
+    };
+    let cuda_graphs = if cfg!(target_os = "macos") {
+        false
+    } else {
+        s.cuda_graphs
+    };
+
     let mut envs: Vec<(String, String)> = Vec::new();
     envs.push(("KILN_HOST".to_string(), s.host.clone()));
     envs.push(("KILN_PORT".to_string(), s.port.to_string()));
@@ -93,14 +161,8 @@ pub fn apply_to_supervisor_config(s: &Settings, cfg: &mut SupervisorConfig) {
     ));
     // Booleans: always emit so the env value is the source of truth (a
     // setting toggled off must be able to override a true default).
-    envs.push((
-        "KILN_KV_CACHE_FP8".to_string(),
-        bool_env(s.fp8_kv_cache),
-    ));
-    envs.push((
-        "KILN_CUDA_GRAPHS".to_string(),
-        bool_env(s.cuda_graphs),
-    ));
+    envs.push(("KILN_KV_CACHE_FP8".to_string(), bool_env(fp8_kv_cache)));
+    envs.push(("KILN_CUDA_GRAPHS".to_string(), bool_env(cuda_graphs)));
     envs.push((
         "KILN_PREFIX_CACHE_ENABLED".to_string(),
         bool_env(s.prefix_cache),
@@ -134,7 +196,11 @@ pub fn apply_to_supervisor_config(s: &Settings, cfg: &mut SupervisorConfig) {
 }
 
 fn bool_env(b: bool) -> String {
-    if b { "1".into() } else { "0".into() }
+    if b {
+        "1".into()
+    } else {
+        "0".into()
+    }
 }
 
 #[cfg(test)]
@@ -148,7 +214,7 @@ mod tests {
         assert_eq!(s.port, 8000);
         assert!((s.inference_fraction - 0.9).abs() < f32::EPSILON);
         assert!(!s.fp8_kv_cache);
-        assert!(s.cuda_graphs);
+        assert_eq!(s.cuda_graphs, !cfg!(target_os = "macos"));
         assert!(s.prefix_cache);
         assert!(!s.speculative_decoding);
         assert!(s.auto_start);
@@ -175,12 +241,21 @@ mod tests {
 
         // Settings flow through KILN_* env vars (see kiln-server config.rs).
         let env_get = |k: &str| -> Option<&str> {
-            cfg.envs.iter().find(|(name, _)| name == k).map(|(_, v)| v.as_str())
+            cfg.envs
+                .iter()
+                .find(|(name, _)| name == k)
+                .map(|(_, v)| v.as_str())
         };
         assert_eq!(env_get("KILN_HOST"), Some("0.0.0.0"));
         assert_eq!(env_get("KILN_PORT"), Some("9000"));
-        assert_eq!(env_get("KILN_KV_CACHE_FP8"), Some("1"));
-        assert_eq!(env_get("KILN_CUDA_GRAPHS"), Some("1")); // default true
+        assert_eq!(
+            env_get("KILN_KV_CACHE_FP8"),
+            Some(if cfg!(target_os = "macos") { "0" } else { "1" })
+        );
+        assert_eq!(
+            env_get("KILN_CUDA_GRAPHS"),
+            Some(if cfg!(target_os = "macos") { "0" } else { "1" })
+        );
         assert_eq!(env_get("KILN_PREFIX_CACHE_ENABLED"), Some("1")); // default true
         assert_eq!(env_get("KILN_SPEC_ENABLED"), Some("0")); // default false
         assert_eq!(env_get("KILN_MODEL_PATH"), Some("/models/foo"));
@@ -225,6 +300,16 @@ mod tests {
         let s: Settings = serde_json::from_str(partial).unwrap();
         assert_eq!(s.port, 9001);
         assert_eq!(s.host, "127.0.0.1");
-        assert!(s.cuda_graphs);
+        assert_eq!(s.cuda_graphs, !cfg!(target_os = "macos"));
+    }
+
+    #[test]
+    fn normalize_for_platform_forces_cuda_only_toggles_off_on_macos() {
+        let mut s = Settings::default();
+        s.fp8_kv_cache = true;
+        s.cuda_graphs = true;
+        let normalized = normalize_for_platform(s);
+        assert_eq!(normalized.fp8_kv_cache, !cfg!(target_os = "macos"));
+        assert_eq!(normalized.cuda_graphs, !cfg!(target_os = "macos"));
     }
 }

--- a/desktop/src/supervisor.rs
+++ b/desktop/src/supervisor.rs
@@ -189,7 +189,10 @@ impl Supervisor {
             ServerState::Starting | ServerState::Running | ServerState::TrainingActive
         ) {
             if let Err(e) = self.stop().await {
-                eprintln!("[supervisor] restart: stop failed, attempting start anyway: {}", e);
+                eprintln!(
+                    "[supervisor] restart: stop failed, attempting start anyway: {}",
+                    e
+                );
             }
         }
         self.start().await
@@ -216,18 +219,32 @@ async fn run_loop(
         // state, not an Error. This both suppresses the "server crashed"
         // OS notification on fresh installs and lets the dashboard show a
         // download prompt instead of a raw spawn error.
-        if crate::installer::resolve_binary(&config.binary_path).is_none() {
-            let msg = config.binary_path.display().to_string();
-            push_log(
-                &logs,
-                format!("[supervisor] kiln binary not found: {}", msg),
-            )
-            .await;
-            *state.lock().await = ServerState::NoBinary(msg);
-            return;
-        }
+        let resolved_binary = match crate::installer::resolve_binary(&config.binary_path) {
+            Some(path) => path,
+            None => {
+                let msg = config.binary_path.display().to_string();
+                push_log(
+                    &logs,
+                    format!("[supervisor] kiln binary not found: {}", msg),
+                )
+                .await;
+                *state.lock().await = ServerState::NoBinary(msg);
+                return;
+            }
+        };
+        push_log(
+            &logs,
+            format!(
+                "[supervisor] spawning {} (configured as {})",
+                resolved_binary.display(),
+                config.binary_path.display()
+            ),
+        )
+        .await;
 
-        let spawn_result = Command::new(&config.binary_path)
+        let mut cmd = Command::new(&resolved_binary);
+        scrub_ambient_env(&mut cmd);
+        let spawn_result = cmd
             .args(&config.args)
             .envs(config.envs.iter().map(|(k, v)| (k.as_str(), v.as_str())))
             .stdout(Stdio::piped())
@@ -251,11 +268,7 @@ async fn run_loop(
                     *state.lock().await = ServerState::NoBinary(msg);
                     return;
                 }
-                let msg = format!(
-                    "failed to spawn {}: {}",
-                    config.binary_path.display(),
-                    e
-                );
+                let msg = format!("failed to spawn {}: {}", resolved_binary.display(), e);
                 push_log(&logs, format!("[supervisor] {}", msg)).await;
                 *state.lock().await = ServerState::Error(msg);
                 return;
@@ -341,6 +354,15 @@ async fn run_loop(
 
 async fn push_log(logs: &Arc<Mutex<RingBuffer>>, line: String) {
     logs.lock().await.push(line);
+}
+
+fn scrub_ambient_env(cmd: &mut Command) {
+    for (key, _) in std::env::vars_os() {
+        let Some(name) = key.to_str() else { continue };
+        if name.starts_with("KILN_") || name == "RUST_LOG" {
+            cmd.env_remove(name);
+        }
+    }
 }
 
 #[cfg(all(test, unix))]
@@ -440,7 +462,7 @@ mod tests {
         rb.push("aaaa".to_string()); // 4
         rb.push("bbbb".to_string()); // 8
         rb.push("cccccccccccc".to_string()); // 20
-        // Total bytes = 20, at cap. Push one more pushes out first.
+                                             // Total bytes = 20, at cap. Push one more pushes out first.
         rb.push("d".to_string());
         let snap = rb.snapshot();
         assert!(!snap.contains(&"aaaa".to_string()));

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -377,11 +377,11 @@
         </label>
         <label class="row"><span class="name">FP8 KV cache</span>
           <input type="checkbox" id="fp8_kv_cache" />
-          <span class="hint">Halves KV cache VRAM with minor quality impact. Recommended on.</span>
+          <span class="hint" id="fp8_kv_cache_hint">Halves KV cache VRAM on supported backends. Leave off on macOS/Metal.</span>
         </label>
         <label class="row"><span class="name">CUDA graphs</span>
           <input type="checkbox" id="cuda_graphs" />
-          <span class="hint">Replays fused GPU ops for faster decode. Recommended on.</span>
+          <span class="hint" id="cuda_graphs_hint">Faster decode on CUDA. Ignored on macOS/Metal.</span>
         </label>
         <label class="row"><span class="name">Prefix cache</span>
           <input type="checkbox" id="prefix_cache" />
@@ -474,6 +474,7 @@
       const dialog = window.__TAURI__.dialog;
       const statusEl = document.getElementById("status");
       const restartBtn = document.getElementById("restart");
+      const isMacOS = /mac/i.test(navigator.userAgent || "");
       let lastSavedSnapshot = null;
 
       const fields = [
@@ -606,6 +607,22 @@
       function setStatus(msg, err) {
         statusEl.textContent = msg;
         statusEl.className = err ? "status error" : "status";
+      }
+
+      function applyPlatformSpecificUi() {
+        if (!isMacOS) return;
+        const fp8 = document.getElementById("fp8_kv_cache");
+        const cudaGraphs = document.getElementById("cuda_graphs");
+        fp8.checked = false;
+        cudaGraphs.checked = false;
+        fp8.disabled = true;
+        cudaGraphs.disabled = true;
+        fp8.title = "Kiln Desktop forces this off on macOS because the current Metal FP8 KV path is slower.";
+        cudaGraphs.title = "Kiln Desktop forces this off on macOS because CUDA graph replay is CUDA-only.";
+        document.getElementById("fp8_kv_cache_hint").textContent =
+          "Forced off on macOS. The current Metal FP8 KV path is slower than BF16.";
+        document.getElementById("cuda_graphs_hint").textContent =
+          "Forced off on macOS. CUDA graph replay only applies to CUDA backends.";
       }
 
       function hideRestart() {
@@ -1424,6 +1441,7 @@
       }
       kilnUpdateInstallBtn.addEventListener("click", startKilnUpdateInstall);
 
+      applyPlatformSpecificUi();
       load();
     </script>
   </body>


### PR DESCRIPTION
## Summary
- make the desktop macOS launch path hermetic and stable under the app's default settings
- skip optional MTP load/upload work unless the configured speculative method actually needs it
- add paged-KV fast paths for initial prefill and contiguous-run decode on the Apple default path
- fix the `mlx` server feature to include Metal device selection

## Details
This PR is focused on the path the desktop app actually uses by default on macOS.

Desktop changes:
- inject a managed `KILN_CONFIG` file from the desktop app instead of inheriting ambient config
- strip inherited `KILN_*` and `RUST_LOG` before spawning kiln
- resolve the actual binary before spawn and only auto-start when both model path and binary exist
- force CUDA-only toggles off on macOS in both saved settings and the UI

Model/server changes:
- reuse the already-loaded tokenizer at startup instead of loading it twice
- add `LoadModelOptions` and skip loading native MTP weights on the default non-MTP path
- avoid the initial paged prefill write-then-read round trip
- add contiguous-run paged KV bulk write/read paths
- add a contiguous-run fused decode fast path for paged attention
- make `kiln-server --features mlx` select Metal correctly

## Verification
- `cargo build --release --features metal --bin kiln-bench`
- `cargo check --manifest-path desktop/Cargo.toml`
- `cargo test -p kiln-model paged_kv_cache -- --nocapture`

## Notes
The desktop-installed Qwen checkpoint on this machine does not currently expose usable MTP weights to kiln, so the default-path speedups here do not rely on MTP being available.