### PR TITLE
[codex] speed up macOS desktop defaults

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -154,7 +154,8 @@ pub struct MtpGpuWeights {
     /// Concat-then-project: `[hidden_size, 2 * hidden_size]`, BF16 on device.
     /// Ingests `concat(norm_embed, norm_hidden)` → produces `[seq, hidden_size]`.
     pub fc: Tensor,
-    /// Pre-transposed `fc` for the forward hot path: `[2 * hidden_size, hidden_size]`, contiguous.
+    /// Cached `fc` transpose for the forward hot path: `[2 * hidden_size, hidden_size]`,
+    /// materialized contiguously once at load time.
     /// Same transpose-caching pattern as the base model's `*_proj_t` fields
     /// (PRs #117/#124/#128) — eliminates a per-draft-step `.t().contiguous()`
     /// on a 26 MiB bf16 matrix when drafting.
@@ -209,7 +210,8 @@ pub struct GpuFullAttentionWeights {
     pub o_proj: Tensor,
     pub q_norm: Tensor,
     pub k_norm: Tensor,
-    /// Pre-transposed q_proj for the forward hot path (contiguous).
+    /// Cached q_proj transpose for the forward hot path, materialized
+    /// contiguously once at load time.
     /// Avoids re-transposing bf16 projection weights on every layer / every step.
     /// Per PR #124 PROFILING.md: attention projection ucopy_bf16 was ~6.9% of decode GPU time.
     pub q_proj_t: Tensor,
@@ -234,7 +236,8 @@ pub struct GpuLinearAttentionWeights {
     pub norm: Tensor,
     pub a_log: Tensor,
     pub dt_bias: Tensor,
-    /// Pre-transposed GDN projection weights for the forward hot path (contiguous).
+    /// Cached GDN projection transposes for the forward hot path,
+    /// materialized contiguously once at load time.
     /// Same fix class as PR #128 (MLP/full-attn pre-transpose) and PR #117 (embed_tokens_t).
     /// Per Phase 6 PROFILING.md: GDN in_proj+out_proj together accounted for ~95% of
     /// decode-time `ucopy_bf16` mass on Qwen3.5-4B; eliminating the per-step `.t()` copies
@@ -250,7 +253,8 @@ pub struct GpuFfnWeights {
     pub gate_proj: Tensor,
     pub up_proj: Tensor,
     pub down_proj: Tensor,
-    /// Pre-transposed MLP projections for the forward hot path (contiguous).
+    /// Cached MLP projection transposes for the forward hot path,
+    /// materialized contiguously once at load time.
     /// Avoids re-transposing bf16 projection weights on every layer / every step.
     /// Per PR #124 PROFILING.md: MLP projection ucopy_bf16 was 50.7% of decode GPU time
     /// (61.8% of all ucopy_bf16 mass). Same class of fix as PR #117 (embed_tokens_t).
@@ -382,6 +386,15 @@ fn weight_to_tensor(w: &WeightTensor, device: &Device) -> Result<Tensor> {
     let t = Tensor::from_raw_buffer(&w.data, dtype, &w.shape, device)
         .context("failed to create tensor from raw buffer")?;
     Ok(t)
+}
+
+/// Cache a transpose for repeated GEMMs.
+///
+/// Matmuls on the hot path repeatedly consume these tensors, so materialize
+/// the transpose once at load time instead of relying on backend-specific
+/// strided access behaviour.
+fn cached_transpose(weight: &Tensor) -> Result<Tensor> {
+    Ok(weight.t()?.contiguous()?)
 }
 
 /// Tiny BF16 placeholder that replaces a projection's pre-transposed
@@ -540,11 +553,8 @@ impl GpuWeights {
     ) -> Result<Self> {
         let embed_tokens =
             weight_to_tensor(&weights.embedding.embed_tokens, device).context("embed_tokens")?;
-        let embed_tokens_t = embed_tokens
-            .t()
-            .context("embed_tokens transpose")?
-            .contiguous()
-            .context("embed_tokens transpose contiguous")?;
+        let embed_tokens_t =
+            cached_transpose(&embed_tokens).context("embed_tokens cached transpose")?;
         let final_norm = weight_to_tensor(&weights.final_norm, device).context("final_norm")?;
         let rotary_inv_freq =
             compute_rotary_inv_freq(config.rotary_dim(), config.rope_theta, device)
@@ -575,26 +585,14 @@ impl GpuWeights {
                     let k_proj = weight_to_tensor(&attn.k_proj, device).context(ctx("k_proj"))?;
                     let v_proj = weight_to_tensor(&attn.v_proj, device).context(ctx("v_proj"))?;
                     let o_proj = weight_to_tensor(&attn.o_proj, device).context(ctx("o_proj"))?;
-                    let q_proj_t = q_proj
-                        .t()
-                        .context(ctx("q_proj.t"))?
-                        .contiguous()
-                        .context(ctx("q_proj.t contiguous"))?;
-                    let k_proj_t = k_proj
-                        .t()
-                        .context(ctx("k_proj.t"))?
-                        .contiguous()
-                        .context(ctx("k_proj.t contiguous"))?;
-                    let v_proj_t = v_proj
-                        .t()
-                        .context(ctx("v_proj.t"))?
-                        .contiguous()
-                        .context(ctx("v_proj.t contiguous"))?;
-                    let o_proj_t = o_proj
-                        .t()
-                        .context(ctx("o_proj.t"))?
-                        .contiguous()
-                        .context(ctx("o_proj.t contiguous"))?;
+                    let q_proj_t =
+                        cached_transpose(&q_proj).context(ctx("q_proj cached transpose"))?;
+                    let k_proj_t =
+                        cached_transpose(&k_proj).context(ctx("k_proj cached transpose"))?;
+                    let v_proj_t =
+                        cached_transpose(&v_proj).context(ctx("v_proj cached transpose"))?;
+                    let o_proj_t =
+                        cached_transpose(&o_proj).context(ctx("o_proj cached transpose"))?;
                     // KILN_W4A16=1 opt-in: queue q_proj for the post-loop
                     // Marlin batch pack. The packed weight (and the BF16
                     // drop) are installed after the layer loop via
@@ -632,31 +630,16 @@ impl GpuWeights {
                         weight_to_tensor(&attn.in_proj_a, device).context(ctx("in_proj_a"))?;
                     let in_proj_b =
                         weight_to_tensor(&attn.in_proj_b, device).context(ctx("in_proj_b"))?;
-                    let in_proj_qkv_t = in_proj_qkv
-                        .t()
-                        .context(ctx("in_proj_qkv.t"))?
-                        .contiguous()
-                        .context(ctx("in_proj_qkv.t contiguous"))?;
-                    let in_proj_z_t = in_proj_z
-                        .t()
-                        .context(ctx("in_proj_z.t"))?
-                        .contiguous()
-                        .context(ctx("in_proj_z.t contiguous"))?;
-                    let in_proj_a_t = in_proj_a
-                        .t()
-                        .context(ctx("in_proj_a.t"))?
-                        .contiguous()
-                        .context(ctx("in_proj_a.t contiguous"))?;
-                    let in_proj_b_t = in_proj_b
-                        .t()
-                        .context(ctx("in_proj_b.t"))?
-                        .contiguous()
-                        .context(ctx("in_proj_b.t contiguous"))?;
-                    let out_proj_t = out_proj
-                        .t()
-                        .context(ctx("out_proj.t"))?
-                        .contiguous()
-                        .context(ctx("out_proj.t contiguous"))?;
+                    let in_proj_qkv_t = cached_transpose(&in_proj_qkv)
+                        .context(ctx("in_proj_qkv cached transpose"))?;
+                    let in_proj_z_t =
+                        cached_transpose(&in_proj_z).context(ctx("in_proj_z cached transpose"))?;
+                    let in_proj_a_t =
+                        cached_transpose(&in_proj_a).context(ctx("in_proj_a cached transpose"))?;
+                    let in_proj_b_t =
+                        cached_transpose(&in_proj_b).context(ctx("in_proj_b cached transpose"))?;
+                    let out_proj_t =
+                        cached_transpose(&out_proj).context(ctx("out_proj cached transpose"))?;
                     GpuAttentionWeights::Linear(GpuLinearAttentionWeights {
                         in_proj_qkv,
                         in_proj_z,
@@ -681,21 +664,11 @@ impl GpuWeights {
             let up_proj = weight_to_tensor(&lw.mlp.up_proj, device).context(ctx("up_proj"))?;
             let down_proj =
                 weight_to_tensor(&lw.mlp.down_proj, device).context(ctx("down_proj"))?;
-            let gate_proj_t = gate_proj
-                .t()
-                .context(ctx("gate_proj.t"))?
-                .contiguous()
-                .context(ctx("gate_proj.t contiguous"))?;
-            let up_proj_t = up_proj
-                .t()
-                .context(ctx("up_proj.t"))?
-                .contiguous()
-                .context(ctx("up_proj.t contiguous"))?;
-            let down_proj_t = down_proj
-                .t()
-                .context(ctx("down_proj.t"))?
-                .contiguous()
-                .context(ctx("down_proj.t contiguous"))?;
+            let gate_proj_t =
+                cached_transpose(&gate_proj).context(ctx("gate_proj cached transpose"))?;
+            let up_proj_t = cached_transpose(&up_proj).context(ctx("up_proj cached transpose"))?;
+            let down_proj_t =
+                cached_transpose(&down_proj).context(ctx("down_proj cached transpose"))?;
             // KILN_W4A16=1 opt-in: queue each MLP projection for the
             // post-loop Marlin batch pack. See the q_proj comment above —
             // the `*_proj_marlin` fields start as None, and
@@ -794,11 +767,7 @@ impl GpuWeights {
         // the MTP layer's q_proj + MLP trio.
         let mtp = if let Some(mtp_w) = &weights.mtp {
             let fc = weight_to_tensor(&mtp_w.fc, device).context("mtp.fc")?;
-            let fc_t = fc
-                .t()
-                .context("mtp.fc.t")?
-                .contiguous()
-                .context("mtp.fc.t contiguous")?;
+            let fc_t = cached_transpose(&fc).context("mtp.fc cached transpose")?;
             let pre_fc_norm_embedding = weight_to_tensor(&mtp_w.pre_fc_norm_embedding, device)
                 .context("mtp.pre_fc_norm_embedding")?;
             let pre_fc_norm_hidden = weight_to_tensor(&mtp_w.pre_fc_norm_hidden, device)
@@ -831,26 +800,14 @@ impl GpuWeights {
                             weight_to_tensor(&attn.v_proj, device).context(ctx("v_proj"))?;
                         let o_proj =
                             weight_to_tensor(&attn.o_proj, device).context(ctx("o_proj"))?;
-                        let q_proj_t = q_proj
-                            .t()
-                            .context(ctx("q_proj.t"))?
-                            .contiguous()
-                            .context(ctx("q_proj.t contiguous"))?;
-                        let k_proj_t = k_proj
-                            .t()
-                            .context(ctx("k_proj.t"))?
-                            .contiguous()
-                            .context(ctx("k_proj.t contiguous"))?;
-                        let v_proj_t = v_proj
-                            .t()
-                            .context(ctx("v_proj.t"))?
-                            .contiguous()
-                            .context(ctx("v_proj.t contiguous"))?;
-                        let o_proj_t = o_proj
-                            .t()
-                            .context(ctx("o_proj.t"))?
-                            .contiguous()
-                            .context(ctx("o_proj.t contiguous"))?;
+                        let q_proj_t =
+                            cached_transpose(&q_proj).context(ctx("q_proj cached transpose"))?;
+                        let k_proj_t =
+                            cached_transpose(&k_proj).context(ctx("k_proj cached transpose"))?;
+                        let v_proj_t =
+                            cached_transpose(&v_proj).context(ctx("v_proj cached transpose"))?;
+                        let o_proj_t =
+                            cached_transpose(&o_proj).context(ctx("o_proj cached transpose"))?;
                         GpuAttentionWeights::Full(GpuFullAttentionWeights {
                             q_proj,
                             k_proj,
@@ -879,21 +836,12 @@ impl GpuWeights {
                 let up_proj = weight_to_tensor(&lw.mlp.up_proj, device).context(ctx("up_proj"))?;
                 let down_proj =
                     weight_to_tensor(&lw.mlp.down_proj, device).context(ctx("down_proj"))?;
-                let gate_proj_t = gate_proj
-                    .t()
-                    .context(ctx("gate_proj.t"))?
-                    .contiguous()
-                    .context(ctx("gate_proj.t contiguous"))?;
-                let up_proj_t = up_proj
-                    .t()
-                    .context(ctx("up_proj.t"))?
-                    .contiguous()
-                    .context(ctx("up_proj.t contiguous"))?;
-                let down_proj_t = down_proj
-                    .t()
-                    .context(ctx("down_proj.t"))?
-                    .contiguous()
-                    .context(ctx("down_proj.t contiguous"))?;
+                let gate_proj_t =
+                    cached_transpose(&gate_proj).context(ctx("gate_proj cached transpose"))?;
+                let up_proj_t =
+                    cached_transpose(&up_proj).context(ctx("up_proj cached transpose"))?;
+                let down_proj_t =
+                    cached_transpose(&down_proj).context(ctx("down_proj cached transpose"))?;
 
                 GpuLayerWeights {
                     input_layernorm,
@@ -1482,6 +1430,40 @@ fn compute_w_chunk_fallback(
     Ok(Tensor::cat(&w_rows, 2)?)
 }
 
+/// Specialized single-token GDN recurrence.
+///
+/// This is the non-CUDA fast path for `seq_len == 1`, avoiding the chunkwise
+/// prep work (`KKT`, `QKT`, masks, triangular solve) that is only worthwhile
+/// when a chunk contains multiple tokens.
+fn gdn_single_token_recurrence(
+    q: &Tensor,         // [B, nv, 1, dk]
+    k: &Tensor,         // [B, nv, 1, dk]
+    v: &Tensor,         // [B, nv, 1, dv]
+    beta: &Tensor,      // [B, nv, 1]
+    g: &Tensor,         // [B, nv, 1]
+    state: &mut Tensor, // [B, nv, dk, dv]
+) -> Result<Tensor> {
+    let dtype = q.dtype();
+
+    let p = g.to_dtype(DType::F32)?.exp()?.to_dtype(dtype)?;
+    let p_u = p.unsqueeze(3)?; // [B, nv, 1, 1]
+
+    let k_t = k.transpose(2, 3)?.contiguous()?; // [B, nv, dk, 1]
+    let ks_entry = k.matmul(&*state)?; // [B, nv, 1, dv]
+    let q_s = q.matmul(&*state)?; // [B, nv, 1, dv]
+
+    let v_prime = (v - ks_entry.broadcast_mul(&p_u)?)?;
+    let w = v_prime.broadcast_mul(&beta.unsqueeze(3)?)?; // [B, nv, 1, dv]
+    let qk = q.matmul(&k_t)?; // [B, nv, 1, 1]
+    let out = (q_s.broadcast_mul(&p_u)? + qk.matmul(&w)?)?;
+
+    let state_scaled = state.broadcast_mul(&p_u)?;
+    let delta_state = k_t.matmul(&w)?;
+    *state = (state_scaled + delta_state)?;
+
+    Ok(out)
+}
+
 /// Analytical chunkwise form of the Gated DeltaNet recurrence.
 ///
 /// The per-token recurrence is
@@ -1549,33 +1531,36 @@ fn gdn_chunkwise_recurrence(
     // decode regression in PR #80. The backend's `gdn_recurrent_step`
     // kernel (CUDA today) collapses the whole recurrence into one block
     // per (B,H).
-    if seq_len == 1
-        && dtype == DType::BF16
-        && state.dtype() == DType::BF16
-        && backend.supports_gdn_recurrent_step()
-    {
-        // The five squeeze+contiguous calls below each emit a bf16 ucopy
-        // kernel before the recurrent forward runs. PROFILING.md (PR #107)
-        // marks this block as the suspected source of the 24-GDN-layer
-        // ucopy_bf16 slice; the dedicated NVTX range lets nsys attribute
-        // it separately from the kernel itself.
-        let (q1, k1, v1, beta1, g1) = {
-            kiln_nvtx::range!(c"kiln/attn/gdn/precopy");
-            (
-                q.squeeze(2)?.contiguous()?,
-                k.squeeze(2)?.contiguous()?,
-                v.squeeze(2)?.contiguous()?,
-                beta.squeeze(2)?.contiguous()?,
-                g.squeeze(2)?.contiguous()?,
-            )
-        };
-        let out_opt = {
-            kiln_nvtx::range!(c"kiln/attn/gdn/recurrent");
-            backend.gdn_recurrent_step(&q1, &k1, &v1, &beta1, &g1, state)?
-        };
-        if let Some(out) = out_opt {
-            return Ok(out.unsqueeze(2)?);
+    if seq_len == 1 {
+        if dtype == DType::BF16
+            && state.dtype() == DType::BF16
+            && backend.supports_gdn_recurrent_step()
+        {
+            // The five squeeze+contiguous calls below each emit a bf16 ucopy
+            // kernel before the recurrent forward runs. PROFILING.md (PR #107)
+            // marks this block as the suspected source of the 24-GDN-layer
+            // ucopy_bf16 slice; the dedicated NVTX range lets nsys attribute
+            // it separately from the kernel itself.
+            let (q1, k1, v1, beta1, g1) = {
+                kiln_nvtx::range!(c"kiln/attn/gdn/precopy");
+                (
+                    q.squeeze(2)?.contiguous()?,
+                    k.squeeze(2)?.contiguous()?,
+                    v.squeeze(2)?.contiguous()?,
+                    beta.squeeze(2)?.contiguous()?,
+                    g.squeeze(2)?.contiguous()?,
+                )
+            };
+            let out_opt = {
+                kiln_nvtx::range!(c"kiln/attn/gdn/recurrent");
+                backend.gdn_recurrent_step(&q1, &k1, &v1, &beta1, &g1, state)?
+            };
+            if let Some(out) = out_opt {
+                return Ok(out.unsqueeze(2)?);
+            }
         }
+
+        return gdn_single_token_recurrence(q, k, v, beta, g, state);
     }
 
     let full_chunks = seq_len / chunk_size;
@@ -4609,6 +4594,41 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_cached_transpose_materializes_on_cpu() -> Result<()> {
+        let device = Device::Cpu;
+        let t = Tensor::new(&[[1.0_f32, 2.0, 3.0], [4.0, 5.0, 6.0]], &device)?;
+
+        let tt = cached_transpose(&t)?;
+
+        assert!(tt.is_contiguous());
+        assert_eq!(tt.dims(), &[3, 2]);
+        assert_eq!(
+            tt.to_vec2::<f32>()?,
+            vec![vec![1.0, 4.0], vec![2.0, 5.0], vec![3.0, 6.0]]
+        );
+        Ok(())
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn test_cached_transpose_materializes_on_metal() -> Result<()> {
+        let Some(device) = crate::backend::metal::try_new_metal() else {
+            return Ok(());
+        };
+        let t = Tensor::new(&[[1.0_f32, 2.0, 3.0], [4.0, 5.0, 6.0]], &device)?;
+
+        let tt = cached_transpose(&t)?;
+
+        assert!(tt.is_contiguous());
+        assert_eq!(tt.dims(), &[3, 2]);
+        assert_eq!(
+            tt.to_vec2::<f32>()?,
+            vec![vec![1.0, 4.0], vec![2.0, 5.0], vec![3.0, 6.0]]
+        );
+        Ok(())
+    }
+
     /// Helper: build tiny GpuWeights for testing model_forward shape propagation.
     /// Uses full-attention layers only (no linear attention) with small dimensions.
     fn make_tiny_gpu_weights(
@@ -5734,6 +5754,68 @@ mod tests {
             assert!(sd < 1e-3, "chunkwise(cs={cs}) state diff {sd}");
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_gdn_single_token_matches_sequential() -> Result<()> {
+        let device = Device::Cpu;
+        let dtype = DType::F32;
+
+        let b = 1;
+        let nv = 2;
+        let t = 1;
+        let dk = 4;
+        let dv = 4;
+
+        let q = det_tensor(&[b, nv, t, dk], 1.0, 0.0, &device)?.to_dtype(dtype)?;
+        let k = det_tensor(&[b, nv, t, dk], 0.8, 0.1, &device)?.to_dtype(dtype)?;
+        let v = det_tensor(&[b, nv, t, dv], 0.6, -0.2, &device)?.to_dtype(dtype)?;
+        let beta_raw = det_tensor(&[b, nv, t], 1.5, 0.0, &device)?.to_dtype(dtype)?;
+        let beta = {
+            let ones = Tensor::ones_like(&beta_raw)?;
+            (&ones / (&ones + &beta_raw.neg()?.exp()?)?)?
+        };
+        let g_raw = det_tensor(&[b, nv, t], 0.2, 0.0, &device)?.to_dtype(dtype)?;
+        let g = (g_raw.abs()? * (-1.0_f64))?;
+
+        let state_init = det_tensor(&[b, nv, dk, dv], 0.1, 0.0, &device)?.to_dtype(dtype)?;
+        let backend = test_backend(&device);
+
+        let mut state_fast = state_init.clone();
+        let out_fast = gdn_chunkwise_recurrence(
+            &backend,
+            &q,
+            &k,
+            &v,
+            &beta,
+            &g,
+            &mut state_fast,
+            GDN_CHUNK_SIZE,
+        )?;
+
+        let mut state_seq = state_init.clone();
+        let out_seq = gdn_sequential_reference(&q, &k, &v, &beta, &g, &mut state_seq)?;
+
+        let out_diff = (&out_fast - &out_seq)?
+            .abs()?
+            .flatten_all()?
+            .max(0)?
+            .to_scalar::<f32>()?;
+        let state_diff = (&state_fast - &state_seq)?
+            .abs()?
+            .flatten_all()?
+            .max(0)?
+            .to_scalar::<f32>()?;
+
+        assert!(
+            out_diff < 1e-5,
+            "single-token fast path output drifted: max_abs_diff={out_diff:e}"
+        );
+        assert!(
+            state_diff < 1e-5,
+            "single-token fast path state drifted: max_abs_diff={state_diff:e}"
+        );
         Ok(())
     }
 

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -6,7 +6,7 @@
 use anyhow::{Context, Result};
 use candle_core::DType;
 use std::path::Path;
-use std::sync::{mpsc, Arc, Mutex};
+use std::sync::{Arc, Mutex, mpsc};
 
 use kiln_core::config::ModelConfig;
 use kiln_core::sampling::SamplingParams;
@@ -16,17 +16,14 @@ use kiln_core::tokenizer::KilnTokenizer;
 use crate::backend::{self, BackendRuntime};
 use crate::cuda_graph::CudaGraphRunner;
 use crate::forward::{
-    model_forward, model_forward_paged, model_forward_paged_streaming,
-    model_forward_paged_with_last_hidden, streaming_prefill_enabled, GpuWeights,
-    LinearAttentionState,
+    GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
+    model_forward_paged_streaming, model_forward_paged_with_last_hidden, streaming_prefill_enabled,
 };
 use crate::kv_cache::KvCache;
 use crate::lora_loader::LoraWeights;
 use crate::paged_kv_cache::PagedKvCache;
 use crate::sampling::{greedy_sample, sample_with_params};
-use crate::speculative::{
-    speculative_decode_step, speculative_mtp_decode_step, SpeculativeConfig,
-};
+use crate::speculative::{SpeculativeConfig, speculative_decode_step, speculative_mtp_decode_step};
 
 use kiln_core::block::{BlockManager, BlockTable};
 
@@ -102,6 +99,80 @@ pub enum StreamEvent {
     Done(StreamDone),
 }
 
+enum StreamTokenDisposition {
+    Continue,
+    Finished(FinishReason),
+    ReceiverDropped,
+}
+
+struct SharedBlockReservation<'a> {
+    block_manager: &'a Mutex<BlockManager>,
+    block_ids: Vec<u32>,
+}
+
+impl Drop for SharedBlockReservation<'_> {
+    fn drop(&mut self) {
+        if self.block_ids.is_empty() {
+            return;
+        }
+        match self.block_manager.lock() {
+            Ok(mut guard) => guard.free_all(&self.block_ids),
+            Err(e) => tracing::error!("failed to lock block manager to free blocks: {e}"),
+        }
+    }
+}
+
+fn lock_block_manager(
+    block_manager: &Mutex<BlockManager>,
+) -> Result<std::sync::MutexGuard<'_, BlockManager>> {
+    block_manager
+        .lock()
+        .map_err(|e| anyhow::anyhow!("failed to lock block manager: {e}"))
+}
+
+fn lock_paged_cache(
+    paged_cache: &Mutex<PagedKvCache>,
+) -> Result<std::sync::MutexGuard<'_, PagedKvCache>> {
+    paged_cache
+        .lock()
+        .map_err(|e| anyhow::anyhow!("failed to lock paged KV cache: {e}"))
+}
+
+fn emit_stream_token(
+    tx: &mpsc::Sender<StreamEvent>,
+    tokenizer: &KilnTokenizer,
+    generated_tokens: &mut Vec<TokenId>,
+    token: TokenId,
+    stop_sequences: &[String],
+) -> StreamTokenDisposition {
+    generated_tokens.push(token);
+
+    let token_text = tokenizer.decode(&[token]).unwrap_or_default();
+    if tx
+        .send(StreamEvent::Token(StreamToken {
+            token_id: token,
+            text: token_text,
+        }))
+        .is_err()
+    {
+        return StreamTokenDisposition::ReceiverDropped;
+    }
+
+    if !stop_sequences.is_empty() {
+        if let Ok(text) = tokenizer.decode(generated_tokens) {
+            for stop_seq in stop_sequences {
+                if text.contains(stop_seq.as_str()) {
+                    return StreamTokenDisposition::Finished(FinishReason::StopSequence(
+                        stop_seq.clone(),
+                    ));
+                }
+            }
+        }
+    }
+
+    StreamTokenDisposition::Continue
+}
+
 /// Why generation stopped.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FinishReason {
@@ -151,8 +222,8 @@ impl ModelRunner {
     pub fn load_adapter(&mut self, path: &Path) -> Result<()> {
         let device = self.weights.embed_tokens.device().clone();
         let num_layers = self.config.num_layers;
-        let lora = LoraWeights::load(path, num_layers, &device)
-            .context("failed to load LoRA adapter")?;
+        let lora =
+            LoraWeights::load(path, num_layers, &device).context("failed to load LoRA adapter")?;
         self.active_lora = Some(lora);
         if let Ok(mut graph) = self.cuda_graph.lock() {
             graph.invalidate();
@@ -263,8 +334,16 @@ impl ModelRunner {
         let mut linear_state = self.new_linear_state()?;
 
         // Prefill: run forward pass on all prompt tokens at once
-        let logits = model_forward(&*self.backend, &prompt_tokens, &self.weights, &self.config, Some(&mut kv_cache), Some(&mut linear_state), self.active_lora.as_ref())
-            .context("prefill forward pass failed")?;
+        let logits = model_forward(
+            &*self.backend,
+            &prompt_tokens,
+            &self.weights,
+            &self.config,
+            Some(&mut kv_cache),
+            Some(&mut linear_state),
+            self.active_lora.as_ref(),
+        )
+        .context("prefill forward pass failed")?;
         kv_cache.advance(prompt_tokens.len());
 
         // Sample first token from the last position's logits
@@ -298,10 +377,7 @@ impl ModelRunner {
             generated_tokens.push(next_token);
 
             // Decode this token's text
-            let token_text = self
-                .tokenizer
-                .decode(&[next_token])
-                .unwrap_or_default();
+            let token_text = self.tokenizer.decode(&[next_token]).unwrap_or_default();
 
             // Send token event; if receiver dropped, stop early
             if tx
@@ -324,8 +400,7 @@ impl ModelRunner {
                 if let Some(text) = &decoded_so_far {
                     for stop_seq in &params.stop {
                         if text.contains(stop_seq.as_str()) {
-                            finish_reason =
-                                FinishReason::StopSequence(stop_seq.clone());
+                            finish_reason = FinishReason::StopSequence(stop_seq.clone());
                             let _ = tx.send(StreamEvent::Done(StreamDone {
                                 finish_reason,
                                 completion_tokens: generated_tokens.len(),
@@ -337,8 +412,16 @@ impl ModelRunner {
             }
 
             // Decode step: forward pass on just the new token
-            let logits = model_forward(&*self.backend, &[next_token], &self.weights, &self.config, Some(&mut kv_cache), Some(&mut linear_state), self.active_lora.as_ref())
-                .context("decode forward pass failed")?;
+            let logits = model_forward(
+                &*self.backend,
+                &[next_token],
+                &self.weights,
+                &self.config,
+                Some(&mut kv_cache),
+                Some(&mut linear_state),
+                self.active_lora.as_ref(),
+            )
+            .context("decode forward pass failed")?;
             kv_cache.advance(1);
 
             next_token = if params.temperature == 0.0 {
@@ -379,8 +462,16 @@ impl ModelRunner {
         let mut linear_state = self.new_linear_state()?;
 
         // Prefill: run forward pass on all prompt tokens at once
-        let logits = model_forward(&*self.backend, prompt_tokens, &self.weights, &self.config, Some(&mut kv_cache), Some(&mut linear_state), self.active_lora.as_ref())
-            .context("prefill forward pass failed")?;
+        let logits = model_forward(
+            &*self.backend,
+            prompt_tokens,
+            &self.weights,
+            &self.config,
+            Some(&mut kv_cache),
+            Some(&mut linear_state),
+            self.active_lora.as_ref(),
+        )
+        .context("prefill forward pass failed")?;
         kv_cache.advance(prompt_tokens.len());
 
         let mut generated_tokens: Vec<TokenId> = Vec::new();
@@ -437,8 +528,16 @@ impl ModelRunner {
             }
 
             // Decode step: forward pass on just the new token (KV cache has all previous)
-            let logits = model_forward(&*self.backend, &[next_token], &self.weights, &self.config, Some(&mut kv_cache), Some(&mut linear_state), self.active_lora.as_ref())
-                .context("decode forward pass failed")?;
+            let logits = model_forward(
+                &*self.backend,
+                &[next_token],
+                &self.weights,
+                &self.config,
+                Some(&mut kv_cache),
+                Some(&mut linear_state),
+                self.active_lora.as_ref(),
+            )
+            .context("decode forward pass failed")?;
             kv_cache.advance(1);
 
             // Sample next token from the new logits
@@ -484,7 +583,8 @@ impl ModelRunner {
             .map_err(|e| anyhow::anyhow!("{e}"))
             .context("failed to tokenize prompt")?;
 
-        let output = self.generate_from_tokens_paged(&prompt_tokens, params, block_manager, paged_cache)?;
+        let output =
+            self.generate_from_tokens_paged(&prompt_tokens, params, block_manager, paged_cache)?;
 
         let text = self
             .tokenizer
@@ -526,14 +626,241 @@ impl ModelRunner {
         }
 
         // Run generation with paged cache; free blocks on completion (or error)
-        let result = self.generate_from_tokens_paged_inner(
-            prompt_tokens, params, paged_cache, &block_table,
-        );
+        let result =
+            self.generate_from_tokens_paged_inner(prompt_tokens, params, paged_cache, &block_table);
 
         // Always free allocated blocks
         block_manager.free_all(&allocated_blocks);
 
         result
+    }
+
+    /// Generate text from a prompt using shared paged-cache state protected by
+    /// short-lived mutexes.
+    ///
+    /// On backends with CUDA graph replay enabled we preserve the existing
+    /// whole-request lock scope because the graph state is runner-global.
+    /// On non-CUDA desktop paths (Metal / CPU), blocks are reserved up front,
+    /// the block manager is released immediately, and the paged cache is locked
+    /// only around prefill / decode forward passes so concurrent requests can
+    /// interleave between decode steps.
+    pub fn generate_paged_shared(
+        &self,
+        prompt: &str,
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+    ) -> Result<GenerationOutput> {
+        let prompt_tokens = self
+            .tokenizer
+            .encode(prompt)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("failed to tokenize prompt")?;
+
+        let output = self.generate_from_tokens_paged_shared(
+            &prompt_tokens,
+            params,
+            block_manager,
+            paged_cache,
+        )?;
+
+        let text = self
+            .tokenizer
+            .decode(&output.token_ids)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("failed to decode output tokens")?;
+
+        Ok(GenerationOutput {
+            text,
+            token_ids: output.token_ids,
+            finish_reason: output.finish_reason,
+        })
+    }
+
+    fn generate_from_tokens_paged_shared(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+    ) -> Result<GenerationOutput> {
+        anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
+
+        let cuda_graph_enabled = self
+            .cuda_graph
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?
+            .is_enabled();
+        if cuda_graph_enabled {
+            let mut bm_guard = lock_block_manager(block_manager)?;
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            return self.generate_from_tokens_paged(
+                prompt_tokens,
+                params,
+                &mut bm_guard,
+                &mut pc_guard,
+            );
+        }
+
+        let max_total = prompt_tokens.len() + params.max_tokens;
+        let (reservation, block_table) = {
+            let mut bm_guard = lock_block_manager(block_manager)?;
+            let block_size = bm_guard.block_size();
+            let num_blocks = Self::blocks_needed(max_total, block_size);
+            let block_ids = bm_guard
+                .allocate(num_blocks)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let mut block_table = BlockTable::new();
+            for &block_id in &block_ids {
+                block_table.push(block_id);
+            }
+            (
+                SharedBlockReservation {
+                    block_manager,
+                    block_ids,
+                },
+                block_table,
+            )
+        };
+
+        let result = self.generate_from_tokens_paged_interleaved(
+            prompt_tokens,
+            params,
+            paged_cache,
+            &block_table,
+        );
+
+        drop(reservation);
+        result
+    }
+
+    fn generate_from_tokens_paged_interleaved(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+    ) -> Result<GenerationOutput> {
+        let mut linear_state = self.new_linear_state()?;
+
+        let logits = {
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            if streaming_prefill_enabled() {
+                model_forward_paged_streaming(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                )
+                .context("prefill forward pass (paged, streaming) failed")?
+            } else {
+                model_forward_paged(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("prefill forward pass (paged) failed")?
+            }
+        };
+
+        let mut seq_len = prompt_tokens.len();
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
+        let mut step_seed = params.seed;
+
+        let mut next_token = if params.temperature == 0.0 {
+            greedy_sample(&logits)?
+        } else {
+            sample_with_params(
+                &logits,
+                params.temperature,
+                params.top_p,
+                params.top_k,
+                step_seed,
+            )?
+        };
+
+        for _step in 0..params.max_tokens {
+            if let Some(s) = step_seed.as_mut() {
+                *s = s.wrapping_add(1);
+            }
+
+            if self.eos_token_ids.contains(&next_token) {
+                return Ok(GenerationOutput {
+                    text: String::new(),
+                    token_ids: generated_tokens,
+                    finish_reason: FinishReason::Eos,
+                });
+            }
+
+            generated_tokens.push(next_token);
+
+            if !params.stop.is_empty() {
+                let decoded_so_far = self
+                    .tokenizer
+                    .decode(&generated_tokens)
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+                    .ok();
+                if let Some(text) = &decoded_so_far {
+                    for stop_seq in &params.stop {
+                        if text.contains(stop_seq.as_str()) {
+                            return Ok(GenerationOutput {
+                                text: String::new(),
+                                token_ids: generated_tokens,
+                                finish_reason: FinishReason::StopSequence(stop_seq.clone()),
+                            });
+                        }
+                    }
+                }
+            }
+
+            let logits = {
+                let mut pc_guard = lock_paged_cache(paged_cache)?;
+                model_forward_paged(
+                    &*self.backend,
+                    &[next_token],
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    seq_len,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("decode forward pass (paged) failed")?
+            };
+            seq_len += 1;
+
+            next_token = if params.temperature == 0.0 {
+                greedy_sample(&logits)?
+            } else {
+                sample_with_params(
+                    &logits,
+                    params.temperature,
+                    params.top_p,
+                    params.top_k,
+                    step_seed,
+                )?
+            };
+        }
+
+        Ok(GenerationOutput {
+            text: String::new(),
+            token_ids: generated_tokens,
+            finish_reason: FinishReason::MaxTokens,
+        })
     }
 
     /// Inner generation loop using paged KV cache (blocks already allocated).
@@ -583,7 +910,9 @@ impl ModelRunner {
         let mut step_seed = params.seed;
 
         // Acquire the CUDA graph runner for decode steps
-        let mut graph_runner = self.cuda_graph.lock()
+        let mut graph_runner = self
+            .cuda_graph
+            .lock()
             .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?;
 
         // Sample first token
@@ -1188,6 +1517,596 @@ impl ModelRunner {
         })
     }
 
+    /// Streaming self-speculative decoding (skip-layer draft).
+    ///
+    /// Mirrors [`generate_from_tokens_speculative`] but emits committed tokens
+    /// incrementally through the returned channel so the SSE desktop path can
+    /// benefit from the existing speculative setting.
+    pub fn generate_streaming_speculative(
+        &self,
+        prompt: &str,
+        params: &SamplingParams,
+        spec_config: &SpeculativeConfig,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        use rand::SeedableRng;
+
+        let prompt_tokens = self
+            .tokenizer
+            .encode(prompt)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("failed to tokenize prompt")?;
+
+        anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
+        spec_config
+            .validate(&self.config)
+            .context("invalid speculative config")?;
+
+        let (tx, rx) = mpsc::channel();
+        let max_total = prompt_tokens.len() + params.max_tokens;
+        let mut kv_cache = self.new_kv_cache(max_total)?;
+        let mut linear_state = self.new_linear_state()?;
+        let mut draft_linear_state = self.new_linear_state()?;
+
+        let logits = model_forward(
+            &*self.backend,
+            &prompt_tokens,
+            &self.weights,
+            &self.config,
+            Some(&mut kv_cache),
+            Some(&mut linear_state),
+            self.active_lora.as_ref(),
+        )
+        .context("prefill forward pass failed")?;
+        kv_cache.advance(prompt_tokens.len());
+
+        let _ = crate::speculative::draft_forward_for_state_init(
+            &*self.backend,
+            &prompt_tokens,
+            &self.weights,
+            &self.config,
+            spec_config.draft_layers,
+            &mut draft_linear_state,
+        );
+
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
+        let mut finish_reason = FinishReason::MaxTokens;
+        let mut rng = match params.seed {
+            Some(s) => rand::rngs::StdRng::seed_from_u64(s),
+            None => rand::rngs::StdRng::from_entropy(),
+        };
+
+        let mut last_token = if params.temperature == 0.0 {
+            greedy_sample(&logits)?
+        } else {
+            sample_with_params(
+                &logits,
+                params.temperature,
+                params.top_p,
+                params.top_k,
+                params.seed,
+            )?
+        };
+
+        loop {
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            if self.eos_token_ids.contains(&last_token) {
+                finish_reason = FinishReason::Eos;
+                break;
+            }
+
+            match emit_stream_token(
+                &tx,
+                &self.tokenizer,
+                &mut generated_tokens,
+                last_token,
+                &params.stop,
+            ) {
+                StreamTokenDisposition::Continue => {}
+                StreamTokenDisposition::Finished(reason) => {
+                    let completion_tokens = generated_tokens.len();
+                    let _ = tx.send(StreamEvent::Done(StreamDone {
+                        finish_reason: reason,
+                        completion_tokens,
+                    }));
+                    return Ok(rx);
+                }
+                StreamTokenDisposition::ReceiverDropped => return Ok(rx),
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            let remaining = params.max_tokens - generated_tokens.len();
+            let effective_k = spec_config.num_speculative_tokens.min(remaining);
+            let effective_config = SpeculativeConfig {
+                num_speculative_tokens: effective_k,
+                draft_layers: spec_config.draft_layers,
+            };
+
+            let result = speculative_decode_step(
+                &*self.backend,
+                last_token,
+                &self.weights,
+                &self.config,
+                &mut kv_cache,
+                &mut linear_state,
+                &mut draft_linear_state,
+                &effective_config,
+                params,
+                &self.eos_token_ids,
+                &mut rng,
+                self.active_lora.as_ref(),
+            )
+            .context("speculative decode step failed")?;
+
+            if result.accepted_tokens.is_empty() {
+                if result.hit_eos {
+                    finish_reason = FinishReason::Eos;
+                }
+                break;
+            }
+
+            for &token in &result.accepted_tokens[..result.accepted_tokens.len() - 1] {
+                match emit_stream_token(
+                    &tx,
+                    &self.tokenizer,
+                    &mut generated_tokens,
+                    token,
+                    &params.stop,
+                ) {
+                    StreamTokenDisposition::Continue => {}
+                    StreamTokenDisposition::Finished(reason) => {
+                        let completion_tokens = generated_tokens.len();
+                        let _ = tx.send(StreamEvent::Done(StreamDone {
+                            finish_reason: reason,
+                            completion_tokens,
+                        }));
+                        return Ok(rx);
+                    }
+                    StreamTokenDisposition::ReceiverDropped => return Ok(rx),
+                }
+
+                if generated_tokens.len() >= params.max_tokens {
+                    break;
+                }
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            last_token = *result.accepted_tokens.last().unwrap();
+
+            if result.hit_eos {
+                finish_reason = FinishReason::Eos;
+                break;
+            }
+        }
+
+        let _ = tx.send(StreamEvent::Done(StreamDone {
+            finish_reason,
+            completion_tokens: generated_tokens.len(),
+        }));
+
+        Ok(rx)
+    }
+
+    /// Streaming native-MTP speculative decoding.
+    ///
+    /// Mirrors [`generate_from_tokens_mtp_speculative`] but emits committed
+    /// tokens as they are accepted so the desktop streaming path can use MTP
+    /// when the checkpoint and request settings allow it.
+    pub fn generate_streaming_mtp_speculative(
+        &self,
+        prompt: &str,
+        params: &SamplingParams,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        use rand::SeedableRng;
+
+        let prompt_tokens = self
+            .tokenizer
+            .encode(prompt)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("failed to tokenize prompt")?;
+
+        anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
+        anyhow::ensure!(
+            self.weights.mtp.is_some(),
+            "generate_streaming_mtp_speculative requires the checkpoint to carry mtp.* tensors \
+             (Qwen3.5-4B native MTP head)"
+        );
+        anyhow::ensure!(
+            params.temperature == 0.0,
+            "generate_streaming_mtp_speculative currently only supports greedy decoding \
+             (temperature == 0)"
+        );
+
+        const BLOCK_SIZE: usize = 16;
+
+        let max_total = prompt_tokens.len() + params.max_tokens;
+        let device = self.weights.embed_tokens.device();
+        let dtype = match self.config.dtype {
+            kiln_core::config::DType::BF16 => DType::BF16,
+            kiln_core::config::DType::FP16 => DType::F16,
+            kiln_core::config::DType::FP32 => DType::F32,
+        };
+
+        let num_blocks = Self::blocks_needed(max_total, BLOCK_SIZE);
+        let mut base_cache = PagedKvCache::new(
+            self.config.num_full_attention_layers,
+            num_blocks,
+            BLOCK_SIZE,
+            self.config.num_kv_heads,
+            self.config.head_dim,
+            dtype,
+            device,
+        )?;
+        let mut mtp_cache = PagedKvCache::new(
+            1,
+            num_blocks,
+            BLOCK_SIZE,
+            self.config.num_kv_heads,
+            self.config.head_dim,
+            dtype,
+            device,
+        )?;
+        let mut base_block_table = BlockTable::new();
+        let mut mtp_block_table = BlockTable::new();
+        for i in 0..num_blocks as u32 {
+            base_block_table.push(i);
+            mtp_block_table.push(i);
+        }
+
+        let (tx, rx) = mpsc::channel();
+        let mut linear_state = self.new_linear_state()?;
+
+        let (prefill_logits, mut h_prev) = model_forward_paged_with_last_hidden(
+            &*self.backend,
+            &prompt_tokens,
+            &self.weights,
+            &self.config,
+            &mut base_cache,
+            &base_block_table,
+            0,
+            Some(&mut linear_state),
+            self.active_lora.as_ref(),
+            None,
+        )
+        .context("mtp prefill forward pass failed")?;
+
+        let prefill_last = prefill_logits
+            .narrow(1, prompt_tokens.len() - 1, 1)?
+            .squeeze(1)?;
+        let mut last_token = greedy_sample(&prefill_last)?;
+
+        let mut base_pos = prompt_tokens.len();
+        let mut mtp_pos = 0usize;
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
+        let mut finish_reason = FinishReason::MaxTokens;
+        let mut rng = match params.seed {
+            Some(s) => rand::rngs::StdRng::seed_from_u64(s),
+            None => rand::rngs::StdRng::from_entropy(),
+        };
+
+        loop {
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            if self.eos_token_ids.contains(&last_token) {
+                finish_reason = FinishReason::Eos;
+                break;
+            }
+
+            match emit_stream_token(
+                &tx,
+                &self.tokenizer,
+                &mut generated_tokens,
+                last_token,
+                &params.stop,
+            ) {
+                StreamTokenDisposition::Continue => {}
+                StreamTokenDisposition::Finished(reason) => {
+                    let completion_tokens = generated_tokens.len();
+                    let _ = tx.send(StreamEvent::Done(StreamDone {
+                        finish_reason: reason,
+                        completion_tokens,
+                    }));
+                    return Ok(rx);
+                }
+                StreamTokenDisposition::ReceiverDropped => return Ok(rx),
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            let result = speculative_mtp_decode_step(
+                &*self.backend,
+                last_token,
+                &h_prev,
+                &self.weights,
+                &self.config,
+                &mut base_cache,
+                &base_block_table,
+                base_pos,
+                &mut mtp_cache,
+                &mtp_block_table,
+                mtp_pos,
+                params,
+                &self.eos_token_ids,
+                &mut rng,
+            )
+            .context("mtp speculative decode step failed")?;
+
+            base_pos += result.base_advance;
+            mtp_pos += result.mtp_advance;
+            h_prev = result.new_h_prev;
+
+            if result.accepted_tokens.is_empty() {
+                if result.hit_eos {
+                    finish_reason = FinishReason::Eos;
+                }
+                break;
+            }
+
+            for &token in &result.accepted_tokens[..result.accepted_tokens.len() - 1] {
+                match emit_stream_token(
+                    &tx,
+                    &self.tokenizer,
+                    &mut generated_tokens,
+                    token,
+                    &params.stop,
+                ) {
+                    StreamTokenDisposition::Continue => {}
+                    StreamTokenDisposition::Finished(reason) => {
+                        let completion_tokens = generated_tokens.len();
+                        let _ = tx.send(StreamEvent::Done(StreamDone {
+                            finish_reason: reason,
+                            completion_tokens,
+                        }));
+                        return Ok(rx);
+                    }
+                    StreamTokenDisposition::ReceiverDropped => return Ok(rx),
+                }
+
+                if generated_tokens.len() >= params.max_tokens {
+                    break;
+                }
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            last_token = *result.accepted_tokens.last().unwrap();
+
+            if result.hit_eos {
+                finish_reason = FinishReason::Eos;
+                break;
+            }
+        }
+
+        let _ = tx.send(StreamEvent::Done(StreamDone {
+            finish_reason,
+            completion_tokens: generated_tokens.len(),
+        }));
+
+        Ok(rx)
+    }
+
+    /// Streaming generation using shared paged-cache state protected by
+    /// short-lived mutexes.
+    ///
+    /// Mirrors [`generate_paged_shared`]: CUDA graph-enabled runtimes keep the
+    /// existing whole-request lock scope, while non-CUDA desktop paths reserve
+    /// blocks up front and lock the paged cache only around prefill / decode
+    /// forward passes.
+    pub fn generate_streaming_paged_shared(
+        &self,
+        prompt: &str,
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        let prompt_tokens = self
+            .tokenizer
+            .encode(prompt)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("failed to tokenize prompt")?;
+
+        self.generate_from_tokens_streaming_paged_shared(
+            &prompt_tokens,
+            params,
+            block_manager,
+            paged_cache,
+        )
+    }
+
+    fn generate_from_tokens_streaming_paged_shared(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
+
+        let cuda_graph_enabled = self
+            .cuda_graph
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?
+            .is_enabled();
+        if cuda_graph_enabled {
+            let mut bm_guard = lock_block_manager(block_manager)?;
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            return self.generate_from_tokens_streaming_paged_locked(
+                prompt_tokens,
+                params,
+                &mut bm_guard,
+                &mut pc_guard,
+            );
+        }
+
+        let max_total = prompt_tokens.len() + params.max_tokens;
+        let (reservation, block_table) = {
+            let mut bm_guard = lock_block_manager(block_manager)?;
+            let block_size = bm_guard.block_size();
+            let num_blocks = Self::blocks_needed(max_total, block_size);
+            let block_ids = bm_guard
+                .allocate(num_blocks)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let mut block_table = BlockTable::new();
+            for &block_id in &block_ids {
+                block_table.push(block_id);
+            }
+            (
+                SharedBlockReservation {
+                    block_manager,
+                    block_ids,
+                },
+                block_table,
+            )
+        };
+
+        let result = self.generate_from_tokens_streaming_paged_interleaved(
+            prompt_tokens,
+            params,
+            paged_cache,
+            &block_table,
+        );
+
+        drop(reservation);
+        result
+    }
+
+    fn generate_from_tokens_streaming_paged_interleaved(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        let (tx, rx) = mpsc::channel();
+        let mut linear_state = self.new_linear_state()?;
+
+        let logits = {
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            if streaming_prefill_enabled() {
+                model_forward_paged_streaming(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                )
+                .context("prefill forward pass (paged, streaming) failed")?
+            } else {
+                model_forward_paged(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("prefill forward pass (paged) failed")?
+            }
+        };
+
+        let mut seq_len = prompt_tokens.len();
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
+        let mut step_seed = params.seed;
+        let mut finish_reason = FinishReason::MaxTokens;
+
+        let mut next_token = if params.temperature == 0.0 {
+            greedy_sample(&logits)?
+        } else {
+            sample_with_params(
+                &logits,
+                params.temperature,
+                params.top_p,
+                params.top_k,
+                step_seed,
+            )?
+        };
+
+        for _step in 0..params.max_tokens {
+            if let Some(s) = step_seed.as_mut() {
+                *s = s.wrapping_add(1);
+            }
+
+            if self.eos_token_ids.contains(&next_token) {
+                finish_reason = FinishReason::Eos;
+                break;
+            }
+
+            match emit_stream_token(
+                &tx,
+                &self.tokenizer,
+                &mut generated_tokens,
+                next_token,
+                &params.stop,
+            ) {
+                StreamTokenDisposition::Continue => {}
+                StreamTokenDisposition::Finished(reason) => {
+                    finish_reason = reason;
+                    break;
+                }
+                StreamTokenDisposition::ReceiverDropped => return Ok(rx),
+            }
+
+            let logits = {
+                let mut pc_guard = lock_paged_cache(paged_cache)?;
+                model_forward_paged(
+                    &*self.backend,
+                    &[next_token],
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    seq_len,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("decode forward pass (paged) failed")?
+            };
+            seq_len += 1;
+
+            next_token = if params.temperature == 0.0 {
+                greedy_sample(&logits)?
+            } else {
+                sample_with_params(
+                    &logits,
+                    params.temperature,
+                    params.top_p,
+                    params.top_k,
+                    step_seed,
+                )?
+            };
+        }
+
+        let _ = tx.send(StreamEvent::Done(StreamDone {
+            finish_reason,
+            completion_tokens: generated_tokens.len(),
+        }));
+
+        Ok(rx)
+    }
+
     /// Streaming generation using paged KV cache.
     ///
     /// Same as [`generate_streaming`] but uses paged KV cache for memory-efficient
@@ -1205,6 +2124,21 @@ impl ModelRunner {
             .map_err(|e| anyhow::anyhow!("{e}"))
             .context("failed to tokenize prompt")?;
 
+        self.generate_from_tokens_streaming_paged_locked(
+            &prompt_tokens,
+            params,
+            block_manager,
+            paged_cache,
+        )
+    }
+
+    fn generate_from_tokens_streaming_paged_locked(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &mut BlockManager,
+        paged_cache: &mut PagedKvCache,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
         anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
 
         let block_size = block_manager.block_size();
@@ -1265,7 +2199,9 @@ impl ModelRunner {
         let mut finish_reason = FinishReason::MaxTokens;
 
         // Acquire CUDA graph runner for decode steps
-        let mut graph_runner = self.cuda_graph.lock()
+        let mut graph_runner = self
+            .cuda_graph
+            .lock()
             .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?;
 
         let mut next_token = if params.temperature == 0.0 {
@@ -1292,10 +2228,7 @@ impl ModelRunner {
 
             generated_tokens.push(next_token);
 
-            let token_text = self
-                .tokenizer
-                .decode(&[next_token])
-                .unwrap_or_default();
+            let token_text = self.tokenizer.decode(&[next_token]).unwrap_or_default();
 
             if tx
                 .send(StreamEvent::Token(StreamToken {
@@ -1465,12 +2398,9 @@ mod tests {
             },
         };
 
-        let rotary_inv_freq = crate::forward::compute_rotary_inv_freq(
-            config.rotary_dim(),
-            config.rope_theta,
-            device,
-        )
-        .unwrap();
+        let rotary_inv_freq =
+            crate::forward::compute_rotary_inv_freq(config.rotary_dim(), config.rope_theta, device)
+                .unwrap();
 
         GpuWeights {
             embed_tokens: embed,
@@ -1633,7 +2563,10 @@ mod tests {
         let out2 = runner.generate_from_tokens(&[1, 2], &params)?;
 
         // Same seed should give same results
-        assert_eq!(out1.token_ids, out2.token_ids, "same seed should be deterministic");
+        assert_eq!(
+            out1.token_ids, out2.token_ids,
+            "same seed should be deterministic"
+        );
         assert_eq!(out1.token_ids.len(), 5);
 
         Ok(())
@@ -1725,6 +2658,48 @@ mod tests {
 
         // Blocks should be freed after generation
         assert_eq!(block_manager.num_free(), num_blocks);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_generate_paged_shared_max_tokens() -> Result<()> {
+        let config = tiny_config();
+        let device = Device::Cpu;
+        let weights = tiny_weights(&config, &device);
+        let tokenizer = test_tokenizer();
+
+        let runner = ModelRunner::new(weights, tokenizer, config.clone());
+
+        let block_size = 4;
+        let num_blocks = 16;
+        let block_manager = Mutex::new(BlockManager::new(num_blocks, block_size));
+        let paged_cache = Mutex::new(PagedKvCache::new(
+            config.num_full_attention_layers,
+            num_blocks,
+            block_size,
+            config.num_kv_heads,
+            config.head_dim,
+            candle_core::DType::F32,
+            &device,
+        )?);
+
+        let params = SamplingParams {
+            temperature: 0.0,
+            max_tokens: 5,
+            ..Default::default()
+        };
+
+        let output = runner.generate_from_tokens_paged_shared(
+            &[1, 2, 3],
+            &params,
+            &block_manager,
+            &paged_cache,
+        )?;
+
+        assert_eq!(output.token_ids.len(), 5);
+        assert_eq!(output.finish_reason, FinishReason::MaxTokens);
+        assert_eq!(block_manager.lock().unwrap().num_free(), num_blocks);
 
         Ok(())
     }
@@ -1825,6 +2800,73 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_paged_shared_concurrent_requests_complete() -> Result<()> {
+        let config = tiny_config();
+        let device = Device::Cpu;
+        let weights = tiny_weights(&config, &device);
+        let tokenizer = test_tokenizer();
+
+        let runner = std::sync::Arc::new(ModelRunner::new(weights, tokenizer, config.clone()));
+        let block_size = 4;
+        let num_blocks = 16;
+        let block_manager =
+            std::sync::Arc::new(Mutex::new(BlockManager::new(num_blocks, block_size)));
+        let paged_cache = std::sync::Arc::new(Mutex::new(PagedKvCache::new(
+            config.num_full_attention_layers,
+            num_blocks,
+            block_size,
+            config.num_kv_heads,
+            config.head_dim,
+            candle_core::DType::F32,
+            &device,
+        )?));
+
+        let params = SamplingParams {
+            temperature: 0.0,
+            max_tokens: 3,
+            ..Default::default()
+        };
+
+        let handle_a = {
+            let runner = runner.clone();
+            let block_manager = block_manager.clone();
+            let paged_cache = paged_cache.clone();
+            let params = params.clone();
+            std::thread::spawn(move || {
+                runner.generate_from_tokens_paged_shared(
+                    &[1, 2, 3],
+                    &params,
+                    block_manager.as_ref(),
+                    paged_cache.as_ref(),
+                )
+            })
+        };
+        let handle_b = {
+            let runner = runner.clone();
+            let block_manager = block_manager.clone();
+            let paged_cache = paged_cache.clone();
+            let params = params.clone();
+            std::thread::spawn(move || {
+                runner.generate_from_tokens_paged_shared(
+                    &[4, 5, 6],
+                    &params,
+                    block_manager.as_ref(),
+                    paged_cache.as_ref(),
+                )
+            })
+        };
+
+        let output_a = handle_a.join().unwrap()?;
+        let output_b = handle_b.join().unwrap()?;
+
+        assert_eq!(output_a.token_ids.len(), 3);
+        assert_eq!(output_b.token_ids.len(), 3);
+        assert_eq!(block_manager.lock().unwrap().num_free(), num_blocks);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_paged_eos_detection() -> Result<()> {
         let config = tiny_config();
         let device = Device::Cpu;
@@ -1864,7 +2906,10 @@ mod tests {
         )?;
 
         assert_eq!(output.finish_reason, FinishReason::Eos);
-        assert!(output.token_ids.is_empty(), "all tokens are EOS, should stop immediately");
+        assert!(
+            output.token_ids.is_empty(),
+            "all tokens are EOS, should stop immediately"
+        );
 
         // Blocks freed
         assert_eq!(block_manager.num_free(), num_blocks);

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -5,8 +5,8 @@ use axum::response::{IntoResponse, Response};
 use axum::routing::post;
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
-use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
+use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
 use std::path::Path;
@@ -15,8 +15,9 @@ use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
 use kiln_core::tokenizer::ChatMessage;
 use kiln_model::lora_loader::LoraWeights;
-use kiln_model::{ModelRunner, StreamEvent};
+use kiln_model::{GenerationOutput, ModelRunner, SpeculativeConfig, StreamEvent};
 
+use crate::config::{SpecMethod, SpeculativeDecodingConfig};
 use crate::error::ApiError;
 use crate::metrics::RequestStatus;
 use crate::state::{AppState, ModelBackend};
@@ -73,7 +74,9 @@ where
         Content::Parts(parts) => {
             let mut out = String::new();
             for part in parts {
-                let Some(obj) = part.as_object() else { continue };
+                let Some(obj) = part.as_object() else {
+                    continue;
+                };
                 let ty = obj.get("type").and_then(|v| v.as_str()).unwrap_or("");
                 if ty == "text" {
                     if let Some(text) = obj.get("text").and_then(|v| v.as_str()) {
@@ -135,6 +138,67 @@ pub struct Delta {
     pub role: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+enum ResolvedSpeculativeMode {
+    Off,
+    SkipLayer(SpeculativeConfig),
+    Mtp,
+}
+
+fn resolve_skip_layer_config(
+    model_config: &kiln_core::config::ModelConfig,
+    speculative: &SpeculativeDecodingConfig,
+) -> Option<SpeculativeConfig> {
+    let config = SpeculativeConfig {
+        num_speculative_tokens: speculative.num_speculative_tokens,
+        draft_layers: speculative.draft_layers,
+    };
+
+    config.validate(model_config).ok().map(|_| config)
+}
+
+fn resolve_speculative_mode_from_config(
+    model_config: &kiln_core::config::ModelConfig,
+    speculative: &SpeculativeDecodingConfig,
+    sampling: &SamplingParams,
+    mtp_supported: bool,
+    has_active_lora: bool,
+) -> ResolvedSpeculativeMode {
+    let skip_layer = resolve_skip_layer_config(model_config, speculative);
+
+    match speculative.effective_method() {
+        SpecMethod::Off => ResolvedSpeculativeMode::Off,
+        SpecMethod::SkipLayer => skip_layer
+            .map(ResolvedSpeculativeMode::SkipLayer)
+            .unwrap_or(ResolvedSpeculativeMode::Off),
+        SpecMethod::Mtp => {
+            if mtp_supported && sampling.temperature == 0.0 && !has_active_lora {
+                ResolvedSpeculativeMode::Mtp
+            } else {
+                skip_layer
+                    .map(ResolvedSpeculativeMode::SkipLayer)
+                    .unwrap_or(ResolvedSpeculativeMode::Off)
+            }
+        }
+    }
+}
+
+fn resolve_speculative_mode(
+    state: &AppState,
+    sampling: &SamplingParams,
+    mtp_supported: bool,
+    has_active_lora: bool,
+) -> ResolvedSpeculativeMode {
+    let speculative = SpeculativeDecodingConfig::from_env();
+    resolve_speculative_mode_from_config(
+        &state.model_config,
+        &speculative,
+        sampling,
+        mtp_supported,
+        has_active_lora,
+    )
 }
 
 async fn chat_completions(
@@ -284,7 +348,10 @@ async fn ensure_adapter(
             // Two-phase load: read device/num_layers, load weights, then swap.
             let (device, num_layers) = {
                 let guard = runner.read().unwrap();
-                (guard.weights.embed_tokens.device().clone(), guard.config.num_layers)
+                (
+                    guard.weights.embed_tokens.device().clone(),
+                    guard.config.num_layers,
+                )
             };
 
             let runner = runner.clone();
@@ -338,6 +405,13 @@ async fn generate_real(
         .map_err(ApiError::tokenization_failed)?
         .len();
 
+    let (mtp_supported, has_active_lora) = {
+        let guard = runner.read().unwrap();
+        (guard.weights.mtp.is_some(), guard.active_lora().is_some())
+    };
+    let speculative_mode =
+        resolve_speculative_mode(state, sampling, mtp_supported, has_active_lora);
+
     // ModelRunner.generate_paged() is CPU-bound; run on a blocking thread to
     // avoid starving the tokio runtime.
     let runner = runner.clone();
@@ -353,9 +427,22 @@ async fn generate_real(
         // but blocks while training holds the write lock.
         let _gpu_guard = gpu_lock.read().unwrap();
         let runner_guard = runner.read().unwrap();
-        let mut bm_guard = bm.lock().unwrap();
-        let mut pc_guard = pc.lock().unwrap();
-        runner_guard.generate_paged(&prompt, &params, &mut bm_guard, &mut pc_guard)
+        match speculative_mode {
+            ResolvedSpeculativeMode::Off => {
+                runner_guard.generate_paged_shared(&prompt, &params, bm.as_ref(), pc.as_ref())
+            }
+            ResolvedSpeculativeMode::SkipLayer(spec_config) => {
+                runner_guard.generate_speculative(&prompt, &params, &spec_config)
+            }
+            ResolvedSpeculativeMode::Mtp => {
+                let output = runner_guard.generate_mtp_speculative(&prompt, &params)?;
+                Ok(GenerationOutput {
+                    text: output.text,
+                    token_ids: output.token_ids,
+                    finish_reason: output.finish_reason,
+                })
+            }
+        }
     });
 
     let output = match tokio::time::timeout(timeout, generation).await {
@@ -417,6 +504,13 @@ async fn generate_real_streaming(
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
 ) -> Result<Response, ApiError> {
+    let (mtp_supported, has_active_lora) = {
+        let guard = runner.read().unwrap();
+        (guard.weights.mtp.is_some(), guard.active_lora().is_some())
+    };
+    let speculative_mode =
+        resolve_speculative_mode(state, sampling, mtp_supported, has_active_lora);
+
     let runner = runner.clone();
     let bm = block_manager.clone();
     let pc = paged_cache.clone();
@@ -462,21 +556,57 @@ async fn generate_real_streaming(
                 return;
             }
 
-            // Run blocking generation with paged KV cache
-            let sync_rx = match tokio::task::spawn_blocking(move || {
-                // Acquire GPU coordination read lock
-                let _gpu_guard = gpu_lock.read().unwrap();
-                let runner_guard = runner.read().unwrap();
-                let mut bm_guard = bm.lock().unwrap();
-                let mut pc_guard = pc.lock().unwrap();
-                runner_guard.generate_streaming_paged(&prompt, &params, &mut bm_guard, &mut pc_guard)
-            })
-            .await
-            {
-                Ok(Ok(rx)) => rx,
-                _ => {
-                    let _ = tx.send(Event::default().data("[DONE]")).await;
-                    return;
+            let sync_rx = match speculative_mode {
+                ResolvedSpeculativeMode::Off => {
+                    match tokio::task::spawn_blocking(move || {
+                        // Acquire GPU coordination read lock
+                        let _gpu_guard = gpu_lock.read().unwrap();
+                        let runner_guard = runner.read().unwrap();
+                        runner_guard.generate_streaming_paged_shared(
+                            &prompt,
+                            &params,
+                            bm.as_ref(),
+                            pc.as_ref(),
+                        )
+                    })
+                    .await
+                    {
+                        Ok(Ok(rx)) => rx,
+                        _ => {
+                            let _ = tx.send(Event::default().data("[DONE]")).await;
+                            return;
+                        }
+                    }
+                }
+                ResolvedSpeculativeMode::SkipLayer(spec_config) => {
+                    match tokio::task::spawn_blocking(move || {
+                        let _gpu_guard = gpu_lock.read().unwrap();
+                        let runner_guard = runner.read().unwrap();
+                        runner_guard.generate_streaming_speculative(&prompt, &params, &spec_config)
+                    })
+                    .await
+                    {
+                        Ok(Ok(rx)) => rx,
+                        _ => {
+                            let _ = tx.send(Event::default().data("[DONE]")).await;
+                            return;
+                        }
+                    }
+                }
+                ResolvedSpeculativeMode::Mtp => {
+                    match tokio::task::spawn_blocking(move || {
+                        let _gpu_guard = gpu_lock.read().unwrap();
+                        let runner_guard = runner.read().unwrap();
+                        runner_guard.generate_streaming_mtp_speculative(&prompt, &params)
+                    })
+                    .await
+                    {
+                        Ok(Ok(rx)) => rx,
+                        _ => {
+                            let _ = tx.send(Event::default().data("[DONE]")).await;
+                            return;
+                        }
+                    }
                 }
             };
 
@@ -597,10 +727,7 @@ async fn generate_real_streaming(
                     }],
                 };
                 let _ = tx
-                    .send(
-                        Event::default()
-                            .data(serde_json::to_string(&error_chunk).unwrap()),
-                    )
+                    .send(Event::default().data(serde_json::to_string(&error_chunk).unwrap()))
                     .await;
                 let _ = tx.send(Event::default().data("[DONE]")).await;
             }
@@ -653,28 +780,14 @@ async fn generate_mock(
         // Build batch input
         let batch = kiln_model::engine::BatchInput {
             token_ids: vec![0; step_output.total_tokens],
-            seqlens: step_output
-                .scheduled
-                .iter()
-                .map(|s| s.num_tokens)
-                .collect(),
+            seqlens: step_output.scheduled.iter().map(|s| s.num_tokens).collect(),
             slot_mapping: vec![0; step_output.total_tokens],
-            block_tables: step_output
-                .scheduled
-                .iter()
-                .map(|_| vec![0])
-                .collect(),
+            block_tables: step_output.scheduled.iter().map(|_| vec![0]).collect(),
             is_prefill: step_output.scheduled.iter().map(|s| s.is_prefill).collect(),
-            request_ids: step_output
-                .scheduled
-                .iter()
-                .map(|s| s.request_id)
-                .collect(),
+            request_ids: step_output.scheduled.iter().map(|s| s.request_id).collect(),
         };
 
-        let engine_output = engine
-            .step(&batch)
-            .map_err(ApiError::generation_failed)?;
+        let engine_output = engine.step(&batch).map_err(ApiError::generation_failed)?;
 
         for (rid, token, finished) in &engine_output.results {
             if *rid == request_id {
@@ -753,16 +866,23 @@ pub fn routes() -> Router<AppState> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::SpecMethod;
+    use kiln_core::config::ModelConfig;
 
     fn parse_request(json: &str) -> ChatCompletionRequest {
         serde_json::from_str(json).expect("request should deserialize")
     }
 
+    fn make_sampling(temperature: f32) -> SamplingParams {
+        SamplingParams {
+            temperature,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn content_accepts_plain_string() {
-        let req = parse_request(
-            r#"{"messages":[{"role":"user","content":"hello"}]}"#,
-        );
+        let req = parse_request(r#"{"messages":[{"role":"user","content":"hello"}]}"#);
         assert_eq!(req.messages[0].content, "hello");
     }
 
@@ -784,9 +904,7 @@ mod tests {
 
     #[test]
     fn content_empty_array_is_empty_string() {
-        let req = parse_request(
-            r#"{"messages":[{"role":"user","content":[]}]}"#,
-        );
+        let req = parse_request(r#"{"messages":[{"role":"user","content":[]}]}"#);
         assert_eq!(req.messages[0].content, "");
     }
 
@@ -797,5 +915,86 @@ mod tests {
         );
         assert_eq!(req.messages[0].content, "be nice");
         assert_eq!(req.messages[1].content, "hi");
+    }
+
+    #[test]
+    fn speculative_toggle_defaults_to_skip_layer() {
+        let cfg = SpeculativeDecodingConfig {
+            enabled: true,
+            method: SpecMethod::Off,
+            num_speculative_tokens: 4,
+            draft_layers: 8,
+        };
+        let mode = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &make_sampling(1.0),
+            false,
+            false,
+        );
+
+        match mode {
+            ResolvedSpeculativeMode::SkipLayer(spec) => {
+                assert_eq!(spec.num_speculative_tokens, 4);
+                assert_eq!(spec.draft_layers, 8);
+            }
+            _ => panic!("desktop toggle should resolve to skip-layer"),
+        }
+    }
+
+    #[test]
+    fn mtp_requires_greedy_request_and_no_lora() {
+        let cfg = SpeculativeDecodingConfig {
+            enabled: true,
+            method: SpecMethod::Mtp,
+            num_speculative_tokens: 4,
+            draft_layers: 8,
+        };
+
+        let greedy = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &make_sampling(0.0),
+            true,
+            false,
+        );
+        assert!(matches!(greedy, ResolvedSpeculativeMode::Mtp));
+
+        let sampled = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &make_sampling(0.7),
+            true,
+            false,
+        );
+        assert!(matches!(sampled, ResolvedSpeculativeMode::SkipLayer(_)));
+
+        let with_lora = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &make_sampling(0.0),
+            true,
+            true,
+        );
+        assert!(matches!(with_lora, ResolvedSpeculativeMode::SkipLayer(_)));
+    }
+
+    #[test]
+    fn invalid_skip_layer_config_falls_back_to_off() {
+        let cfg = SpeculativeDecodingConfig {
+            enabled: true,
+            method: SpecMethod::SkipLayer,
+            num_speculative_tokens: 4,
+            draft_layers: ModelConfig::qwen3_5_4b().num_layers,
+        };
+        let mode = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &make_sampling(1.0),
+            false,
+            false,
+        );
+
+        assert!(matches!(mode, ResolvedSpeculativeMode::Off));
     }
 }

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -298,6 +298,42 @@ impl Default for SpeculativeDecodingConfig {
 }
 
 impl SpeculativeDecodingConfig {
+    /// Build the speculative config from defaults plus the KILN_SPEC_* env vars.
+    ///
+    /// This mirrors the desktop app's control surface, which drives kiln
+    /// through env vars rather than CLI flags.
+    pub fn from_env() -> Self {
+        let mut cfg = Self::default();
+        cfg.apply_env_overrides();
+        cfg
+    }
+
+    fn apply_env_overrides(&mut self) {
+        if let Ok(v) = std::env::var("KILN_SPEC_ENABLED") {
+            self.enabled = v == "1" || v.eq_ignore_ascii_case("true");
+        }
+        if let Ok(v) = std::env::var("KILN_SPEC_METHOD") {
+            if let Some(m) = SpecMethod::parse_env(&v) {
+                self.method = m;
+            } else {
+                tracing::warn!(
+                    "ignoring unknown KILN_SPEC_METHOD='{}' (expected off|skip_layer|mtp)",
+                    v
+                );
+            }
+        }
+        if let Ok(v) = std::env::var("KILN_SPEC_NUM_TOKENS") {
+            if let Ok(n) = v.parse() {
+                self.num_speculative_tokens = n;
+            }
+        }
+        if let Ok(v) = std::env::var("KILN_SPEC_DRAFT_LAYERS") {
+            if let Ok(n) = v.parse() {
+                self.draft_layers = n;
+            }
+        }
+    }
+
     /// Resolve the effective speculative-decoding method.
     ///
     /// Returns `Off` if the feature is disabled; otherwise returns the

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -11,12 +11,13 @@ use kiln_server::device::select_device;
 use kiln_server::state;
 
 use kiln_core::config::ModelConfig;
+use kiln_core::sampling::SamplingParams;
 use kiln_core::tokenizer::KilnTokenizer;
 use kiln_model::ModelRunner;
 use kiln_model::engine::MockEngine;
 use kiln_model::forward::GpuWeights;
 use kiln_scheduler::{Scheduler, SchedulerConfig};
-use state::AppState;
+use state::{AppState, ModelBackend};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -199,6 +200,7 @@ async fn main() -> Result<()> {
     let shutdown_flag = state.shutdown.clone();
     kiln_server::training_queue::spawn_training_worker(state.clone(), shutdown_flag.clone());
 
+    spawn_backend_prewarm(state.clone());
     let app = api::router(state);
 
     let addr = format!("{host}:{port}");
@@ -209,7 +211,6 @@ async fn main() -> Result<()> {
         model_path = model_path.unwrap_or("none (mock mode)"),
         "kiln listening"
     );
-
     // Graceful shutdown: listen for SIGTERM/SIGINT, drain in-flight requests,
     // then force-exit after a timeout.
     let shutdown_timeout_secs = config.server.shutdown_timeout_secs;
@@ -228,6 +229,63 @@ async fn main() -> Result<()> {
     tracing::warn!("shutdown timeout reached — exiting");
 
     Ok(())
+}
+
+fn spawn_backend_prewarm(state: AppState) {
+    let ModelBackend::Real {
+        runner,
+        block_manager,
+        paged_cache,
+    } = state.backend.as_ref()
+    else {
+        return;
+    };
+
+    let is_metal = {
+        let runner_guard = runner.read().unwrap();
+        matches!(
+            runner_guard.weights.embed_tokens.device(),
+            candle_core::Device::Metal(_)
+        )
+    };
+    if !is_metal {
+        return;
+    }
+
+    let runner = runner.clone();
+    let block_manager = block_manager.clone();
+    let paged_cache = paged_cache.clone();
+
+    tokio::spawn(async move {
+        let prewarm = tokio::task::spawn_blocking(move || {
+            let runner_guard = runner.read().unwrap();
+            let mut bm_guard = block_manager.lock().unwrap();
+            let mut pc_guard = paged_cache.lock().unwrap();
+            let params = SamplingParams {
+                temperature: 0.0,
+                top_p: 1.0,
+                top_k: 0,
+                max_tokens: 1,
+                repetition_penalty: 1.0,
+                stop: Vec::new(),
+                seed: Some(42),
+            };
+            let prompt_tokens = [1_u32, 2, 3, 4, 5, 6, 7, 8];
+            runner_guard.generate_from_tokens_paged(
+                &prompt_tokens,
+                &params,
+                &mut bm_guard,
+                &mut pc_guard,
+            )
+        })
+        .await;
+
+        match prewarm {
+            Ok(Ok(_)) => tracing::info!("background inference prewarm complete"),
+            Ok(Err(err)) => tracing::warn!(error = %err, "background inference prewarm failed"),
+            Err(err) => tracing::warn!(error = %err, "background inference prewarm task failed"),
+        }
+    });
 }
 
 /// Wait for SIGTERM or SIGINT, then signal shutdown.

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -286,19 +286,19 @@ impl AppState {
             * block_size
             * kv_dtype_bytes) as u64;
 
-        // Detect VRAM for auto-configuration
+        // Detect VRAM once and reuse it for both auto-sizing and reporting so
+        // startup doesn't repeat the same probe/logging path.
         let vram_info = kiln_core::vram::detect_vram();
+        let total_vram = detected_gpu_total_memory(&device, &vram_info);
 
         // Determine num_blocks — either from config, or memory-aware auto-calculation
         let num_blocks = if let Some(explicit) = memory_cfg.num_blocks {
             explicit
         } else {
             // Try to compute from available VRAM and inference fraction
-            let total_vram = query_gpu_total_memory(&device);
             if total_vram > 0 && bytes_per_block > 0 {
-                let available_for_kv =
-                    ((total_vram.saturating_sub(estimated_model_bytes)) as f64 * inference_fraction)
-                        as u64;
+                let available_for_kv = ((total_vram.saturating_sub(estimated_model_bytes)) as f64
+                    * inference_fraction) as u64;
                 let auto_blocks = (available_for_kv / bytes_per_block) as usize;
                 let auto_blocks = auto_blocks.max(64); // minimum 64 blocks
                 tracing::info!(
@@ -331,10 +331,7 @@ impl AppState {
                 std::env::var("KILN_ALLOW_FP8_ON_METAL").as_deref(),
                 Ok("1") | Ok("true") | Ok("TRUE")
             );
-            if requested
-                && matches!(device, candle_core::Device::Metal(_))
-                && !metal_override
-            {
+            if requested && matches!(device, candle_core::Device::Metal(_)) && !metal_override {
                 tracing::warn!(
                     "FP8 cache disabled on Metal (CPU round-trip cost); \
                      set KILN_ALLOW_FP8_ON_METAL=1 to override"
@@ -344,7 +341,13 @@ impl AppState {
                 requested
             }
         };
-        tracing::info!(num_blocks, block_size, ?kv_dtype, fp8_enabled, "allocating paged KV cache");
+        tracing::info!(
+            num_blocks,
+            block_size,
+            ?kv_dtype,
+            fp8_enabled,
+            "allocating paged KV cache"
+        );
 
         let block_manager = BlockManager::new(num_blocks, block_size);
         let paged_cache = PagedKvCache::new_with_fp8(
@@ -360,7 +363,6 @@ impl AppState {
         .expect("failed to create PagedKvCache");
 
         let kv_cache_bytes = num_blocks as u64 * bytes_per_block;
-        let total_vram = query_gpu_total_memory(&device);
         let memory_budget = GpuMemoryBudget::compute(
             total_vram,
             estimated_model_bytes,
@@ -418,8 +420,7 @@ fn estimate_model_memory_bytes(config: &ModelConfig) -> u64 {
     // Per layer: ~8 * hidden_size^2 + 3 * hidden_size * intermediate_size (approximate)
     // LM head: vocab_size * hidden_size (often tied with embedding)
     let embedding_params = config.vocab_size as u64 * config.hidden_size as u64;
-    let per_layer_params =
-        8 * (config.hidden_size as u64 * config.hidden_size as u64)
+    let per_layer_params = 8 * (config.hidden_size as u64 * config.hidden_size as u64)
         + 3 * (config.hidden_size as u64 * config.intermediate_size as u64);
     let total_params = embedding_params + per_layer_params * config.num_layers as u64;
 
@@ -430,8 +431,10 @@ fn estimate_model_memory_bytes(config: &ModelConfig) -> u64 {
 ///
 /// Uses the shared VRAM detection from kiln-core (nvidia-smi + sysctl
 /// hw.memsize on Apple Silicon + env override).
-fn query_gpu_total_memory(device: &candle_core::Device) -> u64 {
-    let vram = kiln_core::vram::detect_vram();
+fn detected_gpu_total_memory(
+    device: &candle_core::Device,
+    vram: &kiln_core::vram::GpuVramInfo,
+) -> u64 {
     match device {
         #[cfg(feature = "cuda")]
         candle_core::Device::Cuda(_) => {
@@ -502,13 +505,17 @@ mod tests {
         // Only 4GB available for training
         assert_eq!(budget.training_budget_bytes, 4 * 1024 * 1024 * 1024);
         // Requesting 8GB should fail
-        assert!(budget
-            .check_training_feasible(8 * 1024 * 1024 * 1024)
-            .is_err());
+        assert!(
+            budget
+                .check_training_feasible(8 * 1024 * 1024 * 1024)
+                .is_err()
+        );
         // Requesting 3GB should succeed
-        assert!(budget
-            .check_training_feasible(3 * 1024 * 1024 * 1024)
-            .is_ok());
+        assert!(
+            budget
+                .check_training_feasible(3 * 1024 * 1024 * 1024)
+                .is_ok()
+        );
     }
 
     #[test]
@@ -528,7 +535,10 @@ mod tests {
         let bytes = estimate_model_memory_bytes(&config);
         let gb = bytes as f64 / 1e9;
         // Should be in the ballpark of 8GB for Qwen3.5-4B bf16
-        assert!(gb > 4.0 && gb < 20.0, "model estimate {gb:.1}GB seems wrong");
+        assert!(
+            gb > 4.0 && gb < 20.0,
+            "model estimate {gb:.1}GB seems wrong"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What changed

This tightens the real macOS desktop default path instead of adding another opt-in path.

- restores safe contiguous cached transposes in `kiln-model` and adds a real single-token GDN fallback fast path for non-CUDA backends
- adds a background Metal inference prewarm on server startup so first-request kernel setup happens before the first user prompt
- removes duplicated VRAM detection on startup
- narrows the real paged-generation lock scope so non-CUDA shared generation no longer holds the disabled graph path across the whole request
- makes speculative-mode resolution in completions self-contained from the desktop/env-driven config surface

## Why

The desktop app was still too slow on macOS under its normal default env/arg flow.

The main problems in this batch were:

- first inference on Metal was still paying a large warmup cost
- the real server path still held graph-disabled generation locks for too long on macOS
- the Apple fallback path for single-token GDN decode was far too expensive
- one intermediate transpose-view experiment regressed startup and runtime, so this PR keeps the safe contiguous behavior

## User impact

This does not make macOS fast enough yet, but it improves the default path without requiring hidden flags.

Observed locally against the desktop-installed `Qwen/Qwen3.5-4B` model on Apple Silicon:

- isolated benchmark `Model loaded in` improved back to about `47.45s` after regressing to about `95.77s` during investigation
- tiny paged benchmark prefill improved from the regressed `63.30s` back down to about `28.91s`
- tiny paged benchmark decode improved from about `18.73s/token` to about `12.56s/token`
- background Metal prewarm after `kiln listening` improved from about `58.4s` to about `47.0s`
- a warmed `/v1/chat/completions` request with `max_tokens=1` completed in about `32.49s`

## Root cause

The desktop default path was still bottlenecked by Apple fallback behavior rather than just launch configuration:

- single-token GDN on non-CUDA backends was falling through to the chunkwise recurrence machinery
- the real server path still serialized more than necessary around generation on graph-disabled runtimes
- startup had duplicated VRAM detection and no background inference warmup

## Validation

Ran locally:

- `cargo test -p kiln-model test_gdn_single_token_matches_sequential --features metal`
- `cargo test -p kiln-server content_accepts_plain_string -- --test-threads=1`
- `cargo test -p kiln-model test_model_forward_parity_cpu_vs_metal --features metal`
- `cargo build --release --features metal --bin kiln --bin kiln-bench`
- real-server smoke test against the desktop-installed model
- real benchmark runs with `./target/release/kiln-bench --model-path "$HOME/Library/Application Support/com.eflorenzano.kiln.desktop/models/Qwen__Qwen3.5-4B" --prompt-tokens 8 --max-output-tokens 1 --skip-training --paged`
