### PR TITLE
desktop: tray Copy OpenAI Base URL — notify when server not running

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -352,6 +352,16 @@ async fn copy_openai_base_url_to_clipboard(app: &AppHandle, supervisor: Arc<Supe
             "[tray] copy OpenAI base URL skipped — server not running (state: {})",
             state_label(&state)
         );
+        let body = match &state {
+            ServerState::Error(msg) => format!("Server not running ({}).", msg),
+            _ => format!("Server is {}. Start it first.", state_label(&state)),
+        };
+        let _ = app
+            .notification()
+            .builder()
+            .title("OpenAI base URL unavailable")
+            .body(body)
+            .show();
         return;
     }
     let (host, port) = {


### PR DESCRIPTION
Mirrors the notification pattern already used by Open Kiln UI in Browser (sibling handler in tray.rs). Before this change, clicking Copy OpenAI Base URL while the server was Stopped / Error / NoBinary silently no-opped — no clipboard write and no feedback. Now the user gets a native notification matching the sibling handler.

Local cargo test cannot run in Cloud Eric sessions (missing GTK/glib-2.0). CI (desktop-build.yml across macos-14, ubuntu-22.04, windows-latest, with cargo test on Ubuntu via PR #251) validates. Review diff: ~10 lines, single function.

Follows the preflight/notification polish pattern of PRs #250, #252, and #254.