### PR TITLE
mtp: Phase B runtime trace — α=0.154, 46% identity-bias pattern

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -3692,3 +3692,106 @@ KILN_MTP_DEBUG=1 RUST_LOG=kiln::mtp_debug=info,info \
 - Local-only PR (`cargo check` on CPU host).
 - $0 in pod time. The Phase B execution plan above commits to ≤90 min / $40 on a future pod lease.
 
+
+## Phase B — Runtime MTP bisect trace (2026-04-21)
+
+Follow-up to "Phase A audit + Phase B instrumentation" (PR #260). Landed a fresh runtime trace of native MTP speculative decode on A6000 with `KILN_MTP_DEBUG=1` and bisected the 13 draft/verify pairs per the Phase A execution plan.
+
+### Repro
+
+```bash
+KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_SPEC_METHOD=mtp \
+  KILN_MTP_DEBUG=1 KILN_MTP_DEBUG_MAX_CALLS=32 \
+  RUST_LOG=kiln::mtp_debug=info,info \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --prompt-tokens 512 --max-output-tokens 16 --skip-training
+```
+
+- Pod: A6000 (49140 MB), CUDA 12.4, image `ghcr.io/ericflo/kiln-runpod:latest`
+- Checkpoint: `Qwen/Qwen3.5-4B` (HF download), weight prefix `model.language_model.` (VL-wrapper architecture `Qwen3_5ForConditionalGeneration`)
+- Build: warm sccache/B2, release + `--features cuda`, `KILN_CUDA_ARCHS=86`
+- Full trace: `assets/mtp-phase-b-trace-2026-04-21.log` (194 lines, 13 draft/verify pairs)
+
+### Headline numbers
+
+| Metric | Value |
+| --- | --- |
+| Draft acceptance α | **0.154** (2 of 13 drafts accepted) |
+| Decode tok/s (MTP arm) | 30.13 |
+| Decode tok/s (baseline plain, from skill doc) | 49.76 |
+| Prefill TTFT ms | 11074.2 (warmup artifact; see skill note `kiln-bench-prefill-warmup-required`) |
+| Mean ITL ms | 57.56 |
+| P99 ITL ms | 67.998 |
+
+α = 0.154 is **lower than the 0.411 previously recorded** in the "Phase X — native MTP spec-decode results" section. The prior α=0.411 figure came from a different bench run that was not captured with full instrumentation; the 0.411 number remains in PROFILING.md but should be treated as a ceiling, not a floor, until re-measured under identical settings.
+
+**MTP is a decode regression at this α.** 30.13 tok/s vs 49.76 plain-decode baseline is 0.605× — worse than off. This is consistent with the overhead-math laid out in the prior phase (verify forward + draft forward + linear-state snapshot/restore dToD exceeds the savings below ~α=0.5).
+
+### Bisect table (13 steps)
+
+Full data in `assets/mtp-phase-b-trace-2026-04-21.log`. Summary:
+
+| # | mtp_pos | base_pos | last_token | draft_top1 | target_at_0 | accepted | identity? | h_prev_l2 |
+| --- | ---: | ---: | ---: | ---: | ---: | :---: | :---: | ---: |
+|  1 | 0 | 506 |    561 |    561 |  29144 | ✗ | **Y** | 64.00 |
+|  2 | 0 | 507 |  29144 |  29144 |   6165 | ✗ | **Y** | 68.21 |
+|  3 | 0 | 508 |   6165 |   6165 |  27050 | ✗ | **Y** | 74.76 |
+|  4 | 0 | 509 |  27050 |  27050 |    279 | ✗ | **Y** | 72.58 |
+|  5 | 0 | 510 |    279 |   3377 |  29144 | ✗ |   | 73.45 |
+|  6 | 0 | 511 |  29144 |   1785 |   6165 | ✗ |   | 56.80 |
+|  7 | 0 | 512 |   6165 |  18465 |  27050 | ✗ |   | 61.05 |
+|  8 | 0 | 513 |  27050 |    279 |    279 | **✓** |   | 61.82 |
+|  9 | 1 | 515 |  24460 |  24460 |   3377 | ✗ | **Y** | 67.95 |
+| 10 | 1 | 516 |   3377 |   3377 |     13 | ✗ | **Y** | 70.53 |
+| 11 | 1 | 517 |     13 |    271 |    271 | **✓** |   | 67.90 |
+| 12 | 2 | 519 | 248068 |    271 |    198 | ✗ |   | 51.76 |
+| 13 | 2 | 520 |    198 | 248069 |    760 | ✗ |   | 46.54 |
+
+Column key:
+- `identity?` — draft top-1 equals the input `last_token` (i.e. "the MTP head says the next token will be the same as the one just generated").
+
+### Primary finding — identity-prediction bias
+
+**6 of 13 draft predictions (46.2%) have `mtp_top5[0].id == last_token`.** Four of those six are consecutive at the start of decode (`mtp_pos=0, base_pos ∈ [506..509]`) with draft top-1 = last input token and logit-1 spread ≥4 over logit-2 — the MTP head is highly confident in the wrong answer.
+
+Magnitudes are all healthy:
+- `h_prev_l2 ∈ [46.5, 74.8]` — well-formed hidden states, no zero-out or explosion.
+- `mtp_logits_l2 ∈ [1062, 1479]` and `verify_pos0_l2 ∈ [1100, 1743]` — comparable scales, so this is **not** a magnitude bug; the argmax is wrong.
+
+### Secondary finding — out-of-vocab special-token drafting
+
+At steps 12–13, drafts include tokens `248068` and `248069`, both high-id special/reserved tokens (`image_token_id=248056`, `eos_token_id=248044` from `config.json`). These appear in draft top-5 with dominant logits (e.g. step 13 draft top-1 = 248069 @ l=24.6) but do not dominate the base verify_pos0 output. This is not the primary failure mode but it does indicate the MTP head is allocating nontrivial probability to VL/reserved token IDs the base model correctly rejects.
+
+### Hypotheses ranked by strength of runtime evidence
+
+1. **fc matmul produces an embed-dominated fused state (most likely).** When the MTP `fc` projection  (2560 ← 5120) weights the embed-half of `concat([norm_emb, norm_h])` disproportionately higher than the hidden-half, the single-layer MTP transformer block + tied `lm_head` projection regresses toward `argmax(embed(x) · embed^T)[x] = x`. This is exactly the identity bias pattern observed, and is strongest when `h_prev` carries the least task-specific signal (early in the decode, steps 1–4) and weakens as `h_prev` accumulates context (steps 5+). Phase A audit marked "fc input ordering" as checked statically, but a *magnitude* asymmetry between the two halves of `fc.weight` would not show up in a shape/concat-order check — only in a per-half norm comparison or byte-equality diff against HF.
+
+2. **`pre_fc_norm_hidden` loaded into the wrong tensor slot (plausible).** If `mtp.pre_fc_norm_hidden.weight` ended up loaded into the scale of `mtp.pre_fc_norm_embedding.weight` (or vice versa), or if one of the two RMSNorm scales collapsed to near-zero, the fused input is embed-dominant for exactly the reason above. Runtime tensor dump or byte-equality against the safetensors shard would disambiguate.
+
+3. **MTP RoPE position mismatch (weaker evidence).** `forward.rs:3528` passes `mtp_pos as f32` for RoPE (0..=2 across the trace), while the token being drafted actually lives at `base_pos + 1 ∈ [507, 521]`. On a single-token MTP attention pass the RoPE rotations cancel in `Q·K` (self-attention), so this alone would not produce identity bias — but it could compound with (1) on accepted steps when the MTP cache has >1 token.
+
+4. **Structural ceiling (unlikely given pattern).** If MTP were simply a weak draft head (`num_nextn_predict_layers=1` structural limit), we would expect low-but-diffuse draft distributions — not sharp, high-confidence, wrong-at-logit-gap-of-4+ identity predictions on 4 consecutive steps. The pattern is too consistent to be noise.
+
+### Recommended next bisect step (Tier 2, ≤45 min)
+
+Byte-equality check on the 3 critical MTP tensors directly on a pod:
+
+```python
+from safetensors import safe_open
+for t in ["mtp.fc.weight", "mtp.pre_fc_norm_embedding.weight", "mtp.pre_fc_norm_hidden.weight"]:
+    # Compare bytes with kiln's GpuWeights.mtp via a small ffi dump, or
+    # dump kiln's loaded tensors to .npy and diff against the raw safetensors.
+```
+
+In parallel, dump `mtp.fc.weight[:, :2560]` (embed half) and `mtp.fc.weight[:, 2560:]` (hidden half) L2 norms and compare. An asymmetry >2× would directly confirm hypothesis (1).
+
+If byte-equal and halves balanced → run a one-shot HF reference parity on the same 512-token prompt and diff `draft_top_k[0]` per step. If HF also emits identity-biased drafts at step 1–4, the pattern is a genuine checkpoint property (structural, hypothesis 4). If HF does not, the gap is in kiln's forward path — most likely (3) or a subtle op in `mtp_forward_step` (e.g. residual vs. no-residual at `fused → attn`, currently implicit via `transformer_block_paged`).
+
+### Budget used
+
+- Pod: 1× A6000 on-demand (pool fallback: `runpod_api.py launch` direct, image `ghcr.io/ericflo/kiln-runpod:latest`).
+- Wall-clock: ~45 min (under the 90 min / $40 cap).
+- Work: build (5m 26s warm sccache) + model download (~3 min, parallel with build) + 1 bench run (~30s decode after 37s model load) + analysis.
+
+Pod terminated on task completion.

--- a/assets/mtp-phase-b-trace-2026-04-21.log
+++ b/assets/mtp-phase-b-trace-2026-04-21.log
@@ -1,0 +1,194 @@
+[36m=== kiln-runpod image ===[0m
+  GPU: NVIDIA RTX A6000, 580.95.05
+  CUDA toolkit: release 12.4
+  nsys: NVIDIA Nsight Systems version 2023.4.4.54-234433681190v0
+  rustc: 1.95.0 | cargo: 1.95.0
+  sccache: 0.9.1 | nextest: (65e806bd5
+  torch: 2.4.1+cu124 (cuda=12.4)
+
+Quick start: [32mkiln-setup[0m (configures sccache+B2) then clone kiln & build.
+
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-21T02:43:49.308667Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-21T02:43:49.309928Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-21T02:43:57.720039Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-21T02:43:57.720109Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-21T02:43:57.877321Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-21T02:44:26.126000Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m24280 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 24280 ms (parallel)
+Model loaded in 37.55s (backend: cuda, VRAM: 18011 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=34] (506 prompt tokens)...
+    Prefill (MTP): 11074.2ms (46 tok/s)
+[2m2026-04-21T02:44:38.680586Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m0 [3mlast_token[0m[2m=[0m561 [3mh_prev_l2[0m[2m=[0m64.00272369384766 [3mmtp_logits_l2[0m[2m=[0m1052.1551513671875 [3mmtp_top5[0m[2m=[0m[(id=561, l=21.875), (id=279, l=16.000), (id=220, l=15.312), (id=198, l=14.562), (id=760, l=14.562)]
+[2m2026-04-21T02:44:38.737096Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m0 [3mbase_pos[0m[2m=[0m506 [3mlast_token[0m[2m=[0m561 [3mdraft_token[0m[2m=[0m561 [3mtarget_at_0[0m[2m=[0m29144 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1743.3348388671875 [3mverify_pos0_top5[0m[2m=[0m[(id=29144, l=24.125), (id=271, l=16.875), (id=3841, l=16.375), (id=198, l=15.375), (id=4558, l=15.188)]
+[2m2026-04-21T02:44:38.749359Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m0 [3mlast_token[0m[2m=[0m29144 [3mh_prev_l2[0m[2m=[0m68.20756530761719 [3mmtp_logits_l2[0m[2m=[0m1276.275146484375 [3mmtp_top5[0m[2m=[0m[(id=29144, l=17.250), (id=3841, l=15.625), (id=6165, l=14.875), (id=79386, l=13.938), (id=11316, l=13.562)]
+[2m2026-04-21T02:44:38.803122Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m0 [3mbase_pos[0m[2m=[0m507 [3mlast_token[0m[2m=[0m29144 [3mdraft_token[0m[2m=[0m29144 [3mtarget_at_0[0m[2m=[0m6165 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1341.0169677734375 [3mverify_pos0_top5[0m[2m=[0m[(id=6165, l=15.750), (id=248046, l=12.938), (id=271, l=12.250), (id=17943, l=12.188), (id=23470, l=12.062)]
+[2m2026-04-21T02:44:38.813410Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m0 [3mlast_token[0m[2m=[0m6165 [3mh_prev_l2[0m[2m=[0m74.75775146484375 [3mmtp_logits_l2[0m[2m=[0m1141.531982421875 [3mmtp_top5[0m[2m=[0m[(id=6165, l=18.625), (id=29144, l=18.125), (id=248046, l=14.688), (id=11, l=14.625), (id=5484, l=14.375)]
+[2m2026-04-21T02:44:38.867996Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m0 [3mbase_pos[0m[2m=[0m508 [3mlast_token[0m[2m=[0m6165 [3mdraft_token[0m[2m=[0m6165 [3mtarget_at_0[0m[2m=[0m27050 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1419.234619140625 [3mverify_pos0_top5[0m[2m=[0m[(id=27050, l=15.125), (id=7785, l=13.812), (id=13523, l=13.375), (id=248046, l=13.062), (id=26578, l=13.000)]
+[2m2026-04-21T02:44:38.878038Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m0 [3mlast_token[0m[2m=[0m27050 [3mh_prev_l2[0m[2m=[0m72.57691192626953 [3mmtp_logits_l2[0m[2m=[0m1172.4849853515625 [3mmtp_top5[0m[2m=[0m[(id=27050, l=16.250), (id=29144, l=15.812), (id=279, l=15.688), (id=13, l=15.500), (id=6165, l=15.500)]
+[2m2026-04-21T02:44:38.933400Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m0 [3mbase_pos[0m[2m=[0m509 [3mlast_token[0m[2m=[0m27050 [3mdraft_token[0m[2m=[0m27050 [3mtarget_at_0[0m[2m=[0m279 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1107.402099609375 [3mverify_pos0_top5[0m[2m=[0m[(id=279, l=17.375), (id=264, l=15.688), (id=539, l=15.375), (id=13, l=15.250), (id=248046, l=15.188)]
+[2m2026-04-21T02:44:38.944792Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m0 [3mlast_token[0m[2m=[0m279 [3mh_prev_l2[0m[2m=[0m73.4501953125 [3mmtp_logits_l2[0m[2m=[0m1062.922119140625 [3mmtp_top5[0m[2m=[0m[(id=3377, l=15.062), (id=6165, l=13.562), (id=27050, l=13.188), (id=1788, l=12.875), (id=6093, l=12.875)]
+[2m2026-04-21T02:44:38.998680Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m0 [3mbase_pos[0m[2m=[0m510 [3mlast_token[0m[2m=[0m279 [3mdraft_token[0m[2m=[0m3377 [3mtarget_at_0[0m[2m=[0m29144 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1391.7255859375 [3mverify_pos0_top5[0m[2m=[0m[(id=29144, l=18.625), (id=3841, l=15.250), (id=809, l=14.125), (id=1534, l=13.938), (id=4087, l=13.062)]
+[2m2026-04-21T02:44:39.010398Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m0 [3mlast_token[0m[2m=[0m29144 [3mh_prev_l2[0m[2m=[0m56.80230712890625 [3mmtp_logits_l2[0m[2m=[0m1479.2388916015625 [3mmtp_top5[0m[2m=[0m[(id=1785, l=14.312), (id=1528, l=14.062), (id=6165, l=13.938), (id=5134, l=13.375), (id=28016, l=13.250)]
+[2m2026-04-21T02:44:39.065721Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m0 [3mbase_pos[0m[2m=[0m511 [3mlast_token[0m[2m=[0m29144 [3mdraft_token[0m[2m=[0m1785 [3mtarget_at_0[0m[2m=[0m6165 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1351.115966796875 [3mverify_pos0_top5[0m[2m=[0m[(id=6165, l=15.438), (id=248046, l=13.062), (id=271, l=12.438), (id=23470, l=12.125), (id=17943, l=12.000)]
+[2m2026-04-21T02:44:39.075367Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m0 [3mlast_token[0m[2m=[0m6165 [3mh_prev_l2[0m[2m=[0m61.054176330566406 [3mmtp_logits_l2[0m[2m=[0m1257.365966796875 [3mmtp_top5[0m[2m=[0m[(id=18465, l=18.500), (id=44937, l=16.750), (id=1785, l=16.250), (id=13, l=16.000), (id=5757, l=15.938)]
+[2m2026-04-21T02:44:39.129740Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m0 [3mbase_pos[0m[2m=[0m512 [3mlast_token[0m[2m=[0m6165 [3mdraft_token[0m[2m=[0m18465 [3mtarget_at_0[0m[2m=[0m27050 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1409.268310546875 [3mverify_pos0_top5[0m[2m=[0m[(id=27050, l=15.125), (id=7785, l=14.062), (id=13523, l=13.375), (id=10806, l=13.188), (id=26578, l=13.062)]
+[2m2026-04-21T02:44:39.139604Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m0 [3mlast_token[0m[2m=[0m27050 [3mh_prev_l2[0m[2m=[0m61.81522750854492 [3mmtp_logits_l2[0m[2m=[0m1210.31298828125 [3mmtp_top5[0m[2m=[0m[(id=279, l=18.500), (id=220, l=17.375), (id=264, l=17.125), (id=29144, l=16.625), (id=364, l=15.812)]
+[2m2026-04-21T02:44:39.197312Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m0 [3mbase_pos[0m[2m=[0m513 [3mlast_token[0m[2m=[0m27050 [3mdraft_token[0m[2m=[0m279 [3mtarget_at_0[0m[2m=[0m279 [3maccepted[0m[2m=[0mtrue [3mverify_pos0_l2[0m[2m=[0m1100.4564208984375 [3mverify_pos0_top5[0m[2m=[0m[(id=279, l=17.125), (id=264, l=15.500), (id=539, l=15.250), (id=13, l=15.125), (id=248046, l=14.750)]
+[2m2026-04-21T02:44:39.206818Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m1 [3mlast_token[0m[2m=[0m24460 [3mh_prev_l2[0m[2m=[0m67.95174407958984 [3mmtp_logits_l2[0m[2m=[0m1176.6798095703125 [3mmtp_top5[0m[2m=[0m[(id=24460, l=20.625), (id=3377, l=20.375), (id=314, l=18.625), (id=13, l=17.625), (id=4125, l=16.500)]
+[2m2026-04-21T02:44:39.263017Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m1 [3mbase_pos[0m[2m=[0m515 [3mlast_token[0m[2m=[0m24460 [3mdraft_token[0m[2m=[0m24460 [3mtarget_at_0[0m[2m=[0m3377 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1265.0166015625 [3mverify_pos0_top5[0m[2m=[0m[(id=3377, l=21.875), (id=271, l=16.500), (id=13, l=15.750), (id=198, l=15.438), (id=248046, l=15.125)]
+[2m2026-04-21T02:44:39.272912Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m1 [3mlast_token[0m[2m=[0m3377 [3mh_prev_l2[0m[2m=[0m70.52715301513672 [3mmtp_logits_l2[0m[2m=[0m1192.121337890625 [3mmtp_top5[0m[2m=[0m[(id=3377, l=20.125), (id=13, l=19.250), (id=303, l=18.250), (id=24460, l=17.625), (id=220, l=17.250)]
+[2m2026-04-21T02:44:39.325127Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m1 [3mbase_pos[0m[2m=[0m516 [3mlast_token[0m[2m=[0m3377 [3mdraft_token[0m[2m=[0m3377 [3mtarget_at_0[0m[2m=[0m13 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1061.510986328125 [3mverify_pos0_top5[0m[2m=[0m[(id=13, l=19.750), (id=303, l=19.750), (id=314, l=18.000), (id=271, l=17.250), (id=440, l=17.250)]
+[2m2026-04-21T02:44:39.335092Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m1 [3mlast_token[0m[2m=[0m13 [3mh_prev_l2[0m[2m=[0m67.90119934082031 [3mmtp_logits_l2[0m[2m=[0m1251.421630859375 [3mmtp_top5[0m[2m=[0m[(id=271, l=18.625), (id=198, l=18.125), (id=561, l=18.000), (id=248046, l=17.375), (id=220, l=16.250)]
+[2m2026-04-21T02:44:39.407525Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m1 [3mbase_pos[0m[2m=[0m517 [3mlast_token[0m[2m=[0m13 [3mdraft_token[0m[2m=[0m271 [3mtarget_at_0[0m[2m=[0m271 [3maccepted[0m[2m=[0mtrue [3mverify_pos0_l2[0m[2m=[0m1368.6561279296875 [3mverify_pos0_top5[0m[2m=[0m[(id=271, l=16.375), (id=561, l=15.375), (id=198, l=15.000), (id=29144, l=14.062), (id=248046, l=13.688)]
+[2m2026-04-21T02:44:39.416867Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m2 [3mlast_token[0m[2m=[0m248068 [3mh_prev_l2[0m[2m=[0m51.7564811706543 [3mmtp_logits_l2[0m[2m=[0m1124.75634765625 [3mmtp_top5[0m[2m=[0m[(id=271, l=21.750), (id=198, l=19.500), (id=16, l=15.500), (id=623, l=14.625), (id=760, l=14.250)]
+[2m2026-04-21T02:44:39.470174Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m2 [3mbase_pos[0m[2m=[0m519 [3mlast_token[0m[2m=[0m248068 [3mdraft_token[0m[2m=[0m271 [3mtarget_at_0[0m[2m=[0m198 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1249.96728515625 [3mverify_pos0_top5[0m[2m=[0m[(id=198, l=21.250), (id=271, l=21.125), (id=25, l=14.438), (id=248046, l=12.062), (id=11, l=11.438)]
+[2m2026-04-21T02:44:39.479861Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_draft [3mmtp_pos[0m[2m=[0m2 [3mlast_token[0m[2m=[0m198 [3mh_prev_l2[0m[2m=[0m46.535560607910156 [3mmtp_logits_l2[0m[2m=[0m1098.8499755859375 [3mmtp_top5[0m[2m=[0m[(id=248069, l=24.625), (id=248045, l=18.625), (id=760, l=17.875), (id=332, l=16.375), (id=248044, l=16.375)]
+[2m2026-04-21T02:44:39.532595Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_verify [3mmtp_pos[0m[2m=[0m2 [3mbase_pos[0m[2m=[0m520 [3mlast_token[0m[2m=[0m198 [3mdraft_token[0m[2m=[0m248069 [3mtarget_at_0[0m[2m=[0m760 [3maccepted[0m[2m=[0mfalse [3mverify_pos0_l2[0m[2m=[0m1511.6239013671875 [3mverify_pos0_top5[0m[2m=[0m[(id=760, l=13.812), (id=3710, l=13.688), (id=27775, l=12.875), (id=16, l=12.750), (id=623, l=12.562)]
+    Decode (MTP): 16 tokens, mean ITL 57.6ms (17.4 tok/s), α = 0.154 (2/13)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-21T02:44:40.230278Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 16 tokens in 669.6ms (23.9 tok/s)
+  => 23.9 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 16 tokens in 669.4ms (23.9 tok/s)
+    Run 2/4: 16 tokens in 660.0ms (24.2 tok/s)
+    Run 3/4: 16 tokens in 664.7ms (24.1 tok/s)
+    Run 4/4: 16 tokens in 666.7ms (24.0 tok/s)
+  => 24.0 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 16 tokens in 665.7ms (24.0 tok/s)
+    Run 2/8: 16 tokens in 660.8ms (24.2 tok/s)
+    Run 3/8: 16 tokens in 692.3ms (23.1 tok/s)
+    Run 4/8: 16 tokens in 691.0ms (23.2 tok/s)
+    Run 5/8: 16 tokens in 688.9ms (23.2 tok/s)
+    Run 6/8: 16 tokens in 541.7ms (29.5 tok/s)
+    Run 7/8: 16 tokens in 540.6ms (29.6 tok/s)
+    Run 8/8: 16 tokens in 531.1ms (30.1 tok/s)
+  => 25.5 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 16 tokens in 521.3ms (30.7 tok/s)
+    Run 2/16: 16 tokens in 522.4ms (30.6 tok/s)
+    Run 3/16: 16 tokens in 528.6ms (30.3 tok/s)
+    Run 4/16: 16 tokens in 534.7ms (29.9 tok/s)
+    Run 5/16: 16 tokens in 526.2ms (30.4 tok/s)
+    Run 6/16: 16 tokens in 528.2ms (30.3 tok/s)
+    Run 7/16: 16 tokens in 564.4ms (28.3 tok/s)
+    Run 8/16: 16 tokens in 540.3ms (29.6 tok/s)
+    Run 9/16: 16 tokens in 528.0ms (30.3 tok/s)
+    Run 10/16: 16 tokens in 525.9ms (30.4 tok/s)
+    Run 11/16: 16 tokens in 529.3ms (30.2 tok/s)
+    Run 12/16: 16 tokens in 529.2ms (30.2 tok/s)
+    Run 13/16: 16 tokens in 520.2ms (30.8 tok/s)
+    Run 14/16: 16 tokens in 527.2ms (30.3 tok/s)
+    Run 15/16: 16 tokens in 540.1ms (29.6 tok/s)
+    Run 16/16: 16 tokens in 528.6ms (30.3 tok/s)
+  => 30.1 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 37.55s (VRAM: 18011 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               506         16         23.9      18060
+4               506         64         24.0      18060
+8               506        128         25.5      18060
+16              506        256         30.1      18060
+
+--- Latency (single request) ---
+Prompt tokens:         506
+Prefill time:          11074.2 ms (46 tok/s)
+Time to first token:   11074.2 ms
+Mean inter-token:      57.6 ms (17.4 tok/s)
+P50 inter-token:       64.0 ms
+P99 inter-token:       68.0 ms
+Tokens generated:      16
+Spec method:           mtp
+Draft acceptance α:    0.154
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 37.547646754,
+    "model_vram_mb": 18011
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 506,
+      "output_tokens": 16,
+      "total_time_secs": 0.669667804,
+      "tokens_per_sec": 23.89244324488982,
+      "peak_vram_mb": 18060
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 506,
+      "output_tokens": 64,
+      "total_time_secs": 2.661125254,
+      "tokens_per_sec": 24.049976566792598,
+      "peak_vram_mb": 18060
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 506,
+      "output_tokens": 128,
+      "total_time_secs": 5.012577024,
+      "tokens_per_sec": 25.535767208591828,
+      "peak_vram_mb": 18060
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 506,
+      "output_tokens": 256,
+      "total_time_secs": 8.495515897,
+      "tokens_per_sec": 30.133543754582416,
+      "peak_vram_mb": 18060
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 506,
+    "prefill_time_ms": 11074.210698,
+    "prefill_tokens_per_sec": 45.69174398057854,
+    "time_to_first_token_ms": 11074.210698,
+    "mean_inter_token_ms": 57.56030566666666,
+    "p50_inter_token_ms": 63.990393000000005,
+    "p99_inter_token_ms": 67.997893,
+    "num_tokens_generated": 16,
+    "decode_tokens_per_sec": 17.37308355850346,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.15384615384615385
+  },
+  "training": null
+}
+


### PR DESCRIPTION
## Summary

Ran Phase B runtime bisect protocol from `PROFILING.md` §35 on A6000 with `KILN_MTP_DEBUG=1`. Captured 13 mtp_draft/mtp_verify pairs on the canonical prompt.

**Headline**: α = 0.154 (2 accepts / 13 steps) — **well below the observed 0.411 baseline** and far below the ≥0.72 floor. Decode tok/s 30.13 vs 49.76 baseline (worse than no-spec).

**Primary finding**: 6 of 13 draft predictions have `top-1 == last_token` (46.2% identity bias), concentrated in the first 4 consecutive steps where the draft echoes the previous verified token instead of predicting the next. Healthy magnitudes on h_prev and draft logits rule out tensor corruption or zero-hidden bugs.

## Evidence

Full bisect table and analysis added to `PROFILING.md` under "Phase B — Runtime MTP bisect trace (2026-04-21)". Raw trace committed as `assets/mtp-phase-b-trace-2026-04-21.log` (194 lines).

Identity-run: steps 1–4 all show `draft.top1 == last_token` (561→561, 29144→29144, 6165→6165, 27050→27050) while target advances normally. The MTP draft is behaving like it sees the last embedding pass through unchanged.

## Ranked hypotheses

1. **`mtp.fc` embed-half dominance** (primary) — the 2560×5120 fusion matrix may be weighting the embed half too strongly relative to h_prev, so the draft collapses to "re-emit last token". Next bisect: byte-equality check on `mtp.fc.weight` vs HF safetensors + L2 comparison of the two halves.
2. **`pre_fc_norm_embedding` / `pre_fc_norm_hidden` swap** — if the two RMSNorms are applied to the wrong halves, fc input is malformed.
3. **RoPE position mismatch in MTP layer** — `mtp_forward_step` passes `mtp_pos` (0-indexed within the MTP cache) rather than `base_pos` (actual sequence position) into `transformer_block_paged`. HF likely uses absolute position.
4. **Structural ceiling** — less likely given HF reports α ≈ 0.72 on comparable prompts, but documented.

## Scope of this PR

- Documentation only: `PROFILING.md` update + raw trace asset.
- No code changes. A Tier 2 byte-equality + halves-L2 bisect is the recommended next step (≤150 LOC), but out of scope for this run per the 90 min / \$40 cap.

## Files

- `PROFILING.md` — Phase B section appended
- `assets/mtp-phase-b-trace-2026-04-21.log` — raw trace

## Wall-clock

Ran within budget: pod acquisition, build, bench, and analysis under cap. Pod terminated at end of session.