### PR TITLE
desktop: notify on Copy OpenAI Base URL success + clipboard failure

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -370,8 +370,27 @@ async fn copy_openai_base_url_to_clipboard(app: &AppHandle, supervisor: Arc<Supe
         (s.host.clone(), s.port)
     };
     let url = crate::openai_base_url(&host, port);
-    if let Err(e) = app.clipboard().write_text(url) {
-        eprintln!("[tray] clipboard write_text failed: {}", e);
+    match app.clipboard().write_text(url.clone()) {
+        Ok(()) => {
+            let _ = app
+                .notification()
+                .builder()
+                .title("OpenAI base URL copied")
+                .body(url)
+                .show();
+        }
+        Err(e) => {
+            eprintln!("[tray] clipboard write_text failed: {}", e);
+            let _ = app
+                .notification()
+                .builder()
+                .title("Copy failed")
+                .body(format!(
+                    "Could not write OpenAI base URL to clipboard: {}",
+                    e
+                ))
+                .show();
+        }
     }
 }
 


### PR DESCRIPTION
## Gap

The tray menu item \`Copy OpenAI Base URL\` → \`copy_openai_base_url_to_clipboard\` in \`desktop/src/tray.rs\` notifies when the server is not running (PR #259), but the success path and the clipboard-write failure path were silent:

- **Success**: URL was copied, user saw nothing — tray menu closes instantly → zero feedback.
- **Failure**: \`app.clipboard().write_text(url)\` error was only \`eprintln\`'d — no user-visible notification.

## Change

Edited \`desktop/src/tray.rs\` \`copy_openai_base_url_to_clipboard\` (~lines 345-376):

1. After successful \`app.clipboard().write_text(url)\`, show a notification:
   - title: \`OpenAI base URL copied\`
   - body: the URL that was copied (so the user sees what's on their clipboard), e.g. \`http://127.0.0.1:8420/v1\`
2. On clipboard \`write_text\` error, show a failure notification in addition to the existing \`eprintln\`:
   - title: \`Copy failed\`
   - body: \`Could not write OpenAI base URL to clipboard: {error}\`

The \"server not running\" branch is unchanged — it already notifies.

Mirror-completion of PR #259 for the two remaining silent branches.

## Local validation

\`cd desktop && cargo check\` fails in Cloud Eric sessions because of missing system GTK/webkit2gtk libraries (known limitation per agent note \`tauri-cargo-check-gtk-missing\` — CE sessions cannot install system packages). Truncated output:

\`\`\`
The system library \`glib-2.0\` required by crate \`glib-sys\` was not found.
The file \`glib-2.0.pc\` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
\`\`\`

The change itself is a tight ~20-line edit to a single function; CI matrix validates the full build on Linux/macOS.