### PR TITLE
desktop: suppress spurious "Kiln server ready" toast on Training→Running

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -474,7 +474,7 @@ fn spawn_state_watcher(
                             .show();
                     }
                 }
-                if kind == "running" && prev_kind != Some("running") {
+                if kind == "running" && should_notify_ready(prev_kind) {
                     let _ = app
                         .notification()
                         .builder()
@@ -550,6 +550,16 @@ pub fn ready_notification_body(port: u16) -> String {
 
 pub fn should_notify_stopped(prev_kind: Option<&str>) -> bool {
     matches!(prev_kind, Some("running") | Some("training"))
+}
+
+/// Return true when the state watcher should fire a "Kiln server ready" native
+/// toast on entry into the `running` kind. Training→Running is a
+/// training-job-finished transition, not a server-startup transition, so
+/// firing the ready toast there would be misleading. `running`→`running` is
+/// already filtered by the caller's equality check but we keep it here so the
+/// predicate is self-contained.
+pub fn should_notify_ready(prev_kind: Option<&str>) -> bool {
+    !matches!(prev_kind, Some("running") | Some("training"))
 }
 
 /// Return true when `settings.model_path` is set to a non-empty, non-whitespace
@@ -760,6 +770,17 @@ mod tests {
         assert!(!should_notify_stopped(Some("starting")));
         assert!(!should_notify_stopped(Some("error")));
         assert!(!should_notify_stopped(Some("stopped")));
+    }
+
+    #[test]
+    fn should_notify_ready_skips_running_and_training() {
+        assert!(should_notify_ready(None));
+        assert!(should_notify_ready(Some("stopped")));
+        assert!(should_notify_ready(Some("starting")));
+        assert!(should_notify_ready(Some("error")));
+        assert!(should_notify_ready(Some("no_binary")));
+        assert!(!should_notify_ready(Some("running")));
+        assert!(!should_notify_ready(Some("training")));
     }
 
     #[test]


### PR DESCRIPTION
## Bug

The state watcher at `desktop/src/tray.rs:477` fires a "Kiln server ready" native OS notification whenever `kind` transitions to `running` from any prev_kind other than `running`. That includes `training`→`running`, which happens whenever a training job completes — the user sees a misleading "server ready" toast even though the server was never down.

## Fix

Add a `should_notify_ready(prev_kind)` helper mirroring the existing `should_notify_stopped`, and gate the running-transition notification on it. The predicate skips both `running`→`running` (already filtered today) AND `training`→`running`.

## Tests

New unit test `should_notify_ready_skips_running_and_training` covers each prev_kind variant (None, stopped, starting, error, no_binary → true; running, training → false). Pure helper — no GTK required. Validated via CI on Ubuntu per PR #251.