### PR TITLE
[codex] speed up macOS default warm path

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -297,12 +297,17 @@ impl LinearAttentionState {
         let dv = config.linear_value_head_dim;
         let conv_dim = config.linear_qkv_dim();
         let k_minus_1 = config.linear_conv_kernel_dim.saturating_sub(1);
+        let recurrent_dtype = match (device, config.dtype) {
+            (Device::Metal(_), kiln_core::config::DType::BF16) => DType::BF16,
+            (Device::Metal(_), kiln_core::config::DType::FP16) => DType::F16,
+            _ => DType::F32,
+        };
 
         let mut recurrent_states = Vec::with_capacity(num_linear_layers);
         let mut conv_states = Vec::with_capacity(num_linear_layers);
 
         for _ in 0..num_linear_layers {
-            recurrent_states.push(Tensor::zeros((1, nv, dk, dv), DType::F32, device)?);
+            recurrent_states.push(Tensor::zeros((1, nv, dk, dv), recurrent_dtype, device)?);
             conv_states.push(Tensor::zeros((1, conv_dim, k_minus_1), DType::F32, device)?);
         }
 
@@ -5618,9 +5623,48 @@ mod tests {
         assert_eq!(state.conv_states.len(), 3);
         // Recurrent state shape: [1, nv, dk, dv]
         assert_eq!(state.recurrent_states[0].dims(), &[1, 4, 4, 4]);
+        assert_eq!(state.recurrent_states[0].dtype(), DType::F32);
         // Conv state shape: [1, qkv_dim, kernel_size-1] where qkv_dim = 2*(nk*dk) + nv*dv = 2*8+16=32
         let qkv_dim = 2 * (2 * 4) + 4 * 4; // 32
         assert_eq!(state.conv_states[0].dims(), &[1, qkv_dim, 3]);
+        assert_eq!(state.conv_states[0].dtype(), DType::F32);
+
+        Ok(())
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn test_linear_attention_state_uses_bf16_on_metal_for_bf16_models() -> Result<()> {
+        let Some(device) = crate::backend::metal::try_new_metal() else {
+            return Ok(());
+        };
+
+        let config = kiln_core::config::ModelConfig {
+            hidden_size: 16,
+            num_layers: 4,
+            num_attention_heads: 4,
+            num_kv_heads: 2,
+            head_dim: 4,
+            intermediate_size: 32,
+            vocab_size: 32,
+            max_position_embeddings: 1024,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10000.0,
+            dtype: kiln_core::config::DType::BF16,
+            num_full_attention_layers: 1,
+            full_attention_interval: 4,
+            attn_output_gate: false,
+            linear_num_key_heads: 2,
+            linear_key_head_dim: 4,
+            linear_num_value_heads: 4,
+            linear_value_head_dim: 4,
+            linear_conv_kernel_dim: 4,
+            partial_rotary_factor: 1.0,
+        };
+
+        let state = LinearAttentionState::new(&config, &device)?;
+        assert_eq!(state.recurrent_states[0].dtype(), DType::BF16);
+        assert_eq!(state.conv_states[0].dtype(), DType::F32);
 
         Ok(())
     }

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
 
 use anyhow::Result;
 use clap::Parser;
@@ -200,7 +202,7 @@ async fn main() -> Result<()> {
     let shutdown_flag = state.shutdown.clone();
     kiln_server::training_queue::spawn_training_worker(state.clone(), shutdown_flag.clone());
 
-    spawn_backend_prewarm(state.clone());
+    let prewarm_state = state.clone();
     let app = api::router(state);
 
     let addr = format!("{host}:{port}");
@@ -211,6 +213,7 @@ async fn main() -> Result<()> {
         model_path = model_path.unwrap_or("none (mock mode)"),
         "kiln listening"
     );
+    spawn_backend_prewarm(prewarm_state);
     // Graceful shutdown: listen for SIGTERM/SIGINT, drain in-flight requests,
     // then force-exit after a timeout.
     let shutdown_timeout_secs = config.server.shutdown_timeout_secs;
@@ -255,9 +258,31 @@ fn spawn_backend_prewarm(state: AppState) {
     let runner = runner.clone();
     let block_manager = block_manager.clone();
     let paged_cache = paged_cache.clone();
+    let metrics = state.metrics.clone();
 
     tokio::spawn(async move {
-        let prewarm = tokio::task::spawn_blocking(move || {
+        // Keep startup user-first: only warm a server that stayed idle long
+        // enough to prove no one is about to interact with it.
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        if metrics.request_duration_count.load(Ordering::Relaxed) > 0 {
+            tracing::info!(
+                "skipping background inference prewarm because the server has already handled live traffic"
+            );
+            return;
+        }
+        if metrics.active_requests.load(Ordering::Relaxed) > 0 {
+            tracing::info!(
+                "skipping background inference prewarm because a request is already active"
+            );
+            return;
+        }
+
+        let prewarm = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
+            if metrics.request_duration_count.load(Ordering::Relaxed) > 0
+                || metrics.active_requests.load(Ordering::Relaxed) > 0
+            {
+                return Ok(false);
+            }
             let runner_guard = runner.read().unwrap();
             let mut bm_guard = block_manager.lock().unwrap();
             let mut pc_guard = paged_cache.lock().unwrap();
@@ -276,12 +301,18 @@ fn spawn_backend_prewarm(state: AppState) {
                 &params,
                 &mut bm_guard,
                 &mut pc_guard,
-            )
+            )?;
+            Ok(true)
         })
         .await;
 
         match prewarm {
-            Ok(Ok(_)) => tracing::info!("background inference prewarm complete"),
+            Ok(Ok(true)) => tracing::info!("background inference prewarm complete"),
+            Ok(Ok(false)) => {
+                tracing::info!(
+                    "skipping background inference prewarm because a request became active"
+                );
+            }
             Ok(Err(err)) => tracing::warn!(error = %err, "background inference prewarm failed"),
             Err(err) => tracing::warn!(error = %err, "background inference prewarm task failed"),
         }


### PR DESCRIPTION
## Summary

This PR tightens the macOS default inference path in two places:

- Defers Metal background prewarm until after the listener is up and only if the server remains idle for 30s with no real traffic, so prewarm no longer competes with the first desktop request.
- Keeps GDN recurrent state in the model's native BF16/F16 dtype on Metal instead of forcing F32 recurrent-state traffic on every step. CPU and non-Metal backends keep the existing F32 state behavior.

## Impact

This keeps startup user-first under the desktop default invocation and improves warmed macOS chat latency. In my live-server run on the desktop Qwen checkpoint:

- listen time: ~49.2s
- first request with prewarm skipped: ~41.0s instead of the bad ~92.9s race observed with eager prewarm
- subsequent warmed requests: ~10.5s and ~12.2s for `max_tokens=1`

The isolated paged benchmark on the same checkpoint showed decode around ~8.0s/token for the tiny 14-token prompt case.

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_linear_attention_state_uses_bf16_on_metal_for_bf16_models --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_model_forward_parity_cpu_vs_metal --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo check -p kiln-server --bin kiln`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo build --release --features metal --bin kiln --bin kiln-bench`