### PR TITLE
desktop: Settings Reload — prompt when unsaved changes exist

### DIFF
--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -701,7 +701,12 @@
       const reloadBtn = document.getElementById("reload");
       const saveBtn = document.getElementById("save");
       const restoreBtn = document.getElementById("restore-defaults");
-      reloadBtn.addEventListener("click", load);
+      reloadBtn.addEventListener("click", () => {
+        if (isDirty() && !window.confirm("You have unsaved changes. Discard them and reload from disk?")) {
+          return;
+        }
+        load();
+      });
       saveBtn.addEventListener("click", save);
       restoreBtn.addEventListener("click", restoreDefaults);
       restartBtn.addEventListener("click", restart);


### PR DESCRIPTION
## What
Wrap the Settings 'Reload' button click handler with an isDirty()/window.confirm() guard so it no longer silently discards user edits.

## Why
closeWindow() (line 713) and restoreDefaults() (line 686) already guard against dirty state. The Reload button (line 704) did not, making it the only destructive-to-edits action in the Settings window without a safety prompt. Users who typed into a field and clicked Reload lost their work with no warning.

## Scope
Frontend-only (desktop/ui/settings.html). load() is unchanged because it is also called from DOMContentLoaded, after save(), and after restoreDefaults(); the guard lives at the click handler level only. No Rust changes.

## Test
CI matrix (macOS/Ubuntu/Windows) runs tauri-action. Local 'cd desktop && cargo check' expected to fail in Cloud Eric on GTK/webkit2gtk system libs (known limitation); this PR does not touch any Rust code so that failure is unrelated.