### PR TITLE
mtp: Phase B6 numerical dual-dump bisect — first divergence at post_layer

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -4336,3 +4336,153 @@ If all three runtime hypotheses clear, Phase B5-follow-up should move from struc
 - **Pod:** none. $0 pod spend.
 - **Wall-clock:** ≈ 55 min desk audit (fetching upstream at pinned SHAs, safetensors header probe on both shards, re-reading `loader.rs::load_mtp_if_present` + `load_layer` + `load_full_attention`, cross-checking forward.rs MTP path, writing this appendix).
 - **Output:** this PROFILING.md appendix + this PR. No code changes.
+
+## Phase B6 — MTP numerical dual-dump bisect (per-tap localization, 2026-04-21)
+
+### Goal
+
+Phase B5 disproved the `layer_idx=3` load-time hypothesis and collapsed the
+remaining MTP-α-collapse root-cause candidates to three runtime hypotheses
+(PROFILING.md:4211–4220). This Phase B6 bisect runs a **pure-PyTorch reference
+implementation** of `mtp_forward_step` over the exact same `h_main` +
+`draft_token_id` that kiln's own forward path consumes, and diffs the
+intermediate activations tap-by-tap with `allclose` + cosine similarity. The
+first tap that diverges pinpoints which of the three hypotheses (if any) is
+actually responsible.
+
+### Scope and honest limits
+
+* **Single prompt**, single `mtp_pos=0`. One-shot dump. Does not claim to
+  cover every MTP acceptance path.
+* `h_main` is **taken from the kiln dump** — the reference does not re-run
+  the 24 × GDN + 8 × GQA base stack. If the base model is producing the
+  wrong `h_main`, every downstream tap would match the reference bit-for-bit
+  (since the reference is fed the same bad `h_main`), and Phase B6 would
+  return a clean verdict. That would itself be a signal — pointing
+  upstream of `h_main` to the scheduler / paged KV state / GDN state on
+  the MTP branch.
+* BF16 matmul noise is not a bug: `|Δ|` of order 0.01 at intermediate
+  activations over 5k-dim reductions is normal. The bisect therefore reports
+  cosine similarity alongside `allclose`; a direction-preserving tap (cos≥0.999)
+  with small `|Δ|` is considered a match regardless of strict-`allclose` status.
+
+### Instrumentation
+
+Code added on this branch:
+
+* `crates/kiln-model/src/mtp_debug.rs` — `write_mtp_dump()` writes 8 F32 taps
+  + 3 I32 metadata scalars in safetensors format, gated by `KILN_MTP_DUMP_PATH`.
+  One-shot latch via `AtomicBool` to avoid per-step overhead.
+* `crates/kiln-model/src/forward.rs` — `mtp_forward_step` captures the 8
+  named taps in order. `concat` and `normed` pulled out as named binds so
+  the dump can see them without a second forward pass.
+* `scripts/mtp_reference_dump.py` — pure-PyTorch reference. Loads MTP weights
+  from `/workspace/qwen3.5-4b`, reads `h_main` + `draft_token_id` from the
+  kiln dump, runs the full `embed → dual rms_norm → concat → fc →
+  single transformer block (with RoPE at mtp_pos, per-head Q/K RMSNorm,
+  gated-attn, MLP) → final_layernorm → tied LM head` path, writes the
+  same 8 taps.
+* `scripts/mtp_compare.py` — per-tap diff. Prints a table of
+  (shape, allclose, cos_sim, max|Δ|, mean|Δ|) and maps the first divergence
+  back to the hypothesis it implicates.
+
+Reference RMSNorm uses the Qwen3.5-specific form `out = (1 + w) * x * rsqrt(mean(x²) + ε)`
+(see `forward.rs::rms_norm_fallback` at line 936). This is **not** the
+HF-standard RMSNorm; Qwen3.5 stores RMSNorm weights centered around 0 and
+applies them as `(1 + w)`. Using the standard form here produces a false
+divergence at `fc_input` that masks the real signal — any future additions
+to the reference must use the same semantics.
+
+### Results
+
+Prompt = `PROMPT_POOL[2]`, seed=42, `draft_token_id=561`, `mtp_pos=0`,
+`swap_fc_norms=0`. Kiln built in release mode with `KILN_CUDA_ARCHS=86
+--features cuda --bin kiln-bench`. Reference run with torch 2.x on CPU.
+
+Comparison at `atol=0.05, rtol=0.05` (BF16-realistic):
+
+| tap            | shape           | cos_sim | max\|Δ\|   | mean\|Δ\| | verdict |
+|----------------|-----------------|---------|-----------|-----------|---------|
+| h_main         | 1×1×2560        | 1.000   | 0.00      | 0.00      | match (input) |
+| tok_embed      | 1×1×2560        | 1.000   | 0.00      | 0.00      | match |
+| fc_input       | 1×1×5120        | 1.000   | 2.70e-2   | 7.12e-4   | match (BF16 noise) |
+| fc_output      | 1×1×2560        | 1.000   | 1.16e-2   | 7.06e-4   | match (BF16 noise) |
+| pre_layer      | 1×1×2560        | 1.000   | 1.16e-2   | 7.06e-4   | match |
+| **post_layer** | **1×1×2560**    | **0.600** | **5.37** | **6.95e-1** | **FIRST DIVERGENCE** |
+| post_final_ln  | 1×1×2560        | 0.538   | 21.12     | 2.41      | divergent (propagated) |
+| mtp_logits     | 1×1×248320      | 0.540   | 10.57     | 1.62      | divergent (propagated) |
+
+Metadata checks: `draft_token_id`, `mtp_pos`, `swap_fc_norms` all match.
+
+### Verdict
+
+The first numerically real divergence is at **`post_layer`** — the output of
+the single-layer MTP transformer block. The pipeline is clean through
+`pre_layer` (cos≥1.0, `|Δ|` at BF16-matmul-noise levels), which means:
+
+* **Hypothesis H1 (RoPE `mtp_pos` advancement)**: **STRONG candidate.** The
+  MTP block is the only place `mtp_pos` enters the forward graph. RoPE uses
+  `partial_rotary_factor=0.25` (64 of 256 head dims rotated) and
+  `rope_theta=1e7`. At `mtp_pos=0` the rotation is the identity, so if the
+  divergence persists at `mtp_pos=0`, the root cause is **not** a
+  position-advancement bug per se but something else inside the block
+  (Q/K/V projection layout, per-head Q/K RMSNorm, gated-attn). If on
+  later `mtp_pos > 0` steps the divergence grows with position, H1 is
+  confirmed as an advancement bug.
+* **Hypothesis H2 (tied `embed_tokens_t` transpose vs alias)**: **WEAKENED
+  but not fully eliminated.** `post_final_ln` and `mtp_logits` both end at
+  cos_sim ≈ 0.54 — meaning the `post_final_ln → logits` step preserves the
+  bulk of the direction. A transpose-layout bug in the tied LM head would
+  collapse cos_sim to near-zero, not preserve it. The remaining ~0.6 %
+  cos_sim gap between `post_final_ln` (0.538) and `mtp_logits` (0.540) is
+  within propagation noise for an `[H] → [V]` matmul. The tied transpose
+  is likely fine.
+* **Hypothesis H3 (`mtp.final_layernorm` application site)**: **WEAKENED.**
+  `post_layer` is already divergent, so any mismatch at `post_final_ln` is
+  partly explained by propagation. The `post_layer → post_final_ln`
+  cos_sim drop (0.600 → 0.538) is consistent with a single RMSNorm
+  amplifying an already-divergent input; it does not require an
+  independent bug in the norm application site. This line of inquiry
+  can be parked unless H1 is disproved.
+
+### Narrowed next steps
+
+This bisect collapses the three-hypothesis space to **a single active
+candidate: the MTP inner transformer block itself**, with sub-hypotheses
+ordered by likelihood:
+
+1. **Per-head Q/K RMSNorm** — same `(1 + w)` trap that produced a false
+   divergence in the reference on the first pass. If kiln's Q/K-norm path
+   ever takes a branch that applies bare `w`, it would manifest exactly
+   here.
+2. **Gated attention (`attn_output_gate=true`)** — Qwen3.5-4B applies a
+   sigmoid gate on the attention output. A sign error, wrong split, or
+   missing gate would appear first at `post_layer`.
+3. **Q/K/V projection layout** — `q_proj` is the gated `[8192, 2560]`
+   variant, `k_proj`/`v_proj` are GQA `[1024, 2560]`. A transpose bug
+   here would mangle the attention output specifically.
+4. **RoPE position threading** at `mtp_pos > 0` — not diagnosed by this
+   single-step dump; needs a multi-step variant (Phase B7).
+
+Phase B7 should dump at `mtp_pos = 0, 1, 2` on the same prompt and check
+whether the divergence grows with position (→ H1 confirmed) or is
+position-invariant (→ H1 eliminated, bug is inside the block). If B7
+eliminates H1, the next phase is a **per-sub-op reference inside the MTP
+block**: break down `post_layer` into `q/k/v → rope → attn → out_proj →
+gate → mlp_up → mlp_gate → mlp_down` and dump each one.
+
+### Budget used
+
+- **Pod:** RunPod pool, `s23qwogiqyk76s` (RTX A6000) via lease
+  `pod-37efdfc4f8b4c4bdbcfa0b98`. Hot build (sccache+incremental), two
+  kiln-bench runs for dump capture, one reference-script execution, two
+  compare runs. ≈ 15 min GPU-time. Pod released to pool after PR open.
+- **Wall-clock:** ≈ 80 min total, including one iteration to catch a
+  reference-side RMSNorm bug (`(1 + w)` vs bare `w`) that masqueraded as
+  an `fc_input` divergence on the first pass and would otherwise have
+  produced a false H2-ish verdict.
+- **Output:** this appendix, the `mtp_debug.rs` + `mtp_reference_dump.py`
+  + `mtp_compare.py` scaffold (all preserved for Phase B7), the concrete
+  bisect report at `/tmp/mtp-compare.txt` (copied to
+  `mtp-compare-phase-b6.txt` in the session workspace), and this PR.
+  **No fix included.** Scope is bisect-only per the task brief.

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3534,9 +3534,12 @@ pub fn mtp_forward_step(
     };
 
     // 4. Concat along the hidden dim and fuse: [1, 1, 2H] @ fc_t[2H, H] -> [1, 1, H]
+    //
+    // We keep the concat alive (named `concat`) so the Phase B6 dump can
+    // capture the exact bytes fed into `fc.weight` as `fc_input`.
+    let concat = Tensor::cat(&[&norm_emb, &norm_h], 2)?.contiguous()?;
     let fused = {
         kiln_nvtx::range!(c"kiln/mtp/fc");
-        let concat = Tensor::cat(&[&norm_emb, &norm_h], 2)?.contiguous()?;
         concat.broadcast_matmul(&mtp.fc_t)?
     };
 
@@ -3565,11 +3568,63 @@ pub fn mtp_forward_step(
     .context("mtp transformer block")?;
 
     // 6. Final RMSNorm + weight-tied LM head (reuses base embed_tokens_t).
+    //
+    // We split `normed` out as a distinct bind (rather than inlining into the
+    // `logits` block) so the Phase B6 dump can capture `post_final_ln` ahead
+    // of the `lm_head` matmul. No semantic change vs the previous inlined
+    // form: `rms_norm` has no side effects, and `normed` is only used once.
+    let normed = {
+        kiln_nvtx::range!(c"kiln/mtp/final_layernorm");
+        rms_norm(&mtp_hidden, &mtp.final_layernorm, config.rms_norm_eps)?
+    };
     let logits = {
         kiln_nvtx::range!(c"kiln/mtp/lm_head");
-        let normed = rms_norm(&mtp_hidden, &mtp.final_layernorm, config.rms_norm_eps)?;
         normed.broadcast_matmul(&weights.embed_tokens_t)?
     };
+
+    // Phase B6 numerical-bisect dump. Fires once per process when
+    // `KILN_MTP_DUMP_PATH` is set and this is the first draft call that
+    // reaches this point. Writes a single safetensors file with the 8
+    // taps enumerated in `write_mtp_dump` plus integer metadata (draft
+    // token id, `mtp_pos`, `swap_fc_norms`). The companion Python
+    // reference implementation (`scripts/mtp_reference_dump.py`) produces
+    // the same-shaped file for the same prompt + seed; `scripts/mtp_compare.py`
+    // prints a per-tap first-divergence table. Failure to dump is logged
+    // but non-fatal — we never want an instrumentation bug to break decode.
+    if crate::mtp_debug::try_consume_dump_slot() {
+        if let Some(path) = crate::mtp_debug::dump_path() {
+            let taps: [(&str, &Tensor); 8] = [
+                ("h_main", h_prev),
+                ("tok_embed", &token_emb),
+                ("fc_input", &concat),
+                ("fc_output", &fused),
+                ("pre_layer", &fused),
+                ("post_layer", &mtp_hidden),
+                ("post_final_ln", &normed),
+                ("mtp_logits", &logits),
+            ];
+            match crate::mtp_debug::write_mtp_dump(
+                &path,
+                draft_token_id,
+                mtp_pos,
+                swap_fc_norms,
+                &taps,
+            ) {
+                Ok(()) => tracing::info!(
+                    target: "kiln::mtp_debug",
+                    path = %path,
+                    draft_token_id,
+                    mtp_pos,
+                    "mtp_b6_dump_written"
+                ),
+                Err(e) => tracing::warn!(
+                    target: "kiln::mtp_debug",
+                    error = %e,
+                    "mtp_b6_dump_failed"
+                ),
+            }
+        }
+    }
 
     // Optional Phase B instrumentation. Off by default; enabled with
     // `KILN_MTP_DEBUG=1`. See `crate::mtp_debug` for the rate-limited path.

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -22,12 +22,13 @@
 //! tensor or layout bug appears) or document the runtime evidence in a Tier 2
 //! diagnostic update to `PROFILING.md`.
 
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use candle_core::{DType, Tensor};
 
 static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+static DUMP_DONE: AtomicBool = AtomicBool::new(false);
 
 const DEFAULT_MAX_CALLS: usize = 16;
 
@@ -106,6 +107,130 @@ pub fn is_swap_fc_norms_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// Path to which `mtp_forward_step` should dump all 8 Phase B6 numerical
+/// bisect taps on the first draft call, if set. Unset → no dump. Set →
+/// after the first call with valid tensors, the file is written and any
+/// subsequent call is a no-op (see `try_consume_dump_slot`).
+///
+/// Paired with a Python reference implementation (see
+/// `scripts/mtp_reference_dump.py`) that produces an identically-named
+/// safetensors file for the same fixed prompt + seed. A post-hoc
+/// per-tap `allclose` sweep (see `scripts/mtp_compare.py`) localizes
+/// the first divergence and narrows the remaining runtime hypotheses.
+pub fn dump_path() -> Option<String> {
+    std::env::var("KILN_MTP_DUMP_PATH").ok().filter(|s| !s.is_empty())
+}
+
+/// First call after the path env var is set returns `true`; all later
+/// calls return `false` so we only write the file once. Idempotent across
+/// the whole process.
+pub fn try_consume_dump_slot() -> bool {
+    if dump_path().is_none() {
+        return false;
+    }
+    DUMP_DONE
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+}
+
+/// Reset the dump latch. Test-only helper.
+#[cfg(test)]
+fn reset_dump_latch() {
+    DUMP_DONE.store(false, Ordering::SeqCst);
+}
+
+/// Convert a tensor to a contiguous host float32 `Vec<f32>` plus shape.
+/// Used by [`write_mtp_dump`] to serialize taps uniformly regardless of
+/// whether the source is BF16 on CUDA or F32 on CPU.
+fn tensor_to_f32_host(t: &Tensor) -> Result<(Vec<usize>, Vec<f32>)> {
+    let shape = t.dims().to_vec();
+    let flat = t.flatten_all()?.to_dtype(DType::F32)?.to_vec1::<f32>()?;
+    Ok((shape, flat))
+}
+
+/// Write the Phase B6 per-tap dump to the path from `KILN_MTP_DUMP_PATH`.
+///
+/// Output format is `safetensors` (same format kiln's loader already
+/// supports, so the Python side can read it with the stock `safetensors`
+/// package). All tensors are written as `F32` regardless of source dtype —
+/// precision loss from BF16→F32 is one-directional (upcast) and keeps the
+/// comparison numerically faithful.
+///
+/// The named taps correspond one-to-one with the 8 steps in the task brief:
+///
+/// | Tap name          | Meaning                                              |
+/// | ----------------- | ---------------------------------------------------- |
+/// | `h_main`          | Last-hidden-state from main model at position t.     |
+/// | `tok_embed`       | `embed_tokens(draft_token_t-1)` (pre-norm).          |
+/// | `fc_input`        | `concat([norm_emb, norm_h])` (input to `mtp.fc`).    |
+/// | `fc_output`       | Post-`mtp.fc` linear projection.                     |
+/// | `pre_layer`       | Input to the MTP inner transformer block (== `fc_output`). |
+/// | `post_layer`      | Output of the MTP inner transformer block.           |
+/// | `post_final_ln`   | Output of `mtp.final_layernorm` (pre-LM head).       |
+/// | `mtp_logits`      | Output of `lm_head` on `post_final_ln`.              |
+///
+/// Plus metadata: `draft_token_id`, `mtp_pos`, `swap_fc_norms`.
+pub fn write_mtp_dump(
+    path: &str,
+    draft_token_id: u32,
+    mtp_pos: usize,
+    swap_fc_norms: bool,
+    taps: &[(&str, &Tensor)],
+) -> Result<()> {
+    use safetensors::tensor::{Dtype, TensorView};
+
+    // Materialize every tensor to a host byte buffer first so the
+    // TensorViews we build below can borrow from a stable backing store.
+    let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> =
+        Vec::with_capacity(taps.len() + 3);
+    for (name, t) in taps {
+        let (shape, flat) = tensor_to_f32_host(t)
+            .with_context(|| format!("dump tap `{name}`: tensor→f32 host copy"))?;
+        let mut bytes = Vec::with_capacity(flat.len() * 4);
+        for v in &flat {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        backings.push(((*name).to_string(), shape, Dtype::F32, bytes));
+    }
+
+    // Metadata as 1-element I32 tensors so the Python side can read them
+    // with one loader. Widened to i32 because safetensors 0.5 lacks U32 in
+    // its serialization path on some builds; I32 is always available.
+    let dti = draft_token_id as i32;
+    backings.push((
+        "meta__draft_token_id".into(),
+        vec![1],
+        Dtype::I32,
+        dti.to_le_bytes().to_vec(),
+    ));
+    let mpi = mtp_pos as i32;
+    backings.push((
+        "meta__mtp_pos".into(),
+        vec![1],
+        Dtype::I32,
+        mpi.to_le_bytes().to_vec(),
+    ));
+    let swf = if swap_fc_norms { 1i32 } else { 0i32 };
+    backings.push((
+        "meta__swap_fc_norms".into(),
+        vec![1],
+        Dtype::I32,
+        swf.to_le_bytes().to_vec(),
+    ));
+
+    let mut views: Vec<(String, TensorView)> = Vec::with_capacity(backings.len());
+    for (name, shape, dtype, bytes) in &backings {
+        let view = TensorView::new(*dtype, shape.clone(), bytes.as_slice())
+            .map_err(|e| anyhow::anyhow!("safetensors TensorView::new for `{name}`: {e:?}"))?;
+        views.push((name.clone(), view));
+    }
+
+    let serialized = safetensors::serialize(views, &None)
+        .map_err(|e| anyhow::anyhow!("safetensors::serialize MTP dump: {e:?}"))?;
+    std::fs::write(path, serialized).with_context(|| format!("write MTP dump to {path}"))?;
+    Ok(())
+}
+
 /// Format a top-K list as `"[(id=42, l=12.34), (id=1, l=11.20), ...]"`.
 pub fn format_top_k(top: &[(u32, f32)]) -> String {
     let parts: Vec<String> = top
@@ -153,5 +278,60 @@ mod tests {
         }
         reset_counter();
         assert!(!should_log());
+    }
+
+    #[test]
+    fn dump_slot_fires_once_then_never() {
+        // SAFETY: single-threaded test; scoped env mutation.
+        let tmp = std::env::temp_dir().join("kiln_mtp_dump_slot_once.safetensors");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_PATH", &tmp_s);
+        }
+        reset_dump_latch();
+        assert_eq!(dump_path().as_deref(), Some(tmp_s.as_str()));
+        assert!(try_consume_dump_slot());
+        assert!(!try_consume_dump_slot());
+        assert!(!try_consume_dump_slot());
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_PATH");
+        }
+    }
+
+    #[test]
+    fn write_and_reparse_mtp_dump_round_trips() {
+        use safetensors::SafeTensors;
+
+        let a = Tensor::new(&[1.0_f32, 2.0, 3.0, 4.0][..], &Device::Cpu).unwrap();
+        let b = Tensor::new(&[0.5_f32, -0.25][..], &Device::Cpu).unwrap();
+        let tmp = std::env::temp_dir().join("kiln_mtp_dump_round_trip.safetensors");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        write_mtp_dump(
+            &tmp_s,
+            /* draft_token_id = */ 561,
+            /* mtp_pos = */ 0,
+            /* swap_fc_norms = */ false,
+            &[("h_main", &a), ("mtp_logits", &b)],
+        )
+        .unwrap();
+
+        let raw = std::fs::read(&tmp).unwrap();
+        let st = SafeTensors::deserialize(&raw).unwrap();
+        let names: Vec<&str> = st.names().into_iter().map(|s| s.as_str()).collect();
+        assert!(names.contains(&"h_main"));
+        assert!(names.contains(&"mtp_logits"));
+        assert!(names.contains(&"meta__draft_token_id"));
+        assert!(names.contains(&"meta__mtp_pos"));
+        assert!(names.contains(&"meta__swap_fc_norms"));
+
+        let h = st.tensor("h_main").unwrap();
+        assert_eq!(h.dtype(), safetensors::Dtype::F32);
+        assert_eq!(h.shape(), &[4]);
+        let meta = st.tensor("meta__draft_token_id").unwrap();
+        assert_eq!(meta.dtype(), safetensors::Dtype::I32);
+        let v = i32::from_le_bytes(meta.data()[0..4].try_into().unwrap());
+        assert_eq!(v, 561);
+
+        let _ = std::fs::remove_file(&tmp);
     }
 }

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""
+Phase B6 — Per-tap numerical comparison of MTP intermediates.
+
+Consumes two safetensors dumps (kiln native + PyTorch reference), prints a
+divergence table, and identifies the first tap where the two paths disagree
+beyond (atol=1e-3, rtol=1e-2).
+
+Usage:
+    python3 scripts/mtp_compare.py \\
+        --kiln /tmp/mtp-kiln.safetensors \\
+        --ref  /tmp/mtp-ref.safetensors \\
+        [--atol 1e-3] [--rtol 1e-2] \\
+        [--out /tmp/mtp-compare.txt]
+
+Exit code:
+    0 — all taps match within tolerance
+    1 — at least one tap diverges (normal outcome of a bisect)
+    2 — structural error (missing file, missing tap, shape mismatch)
+"""
+
+import argparse
+import sys
+from typing import Dict, List, Tuple
+
+import numpy as np
+
+try:
+    from safetensors.numpy import load_file
+except ImportError:
+    print("ERROR: safetensors not installed. pip install safetensors", file=sys.stderr)
+    sys.exit(2)
+
+
+# Canonical tap order — must match the order written by write_mtp_dump in
+# mtp_debug.rs and by mtp_reference_dump.py. First divergence is reported by
+# this sequence.
+TAP_ORDER: List[str] = [
+    "h_main",
+    "tok_embed",
+    "fc_input",
+    "fc_output",
+    "pre_layer",
+    "post_layer",
+    "post_final_ln",
+    "mtp_logits",
+]
+
+META_KEYS = ("meta__draft_token_id", "meta__mtp_pos", "meta__swap_fc_norms")
+
+
+def _fmt_sci(x: float) -> str:
+    if not np.isfinite(x):
+        return f"{x}"
+    if x == 0.0:
+        return "0.00e+00"
+    return f"{x:.2e}"
+
+
+def _cos_sim(a: np.ndarray, b: np.ndarray) -> float:
+    a_f = a.astype(np.float64).reshape(-1)
+    b_f = b.astype(np.float64).reshape(-1)
+    na = np.linalg.norm(a_f)
+    nb = np.linalg.norm(b_f)
+    if na == 0.0 or nb == 0.0:
+        return float("nan")
+    return float(np.dot(a_f, b_f) / (na * nb))
+
+
+def _compare_tap(
+    name: str,
+    a: np.ndarray,
+    b: np.ndarray,
+    atol: float,
+    rtol: float,
+) -> Dict[str, object]:
+    row: Dict[str, object] = {
+        "name": name,
+        "shape_kiln": tuple(a.shape),
+        "shape_ref": tuple(b.shape),
+        "shape_match": tuple(a.shape) == tuple(b.shape),
+    }
+    if not row["shape_match"]:
+        row["allclose"] = False
+        row["cos_sim"] = float("nan")
+        row["max_abs_diff"] = float("nan")
+        row["mean_abs_diff"] = float("nan")
+        return row
+
+    a64 = a.astype(np.float64)
+    b64 = b.astype(np.float64)
+    diff = np.abs(a64 - b64)
+    row["max_abs_diff"] = float(diff.max()) if diff.size else 0.0
+    row["mean_abs_diff"] = float(diff.mean()) if diff.size else 0.0
+    row["allclose"] = bool(np.allclose(a64, b64, atol=atol, rtol=rtol))
+    row["cos_sim"] = _cos_sim(a64, b64)
+    return row
+
+
+def _print_meta(title: str, meta: Dict[str, int]) -> None:
+    print(f"  {title}:")
+    for k in META_KEYS:
+        print(f"    {k}: {meta.get(k, '<missing>')}")
+
+
+def _load(path: str) -> Tuple[Dict[str, np.ndarray], Dict[str, int]]:
+    try:
+        tensors = load_file(path)
+    except Exception as e:
+        print(f"ERROR: failed to load {path}: {e}", file=sys.stderr)
+        sys.exit(2)
+    meta: Dict[str, int] = {}
+    arrays: Dict[str, np.ndarray] = {}
+    for key, val in tensors.items():
+        if key in META_KEYS:
+            meta[key] = int(val.item()) if val.size == 1 else int(val.flatten()[0])
+        else:
+            arrays[key] = val
+    return arrays, meta
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--kiln", required=True, help="Path to kiln dump (.safetensors)")
+    ap.add_argument("--ref", required=True, help="Path to reference dump (.safetensors)")
+    ap.add_argument("--atol", type=float, default=1e-3)
+    ap.add_argument("--rtol", type=float, default=1e-2)
+    ap.add_argument("--out", default=None, help="Optional path to write report text")
+    args = ap.parse_args()
+
+    kiln_arr, kiln_meta = _load(args.kiln)
+    ref_arr, ref_meta = _load(args.ref)
+
+    lines: List[str] = []
+
+    def emit(s: str) -> None:
+        print(s)
+        lines.append(s)
+
+    emit(f"MTP Phase B6 numerical bisect — atol={args.atol}, rtol={args.rtol}")
+    emit(f"  kiln dump : {args.kiln}")
+    emit(f"  ref  dump : {args.ref}")
+    emit("")
+    emit("Metadata:")
+    for k in META_KEYS:
+        kv = kiln_meta.get(k, "<missing>")
+        rv = ref_meta.get(k, "<missing>")
+        match = "OK" if kv == rv else "MISMATCH"
+        emit(f"  {k}: kiln={kv} ref={rv} [{match}]")
+    emit("")
+
+    # Header
+    header = (
+        f"{'tap':<18} {'shape':<18} {'shape_ok':<8} "
+        f"{'allclose':<8} {'cos_sim':<10} {'max|Δ|':<12} {'mean|Δ|':<12}"
+    )
+    emit(header)
+    emit("-" * len(header))
+
+    first_div: str = ""
+    all_ok = True
+    rows: List[Dict[str, object]] = []
+
+    for name in TAP_ORDER:
+        if name not in kiln_arr:
+            emit(f"{name:<18} MISSING IN KILN DUMP")
+            all_ok = False
+            if not first_div:
+                first_div = name
+            continue
+        if name not in ref_arr:
+            emit(f"{name:<18} MISSING IN REF DUMP")
+            all_ok = False
+            if not first_div:
+                first_div = name
+            continue
+        row = _compare_tap(name, kiln_arr[name], ref_arr[name], args.atol, args.rtol)
+        rows.append(row)
+        shape_str = "x".join(str(s) for s in row["shape_kiln"])
+        emit(
+            f"{row['name']:<18} {shape_str:<18} {str(row['shape_match']):<8} "
+            f"{str(row['allclose']):<8} {_fmt_sci(row['cos_sim']):<10} "
+            f"{_fmt_sci(row['max_abs_diff']):<12} {_fmt_sci(row['mean_abs_diff']):<12}"
+        )
+        if not row["allclose"] or not row["shape_match"]:
+            all_ok = False
+            if not first_div:
+                first_div = row["name"]
+
+    emit("")
+    if all_ok:
+        emit("VERDICT: all taps match within tolerance — no divergence found.")
+    else:
+        emit(f"VERDICT: first divergence at tap '{first_div}'.")
+        # Map first-divergence tap back to the hypothesis it most directly implicates.
+        hypothesis_map = {
+            "h_main": "upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ",
+            "tok_embed": "tied embed lookup or token-id path",
+            "fc_input": "RMSNorm inputs, concat ordering, or the dual-norm A/B swap",
+            "fc_output": "mtp.fc matmul (weight transpose or layout)",
+            "pre_layer": "(same tensor as fc_output at this site)",
+            "post_layer": "single-layer MTP block: RoPE mtp_pos advancement, Q/K/V proj, or gated-attn",
+            "post_final_ln": "mtp.final_layernorm application site / weight",
+            "mtp_logits": "tied embed_tokens_t transpose vs alias for LM head",
+        }
+        emit(f"  Most-likely cause: {hypothesis_map.get(first_div, '<unknown tap>')}")
+
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write("\n".join(lines) + "\n")
+        print(f"\nWrote report to {args.out}", file=sys.stderr)
+
+    return 0 if all_ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mtp_reference_dump.py
+++ b/scripts/mtp_reference_dump.py
@@ -207,6 +207,16 @@ def load_mtp_weights(checkpoint_dir: str) -> MtpRefWeights:
 
     get = lambda suf: st_load_tensor(checkpoint_dir, mtp_prefix + suf)
 
+    # Avoid `or` on torch.Tensor (it calls __bool__ which errors for >1 element).
+    # Use a helper that tries candidates in order and returns the first hit.
+    def first_match(*names: str) -> torch.Tensor:
+        last_err: Optional[KeyError] = None
+        for n in names:
+            t = st_load_tensor(checkpoint_dir, n, allow_missing=True)
+            if t is not None:
+                return t
+        raise KeyError(f"None of {names} present in checkpoint")
+
     return MtpRefWeights(
         embed_tokens=embed,
         fc_weight=mtp_fc,
@@ -214,21 +224,57 @@ def load_mtp_weights(checkpoint_dir: str) -> MtpRefWeights:
         pre_fc_norm_hidden=get("pre_fc_norm_hidden.weight"),
         # Either `mtp.norm.weight` or `mtp.final_layernorm.weight` — loader
         # accepts both per PR #253.
-        final_layernorm=(
-            st_load_tensor(checkpoint_dir, mtp_prefix + "norm.weight", allow_missing=True)
-            or st_load_tensor(checkpoint_dir, mtp_prefix + "final_layernorm.weight")
+        final_layernorm=first_match(
+            mtp_prefix + "norm.weight",
+            mtp_prefix + "final_layernorm.weight",
         ),
-        input_layernorm=get("layer.input_layernorm.weight"),
-        post_attention_layernorm=get("layer.post_attention_layernorm.weight"),
-        q_proj_weight=get("layer.self_attn.q_proj.weight"),
-        k_proj_weight=get("layer.self_attn.k_proj.weight"),
-        v_proj_weight=get("layer.self_attn.v_proj.weight"),
-        o_proj_weight=get("layer.self_attn.o_proj.weight"),
-        q_norm_weight=get("layer.self_attn.q_norm.weight"),
-        k_norm_weight=get("layer.self_attn.k_norm.weight"),
-        gate_proj_weight=get("layer.mlp.gate_proj.weight"),
-        up_proj_weight=get("layer.mlp.up_proj.weight"),
-        down_proj_weight=get("layer.mlp.down_proj.weight"),
+        # Actual Qwen3.5-4B checkpoint uses `mtp.layers.0.<...>` naming. Some
+        # alternate checkpoints (and some of the older audit docs) referred to
+        # `mtp.layer.<...>` — we try both to be safe.
+        input_layernorm=first_match(
+            mtp_prefix + "layers.0.input_layernorm.weight",
+            mtp_prefix + "layer.input_layernorm.weight",
+        ),
+        post_attention_layernorm=first_match(
+            mtp_prefix + "layers.0.post_attention_layernorm.weight",
+            mtp_prefix + "layer.post_attention_layernorm.weight",
+        ),
+        q_proj_weight=first_match(
+            mtp_prefix + "layers.0.self_attn.q_proj.weight",
+            mtp_prefix + "layer.self_attn.q_proj.weight",
+        ),
+        k_proj_weight=first_match(
+            mtp_prefix + "layers.0.self_attn.k_proj.weight",
+            mtp_prefix + "layer.self_attn.k_proj.weight",
+        ),
+        v_proj_weight=first_match(
+            mtp_prefix + "layers.0.self_attn.v_proj.weight",
+            mtp_prefix + "layer.self_attn.v_proj.weight",
+        ),
+        o_proj_weight=first_match(
+            mtp_prefix + "layers.0.self_attn.o_proj.weight",
+            mtp_prefix + "layer.self_attn.o_proj.weight",
+        ),
+        q_norm_weight=first_match(
+            mtp_prefix + "layers.0.self_attn.q_norm.weight",
+            mtp_prefix + "layer.self_attn.q_norm.weight",
+        ),
+        k_norm_weight=first_match(
+            mtp_prefix + "layers.0.self_attn.k_norm.weight",
+            mtp_prefix + "layer.self_attn.k_norm.weight",
+        ),
+        gate_proj_weight=first_match(
+            mtp_prefix + "layers.0.mlp.gate_proj.weight",
+            mtp_prefix + "layer.mlp.gate_proj.weight",
+        ),
+        up_proj_weight=first_match(
+            mtp_prefix + "layers.0.mlp.up_proj.weight",
+            mtp_prefix + "layer.mlp.up_proj.weight",
+        ),
+        down_proj_weight=first_match(
+            mtp_prefix + "layers.0.mlp.down_proj.weight",
+            mtp_prefix + "layer.mlp.down_proj.weight",
+        ),
         config=cfg,
     )
 
@@ -238,14 +284,22 @@ def load_mtp_weights(checkpoint_dir: str) -> MtpRefWeights:
 # -----------------------------------------------------------------------------
 
 def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
-    """Root Mean Square LayerNorm. Matches `candle_nn::ops::rms_norm` semantics
-    (float32 accumulation) which kiln uses. Returns same dtype as input.
+    """Qwen3.5-style RMSNorm: `out = (1 + w) * x * rsqrt(mean(x^2) + eps)`.
+
+    This matches kiln's `rms_norm_fallback` in forward.rs (line 936), which
+    the production kernel is validated against. The crucial detail is that
+    Qwen3.5 stores RMSNorm weights **centered around 0** and applies them
+    as `(1 + weight)`, not as bare `weight`. See forward.rs:955–957 and HF
+    Qwen3NextRMSNorm.forward.
+
+    Float32 accumulation throughout; output returned in the input dtype.
     """
     orig_dtype = x.dtype
     x = x.to(torch.float32)
     variance = x.pow(2).mean(dim=-1, keepdim=True)
     x = x * torch.rsqrt(variance + eps)
-    return (x * weight.to(torch.float32)).to(orig_dtype)
+    w = weight.to(torch.float32)
+    return (x * (1.0 + w)).to(orig_dtype)
 
 
 def apply_rope_partial(
@@ -427,8 +481,12 @@ def main() -> int:
     w = load_mtp_weights(args.checkpoint)
 
     cfg = w.config
-    rope_theta = float(cfg.get("rope_theta", 10_000_000.0))
-    rotary_frac = float(cfg.get("partial_rotary_factor", 0.25))
+    # Qwen3.5-4B defaults (hardcoded in kiln kiln-core/src/config.rs:80-101 since
+    # the shipped config.json text_config doesn't list them). Let env vars or
+    # explicit CLI override if needed for sensitivity sweeps.
+    rope_theta = float(os.environ.get("KILN_REF_ROPE_THETA", cfg.get("rope_theta", 10_000_000.0)) or 10_000_000.0)
+    rotary_frac = float(os.environ.get("KILN_REF_ROTARY_FRAC", cfg.get("partial_rotary_factor", 0.25)) or 0.25)
+    print(f"[mtp_ref] rope_theta={rope_theta} rotary_frac={rotary_frac}", file=sys.stderr)
 
     # Pull `h_main` and run the full reference forward.
     h_main = kiln["h_main"].to(torch.float32)  # expected shape [1, 1, H]
@@ -452,7 +510,10 @@ def main() -> int:
     fc_output = torch.matmul(fc_input, w.fc_weight.t())  # [1, 1, H]
 
     # 5. Single-layer block.
-    pre_layer = fc_output  # alias; matches kiln's forward exactly
+    # Alias-clone: kiln's forward.rs binds the fused result to BOTH `fused`
+    # (called `fc_output`) and `pre_layer`. For safetensors we need them as
+    # distinct tensors.
+    pre_layer = fc_output.clone()
     post_layer = mtp_inner_block(pre_layer, w, mtp_pos, rope_theta, rotary_frac, args.rms_eps)
 
     # 6-7. Final norm + tied LM head.

--- a/scripts/mtp_reference_dump.py
+++ b/scripts/mtp_reference_dump.py
@@ -1,0 +1,483 @@
+#!/usr/bin/env python3
+"""
+Phase B6 reference MTP dump — pure PyTorch reference implementation of the
+Qwen3.5-4B MTP forward pass, consuming the same `h_main`/draft-token inputs
+that kiln logged to its own dump file.
+
+Usage
+-----
+
+    python3 scripts/mtp_reference_dump.py \\
+        --checkpoint /workspace/qwen3.5-4b \\
+        --kiln-dump /tmp/mtp-kiln.safetensors \\
+        --out /tmp/mtp-ref.safetensors
+
+Design
+------
+
+The Qwen3.5-4B main model is a hybrid 24×GDN + 8×GQA stack that we do **not**
+re-implement here — doing so in a single script would be large, slow, and
+itself a new source of bugs. Instead, the reference script takes `h_main`
+(last-row pre-final-norm hidden state from the base model, `[1, 1, H]`) and
+`draft_token_id` **from the kiln dump itself**, and runs a *pure-tensor*
+reference implementation of every op that lives inside `mtp_forward_step`:
+
+    1. token_emb   = embed_tokens[draft_token_id]           # [1, 1, H]
+    2. norm_emb    = rms_norm(token_emb, pre_fc_norm_embedding)
+    3. norm_h      = rms_norm(h_main,    pre_fc_norm_hidden)
+    4. fc_input    = cat([norm_emb, norm_h], dim=-1)        # [1, 1, 2H]
+       fc_output   = fc_input @ mtp.fc.weight^T             # [1, 1, H]
+    5. post_layer  = mtp_inner_block(fc_output, mtp_pos)    # full-attn, 1 layer
+    6. post_final_ln = rms_norm(post_layer, mtp.final_layernorm)
+    7. mtp_logits  = post_final_ln @ embed_tokens^T
+
+This produces the same 8 named taps as kiln writes, with the same shapes, in
+the same safetensors format. `scripts/mtp_compare.py` then diffs them per-tap
+to localize the first divergence.
+
+Honest limits on what this bisect can prove
+-------------------------------------------
+
+* `h_main` is TAKEN FROM THE KILN DUMP. The reference cannot catch bugs in
+  the base-model forward path (the 24×GDN + 8×GQA stack). If kiln's main
+  model is emitting the wrong `h_main`, every downstream tap will match the
+  reference bit-for-bit (since the reference is fed the same bad `h_main`)
+  and the divergence would only show up at the final quality-of-generation
+  level — which is already how we spotted α=0.154 in the first place.
+* If every tap matches, the bug is upstream of tap #1 (main-model hidden
+  state production) OR in a layer this script doesn't model (token
+  sampling; but that path is already audited as greedy-equal in Phase A).
+* This script explicitly models the 3 remaining runtime hypotheses:
+    - RoPE `mtp_pos` advancement → visible as mismatch at `post_layer` (tap 6)
+    - Tied `embed_tokens_t` transpose vs alias → visible at `mtp_logits` (tap 8)
+    - `mtp.final_layernorm` application site → visible at `post_final_ln` (tap 7)
+
+Dependencies: `torch`, `safetensors`, `numpy`.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import math
+import os
+import sys
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+# -----------------------------------------------------------------------------
+# Dtype helpers
+# -----------------------------------------------------------------------------
+
+def to_f32_numpy(t: torch.Tensor) -> np.ndarray:
+    """Convert a torch tensor to a contiguous float32 numpy array (for the
+    safetensors writer, which wants CPU float32)."""
+    return t.detach().to(torch.float32).cpu().numpy().copy()
+
+
+def st_load_tensor(checkpoint_dir: str, name: str, allow_missing: bool = False) -> Optional[torch.Tensor]:
+    """Load a single tensor from a safetensors shard directory by global name.
+
+    Uses the `model.safetensors.index.json` file if present (standard HF
+    layout). Falls back to scanning every `*.safetensors` file in the dir.
+    Always returns BF16 as float32 on CPU (we operate in float32 on the ref
+    side so the comparison against kiln's BF16-in-GPU path is upcast-only).
+    """
+    idx_path = os.path.join(checkpoint_dir, "model.safetensors.index.json")
+    if os.path.exists(idx_path):
+        with open(idx_path, "r", encoding="utf-8") as f:
+            idx = json.load(f)
+        weight_map = idx.get("weight_map", {})
+        if name in weight_map:
+            shard_path = os.path.join(checkpoint_dir, weight_map[name])
+            with safe_open(shard_path, framework="pt", device="cpu") as g:
+                if name in g.keys():
+                    return g.get_tensor(name).to(torch.float32)
+
+    # Fall back: scan all shards.
+    for shard_path in sorted(glob.glob(os.path.join(checkpoint_dir, "*.safetensors"))):
+        with safe_open(shard_path, framework="pt", device="cpu") as g:
+            if name in g.keys():
+                return g.get_tensor(name).to(torch.float32)
+
+    if allow_missing:
+        return None
+    raise KeyError(
+        f"tensor `{name}` not found under {checkpoint_dir}. "
+        "Check the checkpoint layout — Qwen3.5-4B ships either a `model.` "
+        "prefix (plain LM) or a `model.language_model.` prefix (VL-wrapper)."
+    )
+
+
+def try_load_with_prefixes(checkpoint_dir: str, suffix: str, prefixes: list[str]) -> tuple[torch.Tensor, str]:
+    """Try loading `suffix` under each prefix until one hits. Returns (tensor, prefix_used)."""
+    last_err = None
+    for p in prefixes:
+        try:
+            t = st_load_tensor(checkpoint_dir, p + suffix)
+            assert t is not None
+            return t, p
+        except KeyError as e:
+            last_err = e
+    raise KeyError(f"Could not find `{suffix}` under any of {prefixes}: {last_err}")
+
+
+# -----------------------------------------------------------------------------
+# Qwen3-Next MTP weights container
+# -----------------------------------------------------------------------------
+
+@dataclass
+class MtpRefWeights:
+    # Tied LM head. Shape [V, H] in canonical HF layout; kiln stores
+    # `embed_tokens_t` separately but semantically the matmul uses
+    # `x @ embed_tokens.T` which we reproduce here.
+    embed_tokens: torch.Tensor          # [V, H]
+
+    # MTP fusion layer.
+    fc_weight: torch.Tensor             # [H, 2H]  (HF canonical; applied as x @ fc_weight.T)
+    pre_fc_norm_embedding: torch.Tensor  # [H]
+    pre_fc_norm_hidden: torch.Tensor    # [H]
+    final_layernorm: torch.Tensor       # [H]
+
+    # MTP inner transformer block (single full-attention layer).
+    input_layernorm: torch.Tensor       # [H]
+    post_attention_layernorm: torch.Tensor  # [H]
+    q_proj_weight: torch.Tensor         # [num_heads*head_dim*2, H] (gated)
+    k_proj_weight: torch.Tensor         # [num_kv_heads*head_dim, H]
+    v_proj_weight: torch.Tensor         # [num_kv_heads*head_dim, H]
+    o_proj_weight: torch.Tensor         # [H, num_heads*head_dim]
+    q_norm_weight: torch.Tensor         # [head_dim]
+    k_norm_weight: torch.Tensor         # [head_dim]
+    gate_proj_weight: torch.Tensor      # [ffn, H]
+    up_proj_weight: torch.Tensor        # [ffn, H]
+    down_proj_weight: torch.Tensor      # [H, ffn]
+
+    config: dict
+
+
+MTP_PREFIXES = ["mtp.", "model.mtp.", "model.language_model.mtp."]
+EMBED_PREFIXES = [
+    "model.embed_tokens.weight",
+    "model.language_model.embed_tokens.weight",
+    "language_model.model.embed_tokens.weight",
+    "embed_tokens.weight",
+]
+
+
+def load_mtp_weights(checkpoint_dir: str) -> MtpRefWeights:
+    # Config for num_attention_heads, num_kv_heads, head_dim, etc.
+    config_path = os.path.join(checkpoint_dir, "config.json")
+    with open(config_path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+    # VL-wrapper keeps the LM config nested under `text_config` or
+    # `language_config`; fall back to the top-level if neither present.
+    cfg = raw.get("text_config") or raw.get("language_config") or raw
+
+    # Find embed_tokens under any known prefix.
+    embed = None
+    for ep in EMBED_PREFIXES:
+        try:
+            embed = st_load_tensor(checkpoint_dir, ep)
+            print(f"[mtp_ref] embed_tokens loaded from `{ep}` shape={tuple(embed.shape)}", file=sys.stderr)
+            break
+        except KeyError:
+            continue
+    if embed is None:
+        raise KeyError("No embed_tokens.weight found under any known prefix")
+
+    # Find MTP prefix.
+    mtp_prefix = None
+    mtp_fc = None
+    for p in MTP_PREFIXES:
+        try:
+            mtp_fc = st_load_tensor(checkpoint_dir, p + "fc.weight")
+            mtp_prefix = p
+            break
+        except KeyError:
+            continue
+    if mtp_fc is None:
+        raise KeyError(f"No `mtp.fc.weight` under any of {MTP_PREFIXES}")
+    print(f"[mtp_ref] MTP prefix = `{mtp_prefix}` fc.shape={tuple(mtp_fc.shape)}", file=sys.stderr)
+
+    get = lambda suf: st_load_tensor(checkpoint_dir, mtp_prefix + suf)
+
+    return MtpRefWeights(
+        embed_tokens=embed,
+        fc_weight=mtp_fc,
+        pre_fc_norm_embedding=get("pre_fc_norm_embedding.weight"),
+        pre_fc_norm_hidden=get("pre_fc_norm_hidden.weight"),
+        # Either `mtp.norm.weight` or `mtp.final_layernorm.weight` — loader
+        # accepts both per PR #253.
+        final_layernorm=(
+            st_load_tensor(checkpoint_dir, mtp_prefix + "norm.weight", allow_missing=True)
+            or st_load_tensor(checkpoint_dir, mtp_prefix + "final_layernorm.weight")
+        ),
+        input_layernorm=get("layer.input_layernorm.weight"),
+        post_attention_layernorm=get("layer.post_attention_layernorm.weight"),
+        q_proj_weight=get("layer.self_attn.q_proj.weight"),
+        k_proj_weight=get("layer.self_attn.k_proj.weight"),
+        v_proj_weight=get("layer.self_attn.v_proj.weight"),
+        o_proj_weight=get("layer.self_attn.o_proj.weight"),
+        q_norm_weight=get("layer.self_attn.q_norm.weight"),
+        k_norm_weight=get("layer.self_attn.k_norm.weight"),
+        gate_proj_weight=get("layer.mlp.gate_proj.weight"),
+        up_proj_weight=get("layer.mlp.up_proj.weight"),
+        down_proj_weight=get("layer.mlp.down_proj.weight"),
+        config=cfg,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Core ops (match kiln's forward.rs line-for-line as close as we can)
+# -----------------------------------------------------------------------------
+
+def rms_norm(x: torch.Tensor, weight: torch.Tensor, eps: float) -> torch.Tensor:
+    """Root Mean Square LayerNorm. Matches `candle_nn::ops::rms_norm` semantics
+    (float32 accumulation) which kiln uses. Returns same dtype as input.
+    """
+    orig_dtype = x.dtype
+    x = x.to(torch.float32)
+    variance = x.pow(2).mean(dim=-1, keepdim=True)
+    x = x * torch.rsqrt(variance + eps)
+    return (x * weight.to(torch.float32)).to(orig_dtype)
+
+
+def apply_rope_partial(
+    x: torch.Tensor, position: int, head_dim: int, rotary_dim: int, rope_theta: float
+) -> torch.Tensor:
+    """Apply rotary embedding to the first `rotary_dim` dimensions of each
+    head. `x` is `[batch, num_heads, seq_len, head_dim]`.
+
+    Qwen3-Next uses partial rotary (default 0.25 of head_dim → 64-dim rotary
+    for head_dim=256). Rotate on the leading `rotary_dim`, leave the tail
+    untouched. `position` is the absolute position index for the single-token
+    step we're modelling (MTP has seq_len=1).
+    """
+    if rotary_dim == 0:
+        return x
+    # inv_freq computed over rotary_dim/2 pairs.
+    inv_freq = 1.0 / (rope_theta ** (torch.arange(0, rotary_dim, 2, dtype=torch.float32) / rotary_dim))
+    # freqs for this single position.
+    freqs = torch.tensor([position], dtype=torch.float32)[:, None] * inv_freq[None, :]  # [1, rot/2]
+    cos = freqs.cos()  # [1, rot/2]
+    sin = freqs.sin()  # [1, rot/2]
+
+    # Split rotary half. Shape: [..., rotary_dim]
+    x_rot = x[..., :rotary_dim]
+    x_pass = x[..., rotary_dim:]
+    # Pair up the dims. `candle` uses interleaved even/odd; HF commonly uses
+    # half-rotate (first half vs second half). Qwen3-Next MTP in kiln uses
+    # interleaved rotation — see `apply_rotary_emb` in forward.rs. We model
+    # the "half-rotate" variant here; if the comparison surfaces a mismatch
+    # at `post_layer`, an interleave-vs-halves swap is the single most
+    # likely cause and will print clearly in the divergence table.
+    half = rotary_dim // 2
+    x1 = x_rot[..., :half]
+    x2 = x_rot[..., half:]
+    x_rot_new = torch.cat([x1 * cos - x2 * sin, x1 * sin + x2 * cos], dim=-1)
+    return torch.cat([x_rot_new, x_pass], dim=-1)
+
+
+def mtp_inner_block(
+    x: torch.Tensor,
+    w: MtpRefWeights,
+    mtp_pos: int,
+    rope_theta: float,
+    rotary_frac: float,
+    eps: float,
+) -> torch.Tensor:
+    """Single MTP transformer block with self-attention over exactly one
+    position. `x` shape: `[1, 1, H]`. Returns `[1, 1, H]` (pre-final-norm).
+
+    Self-attention over a single token reduces to: the Q·K product yields a
+    1×1 scalar, so softmax(.) = 1.0 and the attention output equals V. RoPE
+    rotations on Q and K cancel in the Q·K^T product (same position, same
+    rotation), so this path is a pretty good sanity-check for the MTP inner
+    layer.
+    """
+    cfg = w.config
+    H = x.shape[-1]
+    num_heads = cfg["num_attention_heads"]
+    num_kv_heads = cfg.get("num_key_value_heads", num_heads)
+    head_dim = cfg.get("head_dim", H // num_heads)
+    rotary_dim = int(head_dim * rotary_frac)
+
+    # Pre-attn norm.
+    residual = x
+    h = rms_norm(x, w.input_layernorm, eps)  # [1,1,H]
+
+    # Q/K/V projections. The Qwen3-Next gated Q has shape [2*num_heads*head_dim, H]
+    # (kiln's loader splits into Q and a gate). Here we emulate it by taking
+    # the first half as Q (the ungated stream) and discarding the gate — this
+    # is wrong for the full gated-attn semantics but a faithful reproduction
+    # of that would pull in another ~100 LOC. For Phase B6, we flag
+    # gated-attn as a known *reference* simplification; if `post_layer`
+    # diverges by exactly this amount, the bug isn't real. See the compare
+    # script output for this caveat.
+    q_full = torch.matmul(h, w.q_proj_weight.t())  # [1,1, 2*num_heads*head_dim] if gated, else [1,1, num_heads*head_dim]
+    if q_full.shape[-1] == 2 * num_heads * head_dim:
+        q, q_gate = q_full.chunk(2, dim=-1)
+        q_gated = True
+    else:
+        q = q_full
+        q_gate = None
+        q_gated = False
+    k = torch.matmul(h, w.k_proj_weight.t())
+    v = torch.matmul(h, w.v_proj_weight.t())
+
+    # Reshape to heads: [1, 1, num_heads, head_dim] → [1, num_heads, 1, head_dim]
+    q = q.view(1, 1, num_heads, head_dim).transpose(1, 2)
+    k = k.view(1, 1, num_kv_heads, head_dim).transpose(1, 2)
+    v = v.view(1, 1, num_kv_heads, head_dim).transpose(1, 2)
+
+    # Per-head RMSNorm on Q and K (Qwen3-Next style).
+    q = rms_norm(q, w.q_norm_weight, eps)
+    k = rms_norm(k, w.k_norm_weight, eps)
+
+    # RoPE on rotary_dim prefix.
+    q = apply_rope_partial(q, mtp_pos, head_dim, rotary_dim, rope_theta)
+    k = apply_rope_partial(k, mtp_pos, head_dim, rotary_dim, rope_theta)
+
+    # Expand KV heads for GQA.
+    repeat = num_heads // num_kv_heads
+    if repeat > 1:
+        k = k.repeat_interleave(repeat, dim=1)
+        v = v.repeat_interleave(repeat, dim=1)
+
+    # Single-token self-attention reduces to attn_out == V (softmax of a
+    # single scalar == 1.0), so Q·K^T /√d · softmax · V simplifies to V when
+    # seq_len = 1 — modulo rounding. We still compute the full path for
+    # faithfulness to kiln's op order.
+    scale = 1.0 / math.sqrt(head_dim)
+    scores = torch.matmul(q, k.transpose(-2, -1)) * scale  # [1, num_heads, 1, 1]
+    attn = torch.softmax(scores.to(torch.float32), dim=-1).to(v.dtype)
+    attn_out = torch.matmul(attn, v)  # [1, num_heads, 1, head_dim]
+
+    # Apply gated-attn sigmoid(q_gate) if present. We skip a proper
+    # gated-attn implementation (see caveat above); reported divergence at
+    # `post_layer` is expected to include this component.
+    attn_out = attn_out.transpose(1, 2).contiguous().view(1, 1, num_heads * head_dim)
+    if q_gated:
+        # Kiln applies sigmoid gate per-head post-attn before o_proj (see
+        # `transformer_block_paged` branch on `attn_output_gate=true`). We
+        # model that here.
+        q_gate = q_gate.view(1, 1, num_heads, head_dim).transpose(1, 2).contiguous()
+        q_gate = q_gate.transpose(1, 2).contiguous().view(1, 1, num_heads * head_dim)
+        attn_out = attn_out * torch.sigmoid(q_gate.to(attn_out.dtype))
+    attn_out = torch.matmul(attn_out, w.o_proj_weight.t())
+
+    # Residual.
+    h = residual + attn_out
+
+    # MLP.
+    residual = h
+    h2 = rms_norm(h, w.post_attention_layernorm, eps)
+    gate = torch.matmul(h2, w.gate_proj_weight.t())
+    up = torch.matmul(h2, w.up_proj_weight.t())
+    act = torch.nn.functional.silu(gate) * up
+    down = torch.matmul(act, w.down_proj_weight.t())
+    h = residual + down
+
+    return h
+
+
+# -----------------------------------------------------------------------------
+# Entrypoint
+# -----------------------------------------------------------------------------
+
+def load_kiln_dump(path: str) -> Dict[str, torch.Tensor | int]:
+    """Load the safetensors file kiln wrote. Returns a dict with the 8 taps
+    as torch tensors plus integer metadata."""
+    out: Dict[str, torch.Tensor | int] = {}
+    with safe_open(path, framework="pt", device="cpu") as f:
+        for name in f.keys():
+            t = f.get_tensor(name)
+            if name.startswith("meta__"):
+                # Metadata is I32; take the scalar.
+                out[name] = int(t.flatten()[0].item())
+            else:
+                out[name] = t.to(torch.float32)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Phase B6 reference MTP dump")
+    ap.add_argument("--checkpoint", required=True, help="Qwen3.5-4B checkpoint directory")
+    ap.add_argument("--kiln-dump", required=True, help="Path to kiln's mtp dump (safetensors)")
+    ap.add_argument("--out", required=True, help="Output path for reference dump")
+    ap.add_argument("--rms-eps", type=float, default=1e-6)
+    args = ap.parse_args()
+
+    print(f"[mtp_ref] loading kiln dump from {args.kiln_dump}", file=sys.stderr)
+    kiln = load_kiln_dump(args.kiln_dump)
+    for name in ["h_main", "tok_embed", "fc_input", "fc_output", "pre_layer", "post_layer", "post_final_ln", "mtp_logits"]:
+        assert name in kiln, f"kiln dump missing expected tap `{name}`"
+    draft_token_id = kiln["meta__draft_token_id"]
+    mtp_pos = kiln["meta__mtp_pos"]
+    swap = kiln["meta__swap_fc_norms"]
+    print(f"[mtp_ref] draft_token_id={draft_token_id} mtp_pos={mtp_pos} swap_fc_norms={swap}", file=sys.stderr)
+
+    print(f"[mtp_ref] loading MTP weights from {args.checkpoint}", file=sys.stderr)
+    w = load_mtp_weights(args.checkpoint)
+
+    cfg = w.config
+    rope_theta = float(cfg.get("rope_theta", 10_000_000.0))
+    rotary_frac = float(cfg.get("partial_rotary_factor", 0.25))
+
+    # Pull `h_main` and run the full reference forward.
+    h_main = kiln["h_main"].to(torch.float32)  # expected shape [1, 1, H]
+    assert h_main.ndim == 3, f"h_main expected 3-D, got {h_main.shape}"
+
+    # 1. Token embed.
+    tok_embed = w.embed_tokens[draft_token_id : draft_token_id + 1].unsqueeze(0)  # [1, 1, H]
+
+    # 2-3. Dual RMSNorms. Honor swap flag for parity.
+    if swap:
+        norm_emb_w = w.pre_fc_norm_hidden
+        norm_h_w = w.pre_fc_norm_embedding
+    else:
+        norm_emb_w = w.pre_fc_norm_embedding
+        norm_h_w = w.pre_fc_norm_hidden
+    norm_emb = rms_norm(tok_embed, norm_emb_w, args.rms_eps)
+    norm_h = rms_norm(h_main, norm_h_w, args.rms_eps)
+
+    # 4. Concat + fc.
+    fc_input = torch.cat([norm_emb, norm_h], dim=-1)  # [1, 1, 2H]
+    fc_output = torch.matmul(fc_input, w.fc_weight.t())  # [1, 1, H]
+
+    # 5. Single-layer block.
+    pre_layer = fc_output  # alias; matches kiln's forward exactly
+    post_layer = mtp_inner_block(pre_layer, w, mtp_pos, rope_theta, rotary_frac, args.rms_eps)
+
+    # 6-7. Final norm + tied LM head.
+    post_final_ln = rms_norm(post_layer, w.final_layernorm, args.rms_eps)
+    mtp_logits = torch.matmul(post_final_ln, w.embed_tokens.t())  # [1, 1, V]
+
+    # Write dump.
+    out_dict = {
+        "h_main": h_main.contiguous(),
+        "tok_embed": tok_embed.contiguous(),
+        "fc_input": fc_input.contiguous(),
+        "fc_output": fc_output.contiguous(),
+        "pre_layer": pre_layer.contiguous(),
+        "post_layer": post_layer.contiguous(),
+        "post_final_ln": post_final_ln.contiguous(),
+        "mtp_logits": mtp_logits.contiguous(),
+        # Carry metadata forward so the comparator can cross-check.
+        "meta__draft_token_id": torch.tensor([int(draft_token_id)], dtype=torch.int32),
+        "meta__mtp_pos": torch.tensor([int(mtp_pos)], dtype=torch.int32),
+        "meta__swap_fc_norms": torch.tensor([int(swap)], dtype=torch.int32),
+    }
+    save_file(out_dict, args.out)
+    print(f"[mtp_ref] wrote {args.out} ({sum(t.numel()*t.element_size() for t in out_dict.values())} bytes)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase B5 (PR #268) disproved the `layer_idx=3` load-time hypothesis and
collapsed MTP-α-collapse candidates to **three runtime hypotheses**:

1. RoPE `mtp_pos` advancement bug
2. Tied `embed_tokens_t` transpose vs alias bug
3. `mtp.final_layernorm` application site bug

Phase B6 runs a dual-dump numerical bisect: kiln's `mtp_forward_step` and a
**pure-PyTorch reference** consume the same `h_main` + `draft_token_id`, and
8 intermediate activations are diffed tap-by-tap with `allclose` + cosine
similarity. First real divergence localizes the bug.

## Verdict

**First real divergence is at `post_layer` — output of the single MTP
transformer block.** The pipeline is clean through `pre_layer`:

| tap            | cos_sim | max\|Δ\| | notes |
|----------------|---------|----------|-------|
| h_main         | 1.000   | 0.00     | input (taken from kiln) |
| tok_embed      | 1.000   | 0.00     | match |
| fc_input       | 1.000   | 2.70e-2  | match (BF16 matmul noise) |
| fc_output      | 1.000   | 1.16e-2  | match (BF16 matmul noise) |
| pre_layer      | 1.000   | 1.16e-2  | match |
| **post_layer** | **0.600** | **5.37** | **FIRST DIVERGENCE** |
| post_final_ln  | 0.538   | 21.12    | divergent (propagated) |
| mtp_logits     | 0.540   | 10.57    | divergent (propagated) |

Tolerance used: `atol=0.05, rtol=0.05` (BF16-realistic). At stricter
`atol=1e-3, rtol=1e-2` the borderline-match taps fail `allclose` but
cos_sim stays at 1.0 — that's noise, not a bug.

## Hypothesis narrowing

- **H2 (tied transpose)**: WEAKENED. `post_final_ln → mtp_logits` preserves
  cos_sim (0.538 → 0.540). A transpose bug in the tied LM head would
  collapse cos_sim to near-zero.
- **H3 (final_layernorm application site)**: WEAKENED. `post_layer` is
  already divergent, so any mismatch at `post_final_ln` is mostly
  propagation. The `0.600 → 0.538` drop is consistent with a single
  RMSNorm amplifying a divergent input — does not require an independent
  bug in the norm application.
- **H1 (RoPE `mtp_pos`)**: STRONG but **not confirmable from a
  single-step dump**. At `mtp_pos=0` RoPE is the identity, so if the
  divergence is position-independent the root cause is **block-internal**,
  not RoPE-advancement. Phase B7 needs to dump at `mtp_pos = 0, 1, 2` to
  distinguish.

## Sub-hypotheses for Phase B7

Inside the MTP transformer block, ordered by likelihood:

1. **Per-head Q/K RMSNorm** — same `(1 + w)` trap that bit the reference
   on the first pass (see "Reference RMSNorm fix" below). If any kiln
   branch applies bare `w`, it manifests exactly here.
2. **Gated attention (`attn_output_gate=true`)** — sign error, wrong
   split, or missing gate.
3. **Q/K/V projection layout** — `q_proj` is gated `[8192, 2560]`,
   `k_proj`/`v_proj` are GQA `[1024, 2560]`; transpose/layout bug.
4. **RoPE position threading** at `mtp_pos > 0`.

## Reference RMSNorm fix

First bisect pass produced a spurious divergence at `fc_input` because
the reference used HF-standard RMSNorm (`x_normed * w`), but Qwen3.5
stores RMSNorm weights centered around 0 and applies them as
`(1 + w) * x_normed` (see `forward.rs::rms_norm_fallback:936`). Fixed in
this PR. Any future additions to the reference must use Qwen3.5
semantics.

## Files

- `scripts/mtp_reference_dump.py` — pure-PyTorch MTP reference with
  correct `(1 + w)` RMSNorm, `first_match` helper for weight-key
  variants (`mtp.layers.0.<...>` vs `mtp.layer.<...>`), `pre_layer =
  fc_output.clone()` to avoid safetensors aliased-memory refusal.
- `PROFILING.md` — new Phase B6 section with full comparison table,
  hypothesis-narrowing analysis, and Phase B7 plan.

Instrumentation (kiln-side `write_mtp_dump`, `mtp_compare.py`) landed
in the previous B6-scaffolding commit on this branch.

## Scope

**Bisect only. No fix included**, per task brief. Next PR (Phase B7)
should dump at multiple `mtp_pos` values to confirm or eliminate H1,
then break down `post_layer` into per-sub-op taps if H1 is eliminated.

## Budget

- **Pod:** RunPod pool, `s23qwogiqyk76s` (A6000), lease
  `pod-37efdfc4f8b4c4bdbcfa0b98`. Hot build (sccache+incremental), two
  kiln-bench runs, one reference-script execution, two compare runs.
  ≈ 15 min GPU-time. Pod released to pool after PR open.
- **Wall-clock:** ≈ 80 min, including one iteration to catch the
  reference-side RMSNorm bug.

## Test plan

- [x] Kiln dump written (8 F32 taps + 3 I32 metadata, all shapes correct)
- [x] Reference dump produced (same 8 taps, same shapes)
- [x] `mtp_compare.py` reports metadata match across both dumps
- [x] BF16-realistic tolerance sweep confirms first divergence at `post_layer`
- [x] Hypothesis map narrowed: H2 weakened, H3 weakened, H1 still candidate
- [ ] (follow-up) Phase B7: multi-`mtp_pos` dump to disambiguate H1 vs block-internal