### PR TITLE
[codex] speed up default macOS paged inference

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -39,6 +39,10 @@ impl BackendRuntime for MetalBackend {
         true
     }
 
+    fn supports_flash_attn_prefill_head_major(&self) -> bool {
+        true
+    }
+
     fn supports_flash_attn_paged_decode(&self) -> bool {
         true
     }
@@ -71,6 +75,26 @@ impl BackendRuntime for MetalBackend {
             .context("candle-metal sdpa failed")?;
 
         let out = out.transpose(1, 2)?.contiguous()?;
+        Ok(Some(out))
+    }
+
+    fn flash_attn_prefill_head_major(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        softmax_scale: f32,
+        causal: bool,
+    ) -> Result<Option<Tensor>> {
+        if !matches!(q.dtype(), DType::BF16 | DType::F16 | DType::F32) {
+            return Ok(None);
+        }
+        if !metal_sdpa_supports_head_dim(q.dim(candle_core::D::Minus1)?) {
+            return Ok(None);
+        }
+
+        let out = candle_nn::ops::sdpa(q, k, v, None, causal, softmax_scale, 1.0)
+            .context("candle-metal head-major sdpa failed")?;
         Ok(Some(out))
     }
 
@@ -141,14 +165,8 @@ impl BackendRuntime for MetalBackend {
         // [1, 1, num_heads, head_dim]; K/V are [total_seqlen_k, num_kv_heads, head_dim].
         // SDPA handles GQA internally when num_heads % num_kv_heads == 0.
         let q_sdpa = q.transpose(1, 2)?.contiguous()?; // [1, num_heads, 1, head_dim]
-        let k_sdpa = k_live
-            .unsqueeze(0)?
-            .transpose(1, 2)?
-            .contiguous()?; // [1, num_kv_heads, total_seqlen_k, head_dim]
-        let v_sdpa = v_live
-            .unsqueeze(0)?
-            .transpose(1, 2)?
-            .contiguous()?;
+        let k_sdpa = k_live.unsqueeze(0)?.transpose(1, 2)?.contiguous()?; // [1, num_kv_heads, total_seqlen_k, head_dim]
+        let v_sdpa = v_live.unsqueeze(0)?.transpose(1, 2)?.contiguous()?;
 
         let out = candle_nn::ops::sdpa(&q_sdpa, &k_sdpa, &v_sdpa, None, causal, softmax_scale, 1.0)
             .context("candle-metal paged sdpa failed")?;
@@ -214,8 +232,8 @@ mod tests {
         // Shuffled physical block table — exercises the gather, not just
         // sequential blocks.
         let block_ids: [u32; 4] = [3, 7, 0, 5];
-        let block_table = Tensor::new(block_ids.as_slice(), &device)?
-            .reshape((1usize, max_blocks_per_seq))?;
+        let block_table =
+            Tensor::new(block_ids.as_slice(), &device)?.reshape((1usize, max_blocks_per_seq))?;
 
         // Fill the pool with distinctive per-slot values so the gather's
         // correctness is visible in the output. Each slot's values are
@@ -226,16 +244,10 @@ mod tests {
         let v_pool_data: Vec<f32> = (0..total_slots * num_kv_heads * head_dim)
             .map(|i| (i as f32) * 0.0001 + 1.0)
             .collect();
-        let k_pool = Tensor::from_slice(
-            &k_pool_data,
-            (total_slots, num_kv_heads, head_dim),
-            &device,
-        )?;
-        let v_pool = Tensor::from_slice(
-            &v_pool_data,
-            (total_slots, num_kv_heads, head_dim),
-            &device,
-        )?;
+        let k_pool =
+            Tensor::from_slice(&k_pool_data, (total_slots, num_kv_heads, head_dim), &device)?;
+        let v_pool =
+            Tensor::from_slice(&v_pool_data, (total_slots, num_kv_heads, head_dim), &device)?;
 
         let q = Tensor::randn(0.0f32, 0.02, (1, 1, num_heads, head_dim), &device)?;
         let softmax_scale = 1.0 / (head_dim as f32).sqrt();
@@ -243,8 +255,14 @@ mod tests {
 
         let out_paged = backend
             .flash_attn_paged_decode(
-                &q, &k_pool, &v_pool, &block_table, total_seqlen_k,
-                block_size, softmax_scale, true,
+                &q,
+                &k_pool,
+                &v_pool,
+                &block_table,
+                total_seqlen_k,
+                block_size,
+                softmax_scale,
+                true,
             )?
             .expect("backend should handle this shape");
 
@@ -273,7 +291,10 @@ mod tests {
             .flatten_all()?
             .max(D::Minus1)?
             .to_scalar::<f32>()?;
-        assert!(diff < 1e-5, "paged vs direct SDPA diverge: max abs diff = {diff}");
+        assert!(
+            diff < 1e-5,
+            "paged vs direct SDPA diverge: max abs diff = {diff}"
+        );
 
         Ok(())
     }
@@ -292,7 +313,8 @@ mod tests {
         let q = Tensor::zeros((1, 1, 2, head_dim), DType::F32, &device)?;
 
         let backend = MetalBackend::new(device);
-        let out = backend.flash_attn_paged_decode(&q, &k_pool, &v_pool, &block_table, 4, 4, 1.0, true)?;
+        let out =
+            backend.flash_attn_paged_decode(&q, &k_pool, &v_pool, &block_table, 4, 4, 1.0, true)?;
         assert!(out.is_none(), "should decline unsupported head_dim");
         Ok(())
     }

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -45,6 +45,10 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         false
     }
 
+    fn supports_flash_attn_prefill_head_major(&self) -> bool {
+        false
+    }
+
     fn supports_flash_attn_paged_decode(&self) -> bool {
         false
     }
@@ -67,6 +71,23 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
     /// Caller must GQA-expand K/V to match Q's head count. Returns
     /// `[batch, seq_len, num_heads, head_dim]` bf16.
     fn flash_attn_prefill(
+        &self,
+        _q: &Tensor,
+        _k: &Tensor,
+        _v: &Tensor,
+        _softmax_scale: f32,
+        _causal: bool,
+    ) -> Result<Option<Tensor>> {
+        Ok(None)
+    }
+
+    /// FlashAttention-2 forward for prefill with Q/K/V already in SDPA layout.
+    ///
+    /// `q`: `[batch, num_heads, seq_len, head_dim]` bf16 contiguous. `k` and
+    /// `v`: `[batch, num_kv_heads, seq_len, head_dim]` bf16 contiguous.
+    /// Backends may decline when they lack native GQA support. Returns
+    /// `[batch, num_heads, seq_len, head_dim]` bf16.
+    fn flash_attn_prefill_head_major(
         &self,
         _q: &Tensor,
         _k: &Tensor,

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -112,6 +112,43 @@ fn flash_attention_forward(
     Ok(Some(attn_output))
 }
 
+/// Compute attention using a backend fast path when Q/K/V are already in
+/// `[batch, heads, seq_len, head_dim]` layout.
+///
+/// The paged prefill path transposes Q/K/V to this layout before writing the
+/// KV cache. Metal's fused SDPA also consumes this layout, so this variant
+/// avoids transposing all three tensors back to token-major only for the
+/// backend to transpose them again.
+fn flash_attention_forward_head_major(
+    backend: &dyn BackendRuntime,
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    num_heads: usize,
+    head_dim: usize,
+) -> Result<Option<Tensor>> {
+    if !backend.supports_flash_attn_prefill_head_major() {
+        return Ok(None);
+    }
+
+    let softmax_scale = 1.0 / (head_dim as f32).sqrt();
+    let causal = true;
+
+    let Some(attn_output) =
+        backend.flash_attn_prefill_head_major(q, k, v, softmax_scale, causal)?
+    else {
+        return Ok(None);
+    };
+
+    let (batch, _heads, seq_len, _hd) = attn_output.dims4()?;
+    let attn_output = attn_output.transpose(1, 2)?.contiguous()?.reshape((
+        batch,
+        seq_len,
+        num_heads * head_dim,
+    ))?;
+    Ok(Some(attn_output))
+}
+
 /// GPU-ready tensors organized by layer, converted from raw `ModelWeights` bytes.
 pub struct GpuWeights {
     /// Token embedding table: [vocab_size, hidden_size]
@@ -2668,20 +2705,34 @@ pub fn gqa_attention_paged(
     // directly and only write K/V into the paged cache once for future decode.
     // This avoids a pointless write-then-read round-trip through
     // `PagedKvCache` on the first prompt tile.
-    if seq_len > 1 && start_pos == 0 && backend.supports_flash_attn_prefill() {
+    if seq_len > 1
+        && start_pos == 0
+        && (backend.supports_flash_attn_prefill_head_major()
+            || backend.supports_flash_attn_prefill())
+    {
         kiln_nvtx::range!(c"kiln/attn/full/prefill_initial");
-        let q_prefill = q.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_heads, head_dim]
-        let k_prefill = k.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_kv_heads, head_dim]
-        let v_prefill = v.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_kv_heads, head_dim]
-        if let Some(attn_output) = flash_attention_forward(
-            backend,
-            &q_prefill,
-            &k_prefill,
-            &v_prefill,
-            num_heads,
-            num_kv_heads,
-            head_dim,
-        )? {
+        let attn_output = if let Some(attn_output) =
+            flash_attention_forward_head_major(backend, &q, &k, &v, num_heads, head_dim)?
+        {
+            Some(attn_output)
+        } else if backend.supports_flash_attn_prefill() {
+            let q_prefill = q.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_heads, head_dim]
+            let k_prefill = k.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_kv_heads, head_dim]
+            let v_prefill = v.transpose(1, 2)?.contiguous()?; // -> [batch, seq_len, num_kv_heads, head_dim]
+            flash_attention_forward(
+                backend,
+                &q_prefill,
+                &k_prefill,
+                &v_prefill,
+                num_heads,
+                num_kv_heads,
+                head_dim,
+            )?
+        } else {
+            None
+        };
+
+        if let Some(attn_output) = attn_output {
             {
                 kiln_nvtx::range!(c"kiln/kv/copy");
                 paged_cache
@@ -3488,6 +3539,40 @@ pub fn model_forward_paged(
     )?;
     // `LmHeadMode::Full` always returns Some.
     Ok(logits.expect("LmHeadMode::Full always produces logits"))
+}
+
+/// Paged-KV forward pass for generation prefill when only the next-token
+/// distribution is needed.
+///
+/// This runs the same layer loop and paged KV writes as [`model_forward_paged`]
+/// but only projects the final hidden row through the LM head, returning
+/// logits with shape `[1, 1, vocab_size]`.
+pub fn model_forward_paged_last_token(
+    backend: &dyn BackendRuntime,
+    token_ids: &[u32],
+    weights: &GpuWeights,
+    config: &kiln_core::config::ModelConfig,
+    paged_cache: &mut PagedKvCache,
+    block_table: &BlockTable,
+    start_pos: usize,
+    linear_state: Option<&mut LinearAttentionState>,
+    lora: Option<&LoraWeights>,
+    positions_gpu: Option<&Tensor>,
+) -> Result<Tensor> {
+    let (logits, _hidden) = model_forward_paged_inner(
+        backend,
+        token_ids,
+        weights,
+        config,
+        paged_cache,
+        block_table,
+        start_pos,
+        linear_state,
+        lora,
+        positions_gpu,
+        LmHeadMode::LastRowOnly,
+    )?;
+    Ok(logits.expect("LmHeadMode::LastRowOnly always produces logits"))
 }
 
 /// Paged-KV forward pass that ALSO returns the last-row pre-final-norm hidden state.
@@ -6733,6 +6818,73 @@ mod tests {
                 "tile={tile} last-token max_abs_diff={max_abs:e} exceeds 1e-5"
             );
         }
+        Ok(())
+    }
+
+    #[test]
+    fn test_model_forward_paged_last_token_matches_full_last_row_cpu() -> Result<()> {
+        let config = streaming_test_config();
+        let total = 128;
+        let tokens = deterministic_tokens(total, config.vocab_size as u32);
+        let device = Device::Cpu;
+        let weights = make_hybrid_gpu_weights(
+            &device,
+            config.vocab_size,
+            config.hidden_size,
+            config.num_attention_heads,
+            config.num_kv_heads,
+            config.head_dim,
+            config.intermediate_size,
+            config.num_layers,
+            config.full_attention_interval,
+        )?;
+        let backend = test_backend(&device);
+
+        let (mut full_cache, full_bt) = make_paged_setup(&config, total, 64, &device)?;
+        let mut full_state = LinearAttentionState::new(&config, &device)?;
+        let full_logits = model_forward_paged(
+            &backend,
+            &tokens,
+            &weights,
+            &config,
+            &mut full_cache,
+            &full_bt,
+            0,
+            Some(&mut full_state),
+            None,
+            None,
+        )?;
+        let reference_last = full_logits
+            .narrow(1, total - 1, 1)?
+            .flatten_all()?
+            .to_vec1::<f32>()?;
+
+        let (mut last_cache, last_bt) = make_paged_setup(&config, total, 64, &device)?;
+        let mut last_state = LinearAttentionState::new(&config, &device)?;
+        let last_logits = model_forward_paged_last_token(
+            &backend,
+            &tokens,
+            &weights,
+            &config,
+            &mut last_cache,
+            &last_bt,
+            0,
+            Some(&mut last_state),
+            None,
+            None,
+        )?;
+        assert_eq!(last_logits.dims(), &[1, 1, config.vocab_size]);
+        let last = last_logits.flatten_all()?.to_vec1::<f32>()?;
+        let max_abs = reference_last
+            .iter()
+            .zip(last.iter())
+            .map(|(a, b)| (a - b).abs())
+            .fold(0f32, f32::max);
+        assert!(
+            max_abs <= 1e-5,
+            "last-token prefill max_abs_diff={max_abs:e} exceeds 1e-5"
+        );
+
         Ok(())
     }
 

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -17,7 +17,8 @@ use crate::backend::{self, BackendRuntime};
 use crate::cuda_graph::CudaGraphRunner;
 use crate::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
-    model_forward_paged_streaming, model_forward_paged_with_last_hidden, streaming_prefill_enabled,
+    model_forward_paged_last_token, model_forward_paged_streaming,
+    model_forward_paged_with_last_hidden, streaming_prefill_enabled,
 };
 use crate::kv_cache::KvCache;
 use crate::lora_loader::LoraWeights;
@@ -411,6 +412,10 @@ impl ModelRunner {
                 }
             }
 
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
             // Decode step: forward pass on just the new token
             let logits = model_forward(
                 &*self.backend,
@@ -525,6 +530,10 @@ impl ModelRunner {
                         }
                     }
                 }
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
             }
 
             // Decode step: forward pass on just the new token (KV cache has all previous)
@@ -759,7 +768,7 @@ impl ModelRunner {
                 )
                 .context("prefill forward pass (paged, streaming) failed")?
             } else {
-                model_forward_paged(
+                model_forward_paged_last_token(
                     &*self.backend,
                     prompt_tokens,
                     &self.weights,
@@ -823,6 +832,10 @@ impl ModelRunner {
                         }
                     }
                 }
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
             }
 
             let logits = {
@@ -890,7 +903,7 @@ impl ModelRunner {
             )
             .context("prefill forward pass (paged, streaming) failed")?
         } else {
-            model_forward_paged(
+            model_forward_paged_last_token(
                 &*self.backend,
                 prompt_tokens,
                 &self.weights,
@@ -962,6 +975,10 @@ impl ModelRunner {
                         }
                     }
                 }
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
             }
 
             // Decode step: use CUDA graph runner (captures/replays when enabled)
@@ -2070,6 +2087,10 @@ impl ModelRunner {
                 StreamTokenDisposition::ReceiverDropped => return Ok(rx),
             }
 
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
             let logits = {
                 let mut pc_guard = lock_paged_cache(paged_cache)?;
                 model_forward_paged(
@@ -2263,6 +2284,10 @@ impl ModelRunner {
                         }
                     }
                 }
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
             }
 
             // Decode step: use CUDA graph runner

--- a/crates/kiln-model/src/paged_kv_cache.rs
+++ b/crates/kiln-model/src/paged_kv_cache.rs
@@ -125,6 +125,17 @@ impl PagedKvCache {
         let new_len = k.dim(2)?;
         let (k_pool, v_pool) = &mut self.layers[layer_idx];
 
+        if new_len == 1 {
+            let slot = block_table
+                .slot_for(start_pos, self.block_size)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no slot for position {start_pos} in block table")
+                })?;
+            k_pool.slice_set(&k.squeeze(2)?, 0, slot)?;
+            v_pool.slice_set(&v.squeeze(2)?, 0, slot)?;
+            return Ok(());
+        }
+
         // Reshape from [1, num_kv_heads, new_len, head_dim] to [new_len, num_kv_heads, head_dim]
         let k_flat = k.squeeze(0)?.transpose(0, 1)?.contiguous()?;
         let v_flat = v.squeeze(0)?.transpose(0, 1)?.contiguous()?;
@@ -161,6 +172,20 @@ impl PagedKvCache {
         v: &Tensor,
     ) -> Result<()> {
         let new_len = k.dim(2)?;
+
+        if new_len == 1 {
+            let slot = block_table
+                .slot_for(start_pos, self.block_size)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no slot for position {start_pos} in block table")
+                })?;
+            let k_q = fp8::quantize_to_fp8_direct(&k.squeeze(2)?)?;
+            let v_q = fp8::quantize_to_fp8_direct(&v.squeeze(2)?)?;
+            let (k_pool, v_pool) = &mut self.layers[layer_idx];
+            k_pool.slice_set(&k_q, 0, slot)?;
+            v_pool.slice_set(&v_q, 0, slot)?;
+            return Ok(());
+        }
 
         // Reshape from [1, num_kv_heads, new_len, head_dim] to [new_len, num_kv_heads, head_dim]
         let k_flat = k.squeeze(0)?.transpose(0, 1)?.contiguous()?;
@@ -566,6 +591,31 @@ mod tests {
     }
 
     #[test]
+    fn test_single_token_write_preserves_multihead_layout() -> Result<()> {
+        let device = Device::Cpu;
+        let mut cache = PagedKvCache::new(1, 2, 4, 2, 3, DType::F32, &device)?;
+        let mut bt = BlockTable::new();
+        bt.push(1);
+
+        let k = Tensor::new(&[[[[1.0_f32, 2.0, 3.0]], [[4.0_f32, 5.0, 6.0]]]], &device)?;
+        let v = Tensor::new(
+            &[[[[11.0_f32, 12.0, 13.0]], [[14.0_f32, 15.0, 16.0]]]],
+            &device,
+        )?;
+
+        cache.write(0, &bt, 2, &k, &v)?;
+        let (k_out, v_out) = cache.read(0, &bt, 3)?;
+        assert_eq!(k_out.dims(), &[1, 2, 3, 3]);
+
+        let k_last = k_out.narrow(2, 2, 1)?.flatten_all()?.to_vec1::<f32>()?;
+        assert_eq!(k_last, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let v_last = v_out.narrow(2, 2, 1)?.flatten_all()?.to_vec1::<f32>()?;
+        assert_eq!(v_last, vec![11.0, 12.0, 13.0, 14.0, 15.0, 16.0]);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_paged_vs_contiguous_equivalence() -> Result<()> {
         let device = Device::Cpu;
         let num_kv_heads = 2;
@@ -762,6 +812,37 @@ mod tests {
                 rel_err < 0.15,
                 "K index {i}: orig={o}, read={r}, rel_err={rel_err}"
             );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_fp8_single_token_write_roundtrip() -> Result<()> {
+        let device = Device::Cpu;
+        let mut cache = PagedKvCache::new_with_fp8(1, 2, 4, 2, 3, DType::F32, &device, true)?;
+        let mut bt = BlockTable::new();
+        bt.push(0);
+
+        let k = Tensor::new(&[[[[1.0_f32, 2.0, 3.0]], [[4.0_f32, 5.0, 6.0]]]], &device)?;
+        let v = Tensor::new(
+            &[[[[11.0_f32, 12.0, 13.0]], [[14.0_f32, 15.0, 16.0]]]],
+            &device,
+        )?;
+
+        cache.write(0, &bt, 1, &k, &v)?;
+        let (k_out, v_out) = cache.read(0, &bt, 2)?;
+        let k_last = k_out.narrow(2, 1, 1)?.flatten_all()?.to_vec1::<f32>()?;
+        let v_last = v_out.narrow(2, 1, 1)?.flatten_all()?.to_vec1::<f32>()?;
+
+        for (orig, read) in [1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0].iter().zip(k_last.iter()) {
+            assert!((orig - read).abs() / orig.abs().max(0.01) < 0.15);
+        }
+        for (orig, read) in [11.0_f32, 12.0, 13.0, 14.0, 15.0, 16.0]
+            .iter()
+            .zip(v_last.iter())
+        {
+            assert!((orig - read).abs() / orig.abs().max(0.01) < 0.15);
         }
 
         Ok(())

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -5,7 +5,7 @@
 //! Requires a GPU with the Qwen3.5-4B model weights downloaded.
 
 use std::path::Path;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anyhow::{Context, Result};
 use serde::Serialize;
@@ -19,7 +19,8 @@ use kiln_model::ModelRunner;
 use kiln_model::backend as runtime_backend;
 use kiln_model::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
-    model_forward_paged_streaming, model_forward_paged_with_last_hidden, streaming_prefill_enabled,
+    model_forward_paged_last_token, model_forward_paged_streaming,
+    model_forward_paged_with_last_hidden, streaming_prefill_enabled,
 };
 use kiln_model::kv_cache::KvCache;
 use kiln_model::paged_kv_cache::PagedKvCache;
@@ -584,7 +585,7 @@ fn bench_latency_paged(
         )
         .context("paged prefill forward pass (streaming) failed")?
     } else {
-        model_forward_paged(
+        model_forward_paged_last_token(
             &*backend,
             &prompt_token_ids,
             weights,


### PR DESCRIPTION
## Summary

This improves the default macOS/Metal paged inference path without requiring new invocation flags or env vars.

- Add a Metal head-major prefill path so paged prefill can pass the already-transposed Q/K/V tensors directly to candle-metal SDPA, relying on native GQA instead of re-transposing and expanding K/V.
- Add `model_forward_paged_last_token` and use it for non-streaming paged generation and the paged latency bench so prefill only projects the final hidden row through the LM head.
- Stop generation loops immediately after emitting the requested final token, avoiding a wasted decode for `max_tokens=1` and other exact-limit requests.
- Fast-path single-token paged KV writes so decode writes avoid the head-major to token-major transpose/copy.

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model single_token_write --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_model_forward_paged_last_token_matches_full_last_row_cpu --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_model_forward_parity_cpu_vs_metal --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_model_forward_parity_sdpa_path --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo build --release --features metal --bin kiln --bin kiln-bench`

## Measurements

Qwen3.5-4B, Metal, paged, desktop-style defaults:

- Isolated bench: prefill ~17.09s vs prior merged ~18.59s; decode ITL ~317ms vs ~329ms; one-token generation ~410ms vs ~690ms.
- Live server: listen ~52.5s; first one-token request ~18.3s; warmed one-token requests ~3.45s and ~3.53s, down from ~7-12s in the prior merged round.