### PR TITLE
[codex] prewarm Metal inference immediately

### DIFF
--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -1,7 +1,6 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
 
 use anyhow::Result;
 use clap::Parser;
@@ -261,9 +260,6 @@ fn spawn_backend_prewarm(state: AppState) {
     let metrics = state.metrics.clone();
 
     tokio::spawn(async move {
-        // Keep startup user-first: only warm a server that stayed idle long
-        // enough to prove no one is about to interact with it.
-        tokio::time::sleep(Duration::from_secs(30)).await;
         if metrics.request_duration_count.load(Ordering::Relaxed) > 0 {
             tracing::info!(
                 "skipping background inference prewarm because the server has already handled live traffic"
@@ -277,6 +273,7 @@ fn spawn_backend_prewarm(state: AppState) {
             return;
         }
 
+        tracing::info!("starting background inference prewarm");
         let prewarm = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
             if metrics.request_duration_count.load(Ordering::Relaxed) > 0
                 || metrics.active_requests.load(Ordering::Relaxed) > 0


### PR DESCRIPTION
## Summary

Removes the 30-second delay before Metal background inference prewarm. The server now starts the prewarm task as soon as it is listening, instead of waiting long enough for the first desktop request to arrive and force the prewarm to skip.

This keeps the existing safeguards: if live traffic already happened or is active by the time the task runs, prewarm still skips.

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo build --release --features metal --bin kiln`
- Live desktop-style run on Qwen3.5-4B with default macOS env: server listened at ~61.2s, prewarm started immediately at listen time, prewarm completed ~21.5s later, first post-prewarm one-token request took ~4.31s and the next took ~4.11s.

## Impact

Previously, the 30-second delay meant normal desktop usage could hit the server before prewarm ran; when that happened, the background warmup skipped and the first real request paid cold Metal compilation/allocator cost. Now idle time immediately after startup is used to warm the default inference path.