### PR TITLE
[codex] keep desktop starting until health passes

### DIFF
--- a/desktop/src/supervisor.rs
+++ b/desktop/src/supervisor.rs
@@ -275,8 +275,6 @@ async fn run_loop(
             }
         };
 
-        *state.lock().await = ServerState::Running;
-
         if let Some(out) = child.stdout.take() {
             let logs_c = Arc::clone(&logs);
             tokio::spawn(async move {
@@ -403,7 +401,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stop_kills_running_process() {
+    async fn stop_kills_started_process() {
         let config = SupervisorConfig {
             binary_path: PathBuf::from("/bin/sleep"),
             args: vec!["10".to_string()],
@@ -420,8 +418,8 @@ mod tests {
 
         tokio::time::sleep(Duration::from_millis(100)).await;
         assert!(
-            matches!(sup.state().await, ServerState::Running),
-            "expected Running"
+            matches!(sup.state().await, ServerState::Starting | ServerState::Running),
+            "expected Starting or Running"
         );
 
         sup.stop().await.expect("stop");


### PR DESCRIPTION
## Summary

The desktop supervisor was marking the server `Running` immediately after successfully spawning the child process. That happens before model load, listener bind, health, and Metal prewarm, so the tray/UI can advertise readiness while the server is still loading for tens of seconds.

This leaves the state as `Starting` after spawn and lets the existing health poller perform the `Starting -> Running` transition only after `/v1/health` succeeds.

## Validation

- `cargo test supervisor -- --nocapture` from `desktop/`

## Impact

This does not change server invocation params. It fixes the default desktop readiness signal so slow model startup is represented honestly instead of surfacing as a broken first interaction.