### PR TITLE
[codex] mmap dense model weights

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -421,7 +421,7 @@ impl LinearAttentionState {
 /// Convert a `WeightTensor` (raw bytes + shape + dtype) to a candle `Tensor` on `device`.
 fn weight_to_tensor(w: &WeightTensor, device: &Device) -> Result<Tensor> {
     let dtype = weight_dtype(w);
-    let t = Tensor::from_raw_buffer(&w.data, dtype, &w.shape, device)
+    let t = Tensor::from_raw_buffer(w.as_bytes(), dtype, &w.shape, device)
         .context("failed to create tensor from raw buffer")?;
     Ok(t)
 }
@@ -443,25 +443,26 @@ fn transposed_weight_bytes_2d(w: &WeightTensor) -> Result<(Vec<u8>, [usize; 2])>
     let rows = w.shape[0];
     let cols = w.shape[1];
     let elem_size = w.dtype.size_bytes();
+    let data = w.as_bytes();
     let expected_len = rows
         .checked_mul(cols)
         .and_then(|n| n.checked_mul(elem_size))
         .context("weight tensor byte size overflow")?;
     anyhow::ensure!(
-        w.data.len() == expected_len,
+        data.len() == expected_len,
         "weight tensor data length mismatch: got {} bytes, expected {} bytes for shape {:?} and dtype {}",
-        w.data.len(),
+        data.len(),
         expected_len,
         w.shape,
         w.dtype
     );
 
-    let mut out = vec![0u8; w.data.len()];
+    let mut out = vec![0u8; data.len()];
     const ROW_TILE: usize = 32;
     const COL_TILE: usize = 32;
     const PARALLEL_TRANSPOSE_MIN_BYTES: usize = 1 << 20;
 
-    if w.data.len() < PARALLEL_TRANSPOSE_MIN_BYTES {
+    if data.len() < PARALLEL_TRANSPOSE_MIN_BYTES {
         for row0 in (0..rows).step_by(ROW_TILE) {
             let row_end = (row0 + ROW_TILE).min(rows);
             for col0 in (0..cols).step_by(COL_TILE) {
@@ -470,7 +471,7 @@ fn transposed_weight_bytes_2d(w: &WeightTensor) -> Result<(Vec<u8>, [usize; 2])>
                     for col in col0..col_end {
                         let src = (row * cols + col) * elem_size;
                         let dst = (col * rows + row) * elem_size;
-                        out[dst..dst + elem_size].copy_from_slice(&w.data[src..src + elem_size]);
+                        out[dst..dst + elem_size].copy_from_slice(&data[src..src + elem_size]);
                     }
                 }
             }
@@ -494,7 +495,7 @@ fn transposed_weight_bytes_2d(w: &WeightTensor) -> Result<(Vec<u8>, [usize; 2])>
                             let src = (row * cols + col) * elem_size;
                             let dst = out_base + row * elem_size;
                             out_block[dst..dst + elem_size]
-                                .copy_from_slice(&w.data[src..src + elem_size]);
+                                .copy_from_slice(&data[src..src + elem_size]);
                         }
                     }
                 }
@@ -4860,7 +4861,7 @@ mod tests {
         let data: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
         let wt = WeightTensor {
-            data: bytes,
+            data: crate::weights::WeightData::owned(bytes),
             shape: vec![2, 3],
             dtype: TensorDType::F32,
         };
@@ -4882,7 +4883,7 @@ mod tests {
         let data: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
         let wt = WeightTensor {
-            data: bytes,
+            data: crate::weights::WeightData::owned(bytes),
             shape: vec![2, 3],
             dtype: TensorDType::F32,
         };
@@ -4905,7 +4906,7 @@ mod tests {
         let values: Vec<u16> = vec![1, 2, 3, 4, 5, 6];
         let bytes: Vec<u8> = values.iter().flat_map(|v| v.to_le_bytes()).collect();
         let wt = WeightTensor {
-            data: bytes,
+            data: crate::weights::WeightData::owned(bytes),
             shape: vec![2, 3],
             dtype: TensorDType::BF16,
         };
@@ -4931,7 +4932,7 @@ mod tests {
         let data: Vec<f32> = vec![1.0, -2.0, 3.5, 4.25, 5.0, -6.75];
         let bytes: Vec<u8> = data.iter().flat_map(|f| f.to_le_bytes()).collect();
         let wt = WeightTensor {
-            data: bytes,
+            data: crate::weights::WeightData::owned(bytes),
             shape: vec![2, 3],
             dtype: TensorDType::F32,
         };

--- a/crates/kiln-model/src/loader.rs
+++ b/crates/kiln-model/src/loader.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
+use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
 use memmap2::Mmap;
@@ -85,7 +86,7 @@ fn load_model_dense(
     let mmaps = mmap_shards(&shards)?;
     let parsed: Vec<SafeTensors<'_>> = mmaps
         .iter()
-        .map(|mmap| SafeTensors::deserialize(mmap).context("Failed to parse safetensors file"))
+        .map(|mmap| SafeTensors::deserialize(&mmap[..]).context("Failed to parse safetensors file"))
         .collect::<Result<Vec<_>>>()?;
 
     // Build a unified name -> (shard_idx, tensor_view) lookup.
@@ -96,10 +97,10 @@ fn load_model_dense(
             all_tensors.push((name, shard_idx, view));
         }
     }
-    let mut tensor_map: HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)> =
+    let mut tensor_map: HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)> =
         HashMap::new();
     for (name, shard_idx, view) in &all_tensors {
-        tensor_map.insert(name.as_str(), (*shard_idx, view));
+        tensor_map.insert(name.as_str(), (Arc::clone(&mmaps[*shard_idx]), view));
     }
 
     // Auto-detect prefix: try "model.language_model." first, fall back to "model.".
@@ -186,7 +187,7 @@ fn load_model_gptq(
     let mmaps = mmap_shards(&shards)?;
     let parsed: Vec<SafeTensors<'_>> = mmaps
         .iter()
-        .map(|mmap| SafeTensors::deserialize(mmap).context("Failed to parse safetensors file"))
+        .map(|mmap| SafeTensors::deserialize(&mmap[..]).context("Failed to parse safetensors file"))
         .collect::<Result<Vec<_>>>()?;
 
     let mut all_tensors: Vec<(String, usize, safetensors::tensor::TensorView<'_>)> = Vec::new();
@@ -195,10 +196,10 @@ fn load_model_gptq(
             all_tensors.push((name, shard_idx, view));
         }
     }
-    let mut tensor_map: HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)> =
+    let mut tensor_map: HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)> =
         HashMap::new();
     for (name, shard_idx, view) in &all_tensors {
-        tensor_map.insert(name.as_str(), (*shard_idx, view));
+        tensor_map.insert(name.as_str(), (Arc::clone(&mmaps[*shard_idx]), view));
     }
 
     let prefix = detect_prefix(&tensor_map);
@@ -317,7 +318,7 @@ fn discover_shards(model_dir: &Path) -> Result<Vec<std::path::PathBuf>> {
 }
 
 /// Memory-map all shard files.
-fn mmap_shards(paths: &[std::path::PathBuf]) -> Result<Vec<Mmap>> {
+fn mmap_shards(paths: &[std::path::PathBuf]) -> Result<Vec<Arc<Mmap>>> {
     paths
         .iter()
         .map(|path| {
@@ -325,15 +326,16 @@ fn mmap_shards(paths: &[std::path::PathBuf]) -> Result<Vec<Mmap>> {
                 .with_context(|| format!("Failed to open {}", path.display()))?;
             // SAFETY: We assume the file is not modified while mapped.
             // This is standard practice for model weight loading.
-            unsafe { Mmap::map(&file) }
-                .with_context(|| format!("Failed to mmap {}", path.display()))
+            let mmap = unsafe { Mmap::map(&file) }
+                .with_context(|| format!("Failed to mmap {}", path.display()))?;
+            Ok(Arc::new(mmap))
         })
         .collect()
 }
 
 /// Detect the weight name prefix by checking which keys exist.
 fn detect_prefix(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
 ) -> String {
     // Try the VL model prefix first (Qwen3.5-4B ships as VL).
     if tensor_map.contains_key(&format!("{LM_PREFIX}embed_tokens.weight") as &str) {
@@ -353,7 +355,7 @@ fn detect_prefix(
 
 /// Load one transformer layer's weights.
 fn load_layer(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -395,7 +397,7 @@ fn load_layer(
 
 /// Load full GQA attention weights.
 fn load_full_attention(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -437,7 +439,7 @@ fn load_full_attention(
 
 /// Load Gated DeltaNet linear attention weights.
 fn load_linear_attention(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -526,7 +528,7 @@ fn load_linear_attention(
 
 /// Load FFN/MLP weights.
 fn load_ffn(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -570,7 +572,7 @@ fn load_ffn(
 /// `{candidate}fc.weight`, which is always present when MTP is shipped.
 /// Returns `None` if no MTP tensors are present (checkpoint is MTP-less).
 fn detect_mtp_prefix(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     base_prefix: &str,
 ) -> Option<String> {
     let prefixed = format!("{base_prefix}mtp.");
@@ -608,7 +610,7 @@ fn detect_mtp_prefix(
 /// Returns `Ok(Some(..))` when detected, `Ok(None)` when absent (so older
 /// or MTP-less checkpoints continue to load unchanged).
 fn load_mtp_if_present(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     prefix: &str,
     config: &ModelConfig,
 ) -> Result<Option<MtpWeights>> {
@@ -705,10 +707,10 @@ fn load_mtp_if_present(
 
 /// Extract a tensor by name from the unified tensor map.
 fn extract_tensor(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     name: &str,
 ) -> Result<WeightTensor> {
-    let (_shard_idx, view) = tensor_map
+    let (mmap, view) = tensor_map
         .get(name)
         .with_context(|| format!("Weight tensor not found: {name}"))?;
 
@@ -716,7 +718,16 @@ fn extract_tensor(
         .with_context(|| format!("Unsupported dtype {:?} for tensor {name}", view.dtype()))?;
 
     let shape: Vec<usize> = view.shape().to_vec();
-    let data = view.data().to_vec();
+    let view_data = view.data();
+    let mmap_start = mmap.as_ptr() as usize;
+    let mmap_end = mmap_start + mmap.len();
+    let data_start = view_data.as_ptr() as usize;
+    let data_end = data_start + view_data.len();
+    anyhow::ensure!(
+        data_start >= mmap_start && data_end <= mmap_end,
+        "tensor {name} data does not point into its safetensors mmap"
+    );
+    let data = WeightData::mmap_slice(Arc::clone(mmap), data_start - mmap_start, view_data.len());
 
     Ok(WeightTensor { data, shape, dtype })
 }
@@ -752,7 +763,7 @@ fn validate_shape(tensor: &WeightTensor, expected: &[usize], name: &str) -> Resu
 /// loaded from packed INT4 (qweight + scales + qzeros) and dequantized to BF16.
 /// Non-linear weights (norms, conv1d, a_log, dt_bias) are loaded as-is.
 fn load_layer_gptq(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -808,7 +819,7 @@ fn load_layer_gptq(
 /// Looks for `{name}.qweight`, `{name}.scales`, `{name}.qzeros` in the tensor map.
 /// Returns a dense BF16 `WeightTensor` with shape `[out_features, in_features]`.
 fn load_gptq_linear(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     name: &str,
     gptq_config: &GptqConfig,
     ctx: &str,
@@ -840,10 +851,10 @@ fn load_gptq_linear(
 /// Extract raw tensor data (bytes, shape, dtype) without dtype conversion.
 /// Used for GPTQ tensors which may be I32 (not supported by our TensorDType).
 fn extract_raw_tensor(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     name: &str,
 ) -> Result<(Vec<u8>, Vec<usize>, safetensors::Dtype)> {
-    let (_shard_idx, view) = tensor_map
+    let (_mmap, view) = tensor_map
         .get(name)
         .with_context(|| format!("Weight tensor not found: {name}"))?;
     Ok((view.data().to_vec(), view.shape().to_vec(), view.dtype()))
@@ -851,7 +862,7 @@ fn extract_raw_tensor(
 
 /// Load GPTQ-quantized full GQA attention weights.
 fn load_full_attention_gptq(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -915,7 +926,7 @@ fn load_full_attention_gptq(
 
 /// Load GPTQ-quantized Gated DeltaNet linear attention weights.
 fn load_linear_attention_gptq(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -1031,7 +1042,7 @@ fn load_linear_attention_gptq(
 
 /// Load GPTQ-quantized FFN/MLP weights.
 fn load_ffn_gptq(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -1088,7 +1099,7 @@ fn load_ffn_gptq(
 /// Some small projections (e.g., GDN's in_proj_a/b) may not be quantized
 /// in certain GPTQ models. This function handles both cases gracefully.
 fn load_gptq_or_dense(
-    tensor_map: &HashMap<&str, (usize, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
     name: &str,
     gptq_config: &GptqConfig,
     ctx: &str,
@@ -1491,24 +1502,80 @@ mod tests {
         let bf16 = StDtype::BF16;
 
         let mut tensors: Vec<(String, Vec<usize>, StDtype)> = Vec::new();
-        tensors.push((format!("{mtp_prefix}fc.weight"), vec![hidden, 2 * hidden], bf16));
-        tensors.push((format!("{mtp_prefix}pre_fc_norm_embedding.weight"), vec![hidden], bf16));
-        tensors.push((format!("{mtp_prefix}pre_fc_norm_hidden.weight"), vec![hidden], bf16));
-        tensors.push((format!("{mtp_prefix}{final_ln_name}.weight"), vec![hidden], bf16));
+        tensors.push((
+            format!("{mtp_prefix}fc.weight"),
+            vec![hidden, 2 * hidden],
+            bf16,
+        ));
+        tensors.push((
+            format!("{mtp_prefix}pre_fc_norm_embedding.weight"),
+            vec![hidden],
+            bf16,
+        ));
+        tensors.push((
+            format!("{mtp_prefix}pre_fc_norm_hidden.weight"),
+            vec![hidden],
+            bf16,
+        ));
+        tensors.push((
+            format!("{mtp_prefix}{final_ln_name}.weight"),
+            vec![hidden],
+            bf16,
+        ));
 
         // One full-attention transformer layer at mtp.layers.0.*
         let lp = format!("{mtp_prefix}layers.0.");
         tensors.push((format!("{lp}input_layernorm.weight"), vec![hidden], bf16));
-        tensors.push((format!("{lp}post_attention_layernorm.weight"), vec![hidden], bf16));
-        tensors.push((format!("{lp}mlp.gate_proj.weight"), vec![intermediate, hidden], bf16));
-        tensors.push((format!("{lp}mlp.up_proj.weight"), vec![intermediate, hidden], bf16));
-        tensors.push((format!("{lp}mlp.down_proj.weight"), vec![hidden, intermediate], bf16));
-        tensors.push((format!("{lp}self_attn.q_proj.weight"), vec![q_proj_dim, hidden], bf16));
-        tensors.push((format!("{lp}self_attn.k_proj.weight"), vec![kv_dim, hidden], bf16));
-        tensors.push((format!("{lp}self_attn.v_proj.weight"), vec![kv_dim, hidden], bf16));
-        tensors.push((format!("{lp}self_attn.o_proj.weight"), vec![hidden, q_out_dim], bf16));
-        tensors.push((format!("{lp}self_attn.q_norm.weight"), vec![config.head_dim], bf16));
-        tensors.push((format!("{lp}self_attn.k_norm.weight"), vec![config.head_dim], bf16));
+        tensors.push((
+            format!("{lp}post_attention_layernorm.weight"),
+            vec![hidden],
+            bf16,
+        ));
+        tensors.push((
+            format!("{lp}mlp.gate_proj.weight"),
+            vec![intermediate, hidden],
+            bf16,
+        ));
+        tensors.push((
+            format!("{lp}mlp.up_proj.weight"),
+            vec![intermediate, hidden],
+            bf16,
+        ));
+        tensors.push((
+            format!("{lp}mlp.down_proj.weight"),
+            vec![hidden, intermediate],
+            bf16,
+        ));
+        tensors.push((
+            format!("{lp}self_attn.q_proj.weight"),
+            vec![q_proj_dim, hidden],
+            bf16,
+        ));
+        tensors.push((
+            format!("{lp}self_attn.k_proj.weight"),
+            vec![kv_dim, hidden],
+            bf16,
+        ));
+        tensors.push((
+            format!("{lp}self_attn.v_proj.weight"),
+            vec![kv_dim, hidden],
+            bf16,
+        ));
+        tensors.push((
+            format!("{lp}self_attn.o_proj.weight"),
+            vec![hidden, q_out_dim],
+            bf16,
+        ));
+        tensors.push((
+            format!("{lp}self_attn.q_norm.weight"),
+            vec![config.head_dim],
+            bf16,
+        ));
+        tensors.push((
+            format!("{lp}self_attn.k_norm.weight"),
+            vec![config.head_dim],
+            bf16,
+        ));
         tensors
     }
 
@@ -1539,11 +1606,8 @@ mod tests {
     fn test_load_mtp_vl_prefix_with_norm() {
         // VL-wrapped layout: mtp tensors nested under the LM prefix,
         // final RMSNorm is `norm.weight`.
-        let weights = load_tiny_with_mtp(
-            "model.language_model.",
-            "model.language_model.mtp.",
-            "norm",
-        );
+        let weights =
+            load_tiny_with_mtp("model.language_model.", "model.language_model.mtp.", "norm");
         let mtp = weights.mtp.expect("MTP weights should have loaded");
         assert_eq!(mtp.fc.shape, vec![64, 128]);
         assert_eq!(mtp.final_layernorm.shape, vec![64]);
@@ -1554,12 +1618,10 @@ mod tests {
     fn test_load_mtp_bare_prefix_qwen35() {
         // Qwen3.5-4B stock layout: LM under `model.language_model.` prefix
         // but MTP tensors at bare `mtp.*` with `norm.weight` head norm.
-        let weights = load_tiny_with_mtp(
-            "model.language_model.",
-            "mtp.",
-            "norm",
-        );
-        let mtp = weights.mtp.expect("MTP weights should have loaded (bare prefix)");
+        let weights = load_tiny_with_mtp("model.language_model.", "mtp.", "norm");
+        let mtp = weights
+            .mtp
+            .expect("MTP weights should have loaded (bare prefix)");
         assert_eq!(mtp.fc.shape, vec![64, 128]);
         assert_eq!(mtp.final_layernorm.shape, vec![64]);
         assert!(matches!(mtp.layer.attention, AttentionWeights::Full(_)));
@@ -1569,12 +1631,10 @@ mod tests {
     fn test_load_mtp_final_layernorm_alias() {
         // Older convention / vLLM naming: final RMSNorm is
         // `final_layernorm.weight`. Must still load.
-        let weights = load_tiny_with_mtp(
-            "model.language_model.",
-            "mtp.",
-            "final_layernorm",
-        );
-        let mtp = weights.mtp.expect("MTP weights should have loaded with final_layernorm alias");
+        let weights = load_tiny_with_mtp("model.language_model.", "mtp.", "final_layernorm");
+        let mtp = weights
+            .mtp
+            .expect("MTP weights should have loaded with final_layernorm alias");
         assert_eq!(mtp.final_layernorm.shape, vec![64]);
     }
 
@@ -1593,7 +1653,10 @@ mod tests {
 
         let config = tiny_model_config();
         let weights = load_model(dir.path(), &config).unwrap();
-        assert!(weights.mtp.is_none(), "MTP should be None when tensors are absent");
+        assert!(
+            weights.mtp.is_none(),
+            "MTP should be None when tensors are absent"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -1956,7 +2019,7 @@ mod tests {
 
         // Verify dequantized values are reasonable.
         // With weight=5, zero=8, scale=1.0: expected = (5-8)*1.0 = -3.0
-        let gate_data = &weights.layers[0].mlp.gate_proj.data;
+        let gate_data = weights.layers[0].mlp.gate_proj.as_bytes();
         let first_bf16 = u16::from_le_bytes([gate_data[0], gate_data[1]]);
         let first_val = f32::from_bits((first_bf16 as u32) << 16);
         assert!(

--- a/crates/kiln-model/src/quantized.rs
+++ b/crates/kiln-model/src/quantized.rs
@@ -18,7 +18,7 @@
 //! A future follow-up will add GPU-native INT4 storage with a custom CUDA
 //! dequantization kernel for ~50% GPU memory savings.
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use std::path::Path;
 
@@ -80,10 +80,7 @@ pub fn dequantize_gptq_weight(
     let pack_factor = 8usize; // 32 / 4 bits
 
     if qweight_shape.len() != 2 {
-        bail!(
-            "qweight must be 2-D, got shape {:?}",
-            qweight_shape
-        );
+        bail!("qweight must be 2-D, got shape {:?}", qweight_shape);
     }
 
     let in_features_packed = qweight_shape[0];
@@ -106,10 +103,8 @@ pub fn dequantize_gptq_weight(
     }
 
     // Interpret raw bytes as u32 slices (GPTQ stores as I32 but bit patterns are the same).
-    let qweight = bytes_as_u32(qweight_data)
-        .context("qweight byte alignment")?;
-    let qzeros = bytes_as_u32(qzeros_data)
-        .context("qzeros byte alignment")?;
+    let qweight = bytes_as_u32(qweight_data).context("qweight byte alignment")?;
+    let qzeros = bytes_as_u32(qzeros_data).context("qzeros byte alignment")?;
 
     if qweight.len() < in_features_packed * out_features {
         bail!(
@@ -156,13 +151,10 @@ pub fn dequantize_gptq_weight(
     }
 
     // Convert u16 slice to bytes
-    let output_bytes: Vec<u8> = output_bf16
-        .iter()
-        .flat_map(|v| v.to_le_bytes())
-        .collect();
+    let output_bytes: Vec<u8> = output_bf16.iter().flat_map(|v| v.to_le_bytes()).collect();
 
     Ok(WeightTensor {
-        data: output_bytes,
+        data: crate::weights::WeightData::owned(output_bytes),
         shape: vec![out_features, in_features],
         dtype: TensorDType::BF16,
     })
@@ -175,10 +167,7 @@ pub fn dequantize_gptq_weight(
 /// Reinterpret a byte slice as a u32 slice (little-endian assumed).
 fn bytes_as_u32(data: &[u8]) -> Result<Vec<u32>> {
     if data.len() % 4 != 0 {
-        bail!(
-            "byte slice length {} is not a multiple of 4",
-            data.len()
-        );
+        bail!("byte slice length {} is not a multiple of 4", data.len());
     }
     Ok(data
         .chunks_exact(4)
@@ -329,9 +318,7 @@ mod tests {
 
         // Pack weight values: all 5s (INT4 value = 5)
         // u32 with 8 copies of 5: 5 | (5<<4) | (5<<8) | ... | (5<<28)
-        let packed_5: u32 = (0..pack_factor)
-            .map(|i| 5u32 << (i * 4))
-            .sum();
+        let packed_5: u32 = (0..pack_factor).map(|i| 5u32 << (i * 4)).sum();
 
         // qweight: [2, 2] flattened row-major
         let qweight: Vec<u32> = vec![packed_5; (in_features / pack_factor) * out_features];
@@ -339,9 +326,7 @@ mod tests {
 
         // qzeros: all 8s (midpoint for symmetric INT4)
         // [2, 1] = 2 u32 values, each packing 8 zero points
-        let packed_8: u32 = (0..pack_factor)
-            .map(|i| 8u32 << (i * 4))
-            .sum();
+        let packed_8: u32 = (0..pack_factor).map(|i| 8u32 << (i * 4)).sum();
         let qzeros: Vec<u32> = vec![packed_8; 2];
         let qzeros_bytes: Vec<u8> = qzeros.iter().flat_map(|v| v.to_le_bytes()).collect();
 
@@ -369,7 +354,7 @@ mod tests {
         // Expected: (5 - 8) * 0.5 = -1.5 for all elements
         let expected_bf16 = f32_to_bf16(-1.5);
         let result_u16: Vec<u16> = result
-            .data
+            .as_bytes()
             .chunks_exact(2)
             .map(|c| u16::from_le_bytes([c[0], c[1]]))
             .collect();
@@ -415,7 +400,7 @@ mod tests {
         assert_eq!(result.shape, vec![1, 8]);
 
         let result_values: Vec<f32> = result
-            .data
+            .as_bytes()
             .chunks_exact(2)
             .map(|c| bf16_to_f32(u16::from_le_bytes([c[0], c[1]])))
             .collect();

--- a/crates/kiln-model/src/weights.rs
+++ b/crates/kiln-model/src/weights.rs
@@ -1,4 +1,8 @@
 use std::fmt;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use memmap2::Mmap;
 
 /// Data type for stored tensor data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -28,12 +32,70 @@ impl fmt::Display for TensorDType {
     }
 }
 
-/// A loaded tensor: owned raw bytes with shape and dtype metadata.
+/// Backing storage for loaded tensor bytes.
+pub enum WeightData {
+    /// Owned bytes, used by generated/dequantized tensors and tests.
+    Owned(Vec<u8>),
+    /// Read-only slice into a memory-mapped safetensors shard.
+    MmapSlice {
+        mmap: Arc<Mmap>,
+        offset: usize,
+        len: usize,
+    },
+}
+
+impl WeightData {
+    pub fn owned(data: Vec<u8>) -> Self {
+        Self::Owned(data)
+    }
+
+    pub fn mmap_slice(mmap: Arc<Mmap>, offset: usize, len: usize) -> Self {
+        Self::MmapSlice { mmap, offset, len }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        match self {
+            WeightData::Owned(data) => data,
+            WeightData::MmapSlice { mmap, offset, len } => &mmap[*offset..*offset + *len],
+        }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        self.as_bytes()
+    }
+
+    pub fn len(&self) -> usize {
+        self.as_bytes().len()
+    }
+}
+
+impl Deref for WeightData {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_bytes()
+    }
+}
+
+impl fmt::Debug for WeightData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WeightData::Owned(data) => f.debug_struct("Owned").field("len", &data.len()).finish(),
+            WeightData::MmapSlice { offset, len, .. } => f
+                .debug_struct("MmapSlice")
+                .field("offset", offset)
+                .field("len", len)
+                .finish(),
+        }
+    }
+}
+
+/// A loaded tensor: raw bytes with shape and dtype metadata.
 ///
 /// This is a CPU-side representation. The forward pass will convert these
 /// to GPU tensors (candle Tensor or raw CUDA buffers).
 pub struct WeightTensor {
-    pub data: Vec<u8>,
+    pub data: WeightData,
     pub shape: Vec<usize>,
     pub dtype: TensorDType,
 }
@@ -47,6 +109,11 @@ impl WeightTensor {
     /// Total size in bytes.
     pub fn size_bytes(&self) -> usize {
         self.data.len()
+    }
+
+    /// Raw tensor bytes in row-major safetensors order.
+    pub fn as_bytes(&self) -> &[u8] {
+        self.data.as_bytes()
     }
 }
 


### PR DESCRIPTION
## Summary

- Keep dense safetensors weights backed by their read-only mmap instead of copying every tensor into owned CPU buffers during load.
- Add a `WeightData` backing enum so existing forward/upload paths can consume either owned/generated bytes or mmap slices through `WeightTensor::as_bytes()`.
- Preserve owned extraction for GPTQ raw tensors and generated dequantized BF16 weights.

## Why

The default macOS desktop model load was paying an up-front CPU copy over roughly 8 GiB of dense model weights before Metal upload/transposition even began. That copy sat directly on the startup critical path and also inflated memory pressure on unified-memory Macs. Under the desktop default invocation/env, this patch removes that copy while keeping the existing model execution path unchanged.

## Measured locally

Default desktop-style model: `Qwen__Qwen3.5-4B`, Metal, paged inference, prefix cache enabled, spec disabled.

- `kiln-bench` model load: ~27.99s after this patch, down from ~51.45s in the previous merged round.
- Live server listen: ~24.6s after process start on port 8019.
- Background prewarm complete: ~15.8s after listen.
- Post-prewarm one-token requests: 4.59s, then 4.18s.

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model loader --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_weight_to_transposed_tensor_2d_metal_matches_cpu_cached_transpose --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo build --release --features metal --bin kiln --bin kiln-bench`