### PR TITLE
mtp: Phase B7 — multi-position dual-dump + per-sub-op tap bisect

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2615,6 +2615,11 @@ pub fn gqa_attention_paged(
         )?;
         (q_raw, k, v)
     };
+    // Phase B7b sub-op taps: post-projection (pre-split). `q_raw` may include
+    // the gate half when `attn_output_gate` is on, so its trailing dim is 2H.
+    let _ = crate::mtp_debug::capture_subop("post_q_proj_raw", &q_raw);
+    let _ = crate::mtp_debug::capture_subop("post_k_proj", &k);
+    let _ = crate::mtp_debug::capture_subop("post_v_proj", &v);
 
     let (q, gate) = {
         kiln_nvtx::range!(c"kiln/proj/qkv_split");
@@ -2631,6 +2636,11 @@ pub fn gqa_attention_paged(
             (q, None)
         }
     };
+    // After the gate split, q is the rotation target.
+    let _ = crate::mtp_debug::capture_subop("post_q_split", &q);
+    if let Some(ref g) = gate {
+        let _ = crate::mtp_debug::capture_subop("post_gate_split", g);
+    }
 
     let k = k.reshape(((), seq_len, num_kv_heads, head_dim))?;
     let v = v.reshape(((), seq_len, num_kv_heads, head_dim))?;
@@ -2642,6 +2652,8 @@ pub fn gqa_attention_paged(
         let k = rms_norm(&k, &attn_weights.k_norm, rms_norm_eps)?;
         (q, k)
     };
+    let _ = crate::mtp_debug::capture_subop("post_q_norm", &q);
+    let _ = crate::mtp_debug::capture_subop("post_k_norm", &k);
 
     // RoPE — only rotate first rotary_dim dimensions
     // Use the GPU tensor variant so positions remain at a stable GPU address
@@ -2650,6 +2662,8 @@ pub fn gqa_attention_paged(
         kiln_nvtx::range!(c"kiln/attn/rope");
         rotary_embedding_from_tensor(&q, &k, positions, head_dim, rotary_dim, inv_freq)?
     };
+    let _ = crate::mtp_debug::capture_subop("post_q_rope", &q);
+    let _ = crate::mtp_debug::capture_subop("post_k_rope", &k);
 
     // Transpose to [batch, heads, seq_len, head_dim]
     let (q, k, v) = {
@@ -2863,6 +2877,7 @@ pub fn gqa_attention_paged(
             .transpose(1, 2)?
             .contiguous()?
             .reshape((batch, 1, num_heads * head_dim))?;
+        let _ = crate::mtp_debug::capture_subop("post_attn_raw", &attn_output);
 
         let attn_output = if let Some(ref gate) = gate {
             let sigmoid_gate = cuda_sigmoid(gate)?;
@@ -2870,6 +2885,7 @@ pub fn gqa_attention_paged(
         } else {
             attn_output
         };
+        let _ = crate::mtp_debug::capture_subop("post_attn_gated", &attn_output);
         let out = {
             kiln_nvtx::range!(c"kiln/proj/o");
             linear_with_lora_t(
@@ -2879,6 +2895,7 @@ pub fn gqa_attention_paged(
                 lora_scale,
             )?
         };
+        let _ = crate::mtp_debug::capture_subop("post_o_proj", &out);
         return Ok(out);
     }
 
@@ -2916,6 +2933,7 @@ pub fn gqa_attention_paged(
             .transpose(1, 2)?
             .contiguous()?
             .reshape(((), seq_len, num_heads * head_dim))?;
+    let _ = crate::mtp_debug::capture_subop("post_attn_raw", &attn_output);
 
     let attn_output = if let Some(ref gate) = gate {
         let sigmoid_gate = cuda_sigmoid(gate)?;
@@ -2923,6 +2941,7 @@ pub fn gqa_attention_paged(
     } else {
         attn_output
     };
+    let _ = crate::mtp_debug::capture_subop("post_attn_gated", &attn_output);
 
     let out = {
         kiln_nvtx::range!(c"kiln/proj/o");
@@ -2933,6 +2952,7 @@ pub fn gqa_attention_paged(
             lora_scale,
         )?
     };
+    let _ = crate::mtp_debug::capture_subop("post_o_proj", &out);
     Ok(out)
 }
 
@@ -3103,6 +3123,7 @@ pub fn transformer_block_paged(
         kiln_nvtx::range!(c"kiln/norm/pre_attn");
         rms_norm(x, &layer.input_layernorm, rms_norm_eps)?
     };
+    let _ = crate::mtp_debug::capture_subop("post_pre_attn_norm", &normed);
 
     // Self-attention with paged cache
     let attn_out = gqa_attention_paged(
@@ -3123,27 +3144,33 @@ pub fn transformer_block_paged(
         config.attn_output_gate,
         lora,
     )?;
+    let _ = crate::mtp_debug::capture_subop("post_attn_block", &attn_out);
 
     // Residual connection
     let x = {
         kiln_nvtx::range!(c"kiln/residual");
         (x + attn_out)?
     };
+    let _ = crate::mtp_debug::capture_subop("post_attn_residual", &x);
 
     // Post-attention norm
     let normed = {
         kiln_nvtx::range!(c"kiln/norm/pre_mlp");
         rms_norm(&x, &layer.post_attention_layernorm, rms_norm_eps)?
     };
+    let _ = crate::mtp_debug::capture_subop("post_pre_mlp_norm", &normed);
 
     // Feed-forward network
     let ffn_out = swiglu_ffn(&normed, &layer.mlp, lora)?;
+    let _ = crate::mtp_debug::capture_subop("post_mlp", &ffn_out);
 
     // Residual connection
     let out = {
         kiln_nvtx::range!(c"kiln/residual");
         (x + ffn_out)?
     };
+    // Note: the final block output (`out`) is dumped as `post_layer` at the
+    // outer MTP call site, so we do not re-capture it here.
     Ok(out)
 }
 
@@ -3628,11 +3655,29 @@ pub fn mtp_forward_step(
         concat.broadcast_matmul(&mtp.fc_t)?
     };
 
+    // Phase B7 dump pre-flight: decide whether this draft step should
+    // dump for the current `mtp_pos` and whether to capture per-sub-op
+    // taps inside the inner transformer block. Both decisions happen
+    // BEFORE we run the block so that arming the sub-op capture window
+    // and running the block are bracketed correctly.
+    //
+    // `should_dump` is true at most once per (process, mtp_pos) pair
+    // (see `try_consume_dump_slot_for_pos`). `dump_subops` is a strict
+    // subset: only true when KILN_MTP_DUMP_SUBOPS=1 AND we are about to
+    // dump anyway. This keeps the production path entirely free of
+    // sub-op capture overhead — the TLS check inside `capture_subop`
+    // is a no-op when the window is closed.
+    let should_dump = crate::mtp_debug::try_consume_dump_slot_for_pos(mtp_pos);
+    let dump_subops = should_dump && crate::mtp_debug::is_dump_subops_enabled();
+    if dump_subops {
+        crate::mtp_debug::arm_subop_capture();
+    }
+
     // 5. Single full-attention transformer block with its own paged cache.
     //    Build a one-element position tensor since MTP has its own position
     //    space (distinct from the base model's) and is not CUDA-graph-captured.
     let positions = Tensor::new(&[mtp_pos as f32][..], device)?;
-    let mtp_hidden = transformer_block_paged(
+    let mtp_hidden_result = transformer_block_paged(
         backend,
         &fused,
         &mtp.layer,
@@ -3649,8 +3694,17 @@ pub fn mtp_forward_step(
         mtp_block_table,
         /* full_attn_layer_idx = */ 0,
         /* lora = */ None,
-    )
-    .context("mtp transformer block")?;
+    );
+
+    // Drain the sub-op capture window in BOTH success and error paths so the
+    // TLS slot is not left armed for the next draft step (which would corrupt
+    // the next dump or leak captures into other transformer block calls).
+    let extra_subops = if dump_subops {
+        crate::mtp_debug::drain_subop_capture()
+    } else {
+        Vec::new()
+    };
+    let mtp_hidden = mtp_hidden_result.context("mtp transformer block")?;
 
     // 6. Final RMSNorm + weight-tied LM head (reuses base embed_tokens_t).
     //
@@ -3667,17 +3721,24 @@ pub fn mtp_forward_step(
         normed.broadcast_matmul(&weights.embed_tokens_t)?
     };
 
-    // Phase B6 numerical-bisect dump. Fires once per process when
-    // `KILN_MTP_DUMP_PATH` is set and this is the first draft call that
-    // reaches this point. Writes a single safetensors file with the 8
+    // Phase B6/B7 numerical-bisect dump. Fires once per (process, mtp_pos)
+    // pair when `KILN_MTP_DUMP_PATH` is set and the current `mtp_pos` is
+    // listed in `KILN_MTP_DUMP_POS` (defaults to "0" for B6 compatibility).
+    // Writes one safetensors file per targeted position with the 8 outer
     // taps enumerated in `write_mtp_dump` plus integer metadata (draft
-    // token id, `mtp_pos`, `swap_fc_norms`). The companion Python
-    // reference implementation (`scripts/mtp_reference_dump.py`) produces
-    // the same-shaped file for the same prompt + seed; `scripts/mtp_compare.py`
-    // prints a per-tap first-divergence table. Failure to dump is logged
-    // but non-fatal — we never want an instrumentation bug to break decode.
-    if crate::mtp_debug::try_consume_dump_slot() {
-        if let Some(path) = crate::mtp_debug::dump_path() {
+    // token id, `mtp_pos`, `swap_fc_norms`). When `KILN_MTP_DUMP_SUBOPS=1`
+    // is also set, per-sub-op activations from inside the MTP transformer
+    // block are appended (Phase B7b).
+    //
+    // Use `KILN_MTP_DUMP_PATH=/path/dump_pos{pos}.st` plus
+    // `KILN_MTP_DUMP_POS=0,1,2` to capture three positions in one process.
+    // The companion Python reference (`scripts/mtp_reference_dump.py`)
+    // produces same-shaped files for the same prompt + seed;
+    // `scripts/mtp_compare.py` prints a per-tap first-divergence table.
+    // Failure to dump is logged but non-fatal — we never want an
+    // instrumentation bug to break decode.
+    if should_dump {
+        if let Some(path) = crate::mtp_debug::dump_path_for_pos(mtp_pos) {
             let taps: [(&str, &Tensor); 8] = [
                 ("h_main", h_prev),
                 ("tok_embed", &token_emb),
@@ -3694,18 +3755,20 @@ pub fn mtp_forward_step(
                 mtp_pos,
                 swap_fc_norms,
                 &taps,
+                &extra_subops,
             ) {
                 Ok(()) => tracing::info!(
                     target: "kiln::mtp_debug",
                     path = %path,
                     draft_token_id,
                     mtp_pos,
-                    "mtp_b6_dump_written"
+                    subops = extra_subops.len(),
+                    "mtp_b7_dump_written"
                 ),
                 Err(e) => tracing::warn!(
                     target: "kiln::mtp_debug",
                     error = %e,
-                    "mtp_b6_dump_failed"
+                    "mtp_b7_dump_failed"
                 ),
             }
         }

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -22,13 +22,31 @@
 //! tensor or layout bug appears) or document the runtime evidence in a Tier 2
 //! diagnostic update to `PROFILING.md`.
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
 use candle_core::{DType, Tensor};
 
 static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
-static DUMP_DONE: AtomicBool = AtomicBool::new(false);
+// Phase B7a: track which mtp_pos values have already been dumped so a single
+// process can capture multiple positions. Initialized lazily on first use.
+static DUMP_DONE_POSITIONS: Mutex<Option<HashSet<usize>>> = Mutex::new(None);
+
+thread_local! {
+    /// Phase B7b: thread-local sink for sub-op taps captured inside the MTP
+    /// inner transformer block. `None` = disabled (every `capture_subop` call
+    /// is a no-op). `Some(buf)` = currently capturing into `buf`.
+    ///
+    /// Driven by [`arm_subop_capture`] / [`drain_subop_capture`]. Lives in TLS
+    /// because the MTP debug call sites all run on the inference thread that
+    /// also owns the transformer block; cross-thread capture is not supported
+    /// (and not needed — the dump is single-call, single-thread).
+    static SUBOP_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
+        const { RefCell::new(None) };
+}
 
 const DEFAULT_MAX_CALLS: usize = 16;
 
@@ -108,35 +126,118 @@ pub fn is_swap_fc_norms_enabled() -> bool {
 }
 
 /// Path to which `mtp_forward_step` should dump all 8 Phase B6 numerical
-/// bisect taps on the first draft call, if set. Unset → no dump. Set →
-/// after the first call with valid tensors, the file is written and any
-/// subsequent call is a no-op (see `try_consume_dump_slot`).
+/// bisect taps on each targeted MTP draft call, if set. Unset → no dump.
+///
+/// Phase B7a: when the path contains the literal substring `{pos}`, it is
+/// substituted with the current `mtp_pos` value (e.g. `dump_pos{pos}.st`
+/// becomes `dump_pos0.st`, `dump_pos1.st`, `dump_pos2.st`). This lets a
+/// single run capture multiple positions for monotonic-degradation tests.
+/// If the substring is absent, the path is used as-is — but the dump still
+/// fires once per position in `KILN_MTP_DUMP_POS`, so include `{pos}` to
+/// avoid each later position overwriting the prior file.
 ///
 /// Paired with a Python reference implementation (see
-/// `scripts/mtp_reference_dump.py`) that produces an identically-named
-/// safetensors file for the same fixed prompt + seed. A post-hoc
+/// `scripts/mtp_reference_dump.py`) that produces identically-named
+/// safetensors files for the same fixed prompt + seed. A post-hoc
 /// per-tap `allclose` sweep (see `scripts/mtp_compare.py`) localizes
 /// the first divergence and narrows the remaining runtime hypotheses.
 pub fn dump_path() -> Option<String> {
     std::env::var("KILN_MTP_DUMP_PATH").ok().filter(|s| !s.is_empty())
 }
 
-/// First call after the path env var is set returns `true`; all later
-/// calls return `false` so we only write the file once. Idempotent across
-/// the whole process.
-pub fn try_consume_dump_slot() -> bool {
+/// Path with `{pos}` substituted. Falls through to `dump_path()` when
+/// the placeholder is absent (callers that capture multiple positions
+/// should always include `{pos}` to avoid overwriting prior dumps).
+pub fn dump_path_for_pos(mtp_pos: usize) -> Option<String> {
+    let raw = dump_path()?;
+    Some(raw.replace("{pos}", &mtp_pos.to_string()))
+}
+
+/// Set of `mtp_pos` values for which a dump should be written. Defaults
+/// to `{0}` for backwards compatibility with Phase B6 (which always
+/// dumped pos 0). Set `KILN_MTP_DUMP_POS=0,1,2` to capture three
+/// positions in one process.
+pub fn target_dump_positions() -> HashSet<usize> {
+    let raw = std::env::var("KILN_MTP_DUMP_POS").unwrap_or_default();
+    if raw.trim().is_empty() {
+        let mut s = HashSet::new();
+        s.insert(0);
+        return s;
+    }
+    raw.split(',')
+        .filter_map(|s| s.trim().parse::<usize>().ok())
+        .collect()
+}
+
+/// Returns `true` if this is the first call for `mtp_pos` AND that
+/// position is targeted by `KILN_MTP_DUMP_POS`. Idempotent within the
+/// process — each (pos) value fires at most once.
+pub fn try_consume_dump_slot_for_pos(mtp_pos: usize) -> bool {
     if dump_path().is_none() {
         return false;
     }
-    DUMP_DONE
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_ok()
+    if !target_dump_positions().contains(&mtp_pos) {
+        return false;
+    }
+    let mut guard = DUMP_DONE_POSITIONS
+        .lock()
+        .expect("DUMP_DONE_POSITIONS mutex poisoned");
+    let set = guard.get_or_insert_with(HashSet::new);
+    set.insert(mtp_pos)
 }
 
 /// Reset the dump latch. Test-only helper.
 #[cfg(test)]
 fn reset_dump_latch() {
-    DUMP_DONE.store(false, Ordering::SeqCst);
+    let mut guard = DUMP_DONE_POSITIONS.lock().unwrap();
+    *guard = None;
+}
+
+/// True when `KILN_MTP_DUMP_SUBOPS=1` (or `true`) is set. Phase B7b
+/// opt-in: when enabled and `mtp_forward_step` is about to dump for the
+/// targeted `mtp_pos`, the inner transformer block records each named
+/// sub-op tensor (post_q_proj, post_qk_norm, post_rope, …) into a
+/// thread-local buffer that is appended to the safetensors file.
+pub fn is_dump_subops_enabled() -> bool {
+    std::env::var("KILN_MTP_DUMP_SUBOPS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Begin a sub-op capture window. Subsequent [`capture_subop`] calls
+/// from the same thread record into a fresh buffer until
+/// [`drain_subop_capture`] is called.
+pub fn arm_subop_capture() {
+    SUBOP_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
+}
+
+/// Drain the captured sub-op tensors and disarm. Returns whatever was
+/// recorded since the matching [`arm_subop_capture`] call, in order.
+pub fn drain_subop_capture() -> Vec<(String, Vec<usize>, Vec<f32>)> {
+    SUBOP_CAPTURE.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+/// Record one named tap if a capture window is currently open on this
+/// thread. Cheap no-op (single TLS access + borrow) when the window is
+/// closed, which is the production case. The tensor is materialized to
+/// host F32 immediately so the GPU scratch is free to be reused.
+///
+/// Unlike `write_mtp_dump`, this is best-effort: serialization errors
+/// are swallowed (returned via `Result` so callers using `?` get the
+/// usual propagation, but production callers wrap in `let _ = ...`).
+pub fn capture_subop(name: &str, t: &Tensor) -> Result<()> {
+    let armed = SUBOP_CAPTURE.with(|c| c.borrow().is_some());
+    if !armed {
+        return Ok(());
+    }
+    let (shape, flat) = tensor_to_f32_host(t)
+        .with_context(|| format!("capture_subop `{name}`: tensor→f32 host copy"))?;
+    SUBOP_CAPTURE.with(|c| {
+        if let Some(buf) = c.borrow_mut().as_mut() {
+            buf.push((name.to_string(), shape, flat));
+        }
+    });
+    Ok(())
 }
 
 /// Convert a tensor to a contiguous host float32 `Vec<f32>` plus shape.
@@ -170,19 +271,25 @@ fn tensor_to_f32_host(t: &Tensor) -> Result<(Vec<usize>, Vec<f32>)> {
 /// | `mtp_logits`      | Output of `lm_head` on `post_final_ln`.              |
 ///
 /// Plus metadata: `draft_token_id`, `mtp_pos`, `swap_fc_norms`.
+///
+/// Phase B7b: pass `extra_subops` to append per-sub-op taps captured via
+/// the [`arm_subop_capture`] / [`drain_subop_capture`] / [`capture_subop`]
+/// trio. These are written under their captured names alongside the
+/// static taps; an empty slice makes this behave identically to Phase B6.
 pub fn write_mtp_dump(
     path: &str,
     draft_token_id: u32,
     mtp_pos: usize,
     swap_fc_norms: bool,
     taps: &[(&str, &Tensor)],
+    extra_subops: &[(String, Vec<usize>, Vec<f32>)],
 ) -> Result<()> {
     use safetensors::tensor::{Dtype, TensorView};
 
     // Materialize every tensor to a host byte buffer first so the
     // TensorViews we build below can borrow from a stable backing store.
     let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> =
-        Vec::with_capacity(taps.len() + 3);
+        Vec::with_capacity(taps.len() + extra_subops.len() + 3);
     for (name, t) in taps {
         let (shape, flat) = tensor_to_f32_host(t)
             .with_context(|| format!("dump tap `{name}`: tensor→f32 host copy"))?;
@@ -191,6 +298,13 @@ pub fn write_mtp_dump(
             bytes.extend_from_slice(&v.to_le_bytes());
         }
         backings.push(((*name).to_string(), shape, Dtype::F32, bytes));
+    }
+    for (name, shape, flat) in extra_subops {
+        let mut bytes = Vec::with_capacity(flat.len() * 4);
+        for v in flat {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        backings.push((name.clone(), shape.clone(), Dtype::F32, bytes));
     }
 
     // Metadata as 1-element I32 tensors so the Python side can read them
@@ -281,21 +395,99 @@ mod tests {
     }
 
     #[test]
-    fn dump_slot_fires_once_then_never() {
+    fn dump_slot_fires_once_per_position() {
         // SAFETY: single-threaded test; scoped env mutation.
         let tmp = std::env::temp_dir().join("kiln_mtp_dump_slot_once.safetensors");
         let tmp_s = tmp.to_string_lossy().into_owned();
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_PATH", &tmp_s);
+            std::env::remove_var("KILN_MTP_DUMP_POS");
         }
         reset_dump_latch();
         assert_eq!(dump_path().as_deref(), Some(tmp_s.as_str()));
-        assert!(try_consume_dump_slot());
-        assert!(!try_consume_dump_slot());
-        assert!(!try_consume_dump_slot());
+        // Default targets only pos 0.
+        assert!(try_consume_dump_slot_for_pos(0));
+        assert!(!try_consume_dump_slot_for_pos(0));
+        assert!(!try_consume_dump_slot_for_pos(1));
         unsafe {
             std::env::remove_var("KILN_MTP_DUMP_PATH");
         }
+    }
+
+    #[test]
+    fn dump_slot_supports_multi_position_targets() {
+        let tmp = std::env::temp_dir().join("kiln_mtp_dump_multi_pos.safetensors");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_PATH", &tmp_s);
+            std::env::set_var("KILN_MTP_DUMP_POS", "0,1,2");
+        }
+        reset_dump_latch();
+        let positions = target_dump_positions();
+        assert!(positions.contains(&0));
+        assert!(positions.contains(&1));
+        assert!(positions.contains(&2));
+        assert!(!positions.contains(&3));
+        // Each targeted position fires exactly once.
+        assert!(try_consume_dump_slot_for_pos(0));
+        assert!(!try_consume_dump_slot_for_pos(0));
+        assert!(try_consume_dump_slot_for_pos(1));
+        assert!(try_consume_dump_slot_for_pos(2));
+        // A non-targeted position never fires.
+        assert!(!try_consume_dump_slot_for_pos(3));
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_PATH");
+            std::env::remove_var("KILN_MTP_DUMP_POS");
+        }
+    }
+
+    #[test]
+    fn dump_path_for_pos_substitutes_placeholder() {
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_PATH", "/tmp/dump_pos{pos}.safetensors");
+        }
+        assert_eq!(
+            dump_path_for_pos(0).as_deref(),
+            Some("/tmp/dump_pos0.safetensors")
+        );
+        assert_eq!(
+            dump_path_for_pos(2).as_deref(),
+            Some("/tmp/dump_pos2.safetensors")
+        );
+        // Without `{pos}`, the path is returned as-is (caller should always
+        // include `{pos}` when capturing multiple positions).
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_PATH", "/tmp/dump.safetensors");
+        }
+        assert_eq!(
+            dump_path_for_pos(1).as_deref(),
+            Some("/tmp/dump.safetensors")
+        );
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_PATH");
+        }
+    }
+
+    #[test]
+    fn subop_capture_records_then_drains() {
+        let a = Tensor::new(&[1.0_f32, 2.0, 3.0][..], &Device::Cpu).unwrap();
+        let b = Tensor::new(&[10.0_f32, 20.0][..], &Device::Cpu).unwrap();
+        // Disarmed: capture is a silent no-op.
+        capture_subop("post_q_proj", &a).unwrap();
+        assert!(drain_subop_capture().is_empty());
+        // Armed: records in order.
+        arm_subop_capture();
+        capture_subop("post_q_proj", &a).unwrap();
+        capture_subop("post_k_proj", &b).unwrap();
+        let drained = drain_subop_capture();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].0, "post_q_proj");
+        assert_eq!(drained[0].1, vec![3]);
+        assert_eq!(drained[0].2, vec![1.0, 2.0, 3.0]);
+        assert_eq!(drained[1].0, "post_k_proj");
+        // Drain disarms.
+        capture_subop("post_v_proj", &a).unwrap();
+        assert!(drain_subop_capture().is_empty());
     }
 
     #[test]
@@ -312,6 +504,7 @@ mod tests {
             /* mtp_pos = */ 0,
             /* swap_fc_norms = */ false,
             &[("h_main", &a), ("mtp_logits", &b)],
+            &[("post_q_proj".to_string(), vec![2], vec![0.1_f32, 0.2])],
         )
         .unwrap();
 

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -1,27 +1,41 @@
 #!/usr/bin/env python3
 """
-Phase B6 — Per-tap numerical comparison of MTP intermediates.
+Phase B6/B7 — Per-tap numerical comparison of MTP intermediates.
 
-Consumes two safetensors dumps (kiln native + PyTorch reference), prints a
-divergence table, and identifies the first tap where the two paths disagree
-beyond (atol=1e-3, rtol=1e-2).
-
-Usage:
+Single-pair mode (Phase B6 — backward compatible):
     python3 scripts/mtp_compare.py \\
         --kiln /tmp/mtp-kiln.safetensors \\
         --ref  /tmp/mtp-ref.safetensors \\
         [--atol 1e-3] [--rtol 1e-2] \\
         [--out /tmp/mtp-compare.txt]
 
+Multi-position mode (Phase B7a — H1 RoPE bisect):
+    python3 scripts/mtp_compare.py \\
+        --pair 0:/tmp/dump_pos0.st,/tmp/ref_pos0.st \\
+        --pair 1:/tmp/dump_pos1.st,/tmp/ref_pos1.st \\
+        --pair 2:/tmp/dump_pos2.st,/tmp/ref_pos2.st \\
+        [--atol 1e-3] [--rtol 1e-2] \\
+        [--out /tmp/mtp-compare-pos.txt]
+
+In multi-position mode, prints a per-position cos_sim table for each tap, then
+a B7a verdict line: monotonic degradation in `post_layer` across mtp_pos
+implicates H1 (RoPE position threading); flat (invariant) cos_sim across
+positions REJECTS H1 and the next step is per-sub-op tap bisect (B7b).
+
+Sub-op tap mode (Phase B7b — fine-grained bisect):
+    Sub-op taps are auto-detected. Any non-meta tensor present in both
+    dumps that isn't a primary tap is compared at the end of the table
+    in the canonical capture order from mtp_inner_block.
+
 Exit code:
-    0 — all taps match within tolerance
+    0 — all taps match within tolerance (all positions, in multi mode)
     1 — at least one tap diverges (normal outcome of a bisect)
-    2 — structural error (missing file, missing tap, shape mismatch)
+    2 — structural error (missing file, missing tap, shape mismatch, bad CLI)
 """
 
 import argparse
 import sys
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -32,8 +46,8 @@ except ImportError:
     sys.exit(2)
 
 
-# Canonical tap order — must match the order written by write_mtp_dump in
-# mtp_debug.rs and by mtp_reference_dump.py. First divergence is reported by
+# Canonical primary tap order — must match the order written by write_mtp_dump
+# in mtp_debug.rs and by mtp_reference_dump.py. First divergence is reported by
 # this sequence.
 TAP_ORDER: List[str] = [
     "h_main",
@@ -46,7 +60,70 @@ TAP_ORDER: List[str] = [
     "mtp_logits",
 ]
 
-META_KEYS = ("meta__draft_token_id", "meta__mtp_pos", "meta__swap_fc_norms")
+# Phase B7b sub-op taps — match capture order in mtp_inner_block (Python ref)
+# and gqa_attention_paged + transformer_block_paged (Rust). Any sub-op present
+# in both dumps but not listed here gets appended at the end in name-sort order.
+SUBOP_ORDER: List[str] = [
+    "post_pre_attn_norm",
+    "post_q_proj_raw",
+    "post_k_proj",
+    "post_v_proj",
+    "post_q_split",
+    "post_gate_split",
+    "post_q_norm",
+    "post_k_norm",
+    "post_q_rope",
+    "post_k_rope",
+    "post_attn_raw",
+    "post_attn_gated",
+    "post_o_proj",
+    "post_attn_block",
+    "post_attn_residual",
+    "post_pre_mlp_norm",
+    "post_mlp",
+]
+
+META_KEYS = (
+    "meta__draft_token_id",
+    "meta__mtp_pos",
+    "meta__swap_fc_norms",
+    "meta__kiln_mtp_pos",
+    "meta__capture_subops",
+)
+
+# Hypothesis map for the 8 primary taps. Keep in sync with the planning notes
+# in mtp_debug.rs / forward.rs.
+PRIMARY_HYPOTHESIS = {
+    "h_main": "upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ",
+    "tok_embed": "tied embed lookup or token-id path",
+    "fc_input": "RMSNorm inputs, concat ordering, or the dual-norm A/B swap",
+    "fc_output": "mtp.fc matmul (weight transpose or layout)",
+    "pre_layer": "(same tensor as fc_output at this site)",
+    "post_layer": "single-layer MTP block: RoPE mtp_pos advancement, Q/K/V proj, or gated-attn",
+    "post_final_ln": "mtp.final_layernorm application site / weight",
+    "mtp_logits": "tied embed_tokens_t transpose vs alias for LM head",
+}
+
+# Hypothesis map for sub-op taps (B7b bisect targets).
+SUBOP_HYPOTHESIS = {
+    "post_pre_attn_norm": "input_layernorm weight or eps mismatch",
+    "post_q_proj_raw": "q_proj weight layout or transpose",
+    "post_k_proj": "k_proj weight layout or transpose",
+    "post_v_proj": "v_proj weight layout or transpose",
+    "post_q_split": "Q/gate split: per-head narrow vs flat-half chunk semantic mismatch",
+    "post_gate_split": "Q/gate split: gate half order or layout",
+    "post_q_norm": "q_norm weight or per-head broadcast",
+    "post_k_norm": "k_norm weight or per-head broadcast",
+    "post_q_rope": "RoPE on Q: mtp_pos value, rotary_dim, half-rotate vs interleaved, theta",
+    "post_k_rope": "RoPE on K: mtp_pos value, rotary_dim, half-rotate vs interleaved, theta",
+    "post_attn_raw": "softmax(QK^T)V mechanics (single-token reduces to V — divergence here is unusual)",
+    "post_attn_gated": "gated attention: sigmoid/silu choice, gate broadcast",
+    "post_o_proj": "o_proj weight layout or transpose",
+    "post_attn_block": "post-attn output before residual",
+    "post_attn_residual": "residual addition site / dtype",
+    "post_pre_mlp_norm": "post_attention_layernorm weight or eps",
+    "post_mlp": "MLP path: gate/up/down matmul + activation",
+}
 
 
 def _fmt_sci(x: float) -> str:
@@ -97,12 +174,6 @@ def _compare_tap(
     return row
 
 
-def _print_meta(title: str, meta: Dict[str, int]) -> None:
-    print(f"  {title}:")
-    for k in META_KEYS:
-        print(f"    {k}: {meta.get(k, '<missing>')}")
-
-
 def _load(path: str) -> Tuple[Dict[str, np.ndarray], Dict[str, int]]:
     try:
         tensors = load_file(path)
@@ -112,35 +183,51 @@ def _load(path: str) -> Tuple[Dict[str, np.ndarray], Dict[str, int]]:
     meta: Dict[str, int] = {}
     arrays: Dict[str, np.ndarray] = {}
     for key, val in tensors.items():
-        if key in META_KEYS:
+        if key in META_KEYS or key.startswith("meta__"):
             meta[key] = int(val.item()) if val.size == 1 else int(val.flatten()[0])
         else:
             arrays[key] = val
     return arrays, meta
 
 
-def main() -> int:
-    ap = argparse.ArgumentParser()
-    ap.add_argument("--kiln", required=True, help="Path to kiln dump (.safetensors)")
-    ap.add_argument("--ref", required=True, help="Path to reference dump (.safetensors)")
-    ap.add_argument("--atol", type=float, default=1e-3)
-    ap.add_argument("--rtol", type=float, default=1e-2)
-    ap.add_argument("--out", default=None, help="Optional path to write report text")
-    args = ap.parse_args()
+def _ordered_taps(
+    kiln_arr: Dict[str, np.ndarray],
+    ref_arr: Dict[str, np.ndarray],
+) -> List[str]:
+    """Return tap names in canonical order: primary taps first, then sub-op
+    taps in SUBOP_ORDER, then any extras alpha-sorted. Only taps present in
+    BOTH dumps are emitted here; missing-on-one-side is reported separately."""
+    out: List[str] = []
+    common = set(kiln_arr.keys()) & set(ref_arr.keys())
+    for name in TAP_ORDER:
+        if name in common:
+            out.append(name)
+    for name in SUBOP_ORDER:
+        if name in common:
+            out.append(name)
+    extras = sorted(common - set(out))
+    out.extend(extras)
+    return out
 
-    kiln_arr, kiln_meta = _load(args.kiln)
-    ref_arr, ref_meta = _load(args.ref)
 
-    lines: List[str] = []
+def _compare_pair(
+    label: str,
+    kiln_path: str,
+    ref_path: str,
+    atol: float,
+    rtol: float,
+    emit,
+) -> Tuple[bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]:
+    """Compare a single (kiln, ref) pair. Returns (all_ok, first_divergence,
+    rows, kiln_meta, ref_meta). `label` is shown in headers for multi-pair
+    runs."""
+    kiln_arr, kiln_meta = _load(kiln_path)
+    ref_arr, ref_meta = _load(ref_path)
 
-    def emit(s: str) -> None:
-        print(s)
-        lines.append(s)
-
-    emit(f"MTP Phase B6 numerical bisect — atol={args.atol}, rtol={args.rtol}")
-    emit(f"  kiln dump : {args.kiln}")
-    emit(f"  ref  dump : {args.ref}")
-    emit("")
+    if label:
+        emit(f"\n=== {label} ===")
+    emit(f"  kiln dump : {kiln_path}")
+    emit(f"  ref  dump : {ref_path}")
     emit("Metadata:")
     for k in META_KEYS:
         kv = kiln_meta.get(k, "<missing>")
@@ -149,9 +236,8 @@ def main() -> int:
         emit(f"  {k}: kiln={kv} ref={rv} [{match}]")
     emit("")
 
-    # Header
     header = (
-        f"{'tap':<18} {'shape':<18} {'shape_ok':<8} "
+        f"{'tap':<22} {'shape':<22} {'shape_ok':<8} "
         f"{'allclose':<8} {'cos_sim':<10} {'max|Δ|':<12} {'mean|Δ|':<12}"
     )
     emit(header)
@@ -160,25 +246,28 @@ def main() -> int:
     first_div: str = ""
     all_ok = True
     rows: List[Dict[str, object]] = []
+    canonical_order = _ordered_taps(kiln_arr, ref_arr)
 
-    for name in TAP_ORDER:
-        if name not in kiln_arr:
-            emit(f"{name:<18} MISSING IN KILN DUMP")
-            all_ok = False
-            if not first_div:
-                first_div = name
-            continue
-        if name not in ref_arr:
-            emit(f"{name:<18} MISSING IN REF DUMP")
-            all_ok = False
-            if not first_div:
-                first_div = name
-            continue
-        row = _compare_tap(name, kiln_arr[name], ref_arr[name], args.atol, args.rtol)
+    # Report missing-on-one-side first so the table itself is uniform width.
+    missing_in_kiln = [n for n in (TAP_ORDER + SUBOP_ORDER) if n in ref_arr and n not in kiln_arr]
+    missing_in_ref = [n for n in (TAP_ORDER + SUBOP_ORDER) if n in kiln_arr and n not in ref_arr]
+    for n in missing_in_kiln:
+        emit(f"{n:<22} MISSING IN KILN DUMP")
+        all_ok = False
+        if not first_div:
+            first_div = n
+    for n in missing_in_ref:
+        emit(f"{n:<22} MISSING IN REF DUMP")
+        all_ok = False
+        if not first_div:
+            first_div = n
+
+    for name in canonical_order:
+        row = _compare_tap(name, kiln_arr[name], ref_arr[name], atol, rtol)
         rows.append(row)
         shape_str = "x".join(str(s) for s in row["shape_kiln"])
         emit(
-            f"{row['name']:<18} {shape_str:<18} {str(row['shape_match']):<8} "
+            f"{row['name']:<22} {shape_str:<22} {str(row['shape_match']):<8} "
             f"{str(row['allclose']):<8} {_fmt_sci(row['cos_sim']):<10} "
             f"{_fmt_sci(row['max_abs_diff']):<12} {_fmt_sci(row['mean_abs_diff']):<12}"
         )
@@ -189,28 +278,155 @@ def main() -> int:
 
     emit("")
     if all_ok:
-        emit("VERDICT: all taps match within tolerance — no divergence found.")
+        emit("  pair verdict: all taps match within tolerance.")
     else:
-        emit(f"VERDICT: first divergence at tap '{first_div}'.")
-        # Map first-divergence tap back to the hypothesis it most directly implicates.
-        hypothesis_map = {
-            "h_main": "upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ",
-            "tok_embed": "tied embed lookup or token-id path",
-            "fc_input": "RMSNorm inputs, concat ordering, or the dual-norm A/B swap",
-            "fc_output": "mtp.fc matmul (weight transpose or layout)",
-            "pre_layer": "(same tensor as fc_output at this site)",
-            "post_layer": "single-layer MTP block: RoPE mtp_pos advancement, Q/K/V proj, or gated-attn",
-            "post_final_ln": "mtp.final_layernorm application site / weight",
-            "mtp_logits": "tied embed_tokens_t transpose vs alias for LM head",
-        }
-        emit(f"  Most-likely cause: {hypothesis_map.get(first_div, '<unknown tap>')}")
+        cause = PRIMARY_HYPOTHESIS.get(first_div) or SUBOP_HYPOTHESIS.get(
+            first_div, "<unknown tap>"
+        )
+        emit(f"  pair verdict: first divergence at tap '{first_div}'.")
+        emit(f"    Most-likely cause: {cause}")
+
+    return all_ok, first_div, rows, kiln_meta, ref_meta
+
+
+def _parse_pair_arg(s: str) -> Tuple[str, str, str]:
+    """Parse `LABEL:KILN_PATH,REF_PATH` (LABEL is typically the mtp_pos)."""
+    if ":" not in s:
+        print(f"ERROR: --pair argument '{s}' missing 'LABEL:' prefix", file=sys.stderr)
+        sys.exit(2)
+    label, paths = s.split(":", 1)
+    if "," not in paths:
+        print(f"ERROR: --pair argument '{s}' must be LABEL:KILN,REF", file=sys.stderr)
+        sys.exit(2)
+    kiln_path, ref_path = paths.split(",", 1)
+    return label.strip(), kiln_path.strip(), ref_path.strip()
+
+
+def _emit_b7a_summary(
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]],
+    emit,
+) -> None:
+    """Print per-position cos_sim summary for the B7a decision: H1 confirmed
+    (monotonic degradation in post_layer across mtp_pos) vs rejected
+    (cos_sim invariant across positions)."""
+    emit("")
+    emit("=" * 78)
+    emit("Phase B7a multi-position summary — cos_sim per primary tap, per position")
+    emit("=" * 78)
+
+    # Build label -> {tap_name: cos_sim} map.
+    labels = [pr[0] for pr in pair_results]
+    cos_table: Dict[str, Dict[str, float]] = {name: {} for name in TAP_ORDER}
+    for label, _ok, _first, rows, _km, _rm in pair_results:
+        for r in rows:
+            n = r["name"]
+            if n in cos_table:
+                cos_table[n][label] = float(r["cos_sim"])
+
+    header = "  " + "tap".ljust(20) + " ".join(f"pos={lab:<8}" for lab in labels)
+    emit(header)
+    emit("  " + "-" * (len(header) - 2))
+    for tap in TAP_ORDER:
+        cells = " ".join(
+            f"{_fmt_sci(cos_table[tap].get(lab, float('nan'))):<12}" for lab in labels
+        )
+        emit(f"  {tap:<20}{cells}")
+
+    # H1 decision on `post_layer` specifically.
+    emit("")
+    pl_vals = [cos_table["post_layer"].get(lab, float("nan")) for lab in labels]
+    finite = [v for v in pl_vals if np.isfinite(v)]
+    if len(finite) < 2:
+        emit("Phase B7a verdict: insufficient finite post_layer cos_sim values to decide.")
+        return
+    spread = max(finite) - min(finite)
+    monotonic_down = all(pl_vals[i] >= pl_vals[i + 1] - 1e-6 for i in range(len(pl_vals) - 1)) and (
+        pl_vals[0] - pl_vals[-1] > 1e-3
+    )
+    invariant = spread < 1e-3
+    emit(f"  post_layer cos_sim across positions: {[round(v, 6) for v in pl_vals]}")
+    emit(f"  spread (max-min): {_fmt_sci(spread)}")
+    if invariant:
+        emit("Phase B7a verdict: H1 REJECTED — post_layer cos_sim is essentially invariant")
+        emit("  across mtp_pos. RoPE-position threading is NOT the divergence source.")
+        emit("  -> Proceed to Phase B7b (per-sub-op tap bisect).")
+    elif monotonic_down:
+        emit("Phase B7a verdict: H1 CONFIRMED — post_layer cos_sim degrades monotonically")
+        emit("  with mtp_pos. The MTP path's RoPE position threading is the divergence")
+        emit("  source. -> Land Phase B7 PR with this finding; queue B8 fix task to")
+        emit("  thread the correct mtp_pos through the inner block's RoPE call site.")
+    else:
+        emit("Phase B7a verdict: INCONCLUSIVE — post_layer cos_sim varies across positions")
+        emit("  but not monotonically. May indicate a position-dependent issue mixed with")
+        emit("  another bug. Recommend running B7b anyway and re-evaluating.")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--kiln", help="Path to kiln dump (.safetensors) — single-pair mode")
+    ap.add_argument("--ref", help="Path to reference dump (.safetensors) — single-pair mode")
+    ap.add_argument(
+        "--pair",
+        action="append",
+        default=[],
+        help="Multi-position mode: LABEL:KILN_PATH,REF_PATH. Repeat for each position.",
+    )
+    ap.add_argument("--atol", type=float, default=1e-3)
+    ap.add_argument("--rtol", type=float, default=1e-2)
+    ap.add_argument("--out", default=None, help="Optional path to write report text")
+    args = ap.parse_args()
+
+    pairs: List[Tuple[str, str, str]] = []
+    if args.pair:
+        if args.kiln or args.ref:
+            print("ERROR: cannot mix --pair with --kiln/--ref", file=sys.stderr)
+            return 2
+        for s in args.pair:
+            pairs.append(_parse_pair_arg(s))
+    else:
+        if not (args.kiln and args.ref):
+            print("ERROR: must specify --kiln and --ref, or one or more --pair args", file=sys.stderr)
+            return 2
+        pairs.append(("", args.kiln, args.ref))
+
+    lines: List[str] = []
+
+    def emit(s: str) -> None:
+        print(s)
+        lines.append(s)
+
+    multi = len(pairs) > 1
+    mode = "multi-position (B7a)" if multi else "single-pair (B6/B7)"
+    emit(f"MTP numerical bisect — mode: {mode}, atol={args.atol}, rtol={args.rtol}")
+
+    pair_results: List[
+        Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]
+    ] = []
+    overall_ok = True
+    for label, kpath, rpath in pairs:
+        ok, first_div, rows, km, rm = _compare_pair(
+            label, kpath, rpath, args.atol, args.rtol, emit
+        )
+        pair_results.append((label, ok, first_div, rows, km, rm))
+        if not ok:
+            overall_ok = False
+
+    if multi:
+        _emit_b7a_summary(pair_results, emit)
+
+    emit("")
+    if overall_ok:
+        emit("Overall verdict: all taps match within tolerance.")
+    else:
+        first_divs = [pr[2] for pr in pair_results if pr[2]]
+        emit(f"Overall verdict: divergence(s) at: {first_divs}")
 
     if args.out:
         with open(args.out, "w") as f:
             f.write("\n".join(lines) + "\n")
         print(f"\nWrote report to {args.out}", file=sys.stderr)
 
-    return 0 if all_ok else 1
+    return 0 if overall_ok else 1
 
 
 if __name__ == "__main__":

--- a/scripts/mtp_reference_dump.py
+++ b/scripts/mtp_reference_dump.py
@@ -306,12 +306,19 @@ def apply_rope_partial(
     x: torch.Tensor, position: int, head_dim: int, rotary_dim: int, rope_theta: float
 ) -> torch.Tensor:
     """Apply rotary embedding to the first `rotary_dim` dimensions of each
-    head. `x` is `[batch, num_heads, seq_len, head_dim]`.
+    head. `x` is `[batch, num_heads, seq_len, head_dim]` (legacy callers) or
+    `[batch, seq_len, num_heads, head_dim]` (Phase B7b kiln-aligned form —
+    same per-element semantics regardless of the head/seq order).
 
     Qwen3-Next uses partial rotary (default 0.25 of head_dim → 64-dim rotary
     for head_dim=256). Rotate on the leading `rotary_dim`, leave the tail
     untouched. `position` is the absolute position index for the single-token
     step we're modelling (MTP has seq_len=1).
+
+    Verified against kiln in forward.rs:1108-1148 — both use **half-rotate**
+    (split into first half + second half, recombine `[r1, r2, pass]`). Earlier
+    versions of this docstring claimed kiln used interleaved rotation; that
+    was wrong and has been corrected.
     """
     if rotary_dim == 0:
         return x
@@ -325,17 +332,21 @@ def apply_rope_partial(
     # Split rotary half. Shape: [..., rotary_dim]
     x_rot = x[..., :rotary_dim]
     x_pass = x[..., rotary_dim:]
-    # Pair up the dims. `candle` uses interleaved even/odd; HF commonly uses
-    # half-rotate (first half vs second half). Qwen3-Next MTP in kiln uses
-    # interleaved rotation — see `apply_rotary_emb` in forward.rs. We model
-    # the "half-rotate" variant here; if the comparison surfaces a mismatch
-    # at `post_layer`, an interleave-vs-halves swap is the single most
-    # likely cause and will print clearly in the divergence table.
     half = rotary_dim // 2
     x1 = x_rot[..., :half]
     x2 = x_rot[..., half:]
     x_rot_new = torch.cat([x1 * cos - x2 * sin, x1 * sin + x2 * cos], dim=-1)
     return torch.cat([x_rot_new, x_pass], dim=-1)
+
+
+def _capture(buf: Optional[Dict[str, torch.Tensor]], name: str, t: torch.Tensor) -> None:
+    """Best-effort sub-op capture. No-op when `buf` is None (production path
+    when --capture-subops is not set). Always stores a contiguous F32 clone so
+    the writer can serialize without later in-place ops corrupting the buffer.
+    """
+    if buf is None:
+        return
+    buf[name] = t.detach().to(torch.float32).contiguous().clone()
 
 
 def mtp_inner_block(
@@ -345,6 +356,7 @@ def mtp_inner_block(
     rope_theta: float,
     rotary_frac: float,
     eps: float,
+    capture_subops: Optional[Dict[str, torch.Tensor]] = None,
 ) -> torch.Tensor:
     """Single MTP transformer block with self-attention over exactly one
     position. `x` shape: `[1, 1, H]`. Returns `[1, 1, H]` (pre-final-norm).
@@ -354,6 +366,13 @@ def mtp_inner_block(
     rotations on Q and K cancel in the Q·K^T product (same position, same
     rotation), so this path is a pretty good sanity-check for the MTP inner
     layer.
+
+    Phase B7b: when `capture_subops` is a dict, every named tap below is
+    written into it under the same name kiln captures (see
+    `gqa_attention_paged` and `transformer_block_paged` in forward.rs). The
+    tensor layouts at each tap match kiln's exactly so per-element comparison
+    is meaningful — see in particular the per-head Q/gate narrow that
+    replaces the older flat-half chunk.
     """
     cfg = w.config
     H = x.shape[-1]
@@ -362,82 +381,119 @@ def mtp_inner_block(
     head_dim = cfg.get("head_dim", H // num_heads)
     rotary_dim = int(head_dim * rotary_frac)
 
-    # Pre-attn norm.
+    # Pre-attn norm. Tap matches transformer_block_paged in forward.rs:3122-3126.
     residual = x
     h = rms_norm(x, w.input_layernorm, eps)  # [1,1,H]
+    _capture(capture_subops, "post_pre_attn_norm", h)
 
-    # Q/K/V projections. The Qwen3-Next gated Q has shape [2*num_heads*head_dim, H]
-    # (kiln's loader splits into Q and a gate). Here we emulate it by taking
-    # the first half as Q (the ungated stream) and discarding the gate — this
-    # is wrong for the full gated-attn semantics but a faithful reproduction
-    # of that would pull in another ~100 LOC. For Phase B6, we flag
-    # gated-attn as a known *reference* simplification; if `post_layer`
-    # diverges by exactly this amount, the bug isn't real. See the compare
-    # script output for this caveat.
-    q_full = torch.matmul(h, w.q_proj_weight.t())  # [1,1, 2*num_heads*head_dim] if gated, else [1,1, num_heads*head_dim]
-    if q_full.shape[-1] == 2 * num_heads * head_dim:
-        q, q_gate = q_full.chunk(2, dim=-1)
-        q_gated = True
+    # Q/K/V projections. q_proj is gated for Qwen3-Next when q_proj.weight has
+    # shape [num_heads*head_dim*2, H]; the trailing 2H output is split into
+    # the rotation target (Q) and a sigmoid gate applied post-attention. Tap
+    # name matches gqa_attention_paged in forward.rs:2620-2622.
+    q_raw = torch.matmul(h, w.q_proj_weight.t())  # [1, 1, num_heads*head_dim*2 if gated else num_heads*head_dim]
+    k = torch.matmul(h, w.k_proj_weight.t())       # [1, 1, num_kv_heads*head_dim]
+    v = torch.matmul(h, w.v_proj_weight.t())       # [1, 1, num_kv_heads*head_dim]
+    _capture(capture_subops, "post_q_proj_raw", q_raw)
+    _capture(capture_subops, "post_k_proj", k)
+    _capture(capture_subops, "post_v_proj", v)
+
+    # Per-head Q/gate split — must mirror kiln's narrow exactly. Kiln does:
+    #   q_pair = q_raw.reshape((batch, seq_len, num_heads, head_dim*2))
+    #   q      = q_pair.narrow(3, 0,        head_dim)         # [B, S, H, D]
+    #   gate   = q_pair.narrow(3, head_dim, head_dim)         # [B, S, H, D]
+    #   gate   = gate.reshape((batch, seq_len, num_heads*head_dim))
+    # An earlier reference used `q_full.chunk(2, dim=-1)` which splits the
+    # *flat* trailing dim in half — that produces a DIFFERENT q tensor for
+    # any weight layout that pairs (q_dim, gate_dim) per head. The flat
+    # chunk was a known-wrong simplification noted in PR #271; this is the
+    # corrected per-head split.
+    q_gated = (q_raw.shape[-1] == 2 * num_heads * head_dim)
+    if q_gated:
+        q_pair = q_raw.view(1, 1, num_heads, head_dim * 2)
+        q = q_pair[..., :head_dim].contiguous()                             # [1, 1, num_heads, head_dim]
+        gate = q_pair[..., head_dim:].contiguous().view(1, 1, num_heads * head_dim)  # [1, 1, num_heads*head_dim]
     else:
-        q = q_full
-        q_gate = None
-        q_gated = False
-    k = torch.matmul(h, w.k_proj_weight.t())
-    v = torch.matmul(h, w.v_proj_weight.t())
+        q = q_raw.view(1, 1, num_heads, head_dim)                           # [1, 1, num_heads, head_dim]
+        gate = None
+    _capture(capture_subops, "post_q_split", q)
+    if gate is not None:
+        _capture(capture_subops, "post_gate_split", gate)
 
-    # Reshape to heads: [1, 1, num_heads, head_dim] → [1, num_heads, 1, head_dim]
-    q = q.view(1, 1, num_heads, head_dim).transpose(1, 2)
-    k = k.view(1, 1, num_kv_heads, head_dim).transpose(1, 2)
-    v = v.view(1, 1, num_kv_heads, head_dim).transpose(1, 2)
+    k = k.view(1, 1, num_kv_heads, head_dim)  # [1, 1, num_kv_heads, head_dim]
+    v = v.view(1, 1, num_kv_heads, head_dim)  # [1, 1, num_kv_heads, head_dim]
 
-    # Per-head RMSNorm on Q and K (Qwen3-Next style).
+    # Per-head RMSNorm on Q and K (Qwen3-Next style). Same shape in/out.
     q = rms_norm(q, w.q_norm_weight, eps)
     k = rms_norm(k, w.k_norm_weight, eps)
+    _capture(capture_subops, "post_q_norm", q)
+    _capture(capture_subops, "post_k_norm", k)
 
-    # RoPE on rotary_dim prefix.
+    # RoPE on rotary_dim prefix in the [B, S, H, D] layout — matches kiln's
+    # `rotary_embedding_from_tensor` call site in forward.rs:2661-2666 (both
+    # use half-rotate; see `apply_rope_partial` docstring above).
     q = apply_rope_partial(q, mtp_pos, head_dim, rotary_dim, rope_theta)
     k = apply_rope_partial(k, mtp_pos, head_dim, rotary_dim, rope_theta)
+    _capture(capture_subops, "post_q_rope", q)
+    _capture(capture_subops, "post_k_rope", k)
 
-    # Expand KV heads for GQA.
+    # Transpose to [batch, num_heads, seq_len, head_dim] for the attention
+    # matmuls. This mirrors forward.rs:2669-2675 (the qkv_transpose block).
+    q_t = q.transpose(1, 2).contiguous()  # [1, num_heads,    1, head_dim]
+    k_t = k.transpose(1, 2).contiguous()  # [1, num_kv_heads, 1, head_dim]
+    v_t = v.transpose(1, 2).contiguous()  # [1, num_kv_heads, 1, head_dim]
+
+    # Expand KV for GQA. seq_len=1 so this is a no-op cost-wise; included
+    # only so the math matches the gqa-grouped path in forward.rs:2837-2879
+    # without having to reproduce the per-group reshape.
     repeat = num_heads // num_kv_heads
     if repeat > 1:
-        k = k.repeat_interleave(repeat, dim=1)
-        v = v.repeat_interleave(repeat, dim=1)
+        k_full = k_t.repeat_interleave(repeat, dim=1)
+        v_full = v_t.repeat_interleave(repeat, dim=1)
+    else:
+        k_full = k_t
+        v_full = v_t
 
-    # Single-token self-attention reduces to attn_out == V (softmax of a
-    # single scalar == 1.0), so Q·K^T /√d · softmax · V simplifies to V when
-    # seq_len = 1 — modulo rounding. We still compute the full path for
-    # faithfulness to kiln's op order.
+    # Single-token self-attention.
     scale = 1.0 / math.sqrt(head_dim)
-    scores = torch.matmul(q, k.transpose(-2, -1)) * scale  # [1, num_heads, 1, 1]
-    attn = torch.softmax(scores.to(torch.float32), dim=-1).to(v.dtype)
-    attn_out = torch.matmul(attn, v)  # [1, num_heads, 1, head_dim]
+    scores = torch.matmul(q_t, k_full.transpose(-2, -1)) * scale  # [1, num_heads, 1, 1]
+    attn = torch.softmax(scores.to(torch.float32), dim=-1).to(v_full.dtype)
+    attn_out = torch.matmul(attn, v_full)  # [1, num_heads, 1, head_dim]
 
-    # Apply gated-attn sigmoid(q_gate) if present. We skip a proper
-    # gated-attn implementation (see caveat above); reported divergence at
-    # `post_layer` is expected to include this component.
+    # Reshape into kiln's `post_attn_raw` form: [1, 1, num_heads * head_dim].
+    # Mirrors forward.rs:2875-2879 (the attn_output reshape after softmax/V).
     attn_out = attn_out.transpose(1, 2).contiguous().view(1, 1, num_heads * head_dim)
-    if q_gated:
-        # Kiln applies sigmoid gate per-head post-attn before o_proj (see
-        # `transformer_block_paged` branch on `attn_output_gate=true`). We
-        # model that here.
-        q_gate = q_gate.view(1, 1, num_heads, head_dim).transpose(1, 2).contiguous()
-        q_gate = q_gate.transpose(1, 2).contiguous().view(1, 1, num_heads * head_dim)
-        attn_out = attn_out * torch.sigmoid(q_gate.to(attn_out.dtype))
-    attn_out = torch.matmul(attn_out, w.o_proj_weight.t())
+    _capture(capture_subops, "post_attn_raw", attn_out)
 
-    # Residual.
-    h = residual + attn_out
+    # Gated-attn: per-element sigmoid(gate) * attn_out, both flat last dim.
+    if gate is not None:
+        attn_out = attn_out * torch.sigmoid(gate.to(attn_out.dtype))
+    _capture(capture_subops, "post_attn_gated", attn_out)
 
-    # MLP.
+    # Output projection. Tap matches forward.rs:2898 / 2955.
+    o = torch.matmul(attn_out, w.o_proj_weight.t())  # [1, 1, H]
+    _capture(capture_subops, "post_o_proj", o)
+
+    # Capture the inner-attn-block output BEFORE the residual add.
+    # Matches forward.rs:3147 (`post_attn_block`).
+    _capture(capture_subops, "post_attn_block", o)
+
+    # Residual. Tap matches forward.rs:3154.
+    h = residual + o
+    _capture(capture_subops, "post_attn_residual", h)
+
+    # MLP path.
     residual = h
     h2 = rms_norm(h, w.post_attention_layernorm, eps)
-    gate = torch.matmul(h2, w.gate_proj_weight.t())
-    up = torch.matmul(h2, w.up_proj_weight.t())
-    act = torch.nn.functional.silu(gate) * up
-    down = torch.matmul(act, w.down_proj_weight.t())
-    h = residual + down
+    _capture(capture_subops, "post_pre_mlp_norm", h2)
 
+    gate_p = torch.matmul(h2, w.gate_proj_weight.t())
+    up_p = torch.matmul(h2, w.up_proj_weight.t())
+    act = torch.nn.functional.silu(gate_p) * up_p
+    down = torch.matmul(act, w.down_proj_weight.t())
+    _capture(capture_subops, "post_mlp", down)
+
+    # Final residual; outer caller dumps this as `post_layer`.
+    h = residual + down
     return h
 
 
@@ -461,11 +517,22 @@ def load_kiln_dump(path: str) -> Dict[str, torch.Tensor | int]:
 
 
 def main() -> int:
-    ap = argparse.ArgumentParser(description="Phase B6 reference MTP dump")
+    ap = argparse.ArgumentParser(description="Phase B6/B7 reference MTP dump")
     ap.add_argument("--checkpoint", required=True, help="Qwen3.5-4B checkpoint directory")
     ap.add_argument("--kiln-dump", required=True, help="Path to kiln's mtp dump (safetensors)")
     ap.add_argument("--out", required=True, help="Output path for reference dump")
     ap.add_argument("--rms-eps", type=float, default=1e-6)
+    ap.add_argument(
+        "--capture-subops",
+        action="store_true",
+        help="Phase B7b: capture per-sub-op taps inside mtp_inner_block and write them into the output safetensors alongside the 8 standard taps.",
+    )
+    ap.add_argument(
+        "--mtp-pos-override",
+        type=int,
+        default=None,
+        help="Phase B7a sweep: override the mtp_pos used for RoPE without re-running kiln. Lets one kiln dump be replayed against the reference at different positions.",
+    )
     args = ap.parse_args()
 
     print(f"[mtp_ref] loading kiln dump from {args.kiln_dump}", file=sys.stderr)
@@ -473,9 +540,20 @@ def main() -> int:
     for name in ["h_main", "tok_embed", "fc_input", "fc_output", "pre_layer", "post_layer", "post_final_ln", "mtp_logits"]:
         assert name in kiln, f"kiln dump missing expected tap `{name}`"
     draft_token_id = kiln["meta__draft_token_id"]
-    mtp_pos = kiln["meta__mtp_pos"]
+    kiln_mtp_pos = int(kiln["meta__mtp_pos"])
     swap = kiln["meta__swap_fc_norms"]
-    print(f"[mtp_ref] draft_token_id={draft_token_id} mtp_pos={mtp_pos} swap_fc_norms={swap}", file=sys.stderr)
+    if args.mtp_pos_override is not None:
+        mtp_pos = int(args.mtp_pos_override)
+        print(
+            f"[mtp_ref] draft_token_id={draft_token_id} kiln_mtp_pos={kiln_mtp_pos} -> overridden mtp_pos={mtp_pos} swap_fc_norms={swap}",
+            file=sys.stderr,
+        )
+    else:
+        mtp_pos = kiln_mtp_pos
+        print(
+            f"[mtp_ref] draft_token_id={draft_token_id} mtp_pos={mtp_pos} swap_fc_norms={swap}",
+            file=sys.stderr,
+        )
 
     print(f"[mtp_ref] loading MTP weights from {args.checkpoint}", file=sys.stderr)
     w = load_mtp_weights(args.checkpoint)
@@ -514,14 +592,28 @@ def main() -> int:
     # (called `fc_output`) and `pre_layer`. For safetensors we need them as
     # distinct tensors.
     pre_layer = fc_output.clone()
-    post_layer = mtp_inner_block(pre_layer, w, mtp_pos, rope_theta, rotary_frac, args.rms_eps)
+    capture_subops: Optional[Dict[str, torch.Tensor]] = {} if args.capture_subops else None
+    post_layer = mtp_inner_block(
+        pre_layer,
+        w,
+        mtp_pos,
+        rope_theta,
+        rotary_frac,
+        args.rms_eps,
+        capture_subops=capture_subops,
+    )
+    if capture_subops is not None:
+        print(
+            f"[mtp_ref] captured {len(capture_subops)} sub-op taps: {sorted(capture_subops.keys())}",
+            file=sys.stderr,
+        )
 
     # 6-7. Final norm + tied LM head.
     post_final_ln = rms_norm(post_layer, w.final_layernorm, args.rms_eps)
     mtp_logits = torch.matmul(post_final_ln, w.embed_tokens.t())  # [1, 1, V]
 
     # Write dump.
-    out_dict = {
+    out_dict: Dict[str, torch.Tensor] = {
         "h_main": h_main.contiguous(),
         "tok_embed": tok_embed.contiguous(),
         "fc_input": fc_input.contiguous(),
@@ -533,8 +625,14 @@ def main() -> int:
         # Carry metadata forward so the comparator can cross-check.
         "meta__draft_token_id": torch.tensor([int(draft_token_id)], dtype=torch.int32),
         "meta__mtp_pos": torch.tensor([int(mtp_pos)], dtype=torch.int32),
+        "meta__kiln_mtp_pos": torch.tensor([int(kiln_mtp_pos)], dtype=torch.int32),
         "meta__swap_fc_norms": torch.tensor([int(swap)], dtype=torch.int32),
+        "meta__capture_subops": torch.tensor([int(args.capture_subops)], dtype=torch.int32),
     }
+    if capture_subops is not None:
+        for name, t in capture_subops.items():
+            assert name not in out_dict, f"sub-op tap name `{name}` collides with existing tap"
+            out_dict[name] = t.contiguous()
     save_file(out_dict, args.out)
     print(f"[mtp_ref] wrote {args.out} ({sum(t.numel()*t.element_size() for t in out_dict.values())} bytes)", file=sys.stderr)
     return 0


### PR DESCRIPTION
## What

Builds on the Phase B6 dual-dump framework (PR #271) by varying `mtp_pos`
and adding per-sub-op tap visibility inside the MTP inner transformer
block. Three pieces:

1. **`crates/kiln-model/src/mtp_debug.rs`** — `KILN_MTP_DUMP_POS="0,1,2"`
   parses a target-position set and latches a one-shot dump per position
   via `Mutex<Option<HashSet<usize>>>`. `KILN_MTP_DUMP_PATH` substitutes
   `{pos}` so a single decode session emits distinct files. A new
   thread-local capture buffer powers `KILN_MTP_DUMP_SUBOPS=1` (Phase B7b)
   as zero-cost early-out when disarmed, per-tensor F32 record when armed.
2. **`crates/kiln-model/src/forward.rs`** — `mtp_forward_step` restructured
   around the multi-position slot-consume + arm/drain bracket; both code
   paths drain the capture buffer so state can't leak across calls.
   17 sub-op tap call sites added in `gqa_attention_paged` + the outer
   transformer-block wrapper (fallback path — set
   `KILN_DISABLE_FUSED_PAGED_DECODE=1` to exercise when running B7b).
3. **`scripts/mtp_reference_dump.py` + `scripts/mtp_compare.py`** — new
   `--pair LABEL:KILN,REF` (repeatable) multi-position mode, auto-detect
   of sub-op taps, and an explicit B7a verdict block (H1 CONFIRMED /
   REJECTED / INCONCLUSIVE).

## Phase B7a results — H1 CONFIRMED

**One `kiln-bench --paged --skip-training --max-output-tokens 256` run
on A6000 with `KILN_SPEC_METHOD=mtp KILN_MTP_DEBUG=1 KILN_MTP_DUMP_POS="0,1,2"`
produced pos=0, pos=1, pos=2 dumps. Reference dumps replayed against the
PyTorch MTP inner block. Comparator output:**

| tap           | pos=0    | pos=1    | pos=2    |
|---------------|----------|----------|----------|
| h_main        | 1.00e+00 | 1.00e+00 | 1.00e+00 |
| tok_embed     | 1.00e+00 | 1.00e+00 | 1.00e+00 |
| fc_input      | 1.00e+00 | 1.00e+00 | 1.00e+00 |
| fc_output     | 1.00e+00 | 1.00e+00 | 1.00e+00 |
| pre_layer     | 1.00e+00 | 1.00e+00 | 1.00e+00 |
| **post_layer**| **0.999977** | **0.999531** | **0.997527** |
| post_final_ln | 1.00e+00 | 9.99e-01 | 9.97e-01 |
| mtp_logits    | 1.00e+00 | 1.00e+00 | 9.98e-01 |

`post_layer` cos_sim sequence: `[0.999977, 0.999531, 0.997527]`,
spread `2.45e-03`. Also:

| tap        | max\|Δ\| pos=0 | pos=1    | pos=2    | mean\|Δ\| pos=0 | pos=1    | pos=2    |
|------------|----------------|----------|----------|-----------------|----------|----------|
| post_layer | 7.85e-02       | 1.75e-01 | 3.98e-01 | 3.34e-03        | 1.42e-02 | 3.85e-02 |

Monotonic degradation at `post_layer` with every upstream tap clean →
the MTP inner block behaves correctly **at mtp_pos=0** but drifts as
mtp_pos rises. That is the signature of RoPE taking a wrong position
index inside the MTP transformer block.

**Verdict**: H1 CONFIRMED. Phase B6 localized divergence to the inner
block; Phase B7a shows that divergence is a monotonic function of
`mtp_pos`. The RoPE call site in the MTP block is threading the wrong
position — most likely the base prompt position rather than
`base_pos + mtp_pos`.

## Recommended Phase B8 (follow-up task)

Audit the RoPE call site that the MTP inner transformer block uses and
compare against how the main-stack `gqa_attention_paged` threads its
position argument. The specific checks:

1. Confirm whether the MTP block reuses the main paged-attention
   `position_ids` unchanged, or whether it adds `mtp_pos` to them.
2. Compare against the PyTorch reference in `scripts/mtp_reference_dump.py`
   where the reference applies RoPE at position `base_pos + mtp_pos`.
3. If the reference is right, patch the MTP block's RoPE position
   argument to include the +mtp_pos offset, rerun the B7a sweep, and
   expect all three post_layer cos_sim to return to ≈1.0.

Once the fix lands, a final α=0.411 acceptance-rate check on Qwen3.5-4B
will tell us whether H1 accounts for the full collapse or whether H2
(qk-norm semantics) and H3 (gated-attn split) still contribute
second-order error.

## No-op for B7b

Because H1 is already confirmed at the tap level, the Phase B7b
per-sub-op tap sweep is not needed for this round. The sub-op
instrumentation is still in the tree and will help triage the next
round of divergence hunts (e.g. after the B8 RoPE fix, to check whether
residual error sits inside q_rope / k_rope or elsewhere).

## Validation

- `cargo check -p kiln-model` — passes (only pre-existing warnings)
- `cargo nextest run -p kiln-model mtp_debug` — 9/9 pass
- GPU run: RunPod A6000 from the kiln pod pool
  - Build: 17s (sccache+B2 warm)
  - 3-position dump: 210s decode (256 tokens, 73 drafts accepted)
  - 3 reference dumps: 17s total
  - Compare: <1s

## Wall-clock budget

90 min / $40 cap; actual: ~20 min / ~$0.16. Within budget.
