### PR TITLE
desktop: notify tray Start/Stop/Restart synchronous errors

### DIFF
--- a/desktop/src/tray.rs
+++ b/desktop/src/tray.rs
@@ -141,13 +141,26 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                         }
                         if let Err(e) = supervisor.start().await {
                             eprintln!("[tray] start_server failed: {}", e);
+                            let _ = app_for_spawn
+                                .notification()
+                                .builder()
+                                .title("Start Server failed")
+                                .body(tray_op_error_body("start", &e.to_string()))
+                                .show();
                         }
                     });
                 }
                 ITEM_STOP => {
+                    let app_for_spawn = app_handle.clone();
                     tauri::async_runtime::spawn(async move {
                         if let Err(e) = supervisor.stop().await {
                             eprintln!("[tray] stop_server failed: {}", e);
+                            let _ = app_for_spawn
+                                .notification()
+                                .builder()
+                                .title("Stop Server failed")
+                                .body(tray_op_error_body("stop", &e.to_string()))
+                                .show();
                         }
                     });
                 }
@@ -192,6 +205,12 @@ pub fn build_tray(app: &AppHandle, supervisor: Arc<Supervisor>) -> tauri::Result
                         }
                         if let Err(e) = supervisor.restart().await {
                             eprintln!("[tray] restart_server failed: {}", e);
+                            let _ = app_for_spawn
+                                .notification()
+                                .builder()
+                                .title("Restart Server failed")
+                                .body(tray_op_error_body("restart", &e.to_string()))
+                                .show();
                         }
                     });
                 }
@@ -548,6 +567,13 @@ pub fn ready_notification_body(port: u16) -> String {
     format!("OpenAI base URL: http://localhost:{}/v1", port)
 }
 
+/// Format the body of a "tray action failed" notification for the three
+/// supervisor-driven tray actions (Start / Stop / Restart). Kept as a pure
+/// helper so it can be unit-tested without GTK/webkit2gtk.
+pub fn tray_op_error_body(op: &str, err: &str) -> String {
+    format!("Could not {} the Kiln server: {}", op, err)
+}
+
 pub fn should_notify_stopped(prev_kind: Option<&str>) -> bool {
     matches!(prev_kind, Some("running") | Some("training"))
 }
@@ -856,5 +882,22 @@ mod tests {
             ptrs.len(),
             "each ServerState must map to a distinct icon slice"
         );
+    }
+
+    #[test]
+    fn tray_op_error_body_includes_op_and_err() {
+        for op in ["start", "stop", "restart"] {
+            let err = "supervisor already running";
+            let body = tray_op_error_body(op, err);
+            assert!(body.contains(op), "body {body:?} should contain op {op:?}");
+            assert!(body.contains(err), "body {body:?} should contain err {err:?}");
+        }
+    }
+
+    #[test]
+    fn tray_op_error_body_empty_err() {
+        let body = tray_op_error_body("start", "");
+        assert!(!body.is_empty(), "body should be non-empty even when err is empty");
+        assert!(body.contains("start"), "body {body:?} should contain op");
     }
 }


### PR DESCRIPTION
## What
Notify the user when tray Start/Stop/Restart clicks fail synchronously (e.g. `supervisor already running`). Previously the `Err` branches only did `eprintln!` so the user got no tray feedback.

Added a pure helper `tray_op_error_body(op, err) -> String` next to the existing `ready_notification_body` / `should_notify_stopped` predicates so the format is unit-testable without GTK. Wired it into the three `match` arms (`ITEM_START`, `ITEM_STOP`, `ITEM_RESTART`) via the already-captured `AppHandle` pattern used for the model-path / binary preflight notifications. Cloned `app_handle` for the `ITEM_STOP` arm (the only one that wasn't already cloning it).

## Why
Consistent polish pattern — mirrors PR #262 (Copy OpenAI Base URL when server stopped) and the existing model_path/binary preflight notifications. Tray actions should never be silently inert. The most user-visible case: clicking "Start Server" while the server is already running currently produces zero feedback; supervisor returns ``Err("supervisor already running")`` which was dropped into stderr.

## Test plan
- Two new unit tests for the `tray_op_error_body` pure helper (includes-op-and-err, empty-err).
- Full CI matrix (macOS/Windows/Ubuntu) validates the Tauri build.
- Manual: click Start Server while already running → "Start Server failed" notification appears with the supervisor error message.

Local ``cargo test`` fails in the Cloud Eric environment at the `glib-sys` build step (missing `glib-2.0` system lib — see the `kiln-desktop-cargo-check-syslibs` note). CI matrix covers the actual build validation.