### PR TITLE
[codex] speed up default paged chat setup

### DIFF
--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -686,6 +686,35 @@ impl ModelRunner {
         })
     }
 
+    /// Same as [`generate_paged_shared`], but accepts an already-tokenized
+    /// prompt so API callers do not render/tokenize the same prompt twice.
+    pub fn generate_paged_shared_tokens(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+    ) -> Result<GenerationOutput> {
+        let output = self.generate_from_tokens_paged_shared(
+            prompt_tokens,
+            params,
+            block_manager,
+            paged_cache,
+        )?;
+
+        let text = self
+            .tokenizer
+            .decode(&output.token_ids)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("failed to decode output tokens")?;
+
+        Ok(GenerationOutput {
+            text,
+            token_ids: output.token_ids,
+            finish_reason: output.finish_reason,
+        })
+    }
+
     fn generate_from_tokens_paged_shared(
         &self,
         prompt_tokens: &[TokenId],
@@ -1946,6 +1975,22 @@ impl ModelRunner {
         )
     }
 
+    /// Streaming variant of [`generate_paged_shared_tokens`].
+    pub fn generate_streaming_paged_shared_tokens(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        self.generate_from_tokens_streaming_paged_shared(
+            prompt_tokens,
+            params,
+            block_manager,
+            paged_cache,
+        )
+    }
+
     fn generate_from_tokens_streaming_paged_shared(
         &self,
         prompt_tokens: &[TokenId],
@@ -2029,7 +2074,7 @@ impl ModelRunner {
                 )
                 .context("prefill forward pass (paged, streaming) failed")?
             } else {
-                model_forward_paged(
+                model_forward_paged_last_token(
                     &*self.backend,
                     prompt_tokens,
                     &self.weights,

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 
 use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
+use kiln_core::token::TokenId;
 use kiln_core::tokenizer::ChatMessage;
 use kiln_model::lora_loader::LoraWeights;
 use kiln_model::{GenerationOutput, ModelRunner, SpeculativeConfig, StreamEvent};
@@ -247,6 +248,10 @@ async fn chat_completions_inner(
         .tokenizer
         .apply_chat_template(&chat_messages)
         .map_err(ApiError::chat_template_failed)?;
+    let prompt_tokens = state
+        .tokenizer
+        .encode(&prompt_text)
+        .map_err(ApiError::tokenization_failed)?;
 
     let sampling = SamplingParams {
         temperature: req.temperature.unwrap_or(1.0),
@@ -276,6 +281,7 @@ async fn chat_completions_inner(
                     block_manager,
                     paged_cache,
                     &prompt_text,
+                    &prompt_tokens,
                     &sampling,
                     &req,
                 )
@@ -296,6 +302,7 @@ async fn chat_completions_inner(
                     block_manager,
                     paged_cache,
                     &prompt_text,
+                    &prompt_tokens,
                     &sampling,
                     &req,
                 )
@@ -395,15 +402,11 @@ async fn generate_real(
     block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
     paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
     prompt_text: &str,
+    prompt_tokens: &[TokenId],
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
 ) -> Result<ChatCompletionResponse, ApiError> {
-    // Count prompt tokens for usage stats.
-    let prompt_token_count = state
-        .tokenizer
-        .encode(prompt_text)
-        .map_err(ApiError::tokenization_failed)?
-        .len();
+    let prompt_token_count = prompt_tokens.len();
 
     let (mtp_supported, has_active_lora) = {
         let guard = runner.read().unwrap();
@@ -418,6 +421,7 @@ async fn generate_real(
     let bm = block_manager.clone();
     let pc = paged_cache.clone();
     let prompt = prompt_text.to_owned();
+    let prompt_tokens = prompt_tokens.to_vec();
     let params = sampling.clone();
 
     let gpu_lock = state.gpu_lock.clone();
@@ -428,9 +432,12 @@ async fn generate_real(
         let _gpu_guard = gpu_lock.read().unwrap();
         let runner_guard = runner.read().unwrap();
         match speculative_mode {
-            ResolvedSpeculativeMode::Off => {
-                runner_guard.generate_paged_shared(&prompt, &params, bm.as_ref(), pc.as_ref())
-            }
+            ResolvedSpeculativeMode::Off => runner_guard.generate_paged_shared_tokens(
+                &prompt_tokens,
+                &params,
+                bm.as_ref(),
+                pc.as_ref(),
+            ),
             ResolvedSpeculativeMode::SkipLayer(spec_config) => {
                 runner_guard.generate_speculative(&prompt, &params, &spec_config)
             }
@@ -501,6 +508,7 @@ async fn generate_real_streaming(
     block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
     paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
     prompt_text: &str,
+    prompt_tokens: &[TokenId],
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
 ) -> Result<Response, ApiError> {
@@ -515,6 +523,7 @@ async fn generate_real_streaming(
     let bm = block_manager.clone();
     let pc = paged_cache.clone();
     let prompt = prompt_text.to_owned();
+    let prompt_tokens = prompt_tokens.to_vec();
     let params = sampling.clone();
     let model = req
         .model
@@ -562,8 +571,8 @@ async fn generate_real_streaming(
                         // Acquire GPU coordination read lock
                         let _gpu_guard = gpu_lock.read().unwrap();
                         let runner_guard = runner.read().unwrap();
-                        runner_guard.generate_streaming_paged_shared(
-                            &prompt,
+                        runner_guard.generate_streaming_paged_shared_tokens(
+                            &prompt_tokens,
                             &params,
                             bm.as_ref(),
                             pc.as_ref(),


### PR DESCRIPTION
## Summary

- Add token-ID entry points for shared paged generation so the HTTP chat path can render and tokenize the prompt once, then pass the tokens directly to the model runner.
- Use the last-token LM-head paged prefill path for streaming responses, matching the optimized non-streaming path instead of projecting logits for every prompt position.

## Why

After the mmap loader change, default macOS requests are dominated by real prompt prefill and setup. The chat API was still doing prompt tokenization once for usage accounting and again inside `ModelRunner::generate_paged_shared`. Streaming also missed the last-token prefill optimization that non-streaming already used.

These changes are active on the default desktop invocation path and do not require a hidden flag.

## Measured locally

Default desktop-style env, Metal, Qwen3.5-4B, `KILN_SPEC_ENABLED=0`, port 8020:

- Server listen: ~28.5s in this run; loader still completed in milliseconds and Metal materialization remains dominant.
- Background prewarm: ~15.75s after listen.
- Sequential post-prewarm non-streaming one-token requests: 4.20s, then 4.61s.
- Sequential streaming request: first content chunk at 4.57s.

MTP check, not enabled by this PR:

- `KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp` loaded MTP but increased load time to ~30.95s and had worse paged TTFT in the latency bench, despite 100% draft acceptance on the short sample. Throughput was effectively the same as non-MTP for the measured 8-token runs, so it is not safe to make the desktop default yet.

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_generate_paged_shared_max_tokens --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_generate_streaming_paged --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-server completions --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo build --release --features metal --bin kiln --bin kiln-bench`