### PR TITLE
[codex] Fuse Metal conv prefill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1876,6 +1876,7 @@ version = "0.1.2"
 dependencies = [
  "anyhow",
  "candle-core",
+ "candle-metal-kernels",
  "candle-nn",
  "half",
  "kiln-conv1d-kernel",
@@ -1887,6 +1888,7 @@ dependencies = [
  "kiln-rmsnorm-kernel",
  "memmap2",
  "mlx-rs",
+ "objc2-metal",
  "rand 0.8.6",
  "rayon",
  "safetensors 0.5.3",

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -16,6 +16,7 @@ safetensors = { workspace = true }
 memmap2 = { workspace = true }
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
+candle-metal-kernels = { version = "0.10", optional = true }
 kiln-conv1d-kernel = { workspace = true, optional = true }
 kiln-flash-attn = { workspace = true, optional = true }
 kiln-gdn-kernel = { workspace = true, optional = true }
@@ -28,12 +29,13 @@ mlx-rs = { workspace = true, optional = true }
 # Pin to the same major as candle-core and mlx-rs. Only pulled in by the
 # mlx backend for native bf16/f16 conversion at the candle↔mlx boundary.
 half = { version = "2", optional = true }
+objc2-metal = { version = "0.3", optional = true }
 
 [features]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-conv1d-kernel", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel", "dep:kiln-marlin-gemm", "dep:kiln-rmsnorm-kernel", "dep:half"]
 # Enable candle's Metal backend on Apple Silicon. Pulls in candle-metal-kernels
 # (JIT-compiled MSL shaders cached in the MetalDevice); no Xcode required.
-metal = ["candle-core/metal", "candle-nn/metal"]
+metal = ["candle-core/metal", "candle-nn/metal", "dep:candle-metal-kernels", "dep:objc2-metal"]
 # Wave 2 mlx-rs backend. Peak Apple Silicon perf via Apple's MLX framework.
 # Layers on top of `metal` so candle still handles weight loading and the
 # ops mlx doesn't replace. Requires full Xcode (mlx-sys compiles MSL at

--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -11,6 +11,8 @@ use candle_core::{DType, Device, Tensor};
 
 use super::BackendRuntime;
 
+const DISABLE_METAL_CONV1D_PREFILL: &str = "KILN_DISABLE_METAL_CONV1D_PREFILL";
+
 #[derive(Debug)]
 pub struct MetalBackend {
     device: Device,
@@ -45,6 +47,10 @@ impl BackendRuntime for MetalBackend {
 
     fn supports_flash_attn_paged_decode(&self) -> bool {
         true
+    }
+
+    fn supports_causal_conv1d_prefill(&self) -> bool {
+        !metal_conv1d_prefill_disabled()
     }
 
     fn flash_attn_prefill(
@@ -176,6 +182,23 @@ impl BackendRuntime for MetalBackend {
         debug_assert_eq!(out.dims(), &[1, 1, num_heads, head_dim]);
         Ok(Some(out))
     }
+
+    fn causal_conv1d_prefill(
+        &self,
+        x: &Tensor,
+        weight: &Tensor,
+        conv_state: &mut Tensor,
+        kernel_size: usize,
+    ) -> Result<Option<Tensor>> {
+        if metal_conv1d_prefill_disabled()
+            || !metal_conv1d_prefill_supports(x, weight, conv_state, kernel_size)
+        {
+            return Ok(None);
+        }
+        let out = metal_causal_conv1d_prefill_bf16_f32_k4(x, weight, conv_state, kernel_size)
+            .context("metal causal_conv1d_prefill kernel failed")?;
+        Ok(Some(out))
+    }
 }
 
 /// Mirrors the head-dim whitelist in candle-nn 0.10.2's
@@ -184,6 +207,233 @@ impl BackendRuntime for MetalBackend {
 /// slower). Re-check this on candle bumps.
 fn metal_sdpa_supports_head_dim(head_dim: usize) -> bool {
     matches!(head_dim, 32 | 64 | 72 | 80 | 96 | 128 | 256 | 512)
+}
+
+fn metal_conv1d_prefill_disabled() -> bool {
+    matches!(
+        std::env::var(DISABLE_METAL_CONV1D_PREFILL)
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            .map(str::to_ascii_lowercase)
+            .as_deref(),
+        Some("1") | Some("true") | Some("yes")
+    )
+}
+
+fn metal_conv1d_prefill_supports(
+    x: &Tensor,
+    weight: &Tensor,
+    conv_state: &Tensor,
+    kernel_size: usize,
+) -> bool {
+    if kernel_size != 4 {
+        return false;
+    }
+    if !matches!(x.device(), Device::Metal(_)) {
+        return false;
+    }
+    if x.dtype() != DType::BF16 || weight.dtype() != DType::BF16 || conv_state.dtype() != DType::F32
+    {
+        return false;
+    }
+    let Ok((batch, channels, seq_len)) = x.dims3() else {
+        return false;
+    };
+    if seq_len <= 1 {
+        return false;
+    }
+    let weight_ok = match weight.rank() {
+        3 => weight
+            .dims3()
+            .is_ok_and(|(c, one, k)| c == channels && one == 1 && k == kernel_size),
+        2 => weight
+            .dims2()
+            .is_ok_and(|(c, k)| c == channels && k == kernel_size),
+        _ => false,
+    };
+    if !weight_ok {
+        return false;
+    }
+    conv_state
+        .dims3()
+        .is_ok_and(|(b, c, k)| (b, c, k) == (batch, channels, kernel_size - 1))
+}
+
+const METAL_CONV1D_PREFILL_KERNEL: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void kiln_causal_conv1d_prefill_bf16_f32_k4(
+    device const bfloat* x [[buffer(0)]],
+    device const bfloat* weight [[buffer(1)]],
+    device float* conv_state [[buffer(2)]],
+    device float* out [[buffer(3)]],
+    constant uint& batch [[buffer(4)]],
+    constant uint& channels [[buffer(5)]],
+    constant uint& seq_len [[buffer(6)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    const uint total_channels = batch * channels;
+    if (gid >= total_channels) {
+        return;
+    }
+
+    const uint b = gid / channels;
+    const uint c = gid - b * channels;
+    const uint x_base = (b * channels + c) * seq_len;
+    const uint state_base = (b * channels + c) * 3;
+    const uint weight_base = c * 4;
+
+    for (uint t = 0; t < seq_len; ++t) {
+        float acc = 0.0f;
+        for (uint j = 0; j < 4; ++j) {
+            const uint padded_idx = t + j;
+            float v;
+            if (padded_idx < 3) {
+                v = conv_state[state_base + padded_idx];
+            } else {
+                v = static_cast<float>(x[x_base + padded_idx - 3]);
+            }
+            acc += v * static_cast<float>(weight[weight_base + j]);
+        }
+        out[x_base + t] = acc / (1.0f + exp(-acc));
+    }
+
+    if (seq_len >= 3) {
+        conv_state[state_base + 0] = static_cast<float>(x[x_base + seq_len - 3]);
+        conv_state[state_base + 1] = static_cast<float>(x[x_base + seq_len - 2]);
+        conv_state[state_base + 2] = static_cast<float>(x[x_base + seq_len - 1]);
+    } else if (seq_len == 2) {
+        conv_state[state_base + 0] = conv_state[state_base + 2];
+        conv_state[state_base + 1] = static_cast<float>(x[x_base + 0]);
+        conv_state[state_base + 2] = static_cast<float>(x[x_base + 1]);
+    } else if (seq_len == 1) {
+        conv_state[state_base + 0] = conv_state[state_base + 1];
+        conv_state[state_base + 1] = conv_state[state_base + 2];
+        conv_state[state_base + 2] = static_cast<float>(x[x_base]);
+    }
+}
+"#;
+
+fn metal_conv1d_prefill_pipeline(
+    device: &candle_core::metal_backend::MetalDevice,
+) -> Result<candle_metal_kernels::metal::ComputePipeline> {
+    use candle_core::metal_backend::DeviceId;
+    use candle_metal_kernels::metal::ComputePipeline;
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    static PIPELINES: OnceLock<Mutex<HashMap<DeviceId, ComputePipeline>>> = OnceLock::new();
+    let cache = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut cache = cache
+        .lock()
+        .map_err(|_| anyhow::anyhow!("metal conv1d prefill pipeline cache poisoned"))?;
+    if let Some(pipeline) = cache.get(&device.id()) {
+        return Ok(pipeline.clone());
+    }
+
+    let library = device
+        .device()
+        .new_library_with_source(METAL_CONV1D_PREFILL_KERNEL, None)
+        .map_err(|e| anyhow::anyhow!("compile metal conv1d prefill library: {e:?}"))?;
+    let function = library
+        .get_function("kiln_causal_conv1d_prefill_bf16_f32_k4", None)
+        .map_err(|e| anyhow::anyhow!("load metal conv1d prefill function: {e:?}"))?;
+    let pipeline = device
+        .device()
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(|e| anyhow::anyhow!("build metal conv1d prefill pipeline: {e:?}"))?;
+    cache.insert(device.id(), pipeline.clone());
+    Ok(pipeline)
+}
+
+fn metal_causal_conv1d_prefill_bf16_f32_k4(
+    x: &Tensor,
+    weight: &Tensor,
+    conv_state: &mut Tensor,
+    kernel_size: usize,
+) -> Result<Tensor> {
+    anyhow::ensure!(kernel_size == 4, "metal conv1d prefill only supports K=4");
+    let (batch, channels, seq_len) = x.dims3()?;
+    anyhow::ensure!(seq_len > 1, "metal conv1d prefill requires seq_len > 1");
+
+    let x = x.contiguous()?;
+    let weight = match weight.rank() {
+        3 => weight.reshape((channels, kernel_size))?,
+        2 => weight.clone(),
+        r => anyhow::bail!("metal conv1d prefill weight rank must be 2 or 3, got {r}"),
+    }
+    .contiguous()?;
+    if !conv_state.is_contiguous() {
+        *conv_state = conv_state.contiguous()?;
+    }
+    let out = Tensor::zeros((batch, channels, seq_len), DType::F32, x.device())?;
+
+    let Device::Metal(device) = x.device() else {
+        anyhow::bail!("metal conv1d prefill requires a Metal tensor");
+    };
+    let pipeline = metal_conv1d_prefill_pipeline(device)?;
+    let encoder = device.command_encoder()?;
+    encoder.set_label("kiln_causal_conv1d_prefill_bf16_f32_k4");
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    {
+        let (x_storage, x_layout) = x.storage_and_layout();
+        let (w_storage, w_layout) = weight.storage_and_layout();
+        let (s_storage, s_layout) = conv_state.storage_and_layout();
+        let (o_storage, o_layout) = out.storage_and_layout();
+
+        let x_metal = match &*x_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal conv1d prefill x must be on Metal"),
+        };
+        let w_metal = match &*w_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal conv1d prefill weight must be on Metal"),
+        };
+        let s_metal = match &*s_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal conv1d prefill state must be on Metal"),
+        };
+        let o_metal = match &*o_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal conv1d prefill output must be on Metal"),
+        };
+
+        let x_buf = candle_core::metal_backend::buffer_o(x_metal.buffer(), &x_layout, x.dtype());
+        let w_buf =
+            candle_core::metal_backend::buffer_o(w_metal.buffer(), &w_layout, weight.dtype());
+        let s_buf =
+            candle_core::metal_backend::buffer_o(s_metal.buffer(), &s_layout, conv_state.dtype());
+        let o_buf = candle_core::metal_backend::buffer_o(o_metal.buffer(), &o_layout, out.dtype());
+
+        encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
+        encoder.set_buffer(1, Some(w_buf.buffer), w_buf.offset_in_bytes);
+        encoder.set_buffer(2, Some(s_buf.buffer), s_buf.offset_in_bytes);
+        encoder.set_buffer(3, Some(o_buf.buffer), o_buf.offset_in_bytes);
+
+        let batch_u32 = batch as u32;
+        let channels_u32 = channels as u32;
+        let seq_len_u32 = seq_len as u32;
+        encoder.set_bytes(4, &batch_u32);
+        encoder.set_bytes(5, &channels_u32);
+        encoder.set_bytes(6, &seq_len_u32);
+
+        let threads_per_grid = objc2_metal::MTLSize {
+            width: batch * channels,
+            height: 1,
+            depth: 1,
+        };
+        let threads_per_threadgroup = objc2_metal::MTLSize {
+            width: 256,
+            height: 1,
+            depth: 1,
+        };
+        encoder.dispatch_threads(threads_per_grid, threads_per_threadgroup);
+    }
+
+    Ok(out)
 }
 
 /// Test helper: try to initialize a Metal device, returning `None` if Metal

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -198,6 +198,10 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         false
     }
 
+    fn supports_causal_conv1d_prefill(&self) -> bool {
+        false
+    }
+
     /// Fused single-step causal depthwise conv1d + state update + silu.
     ///
     /// Replaces the candle `to_f32 -> cat(state, x) -> sum(window * weight) ->
@@ -215,6 +219,25 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
     /// violation, disabled via env kill switch). When `Some`, the caller must
     /// NOT apply `silu` again — it is fused into the kernel epilogue.
     fn causal_conv1d_update(
+        &self,
+        _x: &Tensor,
+        _weight: &Tensor,
+        _conv_state: &mut Tensor,
+        _kernel_size: usize,
+    ) -> Result<Option<Tensor>> {
+        Ok(None)
+    }
+
+    /// Fused prefill causal depthwise conv1d + state update + silu.
+    ///
+    /// `x`: `[B, C, T]` bf16 contiguous with `T > 1`. `weight`: `[C, 1, K]`
+    /// bf16 contiguous (or `[C, K]`). `conv_state`: `[B, C, K-1]` F32,
+    /// mutated in place after all outputs have consumed the entry state.
+    ///
+    /// Returns `Ok(Some(out))` with `out: [B, C, T]` F32 (silu-fused), or
+    /// `Ok(None)` when the backend declines. When `Some`, the caller must not
+    /// apply `silu` again.
+    fn causal_conv1d_prefill(
         &self,
         _x: &Tensor,
         _weight: &Tensor,

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2191,8 +2191,29 @@ pub fn gated_deltanet_forward(
                 }
             }
         } else if seq_len > 1 {
-            let y = causal_conv1d_prefill(&mixed_qkv_ct, &weights.conv1d, conv_state, kernel_size)?;
-            cuda_silu(&y)?
+            if backend.supports_causal_conv1d_prefill() {
+                match backend.causal_conv1d_prefill(
+                    &mixed_qkv_ct,
+                    &weights.conv1d,
+                    conv_state,
+                    kernel_size,
+                )? {
+                    Some(out) => out, // F32, SiLU fused into the kernel epilogue
+                    None => {
+                        let y = causal_conv1d_prefill(
+                            &mixed_qkv_ct,
+                            &weights.conv1d,
+                            conv_state,
+                            kernel_size,
+                        )?;
+                        cuda_silu(&y)?
+                    }
+                }
+            } else {
+                let y =
+                    causal_conv1d_prefill(&mixed_qkv_ct, &weights.conv1d, conv_state, kernel_size)?;
+                cuda_silu(&y)?
+            }
         } else {
             let y = causal_conv1d_decode(&mixed_qkv_ct, &weights.conv1d, conv_state, kernel_size)?;
             cuda_silu(&y.to_dtype(DType::F32)?)?
@@ -6974,6 +6995,84 @@ mod tests {
         assert!(
             smax < 1e-6,
             "bf16 prefill state max_abs_diff={smax:e} exceeds 1e-6"
+        );
+
+        Ok(())
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn test_metal_causal_conv1d_prefill_kernel_matches_fallback() -> Result<()> {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let Some(device) = crate::backend::metal::try_new_metal() else {
+            eprintln!(
+                "Metal not available, skipping test_metal_causal_conv1d_prefill_kernel_matches_fallback"
+            );
+            return Ok(());
+        };
+
+        let batch = 1usize;
+        let channels = 8192usize; // Qwen3.5-4B linear_qkv_dim
+        let seq_len = 16usize;
+        let kernel_size = 4usize;
+
+        let mut rng = StdRng::seed_from_u64(0xC0FFEE_8175);
+        let n_x = batch * channels * seq_len;
+        let n_w = channels * kernel_size;
+        let n_s = batch * channels * (kernel_size - 1);
+
+        let x_data: Vec<f32> = (0..n_x).map(|_| rng.gen_range(-0.5f32..0.5f32)).collect();
+        let w_data: Vec<f32> = (0..n_w).map(|_| rng.gen_range(-0.1f32..0.1f32)).collect();
+        let s_data: Vec<f32> = (0..n_s).map(|_| rng.gen_range(-0.3f32..0.3f32)).collect();
+
+        let x = Tensor::from_slice(&x_data, (batch, channels, seq_len), &device)?
+            .to_dtype(DType::BF16)?;
+        let w = Tensor::from_slice(&w_data, (channels, 1, kernel_size), &device)?
+            .to_dtype(DType::BF16)?;
+        let s_init = Tensor::from_slice(&s_data, (batch, channels, kernel_size - 1), &device)?;
+
+        let mut s_ref = s_init.clone();
+        let out_ref =
+            causal_conv1d_prefill_with_dtype(&x, &w, &mut s_ref, kernel_size, DType::F32)?;
+        let out_ref = cuda_silu(&out_ref)?;
+
+        let backend = crate::backend::for_device(&device);
+        assert!(backend.supports_causal_conv1d_prefill());
+        let mut s_kernel = s_init.clone();
+        let out_kernel = match backend.causal_conv1d_prefill(&x, &w, &mut s_kernel, kernel_size)? {
+            Some(out) => out,
+            None => {
+                eprintln!("Metal backend declined causal_conv1d_prefill; skipping");
+                return Ok(());
+            }
+        };
+        assert_eq!(out_kernel.dtype(), DType::F32);
+        assert_eq!(s_kernel.dtype(), DType::F32);
+
+        let diff = (out_kernel.to_dtype(DType::F32)? - out_ref.to_dtype(DType::F32)?)?;
+        let abs = diff.abs()?;
+        let max = abs.flatten_all()?.max(0)?.to_scalar::<f32>()?;
+        let mean = abs.flatten_all()?.mean(0)?.to_scalar::<f32>()?;
+        eprintln!(
+            "metal conv1d_prefill kernel vs fallback: max_abs_diff={max:e} mean_abs_diff={mean:e}"
+        );
+        assert!(
+            max < 1e-5,
+            "metal prefill output max_abs_diff={max:e} exceeds 1e-5"
+        );
+        assert!(
+            mean < 1e-6,
+            "metal prefill output mean_abs_diff={mean:e} exceeds 1e-6"
+        );
+
+        let sdiff = (s_kernel.to_dtype(DType::F32)? - s_ref.to_dtype(DType::F32)?)?;
+        let smax = sdiff.abs()?.flatten_all()?.max(0)?.to_scalar::<f32>()?;
+        eprintln!("metal conv1d_prefill kernel state parity: max_abs_diff={smax:e}");
+        assert!(
+            smax < 1e-6,
+            "metal prefill state max_abs_diff={smax:e} exceeds 1e-6"
         );
 
         Ok(())


### PR DESCRIPTION
## Summary

Adds a Kiln-owned Metal fused `causal_conv1d_prefill + SiLU` backend hook for the Qwen3.5 GDN prefill path.

The kernel is deliberately narrow and fallback-safe: Metal only, BF16 input/weight, F32 conv state/output, contiguous `[B, C, T]`, and `kernel_size == 4`. It uses one GPU thread per `(batch, channel)` so all output timesteps read the original state before that thread updates the rolling F32 conv state. Backends can still decline via `Ok(None)`, and `KILN_DISABLE_METAL_CONV1D_PREFILL=1` forces the previous candle path.

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_metal_causal_conv1d_prefill_kernel_matches_fallback --features metal -- --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_model_forward_parity_cpu_vs_metal --features metal -- --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_generate_paged_shared_max_tokens --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo build --release --features metal --bin kiln --bin kiln-bench`
- `KILN_SPEC_ENABLED=0 /usr/bin/time -l /Users/ericflo/Development/kiln/target/release/kiln-bench --model-path "$HOME/Library/Application Support/com.eflorenzano.kiln.desktop/models/Qwen__Qwen3.5-4B" --prompt-tokens 8 --max-output-tokens 1 --skip-training --paged`
- `KILN_SPEC_ENABLED=0 KILN_DISABLE_METAL_CONV1D_PREFILL=1 /usr/bin/time -l /Users/ericflo/Development/kiln/target/release/kiln-bench --model-path "$HOME/Library/Application Support/com.eflorenzano.kiln.desktop/models/Qwen__Qwen3.5-4B" --prompt-tokens 8 --max-output-tokens 1 --skip-training --paged`

## Measurements

- Kernel parity test: output `max_abs_diff=7.45e-9`, `mean_abs_diff=1.71e-11`; conv state parity exact.
- Enabled path: model load `20.04s`, paged prefill `9134.5ms`, sequential one-token generations around `381-393ms`.
- Disabled path on same binary: paged prefill `9994.9ms`, sequential one-token generations around `411-428ms`.
- This is the first real default-path Metal GDN fusion; it cuts launch/traffic in the conv+SILU bubble without changing the desktop invocation params.