### PR TITLE
mtp: fix RoPE position in MTP inner block (base_pos + mtp_pos)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3878,6 +3878,7 @@ pub fn mtp_forward_step(
     config: &kiln_core::config::ModelConfig,
     mtp_cache: &mut PagedKvCache,
     mtp_block_table: &BlockTable,
+    base_pos: usize,
     mtp_pos: usize,
 ) -> Result<(Tensor, Tensor)> {
     kiln_nvtx::range!(c"kiln/mtp/step");
@@ -3946,9 +3947,27 @@ pub fn mtp_forward_step(
     }
 
     // 5. Single full-attention transformer block with its own paged cache.
-    //    Build a one-element position tensor since MTP has its own position
-    //    space (distinct from the base model's) and is not CUDA-graph-captured.
-    let positions = Tensor::new(&[mtp_pos as f32][..], device)?;
+    //
+    //    Two distinct position counters are in play here:
+    //
+    //    * `base_pos + mtp_pos` — the ABSOLUTE sequence position the draft
+    //      token would occupy in the prompt+decode stream. This is what
+    //      RoPE must use so the MTP head sees the same rotation angles the
+    //      base Qwen3-Next block would have applied at that position. The
+    //      PyTorch reference (`scripts/mtp_reference_dump.py`) applies RoPE
+    //      at the absolute position; Phase B7a (PR #276) confirmed kiln's
+    //      prior use of bare `mtp_pos` here caused monotonic `post_layer`
+    //      drift at pos=1,2 — the RoPE-wrong-position signature.
+    //
+    //    * `mtp_pos` — the LOCAL slot index into the MTP paged KV cache.
+    //      The MTP cache is its own isolated address space (distinct from
+    //      the base KV cache); slot `mtp_pos` is the right write target
+    //      regardless of where the token sits in absolute stream order.
+    //
+    //    MTP is not CUDA-graph-captured, so rebuilding the position tensor
+    //    per step is fine.
+    let abs_pos = base_pos + mtp_pos;
+    let positions = Tensor::new(&[abs_pos as f32][..], device)?;
     let mtp_hidden_result = transformer_block_paged(
         backend,
         &fused,

--- a/crates/kiln-model/src/speculative.rs
+++ b/crates/kiln-model/src/speculative.rs
@@ -552,6 +552,15 @@ pub fn speculative_mtp_decode_step(
     _rng: &mut StdRng,
 ) -> Result<MtpSpeculativeStepResult> {
     // 1. Draft: one MTP step produces a single candidate next token.
+    //
+    // We pass both `base_pos` (the absolute sequence index the draft token
+    // will occupy in the base stream) and `mtp_pos` (the MTP-cache slot
+    // index). The inner block uses `base_pos + mtp_pos` for RoPE — so the
+    // MTP head sees the same rotation angles the main GQA block would have
+    // applied at that absolute position — and keeps `mtp_pos` as the
+    // write slot in the isolated MTP paged cache. See Phase B7a evidence
+    // in PR #276: without this, `post_layer` drifts monotonically with
+    // `mtp_pos` (cos_sim 0.999977 → 0.999531 → 0.997527 at pos 0/1/2).
     let (mtp_logits, _mtp_hidden) = mtp_forward_step(
         backend,
         last_token,
@@ -560,6 +569,7 @@ pub fn speculative_mtp_decode_step(
         config,
         mtp_cache,
         mtp_block_table,
+        base_pos,
         mtp_pos,
     )
     .context("mtp draft step failed")?;


### PR DESCRIPTION
## What

Implements the Phase B8 fix diagnosed in PR #276: the MTP inner block's RoPE call site now threads `base_pos + mtp_pos` (absolute sequence position) instead of bare `mtp_pos`. `mtp_forward_step` gains a `base_pos: usize` parameter, and `speculative_mtp_decode_step` passes it through.

## Evidence (A6000, Qwen3.5-4B, seed=42, prompt=512)

| metric                          | main         | B8 fix       |
|---------------------------------|--------------|--------------|
| α (draft acceptance rate)       | 0.085 (10/118) | 0.085 (10/118) |
| post_layer cos_sim pos=0        | 0.999977     | 0.999977     |
| post_layer cos_sim pos=1        | 0.999531     | 0.99985      |
| post_layer cos_sim pos=2        | 0.997527     | 0.999018     |
| post_layer spread (max-min)     | 2.45e-03     | 9.59e-04     |
| post_layer max\|Δ\| at pos=2    | 3.98e-01     | 2.70e-01     |
| `mtp_compare.py` H1 verdict     | CONFIRMED    | REJECTED     |

A/B used distinct binaries (main md5=`874f10d9…`, B8 md5=`a89e4cfc…`).

## Interpretation

- ✅ **H1 (RoPE position) validated at the tap level**: post_layer cos_sim spread narrows 2.5× and no longer monotonically degrades with `mtp_pos`. `mtp_compare.py`'s auto-verdict flips from CONFIRMED to REJECTED — the RoPE-wrong-position signature is gone.
- ❌ **α is unchanged**: H1 alone does not drive the α=0.085 collapse. H2 (qk-norm semantics) and/or H3 (gated-attn split) dominate.

This answers the open question from PR #276: "Once H1 fix lands… α=0.411 acceptance-rate check will tell us whether H1 accounts for the full collapse OR whether H2 and H3 still contribute." H1 does **not** account for the collapse.

## Phase B9 recommendation

Land this for tap-level correctness, then investigate H2 (qk-norm semantics) and H3 (gated-attn split) as the dominant drivers of α.

## Validation

- `cargo build --release --features cuda --bin kiln-bench` — clean
- A/B bench on A6000 pod `hrc5t1zz4nwi9h`, 3 dumps per branch at `mtp_pos={0,1,2}`, compared against pytorch reference via `scripts/mtp_compare.py`