### PR TITLE
mtp: Phase B9 — H2/H3 dual-dump bisect (qk-norm vs gated-attn split)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2920,6 +2920,10 @@ pub fn gqa_attention_paged(
     let _ = crate::mtp_debug::capture_subop("post_q_proj_raw", &q_raw);
     let _ = crate::mtp_debug::capture_subop("post_k_proj", &k);
     let _ = crate::mtp_debug::capture_subop("post_v_proj", &v);
+    // Phase B9 H3 alias: pre_gated_attn_split is the q_raw tensor before the
+    // (q, gate) narrow split. Captured as alias of post_q_proj_raw so the
+    // comparator can locate H3 zone divergence by name.
+    let _ = crate::mtp_debug::capture_subop("pre_gated_attn_split", &q_raw);
 
     let (q, gate) = {
         kiln_nvtx::range!(c"kiln/proj/qkv_split");
@@ -2938,12 +2942,22 @@ pub fn gqa_attention_paged(
     };
     // After the gate split, q is the rotation target.
     let _ = crate::mtp_debug::capture_subop("post_q_split", &q);
+    // Phase B9 H3 alias: post_gated_attn_split_value mirrors post_q_split.
+    let _ = crate::mtp_debug::capture_subop("post_gated_attn_split_value", &q);
     if let Some(ref g) = gate {
         let _ = crate::mtp_debug::capture_subop("post_gate_split", g);
+        // Phase B9 H3 alias: post_gated_attn_split_gate mirrors post_gate_split.
+        let _ = crate::mtp_debug::capture_subop("post_gated_attn_split_gate", g);
     }
 
     let k = k.reshape(((), seq_len, num_kv_heads, head_dim))?;
     let v = v.reshape(((), seq_len, num_kv_heads, head_dim))?;
+
+    // Phase B9 H2 taps: pre_qk_norm_{q,k} are the per-head reshaped tensors
+    // immediately before per-head RMSNorm. pre_qk_norm_q is alias of
+    // post_q_split; pre_qk_norm_k is genuinely new (post_k_proj is pre-reshape).
+    let _ = crate::mtp_debug::capture_subop("pre_qk_norm_q", &q);
+    let _ = crate::mtp_debug::capture_subop("pre_qk_norm_k", &k);
 
     // QK-norm
     let (q, k) = {
@@ -2954,6 +2968,9 @@ pub fn gqa_attention_paged(
     };
     let _ = crate::mtp_debug::capture_subop("post_q_norm", &q);
     let _ = crate::mtp_debug::capture_subop("post_k_norm", &k);
+    // Phase B9 H2 aliases: post_qk_norm_{q,k} mirror post_{q,k}_norm.
+    let _ = crate::mtp_debug::capture_subop("post_qk_norm_q", &q);
+    let _ = crate::mtp_debug::capture_subop("post_qk_norm_k", &k);
 
     // RoPE — only rotate first rotary_dim dimensions
     // Use the GPU tensor variant so positions remain at a stable GPU address

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -68,10 +68,21 @@ SUBOP_ORDER: List[str] = [
     "post_q_proj_raw",
     "post_k_proj",
     "post_v_proj",
+    # Phase B9 H3 zone: pre/post gated-attn split (mostly aliases of the
+    # neighbouring B7b taps, kept distinct so the comparator can localize
+    # the H3 hypothesis by name).
+    "pre_gated_attn_split",
     "post_q_split",
+    "post_gated_attn_split_value",
     "post_gate_split",
+    "post_gated_attn_split_gate",
+    # Phase B9 H2 zone: pre/post per-head qk-norm.
+    "pre_qk_norm_q",
+    "pre_qk_norm_k",
     "post_q_norm",
     "post_k_norm",
+    "post_qk_norm_q",
+    "post_qk_norm_k",
     "post_q_rope",
     "post_k_rope",
     "post_attn_raw",
@@ -82,6 +93,15 @@ SUBOP_ORDER: List[str] = [
     "post_pre_mlp_norm",
     "post_mlp",
 ]
+
+# Phase B9 hypothesis zones — the comparator classifies the first sub-op
+# divergence into one of these zones to emit an H2/H3/both/neither verdict.
+B9_H2_ZONE = ("pre_qk_norm_q", "pre_qk_norm_k", "post_qk_norm_q", "post_qk_norm_k")
+B9_H3_ZONE = (
+    "pre_gated_attn_split",
+    "post_gated_attn_split_value",
+    "post_gated_attn_split_gate",
+)
 
 META_KEYS = (
     "meta__draft_token_id",
@@ -112,6 +132,13 @@ SUBOP_HYPOTHESIS = {
     "post_v_proj": "v_proj weight layout or transpose",
     "post_q_split": "Q/gate split: per-head narrow vs flat-half chunk semantic mismatch",
     "post_gate_split": "Q/gate split: gate half order or layout",
+    "pre_gated_attn_split": "B9 H3: q_raw input to gated-attn split (alias of post_q_proj_raw)",
+    "post_gated_attn_split_value": "B9 H3: value half after split (alias of post_q_split)",
+    "post_gated_attn_split_gate": "B9 H3: gate half after split (alias of post_gate_split)",
+    "pre_qk_norm_q": "B9 H2: per-head Q before RMSNorm (alias of post_q_split)",
+    "pre_qk_norm_k": "B9 H2: per-head K before RMSNorm (post_k_proj reshaped)",
+    "post_qk_norm_q": "B9 H2: per-head Q after RMSNorm (alias of post_q_norm)",
+    "post_qk_norm_k": "B9 H2: per-head K after RMSNorm (alias of post_k_norm)",
     "post_q_norm": "q_norm weight or per-head broadcast",
     "post_k_norm": "k_norm weight or per-head broadcast",
     "post_q_rope": "RoPE on Q: mtp_pos value, rotary_dim, half-rotate vs interleaved, theta",
@@ -361,6 +388,130 @@ def _emit_b7a_summary(
         emit("  another bug. Recommend running B7b anyway and re-evaluating.")
 
 
+def _emit_b9_summary(
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]],
+    atol: float,
+    rtol: float,
+    emit,
+) -> None:
+    """Phase B9 — H2 (qk-norm) vs H3 (gated-attn split) bisect.
+
+    Walks the canonical sub-op order across every position and finds the first
+    diverging sub-op tap. If that tap lands in the H2 zone, prints
+    'H2 dominant'; if in the H3 zone, 'H3 dominant'; if BOTH zones diverge in
+    one or more positions, prints 'BOTH'; if neither zone diverges, prints
+    'NEITHER (look upstream)'. Per-sub-op cos_sim + max|Δ| table per position
+    is also emitted so the verdict is auditable.
+    """
+    emit("")
+    emit("=" * 78)
+    emit("Phase B9 H2/H3 sub-op bisect — per-position cos_sim + max|Δ|")
+    emit("=" * 78)
+
+    labels = [pr[0] for pr in pair_results]
+
+    # B9 zone tap names in canonical capture order. We restrict the table to
+    # zone taps so the verdict is unambiguous; the full sub-op table for
+    # context already prints in the per-pair section above.
+    zone_taps: List[str] = []
+    for n in SUBOP_ORDER:
+        if n in B9_H2_ZONE or n in B9_H3_ZONE:
+            zone_taps.append(n)
+
+    # Build {tap: {label: (cos_sim, max_abs_diff, allclose)}} from rows.
+    cell: Dict[str, Dict[str, Tuple[float, float, bool]]] = {n: {} for n in zone_taps}
+    for label, _ok, _fd, rows, _km, _rm in pair_results:
+        for r in rows:
+            n = r["name"]
+            if n in cell:
+                cell[n][label] = (
+                    float(r["cos_sim"]),
+                    float(r["max_abs_diff"]),
+                    bool(r["allclose"]),
+                )
+
+    # Header.
+    header = "  " + "tap".ljust(30) + " ".join(
+        f"pos={lab:<22}" for lab in labels
+    )
+    emit(header)
+    emit("  " + "-" * (len(header) - 2))
+    for tap in zone_taps:
+        zone_marker = "[H2]" if tap in B9_H2_ZONE else "[H3]"
+        cells = []
+        for lab in labels:
+            entry = cell[tap].get(lab)
+            if entry is None:
+                cells.append(f"{'<missing>':<26}")
+            else:
+                cs, mxd, ok = entry
+                tag = "ok" if ok else "DIV"
+                cells.append(
+                    f"cos={_fmt_sci(cs):<10} max|Δ|={_fmt_sci(mxd):<8} {tag:<3} "
+                )
+        emit(f"  {zone_marker} {tap:<26}{' '.join(cells)}")
+
+    # Decide H2 / H3 / both / neither based on whether ANY pair has a divergent
+    # tap in each zone, keyed off the row-level allclose flag the comparator
+    # already computed at the requested atol/rtol.
+    h2_div = any(
+        not entry[2]
+        for tap in B9_H2_ZONE
+        for entry in cell.get(tap, {}).values()
+    )
+    h3_div = any(
+        not entry[2]
+        for tap in B9_H3_ZONE
+        for entry in cell.get(tap, {}).values()
+    )
+
+    # First-diverging zone tap in canonical order, taken across all positions.
+    first_zone_div: Optional[str] = None
+    first_zone_pos: Optional[str] = None
+    for tap in zone_taps:
+        for lab in labels:
+            entry = cell[tap].get(lab)
+            if entry is not None and not entry[2]:
+                first_zone_div = tap
+                first_zone_pos = lab
+                break
+        if first_zone_div is not None:
+            break
+
+    emit("")
+    emit(f"  H2 zone (qk-norm) divergence present:   {h2_div}")
+    emit(f"  H3 zone (gated-attn split) divergence present: {h3_div}")
+    if first_zone_div is not None:
+        emit(f"  First zone-tap divergence in canonical order: '{first_zone_div}' (pos={first_zone_pos})")
+
+    if h2_div and h3_div:
+        # Tie-break by which zone the canonical-first-diverging tap lands in.
+        if first_zone_div in B9_H2_ZONE:
+            emit("Phase B9 verdict: BOTH zones diverge; canonical-first divergence is in H2 zone")
+            emit("  -> H2 (qk-norm semantics) is the upstream cause; H3 likely inherits.")
+            emit("  -> Land Phase B9 PR with this finding; queue B10 fix targeting qk-norm.")
+        elif first_zone_div in B9_H3_ZONE:
+            emit("Phase B9 verdict: BOTH zones diverge; canonical-first divergence is in H3 zone")
+            emit("  -> H3 (gated-attn split semantics) is the upstream cause; H2 likely inherits.")
+            emit("  -> Land Phase B9 PR with this finding; queue B10 fix targeting gated-attn split.")
+        else:
+            emit("Phase B9 verdict: BOTH zones diverge; cannot pick canonical-first cleanly.")
+            emit("  -> Land Phase B9 PR with this finding; queue B10 to investigate both zones.")
+    elif h2_div:
+        emit("Phase B9 verdict: H2 DOMINANT — qk-norm zone diverges, gated-attn split zone matches.")
+        emit("  -> H2 (qk-norm semantics) drives the post_layer divergence on this pair.")
+        emit("  -> Land Phase B9 PR with this finding; queue B10 fix targeting qk-norm.")
+    elif h3_div:
+        emit("Phase B9 verdict: H3 DOMINANT — gated-attn split zone diverges, qk-norm zone matches.")
+        emit("  -> H3 (gated-attn split semantics) drives the post_layer divergence on this pair.")
+        emit("  -> Land Phase B9 PR with this finding; queue B10 fix targeting gated-attn split.")
+    else:
+        emit("Phase B9 verdict: NEITHER zone diverges in the H2/H3 bisect.")
+        emit("  -> The post_layer divergence is upstream of qk-norm and the gated-attn split,")
+        emit("     OR the divergence emerges only at a downstream tap (RoPE/attn/o_proj/MLP).")
+        emit("  -> Re-check the full sub-op table above for the first non-zone divergence.")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--kiln", help="Path to kiln dump (.safetensors) — single-pair mode")
@@ -413,6 +564,20 @@ def main() -> int:
 
     if multi:
         _emit_b7a_summary(pair_results, emit)
+
+    # B9 sub-op zone bisect — emitted whenever any pair captured zone taps,
+    # whether single- or multi-pair. Exits cleanly with a "no zone taps
+    # captured" note when the dump didn't include the B9 sub-ops (e.g.
+    # legacy dumps from before this PR).
+    have_b9_taps = any(
+        any(r["name"] in B9_H2_ZONE or r["name"] in B9_H3_ZONE for r in pr[3])
+        for pr in pair_results
+    )
+    if have_b9_taps:
+        _emit_b9_summary(pair_results, args.atol, args.rtol, emit)
+    elif multi:
+        emit("")
+        emit("Phase B9 zone bisect: skipped (no H2/H3 zone sub-op taps in dumps).")
 
     emit("")
     if overall_ok:

--- a/scripts/mtp_reference_dump.py
+++ b/scripts/mtp_reference_dump.py
@@ -396,6 +396,8 @@ def mtp_inner_block(
     _capture(capture_subops, "post_q_proj_raw", q_raw)
     _capture(capture_subops, "post_k_proj", k)
     _capture(capture_subops, "post_v_proj", v)
+    # Phase B9 H3 alias: pre_gated_attn_split = q_raw before per-head narrow.
+    _capture(capture_subops, "pre_gated_attn_split", q_raw)
 
     # Per-head Q/gate split — must mirror kiln's narrow exactly. Kiln does:
     #   q_pair = q_raw.reshape((batch, seq_len, num_heads, head_dim*2))
@@ -416,17 +418,30 @@ def mtp_inner_block(
         q = q_raw.view(1, 1, num_heads, head_dim)                           # [1, 1, num_heads, head_dim]
         gate = None
     _capture(capture_subops, "post_q_split", q)
+    # Phase B9 H3 alias: post_gated_attn_split_value mirrors post_q_split.
+    _capture(capture_subops, "post_gated_attn_split_value", q)
     if gate is not None:
         _capture(capture_subops, "post_gate_split", gate)
+        # Phase B9 H3 alias: post_gated_attn_split_gate mirrors post_gate_split.
+        _capture(capture_subops, "post_gated_attn_split_gate", gate)
 
     k = k.view(1, 1, num_kv_heads, head_dim)  # [1, 1, num_kv_heads, head_dim]
     v = v.view(1, 1, num_kv_heads, head_dim)  # [1, 1, num_kv_heads, head_dim]
+
+    # Phase B9 H2 taps: pre_qk_norm_{q,k} are per-head reshaped tensors
+    # immediately before per-head RMSNorm. pre_qk_norm_q is alias of
+    # post_q_split; pre_qk_norm_k is genuinely new (post_k_proj is pre-reshape).
+    _capture(capture_subops, "pre_qk_norm_q", q)
+    _capture(capture_subops, "pre_qk_norm_k", k)
 
     # Per-head RMSNorm on Q and K (Qwen3-Next style). Same shape in/out.
     q = rms_norm(q, w.q_norm_weight, eps)
     k = rms_norm(k, w.k_norm_weight, eps)
     _capture(capture_subops, "post_q_norm", q)
     _capture(capture_subops, "post_k_norm", k)
+    # Phase B9 H2 aliases: post_qk_norm_{q,k} mirror post_{q,k}_norm.
+    _capture(capture_subops, "post_qk_norm_q", q)
+    _capture(capture_subops, "post_qk_norm_k", k)
 
     # RoPE on rotary_dim prefix in the [B, S, H, D] layout — matches kiln's
     # `rotary_embedding_from_tensor` call site in forward.rs:2661-2666 (both


### PR DESCRIPTION
## Phase B9 — H2/H3 dual-dump bisect (qk-norm vs gated-attn split)

### What

- Adds 7 sub-op taps inside the MTP inner attention block (gated-attn split + qk-norm boundaries) in `crates/kiln-model/src/forward.rs` via the existing `KILN_MTP_DUMP_*` gate. Zero cost when disabled.
- Mirrors the same 7 named taps in the pure-tensor PyTorch reference `scripts/mtp_reference_dump.py::mtp_inner_block`.
- Extends `scripts/mtp_compare.py` with a Phase B9 zone-bisect summary: per-position cos_sim + max|Δ| across H2 (qk-norm) and H3 (gated-attn split) taps, plus an automated H2-dominant / H3-dominant / both / neither verdict based on allclose.

### Why

Phase B8 / PR #284 validated H1 (RoPE position threading) at the layer level: `post_layer` cos_sim jumped to 1.00 across `mtp_pos` ∈ {0,1,2}. But α acceptance remained at 0.085 (floor ≥0.72), proving H1 alone does not drive the collapse. B9 adds sub-op taps so we can run a dual-dump A/B inside the inner block and isolate H2 (qk-norm semantics) vs H3 (gated-attn split) at tap granularity.

### Tap inventory (new in B9)

H3 zone (gated-attn split):
- `pre_gated_attn_split` — raw 2H output of q_proj
- `post_gated_attn_split_value` — value half after per-head split
- `post_gated_attn_split_gate` — gate half after per-head split

H2 zone (qk-norm):
- `pre_qk_norm_q`, `pre_qk_norm_k` — inputs to per-head RMSNorm
- `post_qk_norm_q`, `post_qk_norm_k` — outputs of per-head RMSNorm

### Evidence (A6000, bs=1, prompt=512, seed=42, W4A16 prod decode)

```
tap                             pos=0                       pos=1                       pos=2
----------------------------------------------------------------------------------------------------
[H3] pre_gated_attn_split       cos=1.00  max|Δ|=5.81e-02   cos=1.00  max|Δ|=4.59e-02   cos=1.00  max|Δ|=5.83e-02
[H3] post_gated_attn_split_value cos=1.00  max|Δ|=5.81e-02  cos=1.00  max|Δ|=4.59e-02   cos=1.00  max|Δ|=5.83e-02
[H3] post_gated_attn_split_gate cos=1.00  max|Δ|=4.11e-02   cos=1.00  max|Δ|=4.36e-02   cos=1.00  max|Δ|=5.07e-02
[H2] pre_qk_norm_q              cos=1.00  max|Δ|=5.81e-02   cos=1.00  max|Δ|=4.59e-02   cos=1.00  max|Δ|=5.83e-02
[H2] pre_qk_norm_k              cos=1.00  max|Δ|=3.02e-02   cos=1.00  max|Δ|=2.76e-02   cos=1.00  max|Δ|=3.41e-02
[H2] post_qk_norm_q             cos=1.00  max|Δ|=4.51e-02   cos=1.00  max|Δ|=4.70e-02   cos=1.00  max|Δ|=3.93e-02
[H2] post_qk_norm_k             cos=1.00  max|Δ|=3.38e-02   cos=1.00  max|Δ|=2.84e-02   cos=1.00  max|Δ|=4.39e-02
```

Downstream reference-vs-kiln agreement at the MTP head (from the same run):

```
tap            pos=0    pos=1    pos=2
post_layer     1.00e+00 1.00e+00 9.99e-01   (spread across mtp_pos: 4.94e-04)
post_final_ln  1.00e+00 1.00e+00 9.99e-01
mtp_logits     1.00e+00 1.00e+00 9.99e-01
```

### Verdict (automated)

```
Phase B9 verdict: BOTH zones diverge; canonical-first divergence is in H3 zone
  -> H3 (gated-attn split semantics) is the upstream cause; H2 likely inherits.
```

### Interpretation (magnitude-aware)

The automated "BOTH / H3 canonical-first" verdict fires because `max|Δ|` at every H2/H3 tap exceeds the tight allclose threshold (`atol=1e-3`, `rtol=1e-2`). But the magnitudes tell a different story:

- All 7 H2/H3 taps show **cos_sim = 1.00** with `max|Δ|` in the 3–6% range — uniform across zones, across positions, across positive/negative sides of each boundary.
- The H1-zone `post_q_rope` tap (from the B7a summary), by contrast, shows cos_sim ≈ 0.71 and `max|Δ|` ≈ 17.6 at pos=0 — two orders of magnitude larger pointwise deviation, though softmax absorbs it into small downstream deltas.
- Downstream of the full inner block, `post_layer` → `post_final_ln` → `mtp_logits` all sit at cos_sim ≈ 1.00.

That pattern is consistent with **BF16 accumulation noise** throughout the H2/H3 region, not a semantic bug in either zone. Neither qk-norm nor gated-attn split shows a single-site concentration of divergence that could plausibly drive α from ≥0.72 down to 0.085.

### Implication for α collapse

Combined with:
- B7a: H1 REJECTED at `post_layer` (cos_sim spread 4.94e-04 across `mtp_pos`).
- B9 (this PR): H2 and H3 zones both within BF16 noise, uniformly.
- Reference architecture: `h_main` is taken from the kiln dump, so bugs in the main-model forward path (24×GDN + 8×GQA stack) would match bit-for-bit and never surface at these taps.

The most likely remaining driver of α=0.085 is **upstream of the MTP head** — specifically in the main-model `h_main` production path that feeds into `mtp_forward_step`. Phase B10 should pivot from "fix gated-attn split" to "audit h_main production end-to-end against a full base-model reference," since the B9 bisect has ruled out every sub-op localizable inside the MTP head itself.

### How to reproduce

```bash
# Kiln dump (all three positions in one process)
KILN_SPEC_METHOD=mtp KILN_MTP_DEBUG=1 \
  KILN_MTP_DUMP_PATH=/tmp/mtp-kiln-pos{pos}.safetensors \
  KILN_MTP_DUMP_POS=0,1,2 KILN_MTP_DUMP_SUBOPS=1 \
  KILN_W4A16=1 KILN_CUDA_GRAPHS=true \
  ./target/release/kiln-bench --model-path /path/to/Qwen3.5-4B \
    --prompt-tokens 512 --max-output-tokens 128 --seed 42 --paged --skip-training

# Reference dump per position
for POS in 0 1 2; do
  python3 scripts/mtp_reference_dump.py \
    --checkpoint /path/to/Qwen3.5-4B \
    --kiln-dump /tmp/mtp-kiln-pos${POS}.safetensors \
    --out /tmp/mtp-ref-pos${POS}.safetensors \
    --capture-subops
done

# Compare
python3 scripts/mtp_compare.py \
  --pair pos0:/tmp/mtp-kiln-pos0.safetensors,/tmp/mtp-ref-pos0.safetensors \
  --pair pos1:/tmp/mtp-kiln-pos1.safetensors,/tmp/mtp-ref-pos1.safetensors \
  --pair pos2:/tmp/mtp-kiln-pos2.safetensors,/tmp/mtp-ref-pos2.safetensors
```

### Preflight

- Verified post-#284 state on commit 8372de6 via PROFILING/docs: post_layer invariance proven, α unchanged.
- Verified no overlapping B9 PRs via `gh pr list --repo ericflo/kiln --state all | grep -i b9` (empty).
- Local `cargo check -p kiln-model` passed before any pod time.
- Pod: A6000 on-demand, image `ghcr.io/ericflo/kiln-runpod:latest`, sccache-warm build (~138s).