### PR TITLE
[codex] Fuse Metal GDN gated RMSNorm

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -16,6 +16,7 @@ const DISABLE_FUSED_CONV1D: &str = "KILN_DISABLE_FUSED_CONV1D";
 const DISABLE_METAL_FUSED_CONV1D: &str = "KILN_DISABLE_METAL_FUSED_CONV1D";
 const DISABLE_GDN_KERNEL: &str = "KILN_DISABLE_GDN_KERNEL";
 const DISABLE_METAL_GDN_RECURRENT: &str = "KILN_DISABLE_METAL_GDN_RECURRENT";
+const DISABLE_METAL_GATED_RMSNORM: &str = "KILN_DISABLE_METAL_GATED_RMSNORM";
 
 #[derive(Debug)]
 pub struct MetalBackend {
@@ -63,6 +64,10 @@ impl BackendRuntime for MetalBackend {
 
     fn supports_gdn_recurrent_step(&self) -> bool {
         !metal_gdn_recurrent_disabled()
+    }
+
+    fn supports_gdn_gated_rms_norm(&self) -> bool {
+        !metal_gated_rms_norm_disabled()
     }
 
     fn flash_attn_prefill(
@@ -246,6 +251,21 @@ impl BackendRuntime for MetalBackend {
             .context("metal gdn_recurrent_step kernel failed")?;
         Ok(Some(out))
     }
+
+    fn gdn_gated_rms_norm(
+        &self,
+        x: &Tensor,
+        z: &Tensor,
+        weight: &Tensor,
+        eps: f64,
+    ) -> Result<Option<Tensor>> {
+        if metal_gated_rms_norm_disabled() || !metal_gated_rms_norm_supports(x, z, weight) {
+            return Ok(None);
+        }
+        let out = metal_gated_rms_norm_bf16(x, z, weight, eps as f32)
+            .context("metal gated_rms_norm kernel failed")?;
+        Ok(Some(out))
+    }
 }
 
 /// Mirrors the head-dim whitelist in candle-nn 0.10.2's
@@ -268,6 +288,10 @@ fn metal_conv1d_update_disabled() -> bool {
 
 fn metal_gdn_recurrent_disabled() -> bool {
     env_truthy(DISABLE_GDN_KERNEL) || env_truthy(DISABLE_METAL_GDN_RECURRENT)
+}
+
+fn metal_gated_rms_norm_disabled() -> bool {
+    env_truthy(DISABLE_METAL_GATED_RMSNORM)
 }
 
 fn env_truthy(var: &str) -> bool {
@@ -411,6 +435,198 @@ fn metal_gdn_recurrent_supports(
         && (b_s, h_s, dk_s, dv_s) == (batch, heads, dk, dv)
         && dk <= 256
         && dv <= 1024
+}
+
+fn metal_gated_rms_norm_supports(x: &Tensor, z: &Tensor, weight: &Tensor) -> bool {
+    if !matches!(x.device(), Device::Metal(_))
+        || !matches!(z.device(), Device::Metal(_))
+        || !matches!(weight.device(), Device::Metal(_))
+    {
+        return false;
+    }
+    if x.dtype() != DType::BF16 || z.dtype() != DType::BF16 || weight.dtype() != DType::BF16 {
+        return false;
+    }
+    let Ok((batch, seq_len, heads, hidden)) = x.dims4() else {
+        return false;
+    };
+    let Ok((z_batch, z_seq_len, z_heads, z_hidden)) = z.dims4() else {
+        return false;
+    };
+    if (z_batch, z_seq_len, z_heads, z_hidden) != (batch, seq_len, heads, hidden) {
+        return false;
+    }
+    weight.dims() == &[hidden] && hidden <= 1024
+}
+
+const METAL_GATED_RMSNORM_KERNEL: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void kiln_gated_rmsnorm_bf16(
+    device const bfloat* x [[buffer(0)]],
+    device const bfloat* z [[buffer(1)]],
+    device const bfloat* weight [[buffer(2)]],
+    device bfloat* out [[buffer(3)]],
+    constant uint& rows [[buffer(4)]],
+    constant uint& hidden [[buffer(5)]],
+    constant float& eps [[buffer(6)]],
+    constant uint& threadgroup_width [[buffer(7)]],
+    uint2 gid [[thread_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]]
+) {
+    threadgroup float scratch[1024];
+
+    const uint row = gid.y;
+    if (row >= rows) {
+        return;
+    }
+
+    const uint base = row * hidden;
+    float sum_sq = 0.0f;
+    if (tid < hidden) {
+        const float xv = static_cast<float>(x[base + tid]);
+        sum_sq = xv * xv;
+    }
+    scratch[tid] = sum_sq;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint stride = threadgroup_width / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            scratch[tid] += scratch[tid + stride];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tid < hidden) {
+        const float rms_inv = rsqrt((scratch[0] / static_cast<float>(hidden)) + eps);
+        const float xv = static_cast<float>(x[base + tid]);
+        const float zv = static_cast<float>(z[base + tid]);
+        const float gate = zv / (1.0f + exp(-zv));
+        out[base + tid] = static_cast<bfloat>(xv * rms_inv * static_cast<float>(weight[tid]) * gate);
+    }
+}
+"#;
+
+fn metal_gated_rms_norm_pipeline(
+    device: &candle_core::metal_backend::MetalDevice,
+) -> Result<candle_metal_kernels::metal::ComputePipeline> {
+    use candle_core::metal_backend::DeviceId;
+    use candle_metal_kernels::metal::ComputePipeline;
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    static PIPELINES: OnceLock<Mutex<HashMap<DeviceId, ComputePipeline>>> = OnceLock::new();
+    let cache = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut cache = cache
+        .lock()
+        .map_err(|_| anyhow::anyhow!("metal gated rmsnorm pipeline cache poisoned"))?;
+    if let Some(pipeline) = cache.get(&device.id()) {
+        return Ok(pipeline.clone());
+    }
+
+    let library = device
+        .device()
+        .new_library_with_source(METAL_GATED_RMSNORM_KERNEL, None)
+        .map_err(|e| anyhow::anyhow!("compile metal gated rmsnorm library: {e:?}"))?;
+    let function = library
+        .get_function("kiln_gated_rmsnorm_bf16", None)
+        .map_err(|e| anyhow::anyhow!("load metal gated rmsnorm function: {e:?}"))?;
+    let pipeline = device
+        .device()
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(|e| anyhow::anyhow!("build metal gated rmsnorm pipeline: {e:?}"))?;
+    cache.insert(device.id(), pipeline.clone());
+    Ok(pipeline)
+}
+
+fn metal_gated_rms_norm_bf16(x: &Tensor, z: &Tensor, weight: &Tensor, eps: f32) -> Result<Tensor> {
+    let (batch, seq_len, heads, hidden) = x.dims4()?;
+    let rows = batch
+        .checked_mul(seq_len)
+        .and_then(|v| v.checked_mul(heads))
+        .context("metal gated rmsnorm row count overflow")?;
+    anyhow::ensure!(
+        rows <= u32::MAX as usize && hidden <= u32::MAX as usize,
+        "metal gated rmsnorm shape too large"
+    );
+    anyhow::ensure!(hidden <= 1024, "metal gated rmsnorm hidden dim > 1024");
+
+    let x = x.contiguous()?;
+    let z = z.contiguous()?;
+    let weight = weight.contiguous()?;
+    let out = Tensor::zeros((batch, seq_len, heads, hidden), DType::BF16, x.device())?;
+
+    if rows == 0 {
+        return Ok(out);
+    }
+
+    let Device::Metal(device) = x.device() else {
+        anyhow::bail!("metal gated rmsnorm requires a Metal tensor");
+    };
+    let pipeline = metal_gated_rms_norm_pipeline(device)?;
+    let encoder = device.command_encoder()?;
+    encoder.set_label("kiln_gated_rmsnorm_bf16");
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    {
+        let (x_storage, x_layout) = x.storage_and_layout();
+        let (z_storage, z_layout) = z.storage_and_layout();
+        let (w_storage, w_layout) = weight.storage_and_layout();
+        let (o_storage, o_layout) = out.storage_and_layout();
+
+        let x_metal = match &*x_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal gated rmsnorm x must be on Metal"),
+        };
+        let z_metal = match &*z_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal gated rmsnorm z must be on Metal"),
+        };
+        let w_metal = match &*w_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal gated rmsnorm weight must be on Metal"),
+        };
+        let out_metal = match &*o_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal gated rmsnorm out must be on Metal"),
+        };
+
+        let x_buf = candle_core::metal_backend::buffer_o(x_metal.buffer(), &x_layout, x.dtype());
+        let z_buf = candle_core::metal_backend::buffer_o(z_metal.buffer(), &z_layout, z.dtype());
+        let w_buf =
+            candle_core::metal_backend::buffer_o(w_metal.buffer(), &w_layout, weight.dtype());
+        let out_buf =
+            candle_core::metal_backend::buffer_o(out_metal.buffer(), &o_layout, out.dtype());
+
+        encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
+        encoder.set_buffer(1, Some(z_buf.buffer), z_buf.offset_in_bytes);
+        encoder.set_buffer(2, Some(w_buf.buffer), w_buf.offset_in_bytes);
+        encoder.set_buffer(3, Some(out_buf.buffer), out_buf.offset_in_bytes);
+
+        let rows_u32 = rows as u32;
+        let hidden_u32 = hidden as u32;
+        let threads = hidden.next_power_of_two().clamp(32, 1024);
+        let threads_u32 = threads as u32;
+        encoder.set_bytes(4, &rows_u32);
+        encoder.set_bytes(5, &hidden_u32);
+        encoder.set_bytes(6, &eps);
+        encoder.set_bytes(7, &threads_u32);
+
+        let threads_per_grid = objc2_metal::MTLSize {
+            width: threads,
+            height: rows,
+            depth: 1,
+        };
+        let threads_per_threadgroup = objc2_metal::MTLSize {
+            width: threads,
+            height: 1,
+            depth: 1,
+        };
+        encoder.dispatch_threads(threads_per_grid, threads_per_threadgroup);
+    }
+
+    Ok(out)
 }
 
 const METAL_GDN_RECURRENT_KERNEL: &str = r#"

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -191,6 +191,10 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         false
     }
 
+    fn supports_gdn_gated_rms_norm(&self) -> bool {
+        false
+    }
+
     fn supports_causal_conv1d_update(&self) -> bool {
         false
     }
@@ -258,6 +262,23 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         _a_log: &Tensor,
         _dt_bias: &Tensor,
     ) -> Result<Option<(Tensor, Tensor)>> {
+        Ok(None)
+    }
+
+    /// Fused GDN gated RMSNorm.
+    ///
+    /// Computes `rms_norm(x, weight) * silu(z)` for Gated DeltaNet outputs.
+    /// `x` and `z` are `[B, T, H, D]`, and `weight` is `[D]`.
+    /// Returns a tensor with the same shape as `x`. Backends may return the
+    /// model dtype directly; the call site already casts to the requested
+    /// dtype after reshaping, matching the portable fallback.
+    fn gdn_gated_rms_norm(
+        &self,
+        _x: &Tensor,
+        _z: &Tensor,
+        _weight: &Tensor,
+        _eps: f64,
+    ) -> Result<Option<Tensor>> {
         Ok(None)
     }
 }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1515,6 +1515,21 @@ fn softplus(x: &Tensor) -> Result<Tensor> {
     Ok((relu_x + log_term)?)
 }
 
+fn gated_rms_norm(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    z: &Tensor,
+    weight: &Tensor,
+    eps: f64,
+) -> Result<Tensor> {
+    if backend.supports_gdn_gated_rms_norm() {
+        if let Some(out) = backend.gdn_gated_rms_norm(x, z, weight, eps)? {
+            return Ok(out);
+        }
+    }
+    gated_rms_norm_fallback(x, z, weight, eps)
+}
+
 /// Gated RMSNorm: rms_norm(x, weight) * silu(z).
 ///
 /// Applied per-group on the last dimension. Returns F32.
@@ -1522,7 +1537,7 @@ fn softplus(x: &Tensor) -> Result<Tensor> {
 /// `x`: [..., dim] — attention output
 /// `z`: [..., dim] — output gate (from in_proj_z)
 /// `weight`: [dim] — learnable scale
-fn gated_rms_norm(x: &Tensor, z: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
+fn gated_rms_norm_fallback(x: &Tensor, z: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
     let x_f32 = x.to_dtype(DType::F32)?;
     let z_f32 = z.to_dtype(DType::F32)?;
     let w_f32 = weight.to_dtype(DType::F32)?;
@@ -2407,7 +2422,7 @@ pub fn gated_deltanet_forward(
     // --- Step 8: Gated RMSNorm — norm(attn_out) * silu(z) ---
     let attn_out = {
         kiln_nvtx::range!(c"kiln/gdn/gated_norm");
-        let attn_out = gated_rms_norm(&attn_out, &z, &weights.norm, config.rms_norm_eps)?;
+        let attn_out = gated_rms_norm(backend, &attn_out, &z, &weights.norm, config.rms_norm_eps)?;
         // Reshape to [B, T, v_dim] and cast back to input dtype
         attn_out
             .reshape((batch, seq_len, v_dim))?
@@ -4590,6 +4605,65 @@ mod tests {
         assert!((vals[0][0] - 1.5).abs() < 1e-4);
         assert!((vals[0][1] - 2.0).abs() < 1e-4);
         assert!((vals[0][2] - 3.0).abs() < 1e-4);
+
+        Ok(())
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn test_metal_gated_rms_norm_matches_fallback() -> Result<()> {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let Some(device) = crate::backend::metal::try_new_metal() else {
+            eprintln!("Metal unavailable, skipping test_metal_gated_rms_norm_matches_fallback");
+            return Ok(());
+        };
+        let backend = crate::backend::for_device(&device);
+        if !backend.supports_gdn_gated_rms_norm() {
+            eprintln!("Metal gated RMSNorm disabled, skipping parity test");
+            return Ok(());
+        }
+
+        let batch = 1usize;
+        let seq_len = 3usize;
+        let heads = 32usize;
+        let hidden = 128usize;
+        let elems = batch * seq_len * heads * hidden;
+
+        let mut rng = StdRng::seed_from_u64(0x6A7E_DA75);
+        let x_data: Vec<f32> = (0..elems).map(|_| rng.gen_range(-1.0f32..1.0f32)).collect();
+        let z_data: Vec<f32> = (0..elems).map(|_| rng.gen_range(-2.0f32..2.0f32)).collect();
+        let w_data: Vec<f32> = (0..hidden).map(|_| rng.gen_range(0.5f32..1.5f32)).collect();
+
+        let x = Tensor::from_slice(&x_data, (batch, seq_len, heads, hidden), &device)?
+            .to_dtype(DType::BF16)?;
+        let z = Tensor::from_slice(&z_data, (batch, seq_len, heads, hidden), &device)?
+            .to_dtype(DType::BF16)?;
+        let weight = Tensor::from_slice(&w_data, (hidden,), &device)?.to_dtype(DType::BF16)?;
+
+        let fallback = gated_rms_norm_fallback(&x, &z, &weight, 1e-6)?;
+        let fused = backend
+            .gdn_gated_rms_norm(&x, &z, &weight, 1e-6)?
+            .context("Metal backend declined gated RMSNorm test shape")?;
+
+        assert_eq!(fused.dims(), fallback.dims());
+        assert_eq!(fused.dtype(), DType::BF16);
+
+        let diff = (fused.to_dtype(DType::F32)?
+            - fallback.to_dtype(DType::BF16)?.to_dtype(DType::F32)?)?;
+        let abs = diff.abs()?;
+        let max = abs.flatten_all()?.max(0)?.to_scalar::<f32>()?;
+        let mean = abs.flatten_all()?.mean(0)?.to_scalar::<f32>()?;
+        eprintln!("gated_rms_norm metal vs fallback: max_abs_diff={max:e} mean_abs_diff={mean:e}");
+        assert!(
+            max < 5e-3,
+            "Metal gated_rms_norm max_abs_diff={max:e} exceeds 5e-3"
+        );
+        assert!(
+            mean < 5e-4,
+            "Metal gated_rms_norm mean_abs_diff={mean:e} exceeds 5e-4"
+        );
 
         Ok(())
     }


### PR DESCRIPTION
## What changed

Adds a default-on Metal kernel for Gated DeltaNet gated RMSNorm, replacing the Candle op chain for `rms_norm(attn_out, weight) * silu(z)` when the desktop-default BF16 Metal shape is used.

The kernel:
- dispatches through the existing backend runtime seam;
- supports `[B, T, H, D]` BF16 GDN tensors with per-head `[D]` weights;
- writes BF16 directly so the existing post-reshape dtype cast is a no-op on the Metal default path;
- falls back to the existing portable implementation when shape/dtype checks fail;
- can be disabled with `KILN_DISABLE_METAL_GATED_RMSNORM=1`.

## Why

`kiln/gdn/gated_norm` is a repeated GDN hot-path region on Qwen3.5. The prior Metal path still expanded this into several tiny Candle ops per linear-attention layer. This collapses the RMS reduction, weight multiply, SiLU gate, and final multiply into one Metal launch per GDN layer.

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_metal_gated_rms_norm_matches_fallback --features metal -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_model_forward_parity_cpu_vs_metal --features metal -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo build --release --features metal --bin kiln-bench --bin kiln`
- `rustfmt --edition 2024 --config skip_children=true --check crates/kiln-model/src/backend/mod.rs crates/kiln-model/src/backend/metal.rs crates/kiln-model/src/forward.rs`
- `git diff --check`

## A/B notes

Using the same patched binary with and without `KILN_DISABLE_METAL_GATED_RMSNORM=1`, Qwen3.5 desktop-style `--prompt-tokens 8 --max-output-tokens 8 --skip-training --paged`:

- enabled: mean ITL `363.4ms`, p99 ITL `1129.6ms`, 16-run sequential `3.734 tok/s`
- disabled: mean ITL `508.5ms`, p99 ITL `2257.6ms`, 16-run sequential `3.726 tok/s`

TTFT/prefill was noisy across runs, so I am treating this as a decode-path kernel win, not a startup/prefill fix.