### PR TITLE
[codex] Fuse Metal RMSNorm

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -17,6 +17,8 @@ const DISABLE_METAL_FUSED_CONV1D: &str = "KILN_DISABLE_METAL_FUSED_CONV1D";
 const DISABLE_GDN_KERNEL: &str = "KILN_DISABLE_GDN_KERNEL";
 const DISABLE_METAL_GDN_RECURRENT: &str = "KILN_DISABLE_METAL_GDN_RECURRENT";
 const DISABLE_METAL_GATED_RMSNORM: &str = "KILN_DISABLE_METAL_GATED_RMSNORM";
+const DISABLE_RMSNORM_KERNEL: &str = "KILN_DISABLE_RMSNORM_KERNEL";
+const DISABLE_METAL_RMSNORM: &str = "KILN_DISABLE_METAL_RMSNORM";
 
 #[derive(Debug)]
 pub struct MetalBackend {
@@ -294,6 +296,10 @@ fn metal_gated_rms_norm_disabled() -> bool {
     env_truthy(DISABLE_METAL_GATED_RMSNORM)
 }
 
+fn metal_rms_norm_disabled() -> bool {
+    std::env::var(DISABLE_RMSNORM_KERNEL).is_ok() || env_truthy(DISABLE_METAL_RMSNORM)
+}
+
 fn env_truthy(var: &str) -> bool {
     matches!(
         std::env::var(var)
@@ -457,6 +463,182 @@ fn metal_gated_rms_norm_supports(x: &Tensor, z: &Tensor, weight: &Tensor) -> boo
         return false;
     }
     weight.dims() == &[hidden] && hidden <= 1024
+}
+
+pub(crate) fn metal_rms_norm_supports(x: &Tensor, weight: &Tensor) -> bool {
+    if metal_rms_norm_disabled() {
+        return false;
+    }
+    if !matches!(x.device(), Device::Metal(_)) || !matches!(weight.device(), Device::Metal(_)) {
+        return false;
+    }
+    if x.dtype() != DType::BF16 || weight.dtype() != DType::BF16 {
+        return false;
+    }
+    let Some(hidden) = x.dims().last().copied() else {
+        return false;
+    };
+    x.rank() >= 1 && weight.dims() == &[hidden] && hidden <= 8192
+}
+
+const METAL_RMSNORM_KERNEL: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void kiln_rmsnorm_bf16(
+    device const bfloat* x [[buffer(0)]],
+    device const bfloat* weight [[buffer(1)]],
+    device bfloat* out [[buffer(2)]],
+    constant uint& rows [[buffer(3)]],
+    constant uint& hidden [[buffer(4)]],
+    constant float& eps [[buffer(5)]],
+    constant uint& threadgroup_width [[buffer(6)]],
+    uint2 gid [[thread_position_in_grid]],
+    uint tid [[thread_index_in_threadgroup]]
+) {
+    threadgroup float scratch[1024];
+
+    const uint row = gid.y;
+    if (row >= rows) {
+        return;
+    }
+
+    const uint base = row * hidden;
+    float sum_sq = 0.0f;
+    for (uint col = tid; col < hidden; col += threadgroup_width) {
+        const float xv = static_cast<float>(x[base + col]);
+        sum_sq += xv * xv;
+    }
+    scratch[tid] = sum_sq;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint stride = threadgroup_width / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            scratch[tid] += scratch[tid + stride];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    const float rms_inv = rsqrt((scratch[0] / static_cast<float>(hidden)) + eps);
+    for (uint col = tid; col < hidden; col += threadgroup_width) {
+        const float xv = static_cast<float>(x[base + col]);
+        const float scale = 1.0f + static_cast<float>(weight[col]);
+        out[base + col] = static_cast<bfloat>(xv * rms_inv * scale);
+    }
+}
+"#;
+
+fn metal_rms_norm_pipeline(
+    device: &candle_core::metal_backend::MetalDevice,
+) -> Result<candle_metal_kernels::metal::ComputePipeline> {
+    use candle_core::metal_backend::DeviceId;
+    use candle_metal_kernels::metal::ComputePipeline;
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    static PIPELINES: OnceLock<Mutex<HashMap<DeviceId, ComputePipeline>>> = OnceLock::new();
+    let cache = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut cache = cache
+        .lock()
+        .map_err(|_| anyhow::anyhow!("metal rmsnorm pipeline cache poisoned"))?;
+    if let Some(pipeline) = cache.get(&device.id()) {
+        return Ok(pipeline.clone());
+    }
+
+    let library = device
+        .device()
+        .new_library_with_source(METAL_RMSNORM_KERNEL, None)
+        .map_err(|e| anyhow::anyhow!("compile metal rmsnorm library: {e:?}"))?;
+    let function = library
+        .get_function("kiln_rmsnorm_bf16", None)
+        .map_err(|e| anyhow::anyhow!("load metal rmsnorm function: {e:?}"))?;
+    let pipeline = device
+        .device()
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(|e| anyhow::anyhow!("build metal rmsnorm pipeline: {e:?}"))?;
+    cache.insert(device.id(), pipeline.clone());
+    Ok(pipeline)
+}
+
+pub(crate) fn metal_rms_norm_bf16(x: &Tensor, weight: &Tensor, eps: f32) -> Result<Tensor> {
+    let x_dims = x.dims().to_vec();
+    let hidden = *x_dims
+        .last()
+        .context("metal rmsnorm requires rank >= 1 input")?;
+    anyhow::ensure!(hidden <= 8192, "metal rmsnorm hidden dim > 8192");
+    let rows: usize = x_dims[..x_dims.len() - 1].iter().product();
+    anyhow::ensure!(
+        rows <= u32::MAX as usize && hidden <= u32::MAX as usize,
+        "metal rmsnorm shape too large"
+    );
+
+    let x = x.contiguous()?;
+    let weight = weight.contiguous()?;
+    let out = Tensor::zeros(x_dims.as_slice(), DType::BF16, x.device())?;
+
+    if rows == 0 {
+        return Ok(out);
+    }
+
+    let Device::Metal(device) = x.device() else {
+        anyhow::bail!("metal rmsnorm requires a Metal tensor");
+    };
+    let pipeline = metal_rms_norm_pipeline(device)?;
+    let encoder = device.command_encoder()?;
+    encoder.set_label("kiln_rmsnorm_bf16");
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    {
+        let (x_storage, x_layout) = x.storage_and_layout();
+        let (w_storage, w_layout) = weight.storage_and_layout();
+        let (o_storage, o_layout) = out.storage_and_layout();
+
+        let x_metal = match &*x_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal rmsnorm x must be on Metal"),
+        };
+        let w_metal = match &*w_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal rmsnorm weight must be on Metal"),
+        };
+        let out_metal = match &*o_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal rmsnorm out must be on Metal"),
+        };
+
+        let x_buf = candle_core::metal_backend::buffer_o(x_metal.buffer(), &x_layout, x.dtype());
+        let w_buf =
+            candle_core::metal_backend::buffer_o(w_metal.buffer(), &w_layout, weight.dtype());
+        let out_buf =
+            candle_core::metal_backend::buffer_o(out_metal.buffer(), &o_layout, out.dtype());
+
+        encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
+        encoder.set_buffer(1, Some(w_buf.buffer), w_buf.offset_in_bytes);
+        encoder.set_buffer(2, Some(out_buf.buffer), out_buf.offset_in_bytes);
+
+        let rows_u32 = rows as u32;
+        let hidden_u32 = hidden as u32;
+        let threads = hidden.next_power_of_two().clamp(32, 1024);
+        let threads_u32 = threads as u32;
+        encoder.set_bytes(3, &rows_u32);
+        encoder.set_bytes(4, &hidden_u32);
+        encoder.set_bytes(5, &eps);
+        encoder.set_bytes(6, &threads_u32);
+
+        let threads_per_grid = objc2_metal::MTLSize {
+            width: threads,
+            height: rows,
+            depth: 1,
+        };
+        let threads_per_threadgroup = objc2_metal::MTLSize {
+            width: threads,
+            height: 1,
+            depth: 1,
+        };
+        encoder.dispatch_threads(threads_per_grid, threads_per_threadgroup);
+    }
+
+    Ok(out)
 }
 
 const METAL_GATED_RMSNORM_KERNEL: &str = r#"

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1258,6 +1258,13 @@ pub fn rms_norm(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
                 .context("fused_rmsnorm kernel failed");
         }
     }
+    #[cfg(feature = "metal")]
+    {
+        if crate::backend::metal::metal_rms_norm_supports(x, weight) {
+            return crate::backend::metal::metal_rms_norm_bf16(x, weight, eps as f32)
+                .context("metal rms_norm kernel failed");
+        }
+    }
     rms_norm_fallback(x, weight, eps)
 }
 
@@ -4663,6 +4670,57 @@ mod tests {
         assert!(
             mean < 5e-4,
             "Metal gated_rms_norm mean_abs_diff={mean:e} exceeds 5e-4"
+        );
+
+        Ok(())
+    }
+
+    #[cfg(feature = "metal")]
+    #[test]
+    fn test_metal_rms_norm_matches_fallback() -> Result<()> {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let Some(device) = crate::backend::metal::try_new_metal() else {
+            eprintln!("Metal unavailable, skipping test_metal_rms_norm_matches_fallback");
+            return Ok(());
+        };
+
+        let batch = 2usize;
+        let seq_len = 3usize;
+        let hidden = 4096usize;
+        let elems = batch * seq_len * hidden;
+
+        let mut rng = StdRng::seed_from_u64(0xA11CE);
+        let x_data: Vec<f32> = (0..elems).map(|_| rng.gen_range(-1.0f32..1.0f32)).collect();
+        let w_data: Vec<f32> = (0..hidden)
+            .map(|_| rng.gen_range(-0.2f32..0.2f32))
+            .collect();
+
+        let x = Tensor::from_slice(&x_data, (batch, seq_len, hidden), &device)?
+            .to_dtype(DType::BF16)?;
+        let weight = Tensor::from_slice(&w_data, (hidden,), &device)?.to_dtype(DType::BF16)?;
+
+        assert!(crate::backend::metal::metal_rms_norm_supports(&x, &weight));
+        let fallback = rms_norm_fallback(&x, &weight, 1e-6)?;
+        let fused = crate::backend::metal::metal_rms_norm_bf16(&x, &weight, 1e-6)?;
+
+        assert_eq!(fused.dims(), fallback.dims());
+        assert_eq!(fused.dtype(), DType::BF16);
+
+        let diff = (fused.to_dtype(DType::F32)?
+            - fallback.to_dtype(DType::BF16)?.to_dtype(DType::F32)?)?;
+        let abs = diff.abs()?;
+        let max = abs.flatten_all()?.max(0)?.to_scalar::<f32>()?;
+        let mean = abs.flatten_all()?.mean(0)?.to_scalar::<f32>()?;
+        eprintln!("rms_norm metal vs fallback: max_abs_diff={max:e} mean_abs_diff={mean:e}");
+        assert!(
+            max < 5e-3,
+            "Metal rms_norm max_abs_diff={max:e} exceeds 5e-3"
+        );
+        assert!(
+            mean < 5e-4,
+            "Metal rms_norm mean_abs_diff={mean:e} exceeds 5e-4"
         );
 
         Ok(())


### PR DESCRIPTION
## What changed

Adds a default-on Metal RMSNorm kernel for BF16 tensors, covering the existing `rms_norm` helper used by pre-attention norms, pre-MLP norms, final norm, MTP norms, and full-attention Q/K norms.

The kernel preserves Qwen3.5 RMSNorm semantics:

```text
out = (1 + weight) * x * rsqrt(mean(x^2, dim=-1) + eps)
```

It accepts arbitrary leading dimensions, normalizes the last dimension, writes BF16 directly, and falls back to the existing portable Candle path for unsupported dtype/device/shape. Kill switches:

- `KILN_DISABLE_METAL_RMSNORM=1`
- existing broad `KILN_DISABLE_RMSNORM_KERNEL` also disables this Metal path.

## Why

The macOS path still paid multiple small Metal/Candle ops for regular RMSNorm at many model points. This fuses the F32 reduction, `(1 + weight)` scale, and cast-back into one Metal launch while preserving the current public `rms_norm(...)` API, so all existing callers pick it up without threading backend arguments through the model.

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_metal_rms_norm_matches_fallback --features metal -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_model_forward_parity_cpu_vs_metal --features metal -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_rms_norm --features metal -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo build --release --features metal --bin kiln-bench --bin kiln`
- `rustfmt --edition 2024 --config skip_children=true --check crates/kiln-model/src/backend/metal.rs crates/kiln-model/src/forward.rs`
- `git diff --check origin/main..HEAD`

## A/B notes

Using the same binary with and without `KILN_DISABLE_METAL_RMSNORM=1`, while leaving the merged Metal gated RMSNorm path enabled in both runs, Qwen3.5 desktop-style `--prompt-tokens 8 --max-output-tokens 8 --skip-training --paged`:

- enabled: mean ITL `518.4ms`, 16-run sequential `3.676 tok/s`, prefill `9557.7ms`
- disabled: mean ITL `545.9ms`, 16-run sequential `3.666 tok/s`, prefill `9979.0ms`

This is an incremental win, not a large throughput unlock.