### PR TITLE
desktop: notify when dashboard Stop/Restart Server buttons fail

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -620,6 +620,34 @@
       const invoke = (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
         || (window.__TAURI__ && window.__TAURI__.invoke);
 
+      const notificationApi = window.__TAURI__ && window.__TAURI__.notification;
+      async function notifyError(title, body) {
+        try {
+          if (notificationApi && typeof notificationApi.isPermissionGranted === "function") {
+            let granted = await notificationApi.isPermissionGranted();
+            if (!granted && typeof notificationApi.requestPermission === "function") {
+              const req = await notificationApi.requestPermission();
+              granted = req === "granted";
+            }
+            if (granted) {
+              await notificationApi.sendNotification({ title: title, body: body });
+            }
+            return;
+          }
+          if (!invoke) return;
+          let granted = await invoke("plugin:notification|is_permission_granted");
+          if (!granted) {
+            const req = await invoke("plugin:notification|request_permission");
+            granted = req === "granted";
+          }
+          if (granted) {
+            await invoke("plugin:notification|notify", { options: { title: title, body: body } });
+          }
+        } catch (_) {
+          // Notification is a best-effort surface; the button flash still fires.
+        }
+      }
+
       const frame = document.getElementById("frame");
       const status = document.getElementById("status");
       const title = document.getElementById("status-title");
@@ -1041,6 +1069,7 @@
         } catch (err) {
           console.warn("stop_server failed", err);
           flashStopBtn("Stop failed", "flash-warn");
+          notifyError("Stop Server failed", String(err || "Unknown error"));
         }
       }
 
@@ -1079,6 +1108,7 @@
         } catch (err) {
           console.warn("restart_server failed", err);
           flashRestartBtn("Restart failed", "flash-warn");
+          notifyError("Restart Server failed", String(err || "Unknown error"));
         }
       }
 


### PR DESCRIPTION
## What

Surface the actual failure reason when the dashboard toolbar's **Stop Server** and **Restart Server** buttons reject. Previously they only emitted `console.warn(...)` and a 1.5s button flash (`Stop failed` / `Restart failed`), hiding the real error from the user.

This mirrors the tray menu fix landed in PR #277 (and the autolaunch fix in PR #292).

## Why — confirmed gap

`startServerInline()` (`desktop/ui/dashboard.html:920-931`) writes the err detail into `detail.textContent`, so Start already surfaces its reason. Stop (`stopServer()` at :1032-1046) and Restart (`restartServer()` at :1069-1083) are toolbar-only — they have no adjacent status pane — so a silent failure leaves the user with no information beyond a vague flash.

The asymmetry with PR #277 (which added notifications to tray ITEM_START/STOP/RESTART) is the active polish pattern for the project.

## How

Added a small `notifyError(title, body)` helper at the top of the dashboard script. It:

1. Prefers `window.__TAURI__.notification` (`sendNotification`) when available (plugin-notification is already initialized in `main.rs` and `notification:default` is granted in `capabilities/default.json`).
2. Falls back to direct `invoke("plugin:notification|notify", { options: {...} })` calls using the same permission-gate pattern.
3. Silently no-ops on any error so the existing button flash still fires — notifications are a best-effort surface.

Both `stopServer()` and `restartServer()` catch blocks now call `notifyError(..., String(err || "Unknown error"))` alongside the existing `flashStopBtn` / `flashRestartBtn` calls. `console.warn` is preserved.

`startServerInline` is left unchanged — it already surfaces errors via `detail.textContent`.

## Validation

- HTML syntax sanity: `python3 -c \"import html.parser; p=html.parser.HTMLParser(); p.feed(open('desktop/ui/dashboard.html').read())\"` → OK.
- `cd desktop && cargo check` fails in Cloud Eric sessions with the expected GTK/webkit2gtk system-library gap (`gio-2.0` not found via pkg-config). This matches the documented kiln-desktop-cargo-check-syslibs behavior; no Rust code was changed in this PR, so the Rust path is not exercised.
- No capability or permission changes needed — `notification:default` was already granted (used by tray notifications).