### PR TITLE
desktop: notify when Check for Updates / Install Update fails

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -1821,6 +1821,7 @@
           updateCheckInFlight = false;
           flashCheckUpdatesBtn("Check failed", "flash-warn");
           console.error("check_for_updates failed", err);
+          notifyError("Update check failed", String(err || "Unknown error"));
           return;
         }
         if (!result || !result.available) {
@@ -1850,6 +1851,7 @@
         } catch (err) {
           flashCheckUpdatesBtn("Install failed", "flash-warn");
           console.error("install_update failed", err);
+          notifyError("Update install failed", String(err || "Unknown error"));
         } finally {
           updateCheckInFlight = false;
         }


### PR DESCRIPTION
## What

Two one-line additions in `desktop/ui/dashboard.html` to route auto-updater failures through the existing `notifyError` helper so users see a native OS notification with detail, matching the Stop/Restart Server path.

- `triggerUpdateCheck()` → `check_for_updates` catch now calls `notifyError("Update check failed", ...)` after the 3s button flash (line ~1824).
- `triggerUpdateCheck()` → `install_update` catch now calls `notifyError("Update install failed", ...)` after the 3s button flash (line ~1854).

No Rust changes — `install_update` at `desktop/src/main.rs:794` already returns `Result<(), String>` with `e.to_string()` bubbled up, so the frontend receives the detail string.

## Why

The updater UX was silently swallowing errors. The `install_update` path was especially bad: user clicks "Install and restart?" expecting the app to restart; on failure (permission denied, signature fail, download fail, etc.) they get a 3s button flash with no detail and no OS notification.

This is the same asymmetry class as the tray Start/Stop/Restart fixes in #277/#285/#292/#296 — per the `kiln-desktop-error-surface-symmetry` agent note, we fix the whole surface, not one button.

## Test plan

- `cd desktop && cargo check` fails in the Cloud Eric build env with GTK/glib-2.0 missing (expected per `kiln-desktop-cargo-check-syslibs`); CI validates real builds on Linux/Windows runners.
- Manual: trigger a failing update check (offline, or point at a bad endpoint) → expect an OS notification titled "Update check failed" with the error detail as body, in addition to the existing 3s "Check failed" button flash.
- Manual: trigger a failing install (stub a non-writable install target) → expect an OS notification titled "Update install failed" with the error detail as body.