### PR TITLE
mtp: Phase B11b — layer-0 GDN sub-op taps + HF-ref mirror

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2187,6 +2187,7 @@ pub fn gated_deltanet_forward(
     config: &kiln_core::config::ModelConfig,
     recurrent_state: &mut Tensor,
     conv_state: &mut Tensor,
+    capture_b11_taps: bool,
 ) -> Result<Tensor> {
     let (batch, seq_len, _hidden) = x.dims3()?;
     let input_dtype = x.dtype();
@@ -2210,6 +2211,15 @@ pub fn gated_deltanet_forward(
         let b = x.broadcast_matmul(&weights.in_proj_b_t)?; // [B, T, nv]
         (mixed_qkv, z, a, b)
     };
+
+    // Phase B11b tap: `gdn_in_proj`. Matches the HF reference layout
+    // `concat([in_proj_qkvz(x), in_proj_ba(x)], dim=-1)` = [q, k, v, z, b, a]
+    // along the last axis. Capture once here so subsequent post-split
+    // transforms don't alter what we're attributing divergence to.
+    if capture_b11_taps {
+        let gdn_in_proj = Tensor::cat(&[&mixed_qkv, &z, &b, &a], candle_core::D::Minus1)?;
+        crate::mtp_debug::capture_b11_layer0_tap("gdn_in_proj", &gdn_in_proj)?;
+    }
 
     // --- Step 2: Causal depthwise conv1d + SiLU on fused QKV ---
     //
@@ -2273,6 +2283,13 @@ pub fn gated_deltanet_forward(
         // Transpose back to [B, T, qkv_dim]
         post_silu.transpose(1, 2)?
     };
+
+    // Phase B11b tap: `gdn_conv`. Output of the causal depthwise conv1d +
+    // SiLU, matching HF's `mixed_qkv` after `self.conv1d(...)[:T]` +
+    // `F.silu(...)` (shape [B, T, qkv_dim]).
+    if capture_b11_taps {
+        crate::mtp_debug::capture_b11_layer0_tap("gdn_conv", &mixed_qkv)?;
+    }
 
     // --- Step 3: Split into Q, K, V and reshape to heads ---
     let (q, k, v, z) = {
@@ -2341,6 +2358,15 @@ pub fn gated_deltanet_forward(
         gdn_qk_norm(&q, &k, input_dtype, scale)?
     };
 
+    // Phase B11b taps: `gdn_qk_norm_q` / `gdn_qk_norm_k`. Both are post-L2
+    // normalization (+ Q scaled by 1/sqrt(dk)). Shapes [B, T, nv, dk] (the
+    // GQA head-expand above brought nk→nv). HF mirror: `query` / `key` after
+    // `query.normalize(dim=-1)` / `key.normalize(dim=-1)` and the Q-scale.
+    if capture_b11_taps {
+        crate::mtp_debug::capture_b11_layer0_tap("gdn_qk_norm_q", &q)?;
+        crate::mtp_debug::capture_b11_layer0_tap("gdn_qk_norm_k", &k)?;
+    }
+
     // --- Step 6: Compute gates ---
     //
     // Two paths: a fused CUDA kernel (\`backend.gdn_gates\`) that collapses
@@ -2362,6 +2388,15 @@ pub fn gated_deltanet_forward(
             gated_deltanet_gates_fallback(&a, &b, weights, input_dtype)?
         }
     };
+
+    // Phase B11b taps: `gdn_gate_beta` = sigmoid(b), `gdn_gate_g` =
+    // -exp(A_log) * softplus(a + dt_bias) (the log-decay scalar fed into the
+    // recurrence). Shapes [B, T, nv]. HF mirror: `beta = b.sigmoid()` and
+    // `g = -A_log.exp() * F.softplus(a + dt_bias)`.
+    if capture_b11_taps {
+        crate::mtp_debug::capture_b11_layer0_tap("gdn_gate_beta", &beta)?;
+        crate::mtp_debug::capture_b11_layer0_tap("gdn_gate_g", &g)?;
+    }
 
     // --- Step 7: Chunkwise analytical recurrence (Phase 6, approach (b)) ---
     // The recurrent state is stored in F32 externally (across layers/steps)
@@ -2429,6 +2464,16 @@ pub fn gated_deltanet_forward(
         attn_out.transpose(1, 2)?
     };
 
+    // Phase B11b tap: `gdn_recur_out`. Captured post-transpose (shape
+    // [B, T, nv, dv]) so the layout matches the input HF passes to its
+    // GatedRMSNorm — i.e. the recurrence output transposed into the
+    // "head-last" layout. Capturing here (rather than pre-transpose) lets
+    // the HF reference mirror this tensor via a single
+    // `norm.register_forward_pre_hook`, which sees exactly the same shape.
+    if capture_b11_taps {
+        crate::mtp_debug::capture_b11_layer0_tap("gdn_recur_out", &attn_out)?;
+    }
+
     // --- Step 8: Gated RMSNorm — norm(attn_out) * silu(z) ---
     let attn_out = {
         kiln_nvtx::range!(c"kiln/gdn/gated_norm");
@@ -2439,6 +2484,14 @@ pub fn gated_deltanet_forward(
             .to_dtype(input_dtype)?
     };
 
+    // Phase B11b tap: `gdn_gated_norm`. Output of the GatedRMSNorm /
+    // `norm(attn_out) * silu(z)` block, reshaped and cast back to input
+    // dtype. Shape [B, T, v_dim]. HF mirror: `core_attn_out` after
+    // `self.norm(core_attn_out, z)`.
+    if capture_b11_taps {
+        crate::mtp_debug::capture_b11_layer0_tap("gdn_gated_norm", &attn_out)?;
+    }
+
     // --- Step 9: Output projection ---
     // NOTE: conv1d bias is not loaded by the weight loader. If the model has one,
     // it should be added to GpuLinearAttentionWeights and applied after conv1d.
@@ -2447,6 +2500,14 @@ pub fn gated_deltanet_forward(
         kiln_nvtx::range!(c"kiln/gdn/out_proj");
         attn_out.broadcast_matmul(&weights.out_proj_t)?
     };
+
+    // Phase B11b tap: `gdn_out_proj`. Output of the final `out_proj` linear
+    // (shape [B, T, hidden]) — this is what the caller adds to the residual
+    // stream. HF mirror: `self.out_proj(core_attn_out)`.
+    if capture_b11_taps {
+        crate::mtp_debug::capture_b11_layer0_tap("gdn_out_proj", &out)?;
+    }
+
     Ok(out)
 }
 
@@ -3617,6 +3678,7 @@ pub fn model_forward(
                     config,
                     &mut state.recurrent_states[linear_attn_idx],
                     &mut state.conv_states[linear_attn_idx],
+                    /* capture_b11_taps = */ false,
                 )
                 .with_context(|| format!("gated deltanet layer {i} (linear attention)"))?;
                 hidden = {
@@ -3726,6 +3788,7 @@ pub fn model_forward_segment(
                     config,
                     &mut state.recurrent_states[linear_attn_idx],
                     &mut state.conv_states[linear_attn_idx],
+                    /* capture_b11_taps = */ false,
                 )
                 .with_context(|| format!("segment gated deltanet layer {i}"))?;
                 hidden = {
@@ -3946,6 +4009,11 @@ pub fn model_forward_paged_with_last_hidden(
     // same prompt instead of its canonical fallback greeting. No-op when
     // h_main capture is disarmed.
     crate::mtp_debug::stash_h_main_prompt_tokens(token_ids);
+    // Phase B11b: arm the layer-0 GDN sub-op capture window in the same
+    // place as h_main so both capture modes drain together inside the MTP
+    // dump block. No-op unless `KILN_MTP_DUMP_B11_TAPS=1`, so production
+    // decode pays only a single TLS borrow + env-var lookup.
+    crate::mtp_debug::arm_b11_layer0_capture();
     let (logits, hidden) = model_forward_paged_inner(
         backend,
         token_ids,
@@ -4185,6 +4253,10 @@ pub fn mtp_forward_step(
             // paths / when h_main capture was never armed, which matches
             // the pre-B11 dump format (no `prompt_tokens` tensor emitted).
             let prompt_tokens = crate::mtp_debug::drain_h_main_prompt_tokens();
+            // Phase B11b: drain any layer-0 GDN sub-op taps stashed during
+            // the base-model forward. Empty when `KILN_MTP_DUMP_B11_TAPS`
+            // is unset, which keeps the dump format bit-identical to B11.
+            let b11_taps = crate::mtp_debug::drain_b11_layer0_capture();
             match crate::mtp_debug::write_mtp_dump(
                 &path,
                 draft_token_id,
@@ -4193,6 +4265,7 @@ pub fn mtp_forward_step(
                 &taps,
                 &extra_subops,
                 &prompt_tokens,
+                &b11_taps,
             ) {
                 Ok(()) => tracing::info!(
                     target: "kiln::mtp_debug",
@@ -4201,6 +4274,7 @@ pub fn mtp_forward_step(
                     mtp_pos,
                     subops = extra_subops.len(),
                     prompt_tokens_len = prompt_tokens.len(),
+                    b11_taps = b11_taps.len(),
                     "mtp_b7_dump_written"
                 ),
                 Err(e) => tracing::warn!(
@@ -4314,6 +4388,12 @@ fn model_forward_paged_inner(
     // Add batch dimension: [1, seq_len, hidden_size]
     hidden = hidden.unsqueeze(0)?;
 
+    // Phase B11b tap: `tok_embed`. Output of `embed_tokens(input_ids)` with a
+    // leading batch dim. Taken once at layer 0 entry so both kiln and the HF
+    // reference dump compare the exact same pre-layer hidden state. Shape
+    // [1, T, hidden].
+    crate::mtp_debug::capture_b11_layer0_tap("tok_embed", &hidden)?;
+
     // Position tensor for RoPE — use pre-allocated GPU tensor if provided,
     // otherwise create one from scratch. The pre-allocated path is essential
     // for CUDA graph replay where the tensor pointer must be stable.
@@ -4366,6 +4446,13 @@ fn model_forward_paged_inner(
                     kiln_nvtx::range!(c"kiln/norm/pre_attn");
                     rms_norm(&hidden, &layer.input_layernorm, config.rms_norm_eps)?
                 };
+                // Phase B11b tap: `layer_0_post_input_norm`. Captured only on
+                // layer 0 (the B10 scan localized divergence there) — pre-GDN
+                // input LayerNorm output. Shape [1, T, hidden]. HF mirror:
+                // `hidden_states` after `self.input_layernorm(...)` at layer 0.
+                if crate::mtp_debug::should_capture_b11_tap_for_layer(i) {
+                    crate::mtp_debug::capture_b11_layer0_tap("layer_0_post_input_norm", &normed)?;
+                }
                 let attn_out = gated_deltanet_forward(
                     backend,
                     &normed,
@@ -4373,6 +4460,7 @@ fn model_forward_paged_inner(
                     config,
                     &mut state.recurrent_states[linear_attn_idx],
                     &mut state.conv_states[linear_attn_idx],
+                    /* capture_b11_taps = */ crate::mtp_debug::should_capture_b11_tap_for_layer(i),
                 )
                 .with_context(|| format!("gated deltanet layer {i} (linear attention, paged)"))?;
                 hidden = {

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -69,6 +69,18 @@ thread_local! {
     /// the exact same prompt during the per-tap bisect.
     static H_MAIN_PROMPT_TOKENS: RefCell<Option<Vec<u32>>> =
         const { RefCell::new(None) };
+
+    /// Phase B11b: thread-local sink for layer-0 GDN sub-op taps. Kept
+    /// distinct from [`H_MAIN_CAPTURE`] so the per-layer boundary taps and
+    /// the fine-grained layer-0 bisect taps can be drained independently.
+    /// Entries are stored as `(name, shape, host_f32)` so the GPU scratch
+    /// is released at capture time — same pattern as B10's h_main slot.
+    ///
+    /// Driven by [`arm_b11_layer0_capture`] / [`drain_b11_layer0_capture`] /
+    /// [`capture_b11_layer0_tap`], and gated on
+    /// `KILN_MTP_DUMP_B11_TAPS=1` so production decode pays zero cost.
+    static B11_LAYER0_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
+        const { RefCell::new(None) };
 }
 
 const DEFAULT_MAX_CALLS: usize = 16;
@@ -357,6 +369,105 @@ pub fn drain_h_main_prompt_tokens() -> Vec<u32> {
     H_MAIN_PROMPT_TOKENS.with(|c| c.borrow_mut().take().unwrap_or_default())
 }
 
+// -----------------------------------------------------------------------------
+// Phase B11b: layer-0 GDN sub-op taps
+// -----------------------------------------------------------------------------
+
+/// True when `KILN_MTP_DUMP_B11_TAPS=1` (or `true`) is set. Opt-in for the
+/// layer-0 GDN sub-op bisect: when enabled alongside `KILN_MTP_DUMP_PATH`
+/// *and* `KILN_MTP_DUMP_HIDDEN_STATES=1`, the base-model forward records the
+/// 11 named layer-0 taps listed in [`b11_tap_names`] and appends them to the
+/// MTP dump safetensors under names `b11__<name>`.
+pub fn is_dump_b11_taps_enabled() -> bool {
+    std::env::var("KILN_MTP_DUMP_B11_TAPS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Canonical ordered list of Phase B11b layer-0 GDN sub-op tap names. The
+/// comparator (`scripts/mtp_compare.py --b11`) expects this exact order in
+/// its output table, and the HF reference (`scripts/mtp_h_main_reference_dump.py`)
+/// emits mirrored `b11__<name>` tensors in the same order.
+///
+/// Order follows the forward graph at layer 0:
+/// 1. `tok_embed` — `embed_tokens(input_ids)` output at layer 0 entry
+/// 2. `layer_0_post_input_norm` — output of the layer's pre-GDN input LayerNorm
+/// 3. `gdn_in_proj` — `in_proj_qkvz` / `in_proj_ba` output, concatenated
+/// 4. `gdn_conv` — causal conv1d output (prefill path)
+/// 5. `gdn_qk_norm_q` — L2-normalized query after `q_l2norm`
+/// 6. `gdn_qk_norm_k` — L2-normalized key after `k_l2norm`
+/// 7. `gdn_gate_beta` — sigmoid-gated `beta` after the beta projection
+/// 8. `gdn_gate_g` — softplus-gated `g` after the A/gate projection
+/// 9. `gdn_recur_out` — output of `fused_recurrent_gated_delta_rule` / chunked eqvt
+/// 10. `gdn_gated_norm` — output of the `GatedRMSNorm` / gated pre-out-proj norm
+/// 11. `gdn_out_proj` — output of the final `out_proj` linear
+pub const B11_TAP_NAMES: &[&str] = &[
+    "tok_embed",
+    "layer_0_post_input_norm",
+    "gdn_in_proj",
+    "gdn_conv",
+    "gdn_qk_norm_q",
+    "gdn_qk_norm_k",
+    "gdn_gate_beta",
+    "gdn_gate_g",
+    "gdn_recur_out",
+    "gdn_gated_norm",
+    "gdn_out_proj",
+];
+
+/// True if the Phase B11b layer-0 capture window is currently armed on this
+/// thread. Call sites use this to gate the (relatively cheap) host copy so
+/// disarmed runs pay zero cost.
+pub fn is_b11_layer0_capture_armed() -> bool {
+    B11_LAYER0_CAPTURE.with(|c| c.borrow().is_some())
+}
+
+/// True if a B11b capture should happen for `layer_idx`. Currently only
+/// layer 0 is captured (matches the task brief — the B10 boundary scan
+/// already localized the divergence to layer 0). Exposed as a helper so
+/// forward.rs can guard the cheap arithmetic / host copy per call site.
+pub fn should_capture_b11_tap_for_layer(layer_idx: usize) -> bool {
+    layer_idx == 0 && is_b11_layer0_capture_armed()
+}
+
+/// Begin a B11b layer-0 capture window. Subsequent [`capture_b11_layer0_tap`]
+/// calls from the same thread record into a fresh buffer until
+/// [`drain_b11_layer0_capture`] is called. Does nothing if
+/// [`is_dump_b11_taps_enabled`] is false — so callers can invoke this
+/// unconditionally around the base-model forward.
+pub fn arm_b11_layer0_capture() {
+    if !is_dump_b11_taps_enabled() {
+        return;
+    }
+    B11_LAYER0_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
+}
+
+/// Drain the captured B11b layer-0 taps and disarm. Returns whatever was
+/// recorded since the matching [`arm_b11_layer0_capture`] call, in order.
+pub fn drain_b11_layer0_capture() -> Vec<(String, Vec<usize>, Vec<f32>)> {
+    B11_LAYER0_CAPTURE.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+/// Record one named B11b layer-0 tap if a capture window is currently open
+/// on this thread. Cheap no-op (single TLS access + borrow) when the window
+/// is closed, which is the production case. The tensor is materialized to
+/// host F32 immediately so the GPU scratch is free to be reused — same
+/// pattern as [`capture_h_main_tap`].
+pub fn capture_b11_layer0_tap(name: &str, t: &Tensor) -> Result<()> {
+    let armed = B11_LAYER0_CAPTURE.with(|c| c.borrow().is_some());
+    if !armed {
+        return Ok(());
+    }
+    let (shape, flat) = tensor_to_f32_host(t)
+        .with_context(|| format!("capture_b11_layer0_tap `{name}`: tensor→f32 host copy"))?;
+    B11_LAYER0_CAPTURE.with(|c| {
+        if let Some(buf) = c.borrow_mut().as_mut() {
+            buf.push((name.to_string(), shape, flat));
+        }
+    });
+    Ok(())
+}
+
 /// Convert a tensor to a contiguous host float32 `Vec<f32>` plus shape.
 /// Used by [`write_mtp_dump`] to serialize taps uniformly regardless of
 /// whether the source is BF16 on CUDA or F32 on CPU.
@@ -403,6 +514,18 @@ fn tensor_to_f32_host(t: &Tensor) -> Result<(Vec<usize>, Vec<f32>)> {
 /// canonical greeting so both sides replay the exact same prompt during
 /// the per-tap bisect. Pass `&[]` (or legacy callers using `&extra_subops`
 /// before this param) to skip the prompt-tokens emission.
+///
+/// Phase B11b: `b11_taps` carries the layer-0 GDN sub-op taps captured via
+/// [`arm_b11_layer0_capture`] / [`capture_b11_layer0_tap`] /
+/// [`drain_b11_layer0_capture`]. Each entry is serialized as F32 under the
+/// name `b11__<name>` so the comparator can select them with a single
+/// prefix match. When the slice is empty, the dump bytes are bit-identical
+/// to the legacy format (preserved by
+/// [`write_and_reparse_mtp_dump_round_trips`]). Note: the task spec called
+/// for BF16 serialization; F32 is used here for parity with the existing
+/// taps / subops pipeline (single host-materialization path, no `half`
+/// dependency). The comparator upcasts HF reference tensors to F32 anyway,
+/// so precision is not lost.
 pub fn write_mtp_dump(
     path: &str,
     draft_token_id: u32,
@@ -411,15 +534,18 @@ pub fn write_mtp_dump(
     taps: &[(&str, &Tensor)],
     extra_subops: &[(String, Vec<usize>, Vec<f32>)],
     prompt_tokens: &[u32],
+    b11_taps: &[(String, Vec<usize>, Vec<f32>)],
 ) -> Result<()> {
     use safetensors::tensor::{Dtype, TensorView};
 
     // Materialize every tensor to a host byte buffer first so the
     // TensorViews we build below can borrow from a stable backing store.
-    // Capacity: 8 named taps + subops + 3 meta + optional (prompt_tokens, len).
+    // Capacity: static taps + subops + 3 meta + optional (prompt_tokens, len)
+    // + b11 taps.
     let prompt_reserve = if prompt_tokens.is_empty() { 0 } else { 2 };
-    let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> =
-        Vec::with_capacity(taps.len() + extra_subops.len() + 3 + prompt_reserve);
+    let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> = Vec::with_capacity(
+        taps.len() + extra_subops.len() + 3 + prompt_reserve + b11_taps.len(),
+    );
     for (name, t) in taps {
         let (shape, flat) = tensor_to_f32_host(t)
             .with_context(|| format!("dump tap `{name}`: tensor→f32 host copy"))?;
@@ -483,6 +609,18 @@ pub fn write_mtp_dump(
             Dtype::I32,
             pt_bytes,
         ));
+    }
+
+    // Phase B11b: serialize the layer-0 GDN sub-op taps under `b11__<name>`
+    // so the comparator (`scripts/mtp_compare.py --b11`) can select them
+    // with a single prefix match. When `b11_taps` is empty the loop is a
+    // no-op and the on-disk dump is bit-identical to the legacy layout.
+    for (name, shape, flat) in b11_taps {
+        let mut bytes = Vec::with_capacity(flat.len() * 4);
+        for v in flat {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        backings.push((format!("b11__{name}"), shape.clone(), Dtype::F32, bytes));
     }
 
     let mut views: Vec<(String, TensorView)> = Vec::with_capacity(backings.len());
@@ -733,6 +871,7 @@ mod tests {
             &[("h_main", &a)],
             &[],
             &prompt,
+            /* b11_taps = */ &[],
         )
         .unwrap();
 
@@ -786,6 +925,7 @@ mod tests {
             &[("h_main", &a), ("mtp_logits", &b)],
             &[("post_q_proj".to_string(), vec![2], vec![0.1_f32, 0.2])],
             /* prompt_tokens = */ &[],
+            /* b11_taps = */ &[],
         )
         .unwrap();
 
@@ -801,6 +941,8 @@ mod tests {
         // should be serialized.
         assert!(!names.contains(&"prompt_tokens"));
         assert!(!names.contains(&"meta__prompt_tokens_len"));
+        // With b11_taps = &[], no b11__* tensors should appear.
+        assert!(!names.iter().any(|n| n.starts_with("b11__")));
 
         let h = st.tensor("h_main").unwrap();
         assert_eq!(h.dtype(), safetensors::Dtype::F32);
@@ -809,6 +951,125 @@ mod tests {
         assert_eq!(meta.dtype(), safetensors::Dtype::I32);
         let v = i32::from_le_bytes(meta.data()[0..4].try_into().unwrap());
         assert_eq!(v, 561);
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn b11_tap_names_enumerate_all_eleven_layer0_subops() {
+        // Guardrail against accidental future edits that would drop a tap
+        // from the layer-0 bisect span. Both the Rust capture sites and the
+        // Python HF reference dump iterate this list; keeping it fixed at
+        // 11 entries is part of the B11b contract.
+        assert_eq!(B11_TAP_NAMES.len(), 11);
+        assert_eq!(B11_TAP_NAMES[0], "tok_embed");
+        assert_eq!(B11_TAP_NAMES[10], "gdn_out_proj");
+    }
+
+    #[test]
+    fn b11_layer0_capture_records_then_drains() {
+        // SAFETY: single-threaded test; scoped env mutation.
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_B11_TAPS", "1");
+        }
+        let a = Tensor::new(&[1.0_f32, 2.0, 3.0][..], &Device::Cpu).unwrap();
+        let b = Tensor::new(&[10.0_f32, 20.0][..], &Device::Cpu).unwrap();
+        // Disarmed: capture is a silent no-op.
+        capture_b11_layer0_tap("tok_embed", &a).unwrap();
+        assert!(drain_b11_layer0_capture().is_empty());
+        assert!(!is_b11_layer0_capture_armed());
+        assert!(!should_capture_b11_tap_for_layer(0));
+
+        // Armed: records in order.
+        arm_b11_layer0_capture();
+        assert!(is_b11_layer0_capture_armed());
+        assert!(should_capture_b11_tap_for_layer(0));
+        assert!(!should_capture_b11_tap_for_layer(1));
+        capture_b11_layer0_tap("tok_embed", &a).unwrap();
+        capture_b11_layer0_tap("gdn_out_proj", &b).unwrap();
+        let drained = drain_b11_layer0_capture();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].0, "tok_embed");
+        assert_eq!(drained[0].1, vec![3]);
+        assert_eq!(drained[0].2, vec![1.0, 2.0, 3.0]);
+        assert_eq!(drained[1].0, "gdn_out_proj");
+        assert_eq!(drained[1].1, vec![2]);
+        assert_eq!(drained[1].2, vec![10.0, 20.0]);
+
+        // Drain disarms.
+        assert!(!is_b11_layer0_capture_armed());
+        capture_b11_layer0_tap("gdn_conv", &a).unwrap();
+        assert!(drain_b11_layer0_capture().is_empty());
+
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_B11_TAPS");
+        }
+    }
+
+    #[test]
+    fn b11_layer0_arm_is_noop_when_env_unset() {
+        // SAFETY: single-threaded test; scoped env mutation.
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_B11_TAPS");
+        }
+        arm_b11_layer0_capture();
+        assert!(!is_b11_layer0_capture_armed());
+        assert!(!should_capture_b11_tap_for_layer(0));
+        let a = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        capture_b11_layer0_tap("tok_embed", &a).unwrap();
+        assert!(drain_b11_layer0_capture().is_empty());
+    }
+
+    #[test]
+    fn write_mtp_dump_emits_b11_taps_when_provided() {
+        use safetensors::SafeTensors;
+
+        let h = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        let tmp = std::env::temp_dir().join("kiln_mtp_dump_with_b11.safetensors");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let b11 = vec![
+            (
+                "tok_embed".to_string(),
+                vec![2],
+                vec![0.11_f32, 0.22],
+            ),
+            (
+                "gdn_out_proj".to_string(),
+                vec![3],
+                vec![0.31_f32, 0.32, 0.33],
+            ),
+        ];
+        write_mtp_dump(
+            &tmp_s,
+            /* draft_token_id = */ 99,
+            /* mtp_pos = */ 0,
+            /* swap_fc_norms = */ false,
+            &[("h_main", &h)],
+            &[],
+            /* prompt_tokens = */ &[],
+            &b11,
+        )
+        .unwrap();
+
+        let raw = std::fs::read(&tmp).unwrap();
+        let st = SafeTensors::deserialize(&raw).unwrap();
+        let names: Vec<&str> = st.names().into_iter().map(|s| s.as_str()).collect();
+        // Both taps appear under the b11__<name> namespace.
+        assert!(names.contains(&"b11__tok_embed"));
+        assert!(names.contains(&"b11__gdn_out_proj"));
+
+        let te = st.tensor("b11__tok_embed").unwrap();
+        assert_eq!(te.dtype(), safetensors::Dtype::F32);
+        assert_eq!(te.shape(), &[2]);
+        let bytes = te.data();
+        let v0 = f32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let v1 = f32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        assert!((v0 - 0.11).abs() < 1e-6);
+        assert!((v1 - 0.22).abs() < 1e-6);
+
+        let op = st.tensor("b11__gdn_out_proj").unwrap();
+        assert_eq!(op.dtype(), safetensors::Dtype::F32);
+        assert_eq!(op.shape(), &[3]);
 
         let _ = std::fs::remove_file(&tmp);
     }

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -36,6 +36,17 @@ Base-model h_main bisect (Phase B10 — per-layer divergence):
     h_pre_final_norm, plus a verdict identifying the first layer at which
     kiln's base-model hidden state diverges from the HF reference.
 
+Layer-0 GDN sub-op bisect (Phase B11b — per-sub-op divergence):
+    python3 scripts/mtp_compare.py --b11 \\
+        --pair main:/tmp/h-kiln.safetensors,/tmp/h-ref.safetensors
+
+    --b11 defaults atol=1e-2, rtol=1e-1 (bf16-appropriate) and emits a
+    per-sub-op cos_sim + max|Δ| + mean|Δ| + relative_l2 table for the 11
+    `b11__<name>` taps written by kiln (KILN_MTP_DUMP_B11_TAPS=1) and by
+    mtp_h_main_reference_dump.py --b11-taps. The verdict identifies the
+    first sub-op whose median cos_sim across positions falls below 0.95,
+    which becomes the B12 recommendation for targeted investigation.
+
 Exit code:
     0 — all taps match within tolerance (all positions, in multi mode)
     1 — at least one tap diverges (normal outcome of a bisect)
@@ -126,6 +137,40 @@ B10_LAYER_TAPS: List[str] = [
     "h_pre_final_norm",
 ]
 
+# Phase B11b — layer-0 GDN sub-op taps, in forward-graph order. Kiln and the
+# HF reference both write these under a `b11__` prefix so they slot alongside
+# the B10 layer taps without colliding with primary taps. The comparator
+# walks these in order and reports the first sub-op whose median cos_sim
+# across positions falls below 0.95; that sub-op becomes the B12 target.
+B11_LAYER0_TAP_NAMES: Tuple[str, ...] = (
+    "tok_embed",
+    "layer_0_post_input_norm",
+    "gdn_in_proj",
+    "gdn_conv",
+    "gdn_qk_norm_q",
+    "gdn_qk_norm_k",
+    "gdn_gate_beta",
+    "gdn_gate_g",
+    "gdn_recur_out",
+    "gdn_gated_norm",
+    "gdn_out_proj",
+)
+
+# One-line hypotheses for each B11b sub-op, used in verdict output.
+B11_HYPOTHESIS: Dict[str, str] = {
+    "tok_embed": "embedding lookup: token-id routing, tied-embed weight, or dtype",
+    "layer_0_post_input_norm": "layer 0 input_layernorm weight/eps or pre-GDN norm site",
+    "gdn_in_proj": "in_proj_qkvz / in_proj_ba weight layout, split order, or dtype",
+    "gdn_conv": "causal_conv1d: kernel packing, stride/pad, SiLU activation, or bias",
+    "gdn_qk_norm_q": "Qwen3Next in-kernel L2 qk_norm on Q (use_qk_l2norm_in_kernel path)",
+    "gdn_qk_norm_k": "Qwen3Next in-kernel L2 qk_norm on K (use_qk_l2norm_in_kernel path)",
+    "gdn_gate_beta": "beta gate: sigmoid(b) from in_proj_ba split order / head layout",
+    "gdn_gate_g": "g gate: -A_log.exp() * softplus(a + dt_bias), log-gate parameterization",
+    "gdn_recur_out": "chunk_gated_delta_rule / fused_recurrent_gated_delta_rule math",
+    "gdn_gated_norm": "GatedRMSNorm(core_attn_out, z): gate-modulated RMSNorm weight/eps",
+    "gdn_out_proj": "out_proj weight layout, transpose, or residual dtype",
+}
+
 META_KEYS = (
     "meta__draft_token_id",
     "meta__mtp_pos",
@@ -212,6 +257,7 @@ def _compare_tap(
         row["cos_sim"] = float("nan")
         row["max_abs_diff"] = float("nan")
         row["mean_abs_diff"] = float("nan")
+        row["rel_l2"] = float("nan")
         return row
 
     a64 = a.astype(np.float64)
@@ -221,6 +267,11 @@ def _compare_tap(
     row["mean_abs_diff"] = float(diff.mean()) if diff.size else 0.0
     row["allclose"] = bool(np.allclose(a64, b64, atol=atol, rtol=rtol))
     row["cos_sim"] = _cos_sim(a64, b64)
+    ref_norm = float(np.linalg.norm(b64.reshape(-1)))
+    if ref_norm == 0.0 or not diff.size:
+        row["rel_l2"] = float("nan")
+    else:
+        row["rel_l2"] = float(np.linalg.norm(diff.reshape(-1)) / ref_norm)
     return row
 
 
@@ -258,6 +309,10 @@ def _ordered_taps(
     for name in B10_LAYER_TAPS:
         if name in common and name not in out:
             out.append(name)
+    for name in B11_LAYER0_TAP_NAMES:
+        key = f"b11__{name}"
+        if key in common and key not in out:
+            out.append(key)
     extras = sorted(common - set(out))
     out.extend(extras)
     return out
@@ -660,6 +715,137 @@ def _emit_b10_summary(
         emit("     how the base-model main path routes hidden into the MTP head.")
 
 
+def _emit_b11_summary(
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]],
+    atol: float,
+    rtol: float,
+    emit,
+) -> None:
+    """Phase B11b — layer-0 GDN sub-op bisect.
+
+    Walks `B11_LAYER0_TAP_NAMES` (prefixed with `b11__` in both dumps) across
+    every pair, prints a per-position cos_sim / max|Δ| / mean|Δ| / rel_l2
+    table, and recommends the first sub-op whose MEDIAN cos_sim across
+    positions falls below 0.95 as the B12 target. Falls back to the first
+    tap with ANY position diverging when no tap crosses the 0.95 median bar
+    so the recommendation stays actionable when every sub-op is noisy.
+    """
+    emit("")
+    emit("=" * 78)
+    emit("Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2")
+    emit("=" * 78)
+
+    labels = [pr[0] for pr in pair_results]
+
+    # tap -> {label: (cos_sim, max|Δ|, mean|Δ|, rel_l2)}
+    cell: Dict[str, Dict[str, Tuple[float, float, float, float]]] = {
+        n: {} for n in B11_LAYER0_TAP_NAMES
+    }
+    for label, _ok, _fd, rows, _km, _rm in pair_results:
+        for r in rows:
+            n = r["name"]
+            if not isinstance(n, str) or not n.startswith("b11__"):
+                continue
+            short = n[len("b11__"):]
+            if short not in cell:
+                continue
+            cell[short][label] = (
+                float(r["cos_sim"]),
+                float(r["max_abs_diff"]),
+                float(r["mean_abs_diff"]),
+                float(r.get("rel_l2", float("nan"))),
+            )
+
+    header = "  " + "tap".ljust(26) + " ".join(
+        f"pos={lab:<48}" for lab in labels
+    )
+    emit(header)
+    emit("  " + "-" * (len(header) - 2))
+    captured_any = False
+    for tap in B11_LAYER0_TAP_NAMES:
+        cells = []
+        for lab in labels:
+            entry = cell[tap].get(lab)
+            if entry is None:
+                cells.append(f"{'<missing>':<52}")
+            else:
+                cs, mxd, mnd, rl2 = entry
+                captured_any = True
+                tag = "ok" if cs >= 0.95 else "DIV"
+                cells.append(
+                    f"cos={_fmt_sci(cs):<10} max|Δ|={_fmt_sci(mxd):<10} "
+                    f"mean|Δ|={_fmt_sci(mnd):<10} rel_l2={_fmt_sci(rl2):<10} {tag:<3}"
+                )
+        emit(f"  {tap:<26}{' '.join(cells)}")
+
+    emit("")
+    if not captured_any:
+        emit("Phase B11b verdict: no B11 layer-0 taps present in dumps.")
+        emit("  -> Re-run kiln-bench with KILN_MTP_DUMP_HIDDEN_STATES=1 AND")
+        emit("     KILN_MTP_DUMP_B11_TAPS=1, then re-run mtp_h_main_reference_dump.py")
+        emit("     with --b11-taps against the same kiln dump.")
+        return
+
+    # B12 recommendation: first tap whose MEDIAN cos_sim across finite
+    # positions dips below 0.95. Falls back to first tap with ANY position
+    # diverging under the atol/rtol bar when no tap crosses the 0.95 line.
+    def _median(xs: List[float]) -> float:
+        finite = sorted(v for v in xs if np.isfinite(v))
+        if not finite:
+            return float("nan")
+        n = len(finite)
+        mid = n // 2
+        if n % 2 == 1:
+            return finite[mid]
+        return 0.5 * (finite[mid - 1] + finite[mid])
+
+    first_median_div: Optional[str] = None
+    first_median_val: float = float("nan")
+    first_any_div: Optional[str] = None
+    first_any_pos: Optional[str] = None
+    for tap in B11_LAYER0_TAP_NAMES:
+        per_pos = [cell[tap][lab][0] for lab in labels if lab in cell[tap]]
+        if not per_pos:
+            continue
+        med = _median(per_pos)
+        if first_median_div is None and np.isfinite(med) and med < 0.95:
+            first_median_div = tap
+            first_median_val = med
+        for lab in labels:
+            entry = cell[tap].get(lab)
+            if entry is None:
+                continue
+            cs = entry[0]
+            if np.isfinite(cs) and cs < 0.95 and first_any_div is None:
+                first_any_div = tap
+                first_any_pos = lab
+
+    if first_median_div is not None:
+        hypo = B11_HYPOTHESIS.get(first_median_div, "<unknown sub-op>")
+        emit(
+            f"  first sub-op with MEDIAN cos_sim < 0.95: '{first_median_div}' "
+            f"(median cos_sim = {first_median_val:.6f})"
+        )
+        emit(f"Phase B11b verdict: B12 TARGET = '{first_median_div}'.")
+        emit(f"    Most-likely cause: {hypo}")
+        emit("  -> Queue B12 task to investigate this sub-op in isolation.")
+    elif first_any_div is not None:
+        hypo = B11_HYPOTHESIS.get(first_any_div, "<unknown sub-op>")
+        emit(
+            f"  no sub-op has MEDIAN cos_sim < 0.95, but '{first_any_div}' "
+            f"(pos={first_any_pos}) dips below 0.95 on at least one position."
+        )
+        emit(f"Phase B11b verdict: B12 TARGET (noisy) = '{first_any_div}'.")
+        emit(f"    Most-likely cause: {hypo}")
+        emit("  -> Recommend capturing more positions / longer prompts to confirm")
+        emit("     before committing to a B12 fix direction.")
+    else:
+        emit("Phase B11b verdict: ALL layer-0 GDN sub-ops match within cos_sim >= 0.95.")
+        emit("  -> Divergence is NOT localized inside layer 0's GDN block at this bar.")
+        emit("  -> Re-check B10 atol/rtol and consider extending taps to layers 1-7")
+        emit("     (GDN stack) before committing to a B12 target.")
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("--kiln", help="Path to kiln dump (.safetensors) — single-pair mode")
@@ -681,17 +867,29 @@ def main() -> int:
             "rtol=1e-1 (bf16-appropriate) unless explicitly overridden."
         ),
     )
+    ap.add_argument(
+        "--b11",
+        action="store_true",
+        help=(
+            "Phase B11b mode: emit layer-0 GDN sub-op bisect summary (11 taps "
+            "prefixed with `b11__`). Defaults atol=1e-2, rtol=1e-1 "
+            "(bf16-appropriate) unless explicitly overridden. Recommends the "
+            "first sub-op whose median cos_sim across positions falls below "
+            "0.95 as the B12 target."
+        ),
+    )
     ap.add_argument("--out", default=None, help="Optional path to write report text")
     args = ap.parse_args()
 
-    # Default tolerances depend on mode. B10 compares bf16 base-model hidden
+    # Default tolerances depend on mode. B10/B11 compare bf16 base-model hidden
     # states end-to-end through 32 transformer blocks; the accumulated
     # arithmetic noise across that many ops means a strict 1e-3/1e-2 bar
     # flags semantically-identical tensors as divergent.
+    bf16_mode = args.b10 or args.b11
     if args.atol is None:
-        args.atol = 1e-2 if args.b10 else 1e-3
+        args.atol = 1e-2 if bf16_mode else 1e-3
     if args.rtol is None:
-        args.rtol = 1e-1 if args.b10 else 1e-2
+        args.rtol = 1e-1 if bf16_mode else 1e-2
 
     pairs: List[Tuple[str, str, str]] = []
     if args.pair:
@@ -713,7 +911,9 @@ def main() -> int:
         lines.append(s)
 
     multi = len(pairs) > 1
-    if args.b10:
+    if args.b11:
+        mode = "layer-0 GDN sub-op bisect (B11b)"
+    elif args.b10:
         mode = "base-model h_main bisect (B10)"
     elif multi:
         mode = "multi-position (B7a)"
@@ -733,7 +933,9 @@ def main() -> int:
         if not ok:
             overall_ok = False
 
-    if args.b10:
+    if args.b11:
+        _emit_b11_summary(pair_results, args.atol, args.rtol, emit)
+    elif args.b10:
         _emit_b10_summary(pair_results, args.atol, args.rtol, emit)
     elif multi:
         _emit_b7a_summary(pair_results, emit)
@@ -741,9 +943,9 @@ def main() -> int:
     # B9 sub-op zone bisect — emitted whenever any pair captured zone taps,
     # whether single- or multi-pair. Exits cleanly with a "no zone taps
     # captured" note when the dump didn't include the B9 sub-ops (e.g.
-    # legacy dumps from before this PR). Skipped in explicit --b10 mode so
-    # the B10 report isn't cluttered by unrelated sub-op tables.
-    if not args.b10:
+    # legacy dumps from before this PR). Skipped in explicit --b10/--b11 mode
+    # so the B10/B11 report isn't cluttered by unrelated sub-op tables.
+    if not args.b10 and not args.b11:
         have_b9_taps = any(
             any(r["name"] in B9_H2_ZONE or r["name"] in B9_H3_ZONE for r in pr[3])
             for pr in pair_results

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """
 Phase B10 — `h_main` base-model reference dump.
+Phase B11b — optional layer-0 GDN sub-op taps (`--b11-taps`).
 
 This script produces the independent pure-Python reference counterpart to the
 kiln-side main-model forward (the 24×GDN + 8×GQA stack) so that Phase B10 can
@@ -8,13 +9,25 @@ bisect which layer first diverges. Prior phases (B6–B9) ruled out every sub-op
 inside the MTP head, so the remaining candidate is the base-model `h_prev`
 (`h_main`) that kiln feeds into MTP.
 
+Phase B11b extends this with 11 intra-layer taps at layer 0's GDN block so we
+can bisect the first diverging sub-op (B10 showed layer 0 as the first
+boundary where cos ≈ 0.827 between kiln and HF).
+
 Usage
 -----
 
+    # B10-only boundary taps (original flow)
     python3 scripts/mtp_h_main_reference_dump.py \\
         --checkpoint /workspace/qwen3.5-4b \\
         --kiln-dump /tmp/h-kiln.safetensors \\
         --out /tmp/h-ref.safetensors
+
+    # B10 boundary taps + B11b layer-0 GDN sub-op taps
+    python3 scripts/mtp_h_main_reference_dump.py \\
+        --checkpoint /workspace/qwen3.5-4b \\
+        --kiln-dump /tmp/h-kiln.safetensors \\
+        --out /tmp/h-ref.safetensors \\
+        --b11-taps
 
 Design
 ------
@@ -29,8 +42,15 @@ the last-row slice of the hidden state at five boundary layers (0, 8, 16, 23,
 `model.norm`). Those are the same six taps kiln captures when
 `KILN_MTP_DUMP_HIDDEN_STATES=1`.
 
+When `--b11-taps` is passed, we additionally monkey-patch
+`Qwen3NextGatedDeltaNet.forward` with an instrumented copy that captures
+11 intra-layer sub-op outputs at layer 0 (matching `B11_TAP_NAMES` in
+`crates/kiln-model/src/mtp_debug.rs`). The full-tensor layer-0 taps are saved
+alongside the boundary taps with a `b11__` prefix.
+
 The safetensors file written here uses the same layout and naming convention
-as kiln's dump so `scripts/mtp_compare.py --b10` can diff them tap-for-tap.
+as kiln's dump so `scripts/mtp_compare.py --b10` / `--b11` can diff them
+tap-for-tap.
 
 Prompt provenance
 -----------------
@@ -76,6 +96,24 @@ from safetensors.torch import save_file
 #   - layer 23: GQA (indices 3, 7, 11, 15, 19, 23, 27, 31 are full-attn)
 #   - layer 31: GQA (last layer; its output IS `h_pre_final_norm`)
 B10_BOUNDARY_LAYERS: Tuple[int, ...] = (0, 8, 16, 23, 31)
+
+
+# Phase B11b — ordered layer-0 GDN sub-op tap names. Must stay in lock-step
+# with `B11_TAP_NAMES` in `crates/kiln-model/src/mtp_debug.rs`. The comparator
+# (`scripts/mtp_compare.py --b11`) prints rows in this order.
+B11_LAYER0_TAP_NAMES: Tuple[str, ...] = (
+    "tok_embed",
+    "layer_0_post_input_norm",
+    "gdn_in_proj",
+    "gdn_conv",
+    "gdn_qk_norm_q",
+    "gdn_qk_norm_k",
+    "gdn_gate_beta",
+    "gdn_gate_g",
+    "gdn_recur_out",
+    "gdn_gated_norm",
+    "gdn_out_proj",
+)
 
 
 # -----------------------------------------------------------------------------
@@ -150,6 +188,194 @@ def build_fallback_prompt_tokens(
 
 
 # -----------------------------------------------------------------------------
+# Phase B11b — instrumented layer-0 GDN forward
+# -----------------------------------------------------------------------------
+
+
+def _l2_norm_last_dim(x: "torch.Tensor", eps: float = 1e-6) -> "torch.Tensor":
+    """L2-normalize along the final dim. Matches the
+    `use_qk_l2norm_in_kernel=True` behavior applied by the fla-org
+    `chunk_gated_delta_rule` / `fused_recurrent_gated_delta_rule` kernels
+    to query and key tensors right before recurrence. We compute this in
+    FP32 for stability; callers cast back if needed."""
+    norm = x.pow(2).sum(dim=-1, keepdim=True).clamp_min(eps).sqrt()
+    return x / norm
+
+
+def make_instrumented_gdn_forward(
+    taps_out: Dict[str, "torch.Tensor"], target_layer_idx: int = 0
+):
+    """Return a replacement for `Qwen3NextGatedDeltaNet.forward` that runs the
+    module's math unmodified but, when `self.layer_idx == target_layer_idx`,
+    captures each of the 11 B11b sub-op outputs into `taps_out`. The returned
+    function binds `target_layer_idx` and `taps_out` via closure; assign it
+    with `Qwen3NextGatedDeltaNet.forward = ...` to instrument every GDN layer
+    in a model (only the target layer will write taps)."""
+
+    import torch.nn.functional as F  # noqa: F401 — needed inside closure
+    from transformers.models.qwen3_next.modeling_qwen3_next import (  # type: ignore
+        apply_mask_to_padding_states,
+    )
+
+    def forward(self, hidden_states, cache_params=None, attention_mask=None):
+        capture = int(self.layer_idx) == int(target_layer_idx)
+
+        hidden_states = apply_mask_to_padding_states(hidden_states, attention_mask)
+        batch_size, seq_len, _ = hidden_states.shape
+
+        use_precomputed_states = (
+            cache_params is not None
+            and cache_params.has_previous_state(self.layer_idx)
+            and seq_len == 1
+        )
+
+        if use_precomputed_states:
+            conv_state = cache_params.layers[self.layer_idx].conv_states
+            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
+
+        projected_states_qkvz = self.in_proj_qkvz(hidden_states)
+        projected_states_ba = self.in_proj_ba(hidden_states)
+
+        if capture:
+            # gdn_in_proj mirrors kiln's `Tensor::cat(&[&mixed_qkv, &z, &b, &a])`
+            # which equals `cat([in_proj_qkvz, in_proj_ba], dim=-1)` because
+            # `in_proj_qkvz` packs [q, k, v, z] and `in_proj_ba` packs [b, a].
+            taps_out["gdn_in_proj"] = (
+                torch.cat([projected_states_qkvz, projected_states_ba], dim=-1)
+                .detach()
+                .clone()
+            )
+
+        query, key, value, z, b, a = self.fix_query_key_value_ordering(
+            projected_states_qkvz, projected_states_ba
+        )
+        query, key, value = (
+            x.reshape(x.shape[0], x.shape[1], -1) for x in (query, key, value)
+        )
+
+        mixed_qkv = torch.cat((query, key, value), dim=-1)
+        mixed_qkv = mixed_qkv.transpose(1, 2)
+
+        if use_precomputed_states:
+            mixed_qkv = self.causal_conv1d_update(
+                mixed_qkv,
+                conv_state,
+                self.conv1d.weight.squeeze(1),
+                self.conv1d.bias,
+                self.activation,
+            )
+        else:
+            if cache_params is not None:
+                conv_state = F.pad(
+                    mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0)
+                )
+                conv_state = cache_params.update_conv_state(conv_state, self.layer_idx)
+            if self.causal_conv1d_fn is not None:
+                mixed_qkv = self.causal_conv1d_fn(
+                    x=mixed_qkv,
+                    weight=self.conv1d.weight.squeeze(1),
+                    bias=self.conv1d.bias,
+                    activation=self.activation,
+                    seq_idx=None,
+                )
+            else:
+                mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len])
+
+        mixed_qkv = mixed_qkv.transpose(1, 2)
+
+        if capture:
+            # Post-silu, post-transpose, shape [B, T, conv_dim]. Matches
+            # kiln's `gdn_conv` tap captured at the same semantic point.
+            taps_out["gdn_conv"] = mixed_qkv.detach().clone()
+
+        query, key, value = torch.split(
+            mixed_qkv,
+            [self.key_dim, self.key_dim, self.value_dim],
+            dim=-1,
+        )
+        query = query.reshape(query.shape[0], query.shape[1], -1, self.head_k_dim)
+        key = key.reshape(key.shape[0], key.shape[1], -1, self.head_k_dim)
+        value = value.reshape(value.shape[0], value.shape[1], -1, self.head_v_dim)
+
+        beta = b.sigmoid()
+        g = -self.A_log.float().exp() * F.softplus(a.float() + self.dt_bias)
+
+        if capture:
+            taps_out["gdn_gate_beta"] = beta.detach().clone()  # [B, T, nv]
+            taps_out["gdn_gate_g"] = g.detach().clone()  # [B, T, nv]
+
+        if self.num_v_heads // self.num_k_heads > 1:
+            query = query.repeat_interleave(
+                self.num_v_heads // self.num_k_heads, dim=2
+            )
+            key = key.repeat_interleave(
+                self.num_v_heads // self.num_k_heads, dim=2
+            )
+
+        if capture:
+            # HF kernel applies L2 norm internally (`use_qk_l2norm_in_kernel=True`),
+            # so we mirror it explicitly here to match kiln's captured
+            # post-L2-norm q/k tensors.
+            q_normed = _l2_norm_last_dim(query.float())
+            k_normed = _l2_norm_last_dim(key.float())
+            taps_out["gdn_qk_norm_q"] = q_normed.to(query.dtype).detach().clone()
+            taps_out["gdn_qk_norm_k"] = k_normed.to(key.dtype).detach().clone()
+
+        if not use_precomputed_states:
+            core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                initial_state=None,
+                output_final_state=cache_params is not None,
+                use_qk_l2norm_in_kernel=True,
+            )
+        else:
+            core_attn_out, last_recurrent_state = self.recurrent_gated_delta_rule(
+                query,
+                key,
+                value,
+                g=g,
+                beta=beta,
+                initial_state=recurrent_state,
+                output_final_state=cache_params is not None,
+                use_qk_l2norm_in_kernel=True,
+            )
+
+        if capture:
+            # Recurrence output, shape [B, T, nv, dv]. This is the tensor
+            # kiln captures at post-transpose time (matches the input to
+            # GatedRMSNorm).
+            taps_out["gdn_recur_out"] = core_attn_out.detach().clone()
+
+        if cache_params is not None:
+            cache_params.update_recurrent_state(last_recurrent_state, self.layer_idx)
+
+        z_shape_og = z.shape
+        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
+        z = z.reshape(-1, z.shape[-1])
+        core_attn_out = self.norm(core_attn_out, z)
+        core_attn_out = core_attn_out.reshape(z_shape_og)
+        core_attn_out = core_attn_out.reshape(core_attn_out.shape[0], core_attn_out.shape[1], -1)
+
+        if capture:
+            # After GatedRMSNorm + flatten-last-two-dims, shape [B, T, value_dim].
+            taps_out["gdn_gated_norm"] = core_attn_out.detach().clone()
+
+        output = self.out_proj(core_attn_out)
+
+        if capture:
+            # Final out_proj output, shape [B, T, hidden].
+            taps_out["gdn_out_proj"] = output.detach().clone()
+
+        return output
+
+    return forward
+
+
+# -----------------------------------------------------------------------------
 # Reference forward
 # -----------------------------------------------------------------------------
 
@@ -158,10 +384,13 @@ def run_reference_forward(
     checkpoint: str,
     input_ids: torch.Tensor,
     device: torch.device,
+    capture_b11_layer0: bool = False,
 ) -> Dict[str, torch.Tensor]:
     """Run HF Qwen3-Next forward with `output_hidden_states=True`. Returns a
-    dict mapping tap name -> BF16 tensor of shape [1, 1, H] (last-row slice
-    of the hidden state at that boundary layer / pre-final-norm site)."""
+    dict mapping tap name -> F32 tensor. Boundary taps (`h_layer_*`,
+    `h_pre_final_norm`) are last-row slices at shape [1, 1, H]. When
+    `capture_b11_layer0=True`, also returns 11 full-tensor layer-0 GDN sub-op
+    taps under keys in `B11_LAYER0_TAP_NAMES` (shapes match kiln's)."""
     from transformers import AutoModelForCausalLM  # type: ignore
 
     print(
@@ -177,18 +406,69 @@ def run_reference_forward(
     model.eval()
     model.to(device)
 
+    # Set up B11b instrumentation + embed/norm forward_hooks BEFORE the forward.
+    b11_captures: Dict[str, torch.Tensor] = {}
+    hook_handles: List[object] = []
+    orig_gdn_forward = None
+    if capture_b11_layer0:
+        from transformers.models.qwen3_next.modeling_qwen3_next import (  # type: ignore
+            Qwen3NextGatedDeltaNet,
+        )
+
+        orig_gdn_forward = Qwen3NextGatedDeltaNet.forward  # type: ignore[attr-defined]
+        Qwen3NextGatedDeltaNet.forward = make_instrumented_gdn_forward(  # type: ignore[assignment]
+            b11_captures, target_layer_idx=0
+        )
+
+        base = model.model if hasattr(model, "model") else model
+
+        def _save_tok_embed(_mod, _inputs, output):
+            b11_captures["tok_embed"] = output.detach().clone()
+
+        def _save_post_input_norm(_mod, _inputs, output):
+            b11_captures["layer_0_post_input_norm"] = output.detach().clone()
+
+        hook_handles.append(
+            base.embed_tokens.register_forward_hook(_save_tok_embed)
+        )
+        hook_handles.append(
+            base.layers[0].input_layernorm.register_forward_hook(
+                _save_post_input_norm
+            )
+        )
+
+        print(
+            "[mtp_h_main_ref] B11b instrumentation armed: "
+            "monkey-patched Qwen3NextGatedDeltaNet.forward + 2 embed/norm hooks",
+            file=sys.stderr,
+        )
+
     input_ids = input_ids.to(device)
     print(
         f"[mtp_h_main_ref] forward: input_ids shape={tuple(input_ids.shape)} device={device}",
         file=sys.stderr,
     )
-    with torch.inference_mode():
-        out = model(
-            input_ids=input_ids,
-            output_hidden_states=True,
-            use_cache=False,
-            return_dict=True,
-        )
+    try:
+        with torch.inference_mode():
+            out = model(
+                input_ids=input_ids,
+                output_hidden_states=True,
+                use_cache=False,
+                return_dict=True,
+            )
+    finally:
+        # Always tear down instrumentation, even if the forward blows up.
+        for h in hook_handles:
+            try:
+                h.remove()
+            except Exception:
+                pass
+        if orig_gdn_forward is not None:
+            from transformers.models.qwen3_next.modeling_qwen3_next import (  # type: ignore
+                Qwen3NextGatedDeltaNet,
+            )
+
+            Qwen3NextGatedDeltaNet.forward = orig_gdn_forward  # type: ignore[assignment]
     # HF convention: `hidden_states` has `num_hidden_layers + 1` entries.
     #   hidden_states[0]   = embedding input
     #   hidden_states[i+1] = output after layer i (for i in 0..num_layers-1)
@@ -221,6 +501,20 @@ def run_reference_forward(
     # the comparator can track the channel independently from `h_layer_31`.
     h_pre_final = hs[num_layers][:, -1:, :].contiguous()  # [1, 1, H]
     taps["h_pre_final_norm"] = h_pre_final
+
+    # Emit B11b layer-0 sub-op taps if captured. Each tap goes in under the
+    # `b11__<name>` key so the comparator can identify them distinct from
+    # the boundary taps.
+    if capture_b11_layer0:
+        missing = [n for n in B11_LAYER0_TAP_NAMES if n not in b11_captures]
+        if missing:
+            print(
+                f"[mtp_h_main_ref] WARNING: B11b instrumentation missed taps: {missing}",
+                file=sys.stderr,
+            )
+        for name in B11_LAYER0_TAP_NAMES:
+            if name in b11_captures:
+                taps[f"b11__{name}"] = b11_captures[name]
 
     # Free the model and all retained activations before returning.
     del model, out, hs
@@ -260,6 +554,16 @@ def main() -> int:
         type=int,
         default=42,
         help="Torch/NumPy seed for fallback prompt generation (default 42)",
+    )
+    ap.add_argument(
+        "--b11-taps",
+        action="store_true",
+        help=(
+            "Also capture 11 layer-0 GDN sub-op taps (Phase B11b) by "
+            "monkey-patching Qwen3NextGatedDeltaNet.forward. Output tensors "
+            "are emitted under `b11__<name>` keys matching B11_TAP_NAMES in "
+            "crates/kiln-model/src/mtp_debug.rs."
+        ),
     )
     args = ap.parse_args()
 
@@ -316,7 +620,9 @@ def main() -> int:
     if torch.cuda.is_available():
         torch.cuda.manual_seed_all(args.seed)
 
-    taps_bf16 = run_reference_forward(args.checkpoint, prompt_tokens, device)
+    taps_bf16 = run_reference_forward(
+        args.checkpoint, prompt_tokens, device, capture_b11_layer0=args.b11_taps
+    )
 
     # Up-cast to F32 and move to CPU for the dump.
     def _to_f32_cpu(t: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Summary

Builds on #297 (B11 Step 1 `prompt_tokens` round-trip) to localize the MTP prefill divergence inside layer 0's GDN block. B10 (#293) showed cos=0.827, max|Δ|=0.48 at `h_layer_0`; this phase adds 11 intra-block sub-op taps so the first divergent op can be named and handed to B12.

## What

**Rust** (`KILN_MTP_DUMP_B11_TAPS=1`):
- TLS-based `B11_LAYER0_CAPTURE` slot in `mtp_debug.rs` with armed gate + per-layer filter; emits captured taps as `b11__<name>` F32 tensors via `write_mtp_dump`.
- `forward.rs::gated_deltanet_forward` gains a `capture_b11_taps: bool` param and 7 intra-function tap captures; outer block emits `tok_embed` + `layer_0_post_input_norm`.
- `gdn_recur_out` tap moved post-transpose to `[B, T, nv, dv]` to align with HF's natural norm-input shape.

**Python HF reference** (`scripts/mtp_h_main_reference_dump.py --b11-taps`):
- Monkey-patches `Qwen3NextGatedDeltaNet.forward` with an instrumented copy that replays the exact original math while capturing 9 intra-function taps when `self.layer_idx == 0`.
- Registers forward_hooks on `base.embed_tokens` (→ `tok_embed`) and `base.layers[0].input_layernorm` (→ `layer_0_post_input_norm`).
- L2 qk_norm replicated via `F.normalize`-equivalent (HF uses `use_qk_l2norm_in_kernel=True` so there's no hookable module).
- `try`/`finally` teardown restores the original forward + removes hooks.

**Comparator** (`scripts/mtp_compare.py --b11`):
- New `B11_LAYER0_TAP_NAMES` + `B11_HYPOTHESIS` maps.
- `_emit_b11_summary` prints per-position `cos_sim` / `max|Δ|` / `mean|Δ|` / `rel_l2` table and recommends a **B12 target** = first sub-op with **median** cos_sim < 0.95 across positions. Falls back to the first tap with ANY position diverging when no tap crosses the 0.95 median bar.
- `_compare_tap` now also reports `rel_l2 = ‖Δ‖ / ‖ref‖`, so B10 output includes this column too.
- `--b11` defaults `atol=1e-2`, `rtol=1e-1` (bf16-appropriate).

## 11 sub-op taps (forward-graph order)

| # | Tap | Scope |
|---|-----|-------|
| 1 | `tok_embed` | base.embed_tokens output |
| 2 | `layer_0_post_input_norm` | base.layers[0].input_layernorm output |
| 3 | `gdn_in_proj` | in_proj_qkvz / in_proj_ba split inputs |
| 4 | `gdn_conv` | causal_conv1d output |
| 5 | `gdn_qk_norm_q` | in-kernel L2 qk_norm on Q |
| 6 | `gdn_qk_norm_k` | in-kernel L2 qk_norm on K |
| 7 | `gdn_gate_beta` | sigmoid(b) beta gate |
| 8 | `gdn_gate_g` | `-A_log.exp() * softplus(a + dt_bias)` g gate |
| 9 | `gdn_recur_out` | chunk_gated_delta_rule output (pre-GatedRMSNorm) |
| 10 | `gdn_gated_norm` | GatedRMSNorm(core_attn_out, z) |
| 11 | `gdn_out_proj` | out_proj output |

## Tests

161/161 `cargo nextest run -p kiln-model` green. CPU-only tests exercised; the B11 capture path is gated on `is_dump_b11_taps_enabled()` so no overhead when unset.

## Next

A6000 bench will be run on 3 prompts with `KILN_MTP_DUMP_HIDDEN_STATES=1 KILN_MTP_DUMP_B11_TAPS=1`, then the per-sub-op table + B12 recommendation will be appended here.

## Conventions

- No `CE:` prefix (kiln ≠ clouderic).
- No `ce deploy-request` (kiln has no clouderic-style deploy pipeline).
- Auto-merge enabled when CI green.