### PR TITLE
[codex] Prewarm Metal decode path

### DIFF
--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -287,7 +287,10 @@ fn spawn_backend_prewarm(state: AppState) {
                 temperature: 0.0,
                 top_p: 1.0,
                 top_k: 0,
-                max_tokens: 1,
+                // `max_tokens = 1` only runs prefill and samples the first
+                // token. Use two tokens so Metal also compiles the decode path
+                // before the first live request reaches it.
+                max_tokens: 2,
                 repetition_penalty: 1.0,
                 stop: Vec::new(),
                 seed: Some(42),


### PR DESCRIPTION
## Summary

The existing background Metal prewarm used `max_tokens = 1`, which only runs prefill and samples the first token. It never executes a decode forward pass, so the first live request can still pay lazy Metal decode compilation/allocation costs.

This changes the prewarm request to `max_tokens = 2`, forcing one decode step during the background prewarm while preserving the same request-facing behavior.

## Validation

- `git diff --check`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo build -p kiln-server --bin kiln --features metal --release`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-server --lib --features metal`