### PR TITLE
desktop: notify when Open Logs / Open Settings invocations fail

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -784,7 +784,12 @@
         // Surface the existing Settings window where kiln_binary is
         // already a pickable field — the simplest way to point at a
         // local build without duplicating the file-picker wiring here.
-        try { await invoke("open_settings"); } catch (e) { console.error(e); }
+        try {
+          await invoke("open_settings");
+        } catch (e) {
+          console.error(e);
+          notifyError("Open Settings failed", String(e || "Unknown error"));
+        }
       }
 
       installDownloadBtn.addEventListener("click", triggerInstall);
@@ -875,7 +880,12 @@
       const updateBanner = document.getElementById("update-banner");
       if (updateBannerOpenSettings) {
         updateBannerOpenSettings.addEventListener("click", async () => {
-          try { await invoke("open_settings"); } catch (e) { console.error(e); }
+          try {
+            await invoke("open_settings");
+          } catch (e) {
+            console.error(e);
+            notifyError("Open Settings failed", String(e || "Unknown error"));
+          }
         });
       }
       if (updateBannerDismiss && updateBanner) {
@@ -1027,13 +1037,28 @@
       const logsBtn = document.getElementById("open-logs");
       const settingsBtn = document.getElementById("open-settings");
       logsBtn.addEventListener("click", async () => {
-        try { await invoke("open_logs"); } catch (e) { console.error("open_logs failed", e); }
+        try {
+          await invoke("open_logs");
+        } catch (e) {
+          console.error("open_logs failed", e);
+          notifyError("Open Logs failed", String(e || "Unknown error"));
+        }
       });
       settingsBtn.addEventListener("click", async () => {
-        try { await invoke("open_settings"); } catch (e) { console.error("open_settings failed", e); }
+        try {
+          await invoke("open_settings");
+        } catch (e) {
+          console.error("open_settings failed", e);
+          notifyError("Open Settings failed", String(e || "Unknown error"));
+        }
       });
       settingsNeededBtn.addEventListener("click", async () => {
-        try { await invoke("open_settings"); } catch (e) { console.error("open_settings failed", e); }
+        try {
+          await invoke("open_settings");
+        } catch (e) {
+          console.error("open_settings failed", e);
+          notifyError("Open Settings failed", String(e || "Unknown error"));
+        }
       });
 
       const stopBtn = document.getElementById("stop-server");
@@ -1156,10 +1181,16 @@
         if (!mod) return;
         if (!shift && lower === "l") {
           e.preventDefault();
-          invoke("open_logs").catch((err) => console.error("open_logs failed", err));
+          invoke("open_logs").catch((err) => {
+            console.error("open_logs failed", err);
+            notifyError("Open Logs failed", String(err || "Unknown error"));
+          });
         } else if (!shift && key === ",") {
           e.preventDefault();
-          invoke("open_settings").catch((err) => console.error("open_settings failed", err));
+          invoke("open_settings").catch((err) => {
+            console.error("open_settings failed", err);
+            notifyError("Open Settings failed", String(err || "Unknown error"));
+          });
         } else if (shift && lower === "c") {
           e.preventDefault();
           copyOpenAiBaseUrl();


### PR DESCRIPTION
## What

Extends the error-surface-symmetry pattern from PR #296 (dashboard Stop/Restart) and PR #300 (Check for Updates / Install Update) to the seven `open_logs` / `open_settings` invocations in `desktop/ui/dashboard.html` that previously eat errors silently.

If the Tauri webview plugin fails to create the Logs or Settings child window (permission error, window state corruption, etc.), the user now gets a desktop notification instead of nothing.

## Sites updated (7)

All in `desktop/ui/dashboard.html`. Existing `console.error` calls are preserved; `notifyError(...)` is added alongside.

1. Install panel `browseForBinary()` — opens Settings to point at a local kiln binary
2. `update-banner-open-settings` click — opens Settings to install a newer kiln
3. Toolbar Logs button click
4. Toolbar Settings button click
5. `settingsNeededBtn` first-run empty-state click
6. Cmd/Ctrl+L keyboard shortcut (Open Logs)
7. Cmd/Ctrl+, keyboard shortcut (Open Settings)

## Validation

HTML/JS-only diff. `cd desktop && cargo check` was not run locally because GTK/webkit2gtk system deps are not installed in the Cloud Eric session (see note `kiln-desktop-cargo-check-syslibs`). CI on Linux/Windows/macOS validates the full build.

The `notifyError` helper at `desktop/ui/dashboard.html:624` is the same one already used by Stop/Restart (lines 1078, 1117) and Check for Updates / Install Update (PR #300), so no new helper wiring is needed.