### PR TITLE
[codex] Avoid full MTP prefill logits

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -4052,6 +4052,45 @@ pub fn model_forward_paged_with_last_hidden(
     ))
 }
 
+/// Paged-KV forward pass for MTP prefill.
+///
+/// Returns only the last-row logits plus the last-row pre-final-norm hidden
+/// state. MTP prefill does not need per-position logits, so this avoids
+/// projecting every prompt row through the large tied LM head.
+pub fn model_forward_paged_last_token_with_last_hidden(
+    backend: &dyn BackendRuntime,
+    token_ids: &[u32],
+    weights: &GpuWeights,
+    config: &kiln_core::config::ModelConfig,
+    paged_cache: &mut PagedKvCache,
+    block_table: &BlockTable,
+    start_pos: usize,
+    linear_state: Option<&mut LinearAttentionState>,
+    lora: Option<&LoraWeights>,
+    positions_gpu: Option<&Tensor>,
+) -> Result<(Tensor, Tensor)> {
+    crate::mtp_debug::arm_h_main_capture();
+    crate::mtp_debug::stash_h_main_prompt_tokens(token_ids);
+    crate::mtp_debug::arm_b11_layer0_capture();
+    let (logits, hidden) = model_forward_paged_inner(
+        backend,
+        token_ids,
+        weights,
+        config,
+        paged_cache,
+        block_table,
+        start_pos,
+        linear_state,
+        lora,
+        positions_gpu,
+        LmHeadMode::LastRowWithLastHidden,
+    )?;
+    Ok((
+        logits.expect("LmHeadMode::LastRowWithLastHidden always produces logits"),
+        hidden.expect("LmHeadMode::LastRowWithLastHidden always produces hidden"),
+    ))
+}
+
 /// Single-step native MTP (Multi-Token Prediction) forward pass.
 ///
 /// Implements the Qwen3-Next-style MTP head described in the vLLM reference
@@ -4371,6 +4410,10 @@ enum LmHeadMode {
     /// for MTP speculative verification at position 0 (draft comparison) and
     /// position 1 (bonus), plus `h_prev` for the next MTP step.
     FullWithLastHidden,
+    /// Compute the LM head over the final token only AND return the last-row
+    /// pre-final-norm hidden state. Used by MTP prefill, which only consumes
+    /// the next-token distribution for the prompt's final row.
+    LastRowWithLastHidden,
     /// Skip RMSNorm + LM head entirely and return `None`. Used for non-final
     /// tiles where the caller throws away the logits.
     Skip,
@@ -4563,6 +4606,18 @@ fn model_forward_paged_inner(
             let logits = {
                 kiln_nvtx::range!(c"kiln/lm_head");
                 let normed = rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?;
+                normed.broadcast_matmul(&weights.embed_tokens_t)?
+            };
+            Ok((Some(logits), Some(last_hidden)))
+        }
+        LmHeadMode::LastRowWithLastHidden => {
+            let last_hidden = hidden.narrow(1, seq_len - 1, 1)?.contiguous()?;
+            if crate::mtp_debug::is_h_main_capture_armed() {
+                let _ = crate::mtp_debug::capture_h_main_tap("h_pre_final_norm", &last_hidden);
+            }
+            let logits = {
+                kiln_nvtx::range!(c"kiln/lm_head");
+                let normed = rms_norm(&last_hidden, &weights.final_norm, config.rms_norm_eps)?;
                 normed.broadcast_matmul(&weights.embed_tokens_t)?
             };
             Ok((Some(logits), Some(last_hidden)))

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -17,8 +17,8 @@ use crate::backend::{self, BackendRuntime};
 use crate::cuda_graph::CudaGraphRunner;
 use crate::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
-    model_forward_paged_last_token, model_forward_paged_streaming,
-    model_forward_paged_with_last_hidden, streaming_prefill_enabled,
+    model_forward_paged_last_token, model_forward_paged_last_token_with_last_hidden,
+    model_forward_paged_streaming, streaming_prefill_enabled,
 };
 use crate::kv_cache::KvCache;
 use crate::lora_loader::LoraWeights;
@@ -1391,7 +1391,7 @@ impl ModelRunner {
         // the last-row pre-final-norm hidden as the seed `h_prev`. Streaming
         // prefill returns logits only, so MTP needs the dedicated path that
         // also yields hidden state.
-        let (prefill_logits, mut h_prev) = model_forward_paged_with_last_hidden(
+        let (prefill_logits, mut h_prev) = model_forward_paged_last_token_with_last_hidden(
             &*self.backend,
             prompt_tokens,
             &self.weights,
@@ -1406,10 +1406,8 @@ impl ModelRunner {
         .context("mtp prefill forward pass failed")?;
 
         // The last-row logits drive the first emitted token (same as the
-        // skip-layer path); slice to [1, V] for greedy_sample.
-        let prefill_last = prefill_logits
-            .narrow(1, prompt_tokens.len() - 1, 1)?
-            .squeeze(1)?;
+        // skip-layer path).
+        let prefill_last = prefill_logits.squeeze(1)?;
         let mut last_token = greedy_sample(&prefill_last)?;
 
         let mut base_pos = prompt_tokens.len();
@@ -1811,7 +1809,7 @@ impl ModelRunner {
         let (tx, rx) = mpsc::channel();
         let mut linear_state = self.new_linear_state()?;
 
-        let (prefill_logits, mut h_prev) = model_forward_paged_with_last_hidden(
+        let (prefill_logits, mut h_prev) = model_forward_paged_last_token_with_last_hidden(
             &*self.backend,
             &prompt_tokens,
             &self.weights,
@@ -1825,9 +1823,7 @@ impl ModelRunner {
         )
         .context("mtp prefill forward pass failed")?;
 
-        let prefill_last = prefill_logits
-            .narrow(1, prompt_tokens.len() - 1, 1)?
-            .squeeze(1)?;
+        let prefill_last = prefill_logits.squeeze(1)?;
         let mut last_token = greedy_sample(&prefill_last)?;
 
         let mut base_pos = prompt_tokens.len();


### PR DESCRIPTION
## Summary

This fixes the native MTP prefill path so it no longer computes full prompt-position logits through the large tied LM head when only the final prompt row is consumed.

- Add a paged forward mode that returns last-token logits plus the last-row pre-final-norm hidden state.
- Route both non-streaming and streaming MTP prefill through that mode.
- Keep the existing full-logits-with-hidden path for MTP verification, where two positions are still consumed.

## Impact

This is an MTP unblocker, not a default-on speedup. The old path projected every prompt row through the vocab head before MTP decode; the new path projects only the final prompt row and still returns `h_prev` for the MTP head.

A real-model smoke run on the desktop Qwen3.5-4B model now keeps MTP prefill around 13.1s for the 15-token benchmark prompt, instead of the prior catastrophic ~44.6s prefill failure mode seen before this patch. MTP decode remains slower than the default non-MTP path, so this does not make MTP suitable for default enablement yet.

## Validation

- `git diff --check`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model --lib --features metal mtp -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo test -p kiln-model test_model_forward_parity_cpu_vs_metal --features metal -- --test-threads=1 --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln/target cargo build -p kiln-server --bin kiln-bench --features metal --release`
- `KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp /Users/ericflo/Development/kiln/target/release/kiln-bench --model-path "$HOME/Library/Application Support/com.eflorenzano.kiln.desktop/models/Qwen__Qwen3.5-4B" --prompt-tokens 8 --max-output-tokens 1 --skip-training --paged`