### PR TITLE
desktop: notify when Copy/Save in log viewer fails

### DIFF
--- a/desktop/ui/logs.html
+++ b/desktop/ui/logs.html
@@ -244,6 +244,34 @@
       const invoke = (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
         || (window.__TAURI__ && window.__TAURI__.invoke);
 
+      const notificationApi = window.__TAURI__ && window.__TAURI__.notification;
+      async function notifyError(title, body) {
+        try {
+          if (notificationApi && typeof notificationApi.isPermissionGranted === "function") {
+            let granted = await notificationApi.isPermissionGranted();
+            if (!granted && typeof notificationApi.requestPermission === "function") {
+              const req = await notificationApi.requestPermission();
+              granted = req === "granted";
+            }
+            if (granted) {
+              await notificationApi.sendNotification({ title: title, body: body });
+            }
+            return;
+          }
+          if (!invoke) return;
+          let granted = await invoke("plugin:notification|is_permission_granted");
+          if (!granted) {
+            const req = await invoke("plugin:notification|request_permission");
+            granted = req === "granted";
+          }
+          if (granted) {
+            await invoke("plugin:notification|notify", { options: { title: title, body: body } });
+          }
+        } catch (_) {
+          // Notification is a best-effort surface; the button flash still fires.
+        }
+      }
+
       const logEl = document.getElementById("log");
       const autoscrollEl = document.getElementById("autoscroll");
       const clearEl = document.getElementById("clear");
@@ -274,6 +302,7 @@
             copyEl.textContent = "Copy";
             copyEl.classList.remove("flash-warn");
           }, 1800);
+          notifyError("Copy logs failed", String(err || "Unknown error"));
         }
       });
 
@@ -304,6 +333,7 @@
             saveEl.textContent = "Save…";
             saveEl.classList.remove("flash-warn");
           }, 2400);
+          notifyError("Save logs failed", String(err || "Unknown error"));
         }
       });
 


### PR DESCRIPTION
## What

Adds OS notifications to the two user-initiated invoke() sites in the log viewer (Copy to clipboard, Save to file). Previously these only flashed the button text for 1.8-2.4s; if the window was not focused the error was missed entirely.

## Why

Closes the last error-surfacing gaps on the logs window, matching PR #296 (dashboard Stop/Restart), PR #300 (updater), and PR #305 (Open Logs/Open Settings tray items). Per kiln-desktop-error-surface-symmetry — audit all equivalent surfaces when closing one silent-failure gap.

## How

- Copies the notifyError() helper from dashboard.html (notificationApi + invoke fallback paths) into logs.html.
- Calls notifyError(title, String(err)) from the Copy and Save catch blocks, keeping the existing button flash-warn intact so users who ARE watching still get instant feedback.
- Leaves the refresh() catch block alone — it already writes the error to logEl prominently.
- Leaves the Clear button alone — its catch is intentional fallback logic, not an error surface.