### PR TITLE
desktop: notify when About window Copy Diagnostics fails

### DIFF
--- a/desktop/ui/about.html
+++ b/desktop/ui/about.html
@@ -113,6 +113,34 @@
       const invoke = (window.__TAURI__ && window.__TAURI__.core && window.__TAURI__.core.invoke)
         || (window.__TAURI__ && window.__TAURI__.invoke);
 
+      const notificationApi = window.__TAURI__ && window.__TAURI__.notification;
+      async function notifyError(title, body) {
+        try {
+          if (notificationApi && typeof notificationApi.isPermissionGranted === "function") {
+            let granted = await notificationApi.isPermissionGranted();
+            if (!granted && typeof notificationApi.requestPermission === "function") {
+              const req = await notificationApi.requestPermission();
+              granted = req === "granted";
+            }
+            if (granted) {
+              await notificationApi.sendNotification({ title: title, body: body });
+            }
+            return;
+          }
+          if (!invoke) return;
+          let granted = await invoke("plugin:notification|is_permission_granted");
+          if (!granted) {
+            const req = await invoke("plugin:notification|request_permission");
+            granted = req === "granted";
+          }
+          if (granted) {
+            await invoke("plugin:notification|notify", { options: { title: title, body: body } });
+          }
+        } catch (_) {
+          // Notification is a best-effort surface; the button flash still fires.
+        }
+      }
+
       const versionEl = document.getElementById("version");
       const platformEl = document.getElementById("platform");
       const diag = {
@@ -183,7 +211,9 @@
           flashCopy("Copied!");
         } catch (err) {
           flashCopy("Copy failed");
+          const detail = String((err && err.message) || err || "Unknown error");
           console.error("clipboard.writeText failed", err);
+          notifyError("Copy diagnostics failed", detail);
         }
       });
 


### PR DESCRIPTION
## What
Add OS-level error notification when About > Copy diagnostic info fails.

## Why
about.html:185-188 currently logs clipboard failures only to console with a 1.2s button flash. This is the last uncovered clipboard surface in the desktop UI and matches the silent-failure pattern addressed by PR #262 (Copy OpenAI Base URL) and PR #310 (log viewer Copy/Save).

## How
- Add notifyError helper identical in shape to logs.html:247-274
- Extend the writeText catch to call notifyError after flashCopy so the user gets both the inline flash and an OS toast with the real error

## Test
Cargo check for Tauri crates is known to fail in Cloud Eric sessions (GTK/webkit2gtk missing per agent note kiln-desktop-cargo-check-syslibs). Change is pure HTML/JS mirroring an existing working pattern; CI validates the full build.