### PR TITLE
mtp: Phase C3 — fix RoPE position threading in MTP path (apply C2 verdict)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2906,12 +2906,17 @@ fn try_flash_attn_paged_decode(
                 num_kv_heads,
                 head_dim,
             )? {
+                // `flash_attention_forward` already reshapes to
+                // [batch, seq_len, num_heads * head_dim].
+                let _ = crate::mtp_debug::capture_subop("post_attn_raw", &attn_output);
+
                 let attn_output = if let Some(gate) = gate {
                     let sigmoid_gate = cuda_sigmoid(gate)?;
                     (attn_output * sigmoid_gate)?
                 } else {
                     attn_output
                 };
+                let _ = crate::mtp_debug::capture_subop("post_attn_gated", &attn_output);
 
                 let out = {
                     kiln_nvtx::range!(c"kiln/proj/o");
@@ -2922,6 +2927,7 @@ fn try_flash_attn_paged_decode(
                         lora_scale,
                     )?
                 };
+                let _ = crate::mtp_debug::capture_subop("post_o_proj", &out);
                 return Ok(Some(out));
             }
         }
@@ -3005,6 +3011,7 @@ fn try_flash_attn_paged_decode(
     // [batch, 1, num_heads * head_dim] for the gate / o_proj path.
     let _ = num_kv_heads; // unused — kept in signature for symmetry / future use
     let attn_output = attn_out.reshape((batch, 1usize, num_heads * head_dim))?;
+    let _ = crate::mtp_debug::capture_subop("post_attn_raw", &attn_output);
 
     let attn_output = if let Some(gate) = gate {
         let sigmoid_gate = cuda_sigmoid(gate)?;
@@ -3012,6 +3019,7 @@ fn try_flash_attn_paged_decode(
     } else {
         attn_output
     };
+    let _ = crate::mtp_debug::capture_subop("post_attn_gated", &attn_output);
 
     let out = {
         kiln_nvtx::range!(c"kiln/proj/o");
@@ -3022,6 +3030,7 @@ fn try_flash_attn_paged_decode(
             lora_scale,
         )?
     };
+    let _ = crate::mtp_debug::capture_subop("post_o_proj", &out);
     Ok(Some(out))
 }
 
@@ -4463,6 +4472,7 @@ pub fn mtp_forward_step(
                 &path,
                 draft_token_id,
                 mtp_pos,
+                base_pos,
                 swap_fc_norms,
                 &taps,
                 &extra_subops,

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -733,6 +733,7 @@ pub fn write_mtp_dump(
     path: &str,
     draft_token_id: u32,
     mtp_pos: usize,
+    base_pos: usize,
     swap_fc_norms: bool,
     taps: &[(&str, &Tensor)],
     extra_subops: &[(String, Vec<usize>, Vec<f32>)],
@@ -744,13 +745,13 @@ pub fn write_mtp_dump(
 
     // Materialize every tensor to a host byte buffer first so the
     // TensorViews we build below can borrow from a stable backing store.
-    // Capacity: static taps + subops + 3 meta + optional (prompt_tokens, len)
+    // Capacity: static taps + subops + 4 meta + optional (prompt_tokens, len)
     // + b11 taps + b12 taps.
     let prompt_reserve = if prompt_tokens.is_empty() { 0 } else { 2 };
     let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> = Vec::with_capacity(
         taps.len()
             + extra_subops.len()
-            + 3
+            + 4
             + prompt_reserve
             + b11_taps.len()
             + b12_taps.len(),
@@ -788,6 +789,17 @@ pub fn write_mtp_dump(
         vec![1],
         Dtype::I32,
         mpi.to_le_bytes().to_vec(),
+    ));
+    // Phase C3: emit absolute base position so the HF reference can compute
+    // `abs_pos = base_pos + mtp_pos` when applying RoPE inside the MTP inner
+    // block. Without this the reference used bare `mtp_pos` for RoPE, which
+    // diverged from kiln's absolute-position threading (PR #284 / Phase B8).
+    let bpi = base_pos as i32;
+    backings.push((
+        "meta__base_pos".into(),
+        vec![1],
+        Dtype::I32,
+        bpi.to_le_bytes().to_vec(),
     ));
     let swf = if swap_fc_norms { 1i32 } else { 0i32 };
     backings.push((
@@ -1087,6 +1099,7 @@ mod tests {
             &tmp_s,
             /* draft_token_id = */ 42,
             /* mtp_pos = */ 0,
+            /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
             &[("h_main", &a)],
             &[],
@@ -1142,6 +1155,7 @@ mod tests {
             &tmp_s,
             /* draft_token_id = */ 561,
             /* mtp_pos = */ 0,
+            /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
             &[("h_main", &a), ("mtp_logits", &b)],
             &[("post_q_proj".to_string(), vec![2], vec![0.1_f32, 0.2])],
@@ -1158,6 +1172,7 @@ mod tests {
         assert!(names.contains(&"mtp_logits"));
         assert!(names.contains(&"meta__draft_token_id"));
         assert!(names.contains(&"meta__mtp_pos"));
+        assert!(names.contains(&"meta__base_pos"));
         assert!(names.contains(&"meta__swap_fc_norms"));
         // With prompt_tokens = &[], neither the tensor nor its length meta
         // should be serialized.
@@ -1267,6 +1282,7 @@ mod tests {
             &tmp_s,
             /* draft_token_id = */ 99,
             /* mtp_pos = */ 0,
+            /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
             &[("h_main", &h)],
             &[],
@@ -1395,6 +1411,7 @@ mod tests {
             &tmp_s,
             /* draft_token_id = */ 77,
             /* mtp_pos = */ 0,
+            /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
             &[("h_main", &h)],
             &[],

--- a/scripts/mtp_reference_dump.py
+++ b/scripts/mtp_reference_dump.py
@@ -357,6 +357,7 @@ def mtp_inner_block(
     rotary_frac: float,
     eps: float,
     capture_subops: Optional[Dict[str, torch.Tensor]] = None,
+    base_pos: int = 0,
 ) -> torch.Tensor:
     """Single MTP transformer block with self-attention over exactly one
     position. `x` shape: `[1, 1, H]`. Returns `[1, 1, H]` (pre-final-norm).
@@ -373,6 +374,15 @@ def mtp_inner_block(
     tensor layouts at each tap match kiln's exactly so per-element comparison
     is meaningful — see in particular the per-head Q/gate narrow that
     replaces the older flat-half chunk.
+
+    Phase C3: RoPE on Q and K must use the *absolute* position
+    `abs_pos = base_pos + mtp_pos`, matching kiln's Phase B8 fix (PR #284).
+    `base_pos` is the sequence-absolute position of the token that was
+    emitted from the base model (i.e. the token the MTP head is drafting
+    a continuation for); `mtp_pos` is the local MTP-cache slot index. The
+    older reference used bare `mtp_pos`, which is wrong for any non-zero
+    base_pos and was the source of the post_q_rope/post_k_rope divergence
+    isolated by Phase C2 (PR #313).
     """
     cfg = w.config
     H = x.shape[-1]
@@ -446,8 +456,15 @@ def mtp_inner_block(
     # RoPE on rotary_dim prefix in the [B, S, H, D] layout — matches kiln's
     # `rotary_embedding_from_tensor` call site in forward.rs:2661-2666 (both
     # use half-rotate; see `apply_rope_partial` docstring above).
-    q = apply_rope_partial(q, mtp_pos, head_dim, rotary_dim, rope_theta)
-    k = apply_rope_partial(k, mtp_pos, head_dim, rotary_dim, rope_theta)
+    #
+    # Phase C3: rotate by `abs_pos = base_pos + mtp_pos`, not bare `mtp_pos`.
+    # Kiln's forward.rs passes `base_pos + mtp_pos` via the `positions`
+    # tensor in `mtp_forward_step` (see forward.rs ~line 4367 for the
+    # Phase B8 fix). The KV-cache write slot remains `mtp_pos`, but the
+    # rotary angle must track the absolute sequence position.
+    abs_pos = base_pos + mtp_pos
+    q = apply_rope_partial(q, abs_pos, head_dim, rotary_dim, rope_theta)
+    k = apply_rope_partial(k, abs_pos, head_dim, rotary_dim, rope_theta)
     _capture(capture_subops, "post_q_rope", q)
     _capture(capture_subops, "post_k_rope", k)
 
@@ -548,6 +565,12 @@ def main() -> int:
         default=None,
         help="Phase B7a sweep: override the mtp_pos used for RoPE without re-running kiln. Lets one kiln dump be replayed against the reference at different positions.",
     )
+    ap.add_argument(
+        "--base-pos-override",
+        type=int,
+        default=None,
+        help="Phase C3 sweep: override the base_pos (sequence-absolute position) without re-running kiln. RoPE uses `abs_pos = base_pos + mtp_pos`, so this lets one kiln dump be replayed with a different base offset.",
+    )
     args = ap.parse_args()
 
     print(f"[mtp_ref] loading kiln dump from {args.kiln_dump}", file=sys.stderr)
@@ -556,6 +579,11 @@ def main() -> int:
         assert name in kiln, f"kiln dump missing expected tap `{name}`"
     draft_token_id = kiln["meta__draft_token_id"]
     kiln_mtp_pos = int(kiln["meta__mtp_pos"])
+    # Phase C3: `meta__base_pos` is the absolute base-model position; RoPE
+    # uses `abs_pos = base_pos + mtp_pos`. Older kiln dumps (pre-C3) omit
+    # this field, so fall back to 0 for backward compatibility — that matches
+    # the pre-C3 reference behavior, which is wrong but non-regressive.
+    kiln_base_pos = int(kiln.get("meta__base_pos", 0))
     swap = kiln["meta__swap_fc_norms"]
     if args.mtp_pos_override is not None:
         mtp_pos = int(args.mtp_pos_override)
@@ -567,6 +595,18 @@ def main() -> int:
         mtp_pos = kiln_mtp_pos
         print(
             f"[mtp_ref] draft_token_id={draft_token_id} mtp_pos={mtp_pos} swap_fc_norms={swap}",
+            file=sys.stderr,
+        )
+    if args.base_pos_override is not None:
+        base_pos = int(args.base_pos_override)
+        print(
+            f"[mtp_ref] kiln_base_pos={kiln_base_pos} -> overridden base_pos={base_pos} (abs_pos={base_pos + mtp_pos})",
+            file=sys.stderr,
+        )
+    else:
+        base_pos = kiln_base_pos
+        print(
+            f"[mtp_ref] base_pos={base_pos} (abs_pos={base_pos + mtp_pos})",
             file=sys.stderr,
         )
 
@@ -616,6 +656,7 @@ def main() -> int:
         rotary_frac,
         args.rms_eps,
         capture_subops=capture_subops,
+        base_pos=base_pos,
     )
     if capture_subops is not None:
         print(
@@ -641,6 +682,9 @@ def main() -> int:
         "meta__draft_token_id": torch.tensor([int(draft_token_id)], dtype=torch.int32),
         "meta__mtp_pos": torch.tensor([int(mtp_pos)], dtype=torch.int32),
         "meta__kiln_mtp_pos": torch.tensor([int(kiln_mtp_pos)], dtype=torch.int32),
+        "meta__base_pos": torch.tensor([int(base_pos)], dtype=torch.int32),
+        "meta__kiln_base_pos": torch.tensor([int(kiln_base_pos)], dtype=torch.int32),
+        "meta__abs_pos": torch.tensor([int(base_pos + mtp_pos)], dtype=torch.int32),
         "meta__swap_fc_norms": torch.tensor([int(swap)], dtype=torch.int32),
         "meta__capture_subops": torch.tensor([int(args.capture_subops)], dtype=torch.int32),
     }


### PR DESCRIPTION
## Context
Phase C2 (PR #313) landed the bisect harness and confirmed the C2 verdict: the MTP inner block's RoPE call was fed only `mtp_pos` as the angle, not `abs_pos = base_pos + mtp_pos`. Kiln's Rust side already uses `abs_pos` for RoPE (via B8 PR #284) while keeping the KV-cache write slot = `mtp_pos`. The remaining gap was twofold:

1. The Python reference (`scripts/mtp_reference_dump.py`) was still using only `mtp_pos` for its RoPE angle — so kiln-vs-reference cos_sim on `post_q_rope`/`post_k_rope` degraded monotonically with `mtp_pos` even though kiln was doing the right thing.
2. `try_flash_attn_paged_decode` (the bf16 single-token GQA fast path) did not emit the `post_attn_raw`/`post_attn_gated`/`post_o_proj` sub-op taps under `KILN_MTP_DUMP_SUBOPS=1`, which meant the MTP bench could not be run end-to-end with sub-op capture.

## Change
1. `crates/kiln-model/src/forward.rs` — in both the contiguous-slot-run and paged fast-path arms of `try_flash_attn_paged_decode`, emit `post_attn_raw`/`post_attn_gated`/`post_o_proj` after the reshape / gate / o_proj steps, matching the semantics of the slow path. Gated by `KILN_MTP_DUMP_SUBOPS=1` via the existing `capture_subop` helper.
2. `crates/kiln-model/src/mtp_debug.rs` — extend `write_mtp_dump` to accept `base_pos: usize` and emit `meta__base_pos` (I32) in the dump. Update the 4 test callers with `base_pos = 0`.
3. `crates/kiln-model/src/forward.rs` — `mtp_forward_step` now passes `base_pos` into `write_mtp_dump`.
4. `scripts/mtp_reference_dump.py` — use `abs_pos = base_pos + mtp_pos` for the RoPE angle in `mtp_inner_block`, with backward-compat fallback when `meta__base_pos` is missing. Add `--base-pos-override` flag and emit `meta__base_pos` / `meta__kiln_base_pos` / `meta__abs_pos` in the reference dump.

## Verification (A6000 pod)

Built `kiln-bench` with CUDA features, then ran the three-position MTP harness with `KILN_MTP_DUMP_POS=0,1,2 KILN_MTP_DUMP_SUBOPS=1` and compared against the reference at each position.

**RoPE sub-op taps — target of the C2 verdict:**

| tap          | pos=0    | pos=1    | pos=2    |
| ------------ | -------- | -------- | -------- |
| post_q_rope  | 1.00e+00 | 1.00e+00 | 1.00e+00 |
| post_k_rope  | 1.00e+00 | 1.00e+00 | 1.00e+00 |

Before C3 (from PR #313's verification): post_q_rope/post_k_rope cos_sim was 0.922/0.935 at pos=1 and 0.834/lower at pos=2. After C3: cos_sim = 1.000 at all three positions. **The RoPE threading divergence is eliminated.**

**Downstream layer output:**

| tap          | pos=0        | pos=1        | pos=2        |
| ------------ | ------------ | ------------ | ------------ |
| post_layer   | 0.999987     | 0.993399     | 0.980906     |
| post_final_ln| 1.00e+00     | 9.93e-01     | 9.78e-01     |
| mtp_logits   | 1.00e+00     | 9.97e-01     | 9.80e-01     |

The residual `post_layer`/`mtp_logits` divergence at pos=1/pos=2 is NOT from RoPE. The comparator's B9 sub-op bisect flags it:
- **H3 zone** (gated-attn split semantics) — first canonical-order divergence
- **H2 zone** (qk-norm) likely inherits from H3

This scope belongs to a follow-up phase (C4 / target: gated-attn split), not C3. C3 correctly applied the C2 verdict: RoPE itself is now numerically clean across all MTP positions.

## Acceptance status
- ✅ `abs_pos = base_pos + mtp_pos` applied in the reference; kiln's Rust side already correct from B8/PR #284
- ✅ Sub-op taps `post_attn_raw`/`post_attn_gated`/`post_o_proj` emitted by `try_flash_attn_paged_decode` fast path behind `KILN_MTP_DUMP_SUBOPS=1`
- ✅ `post_q_rope` and `post_k_rope` cos_sim ≥ 0.999 at mtp_pos=0,1,2
- ⚠️ `post_layer` and `mtp_logits` cos_sim still <0.999 at pos=1,2 — residual H2/H3 divergence, out of scope for C3 (C2 verdict was RoPE-specific)

## Tests
Local CPU: `cargo nextest run` → 174/174 pass.
A6000 pod: `kiln-bench --paged` with MTP enabled + sub-op capture produced the table above.