### PR TITLE
desktop: notify when Dashboard Copy URL button fails

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -1025,10 +1025,12 @@
           } catch (err) {
             flashCopyBtn("Copy failed", "flash-warn");
             console.error("clipboard.writeText failed", err);
+            notifyError("Copy failed", "Could not write to clipboard: " + String(err || "Unknown error"));
           }
         } catch (err) {
           flashCopyBtn("Copy failed", "flash-warn");
           console.error("get_openai_base_url failed", err);
+          notifyError("Copy failed", "Could not get base URL: " + String(err || "Unknown error"));
         }
       }
 


### PR DESCRIPTION
## Gap
Dashboard Copy OpenAI base URL button (`desktop/ui/dashboard.html:1012-1033`, function `copyOpenAiBaseUrl`) silently eats clipboard errors — both catch blocks called only `flashCopyBtn` + `console.error`, no OS notification. PR #262 fixed the tray-menu equivalent; #312 fixed About Copy Diagnostics; #310 fixed logs Copy/Save. This is the last uncovered clipboard surface in the desktop UI.

## Change
Extend both catch blocks in `copyOpenAiBaseUrl` to call `notifyError` (existing helper at `dashboard.html:624`) in addition to the existing flash + console.error:
1. Inner clipboard catch — `notifyError("Copy failed", "Could not write to clipboard: " + ...)`
2. Outer `get_openai_base_url` catch — `notifyError("Copy failed", "Could not get base URL: " + ...)`

Success path and "Server not running" branch are unchanged (the latter is expected state, not an error).

## Local validation
`cd desktop && cargo check` fails in Cloud Eric sessions with missing GTK/webkit2gtk (known limitation — agent note `tauri-cargo-check-gtk-missing`):

```
The system library `glib-2.0` required by crate `glib-sys` was not found.
```

CI on `windows-latest` / `ubuntu-latest` validates real builds.