### PR TITLE
desktop: release v0.1.11

### DIFF
--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Kiln Desktop Changelog
 
+## desktop-v0.1.11 — 2026-04-21
+- Notify when the Dashboard Copy URL button fails (#315)
+- Notify when the About window Copy Diagnostics fails (#312)
+- Notify when Copy/Save in the log viewer fails (#310)
+- Notify when Open Logs / Open Settings invocations fail (#305)
+- Notify when Check for Updates or Install Update fails (#300)
+- Notify when dashboard Stop/Restart Server buttons fail (#296)
+- Notify when the launch-at-login toggle fails to apply (#292)
+- Notify when "Open Kiln UI in Browser" fails to launch the default browser (#285)
+- Notify tray Start/Stop/Restart synchronous errors (#277)
+- Keep desktop starting until health passes
+- Guard Settings Reload button against unsaved changes (#270)
+- Suppress spurious "Kiln server ready" toast on Training → Running transition (#264)
+- Notify on Copy OpenAI Base URL success + clipboard failure (#262)
+- Notify when Copy OpenAI Base URL clicked while server not running (#259)
+- Preflight tray Restart Server — notify when model_path unset / binary missing (#254)
+- Preflight tray Start Server when kiln binary missing (#252)
+- Preflight tray Start Server — notify + open Settings when model_path unset (#250)
+- Enrich About Copy diagnostic info with binary path, model path, and server state (#249)
+- Add Troubleshooting section covering binary download, model path, CUDA driver, ports, logs, uninstall (#248)
+- Add Screenshots section to `desktop/README.md` (#246)
+- Link `desktop/CHANGELOG.md` from root + desktop READMEs (#242)
+- Add CHANGELOG and auto-populate release notes (#239)
+- Refresh `desktop/README.md` to v0.1.10 (#236)
+
 ## desktop-v0.1.10 — 2026-04-20
 - Updater parses `supported_sm` from kiln release notes
 - Updater parses `min_cuda` and refuses to install when the local CUDA driver is too old

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-desktop"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kiln-desktop"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Kiln Desktop — system tray app for the kiln local LLM server"
 authors = ["Eric Florenzano <eric@eflorenzano.com>"]

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kiln Desktop",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "identifier": "com.eflorenzano.kiln.desktop",
   "build": {
     "frontendDist": "ui",


### PR DESCRIPTION
## Summary

Bumps kiln-desktop from 0.1.10 to 0.1.11 to ship the polish and error-notification symmetry work that landed on main after the v0.1.10 tag.

## Changes since v0.1.10

Re-derived from `git log desktop-v0.1.10..main --oneline -- desktop/`:

**Error-notification symmetry (April 21 batch):**
- #315 notify on Dashboard Copy URL button failure
- #312 notify on About window Copy Diagnostics failure
- #310 notify on log-viewer Copy/Save failure
- #305 notify on Open Logs / Open Settings failure
- #300 notify on Check/Install Update failure
- #296 notify on dashboard Stop/Restart Server failure
- #292 notify on launch-at-login toggle failure
- #285 notify on Open Kiln UI in Browser launch failure
- #277 notify tray Start/Stop/Restart synchronous errors

**Preflight + UI polish (April 20 batch):**
- Keep desktop starting until health passes
- #270 guard Settings Reload button against unsaved changes
- #264 suppress spurious server-ready toast on Training → Running
- #262 notify on Copy OpenAI Base URL success + clipboard failure
- #259 notify when Copy OpenAI Base URL clicked while server not running
- #254 preflight tray Restart Server
- #252 preflight tray Start Server (binary missing)
- #250 preflight tray Start Server (model_path unset)

**Docs:**
- #249 enrich About Copy diagnostic info
- #248 Troubleshooting section in desktop/README.md
- #246 Screenshots section in desktop/README.md
- #242 link desktop/CHANGELOG.md from root + READMEs
- #239 add CHANGELOG and auto-populate release notes
- #236 refresh desktop/README.md to v0.1.10

## Validation

- Local `cargo check` skipped (GTK / webkit2gtk missing in Cloud Eric sessions; see agent note `tauri-cargo-check-gtk-missing`)
- CI matrix (Linux AppImage + .deb, Windows MSI) validates full build

## Release

After merge, push tag `desktop-v0.1.11` to trigger the Build kiln-desktop workflow, then publish the resulting draft release with:

```
gh release edit desktop-v0.1.11 --repo ericflo/kiln --draft=false
```

(see note `kiln-desktop-release-draft-publish`).