### PR TITLE
mtp: Phase C8 — fix MTP SDPA kv_len mismatch (single-site)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3262,8 +3262,17 @@ pub fn gqa_attention_paged(
         }
     }
 
+    // Phase C8: when the MTP forward step has armed single-token
+    // self-attention, the MTP layer attends only to the just-computed K/V
+    // (kv_len = 1, no history). Skip the paged-cache write/read and the
+    // fused paged-decode kernel entirely so the per-step (k, v) above
+    // becomes the SDPA input. Cleared back to `false` by the matching
+    // `disarm_mtp_single_token_self_attn` in `mtp_forward_step`, so non-MTP
+    // attention calls on this thread are unaffected.
+    let single_token_self_attn = crate::mtp_debug::is_mtp_single_token_self_attn_armed();
+
     // Write new K/V into paged cache.
-    {
+    if !single_token_self_attn {
         kiln_nvtx::range!(c"kiln/kv/copy");
         paged_cache
             .write(full_attn_layer_idx, block_table, start_pos, &k, &v)
@@ -3281,7 +3290,10 @@ pub fn gqa_attention_paged(
     //   * Single sequence with physically contiguous block allocation
     //     (kiln's BlockManager allocates blocks in order from a free list, so
     //     a freshly-allocated single sequence is always contiguous)
+    //   * Phase C8: not in single-token self-attn mode (kernel reads the
+    //     full cache history, defeating the kv_len = 1 contract).
     if seq_len == 1
+        && !single_token_self_attn
         && !paged_cache.is_fp8()
         && (num_heads / num_kv_heads) > 1
         && std::env::var("KILN_DISABLE_FUSED_PAGED_DECODE").is_err()
@@ -3327,11 +3339,19 @@ pub fn gqa_attention_paged(
         None
     };
 
-    // Read full K/V from paged cache (all positions 0..start_pos+seq_len)
-    let (k, v) = paged_cache
-        .read(full_attn_layer_idx, block_table, total_seq_len)
-        .context("paged KV cache read failed")?;
-    let kv_len = total_seq_len;
+    // Read full K/V from paged cache (all positions 0..start_pos+seq_len).
+    // Phase C8: when single_token_self_attn is armed (MTP inner GQA call),
+    // attend only to the just-computed (k, v) — kv_len = 1, no cache read.
+    // This matches the Qwen3-Next MTP reference contract where the inner
+    // block performs single-token self-attention without a growing KV history.
+    let (k, v, kv_len) = if single_token_self_attn {
+        (k, v, 1usize)
+    } else {
+        let (k, v) = paged_cache
+            .read(full_attn_layer_idx, block_table, total_seq_len)
+            .context("paged KV cache read failed")?;
+        (k, v, total_seq_len)
+    };
 
     // Fused-attention path for prefill with existing prefix history
     // (`start_pos > 0`). Initial prefill is special-cased above so we do not
@@ -4453,6 +4473,17 @@ pub fn mtp_forward_step(
     //    per step is fine.
     let abs_pos = base_pos + mtp_pos;
     let positions = Tensor::new(&[abs_pos as f32][..], device)?;
+    // Phase C8: arm single-token self-attention for the MTP inner GQA call.
+    // The Qwen3-Next reference contract (see `scripts/mtp_reference_dump.py`
+    // and HF/vLLM `Qwen3NextMultiTokenPredictor`) runs the MTP inner
+    // attention as kv_len = 1 — Q·K^T is a 1×1 scalar, softmax = 1.0,
+    // attn_out = V. Phase C7 (PR #319) localized the mtp_pos > 0
+    // attn_out divergence to kiln attending over the growing MTP paged
+    // cache (kv_len = mtp_pos + 1) instead of single-token self-attn.
+    // Arming this flag flips `gqa_attention_paged` onto the per-step
+    // K/V scratch path for the MTP layer only; the disarm below clears
+    // it before any non-MTP attention path on this thread can observe it.
+    crate::mtp_debug::arm_mtp_single_token_self_attn();
     let mtp_hidden_result = transformer_block_paged(
         backend,
         &fused,
@@ -4471,6 +4502,9 @@ pub fn mtp_forward_step(
         /* full_attn_layer_idx = */ 0,
         /* lora = */ None,
     );
+    // Always disarm in both success and error paths (`mtp_hidden_result`
+    // is `?`-propagated below, so we cannot rely on the function tail).
+    crate::mtp_debug::disarm_mtp_single_token_self_attn();
 
     // Drain the sub-op capture window in BOTH success and error paths so the
     // TLS slot is not left armed for the next draft step (which would corrupt

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -137,6 +137,19 @@ thread_local! {
     /// so production decode pays zero cost.
     static C7_SDPA_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
         const { RefCell::new(None) };
+
+    /// Phase C8: thread-local flag that switches the MTP inner GQA attention
+    /// to single-token self-attention (kv_len = 1, no paged-cache history).
+    /// Set by [`arm_mtp_single_token_self_attn`] inside `mtp_forward_step`
+    /// and cleared by [`disarm_mtp_single_token_self_attn`] right after the
+    /// inner block returns. Read by `gqa_attention_paged` to:
+    ///   * Skip the paged KV cache write/read for the MTP layer
+    ///   * Bypass the fused paged-decode flash-attention kernel (which would
+    ///     attend over the entire MTP cache history, defeating the fix)
+    /// Always defaults to `false`, so non-MTP paths and pre-C8 callers see
+    /// the legacy paged-cache behavior unchanged.
+    static MTP_SINGLE_TOKEN_SELF_ATTN_ARMED: RefCell<bool> =
+        const { RefCell::new(false) };
 }
 
 const DEFAULT_MAX_CALLS: usize = 16;
@@ -843,6 +856,40 @@ pub fn arm_c7_sdpa_capture() {
 /// recorded since the matching [`arm_c7_sdpa_capture`] call, in order.
 pub fn drain_c7_sdpa_capture() -> Vec<(String, Vec<usize>, Vec<f32>)> {
     C7_SDPA_CAPTURE.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+/// Phase C8: returns true when the current thread is executing inside an
+/// `mtp_forward_step` call that has armed single-token self-attention for
+/// the MTP inner block. `gqa_attention_paged` checks this to:
+///   * Skip the paged KV cache write (the cache is never read in this mode)
+///   * Skip the paged KV cache read (use per-step K/V scratch directly)
+///   * Bypass the fused paged-decode flash-attention kernel (which reads
+///     over the full cache history, defeating the kv_len=1 contract)
+///
+/// This implements the Phase C8 fix for the MTP SDPA kv_len mismatch
+/// localized in Phase C7. The Qwen3-Next reference contract — see
+/// `scripts/mtp_reference_dump.py` and the HF / vLLM
+/// `Qwen3NextMultiTokenPredictor` — runs the MTP inner attention as a
+/// single-token self-attention over the just-fused hidden state: Q·K^T
+/// yields a 1×1 scalar, softmax = 1.0, and the output equals V.
+pub fn is_mtp_single_token_self_attn_armed() -> bool {
+    MTP_SINGLE_TOKEN_SELF_ATTN_ARMED.with(|c| *c.borrow())
+}
+
+/// Arm single-token self-attention for the MTP inner block on this thread.
+/// Idempotent within a single `mtp_forward_step` call; the matching
+/// [`disarm_mtp_single_token_self_attn`] is required and runs in both the
+/// success and the early-error paths inside `mtp_forward_step`.
+pub fn arm_mtp_single_token_self_attn() {
+    MTP_SINGLE_TOKEN_SELF_ATTN_ARMED.with(|c| *c.borrow_mut() = true);
+}
+
+/// Disarm single-token self-attention for the MTP inner block on this
+/// thread. Always runs after the inner block returns (success or error)
+/// so the next `mtp_forward_step` call (or any non-MTP attention call on
+/// this thread) sees the legacy paged-cache behavior.
+pub fn disarm_mtp_single_token_self_attn() {
+    MTP_SINGLE_TOKEN_SELF_ATTN_ARMED.with(|c| *c.borrow_mut() = false);
 }
 
 /// Record one named SDPA-internal tap if a capture window is currently

--- a/docs/phase-c8/c6_after_fix.txt
+++ b/docs/phase-c8/c6_after_fix.txt
@@ -1,0 +1,379 @@
+MTP numerical bisect — mode: pre-RoPE MTP input bisect (C6), atol=0.001, rtol=0.01
+
+=== mtp_pos=1_seed42 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed42_pos1.st
+  ref  dump : /workspace/c8_ref/ref_seed42_pos1.st
+Metadata:
+  meta__draft_token_id: kiln=2912 ref=2912 [OK]
+  meta__mtp_pos: kiln=1 ref=1 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=1 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   1.79e-02     7.04e-04    
+fc_output              1x1x2560               True     False    1.00e+00   4.44e-03     6.31e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   4.44e-03     6.31e-04    
+post_layer             1x1x2560               True     False    1.00e+00   3.38e-02     3.19e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   1.74e-01     2.00e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   1.06e-01     1.92e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   3.56e-02     3.32e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   5.25e-02     4.64e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   2.26e-02     3.29e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   4.10e-02     5.63e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   5.25e-02     4.64e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   5.25e-02     3.25e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   5.25e-02     3.25e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   4.44e-02     6.03e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   4.44e-02     6.03e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   5.25e-02     3.25e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   2.26e-02     3.29e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   6.19e-02     3.91e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   3.24e-02     5.37e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   6.19e-02     3.91e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   3.24e-02     5.37e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   6.19e-02     3.99e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   3.41e-02     5.44e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   4.10e-02     5.63e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   5.49e-02     1.63e-03    
+post_o_proj            1x1x2560               True     False    1.00e+00   1.05e-02     1.53e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   1.05e-02     1.53e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   1.46e-02     1.74e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   6.39e-02     5.82e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   3.40e-02     2.60e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   7.68e-03     6.85e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   1.79e-02     7.24e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   1.79e-02     7.04e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   4.44e-03     6.31e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   6.19e-02     3.99e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   3.41e-02     5.44e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   4.10e-02     5.63e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   6.65e-02     3.59e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   4.10e-02     5.63e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+=== mtp_pos=2_seed42 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed42_pos2.st
+  ref  dump : /workspace/c8_ref/ref_seed42_pos2.st
+Metadata:
+  meta__draft_token_id: kiln=33 ref=33 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=2 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   3.01e-02     7.03e-04    
+fc_output              1x1x2560               True     False    1.00e+00   7.34e-03     6.17e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   7.34e-03     6.17e-04    
+post_layer             1x1x2560               True     False    1.00e+00   6.03e-02     3.35e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   1.62e-01     2.61e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   1.47e-01     3.01e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   3.66e-02     3.47e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   8.18e-02     5.08e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   3.20e-02     3.60e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   6.93e-02     6.61e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   8.18e-02     5.08e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   8.18e-02     3.41e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   8.18e-02     3.41e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   5.37e-02     6.74e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   5.37e-02     6.74e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   8.18e-02     3.41e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   3.20e-02     3.60e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   4.60e-02     4.06e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   3.89e-02     5.39e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   4.60e-02     4.06e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   3.89e-02     5.39e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   4.64e-02     4.16e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   3.89e-02     5.40e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   6.93e-02     6.61e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   3.47e-02     1.47e-03    
+post_o_proj            1x1x2560               True     False    1.00e+00   1.31e-02     1.64e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   1.31e-02     1.64e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   2.04e-02     1.82e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   4.93e-02     6.47e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   6.51e-02     2.98e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   7.76e-03     6.56e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   3.01e-02     7.49e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   3.01e-02     7.03e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   7.34e-03     6.17e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   4.64e-02     4.16e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   3.89e-02     5.40e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   6.93e-02     6.61e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   8.71e-02     2.75e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   6.93e-02     6.61e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+=== mtp_pos=1_seed43 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed43_pos1.st
+  ref  dump : /workspace/c8_ref/ref_seed43_pos1.st
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=1 ref=1 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=1 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   1.57e-02     7.25e-04    
+fc_output              1x1x2560               True     False    1.00e+00   7.48e-03     5.93e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   7.48e-03     5.93e-04    
+post_layer             1x1x2560               True     False    1.00e+00   5.45e-02     2.10e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   2.31e-01     1.41e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   1.04e-01     1.23e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   3.02e-02     3.14e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   5.75e-02     4.26e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   3.44e-02     3.09e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   4.65e-02     5.76e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   5.75e-02     4.26e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   5.75e-02     2.97e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   5.75e-02     2.97e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   4.61e-02     5.56e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   4.61e-02     5.56e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   5.75e-02     2.97e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   3.44e-02     3.09e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   4.38e-02     4.16e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   3.67e-02     5.25e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   4.38e-02     4.16e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   3.67e-02     5.25e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   4.38e-02     4.24e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   3.67e-02     5.32e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   4.65e-02     5.76e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   2.71e-02     1.15e-03    
+post_o_proj            1x1x2560               True     False    1.00e+00   4.54e-02     1.25e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   4.54e-02     1.25e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   2.70e-02     1.49e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   6.09e-02     3.92e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   1.37e-02     1.65e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   7.48e-03     6.79e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   1.57e-02     7.72e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   1.57e-02     7.25e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   7.48e-03     5.93e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   4.38e-02     4.24e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   3.67e-02     5.32e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   4.65e-02     5.76e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   7.21e-02     2.77e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   4.65e-02     5.76e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+=== mtp_pos=2_seed43 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed43_pos2.st
+  ref  dump : /workspace/c8_ref/ref_seed43_pos2.st
+Metadata:
+  meta__draft_token_id: kiln=919 ref=919 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=2 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   7.66e-03     7.35e-04    
+fc_output              1x1x2560               True     False    1.00e+00   5.07e-03     6.34e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   5.07e-03     6.34e-04    
+post_layer             1x1x2560               True     False    1.00e+00   1.89e-02     2.17e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   1.52e-01     1.55e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   9.18e-02     1.14e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   4.35e-02     3.01e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   4.01e-02     3.64e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   2.13e-02     2.77e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   4.04e-02     5.37e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   4.01e-02     3.64e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   3.03e-02     2.56e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   3.03e-02     2.56e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   4.01e-02     4.72e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   4.01e-02     4.72e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   3.03e-02     2.56e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   2.13e-02     2.77e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   4.06e-02     3.47e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   4.46e-02     4.91e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   4.06e-02     3.47e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   4.46e-02     4.91e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   4.12e-02     3.57e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   4.46e-02     4.99e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   4.04e-02     5.37e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   2.58e-02     9.65e-04    
+post_o_proj            1x1x2560               True     False    1.00e+00   2.21e-02     1.03e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   2.21e-02     1.03e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   2.19e-02     1.33e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   4.85e-02     4.46e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   1.43e-02     1.71e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   5.43e-03     6.64e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   7.66e-03     8.06e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   7.66e-03     7.35e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   5.07e-03     6.34e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   4.12e-02     3.57e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   4.46e-02     4.99e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   4.04e-02     5.37e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   5.32e-02     2.15e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   4.04e-02     5.37e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+=== mtp_pos=1_seed44 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed44_pos1.st
+  ref  dump : /workspace/c8_ref/ref_seed44_pos1.st
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=1 ref=1 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=1 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   1.36e-02     7.18e-04    
+fc_output              1x1x2560               True     False    1.00e+00   1.08e-02     6.03e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   1.08e-02     6.03e-04    
+post_layer             1x1x2560               True     False    1.00e+00   4.12e-02     2.76e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   2.63e-01     1.78e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   9.92e-02     1.44e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   3.49e-02     3.08e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   7.81e-02     4.37e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   5.17e-02     3.52e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   5.36e-02     5.40e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   7.81e-02     4.37e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   7.81e-02     3.20e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   7.81e-02     3.20e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   5.73e-02     5.54e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   5.73e-02     5.54e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   7.81e-02     3.20e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   5.17e-02     3.52e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   4.19e-02     3.54e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   5.24e-02     4.94e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   4.19e-02     3.54e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   5.24e-02     4.94e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   5.18e-02     3.64e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   5.24e-02     4.95e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   5.36e-02     5.40e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   6.64e-02     1.05e-03    
+post_o_proj            1x1x2560               True     False    1.00e+00   2.00e-02     1.38e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   2.00e-02     1.38e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   4.64e-02     1.56e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   7.02e-02     5.51e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   4.56e-02     2.37e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   7.53e-03     6.65e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   1.36e-02     7.70e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   1.36e-02     7.18e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   1.08e-02     6.03e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   5.18e-02     3.64e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   5.24e-02     4.95e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   5.36e-02     5.40e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   4.01e-02     2.63e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   5.36e-02     5.40e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+=== mtp_pos=2_seed44 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed44_pos2.st
+  ref  dump : /workspace/c8_ref/ref_seed44_pos2.st
+Metadata:
+  meta__draft_token_id: kiln=68387 ref=68387 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=2 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   1.46e-02     7.25e-04    
+fc_output              1x1x2560               True     False    1.00e+00   1.60e-02     6.29e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   1.60e-02     6.29e-04    
+post_layer             1x1x2560               True     False    1.00e+00   1.43e-02     2.69e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   9.56e-02     1.89e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   9.29e-02     1.25e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   2.83e-02     2.95e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   5.04e-02     3.84e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   4.35e-02     2.95e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   4.58e-02     5.53e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   5.04e-02     3.84e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   5.04e-02     2.76e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   5.04e-02     2.76e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   4.06e-02     4.93e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   4.06e-02     4.93e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   5.04e-02     2.76e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   4.35e-02     2.95e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   5.56e-02     3.51e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   4.07e-02     4.80e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   5.56e-02     3.51e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   4.07e-02     4.80e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   5.57e-02     3.56e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   4.07e-02     4.82e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   4.58e-02     5.53e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   4.51e-02     9.98e-04    
+post_o_proj            1x1x2560               True     False    1.00e+00   1.26e-02     1.12e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   1.26e-02     1.12e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   2.78e-02     1.35e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   9.37e-02     5.05e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   1.97e-02     2.32e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   3.98e-03     6.60e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   1.46e-02     7.91e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   1.46e-02     7.25e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   1.60e-02     6.29e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   5.57e-02     3.56e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   4.07e-02     4.82e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   4.58e-02     5.53e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   4.82e-02     2.10e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   4.58e-02     5.53e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+==============================================================================
+Phase C6 pre-RoPE MTP input bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap           pos=mtp_pos=1_seed42                                 pos=mtp_pos=2_seed42                                 pos=mtp_pos=1_seed43                                 pos=mtp_pos=2_seed43                                 pos=mtp_pos=1_seed44                                 pos=mtp_pos=2_seed44                                
+  -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  token_emb     cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok 
+  norm_emb      cos=1.00e+00   max|Δ|=7.68e-03   mean|Δ|=6.85e-04   rel_l2=1.71e-03   ok  cos=1.00e+00   max|Δ|=7.76e-03   mean|Δ|=6.56e-04   rel_l2=1.66e-03   ok  cos=1.00e+00   max|Δ|=7.48e-03   mean|Δ|=6.79e-04   rel_l2=1.63e-03   ok  cos=1.00e+00   max|Δ|=5.43e-03   mean|Δ|=6.64e-04   rel_l2=1.61e-03   ok  cos=1.00e+00   max|Δ|=7.53e-03   mean|Δ|=6.65e-04   rel_l2=1.60e-03   ok  cos=1.00e+00   max|Δ|=3.98e-03   mean|Δ|=6.60e-04   rel_l2=1.61e-03   ok 
+  norm_h        cos=1.00e+00   max|Δ|=1.79e-02   mean|Δ|=7.24e-04   rel_l2=1.76e-03   ok  cos=1.00e+00   max|Δ|=3.01e-02   mean|Δ|=7.49e-04   rel_l2=1.62e-03   ok  cos=1.00e+00   max|Δ|=1.57e-02   mean|Δ|=7.72e-04   rel_l2=1.70e-03   ok  cos=1.00e+00   max|Δ|=7.66e-03   mean|Δ|=8.06e-04   rel_l2=1.62e-03   ok  cos=1.00e+00   max|Δ|=1.36e-02   mean|Δ|=7.70e-04   rel_l2=1.59e-03   ok  cos=1.00e+00   max|Δ|=1.46e-02   mean|Δ|=7.91e-04   rel_l2=1.68e-03   ok 
+  concat        cos=1.00e+00   max|Δ|=1.79e-02   mean|Δ|=7.04e-04   rel_l2=1.74e-03   ok  cos=1.00e+00   max|Δ|=3.01e-02   mean|Δ|=7.03e-04   rel_l2=1.63e-03   ok  cos=1.00e+00   max|Δ|=1.57e-02   mean|Δ|=7.25e-04   rel_l2=1.67e-03   ok  cos=1.00e+00   max|Δ|=7.66e-03   mean|Δ|=7.35e-04   rel_l2=1.62e-03   ok  cos=1.00e+00   max|Δ|=1.36e-02   mean|Δ|=7.18e-04   rel_l2=1.59e-03   ok  cos=1.00e+00   max|Δ|=1.46e-02   mean|Δ|=7.25e-04   rel_l2=1.65e-03   ok 
+  fused         cos=1.00e+00   max|Δ|=4.44e-03   mean|Δ|=6.31e-04   rel_l2=2.99e-03   ok  cos=1.00e+00   max|Δ|=7.34e-03   mean|Δ|=6.17e-04   rel_l2=3.17e-03   ok  cos=1.00e+00   max|Δ|=7.48e-03   mean|Δ|=5.93e-04   rel_l2=2.81e-03   ok  cos=1.00e+00   max|Δ|=5.07e-03   mean|Δ|=6.34e-04   rel_l2=2.71e-03   ok  cos=1.00e+00   max|Δ|=1.08e-02   mean|Δ|=6.03e-04   rel_l2=2.89e-03   ok  cos=1.00e+00   max|Δ|=1.60e-02   mean|Δ|=6.29e-04   rel_l2=2.79e-03   ok 
+
+Phase C6 verdict: ALL pre-RoPE taps match within cos_sim >= 0.9999.
+  -> Pre-RoPE input is NOT the dominant source of drift at this bar.
+  -> Look downstream of `fused` (RoPE / attention / final_layernorm)
+     and/or re-check the abs_pos threading in the MTP block.
+
+Overall verdict: divergence(s) at: ['fc_output', 'fc_output', 'fc_output', 'fc_output', 'fc_output', 'fc_output']

--- a/docs/phase-c8/c7_after_fix.txt
+++ b/docs/phase-c8/c7_after_fix.txt
@@ -1,0 +1,381 @@
+MTP numerical bisect — mode: SDPA-internal bisect (C7), atol=0.001, rtol=0.01
+
+=== mtp_pos=1_seed42 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed42_pos1.st
+  ref  dump : /workspace/c8_ref/ref_seed42_pos1.st
+Metadata:
+  meta__draft_token_id: kiln=2912 ref=2912 [OK]
+  meta__mtp_pos: kiln=1 ref=1 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=1 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   1.79e-02     7.04e-04    
+fc_output              1x1x2560               True     False    1.00e+00   4.44e-03     6.31e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   4.44e-03     6.31e-04    
+post_layer             1x1x2560               True     False    1.00e+00   3.38e-02     3.19e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   1.74e-01     2.00e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   1.06e-01     1.92e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   3.56e-02     3.32e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   5.25e-02     4.64e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   2.26e-02     3.29e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   4.10e-02     5.63e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   5.25e-02     4.64e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   5.25e-02     3.25e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   5.25e-02     3.25e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   4.44e-02     6.03e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   4.44e-02     6.03e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   5.25e-02     3.25e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   2.26e-02     3.29e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   6.19e-02     3.91e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   3.24e-02     5.37e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   6.19e-02     3.91e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   3.24e-02     5.37e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   6.19e-02     3.99e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   3.41e-02     5.44e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   4.10e-02     5.63e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   5.49e-02     1.63e-03    
+post_o_proj            1x1x2560               True     False    1.00e+00   1.05e-02     1.53e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   1.05e-02     1.53e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   1.46e-02     1.74e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   6.39e-02     5.82e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   3.40e-02     2.60e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   7.68e-03     6.85e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   1.79e-02     7.24e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   1.79e-02     7.04e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   4.44e-03     6.31e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   6.19e-02     3.99e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   3.41e-02     5.44e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   4.10e-02     5.63e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   6.65e-02     3.59e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   4.10e-02     5.63e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+=== mtp_pos=2_seed42 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed42_pos2.st
+  ref  dump : /workspace/c8_ref/ref_seed42_pos2.st
+Metadata:
+  meta__draft_token_id: kiln=33 ref=33 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=2 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   3.01e-02     7.03e-04    
+fc_output              1x1x2560               True     False    1.00e+00   7.34e-03     6.17e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   7.34e-03     6.17e-04    
+post_layer             1x1x2560               True     False    1.00e+00   6.03e-02     3.35e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   1.62e-01     2.61e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   1.47e-01     3.01e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   3.66e-02     3.47e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   8.18e-02     5.08e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   3.20e-02     3.60e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   6.93e-02     6.61e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   8.18e-02     5.08e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   8.18e-02     3.41e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   8.18e-02     3.41e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   5.37e-02     6.74e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   5.37e-02     6.74e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   8.18e-02     3.41e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   3.20e-02     3.60e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   4.60e-02     4.06e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   3.89e-02     5.39e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   4.60e-02     4.06e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   3.89e-02     5.39e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   4.64e-02     4.16e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   3.89e-02     5.40e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   6.93e-02     6.61e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   3.47e-02     1.47e-03    
+post_o_proj            1x1x2560               True     False    1.00e+00   1.31e-02     1.64e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   1.31e-02     1.64e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   2.04e-02     1.82e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   4.93e-02     6.47e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   6.51e-02     2.98e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   7.76e-03     6.56e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   3.01e-02     7.49e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   3.01e-02     7.03e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   7.34e-03     6.17e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   4.64e-02     4.16e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   3.89e-02     5.40e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   6.93e-02     6.61e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   8.71e-02     2.75e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   6.93e-02     6.61e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+=== mtp_pos=1_seed43 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed43_pos1.st
+  ref  dump : /workspace/c8_ref/ref_seed43_pos1.st
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=1 ref=1 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=1 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   1.57e-02     7.25e-04    
+fc_output              1x1x2560               True     False    1.00e+00   7.48e-03     5.93e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   7.48e-03     5.93e-04    
+post_layer             1x1x2560               True     False    1.00e+00   5.45e-02     2.10e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   2.31e-01     1.41e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   1.04e-01     1.23e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   3.02e-02     3.14e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   5.75e-02     4.26e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   3.44e-02     3.09e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   4.65e-02     5.76e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   5.75e-02     4.26e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   5.75e-02     2.97e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   5.75e-02     2.97e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   4.61e-02     5.56e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   4.61e-02     5.56e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   5.75e-02     2.97e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   3.44e-02     3.09e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   4.38e-02     4.16e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   3.67e-02     5.25e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   4.38e-02     4.16e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   3.67e-02     5.25e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   4.38e-02     4.24e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   3.67e-02     5.32e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   4.65e-02     5.76e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   2.71e-02     1.15e-03    
+post_o_proj            1x1x2560               True     False    1.00e+00   4.54e-02     1.25e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   4.54e-02     1.25e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   2.70e-02     1.49e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   6.09e-02     3.92e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   1.37e-02     1.65e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   7.48e-03     6.79e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   1.57e-02     7.72e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   1.57e-02     7.25e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   7.48e-03     5.93e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   4.38e-02     4.24e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   3.67e-02     5.32e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   4.65e-02     5.76e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   7.21e-02     2.77e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   4.65e-02     5.76e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+=== mtp_pos=2_seed43 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed43_pos2.st
+  ref  dump : /workspace/c8_ref/ref_seed43_pos2.st
+Metadata:
+  meta__draft_token_id: kiln=919 ref=919 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=2 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   7.66e-03     7.35e-04    
+fc_output              1x1x2560               True     False    1.00e+00   5.07e-03     6.34e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   5.07e-03     6.34e-04    
+post_layer             1x1x2560               True     False    1.00e+00   1.89e-02     2.17e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   1.52e-01     1.55e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   9.18e-02     1.14e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   4.35e-02     3.01e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   4.01e-02     3.64e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   2.13e-02     2.77e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   4.04e-02     5.37e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   4.01e-02     3.64e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   3.03e-02     2.56e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   3.03e-02     2.56e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   4.01e-02     4.72e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   4.01e-02     4.72e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   3.03e-02     2.56e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   2.13e-02     2.77e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   4.06e-02     3.47e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   4.46e-02     4.91e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   4.06e-02     3.47e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   4.46e-02     4.91e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   4.12e-02     3.57e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   4.46e-02     4.99e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   4.04e-02     5.37e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   2.58e-02     9.65e-04    
+post_o_proj            1x1x2560               True     False    1.00e+00   2.21e-02     1.03e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   2.21e-02     1.03e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   2.19e-02     1.33e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   4.85e-02     4.46e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   1.43e-02     1.71e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   5.43e-03     6.64e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   7.66e-03     8.06e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   7.66e-03     7.35e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   5.07e-03     6.34e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   4.12e-02     3.57e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   4.46e-02     4.99e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   4.04e-02     5.37e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   5.32e-02     2.15e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   4.04e-02     5.37e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+=== mtp_pos=1_seed44 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed44_pos1.st
+  ref  dump : /workspace/c8_ref/ref_seed44_pos1.st
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=1 ref=1 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=1 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   1.36e-02     7.18e-04    
+fc_output              1x1x2560               True     False    1.00e+00   1.08e-02     6.03e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   1.08e-02     6.03e-04    
+post_layer             1x1x2560               True     False    1.00e+00   4.12e-02     2.76e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   2.63e-01     1.78e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   9.92e-02     1.44e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   3.49e-02     3.08e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   7.81e-02     4.37e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   5.17e-02     3.52e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   5.36e-02     5.40e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   7.81e-02     4.37e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   7.81e-02     3.20e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   7.81e-02     3.20e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   5.73e-02     5.54e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   5.73e-02     5.54e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   7.81e-02     3.20e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   5.17e-02     3.52e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   4.19e-02     3.54e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   5.24e-02     4.94e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   4.19e-02     3.54e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   5.24e-02     4.94e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   5.18e-02     3.64e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   5.24e-02     4.95e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   5.36e-02     5.40e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   6.64e-02     1.05e-03    
+post_o_proj            1x1x2560               True     False    1.00e+00   2.00e-02     1.38e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   2.00e-02     1.38e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   4.64e-02     1.56e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   7.02e-02     5.51e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   4.56e-02     2.37e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   7.53e-03     6.65e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   1.36e-02     7.70e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   1.36e-02     7.18e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   1.08e-02     6.03e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   5.18e-02     3.64e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   5.24e-02     4.95e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   5.36e-02     5.40e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   4.01e-02     2.63e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   5.36e-02     5.40e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+=== mtp_pos=2_seed44 ===
+  kiln dump : /workspace/c8_kiln/kiln_seed44_pos2.st
+  ref  dump : /workspace/c8_ref/ref_seed44_pos2.st
+Metadata:
+  meta__draft_token_id: kiln=68387 ref=68387 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=0 [OK]
+  meta__kiln_mtp_pos: kiln=<missing> ref=2 [MISMATCH]
+  meta__capture_subops: kiln=<missing> ref=1 [MISMATCH]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+tok_embed              1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+fc_input               1x1x5120               True     True     1.00e+00   1.46e-02     7.25e-04    
+fc_output              1x1x2560               True     False    1.00e+00   1.60e-02     6.29e-04    
+pre_layer              1x1x2560               True     False    1.00e+00   1.60e-02     6.29e-04    
+post_layer             1x1x2560               True     False    1.00e+00   1.43e-02     2.69e-03    
+post_final_ln          1x1x2560               True     False    1.00e+00   9.56e-02     1.89e-02    
+mtp_logits             1x1x248320             True     False    1.00e+00   9.29e-02     1.25e-02    
+post_pre_attn_norm     1x1x2560               True     False    1.00e+00   2.83e-02     2.95e-03    
+post_q_proj_raw        1x1x8192               True     False    1.00e+00   5.04e-02     3.84e-03    
+post_k_proj            1x1x1024               True     False    1.00e+00   4.35e-02     2.95e-03    
+post_v_proj            1x1x1024               True     False    1.00e+00   4.58e-02     5.53e-03    
+pre_gated_attn_split   1x1x8192               True     False    1.00e+00   5.04e-02     3.84e-03    
+post_q_split           1x1x16x256             True     False    1.00e+00   5.04e-02     2.76e-03    
+post_gated_attn_split_value 1x1x16x256             True     False    1.00e+00   5.04e-02     2.76e-03    
+post_gate_split        1x1x4096               True     False    1.00e+00   4.06e-02     4.93e-03    
+post_gated_attn_split_gate 1x1x4096               True     False    1.00e+00   4.06e-02     4.93e-03    
+pre_qk_norm_q          1x1x16x256             True     False    1.00e+00   5.04e-02     2.76e-03    
+pre_qk_norm_k          1x1x4x256              True     False    1.00e+00   4.35e-02     2.95e-03    
+post_q_norm            1x1x16x256             True     False    1.00e+00   5.56e-02     3.51e-03    
+post_k_norm            1x1x4x256              True     False    1.00e+00   4.07e-02     4.80e-03    
+post_qk_norm_q         1x1x16x256             True     False    1.00e+00   5.56e-02     3.51e-03    
+post_qk_norm_k         1x1x4x256              True     False    1.00e+00   4.07e-02     4.80e-03    
+post_q_rope            1x1x16x256             True     False    1.00e+00   5.57e-02     3.56e-03    
+post_k_rope            1x1x4x256              True     False    1.00e+00   4.07e-02     4.82e-03    
+post_attn_raw          1x1x4096               True     False    1.00e+00   4.58e-02     5.53e-03    
+post_attn_gated        1x1x4096               True     False    1.00e+00   4.51e-02     9.98e-04    
+post_o_proj            1x1x2560               True     False    1.00e+00   1.26e-02     1.12e-03    
+post_attn_block        1x1x2560               True     False    1.00e+00   1.26e-02     1.12e-03    
+post_attn_residual     1x1x2560               True     False    1.00e+00   2.78e-02     1.35e-03    
+post_pre_mlp_norm      1x1x2560               True     False    1.00e+00   9.37e-02     5.05e-03    
+post_mlp               1x1x2560               True     False    1.00e+00   1.97e-02     2.32e-03    
+c6__token_emb          1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+c6__norm_emb           1x1x2560               True     True     1.00e+00   3.98e-03     6.60e-04    
+c6__norm_h             1x1x2560               True     True     1.00e+00   1.46e-02     7.91e-04    
+c6__concat             1x1x5120               True     True     1.00e+00   1.46e-02     7.25e-04    
+c6__fused              1x1x2560               True     False    1.00e+00   1.60e-02     6.29e-04    
+c7__pre_sdpa_q         1x16x1x256             True     False    1.00e+00   5.57e-02     3.56e-03    
+c7__pre_sdpa_k         1x4x1x256              True     False    1.00e+00   4.07e-02     4.82e-03    
+c7__pre_sdpa_v         1x4x1x256              True     False    1.00e+00   4.58e-02     5.53e-03    
+c7__causal_mask                               True     True     nan        0.00e+00     0.00e+00    
+c7__attn_scores_pre_softmax 1x16x1x1               True     True     1.00e+00   4.82e-02     2.10e-02    
+c7__attn_probs         1x16x1x1               True     True     1.00e+00   0.00e+00     0.00e+00    
+c7__attn_out           1x1x4096               True     False    1.00e+00   4.58e-02     5.53e-03    
+
+  pair verdict: first divergence at tap 'fc_output'.
+    Most-likely cause: mtp.fc matmul (weight transpose or layout)
+
+==============================================================================
+Phase C7 SDPA-internal bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=mtp_pos=1_seed42                                 pos=mtp_pos=2_seed42                                 pos=mtp_pos=1_seed43                                 pos=mtp_pos=2_seed43                                 pos=mtp_pos=1_seed44                                 pos=mtp_pos=2_seed44                                
+  -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  pre_sdpa_q                cos=1.00e+00   max|Δ|=6.19e-02   mean|Δ|=3.99e-03   rel_l2=3.68e-03   ok  cos=1.00e+00   max|Δ|=4.64e-02   mean|Δ|=4.16e-03   rel_l2=3.75e-03   ok  cos=1.00e+00   max|Δ|=4.38e-02   mean|Δ|=4.24e-03   rel_l2=3.95e-03   ok  cos=1.00e+00   max|Δ|=4.12e-02   mean|Δ|=3.57e-03   rel_l2=3.50e-03   ok  cos=1.00e+00   max|Δ|=5.18e-02   mean|Δ|=3.64e-03   rel_l2=3.70e-03   ok  cos=1.00e+00   max|Δ|=5.57e-02   mean|Δ|=3.56e-03   rel_l2=3.46e-03   ok 
+  pre_sdpa_k                cos=1.00e+00   max|Δ|=3.41e-02   mean|Δ|=5.44e-03   rel_l2=4.31e-03   ok  cos=1.00e+00   max|Δ|=3.89e-02   mean|Δ|=5.40e-03   rel_l2=4.35e-03   ok  cos=1.00e+00   max|Δ|=3.67e-02   mean|Δ|=5.32e-03   rel_l2=4.30e-03   ok  cos=1.00e+00   max|Δ|=4.46e-02   mean|Δ|=4.99e-03   rel_l2=4.01e-03   ok  cos=1.00e+00   max|Δ|=5.24e-02   mean|Δ|=4.95e-03   rel_l2=4.13e-03   ok  cos=1.00e+00   max|Δ|=4.07e-02   mean|Δ|=4.82e-03   rel_l2=3.95e-03   ok 
+  pre_sdpa_v                cos=1.00e+00   max|Δ|=4.10e-02   mean|Δ|=5.63e-03   rel_l2=2.91e-03   ok  cos=1.00e+00   max|Δ|=6.93e-02   mean|Δ|=6.61e-03   rel_l2=3.34e-03   ok  cos=1.00e+00   max|Δ|=4.65e-02   mean|Δ|=5.76e-03   rel_l2=3.16e-03   ok  cos=1.00e+00   max|Δ|=4.04e-02   mean|Δ|=5.37e-03   rel_l2=3.05e-03   ok  cos=1.00e+00   max|Δ|=5.36e-02   mean|Δ|=5.40e-03   rel_l2=2.99e-03   ok  cos=1.00e+00   max|Δ|=4.58e-02   mean|Δ|=5.53e-03   rel_l2=2.99e-03   ok 
+  causal_mask               cos=nan        max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=nan        DIV cos=nan        max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=nan        DIV cos=nan        max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=nan        DIV cos=nan        max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=nan        DIV cos=nan        max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=nan        DIV cos=nan        max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=nan        DIV
+  attn_scores_pre_softmax   cos=1.00e+00   max|Δ|=6.65e-02   mean|Δ|=3.59e-02   rel_l2=2.40e-03   ok  cos=1.00e+00   max|Δ|=8.71e-02   mean|Δ|=2.75e-02   rel_l2=2.13e-03   ok  cos=1.00e+00   max|Δ|=7.21e-02   mean|Δ|=2.77e-02   rel_l2=2.26e-03   ok  cos=1.00e+00   max|Δ|=5.32e-02   mean|Δ|=2.15e-02   rel_l2=1.90e-03   ok  cos=1.00e+00   max|Δ|=4.01e-02   mean|Δ|=2.63e-02   rel_l2=1.78e-03   ok  cos=1.00e+00   max|Δ|=4.82e-02   mean|Δ|=2.10e-02   rel_l2=1.63e-03   ok 
+  attn_probs                cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok 
+  attn_out                  cos=1.00e+00   max|Δ|=4.10e-02   mean|Δ|=5.63e-03   rel_l2=2.91e-03   ok  cos=1.00e+00   max|Δ|=6.93e-02   mean|Δ|=6.61e-03   rel_l2=3.34e-03   ok  cos=1.00e+00   max|Δ|=4.65e-02   mean|Δ|=5.76e-03   rel_l2=3.16e-03   ok  cos=1.00e+00   max|Δ|=4.04e-02   mean|Δ|=5.37e-03   rel_l2=3.05e-03   ok  cos=1.00e+00   max|Δ|=5.36e-02   mean|Δ|=5.40e-03   rel_l2=2.99e-03   ok  cos=1.00e+00   max|Δ|=4.58e-02   mean|Δ|=5.53e-03   rel_l2=2.99e-03   ok 
+
+Phase C7 verdict: ALL SDPA taps match within cos_sim >= 0.9999.
+  -> SDPA is NOT the dominant source of post_attn_raw drift at this bar.
+  -> Look downstream of `attn_out` (o_proj, residual, post-attn RMSNorm,
+     MLP) and/or upstream of SDPA (Q/K/V projections, RoPE, dual-norm).
+
+Overall verdict: divergence(s) at: ['fc_output', 'fc_output', 'fc_output', 'fc_output', 'fc_output', 'fc_output']

--- a/docs/phase-c8/c8_fix_report.md
+++ b/docs/phase-c8/c8_fix_report.md
@@ -1,0 +1,130 @@
+# Phase C8 — Fix MTP SDPA kv_len mismatch (single-site)
+
+## Verdict
+
+**Phase C8 fixes the MTP inner-block SDPA divergence localized in Phase C7 (PR #319).** The kiln MTP transformer block now performs single-token self-attention (`kv_len = 1`) for the inner GQA call, matching the HF / vLLM `Qwen3NextMultiTokenPredictor` reference contract. All 7 SDPA-internal taps now meet the strict `cos_sim ≥ 0.9999` bar across 3 seeds × 2 positions = 6 pairs; the C6 pre-RoPE bar continues to pass; shape parity is restored on `pre_sdpa_k`, `pre_sdpa_v`, `attn_scores_pre_softmax`, and `attn_probs`; and `attn_probs` collapses to exactly 1.0 (max|Δ| = 0, mean|Δ| = 0) — confirming the kv_len = 1 softmax-collapse contract.
+
+The downstream `fc_output` divergence reported by the C6/C7 comparator (`pair verdict: first divergence at tap 'fc_output'`) is the pre-existing main-model `fc` matmul drift (Class B 87.6%, see Phase C6 report), out of scope for C8 — that's C9 work.
+
+## Option chosen: A (kiln conforms to single-token self-attention)
+
+Phase C7 explicitly recommended Option A: change kiln so the MTP inner transformer block performs single-token self-attention without participation in the main-model paged KV cache. The competing option (B) would have changed the reference dumper to attend over the full main-model history. We chose A because:
+
+1. **Upstream parity.** HF Transformers `Qwen3NextMultiTokenPredictor` (in the `qwen3_next` modeling file shipped with the Qwen3-Next checkpoints) explicitly runs the MTP inner block as a single-token self-attention over the freshly-fused `h_fused` projection. The vLLM `Qwen3NextMultiTokenPredictor` matches. Conforming kiln to that contract keeps speculative decoding aligned with the only two production reference implementations available.
+2. **Smaller blast radius.** Option A is a single-site change in `gqa_attention_paged` + a TLS arm/disarm pair in `mtp_forward_step`, gated by a thread-local flag that defaults `false`. Non-MTP paths and pre-C8 callers see the legacy paged-cache behavior unchanged. Option B would have required re-engineering the reference dumper to thread the main-model paged history through the HF attention path — fragile and harder to maintain.
+3. **Speculative decoding correctness.** With the MTP layer attending to `mtp_pos + 1` previous MTP-draft tokens, the draft logits encode a stale tail of speculative attempts that the main model never accepted. Single-token self-attention removes this contamination and is the correct contract for token-by-token speculative draft.
+
+## Single-file diff summary (2 files, +87 / −6 lines)
+
+```
+crates/kiln-model/src/forward.rs   | 46 ++++++++++++++++++++++++++++++++-----
+crates/kiln-model/src/mtp_debug.rs | 47 ++++++++++++++++++++++++++++++++++++++
+2 files changed, 87 insertions(+), 6 deletions(-)
+```
+
+### `crates/kiln-model/src/mtp_debug.rs` (+47 lines)
+
+- Added `MTP_SINGLE_TOKEN_SELF_ATTN_ARMED: RefCell<bool>` to the `thread_local!` block (default `false`).
+- Added three pub fns mirroring the existing C7 SDPA-capture armer:
+  - `is_mtp_single_token_self_attn_armed() -> bool`
+  - `arm_mtp_single_token_self_attn()`
+  - `disarm_mtp_single_token_self_attn()`
+
+The TLS slot is read on the hot path (`gqa_attention_paged`) but defaults to `false`, so non-MTP attention paths and production decode pay one TLS-borrow cost per call.
+
+### `crates/kiln-model/src/forward.rs` (+40 / −6 lines, 1 site)
+
+`gqa_attention_paged` reads the TLS flag once at the top, then gates three regions on it:
+
+1. **Skip the paged KV cache write** when armed (no history is being maintained).
+2. **Skip the fused paged-decode flash-attention kernel** when armed (the kernel reads the full cache history, defeating the kv_len = 1 contract).
+3. **Skip the paged KV cache read** when armed; instead use the just-computed `(k, v)` directly with `kv_len = 1`.
+
+`mtp_forward_step` brackets the inner `transformer_block_paged` call with `arm_mtp_single_token_self_attn()` / `disarm_mtp_single_token_self_attn()`. The disarm runs in both success and error paths — the inner block return is `?`-propagated below, so we cannot rely on the function tail.
+
+## Verification
+
+### Build
+
+A6000 on-demand pod (image `ghcr.io/ericflo/kiln-runpod:latest`, SM 86, CUDA 12.4). Cargo release build with `--features cuda`, sccache + B2 remote cache: 145s wall-clock (97% sccache hit rate from B2 cache).
+
+### Bench protocol
+
+```
+KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp \
+KILN_MTP_DUMP_PRE_ROPE=1 KILN_MTP_DUMP_SUBOPS=1 KILN_MTP_DUMP_C7_SDPA=1 \
+KILN_MTP_DUMP_POS=1,2 \
+KILN_MTP_DUMP_PATH="/workspace/c8_kiln/kiln_seed${seed}_pos{pos}.st" \
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b/ --paged \
+  --prompt-tokens 29 --max-output-tokens 32 --skip-training --seed $seed
+```
+
+Coverage: seeds 42 / 43 / 44, positions 1 / 2 — 6 pair dumps. Reference dumps captured with `python3 scripts/mtp_reference_dump.py --capture-subops` against the same checkpoint at `/workspace/qwen3.5-4b/`.
+
+### C7 sweep (strict bar `cos_sim ≥ 0.9999`)
+
+| Tap | shape (kiln, ref) | shape ok | median cos_sim | max max\|Δ\| | status |
+| --- | --- | --- | --- | --- | --- |
+| `c7__pre_sdpa_q` | `(1, 16, 1, 256)` / `(1, 16, 1, 256)` | yes | 1.0000 | 6.19e-02 | **ok** |
+| `c7__pre_sdpa_k` | `(1, 4, 1, 256)` / `(1, 4, 1, 256)` | yes (was `kv_len=mtp_pos+1`) | 1.0000 | 5.24e-02 | **ok** |
+| `c7__pre_sdpa_v` | `(1, 4, 1, 256)` / `(1, 4, 1, 256)` | yes (was `kv_len=mtp_pos+1`) | 1.0000 | 6.93e-02 | **ok** |
+| `c7__causal_mask` | `()` / `()` | yes | n/a (0-d sentinel) | 0 | n/a |
+| `c7__attn_scores_pre_softmax` | `(1, 16, 1, 1)` / `(1, 16, 1, 1)` | yes (was `(1, 16, 1, kv_len)`) | 1.0000 | 8.71e-02 | **ok** |
+| `c7__attn_probs` | `(1, 16, 1, 1)` / `(1, 16, 1, 1)` | yes (was `(1, 16, 1, kv_len)`) | 1.0000 | 0.00 | **ok** (softmax collapse to 1.0 confirmed) |
+| `c7__attn_out` | `(1, 1, 4096)` / `(1, 1, 4096)` | yes | 1.0000 | 6.93e-02 | **ok** (was 0.986–0.996 pre-fix) |
+
+Comparator output:
+
+```
+Phase C7 verdict: ALL SDPA taps match within cos_sim >= 0.9999.
+  -> SDPA is NOT the dominant source of post_attn_raw drift at this bar.
+```
+
+Full report: [`c7_after_fix.txt`](./c7_after_fix.txt) (381 lines, 6 pair verdicts).
+
+### C6 sweep (re-run for completeness, strict bar `cos_sim ≥ 0.9999`)
+
+| Tap | median cos_sim | max max\|Δ\| | status |
+| --- | --- | --- | --- |
+| `c6__token_emb` | 1.0000 | 0.00 | **ok** |
+| `c6__norm_emb` | 1.0000 | 7.76e-03 | **ok** |
+| `c6__norm_h` | 1.0000 | 3.01e-02 | **ok** |
+| `c6__concat` | 1.0000 | 3.01e-02 | **ok** |
+| `c6__fused` | 1.0000 | 1.60e-02 | **ok** |
+
+Comparator output:
+
+```
+Phase C6 verdict: ALL pre-RoPE taps match within cos_sim >= 0.9999.
+  -> Pre-RoPE input is NOT the dominant source of pre-RoPE drift at this bar.
+```
+
+Full report: [`c6_after_fix.txt`](./c6_after_fix.txt) (379 lines, 6 pair verdicts).
+
+### Cos_sim before / after
+
+| Tap | C7 before fix (median, 6 pairs) | C7 after fix (median, 6 pairs) | Bar |
+| --- | --- | --- | --- |
+| `c7__attn_out` | **0.9926** (range 0.9857–0.9957) | **1.0000** | `≥ 0.9999` |
+| `c7__pre_sdpa_k` | shape mismatch (kiln `(1, 4, kv_len, 256)` vs ref `(1, 4, 1, 256)`) | 1.0000 | shape parity + `≥ 0.9999` |
+| `c7__pre_sdpa_v` | shape mismatch | 1.0000 | shape parity + `≥ 0.9999` |
+| `c7__attn_scores_pre_softmax` | shape mismatch | 1.0000 | shape parity + `≥ 0.9999` |
+| `c7__attn_probs` | shape mismatch | 1.0000 (max\|Δ\| = 0, mean\|Δ\| = 0) | shape parity + softmax = 1.0 |
+| `c6__fused` (re-check) | 1.0000 | 1.0000 | `≥ 0.9999` |
+
+## Out of scope: C9 follow-up
+
+The C6/C7 comparator's overall verdict still reports `first divergence at tap 'fc_output'` for every pair. This is the **pre-existing main-model `mtp.fc` matmul drift** identified in Phase C6 (Class B, 87.6% of total `fc_output` drift). Phase C8 was scoped narrowly to the SDPA kv_len mismatch. The next phase, C9, addresses the `mtp.fc` weight transpose / layout question against a fresh bf16 vs fp32 reference and is out of scope for this PR.
+
+The MTP acceptance rate (`α`) — which Phase C7 hypothesized would lift once the SDPA contract is correct — should be re-measured in C9 once the `fc_output` divergence is also resolved. The C8 fix is a pre-condition: speculative drafts that attend over the wrong key set cannot have meaningful α, regardless of `fc` correctness.
+
+## Files added in this PR
+
+- `docs/phase-c8/c8_fix_report.md` (this file)
+- `docs/phase-c8/c7_after_fix.txt` (full C7 comparator log, 6 pairs)
+- `docs/phase-c8/c6_after_fix.txt` (full C6 comparator log, 6 pairs)
+
+## Code changes
+
+- `crates/kiln-model/src/mtp_debug.rs` (+47 lines): TLS arm/disarm slot + accessors
+- `crates/kiln-model/src/forward.rs` (+40 / −6 lines): single-site gating in `gqa_attention_paged` + arm/disarm bracket in `mtp_forward_step`


### PR DESCRIPTION
## Summary

Fixes the MTP SDPA `kv_len` mismatch localized in Phase C7 (PR #319). The kiln MTP inner transformer block now performs **single-token self-attention** (`kv_len = 1`), matching the HF / vLLM `Qwen3NextMultiTokenPredictor` reference contract.

## What changed

Single-site fix in `gqa_attention_paged` gated on a thread-local flag set by `mtp_forward_step`:

- **`crates/kiln-model/src/mtp_debug.rs`** (+47 lines) — Adds `MTP_SINGLE_TOKEN_SELF_ATTN_ARMED` TLS slot + `arm/disarm/is_armed` accessors (mirrors the existing C7 SDPA-capture armer pattern). Default `false`, so non-MTP paths see legacy paged-cache behavior unchanged.
- **`crates/kiln-model/src/forward.rs`** (+40 / −6 lines, 1 site) — In `gqa_attention_paged`, when the TLS flag is armed:
  1. Skip the paged KV cache write
  2. Bypass the fused paged-decode flash-attention kernel (which reads the full cache history)
  3. Use the just-computed `(k, v)` directly with `kv_len = 1` (no cache read)

  In `mtp_forward_step`, bracket the inner `transformer_block_paged` call with `arm/disarm`. Disarm runs in both success and error paths.

## Why Option A

Phase C7 explicitly recommended Option A (kiln conforms to single-token self-attn) over Option B (change the reference dumper to attend over the full main-model history). Reasons:

1. **Upstream parity** — both HF Transformers `Qwen3NextMultiTokenPredictor` and vLLM run the MTP inner block as single-token self-attention. Conforming kiln keeps speculative decoding aligned with the only two production reference implementations.
2. **Smaller blast radius** — single-site change behind a thread-local flag, defaults `false`, no impact on non-MTP paths.
3. **Speculative-decoding correctness** — the previous behavior had the MTP layer attending to `mtp_pos + 1` previously-generated MTP-draft tokens, contaminating the draft logits with a stale tail of speculative attempts the main model never accepted.

## Verification (A6000, on-demand, sccache + B2 cache, 145s build)

3 seeds × 2 positions = 6 pair dumps against the HF reference (`scripts/mtp_reference_dump.py --capture-subops`).

### C7 sweep — strict `cos_sim ≥ 0.9999`

```
Phase C7 verdict: ALL SDPA taps match within cos_sim >= 0.9999.
```

| Tap | Before fix (median) | After fix (median) |
| --- | --- | --- |
| `c7__pre_sdpa_q` | 1.0000 | 1.0000 |
| `c7__pre_sdpa_k` | shape mismatch `(1, 4, kv_len, 256)` vs `(1, 4, 1, 256)` | **1.0000** (shape parity restored) |
| `c7__pre_sdpa_v` | shape mismatch | **1.0000** (shape parity restored) |
| `c7__attn_scores_pre_softmax` | shape mismatch | **1.0000** (shape parity restored) |
| `c7__attn_probs` | shape mismatch | **1.0000** (max\|Δ\| = 0, mean\|Δ\| = 0 — softmax collapse to 1.0 confirmed) |
| `c7__attn_out` | **0.9926** (range 0.9857–0.9957) | **1.0000** |

### C6 sweep — strict `cos_sim ≥ 0.9999` (regression check)

```
Phase C6 verdict: ALL pre-RoPE taps match within cos_sim >= 0.9999.
```

All 5 pre-RoPE taps (`token_emb`, `norm_emb`, `norm_h`, `concat`, `fused`) still pass — no regression from C8 changes.

Full reports: `docs/phase-c8/c7_after_fix.txt` (381 lines) and `docs/phase-c8/c6_after_fix.txt` (379 lines).

## Out of scope: C9

The C6/C7 comparator's overall verdict still reports `first divergence at tap 'fc_output'` for every pair. This is the **pre-existing main-model `mtp.fc` matmul drift** (Class B 87.6%, identified in Phase C6) and is C9 work. The MTP acceptance rate (`α`) re-measurement also belongs to C9 — the C8 fix is a pre-condition.

## Files

- `crates/kiln-model/src/forward.rs` (+40 / −6)
- `crates/kiln-model/src/mtp_debug.rs` (+47)
- `docs/phase-c8/c8_fix_report.md` (new)
- `docs/phase-c8/c7_after_fix.txt` (new — full comparator log)
- `docs/phase-c8/c6_after_fix.txt` (new — full comparator log)