### PR TITLE
[codex] Harden Metal prewarm and KV auto-sizing

### DIFF
--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::Ordering;
 
 use anyhow::Result;
 use clap::Parser;
@@ -252,33 +251,16 @@ fn spawn_backend_prewarm(state: AppState) {
     }
 
     let runner = runner.clone();
-    let metrics = state.metrics.clone();
+    let gpu_lock = state.gpu_lock.clone();
 
     tokio::spawn(async move {
-        // Give immediately-started desktop traffic a chance to claim the GPU
-        // before background warmup begins compiling kernels.
-        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-        if metrics.request_duration_count.load(Ordering::Relaxed) > 0 {
-            tracing::info!(
-                "skipping background inference prewarm because the server has already handled live traffic"
-            );
-            return;
-        }
-        if metrics.active_requests.load(Ordering::Relaxed) > 0 {
-            tracing::info!(
-                "skipping background inference prewarm because a request is already active"
-            );
-            return;
-        }
-
         tracing::info!("starting background inference prewarm");
-        let prewarm = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
-            if metrics.request_duration_count.load(Ordering::Relaxed) > 0
-                || metrics.active_requests.load(Ordering::Relaxed) > 0
-            {
-                return Ok(false);
-            }
+        let prewarm = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            // Hold the exclusive GPU lock so prewarm never races real
+            // generation. If a request starts first, this blocks until that
+            // request is done, then still warms the backend for the next one.
+            let _gpu_guard = gpu_lock.write().unwrap();
+
             let runner_guard = runner.read().unwrap();
             let params = SamplingParams {
                 temperature: 0.0,
@@ -292,11 +274,16 @@ fn spawn_backend_prewarm(state: AppState) {
                 stop: Vec::new(),
                 seed: Some(42),
             };
-            let prompt_tokens = [1_u32, 2, 3, 4, 5, 6, 7, 8];
-            let mut block_manager = BlockManager::new(1, 16);
+            // Warm one full paged block plus a decode step. The previous
+            // 8-token prompt missed first-block prompt shapes that desktop
+            // traffic commonly hits, leaving Metal/Candle kernels to compile
+            // on the first live request.
+            let prompt_tokens = [1_u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+            let num_blocks = 2;
+            let mut block_manager = BlockManager::new(num_blocks, 16);
             let mut paged_cache = PagedKvCache::new(
                 runner_guard.config.num_full_attention_layers,
-                1,
+                num_blocks,
                 16,
                 runner_guard.config.num_kv_heads,
                 runner_guard.config.head_dim,
@@ -309,17 +296,12 @@ fn spawn_backend_prewarm(state: AppState) {
                 &mut block_manager,
                 &mut paged_cache,
             )?;
-            Ok(true)
+            Ok(())
         })
         .await;
 
         match prewarm {
-            Ok(Ok(true)) => tracing::info!("background inference prewarm complete"),
-            Ok(Ok(false)) => {
-                tracing::info!(
-                    "skipping background inference prewarm because a request became active"
-                );
-            }
+            Ok(Ok(())) => tracing::info!("background inference prewarm complete"),
             Ok(Err(err)) => tracing::warn!(error = %err, "background inference prewarm failed"),
             Err(err) => tracing::warn!(error = %err, "background inference prewarm task failed"),
         }

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -18,7 +18,9 @@ use crate::training_queue::{SharedTrainingQueue, ShutdownFlag};
 
 const DEFAULT_BLOCK_SIZE: usize = 16;
 const MIN_AUTO_KV_BLOCKS: usize = 64;
-const METAL_AUTO_MAX_KV_BLOCKS: usize = 2048; // 32K tokens at block_size=16.
+const METAL_AUTO_MAX_KV_BLOCKS_LOW_MEM: usize = 512; // 8K tokens at block_size=16.
+const METAL_AUTO_MAX_KV_BLOCKS_MID_MEM: usize = 1024; // 16K tokens at block_size=16.
+const METAL_AUTO_MAX_KV_BLOCKS_HIGH_MEM: usize = 2048; // 32K tokens at block_size=16.
 
 /// GPU memory budget tracking for coordinating inference and training.
 ///
@@ -309,6 +311,7 @@ impl AppState {
                     model_config.max_position_embeddings,
                     block_size,
                     is_metal_device(&device),
+                    total_vram,
                 );
                 tracing::info!(
                     total_vram_gb = total_vram as f64 / 1e9,
@@ -330,6 +333,7 @@ impl AppState {
                     model_config.max_position_embeddings,
                     block_size,
                     is_metal_device(&device),
+                    total_vram,
                 )
             }
         };
@@ -451,17 +455,29 @@ fn cap_auto_num_blocks(
     max_position_embeddings: usize,
     block_size: usize,
     is_metal: bool,
+    total_vram_bytes: u64,
 ) -> usize {
     let model_cap_blocks = max_position_embeddings
         .div_ceil(block_size)
         .max(MIN_AUTO_KV_BLOCKS);
     let runtime_cap_blocks = if is_metal {
-        model_cap_blocks.min(METAL_AUTO_MAX_KV_BLOCKS)
+        model_cap_blocks.min(metal_auto_max_kv_blocks(total_vram_bytes))
     } else {
         model_cap_blocks
     };
 
     raw_blocks.max(MIN_AUTO_KV_BLOCKS).min(runtime_cap_blocks)
+}
+
+fn metal_auto_max_kv_blocks(total_vram_bytes: u64) -> usize {
+    let gib = total_vram_bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    if gib < 14.0 {
+        METAL_AUTO_MAX_KV_BLOCKS_LOW_MEM
+    } else if gib < 24.0 {
+        METAL_AUTO_MAX_KV_BLOCKS_MID_MEM
+    } else {
+        METAL_AUTO_MAX_KV_BLOCKS_HIGH_MEM
+    }
 }
 
 fn is_metal_device(device: &candle_core::Device) -> bool {
@@ -595,31 +611,75 @@ mod tests {
         // Qwen3.5's 262K context is 16,384 blocks at block_size=16. There is
         // no reason to auto-allocate more KV cache than the model can address.
         assert_eq!(
-            cap_auto_num_blocks(50_000, 262_144, DEFAULT_BLOCK_SIZE, false),
+            cap_auto_num_blocks(
+                50_000,
+                262_144,
+                DEFAULT_BLOCK_SIZE,
+                false,
+                10 * 1024 * 1024 * 1024,
+            ),
             16_384
         );
     }
 
     #[test]
-    fn test_auto_num_blocks_caps_metal_desktop_default() {
-        // On large unified-memory Macs, pure memory-aware sizing can request
-        // tens of GiB of eagerly-zeroed KV cache. Default Metal auto-sizing is
-        // capped at 32K tokens; explicit KILN_NUM_BLOCKS still bypasses this
-        // helper entirely in AppState::new_real.
+    fn test_auto_num_blocks_caps_metal_desktop_defaults_by_memory_tier() {
+        // On unified-memory Macs, pure memory-aware sizing can request a large
+        // eagerly-zeroed KV cache. Default Metal auto-sizing is tier-capped by
+        // detected memory; explicit KILN_NUM_BLOCKS still bypasses this helper
+        // entirely in AppState::new_real.
         assert_eq!(
-            cap_auto_num_blocks(50_000, 262_144, DEFAULT_BLOCK_SIZE, true),
-            METAL_AUTO_MAX_KV_BLOCKS
+            cap_auto_num_blocks(
+                50_000,
+                262_144,
+                DEFAULT_BLOCK_SIZE,
+                true,
+                10 * 1024 * 1024 * 1024,
+            ),
+            METAL_AUTO_MAX_KV_BLOCKS_LOW_MEM
+        );
+        assert_eq!(
+            cap_auto_num_blocks(
+                50_000,
+                262_144,
+                DEFAULT_BLOCK_SIZE,
+                true,
+                16 * 1024 * 1024 * 1024,
+            ),
+            METAL_AUTO_MAX_KV_BLOCKS_MID_MEM
+        );
+        assert_eq!(
+            cap_auto_num_blocks(
+                50_000,
+                262_144,
+                DEFAULT_BLOCK_SIZE,
+                true,
+                32 * 1024 * 1024 * 1024,
+            ),
+            METAL_AUTO_MAX_KV_BLOCKS_HIGH_MEM
         );
     }
 
     #[test]
     fn test_auto_num_blocks_preserves_small_auto_and_minimum() {
         assert_eq!(
-            cap_auto_num_blocks(512, 262_144, DEFAULT_BLOCK_SIZE, true),
+            cap_auto_num_blocks(
+                512,
+                262_144,
+                DEFAULT_BLOCK_SIZE,
+                true,
+                10 * 1024 * 1024 * 1024,
+            ),
             512
         );
         assert_eq!(
-            cap_auto_num_blocks(1, 262_144, DEFAULT_BLOCK_SIZE, true),
+            cap_auto_num_blocks(
+                1,
+                262_144,
+                DEFAULT_BLOCK_SIZE,
+                true,
+                10 * 1024 * 1024 * 1024,
+            ),
             MIN_AUTO_KV_BLOCKS
         );
     }


### PR DESCRIPTION
## Summary

This PR keeps the desktop default path fast under the same invocation/environment the app uses by default.

- Makes background inference prewarm run immediately and serialize through the GPU coordination lock instead of sleeping and skipping when a request races it.
- Warms a full 16-token paged block plus decode, so common first-request Metal/Candle shapes are compiled before interactive traffic.
- Tiers default Metal KV-cache auto-sizing by detected unified memory: 512 blocks below 14 GiB, 1024 below 24 GiB, and 2048 on larger systems. Explicit `KILN_NUM_BLOCKS` still overrides this.
- Adds unit coverage for the new Metal KV sizing tiers.

## Why

On this Mac, the default Metal server auto-sized to 2048 KV blocks after memory detection. That allocated roughly 1 GiB of KV cache next to the 8 GiB+ model and made warmed desktop HTTP latency much worse than the smaller cache sizes. The existing prewarm could also be skipped permanently or race live inference, leaving the first real request to pay Metal/Candle first-use costs.

## Validation

- `CARGO_TARGET_DIR=/tmp/kiln-target-prewarm-hardening cargo build -p kiln-server --bin kiln --features metal --release --locked`
- `CARGO_TARGET_DIR=/tmp/kiln-target-prewarm-hardening cargo test -p kiln-server --features metal --lib --locked -- --test-threads=1`
- `git diff --check`
- Local desktop smoke with default env/no `KILN_NUM_BLOCKS`: auto blocks dropped from 2048 to 512 on this 10.7 GB detected-memory Mac; warmed 16-output-token HTTP request improved from about 13.3s with 2048 blocks to 5.24s then 4.18s with the new default cap.

`cargo fmt -p kiln-server --check` still reports unrelated pre-existing formatting in package files outside this diff, so I did not use package-wide rustfmt as a gate.