### PR TITLE
[codex] Precompile Metal kernels during startup

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -40,6 +40,26 @@ impl MetalBackend {
     }
 }
 
+/// Compile Kiln's custom Metal library and compute pipelines ahead of the
+/// first forward pass. Candle kernels still compile lazily inside Candle, but
+/// this removes Kiln-owned pipeline setup from the first prewarm/request.
+pub fn precompile_custom_kernels(device: &Device) -> Result<()> {
+    let Device::Metal(metal_device) = device else {
+        return Ok(());
+    };
+
+    metal_shared_library(metal_device)?;
+    metal_rms_norm_pipeline(metal_device)?;
+    metal_gdn_qk_norm_pipeline(metal_device)?;
+    metal_gdn_gates_pipeline(metal_device)?;
+    metal_gated_rms_norm_pipeline(metal_device)?;
+    metal_gdn_recurrent_pipeline(metal_device)?;
+    metal_gdn_forward_substitution_pipeline(metal_device)?;
+    metal_conv1d_prefill_pipeline(metal_device)?;
+    metal_conv1d_update_pipeline(metal_device)?;
+    Ok(())
+}
+
 impl BackendRuntime for MetalBackend {
     fn name(&self) -> &'static str {
         "metal"
@@ -2071,6 +2091,16 @@ pub fn try_new_metal() -> Option<Device> {
 mod tests {
     use super::*;
     use candle_core::D;
+
+    #[test]
+    fn test_precompile_custom_kernels_smoke() -> Result<()> {
+        let Some(device) = try_new_metal() else {
+            eprintln!("Metal unavailable, skipping test_precompile_custom_kernels_smoke");
+            return Ok(());
+        };
+
+        precompile_custom_kernels(&device)
+    }
 
     fn gdn_qk_norm_reference(
         q: &Tensor,

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -130,13 +130,15 @@ async fn main() -> Result<()> {
             config.speculative.effective_method(),
             kiln_server::config::SpecMethod::Mtp
         );
+        let device = select_device()?;
+        let metal_kernel_precompile = spawn_metal_kernel_precompile(&device);
         let model_weights = kiln_model::load_model_with_options(
             Path::new(mp),
             &model_config,
             kiln_model::LoadModelOptions { load_mtp },
         )?;
-        let device = select_device()?;
         let gpu_weights = GpuWeights::from_model_weights(&model_weights, &model_config, &device)?;
+        finish_metal_kernel_precompile(metal_kernel_precompile);
 
         let runner = ModelRunner::new_with_options(
             gpu_weights,
@@ -306,6 +308,51 @@ fn spawn_backend_prewarm(state: AppState) {
             Err(err) => tracing::warn!(error = %err, "background inference prewarm task failed"),
         }
     });
+}
+
+#[cfg(feature = "metal")]
+fn spawn_metal_kernel_precompile(
+    device: &candle_core::Device,
+) -> Option<std::thread::JoinHandle<anyhow::Result<std::time::Duration>>> {
+    if !matches!(device, candle_core::Device::Metal(_)) {
+        return None;
+    }
+
+    let device = device.clone();
+    Some(std::thread::spawn(move || {
+        let start = std::time::Instant::now();
+        kiln_model::backend::metal::precompile_custom_kernels(&device)?;
+        Ok(start.elapsed())
+    }))
+}
+
+#[cfg(not(feature = "metal"))]
+fn spawn_metal_kernel_precompile(
+    _device: &candle_core::Device,
+) -> Option<std::thread::JoinHandle<anyhow::Result<std::time::Duration>>> {
+    None
+}
+
+fn finish_metal_kernel_precompile(
+    handle: Option<std::thread::JoinHandle<anyhow::Result<std::time::Duration>>>,
+) {
+    let Some(handle) = handle else {
+        return;
+    };
+
+    match handle.join() {
+        Ok(Ok(elapsed)) => tracing::info!(
+            elapsed_ms = elapsed.as_millis() as u64,
+            "Metal custom kernels precompiled"
+        ),
+        Ok(Err(err)) => tracing::warn!(
+            error = %err,
+            "Metal custom kernel precompile failed; falling back to lazy compilation"
+        ),
+        Err(_) => tracing::warn!(
+            "Metal custom kernel precompile thread panicked; falling back to lazy compilation"
+        ),
+    }
 }
 
 fn prewarm_kv_dtype(config: &ModelConfig) -> candle_core::DType {


### PR DESCRIPTION
## Summary

Moves Kiln-owned Metal source and pipeline compilation out of the first prewarm/request path.

- Adds `precompile_custom_kernels` for the Metal backend, compiling the shared Metal library plus RMSNorm, GDN, and conv1d compute pipelines.
- Starts that work immediately after Metal device selection and overlaps it with model load/GPU weight upload.
- Keeps failures non-fatal: precompile errors warn and fall back to the existing lazy compilation path.
- Adds a Metal smoke test for the precompile hook; it skips when Metal is unavailable.

## Why

The remaining cold macOS path still pays lazy Metal/Candle first-use costs. PR #323 moved more of that work into background prewarm and reduced default KV pressure; this follows up by removing Kiln-owned pipeline creation from that first forward path without changing inference math or adding flags.

Candle SDPA/GEMM kernels still compile lazily by shape, so this is not a complete cold-start fix. It is a low-risk default-path reduction for the Metal pipeline setup Kiln controls directly.

## Validation

- `CARGO_TARGET_DIR=/tmp/kiln-target-metal-kernel-precompile cargo build -p kiln-server --bin kiln --features metal --release --locked`
- `CARGO_TARGET_DIR=/tmp/kiln-target-metal-kernel-precompile cargo test -p kiln-server --features metal --lib --locked -- --test-threads=1`
- `CARGO_TARGET_DIR=/tmp/kiln-target-metal-kernel-precompile cargo test -p kiln-model --features metal backend::metal::tests::test_precompile_custom_kernels_smoke --locked -- --test-threads=1`
- `git diff --check`
- Real default server smoke with Qwen3.5-4B on Metal: precompile log observed, prewarm completed, `/v1/chat/completions` returned 200. Warmed 16-output-token samples were 10.26s then 5.44s in a noisy post-build run; previous same-default post-#323 smoke was 4.18s, and this PR does not change the request hot path.