### PR TITLE
[codex] Speed up default sampling and fix speculative KV advance

### DIFF
--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1096,7 +1096,11 @@ impl ModelRunner {
             .validate(&self.config)
             .context("invalid speculative config")?;
 
-        let max_total = prompt_tokens.len() + params.max_tokens;
+        // Verification writes the full speculative window (`last_token + k`)
+        // before the loop commits accepted tokens, so flat KV needs temporary
+        // headroom beyond the user-visible max token budget.
+        let max_total =
+            prompt_tokens.len() + params.max_tokens + spec_config.num_speculative_tokens + 1;
         let mut kv_cache = self.new_kv_cache(max_total)?;
         let mut linear_state = self.new_linear_state()?;
         let mut draft_linear_state = self.new_linear_state()?;
@@ -1587,7 +1591,11 @@ impl ModelRunner {
             .context("invalid speculative config")?;
 
         let (tx, rx) = mpsc::channel();
-        let max_total = prompt_tokens.len() + params.max_tokens;
+        // Verification writes the full speculative window (`last_token + k`)
+        // before the loop commits accepted tokens, so flat KV needs temporary
+        // headroom beyond the user-visible max token budget.
+        let max_total =
+            prompt_tokens.len() + params.max_tokens + spec_config.num_speculative_tokens + 1;
         let mut kv_cache = self.new_kv_cache(max_total)?;
         let mut linear_state = self.new_linear_state()?;
         let mut draft_linear_state = self.new_linear_state()?;

--- a/crates/kiln-model/src/sampling.rs
+++ b/crates/kiln-model/src/sampling.rs
@@ -81,6 +81,14 @@ pub fn sample_with_params(
     // Apply temperature on-device; result stays on the original device.
     let scaled = flat.to_dtype(DType::F32)?.affine(1.0 / temperature as f64, 0.0)?;
 
+    // The default sampling shape is full-vocab temperature sampling
+    // (`top_k=0`, `top_p=1`). It still needs one host transfer for categorical
+    // RNG, but it does not need an O(V log V) sort because no rank-based
+    // filtering is requested.
+    if top_p >= 1.0 && (top_k == 0 || top_k as usize >= vocab_size) {
+        return sample_full_distribution_unsorted(&scaled, seed);
+    }
+
     // Fetch a descending (index, logit) list, truncated to top_k when active.
     // When top_k selects a real subset of the vocab, we try to sort on-device and
     // transfer only the top_k pairs (e.g. 50 floats + 50 u32 indices = 400 B vs
@@ -148,6 +156,55 @@ pub fn sample_with_params(
 
     // Numerical edge case: cumsum < r due to rounding. Return the last candidate.
     Ok(probs.last().context("no candidates after filtering")?.0)
+}
+
+/// Sample from the full temperature-scaled distribution without sorting.
+///
+/// This is the fast path for the API/UI defaults: `temperature > 0`,
+/// `top_p = 1`, and `top_k = 0`.
+fn sample_full_distribution_unsorted(scaled: &Tensor, seed: Option<u64>) -> Result<u32> {
+    let values: Vec<f32> = scaled.to_vec1()?;
+    if values.is_empty() {
+        anyhow::bail!("empty logits distribution");
+    }
+
+    let max_logit = values
+        .iter()
+        .copied()
+        .filter(|v| v.is_finite())
+        .fold(f32::NEG_INFINITY, |acc, v| acc.max(v));
+    if !max_logit.is_finite() {
+        return Ok((values.len() - 1) as u32);
+    }
+    let mut sum = 0.0_f32;
+    let mut probs = Vec::with_capacity(values.len());
+    for &logit in &values {
+        let p = if logit.is_finite() {
+            (logit - max_logit).exp()
+        } else {
+            0.0
+        };
+        sum += p;
+        probs.push(p);
+    }
+    if !sum.is_finite() || sum <= 0.0 {
+        return Ok((values.len() - 1) as u32);
+    }
+
+    let mut rng: StdRng = match seed {
+        Some(s) => StdRng::seed_from_u64(s),
+        None => StdRng::from_entropy(),
+    };
+    let threshold = rng.r#gen::<f32>() * sum;
+    let mut cumsum = 0.0_f32;
+    for (idx, p) in probs.into_iter().enumerate() {
+        cumsum += p;
+        if threshold < cumsum {
+            return Ok(idx as u32);
+        }
+    }
+
+    Ok((values.len() - 1) as u32)
 }
 
 /// Sort `scaled` descending on-device, transfer only the top-k `(index, value)`
@@ -338,6 +395,15 @@ mod tests {
         let t1 = sample_with_params(&logits, 1.0, 1.0, 0, Some(12345))?;
         let t2 = sample_with_params(&logits, 1.0, 1.0, 0, Some(12345))?;
         assert_eq!(t1, t2, "same seed should produce same result");
+        Ok(())
+    }
+
+    #[test]
+    fn test_full_distribution_sampling_tolerates_non_finite_logits() -> Result<()> {
+        let device = Device::Cpu;
+        let logits = Tensor::new(&[f32::NAN, f32::NEG_INFINITY, f32::NAN], &device)?;
+        let token = sample_with_params(&logits, 1.0, 1.0, 0, Some(12345))?;
+        assert_eq!(token, 2);
         Ok(())
     }
 

--- a/crates/kiln-model/src/speculative.rs
+++ b/crates/kiln-model/src/speculative.rs
@@ -453,12 +453,12 @@ pub fn speculative_decode_step(
         }
     }
 
-    // Advance KV cache by the number of tokens we verified (K+1),
-    // but we'll need to roll back to only the accepted count.
-    // Actually, model_forward already wrote all K+1 positions into the cache.
-    // We need to advance by only the accepted count + 1 (for last_token).
-    // The KV cache advance is handled by the caller based on accepted_tokens.len().
-    kv_cache.advance(1 + accepted_tokens.len());
+    // `model_forward` wrote the whole verification window, but only the
+    // committed prefix is valid for the next step. `accepted_tokens` includes
+    // the target/bonus token that will be fed as `last_token` next time, so
+    // advancing by exactly this count keeps the cache aligned while leaving
+    // rejected/stale slots to be overwritten.
+    kv_cache.advance(accepted_tokens.len());
 
     Ok(SpeculativeStepResult {
         accepted_tokens,

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -783,7 +783,11 @@ fn bench_latency_skiplayer(
         kiln_core::config::DType::FP32 => candle_core::DType::F32,
     };
 
-    let max_total = actual_prompt_tokens + max_output_tokens;
+    // Skip-layer verifies `[last_token, draft_0, ..., draft_k-1]` in one
+    // forward pass. Near the end of generation those speculative KV writes can
+    // extend past the committed token budget before stale slots are overwritten
+    // or ignored, so reserve headroom for the verify window.
+    let max_total = actual_prompt_tokens + max_output_tokens + num_speculative_tokens + 1;
     let mut kv_cache = KvCache::new(
         config.num_full_attention_layers,
         config.num_kv_heads,


### PR DESCRIPTION
## Summary

This PR improves the default macOS HTTP sampling path and fixes a correctness bug in skip-layer speculative decoding.

- Avoids the full O(V log V) host sort for the default temperature-sampling shape (`temperature > 0`, `top_p = 1`, `top_k = 0`). The sampler still transfers logits for categorical RNG, but samples the full distribution directly without rank sorting.
- Keeps compatibility for non-finite logits by falling back to the previous deterministic last-token behavior instead of returning HTTP 500.
- Fixes skip-layer speculative flat-KV advancement: the verification pass wrote the whole speculative window, but the cache advanced by `1 + accepted_tokens.len()`, over-advancing positions and causing KV overflow. It now advances by the committed token count and reserves temporary verify-window headroom.

## Validation

- `cargo test -p kiln-model sampling --features metal --locked`
- `cargo test -p kiln-model speculative --features metal --locked`
- `cargo build -p kiln-server --bin kiln --bin kiln-bench --features metal --release --locked`
- `git diff --check`
- HTTP A/B on Qwen3.5-4B, default desktop env, 32 sampled tokens: baseline sorted path ~`8.62s`, patched unsorted path ~`8.52s`.
- Direct paged greedy bench on Qwen3.5-4B: no regression observed (`293.7 ms` mean ITL in the same noisy range as main).

## Notes

Skip-layer speculative decoding is now correct enough to benchmark without KV overflow, but it is still slower on this Mac (`~765 ms` mean ITL for the tested shape), so this PR does not enable speculative decoding by default.