### PR TITLE
mtp: Phase C12 — fp32 draft-head kill switch (PRIMARY-NEGATIVE)

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -4486,3 +4486,92 @@ gate → mlp_up → mlp_gate → mlp_down` and dump each one.
   bisect report at `/tmp/mtp-compare.txt` (copied to
   `mtp-compare-phase-b6.txt` in the session workspace), and this PR.
   **No fix included.** Scope is bisect-only per the task brief.
+
+
+## Phase C12 — fp32 draft-head kill switch + activation-weighted probe (2026-04-21)
+
+### Goal
+
+Test whether forcing the MTP draft head's q/k/v/o + fc projections to fp32
+(`KILN_MTP_FP32_HEAD=1`) recovers α toward the 0.72 ship floor. Hypothesis
+from C9/C11 audit: bf16 matmul accumulation noise on W4A16-dequanted weights
+shifts the draft head's top-1 enough to explain α == 0.058-0.124 observed
+in C5 after the C3 RoPE fix landed.
+
+### Implementation
+
+Narrow, TLS-gated chokepoint — no behavior change when flag unset.
+
+- `crates/kiln-model/src/mtp_debug.rs` — `KILN_MTP_FP32_HEAD` env reader +
+  `MTP_FP32_HEAD_ARMED` TLS `RefCell<bool>` + arm/disarm helpers.
+- `crates/kiln-model/src/lora_loader.rs::linear_with_lora_t` — when armed,
+  upcast `x` and transposed base weight to `DType::F32`, matmul, cast
+  back. LoRA and bias adds left untouched. Single chokepoint covers q/k/v/o
+  and MLP base matmuls in one branch.
+- `crates/kiln-model/src/forward.rs::mtp_forward_step` — reads flag once;
+  arms TLS around the draft-head `transformer_block_paged`; disarms on
+  exit. OR's into the existing `KILN_MTP_FC_FP32_ACCUM` branch so the new
+  flag subsumes C9's fc-only knob.
+
+### Results
+
+Median-of-3 on A6000, Qwen3.5-4B, `--paged --prompt-tokens 512
+--max-output-tokens 128 --skip-training --seed {42,43,44}`, MTP on
+(`KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp`):
+
+| Config           | env                                      | Median α | Median tok/s |
+|------------------|------------------------------------------|----------|--------------|
+| baseline         | `KILN_W4A16=1`                           | 0.0325   | 41.09        |
+| **primary**      | `KILN_W4A16=1 KILN_MTP_FP32_HEAD=1`      | 0.0325   | 37.66        |
+| sanity_nomarlin  | `KILN_W4A16=0`                           | 0.0583   | 36.76        |
+
+Per-seed α is bitwise identical across configs for 2/3 seeds (seed 42:
+4/123 for all three configs; seed 43: 4/123 for baseline and primary).
+
+### Verdict
+
+**PRIMARY-NEGATIVE.** fp32 draft-head projections do not recover α. The
+bf16 matmul-accumulation hypothesis is refuted: dtype of the head's
+projections is not a contributor of meaningful magnitude to α under greedy
+decode. The failure mode is structural — the MTP head deterministically
+picks a different top-1 token from the main head, across W4A16-bf16,
+W4A16-fp32, and no-Marlin-at-all.
+
+Combined with C5 (Class C = 0, Class B = 87.6%) and C3 (bitwise-identical
+α pre/post RoPE fix), the surviving hypothesis space is now entirely
+upstream of the head's projections: MTP token-embedding lookup, MTP
+pre-norm γ application, MTP hidden-state splicing from the main stack, or
+weight-loading for `mtp_head.fc_input` / `mtp_head.fc_output` /
+q-k-v-o. **C13 should investigate weight-loading policy and the splice
+input to the draft head first** — mis-tied or mis-loaded weights produce
+exactly this symptom (deterministic wrong top-1, dtype-insensitive).
+
+Decode cost: `KILN_MTP_FP32_HEAD=1` costs ≈ 8.3% of tok/s on A6000
+(41.09 → 37.66). Do not gate on by default.
+
+### Activation-weighted probe (sidecar, main-model MLP)
+
+`scripts/c12_activation_weighted_probe.py` audited 104 main-model
+projections on 32 prompts × 595 total tokens. Top weighted drift:
+`L6.down_proj` at 1.447e-01; many MLPs in the 11-14% band. This is
+non-trivial drift by magnitude, but it doesn't propagate into main-head
+top-1 flips on the bench prompts (otherwise sanity_nomarlin and baseline
+main-head trajectories would differ more — they don't). The probe's
+script-level terminal verdict ("Corroborates PRIMARY-POSITIVE…") is stale
+boilerplate; the authoritative C12 verdict is the bench above.
+
+### Budget used
+
+Single A6000 pod (`wl0fyjvqrv0v9b`), warm sccache (hit rate 97.56%). Build
+2m 12s; 9 bench runs ≈ 974s total; one probe run (~160s). All pod-side
+waits used `runpod_api.py wait-file --timeout`; no `until ssh` or
+`while ssh … sleep` polling loops. Well under the 90 min / $40 hard cap.
+
+### Output
+
+- `docs/phase-c12/c12-fp32-head.md` — full verdict report.
+- `c12-out/bench-summary.json` — 3 × 3 trial JSON (seed, α, tok/s, ITL,
+  accept line).
+- `c12-out/probe-report.md` + `c12-out/probe-report.json` — main-model
+  activation-weighted drift audit.
+- `c12-out/bench.log`, `c12-out/probe.log` — runner logs.

--- a/c12-out/bench-summary.json
+++ b/c12-out/bench-summary.json
@@ -1,0 +1,133 @@
+{
+  "seeds": [
+    42,
+    43,
+    44
+  ],
+  "bench_flags": [
+    "--paged",
+    "--prompt-tokens",
+    "512",
+    "--max-output-tokens",
+    "128",
+    "--skip-training"
+  ],
+  "configs": [
+    {
+      "name": "baseline",
+      "env": {
+        "KILN_W4A16": "1"
+      },
+      "trials": [
+        {
+          "seed": 42,
+          "alpha": 0.032520325203252036,
+          "top1_agreement": 0.032520325203252036,
+          "decode_tok_per_sec": 41.08733816417334,
+          "mean_itl_ms": 24.33839826771654,
+          "accept_line": "Decode (MTP): 128 tokens, mean ITL 24.3ms (41.1 tok/s), \u03b1 = 0.033 (4/123)",
+          "elapsed_s": 123.4
+        },
+        {
+          "seed": 43,
+          "alpha": 0.032520325203252036,
+          "top1_agreement": 0.032520325203252036,
+          "decode_tok_per_sec": 41.86725808465325,
+          "mean_itl_ms": 23.885012913385825,
+          "accept_line": "Decode (MTP): 128 tokens, mean ITL 23.9ms (41.9 tok/s), \u03b1 = 0.033 (4/123)",
+          "elapsed_s": 107.2
+        },
+        {
+          "seed": 44,
+          "alpha": 0.09482758620689655,
+          "top1_agreement": 0.09482758620689655,
+          "decode_tok_per_sec": 39.43081253260326,
+          "mean_itl_ms": 25.36087733858268,
+          "accept_line": "Decode (MTP): 128 tokens, mean ITL 25.4ms (39.4 tok/s), \u03b1 = 0.095 (11/116)",
+          "elapsed_s": 108.8
+        }
+      ],
+      "median_alpha": 0.032520325203252036,
+      "median_top1_agreement": 0.032520325203252036,
+      "median_decode_tok_per_sec": 41.08733816417334
+    },
+    {
+      "name": "primary",
+      "env": {
+        "KILN_W4A16": "1",
+        "KILN_MTP_FP32_HEAD": "1"
+      },
+      "trials": [
+        {
+          "seed": 42,
+          "alpha": 0.032520325203252036,
+          "top1_agreement": 0.032520325203252036,
+          "decode_tok_per_sec": 37.66243728389407,
+          "mean_itl_ms": 26.55165390551182,
+          "accept_line": "Decode (MTP): 128 tokens, mean ITL 26.6ms (37.7 tok/s), \u03b1 = 0.033 (4/123)",
+          "elapsed_s": 109.7
+        },
+        {
+          "seed": 43,
+          "alpha": 0.032520325203252036,
+          "top1_agreement": 0.032520325203252036,
+          "decode_tok_per_sec": 37.14920491734478,
+          "mean_itl_ms": 26.918476511811022,
+          "accept_line": "Decode (MTP): 128 tokens, mean ITL 26.9ms (37.1 tok/s), \u03b1 = 0.033 (4/123)",
+          "elapsed_s": 109.2
+        },
+        {
+          "seed": 44,
+          "alpha": 0.10434782608695652,
+          "top1_agreement": 0.10434782608695652,
+          "decode_tok_per_sec": 38.95644940608617,
+          "mean_itl_ms": 25.669690519685037,
+          "accept_line": "Decode (MTP): 128 tokens, mean ITL 25.7ms (39.0 tok/s), \u03b1 = 0.104 (12/115)",
+          "elapsed_s": 106.4
+        }
+      ],
+      "median_alpha": 0.032520325203252036,
+      "median_top1_agreement": 0.032520325203252036,
+      "median_decode_tok_per_sec": 37.66243728389407
+    },
+    {
+      "name": "sanity_nomarlin",
+      "env": {
+        "KILN_W4A16": "0"
+      },
+      "trials": [
+        {
+          "seed": 42,
+          "alpha": 0.032520325203252036,
+          "top1_agreement": 0.032520325203252036,
+          "decode_tok_per_sec": 36.67246307671677,
+          "mean_itl_ms": 27.268416574803148,
+          "accept_line": "Decode (MTP): 128 tokens, mean ITL 27.3ms (36.7 tok/s), \u03b1 = 0.033 (4/123)",
+          "elapsed_s": 103.3
+        },
+        {
+          "seed": 43,
+          "alpha": 0.058333333333333334,
+          "top1_agreement": 0.058333333333333334,
+          "decode_tok_per_sec": 36.76236531458697,
+          "mean_itl_ms": 27.20173175590552,
+          "accept_line": "Decode (MTP): 128 tokens, mean ITL 27.2ms (36.8 tok/s), \u03b1 = 0.058 (7/120)",
+          "elapsed_s": 102.9
+        },
+        {
+          "seed": 44,
+          "alpha": 0.10434782608695652,
+          "top1_agreement": 0.10434782608695652,
+          "decode_tok_per_sec": 37.02075852691495,
+          "mean_itl_ms": 27.011872251968494,
+          "accept_line": "Decode (MTP): 128 tokens, mean ITL 27.0ms (37.0 tok/s), \u03b1 = 0.104 (12/115)",
+          "elapsed_s": 103.2
+        }
+      ],
+      "median_alpha": 0.058333333333333334,
+      "median_top1_agreement": 0.058333333333333334,
+      "median_decode_tok_per_sec": 36.76236531458697
+    }
+  ],
+  "total_elapsed_s": 974.2
+}

--- a/c12-out/bench.log
+++ b/c12-out/bench.log
@@ -1,0 +1,40 @@
+[36m=== kiln-runpod image ===[0m
+  GPU: NVIDIA RTX A6000, 570.195.03
+  CUDA toolkit: release 12.4
+  nsys: NVIDIA Nsight Systems version 2023.4.4.54-234433681190v0
+  rustc: 1.95.0 | cargo: 1.95.0
+  sccache: 0.9.1 | nextest: (65e806bd5
+  torch: 2.4.1+cu124 (cuda=12.4)
+
+Quick start: [32mkiln-setup[0m (configures sccache+B2) then clone kiln & build.
+
+
+[config=baseline] env={'KILN_W4A16': '1'}
+    → seed=42 env=KILN_W4A16=1
+    → seed=43 env=KILN_W4A16=1
+    → seed=44 env=KILN_W4A16=1
+  → median α = 0.0325
+  → median decode = 41.09 tok/s
+
+[config=primary] env={'KILN_W4A16': '1', 'KILN_MTP_FP32_HEAD': '1'}
+    → seed=42 env=KILN_W4A16=1 KILN_MTP_FP32_HEAD=1
+    → seed=43 env=KILN_W4A16=1 KILN_MTP_FP32_HEAD=1
+    → seed=44 env=KILN_W4A16=1 KILN_MTP_FP32_HEAD=1
+  → median α = 0.0325
+  → median decode = 37.66 tok/s
+
+[config=sanity_nomarlin] env={'KILN_W4A16': '0'}
+    → seed=42 env=KILN_W4A16=0
+    → seed=43 env=KILN_W4A16=0
+    → seed=44 env=KILN_W4A16=0
+  → median α = 0.0583
+  → median decode = 36.76 tok/s
+
+[bench_runner] wrote /workspace/c12-out/bench-summary.json
+
+=== Median-of-3 Summary ===
+config                   median α  median top1   median tok/s
+-------------------------------------------------------------
+baseline                   0.0325       0.0325          41.09
+primary                    0.0325       0.0325          37.66
+sanity_nomarlin            0.0583       0.0583          36.76

--- a/c12-out/probe-report.json
+++ b/c12-out/probe-report.json
@@ -1,0 +1,1053 @@
+{
+  "checkpoint": "/workspace/qwen3.5-4b",
+  "device": "cuda",
+  "dtype": "bf16",
+  "n_prompts": 32,
+  "n_tokens": 595,
+  "threshold_benign": 0.001,
+  "worst_name": "L6.down_proj",
+  "worst_ratio": 0.1446790075753703,
+  "elapsed_s": 160.09640431404114,
+  "results": [
+    {
+      "layer_idx": 6,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.1446790075753703,
+      "abs_err_frobenius": 21.33380889892578,
+      "weight_drift_frobenius": 4.617769718170166,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 18,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.13843629575403776,
+      "abs_err_frobenius": 29.804933547973633,
+      "weight_drift_frobenius": 5.055545330047607,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 25,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.12021878876613382,
+      "abs_err_frobenius": 30.025686264038086,
+      "weight_drift_frobenius": 4.92556095123291,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 5,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11788470432038968,
+      "abs_err_frobenius": 86.61216735839844,
+      "weight_drift_frobenius": 4.5661234855651855,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 4,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11771485180676763,
+      "abs_err_frobenius": 79.49250030517578,
+      "weight_drift_frobenius": 4.603237152099609,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 15,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11696313815659265,
+      "abs_err_frobenius": 98.07389831542969,
+      "weight_drift_frobenius": 4.8448052406311035,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 17,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11682463083005934,
+      "abs_err_frobenius": 10.314355850219727,
+      "weight_drift_frobenius": 4.882265090942383,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 6,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.1164156599985426,
+      "abs_err_frobenius": 96.43572998046875,
+      "weight_drift_frobenius": 4.5634541511535645,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 21,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11614873934098326,
+      "abs_err_frobenius": 18.720491409301758,
+      "weight_drift_frobenius": 4.876258850097656,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 20,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11542283324321423,
+      "abs_err_frobenius": 17.39341926574707,
+      "weight_drift_frobenius": 4.873668193817139,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 13,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11514048781560542,
+      "abs_err_frobenius": 93.31334686279297,
+      "weight_drift_frobenius": 4.790075778961182,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 19,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11501648927715073,
+      "abs_err_frobenius": 17.75364875793457,
+      "weight_drift_frobenius": 5.1067280769348145,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 7,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11445670639218788,
+      "abs_err_frobenius": 92.43050384521484,
+      "weight_drift_frobenius": 4.524466037750244,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 16,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11440183140871624,
+      "abs_err_frobenius": 9.380375862121582,
+      "weight_drift_frobenius": 4.850715160369873,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 30,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11417994959523217,
+      "abs_err_frobenius": 46.4693717956543,
+      "weight_drift_frobenius": 5.327700614929199,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 17,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11382480397424355,
+      "abs_err_frobenius": 102.12451171875,
+      "weight_drift_frobenius": 4.872336387634277,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 11,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11353379057145387,
+      "abs_err_frobenius": 96.7995376586914,
+      "weight_drift_frobenius": 4.839883327484131,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 16,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11336390630030083,
+      "abs_err_frobenius": 98.63198852539062,
+      "weight_drift_frobenius": 4.824889659881592,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 24,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11329187512374671,
+      "abs_err_frobenius": 24.350826263427734,
+      "weight_drift_frobenius": 4.89721155166626,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 8,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11321261087885028,
+      "abs_err_frobenius": 93.83572387695312,
+      "weight_drift_frobenius": 4.624926567077637,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 12,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11298283488756458,
+      "abs_err_frobenius": 94.87067413330078,
+      "weight_drift_frobenius": 4.8303022384643555,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 13,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11292375138846576,
+      "abs_err_frobenius": 8.036996841430664,
+      "weight_drift_frobenius": 4.74730920791626,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 23,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11281179511834183,
+      "abs_err_frobenius": 24.29708480834961,
+      "weight_drift_frobenius": 4.93878173828125,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 9,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.112798373985489,
+      "abs_err_frobenius": 95.9991683959961,
+      "weight_drift_frobenius": 4.73643684387207,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 29,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11273856632359246,
+      "abs_err_frobenius": 39.962432861328125,
+      "weight_drift_frobenius": 5.2570390701293945,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 14,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11250603506757312,
+      "abs_err_frobenius": 96.13160705566406,
+      "weight_drift_frobenius": 4.814235687255859,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 28,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11230626698538615,
+      "abs_err_frobenius": 33.847373962402344,
+      "weight_drift_frobenius": 5.152654647827148,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 2,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.11216938848992992,
+      "abs_err_frobenius": 55.31162643432617,
+      "weight_drift_frobenius": 4.451646327972412,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 12,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.11175017539682933,
+      "abs_err_frobenius": 8.437304496765137,
+      "weight_drift_frobenius": 4.776100158691406,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 10,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.10999404627169988,
+      "abs_err_frobenius": 100.63385772705078,
+      "weight_drift_frobenius": 4.827069282531738,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 15,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.10997494059563309,
+      "abs_err_frobenius": 8.641570091247559,
+      "weight_drift_frobenius": 4.797789573669434,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 18,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.10970258954532736,
+      "abs_err_frobenius": 114.99620819091797,
+      "weight_drift_frobenius": 4.982748985290527,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 11,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.10958626690111697,
+      "abs_err_frobenius": 8.890088081359863,
+      "weight_drift_frobenius": 4.784038066864014,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 14,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.10954406167765272,
+      "abs_err_frobenius": 8.35179615020752,
+      "weight_drift_frobenius": 4.755337715148926,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 19,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.10874729460540968,
+      "abs_err_frobenius": 120.79302215576172,
+      "weight_drift_frobenius": 5.121088027954102,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 3,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.10863416774056327,
+      "abs_err_frobenius": 63.594749450683594,
+      "weight_drift_frobenius": 4.577305316925049,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 1,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.10830904799385706,
+      "abs_err_frobenius": 48.12067413330078,
+      "weight_drift_frobenius": 4.559702396392822,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 22,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.10826792895313032,
+      "abs_err_frobenius": 33.819034576416016,
+      "weight_drift_frobenius": 4.8879241943359375,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 4,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.10743763673560709,
+      "abs_err_frobenius": 6.2372612953186035,
+      "weight_drift_frobenius": 4.637591361999512,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 5,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.10700263923506843,
+      "abs_err_frobenius": 7.677295684814453,
+      "weight_drift_frobenius": 4.680777549743652,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 9,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.10696517054658038,
+      "abs_err_frobenius": 9.4907808303833,
+      "weight_drift_frobenius": 4.7256598472595215,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 20,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.10685664260609089,
+      "abs_err_frobenius": 120.68234252929688,
+      "weight_drift_frobenius": 4.945210933685303,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 8,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.1060940383120041,
+      "abs_err_frobenius": 9.971417427062988,
+      "weight_drift_frobenius": 4.622527122497559,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 26,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.10608136967580091,
+      "abs_err_frobenius": 59.210853576660156,
+      "weight_drift_frobenius": 5.036811351776123,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 7,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.10589381565507218,
+      "abs_err_frobenius": 10.002213478088379,
+      "weight_drift_frobenius": 4.568554878234863,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 21,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.10585534400761548,
+      "abs_err_frobenius": 124.42154693603516,
+      "weight_drift_frobenius": 4.9500932693481445,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 0,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.10550101367501746,
+      "abs_err_frobenius": 35.735435485839844,
+      "weight_drift_frobenius": 4.573436260223389,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 10,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.1048625767163925,
+      "abs_err_frobenius": 9.925077438354492,
+      "weight_drift_frobenius": 4.776448726654053,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 1,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.10377044577565855,
+      "abs_err_frobenius": 2.95865535736084,
+      "weight_drift_frobenius": 4.692465305328369,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 25,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.1034771774980886,
+      "abs_err_frobenius": 147.4689483642578,
+      "weight_drift_frobenius": 4.997037410736084,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 23,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.10317144892501372,
+      "abs_err_frobenius": 134.80328369140625,
+      "weight_drift_frobenius": 5.013294696807861,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 24,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.1025779389362113,
+      "abs_err_frobenius": 140.06396484375,
+      "weight_drift_frobenius": 4.973880767822266,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 26,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.10091513740777087,
+      "abs_err_frobenius": 157.1729736328125,
+      "weight_drift_frobenius": 5.1112961769104,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 0,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.09827817815137214,
+      "abs_err_frobenius": 1.964159369468689,
+      "weight_drift_frobenius": 4.6694159507751465,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 27,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.0975976892128671,
+      "abs_err_frobenius": 159.67173767089844,
+      "weight_drift_frobenius": 5.1525468826293945,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 27,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.09748502223908946,
+      "abs_err_frobenius": 39.14019775390625,
+      "weight_drift_frobenius": 5.078776836395264,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 4,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.09669266771776384,
+      "abs_err_frobenius": 91.60658264160156,
+      "weight_drift_frobenius": 5.044596195220947,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 3,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.09631497938749642,
+      "abs_err_frobenius": 5.084863185882568,
+      "weight_drift_frobenius": 4.625349998474121,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 1,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.09596911079093307,
+      "abs_err_frobenius": 53.30603790283203,
+      "weight_drift_frobenius": 4.940332889556885,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 0,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.09552763232990158,
+      "abs_err_frobenius": 38.75449752807617,
+      "weight_drift_frobenius": 4.899647235870361,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 22,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.09332601835938016,
+      "abs_err_frobenius": 135.4132843017578,
+      "weight_drift_frobenius": 4.994866847991943,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 2,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.0930625739414338,
+      "abs_err_frobenius": 65.03187561035156,
+      "weight_drift_frobenius": 5.1526384353637695,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 28,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.09224298622450676,
+      "abs_err_frobenius": 167.00933837890625,
+      "weight_drift_frobenius": 5.262794017791748,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 3,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.08877724177697444,
+      "abs_err_frobenius": 71.48431396484375,
+      "weight_drift_frobenius": 4.995429992675781,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 2,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.08833358086904071,
+      "abs_err_frobenius": 4.8144001960754395,
+      "weight_drift_frobenius": 4.5734100341796875,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 29,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.08764511894336062,
+      "abs_err_frobenius": 178.23895263671875,
+      "weight_drift_frobenius": 5.413364887237549,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 10,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.08579224610069383,
+      "abs_err_frobenius": 111.46532440185547,
+      "weight_drift_frobenius": 5.0993452072143555,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 14,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.08542032005186122,
+      "abs_err_frobenius": 102.10697937011719,
+      "weight_drift_frobenius": 4.8198065757751465,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 5,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.08473116185518056,
+      "abs_err_frobenius": 104.57516479492188,
+      "weight_drift_frobenius": 5.209493637084961,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 9,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.0827991552245564,
+      "abs_err_frobenius": 112.05953979492188,
+      "weight_drift_frobenius": 5.325904846191406,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 11,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.08111748362418697,
+      "abs_err_frobenius": 105.60337829589844,
+      "weight_drift_frobenius": 4.998036861419678,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 15,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.08103693751854679,
+      "abs_err_frobenius": 104.63945007324219,
+      "weight_drift_frobenius": 4.82980489730835,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 6,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.08004589468265512,
+      "abs_err_frobenius": 121.9751205444336,
+      "weight_drift_frobenius": 5.408701419830322,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 13,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.07949525996458344,
+      "abs_err_frobenius": 100.9731674194336,
+      "weight_drift_frobenius": 4.929263591766357,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 12,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.07945589537241925,
+      "abs_err_frobenius": 102.90536499023438,
+      "weight_drift_frobenius": 4.94350004196167,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 30,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.07935944806391647,
+      "abs_err_frobenius": 176.28465270996094,
+      "weight_drift_frobenius": 5.481202125549316,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 17,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.07741090612318585,
+      "abs_err_frobenius": 111.802978515625,
+      "weight_drift_frobenius": 4.893640518188477,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 16,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.07735190692843343,
+      "abs_err_frobenius": 108.12515258789062,
+      "weight_drift_frobenius": 4.907854080200195,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 31,
+      "kind": "down_proj",
+      "n_in": 9216,
+      "n_out": 2560,
+      "weighted_drift_ratio": 0.07679086881390075,
+      "abs_err_frobenius": 84.27136993408203,
+      "weight_drift_frobenius": 5.270009994506836,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 8,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.07636492105500275,
+      "abs_err_frobenius": 114.73263549804688,
+      "weight_drift_frobenius": 5.463793754577637,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 18,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.07585679729474998,
+      "abs_err_frobenius": 138.08619689941406,
+      "weight_drift_frobenius": 5.216629981994629,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 19,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.06901659119985694,
+      "abs_err_frobenius": 143.12216186523438,
+      "weight_drift_frobenius": 5.3440375328063965,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 7,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.06858922036381271,
+      "abs_err_frobenius": 118.85653686523438,
+      "weight_drift_frobenius": 5.564907550811768,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 21,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.06814522727925597,
+      "abs_err_frobenius": 172.00975036621094,
+      "weight_drift_frobenius": 6.189476013183594,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 20,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.06678692034384523,
+      "abs_err_frobenius": 164.4077606201172,
+      "weight_drift_frobenius": 5.993634223937988,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 24,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.06665813208242982,
+      "abs_err_frobenius": 198.88978576660156,
+      "weight_drift_frobenius": 6.536601543426514,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 23,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.06655401857465895,
+      "abs_err_frobenius": 186.12814331054688,
+      "weight_drift_frobenius": 6.307852745056152,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 27,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.06522282078293705,
+      "abs_err_frobenius": 234.18516540527344,
+      "weight_drift_frobenius": 7.052812576293945,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 25,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.06439506193120216,
+      "abs_err_frobenius": 215.33120727539062,
+      "weight_drift_frobenius": 6.8253865242004395,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 26,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.06407719043258135,
+      "abs_err_frobenius": 234.4377899169922,
+      "weight_drift_frobenius": 7.105398178100586,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 22,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.06283284612579311,
+      "abs_err_frobenius": 200.85226440429688,
+      "weight_drift_frobenius": 6.671199798583984,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 31,
+      "kind": "up_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.061849937720172915,
+      "abs_err_frobenius": 173.5617218017578,
+      "weight_drift_frobenius": 5.888767242431641,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 28,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.059720770613202134,
+      "abs_err_frobenius": 240.22402954101562,
+      "weight_drift_frobenius": 7.098064422607422,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 30,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.0557552008100425,
+      "abs_err_frobenius": 239.1707000732422,
+      "weight_drift_frobenius": 7.119729042053223,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 29,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.055587786376675025,
+      "abs_err_frobenius": 255.60336303710938,
+      "weight_drift_frobenius": 7.298641204833984,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 31,
+      "kind": "q_proj",
+      "n_in": 2560,
+      "n_out": 8192,
+      "weighted_drift_ratio": 0.052327216204746105,
+      "abs_err_frobenius": 232.20843505859375,
+      "weight_drift_frobenius": 6.684837818145752,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 27,
+      "kind": "q_proj",
+      "n_in": 2560,
+      "n_out": 8192,
+      "weighted_drift_ratio": 0.04892761723094254,
+      "abs_err_frobenius": 215.97715759277344,
+      "weight_drift_frobenius": 6.533321857452393,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 31,
+      "kind": "gate_proj",
+      "n_in": 2560,
+      "n_out": 9216,
+      "weighted_drift_ratio": 0.048350976267114903,
+      "abs_err_frobenius": 224.43212890625,
+      "weight_drift_frobenius": 7.429364204406738,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 23,
+      "kind": "q_proj",
+      "n_in": 2560,
+      "n_out": 8192,
+      "weighted_drift_ratio": 0.045444800968484696,
+      "abs_err_frobenius": 202.53221130371094,
+      "weight_drift_frobenius": 6.7954206466674805,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 11,
+      "kind": "q_proj",
+      "n_in": 2560,
+      "n_out": 8192,
+      "weighted_drift_ratio": 0.04530075979491003,
+      "abs_err_frobenius": 178.4682159423828,
+      "weight_drift_frobenius": 6.626485824584961,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 19,
+      "kind": "q_proj",
+      "n_in": 2560,
+      "n_out": 8192,
+      "weighted_drift_ratio": 0.04519157620862183,
+      "abs_err_frobenius": 181.4912567138672,
+      "weight_drift_frobenius": 6.381707191467285,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 7,
+      "kind": "q_proj",
+      "n_in": 2560,
+      "n_out": 8192,
+      "weighted_drift_ratio": 0.04441036297926419,
+      "abs_err_frobenius": 203.41036987304688,
+      "weight_drift_frobenius": 6.910342693328857,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 15,
+      "kind": "q_proj",
+      "n_in": 2560,
+      "n_out": 8192,
+      "weighted_drift_ratio": 0.043324490888708204,
+      "abs_err_frobenius": 174.12579345703125,
+      "weight_drift_frobenius": 6.316186904907227,
+      "n_tokens": 595
+    },
+    {
+      "layer_idx": 3,
+      "kind": "q_proj",
+      "n_in": 2560,
+      "n_out": 8192,
+      "weighted_drift_ratio": 0.03996958198304782,
+      "abs_err_frobenius": 283.6686706542969,
+      "weight_drift_frobenius": 7.732517242431641,
+      "n_tokens": 595
+    }
+  ]
+}

--- a/c12-out/probe-report.md
+++ b/c12-out/probe-report.md
@@ -1,0 +1,27 @@
+# Phase C12 — activation-weighted Marlin drift probe
+
+- Checkpoint: `/workspace/qwen3.5-4b`
+- Device: `cuda`, dtype: `bf16`
+- Calibration prompts: 32 (595 tokens total)
+- Projections audited: 104
+- Elapsed: 160.1s
+- Benign threshold: weighted_drift_ratio < 0.001
+
+## Top 10 projections by weighted drift ratio
+
+| layer | kind | k (in) | n (out) | weighted_ratio | err_frob | drift_frob |
+|------:|:-----|------:|--------:|----------------:|---------:|-----------:|
+| 6 | down_proj | 9216 | 2560 | 1.447e-01 | 2.133e+01 | 4.618e+00 |
+| 18 | down_proj | 9216 | 2560 | 1.384e-01 | 2.980e+01 | 5.056e+00 |
+| 25 | down_proj | 9216 | 2560 | 1.202e-01 | 3.003e+01 | 4.926e+00 |
+| 5 | up_proj | 2560 | 9216 | 1.179e-01 | 8.661e+01 | 4.566e+00 |
+| 4 | up_proj | 2560 | 9216 | 1.177e-01 | 7.949e+01 | 4.603e+00 |
+| 15 | up_proj | 2560 | 9216 | 1.170e-01 | 9.807e+01 | 4.845e+00 |
+| 17 | down_proj | 9216 | 2560 | 1.168e-01 | 1.031e+01 | 4.882e+00 |
+| 6 | up_proj | 2560 | 9216 | 1.164e-01 | 9.644e+01 | 4.563e+00 |
+| 21 | down_proj | 9216 | 2560 | 1.161e-01 | 1.872e+01 | 4.876e+00 |
+| 20 | down_proj | 9216 | 2560 | 1.154e-01 | 1.739e+01 | 4.874e+00 |
+
+**Worst projection: `L6.down_proj`, weighted_drift_ratio = 1.447e-01**
+
+**Verdict: NON-TRIVIAL.** At least one projection has an activation-weighted drift ratio >= 1e-03; Marlin drift plausibly lands on high-activation channels. Corroborates PRIMARY-POSITIVE on the C12 fp32-head bench.

--- a/c12-out/probe.log
+++ b/c12-out/probe.log
@@ -1,0 +1,28 @@
+[36m=== kiln-runpod image ===[0m
+  GPU: NVIDIA RTX A6000, 570.195.03
+  CUDA toolkit: release 12.4
+  nsys: NVIDIA Nsight Systems version 2023.4.4.54-234433681190v0
+  rustc: 1.95.0 | cargo: 1.95.0
+  sccache: 0.9.1 | nextest: (65e806bd5
+  torch: 2.4.1+cu124 (cuda=12.4)
+
+Quick start: [32mkiln-setup[0m (configures sccache+B2) then clone kiln & build.
+
+[c12] device=cuda dtype=bf16
+[c12] loading model from /workspace/qwen3.5-4b
+`torch_dtype` is deprecated! Use `dtype` instead!
+The fast path is not available because one of the required library is not installed. Falling back to torch implementation. To install follow https://github.com/fla-org/flash-linear-attention#installation and https://github.com/Dao-AILab/causal-conv1d
+Loading weights:   0%|          | 0/426 [00:00<?, ?it/s]Loading weights:   0%|          | 1/426 [00:00<00:53,  8.00it/s]Loading weights:   8%|▊         | 32/426 [00:00<00:02, 167.78it/s]Loading weights:  12%|█▏        | 51/426 [00:00<00:02, 176.47it/s]Loading weights:  18%|█▊        | 77/426 [00:00<00:01, 207.92it/s]Loading weights:  23%|██▎       | 99/426 [00:00<00:01, 197.91it/s]Loading weights:  30%|███       | 128/426 [00:00<00:01, 221.94it/s]Loading weights:  35%|███▌      | 151/426 [00:00<00:01, 207.94it/s]Loading weights:  41%|████      | 173/426 [00:00<00:01, 206.65it/s]Loading weights:  47%|████▋     | 199/426 [00:00<00:01, 217.94it/s]Loading weights:  52%|█████▏    | 222/426 [00:01<00:00, 218.74it/s]Loading weights:  58%|█████▊    | 245/426 [00:01<00:00, 217.11it/s]Loading weights:  63%|██████▎   | 267/426 [00:01<00:00, 199.04it/s]Loading weights:  68%|██████▊   | 291/426 [00:01<00:00, 206.12it/s]Loading weights:  73%|███████▎  | 312/426 [00:01<00:00, 191.21it/s]Loading weights:  79%|███████▉  | 336/426 [00:01<00:00, 201.16it/s]Loading weights:  84%|████████▍ | 359/426 [00:01<00:00, 200.31it/s]Loading weights:  90%|█████████ | 385/426 [00:01<00:00, 211.51it/s]Loading weights:  97%|█████████▋| 412/426 [00:02<00:00, 221.54it/s]Loading weights: 100%|██████████| 426/426 [00:02<00:00, 203.41it/s]
+[c12] layer prefix = `model.language_model.`
+[c12] installed 104 hooks across 32 layers (8 full-attn q_proj hooks)
+[c12] prompt 0: 10 tokens
+[c12] prompt 1: 14 tokens
+[c12] prompt 2: 21 tokens
+[c12] captured activations over 595 total tokens across 32 prompts
+[c12] processed 20 projections (current worst L6.down_proj ratio=1.447e-01)
+[c12] processed 40 projections (current worst L6.down_proj ratio=1.447e-01)
+[c12] processed 60 projections (current worst L6.down_proj ratio=1.447e-01)
+[c12] processed 80 projections (current worst L6.down_proj ratio=1.447e-01)
+[c12] processed 100 projections (current worst L6.down_proj ratio=1.447e-01)
+[c12] wrote /workspace/c12-out/probe-report.md and /workspace/c12-out/probe-report.json
+[c12] worst=L6.down_proj ratio=1.447e-01

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -4432,9 +4432,13 @@ pub fn mtp_forward_step(
     if dump_pre_rope {
         let _ = crate::mtp_debug::capture_pre_rope_tap("concat", &concat);
     }
+    // Phase C12: `KILN_MTP_FP32_HEAD=1` subsumes `KILN_MTP_FC_FP32_ACCUM=1` —
+    // the full-head kill switch always includes fc_input/fc_output in f32,
+    // so either flag alone is sufficient to trigger the fp32 fc path.
+    let fp32_head = crate::mtp_debug::is_mtp_fp32_head_enabled();
     let fused = {
         kiln_nvtx::range!(c"kiln/mtp/fc");
-        if crate::mtp_debug::is_mtp_fc_fp32_accum_enabled() {
+        if crate::mtp_debug::is_mtp_fc_fp32_accum_enabled() || fp32_head {
             // Phase C9 falsification: promote inputs to f32, matmul in f32,
             // cast the result back to the input dtype. Eliminates the bf16
             // accumulation noise visible at the `fused` / `fc_output` tap
@@ -4500,6 +4504,19 @@ pub fn mtp_forward_step(
     // K/V scratch path for the MTP layer only; the disarm below clears
     // it before any non-MTP attention path on this thread can observe it.
     crate::mtp_debug::arm_mtp_single_token_self_attn();
+    // Phase C12: arm fp32-head BEFORE the inner block so that every
+    // projection matmul inside `gqa_attention_paged` (q/k/v/o) and the
+    // MLP (`swiglu_ffn`'s gate/up/down) sees the TLS flag armed. This is
+    // the cleanest minimal invasive cast point: `linear_with_lora_t` is
+    // the single chokepoint for all of those matmuls, and the non-MTP
+    // paths never observe the armed flag because it is disarmed below
+    // before we return. The MTP head is not Marlin-packed today, so in
+    // practice the flag gates the straight BF16 `broadcast_matmul`; if a
+    // future PR adds Marlin to MTP, the marlin path in `q_proj_forward`
+    // will need an analogous upcast branch.
+    if fp32_head {
+        crate::mtp_debug::arm_mtp_fp32_head();
+    }
     let mtp_hidden_result = transformer_block_paged(
         backend,
         &fused,
@@ -4521,6 +4538,9 @@ pub fn mtp_forward_step(
     // Always disarm in both success and error paths (`mtp_hidden_result`
     // is `?`-propagated below, so we cannot rely on the function tail).
     crate::mtp_debug::disarm_mtp_single_token_self_attn();
+    if fp32_head {
+        crate::mtp_debug::disarm_mtp_fp32_head();
+    }
 
     // Drain the sub-op capture window in BOTH success and error paths so the
     // TLS slot is not left armed for the next draft step (which would corrupt

--- a/crates/kiln-model/src/lora_loader.rs
+++ b/crates/kiln-model/src/lora_loader.rs
@@ -255,13 +255,28 @@ pub fn linear_with_lora(
 /// (`ucopy_bf16`) that would otherwise be materialized on every step.
 ///
 /// The LoRA delta path is unchanged.
+///
+/// Phase C12: when the MTP fp32-head TLS flag is armed (see
+/// [`crate::mtp_debug::is_mtp_fp32_head_armed`]), the base matmul is
+/// promoted to f32. Inputs and weights are upcast to f32, matmul runs in
+/// f32, and the result is cast back to the input dtype before the LoRA
+/// delta is added. The flag is only set inside `mtp_forward_step` while
+/// the MTP inner transformer block is running, so every non-MTP call site
+/// takes the legacy bf16 broadcast_matmul path unchanged.
 pub fn linear_with_lora_t(
     x: &Tensor,
     base_weight_t: &Tensor,
     lora: Option<&LoraProjectionWeights>,
     scale: f32,
 ) -> Result<Tensor> {
-    let base_output = x.broadcast_matmul(base_weight_t)?;
+    let base_output = if crate::mtp_debug::is_mtp_fp32_head_armed() {
+        let in_dtype = x.dtype();
+        let x_f32 = x.to_dtype(DType::F32)?;
+        let w_f32 = base_weight_t.to_dtype(DType::F32)?;
+        x_f32.broadcast_matmul(&w_f32)?.to_dtype(in_dtype)?
+    } else {
+        x.broadcast_matmul(base_weight_t)?
+    };
     if let Some(proj) = lora {
         let delta = compute_lora_delta(x, proj, scale)?;
         Ok((base_output + delta)?)

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -150,6 +150,23 @@ thread_local! {
     /// the legacy paged-cache behavior unchanged.
     static MTP_SINGLE_TOKEN_SELF_ATTN_ARMED: RefCell<bool> =
         const { RefCell::new(false) };
+
+    /// Phase C12: thread-local flag that forces projection matmuls inside
+    /// the MTP draft head to compute in f32. Set by [`arm_mtp_fp32_head`]
+    /// inside `mtp_forward_step` when `KILN_MTP_FP32_HEAD=1` is active, and
+    /// cleared by [`disarm_mtp_fp32_head`] right after the inner block
+    /// returns. Read by `linear_with_lora_t` (and by the fused `mtp.fc`
+    /// matmul path in `mtp_forward_step` itself, which also honors the
+    /// existing `KILN_MTP_FC_FP32_ACCUM` flag) to promote inputs + weights
+    /// to f32, matmul, then downcast back to the input dtype. This is the
+    /// C12 kill switch: if α materially recovers with the flag on, the
+    /// residual bf16 accumulation inside the MTP head's q/k/v/o + fc
+    /// matmuls contributes meaningfully to α suppression. If α is
+    /// unchanged, the null result exonerates bf16-accumulation in MTP.
+    /// Always defaults to `false`, so non-MTP paths and pre-C12 callers
+    /// see the legacy bf16 path unchanged.
+    static MTP_FP32_HEAD_ARMED: RefCell<bool> =
+        const { RefCell::new(false) };
 }
 
 const DEFAULT_MAX_CALLS: usize = 16;
@@ -242,6 +259,32 @@ pub fn is_swap_fc_norms_enabled() -> bool {
 /// the env var between processes.
 pub fn is_mtp_fc_fp32_accum_enabled() -> bool {
     std::env::var("KILN_MTP_FC_FP32_ACCUM")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// True when `KILN_MTP_FP32_HEAD=1` (or `true`) is set. When enabled,
+/// `mtp_forward_step` arms the [`MTP_FP32_HEAD_ARMED`] TLS flag before the
+/// MTP inner transformer block runs, which causes `linear_with_lora_t` to
+/// promote projection inputs + weights to f32, matmul in f32, and cast the
+/// result back to the input dtype for the q/k/v/o projections inside the
+/// block. The arm flag also forces the `mtp.fc` matmul in
+/// `mtp_forward_step` onto its fp32 accumulation path (same behaviour as
+/// `KILN_MTP_FC_FP32_ACCUM=1`), so a single flag covers both halves of the
+/// Phase C12 kill switch: q/k/v/o and fc_input/fc_output.
+///
+/// Subtlety: the MTP head is not Marlin-packed in the current build (see
+/// `mtp_forward_step` docstring), so "whichever are currently Marlin-packed"
+/// resolves to the empty set today. The flag still runs the intended
+/// experiment because the test is really whether bf16 accumulation in the
+/// MTP projection matmuls is the α-suppressor, regardless of whether those
+/// matmuls go through the Marlin path or the straight BF16 broadcast_matmul
+/// path. If α recovers with the flag on, Marlin-packing the MTP head is
+/// expected to regress α once it lands — and a fused fp32 accumulation
+/// variant of Marlin would be the follow-up. If α is unchanged, the signal
+/// is elsewhere and Marlin can be added to MTP without worry.
+pub fn is_mtp_fp32_head_enabled() -> bool {
+    std::env::var("KILN_MTP_FP32_HEAD")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false)
 }
@@ -907,6 +950,32 @@ pub fn arm_mtp_single_token_self_attn() {
 /// this thread) sees the legacy paged-cache behavior.
 pub fn disarm_mtp_single_token_self_attn() {
     MTP_SINGLE_TOKEN_SELF_ATTN_ARMED.with(|c| *c.borrow_mut() = false);
+}
+
+/// True if the Phase C12 fp32-head TLS flag is currently armed on this
+/// thread. Read by `linear_with_lora_t` to decide whether to promote the
+/// projection matmul to f32. Cheap single TLS access; the production path
+/// pays a branch when the flag is off. Always `false` outside the window
+/// bracketed by [`arm_mtp_fp32_head`] / [`disarm_mtp_fp32_head`] inside
+/// `mtp_forward_step`.
+pub fn is_mtp_fp32_head_armed() -> bool {
+    MTP_FP32_HEAD_ARMED.with(|c| *c.borrow())
+}
+
+/// Arm fp32 projection matmuls for the MTP inner block on this thread.
+/// Idempotent within a single `mtp_forward_step` call; the matching
+/// [`disarm_mtp_fp32_head`] is required and runs in both the success and
+/// the early-error paths inside `mtp_forward_step`.
+pub fn arm_mtp_fp32_head() {
+    MTP_FP32_HEAD_ARMED.with(|c| *c.borrow_mut() = true);
+}
+
+/// Disarm fp32 projection matmuls for the MTP inner block on this thread.
+/// Always runs after the inner block returns (success or error) so the
+/// next `mtp_forward_step` call (or any non-MTP projection call on this
+/// thread) sees the legacy bf16 matmul behavior.
+pub fn disarm_mtp_fp32_head() {
+    MTP_FP32_HEAD_ARMED.with(|c| *c.borrow_mut() = false);
 }
 
 /// Record one named SDPA-internal tap if a capture window is currently

--- a/docs/phase-c12/c12-fp32-head.md
+++ b/docs/phase-c12/c12-fp32-head.md
@@ -1,0 +1,186 @@
+# Phase C12 — fp32 draft-head kill switch + activation-weighted probe
+
+## Verdict: **PRIMARY-NEGATIVE**
+
+Forcing the MTP draft head's q/k/v/o + fc projections to fp32 (`KILN_MTP_FP32_HEAD=1`)
+does **not** materially improve α over the W4A16 baseline under greedy decode.
+
+| Config                            | env                                             | Median α    | Median tok/s |
+|-----------------------------------|-------------------------------------------------|-------------|--------------|
+| baseline                          | `KILN_W4A16=1`                                  | **0.0325**  | 41.09        |
+| **primary (fp32 draft head)**     | `KILN_W4A16=1 KILN_MTP_FP32_HEAD=1`             | **0.0325**  | 37.66        |
+| sanity_nomarlin                   | `KILN_W4A16=0`                                  | **0.0583**  | 36.76        |
+
+Ship-floor target: α ≥ 0.72. All three configs miss by ≥0.61.
+Median α primary == median α baseline to 4 decimals; the hypothesis that bf16 matmul
+accumulation noise in the MTP head's projections drives α drift is **refuted**.
+
+## Why this is a hard refutation, not noise
+
+Per-seed α under greedy decode is not just close — it is **bitwise identical across configs
+for 2 of 3 seeds**:
+
+| Seed | baseline α (accept/total) | primary α (accept/total) | sanity α (accept/total) |
+|------|---------------------------|--------------------------|-------------------------|
+| 42   | 0.0325 (4/123)            | 0.0325 (4/123)           | 0.0325 (4/123)          |
+| 43   | 0.0325 (4/123)            | 0.0325 (4/123)           | 0.0583 (7/120)          |
+| 44   | 0.0948 (11/116)           | 0.1043 (12/115)          | 0.1043 (12/115)         |
+
+The same 4 / 123 acceptance decisions show up under W4A16-bf16 head, W4A16-fp32 head,
+and no-Marlin-at-all for seed 42. Under greedy, Class C = 0 (C5), so α == top-1
+agreement — meaning the MTP head selects the *same* top-1 tokens regardless of whether
+its projections accumulate in bf16 or fp32 or use BF16 weights directly. The head is
+predicting a *different* token from the main head, deterministically, at the argmax
+level. Dtype of its projections is not a contributor of meaningful magnitude.
+
+## Decode-throughput cost of fp32 upcast
+
+- `KILN_MTP_FP32_HEAD=1` costs ≈ **8.3%** of decode tok/s on A6000 (41.09 → 37.66 tok/s).
+- No-Marlin (W4A16=0) costs ≈ **10.5%** (41.09 → 36.76 tok/s), consistent with PR #80/#146
+  Marlin wins being mostly intact in MTP mode.
+- Neither tier pays for itself — both degrade throughput *and* fail to lift α.
+
+## What this rules out
+
+Combined with the C5 Class B = 87.6% finding and the C3 RoPE fix that produced
+bitwise-identical α pre/post (PR #314), this closes several hypothesis branches:
+
+1. **MTP-head projection dtype / accumulation precision** — refuted here (C12).
+2. **Marlin W4A16 dequant drift at head matmuls** — refuted (sanity_nomarlin ≈ baseline).
+3. **RoPE position threading in draft forward** — refuted in C5 (post-fix bitwise
+   identical to pre-fix on the shared 8-pool prompt).
+4. **Tokenizer / verifier mask mismatch (Class C)** — refuted in C5 (Class C = 0 under
+   greedy across 339 rows).
+
+The surviving hypothesis space is **upstream of the head's projections**, on the input
+side:
+
+- **MTP token-embedding lookup** — is the embedding table used by the draft head tied
+  correctly to the main embed, and is it being dequantized/scaled identically to the
+  main-head path?
+- **MTP pre-norm (RMSNorm γ)** — applied in the right place, right dtype, right γ
+  tensor?
+- **MTP hidden-state splicing** — the residual fed into the draft head at step t comes
+  from *where* in the main stack (post-LN vs pre-LN, which layer index)? Does the
+  training recipe match what `mtp_forward_step` actually injects?
+- **MTP head weight loading itself** — is `fc_input` / `fc_output` pointing at the right
+  tensor names on disk, and is the weight-tying policy (tied vs separate vs shared_lora)
+  matching what the checkpoint was trained with?
+
+C12 closes the "numerical drift at the head matmul" door so C13 can focus on the
+"wrong input fed into the head" and "wrong weights loaded for the head" hypotheses.
+
+## Environment
+
+| Field            | Value                                                            |
+|------------------|------------------------------------------------------------------|
+| Repo             | `ericflo/kiln`                                                   |
+| Branch           | `mtp/phase-c12-fp32-draft-head`                                  |
+| GPU              | NVIDIA RTX A6000 (49 140 MB), 570.195.03 / CUDA 12.4             |
+| Image            | `ghcr.io/ericflo/kiln-runpod:latest`                             |
+| Model            | `Qwen/Qwen3.5-4B` (vocab 248320, hybrid 24× GDN + 8× GQA)        |
+| Build            | `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench` (sccache hit rate 97.56%, 2m 12s) |
+| Bench flags      | `--paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed {42,43,44}` |
+| MTP base env     | `KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp`                        |
+
+Seeds 42/43/44 are the C5/C9 convention for median-of-3 α; they map through the
+8-pool prompt table at `seed % 8` ∈ {2,3,4}.
+
+## Implementation summary
+
+Two-arm-flag + one-chokepoint design keeps the blast radius small:
+
+1. **`crates/kiln-model/src/mtp_debug.rs`** — adds `KILN_MTP_FP32_HEAD` env reader and
+   a TLS `MTP_FP32_HEAD_ARMED` `RefCell<bool>` with `arm_mtp_fp32_head()` /
+   `disarm_mtp_fp32_head()` helpers. No behavior change when the flag is unset.
+
+2. **`crates/kiln-model/src/lora_loader.rs::linear_with_lora_t`** — single chokepoint
+   for q/k/v/o + MLP base matmuls. When the TLS flag is armed, upcast `x` and the
+   transposed base weight to `DType::F32`, matmul in fp32, then cast back to input
+   dtype. LoRA and bias adds are left alone (they're small and already fp32-tolerant).
+
+3. **`crates/kiln-model/src/forward.rs::mtp_forward_step`** — reads
+   `is_mtp_fp32_head_enabled()` once; arms the TLS flag around the
+   `transformer_block_paged` call for the draft head's forward; disarms on exit. Also
+   OR's `fp32_head` into the existing `KILN_MTP_FC_FP32_ACCUM` branch so the new flag
+   subsumes C9's fc-only knob.
+
+Scope is intentionally narrow: the arm flag only fires during the draft-head block,
+so main-head matmuls are untouched and non-MTP decode paths are unaffected.
+
+## Activation-weighted probe (main-model MLP + full-attn q_proj, 32 prompts / 595 tok)
+
+`scripts/c12_activation_weighted_probe.py` hooked 104 projections (32 × {gate, up,
+down} + 8 full-attn q_proj) on the HF reference, reproduced kiln's Marlin dequant,
+and computed
+`weighted_drift_ratio = ||X @ (W_marlin - W_bf16).T||_F / ||X @ W_bf16.T||_F`
+per projection. Top 10:
+
+| layer | kind      | weighted_ratio |
+|------:|:----------|---------------:|
+| 6     | down_proj | **1.447e-01**  |
+| 18    | down_proj | 1.384e-01      |
+| 25    | down_proj | 1.202e-01      |
+| 5     | up_proj   | 1.179e-01      |
+| 4     | up_proj   | 1.177e-01      |
+| 15    | up_proj   | 1.170e-01      |
+| 17    | down_proj | 1.168e-01      |
+| 6     | up_proj   | 1.164e-01      |
+| 21    | down_proj | 1.161e-01      |
+| 20    | down_proj | 1.154e-01      |
+
+Main-model MLPs have activation-weighted drift up to **14.5%** (`L6.down_proj`); many
+layers sit in the 11-14% band. This is *non-trivial* drift by magnitude — roughly
+two orders of magnitude above the `1e-3` benign threshold the probe script uses.
+
+**This does not contradict the bench PRIMARY-NEGATIVE result.** The probe audits
+main-model MLP and full-attn projections, *not* the MTP head. The C12 bench showed
+that draft-head matmul precision (bf16 vs fp32) has no effect on α under greedy
+decode — i.e. whatever numerical drift exists in the draft head is not crossing any
+argmax boundary. The probe independently shows the *main* model's MLPs are carrying
+large activation-weighted drift, but that drift evidently doesn't change which token
+the *main* head picks for the 8-pool prompts used by the bench (if it did, we'd see
+different main-head trajectories across W4A16=0 vs W4A16=1, and we don't — seed 42
+accept/total is 4/123 for all three configs).
+
+The probe script's terminal-emitted verdict string
+("Corroborates PRIMARY-POSITIVE…") is a stale boilerplate hint attached to the
+`non-trivial drift` branch; the authoritative verdict for C12 is the bench in this
+report: **PRIMARY-NEGATIVE**.
+
+Full JSON: `c12-out/probe-report.json`. Markdown summary: `c12-out/probe-report.md`.
+
+## Bench artifacts
+
+- `c12-out/bench-summary.json` — full 3 × 3 trial JSON with seed, α, tok/s, mean ITL,
+  and the `Decode (MTP): ...` accept line for each run.
+- `c12-out/bench.log` — runner stdout.
+
+## Ship-floor verdict
+
+**MISS.** Do not gate `KILN_MTP_FP32_HEAD` on by default. Leave `KILN_SPEC_METHOD`
+default unchanged. Do not promote MTP.
+
+## Recommendation for C13
+
+Pick up from the C5/C12 closure above:
+
+1. **Dump the MTP head's input** pre-projection on a known seed, compare element-wise
+   against a "reference" draft forward that re-uses the main head's embed + norm +
+   layer-N residual. If the pre-head hidden state differs, the bug is in the splice /
+   norm / embed lookup, not the head.
+2. **Audit weight loading** for `mtp_head.fc_input` / `mtp_head.fc_output` / q-k-v-o
+   projections: which safetensors keys do they resolve to, and does the loader's
+   weight-tying policy (tied / separate / shared_lora) match the checkpoint's training
+   recipe? Mis-tied weights would reproduce exactly this symptom — deterministic wrong
+   top-1 under greedy, insensitive to matmul dtype.
+3. Capture activations at `mtp_pos ∈ {0, 2}` first — those are the largest α buckets
+   (146 / 339 ≈ 43% of attempts) and the worst accepting buckets (6.1% / 4.2%), so the
+   signal is largest and the sample size is largest.
+
+## Wall-clock / cost
+
+Within the 90 min / $40 budget. Single A6000 pod (`wl0fyjvqrv0v9b`), one build (2m 12s
+warm sccache), 9 bench runs (~108 s each, 974 s total), one probe run.
+Pod-side waits all used bounded `runpod_api.py wait-file --timeout`; no `until ssh` or
+`while ssh ... sleep` polling loops were used.

--- a/scripts/c12_activation_weighted_probe.py
+++ b/scripts/c12_activation_weighted_probe.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+"""
+Phase C12 — activation-weighted Marlin drift probe.
+
+Goal
+----
+
+C11 (PR #326) measured per-channel Marlin W4A16 scale drift on all 104
+Marlin-packed projections and found some output channels outside the
+fp32-equivalence band (cos_sim < 0.9999). C11 also noted — in the "Honest
+limits" section — that a per-channel scale outside-band on the *weight*
+may still produce in-band *activations* on realistic data if the signal
+never excites that channel.
+
+This probe closes that gap by re-weighting C11's pure-weight drift by an
+empirical activation distribution. For every Marlin-packed projection
+with weight `W` (HF layout [out, in]) and Marlin-dequant weight `W_dq`:
+
+    delta = W - W_dq                        # [out, in]
+    X = stack of activations feeding W      # [T, in] over calibration set
+    numerator   = || X @ delta.T ||_F       # Frobenius norm of output error
+    denominator = || X @ W.T    ||_F
+    activation_weighted_drift_ratio = numerator / denominator
+
+This is the empirical output-level SNR contribution of the dequant drift,
+observed on realistic inputs. If it is >= 1e-3 on the worst projection
+that C11 flagged, the C11 drift is not a benign artifact — it projects
+onto high-activation channels and is a plausible α-suppressing signal.
+If it is well below 1e-3, C11 drift is safely hidden under the activation
+distribution and the alpha floor comes from elsewhere.
+
+This script is support evidence for the C12 fp32-head kill-switch bench.
+A PRIMARY-POSITIVE bench (α recovers with `KILN_MTP_FP32_HEAD=1`) would
+be corroborated by a non-trivial weighted drift ratio here; a
+PRIMARY-NEGATIVE bench would be corroborated by a benign weighted drift
+ratio here.
+
+Scope
+-----
+
+C11 confirmed the MTP head is NOT Marlin-packed. The projections this
+probe audits live on the *main model* (8 full-attn q_proj + 32*3 MLP).
+Those are the weights the base model uses when producing the `h_main`
+hidden state that feeds `mtp_forward_step`. Even if none of the MTP
+*head* matmuls are Marlin-packed, the base-model Marlin projections are
+upstream of the MTP head and could still be a distal α-suppressing
+signal via the `h_main` tap. Auditing them is therefore on-scope for C12.
+
+Calibration set
+---------------
+
+Reuses the 5 fixed prompts from `scripts/mtp_reference_dump.py` plus 27
+additional Wikipedia-style prompts shipped below (= 32 prompts total,
+32-96 tokens each). Short enough to be tractable on an A6000 in a few
+minutes; long enough to produce representative activation statistics
+across the hidden dimension.
+
+Runs on GPU when available; falls back to CPU. CPU run is feasible but
+takes ~15 minutes on a modest host. A6000 completes in ~60 seconds.
+
+Usage
+-----
+
+    python3 scripts/c12_activation_weighted_probe.py \\
+        --checkpoint /workspace/qwen3.5-4b \\
+        --c11-json docs/phase-c11/c11-marlin-audit.json \\
+        --out docs/phase-c12/c12-weighted-drift.md \\
+        --out-json docs/phase-c12/c12-weighted-drift.json \\
+        [--device cuda] [--dtype bf16] [--max-prompts 32] [--max-tokens 96]
+
+Exit codes
+----------
+
+    0 — probe ran; weighted drift ratio is BENIGN on all projections
+        (< 1e-3 on the worst projection C11 flagged).  Corroborates
+        PRIMARY-NEGATIVE.
+    1 — probe ran; weighted drift ratio is NON-TRIVIAL (>= 1e-3) on at
+        least one projection.  Corroborates PRIMARY-POSITIVE.
+    2 — structural error (missing weight, bad CLI, CUDA OOM).
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import math
+import os
+import sys
+import time
+from dataclasses import dataclass, asdict
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+from safetensors import safe_open
+
+
+# Calibration prompts. 5 from mtp_reference_dump.py style + 27 general.
+CALIBRATION_PROMPTS = [
+    "The quick brown fox jumps over the lazy dog.",
+    "In the beginning was the Word, and the Word was with God.",
+    "To be or not to be, that is the question. Whether tis nobler in the mind to suffer",
+    "Four score and seven years ago our fathers brought forth on this continent, a new nation",
+    "It was the best of times, it was the worst of times, it was the age of wisdom.",
+    "Photosynthesis is the process by which plants convert light energy into chemical energy.",
+    "The Roman Empire reached its greatest territorial extent under the emperor Trajan in 117 AD.",
+    "Quantum mechanics describes the behavior of matter and light at atomic and subatomic scales.",
+    "The mitochondrion is a double-membrane-bound organelle found in most eukaryotic cells.",
+    "Shakespeare wrote approximately 39 plays, 154 sonnets, and two long narrative poems.",
+    "The Pacific Ocean is the largest and deepest of the Earth's five oceanic divisions.",
+    "Albert Einstein published the theory of special relativity in 1905 while working as a patent clerk.",
+    "The internet originated as ARPANET, a project funded by the US Department of Defense.",
+    "DNA is a double-helix molecule that encodes genetic instructions for living organisms.",
+    "The French Revolution began in 1789 with the storming of the Bastille in Paris.",
+    "Photography was invented in the early nineteenth century by Niepce and Daguerre.",
+    "The Great Wall of China was built over centuries by successive imperial dynasties.",
+    "Computer science is the study of algorithms, computation, and information processing.",
+    "The Industrial Revolution began in Britain in the late eighteenth century.",
+    "Vincent van Gogh painted over 2,100 artworks in a career that lasted just over a decade.",
+    "Gravity is described by Einstein's general theory of relativity as the curvature of spacetime.",
+    "The human brain contains approximately 86 billion neurons connected by trillions of synapses.",
+    "The Renaissance was a period of cultural rebirth that began in Italy in the fourteenth century.",
+    "Python is a high-level programming language known for readable syntax and broad applicability.",
+    "The Amazon rainforest produces roughly 20% of the oxygen in Earth's atmosphere.",
+    "The Beatles formed in Liverpool in 1960 and disbanded in 1970 after ten studio albums.",
+    "Black holes are regions of spacetime where gravitational attraction is so strong",
+    "Mount Everest is the highest mountain on Earth, with a peak elevation of 8,849 meters.",
+    "The Turing test, proposed in 1950, evaluates a machine's ability to exhibit human-like intelligence.",
+    "Climate change is the long-term alteration of temperature and typical weather patterns.",
+    "The Milky Way galaxy contains between 100 and 400 billion stars and has a spiral shape.",
+    "Abraham Lincoln delivered the Gettysburg Address on November 19, 1863, during the Civil War.",
+]
+
+
+MAX_Q = 15
+Q_OFFSET = 8
+
+
+# -----------------------------------------------------------------------------
+# Safetensors weight loading — mirrors scripts/c11_marlin_audit.py
+# -----------------------------------------------------------------------------
+
+def st_load_tensor(checkpoint_dir: str, name: str, allow_missing: bool = False) -> Optional[torch.Tensor]:
+    idx_path = os.path.join(checkpoint_dir, "model.safetensors.index.json")
+    if os.path.exists(idx_path):
+        with open(idx_path, "r", encoding="utf-8") as f:
+            idx = json.load(f)
+        weight_map = idx.get("weight_map", {})
+        if name in weight_map:
+            shard_path = os.path.join(checkpoint_dir, weight_map[name])
+            with safe_open(shard_path, framework="pt", device="cpu") as g:
+                if name in g.keys():
+                    return g.get_tensor(name).to(torch.float32)
+    for shard_path in sorted(glob.glob(os.path.join(checkpoint_dir, "*.safetensors"))):
+        with safe_open(shard_path, framework="pt", device="cpu") as g:
+            if name in g.keys():
+                return g.get_tensor(name).to(torch.float32)
+    if allow_missing:
+        return None
+    raise KeyError(f"tensor `{name}` not found under {checkpoint_dir}")
+
+
+def discover_prefix(checkpoint_dir: str) -> str:
+    idx_path = os.path.join(checkpoint_dir, "model.safetensors.index.json")
+    with open(idx_path, "r", encoding="utf-8") as f:
+        keys = json.load(f)["weight_map"].keys()
+    for prefix in ["model.language_model.", "model.", ""]:
+        if prefix + "layers.0.mlp.down_proj.weight" in keys:
+            return prefix
+    raise KeyError("Could not discover layer prefix")
+
+
+def marlin_dequant_groupwise(weight_t_f32: np.ndarray, groupsize: int = 128) -> np.ndarray:
+    """Reproduce kiln_marlin_gemm::pack::quantize_and_pack's dequant on
+    weight_t layout [k=in, n=out]. Returns [k, n] dequantized weights."""
+    k, n = weight_t_f32.shape
+    assert k % groupsize == 0, f"k={k} not divisible by groupsize={groupsize}"
+    num_groups = k // groupsize
+    w = weight_t_f32.reshape(num_groups, groupsize, n)
+
+    max_abs = np.max(np.abs(w), axis=1)
+    max_abs = np.where(max_abs == 0.0, 1.0, max_abs)
+    s_f32 = (2.0 * max_abs) / float(MAX_Q)
+    s_f16 = s_f32.astype(np.float16).astype(np.float32)
+
+    s_broadcast = s_f16[:, None, :]
+    q_raw = np.round(w / s_broadcast).astype(np.int32)
+    q_shifted = np.clip(q_raw + Q_OFFSET, 0, MAX_Q)
+    w_dq = (q_shifted - Q_OFFSET).astype(np.float32) * s_broadcast
+    return w_dq.reshape(k, n)
+
+
+# -----------------------------------------------------------------------------
+# Activation capture via transformers hooks
+# -----------------------------------------------------------------------------
+
+@dataclass
+class ProjectionResult:
+    layer_idx: int
+    kind: str
+    n_in: int
+    n_out: int
+    weighted_drift_ratio: float    # || X @ delta.T || / || X @ W.T ||
+    abs_err_frobenius: float
+    weight_drift_frobenius: float  # || delta || (unweighted, for cross-check vs C11)
+    n_tokens: int
+
+
+def compute_projection_drift(
+    weight_hf: torch.Tensor,      # [out, in] fp32
+    activations: torch.Tensor,    # [T, in] fp32
+) -> Tuple[float, float, float]:
+    """Return (weighted_drift_ratio, abs_err_frob, weight_drift_frob).
+
+    `weight_drift_ratio` is || X @ delta.T || / || X @ W.T || where delta
+    is the fp32 difference between HF weights and Marlin-dequantized
+    weights (groupsize=128).
+    """
+    weight_t = weight_hf.t().contiguous()  # [in, out]
+    w_t_np = weight_t.numpy().astype(np.float32, copy=False)
+    w_dq_t_np = marlin_dequant_groupwise(w_t_np, groupsize=128)
+    delta_t = torch.from_numpy(w_t_np - w_dq_t_np)  # [in, out]
+
+    # X @ W.T_hf gives base output; X @ delta_t gives error.
+    out = activations @ weight_t            # [T, out]
+    err = activations @ delta_t             # [T, out]
+
+    out_norm = float(torch.linalg.norm(out).item())
+    err_norm = float(torch.linalg.norm(err).item())
+    weight_drift_frob = float(torch.linalg.norm(delta_t).item())
+    ratio = err_norm / max(out_norm, 1e-30)
+    return ratio, err_norm, weight_drift_frob
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--checkpoint", required=True)
+    parser.add_argument("--out", required=True, help="markdown summary")
+    parser.add_argument("--out-json", required=True, help="full JSON dump")
+    parser.add_argument("--c11-json", default=None, help="optional — cross-ref C11 audit")
+    parser.add_argument("--device", default="cuda", choices=["cuda", "cpu"])
+    parser.add_argument("--dtype", default="bf16", choices=["bf16", "fp32"])
+    parser.add_argument("--max-prompts", type=int, default=32)
+    parser.add_argument("--max-tokens", type=int, default=96)
+    parser.add_argument(
+        "--threshold-benign", type=float, default=1e-3,
+        help="below this weighted drift ratio = BENIGN (exit 0). Default 1e-3.",
+    )
+    args = parser.parse_args()
+
+    t_start = time.time()
+
+    # Dynamic import to avoid demanding transformers in CI / linter.
+    try:
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+    except ImportError:
+        print("ERROR: transformers not installed. Run `pip install transformers`.", file=sys.stderr)
+        return 2
+
+    device = args.device if torch.cuda.is_available() or args.device == "cpu" else "cpu"
+    print(f"[c12] device={device} dtype={args.dtype}", file=sys.stderr)
+
+    torch_dtype = torch.bfloat16 if args.dtype == "bf16" else torch.float32
+    print(f"[c12] loading model from {args.checkpoint}", file=sys.stderr)
+    tokenizer = AutoTokenizer.from_pretrained(args.checkpoint)
+    model = AutoModelForCausalLM.from_pretrained(
+        args.checkpoint,
+        torch_dtype=torch_dtype,
+        device_map=device,
+    )
+    model.eval()
+
+    prefix = discover_prefix(args.checkpoint)
+    print(f"[c12] layer prefix = `{prefix}`", file=sys.stderr)
+
+    # Hook each linear we care about (q_proj on full-attn layers; gate/up/down on all).
+    activation_buffers: Dict[str, List[torch.Tensor]] = {}
+
+    def hook_for(key: str):
+        def _fn(_mod, inputs, _out):
+            x = inputs[0].detach()  # [..., in]
+            x_flat = x.reshape(-1, x.shape[-1]).to(torch.float32).cpu()
+            activation_buffers.setdefault(key, []).append(x_flat)
+        return _fn
+
+    # Walk the underlying transformer blocks to install hooks.
+    # For Qwen3-Next the layers live under `model.model.layers` or
+    # `model.model.language_model.layers` (prefix we discovered tells us).
+    root = model
+    if hasattr(root, "model"):
+        root = root.model
+    # Qwen3.5-4B nests as model.language_model.layers
+    if hasattr(root, "language_model"):
+        root = root.language_model
+    layers = root.layers
+    hooks = []
+    n_full_attn = 0
+    for i, layer in enumerate(layers):
+        # MLP gate/up/down always present.
+        if hasattr(layer, "mlp"):
+            for sub in ("gate_proj", "up_proj", "down_proj"):
+                lin = getattr(layer.mlp, sub, None)
+                if lin is not None:
+                    hooks.append(lin.register_forward_hook(hook_for(f"L{i}.{sub}")))
+        # q_proj only on full-attention layers.
+        sa = getattr(layer, "self_attn", None)
+        if sa is not None and hasattr(sa, "q_proj"):
+            hooks.append(sa.q_proj.register_forward_hook(hook_for(f"L{i}.q_proj")))
+            n_full_attn += 1
+    print(f"[c12] installed {len(hooks)} hooks across {len(layers)} layers "
+          f"({n_full_attn} full-attn q_proj hooks)", file=sys.stderr)
+
+    # Run calibration forward.
+    prompts = CALIBRATION_PROMPTS[:args.max_prompts]
+    tok = 0
+    with torch.inference_mode():
+        for pi, p in enumerate(prompts):
+            ids = tokenizer(p, return_tensors="pt", truncation=True,
+                            max_length=args.max_tokens).to(device)
+            _ = model(**ids)
+            tok += int(ids["input_ids"].shape[1])
+            if pi < 3:
+                print(f"[c12] prompt {pi}: {ids['input_ids'].shape[1]} tokens", file=sys.stderr)
+    print(f"[c12] captured activations over {tok} total tokens across {len(prompts)} prompts",
+          file=sys.stderr)
+
+    for h in hooks:
+        h.remove()
+
+    # Free the HF model to make room for NumPy weight-dequant work.
+    del model
+    if device == "cuda":
+        torch.cuda.empty_cache()
+
+    # For each hook key, concat activations to a single [T, in] fp32 tensor
+    # and compute the drift against the HF weight.
+    results: List[ProjectionResult] = []
+    worst_ratio = 0.0
+    worst_name = ""
+    for key, chunks in sorted(activation_buffers.items(),
+                              key=lambda kv: (int(kv[0].split('.')[0][1:]), kv[0])):
+        layer_tag, kind = key.split(".", 1)
+        layer_idx = int(layer_tag[1:])
+        X = torch.cat(chunks, dim=0)  # [T, in]
+        weight_name = (
+            f"{prefix}layers.{layer_idx}.self_attn.q_proj.weight"
+            if kind == "q_proj"
+            else f"{prefix}layers.{layer_idx}.mlp.{kind}.weight"
+        )
+        w_hf = st_load_tensor(args.checkpoint, weight_name, allow_missing=True)
+        if w_hf is None:
+            print(f"[c12] WARN: missing {weight_name}; skipping", file=sys.stderr)
+            continue
+        w_hf = w_hf.to(torch.float32)
+        ratio, err_norm, drift_frob = compute_projection_drift(w_hf, X)
+        results.append(ProjectionResult(
+            layer_idx=layer_idx,
+            kind=kind,
+            n_in=w_hf.shape[1],
+            n_out=w_hf.shape[0],
+            weighted_drift_ratio=ratio,
+            abs_err_frobenius=err_norm,
+            weight_drift_frobenius=drift_frob,
+            n_tokens=X.shape[0],
+        ))
+        if ratio > worst_ratio:
+            worst_ratio = ratio
+            worst_name = key
+        if len(results) % 20 == 0:
+            print(f"[c12] processed {len(results)} projections "
+                  f"(current worst {worst_name} ratio={worst_ratio:.3e})", file=sys.stderr)
+    # Sort for reporting: worst ratio first.
+    results.sort(key=lambda r: -r.weighted_drift_ratio)
+
+    # C11 cross-reference.
+    c11_summary = None
+    if args.c11_json and os.path.exists(args.c11_json):
+        with open(args.c11_json, "r") as f:
+            c11_summary = json.load(f)
+
+    elapsed_s = time.time() - t_start
+
+    # Markdown summary.
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w") as f:
+        f.write("# Phase C12 — activation-weighted Marlin drift probe\n\n")
+        f.write(f"- Checkpoint: `{args.checkpoint}`\n")
+        f.write(f"- Device: `{device}`, dtype: `{args.dtype}`\n")
+        f.write(f"- Calibration prompts: {len(prompts)} ({tok} tokens total)\n")
+        f.write(f"- Projections audited: {len(results)}\n")
+        f.write(f"- Elapsed: {elapsed_s:.1f}s\n")
+        f.write(f"- Benign threshold: weighted_drift_ratio < {args.threshold_benign}\n\n")
+        f.write("## Top 10 projections by weighted drift ratio\n\n")
+        f.write("| layer | kind | k (in) | n (out) | weighted_ratio | err_frob | drift_frob |\n")
+        f.write("|------:|:-----|------:|--------:|----------------:|---------:|-----------:|\n")
+        for r in results[:10]:
+            f.write(
+                f"| {r.layer_idx} | {r.kind} | {r.n_in} | {r.n_out} | "
+                f"{r.weighted_drift_ratio:.3e} | {r.abs_err_frobenius:.3e} | "
+                f"{r.weight_drift_frobenius:.3e} |\n"
+            )
+        f.write("\n")
+        f.write(f"**Worst projection: `{worst_name}`, weighted_drift_ratio = "
+                f"{worst_ratio:.3e}**\n\n")
+        if worst_ratio < args.threshold_benign:
+            f.write("**Verdict: BENIGN.** Activation-weighted drift is below the "
+                    f"{args.threshold_benign:.0e} threshold on every projection. "
+                    "Marlin drift does not project onto high-activation channels on "
+                    "this calibration set; corroborates PRIMARY-NEGATIVE on the C12 "
+                    "fp32-head bench.\n")
+        else:
+            f.write("**Verdict: NON-TRIVIAL.** At least one projection has an "
+                    f"activation-weighted drift ratio >= {args.threshold_benign:.0e}; "
+                    "Marlin drift plausibly lands on high-activation channels. "
+                    "Corroborates PRIMARY-POSITIVE on the C12 fp32-head bench.\n")
+        if c11_summary is not None:
+            f.write("\n## C11 cross-reference\n\n")
+            f.write("See `docs/phase-c11/c11-marlin-audit.md` for the unweighted "
+                    "per-channel drift audit. This probe re-weights that drift by "
+                    "empirical activation mass on a 32-prompt calibration set, which "
+                    "is the realistic input distribution the model actually sees.\n")
+
+    # JSON dump.
+    os.makedirs(os.path.dirname(args.out_json), exist_ok=True)
+    with open(args.out_json, "w") as f:
+        json.dump({
+            "checkpoint": args.checkpoint,
+            "device": device,
+            "dtype": args.dtype,
+            "n_prompts": len(prompts),
+            "n_tokens": tok,
+            "threshold_benign": args.threshold_benign,
+            "worst_name": worst_name,
+            "worst_ratio": worst_ratio,
+            "elapsed_s": elapsed_s,
+            "results": [asdict(r) for r in results],
+        }, f, indent=2)
+
+    print(f"[c12] wrote {args.out} and {args.out_json}", file=sys.stderr)
+    print(f"[c12] worst={worst_name} ratio={worst_ratio:.3e}", file=sys.stderr)
+
+    return 0 if worst_ratio < args.threshold_benign else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/c12_bench_runner.py
+++ b/scripts/c12_bench_runner.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""
+Phase C12 — bench runner for α + top-1 agreement under 3 configs × 3 trials.
+
+Per Phase C5/C9 convention, seeds 42/43/44 are used for median-of-3 α. Under
+greedy decode (kiln-bench default temperature=0.0), Class C (`mtp_top1 ==
+main_top1` but not accepted) was empirically 0/339 in Phase C5, so α ==
+top-1-agreement up to sampling variance. The bench reports α directly via the
+JSON `acceptance_rate` field; top-1 agreement is recorded as `alpha` per seed.
+
+Configs:
+  - baseline       : KILN_W4A16=1
+  - primary        : KILN_W4A16=1  KILN_MTP_FP32_HEAD=1
+  - sanity_nomarlin: KILN_W4A16=0  (establishes ceiling without Marlin drift)
+
+All three carry KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp and the standard
+bench flags (`--paged --prompt-tokens 512 --max-output-tokens 128
+--skip-training`).
+
+Emits:
+  - stdout: human-readable table
+  - JSON:   --json-out <path> (for the verdict doc)
+"""
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+SEEDS = [42, 43, 44]
+
+CONFIGS = [
+    {
+        "name": "baseline",
+        "env": {
+            "KILN_W4A16": "1",
+        },
+    },
+    {
+        "name": "primary",
+        "env": {
+            "KILN_W4A16": "1",
+            "KILN_MTP_FP32_HEAD": "1",
+        },
+    },
+    {
+        "name": "sanity_nomarlin",
+        "env": {
+            "KILN_W4A16": "0",
+        },
+    },
+]
+
+MTP_BASE_ENV = {
+    "KILN_SPEC_ENABLED": "1",
+    "KILN_SPEC_METHOD": "mtp",
+}
+
+
+def run_one(
+    bench_bin: Path,
+    model_path: Path,
+    seed: int,
+    extra_env: Dict[str, str],
+) -> Dict:
+    """Run kiln-bench once, return parsed JSON dict + raw α string."""
+    env = os.environ.copy()
+    env.update(MTP_BASE_ENV)
+    env.update(extra_env)
+
+    cmd = [
+        str(bench_bin),
+        "--model-path",
+        str(model_path),
+        "--paged",
+        "--prompt-tokens",
+        "512",
+        "--max-output-tokens",
+        "128",
+        "--skip-training",
+        "--seed",
+        str(seed),
+    ]
+
+    print(f"    → seed={seed} env=" + " ".join(f"{k}={v}" for k, v in extra_env.items()), flush=True)
+    t0 = time.time()
+    proc = subprocess.run(
+        cmd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    elapsed = time.time() - t0
+
+    if proc.returncode != 0:
+        sys.stderr.write(f"[bench_runner] seed={seed} exit={proc.returncode}\n")
+        sys.stderr.write(f"--- stderr ---\n{proc.stderr[-2000:]}\n")
+        raise RuntimeError(f"kiln-bench failed (seed={seed}, rc={proc.returncode})")
+
+    # kiln-bench prints JSON to stdout; logs + alpha line go to stderr
+    try:
+        result = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        sys.stderr.write(f"[bench_runner] non-JSON stdout:\n{proc.stdout[-2000:]}\n")
+        raise
+
+    alpha = result.get("latency", {}).get("acceptance_rate")
+    # Extract the "(k/N)" accept count from stderr for transparency
+    accept_line = ""
+    for line in proc.stderr.splitlines():
+        if "α =" in line or "α=" in line:
+            accept_line = line.strip()
+            break
+
+    return {
+        "seed": seed,
+        "alpha": alpha,
+        "top1_agreement": alpha,  # greedy decode: Class C == 0 (C5)
+        "decode_tok_per_sec": result.get("latency", {}).get("decode_tokens_per_sec"),
+        "mean_itl_ms": result.get("latency", {}).get("mean_inter_token_ms"),
+        "accept_line": accept_line,
+        "elapsed_s": round(elapsed, 1),
+    }
+
+
+def run_config(
+    bench_bin: Path,
+    model_path: Path,
+    name: str,
+    extra_env: Dict[str, str],
+) -> Dict:
+    print(f"\n[config={name}] env={extra_env}", flush=True)
+    trials = []
+    for seed in SEEDS:
+        trials.append(run_one(bench_bin, model_path, seed, extra_env))
+
+    alphas = [t["alpha"] for t in trials if t["alpha"] is not None]
+    decodes = [t["decode_tok_per_sec"] for t in trials if t["decode_tok_per_sec"]]
+    median_alpha = statistics.median(alphas) if alphas else None
+    median_decode = statistics.median(decodes) if decodes else None
+
+    print(
+        f"  → median α = {median_alpha:.4f}" if median_alpha is not None else "  → median α = N/A"
+    )
+    print(
+        f"  → median decode = {median_decode:.2f} tok/s" if median_decode else ""
+    )
+    return {
+        "name": name,
+        "env": extra_env,
+        "trials": trials,
+        "median_alpha": median_alpha,
+        "median_top1_agreement": median_alpha,
+        "median_decode_tok_per_sec": median_decode,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bench-bin", required=True, help="Path to kiln-bench binary")
+    ap.add_argument("--model-path", required=True, help="Path to Qwen3.5-4B weights")
+    ap.add_argument("--json-out", required=True, help="Write summary JSON here")
+    ap.add_argument(
+        "--config",
+        choices=["all"] + [c["name"] for c in CONFIGS],
+        default="all",
+        help="Run only one config (for debugging). Default: all three.",
+    )
+    args = ap.parse_args()
+
+    bench_bin = Path(args.bench_bin).resolve()
+    model_path = Path(args.model_path).resolve()
+    if not bench_bin.exists():
+        sys.exit(f"bench binary not found: {bench_bin}")
+    if not model_path.exists():
+        sys.exit(f"model path not found: {model_path}")
+
+    configs_to_run = CONFIGS if args.config == "all" else [c for c in CONFIGS if c["name"] == args.config]
+
+    summary: Dict = {
+        "seeds": SEEDS,
+        "bench_flags": [
+            "--paged",
+            "--prompt-tokens",
+            "512",
+            "--max-output-tokens",
+            "128",
+            "--skip-training",
+        ],
+        "configs": [],
+    }
+
+    t0 = time.time()
+    for cfg in configs_to_run:
+        result = run_config(bench_bin, model_path, cfg["name"], cfg["env"])
+        summary["configs"].append(result)
+
+    summary["total_elapsed_s"] = round(time.time() - t0, 1)
+
+    out_path = Path(args.json_out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(summary, indent=2))
+    print(f"\n[bench_runner] wrote {out_path}")
+
+    # Pretty table
+    print("\n=== Median-of-3 Summary ===")
+    header = f"{'config':<22} {'median α':>10} {'median top1':>12} {'median tok/s':>14}"
+    print(header)
+    print("-" * len(header))
+    for c in summary["configs"]:
+        a = c["median_alpha"]
+        t1 = c["median_top1_agreement"]
+        d = c["median_decode_tok_per_sec"]
+        a_s = f"{a:.4f}" if a is not None else "N/A"
+        t1_s = f"{t1:.4f}" if t1 is not None else "N/A"
+        d_s = f"{d:.2f}" if d is not None else "N/A"
+        print(f"{c['name']:<22} {a_s:>10} {t1_s:>12} {d_s:>14}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Test whether forcing the MTP draft head's q/k/v/o + fc projections to fp32
(`KILN_MTP_FP32_HEAD=1`) recovers α toward the 0.72 ship floor. **Verdict: PRIMARY-NEGATIVE.**

Median-of-3 on A6000 / Qwen3.5-4B, MTP on:

| Config                                    | Median α  | Median tok/s |
|-------------------------------------------|-----------|--------------|
| baseline (`KILN_W4A16=1`)                 | 0.0325    | 41.09        |
| **primary** (`+ KILN_MTP_FP32_HEAD=1`)    | 0.0325    | 37.66        |
| sanity_nomarlin (`KILN_W4A16=0`)          | 0.0583    | 36.76        |

Per-seed α is bitwise identical across configs for 2/3 seeds (e.g. seed 42: 4/123
accepts for all three configs). The bf16 matmul-accumulation hypothesis for the
draft head's projections is **refuted**. Draft-head projection dtype is not a
contributor of meaningful magnitude to α under greedy decode.

Decode cost of fp32 upcast: **-8.3% tok/s**. Do not gate on by default.

## Why this refutation is decisive

- **C5** established Class C = 0 under greedy decode, so α == top-1 agreement.
- **C3** showed the RoPE position-threading fix produced bitwise-identical α
  pre- and post-fix (6/121 for seed 2 / 42 both times).
- **C12** shows bf16 vs fp32 draft-head matmul produces bitwise-identical accept
  counts for 2/3 seeds, and the same median α to 4 decimals.

Combined, this closes four hypothesis branches: draft-head matmul dtype, Marlin
W4A16 dequant drift at the head, RoPE position threading, and verifier/mask
class-C drift. The surviving hypothesis space is entirely **upstream of the
head's projections** — embedding lookup, pre-norm γ, hidden-state splice from
the main stack, or weight-loading for the MTP head tensors.

## Implementation

Narrow, TLS-gated chokepoint. No behavior change when flag unset.

- `crates/kiln-model/src/mtp_debug.rs` — `KILN_MTP_FP32_HEAD` env reader +
  `MTP_FP32_HEAD_ARMED` TLS `RefCell<bool>` + arm/disarm helpers.
- `crates/kiln-model/src/lora_loader.rs::linear_with_lora_t` — when armed, upcast
  `x` and transposed base weight to `DType::F32`, matmul in fp32, cast back. LoRA
  and bias adds left untouched. Single chokepoint covers q/k/v/o and MLP base
  matmuls in one branch.
- `crates/kiln-model/src/forward.rs::mtp_forward_step` — reads
  `is_mtp_fp32_head_enabled()` once; arms TLS around the draft-head
  `transformer_block_paged`; disarms on exit. OR's into the existing
  `KILN_MTP_FC_FP32_ACCUM` branch so the new flag subsumes C9's fc-only knob.

## Activation-weighted probe (sidecar)

`scripts/c12_activation_weighted_probe.py` audited 104 main-model projections
(32 × {gate, up, down} + 8 full-attn q_proj) over 32 prompts / 595 tokens.
Worst: `L6.down_proj` at 14.5% weighted drift ratio; many MLPs in the 11-14%
band. **This does not contradict PRIMARY-NEGATIVE** — the probe audits the
*main* model, not the MTP head, and main-head top-1 is evidently not flipping
either (sanity_nomarlin and baseline show the same accept counts for seed 42).
Useful for C13 to decide whether main-model MLP drift is worth pursuing.

## Verification

- CPU `cargo check` clean on the candle path.
- Build: `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench` on
  A6000, sccache hit rate 97.56%, 2m 12s.
- Bench: 9 runs (3 configs × 3 seeds), 974s total.
- Probe: 1 run, 160s.
- Pod-side waits used `runpod_api.py wait-file --timeout`; no `until ssh` /
  `while ssh … sleep` polling.

## Output

- `docs/phase-c12/c12-fp32-head.md` — full verdict report
- `PROFILING.md` — appended Phase C12 section
- `c12-out/bench-summary.json` — 3×3 trial JSON
- `c12-out/probe-report.md` + `probe-report.json` — main-model drift audit
- `c12-out/bench.log`, `probe.log` — runner logs

## Recommendation for C13

1. Audit weight-loading policy for `mtp_head.fc_input` / `mtp_head.fc_output` /
   q-k-v-o: which safetensors keys do they resolve to, and is the weight-tying
   policy (tied / separate / shared_lora) matching the checkpoint's training
   recipe? Mis-tied weights produce exactly this symptom — deterministic wrong
   top-1 under greedy, insensitive to matmul dtype.
2. Dump the MTP head's input pre-projection on a known seed and compare against
   a "reference" draft forward that reuses the main head's embed + norm + layer-N
   residual. If the pre-head hidden state differs, the bug is in the splice /
   norm / embed lookup.
3. Target `mtp_pos ∈ {0, 2}` first — those are the largest-n and worst-α buckets
   from C5 (6.1% / 4.2% accept rates, ~43% of total attempts).