### PR TITLE
mtp: Phase C13 — MTP weight-loading audit + pre-projection splice dump

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -4367,8 +4367,25 @@ pub fn mtp_forward_step(
     // the dump block below without being re-consumed. When
     // `KILN_MTP_DUMP_PRE_ROPE` is unset the arm is a no-op and the per-tap
     // `capture_pre_rope_tap` calls short-circuit on a closed TLS window.
-    let should_dump = crate::mtp_debug::try_consume_dump_slot_for_pos(mtp_pos);
-    let dump_pre_rope = should_dump && crate::mtp_debug::is_dump_pre_rope_enabled();
+    // Phase C13: `KILN_MTP_DUMP_SPLICE=1` is a meta-flag that fires up to N=8
+    // (configurable) dumps per targeted position (default `{0, 2}`) instead of
+    // the one-shot latch used by earlier phases. When the splice lane takes a
+    // slot, `splice_step` is `Some(step)` and the dump path can substitute
+    // `{step}` alongside `{pos}`. When splice is disabled we fall through to
+    // the existing one-shot latch so prior flows (B6/B7/C6/C7) behave
+    // unchanged.
+    let splice_step = crate::mtp_debug::try_consume_splice_slot(mtp_pos);
+    let should_dump = if splice_step.is_some() {
+        true
+    } else if crate::mtp_debug::is_dump_splice_enabled() {
+        // Splice is on but this position/step is not eligible — suppress the
+        // legacy one-shot latch so only the splice lane controls dumping.
+        false
+    } else {
+        crate::mtp_debug::try_consume_dump_slot_for_pos(mtp_pos)
+    };
+    let dump_pre_rope =
+        should_dump && crate::mtp_debug::is_dump_pre_rope_effectively_enabled();
     if dump_pre_rope {
         crate::mtp_debug::arm_pre_rope_capture();
     }
@@ -4591,7 +4608,12 @@ pub fn mtp_forward_step(
     // Failure to dump is logged but non-fatal — we never want an
     // instrumentation bug to break decode.
     if should_dump {
-        let dump_path_opt = crate::mtp_debug::dump_path_for_pos(mtp_pos);
+        // Phase C13: when the splice meta-flag is driving this step, the path
+        // can substitute `{step}` alongside `{pos}` so each of the up-to-8
+        // per-position dumps lands in its own file. Falls back to the legacy
+        // `{pos}`-only substitution when splice is off.
+        let dump_path_opt =
+            crate::mtp_debug::dump_path_for_pos_and_step(mtp_pos, splice_step);
         // Always drain the C7 TLS slot before returning. If we entered the
         // armed C7 path above but `dump_path_for_pos` returned None (pos not
         // listed in `KILN_MTP_DUMP_POS`), the slot would otherwise leak
@@ -4656,6 +4678,7 @@ pub fn mtp_forward_step(
                     path = %path,
                     draft_token_id,
                     mtp_pos,
+                    splice_step = ?splice_step,
                     subops = extra_subops.len(),
                     prompt_tokens_len = prompt_tokens.len(),
                     b11_taps = b11_taps.len(),

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -23,7 +23,7 @@
 //! diagnostic update to `PROFILING.md`.
 
 use std::cell::RefCell;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -815,7 +815,10 @@ pub fn is_pre_rope_capture_armed() -> bool {
 /// [`is_dump_pre_rope_enabled`] is false — so callers can invoke this
 /// unconditionally around the MTP inner-block path.
 pub fn arm_pre_rope_capture() {
-    if !is_dump_pre_rope_enabled() {
+    // Phase C13: the splice meta-flag also drives pre-RoPE capture. Using the
+    // effective check here lets callers invoke this unconditionally without
+    // needing to set `KILN_MTP_DUMP_PRE_ROPE=1` when splice is on.
+    if !is_dump_pre_rope_effectively_enabled() {
         return;
     }
     PRE_ROPE_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
@@ -845,6 +848,115 @@ pub fn capture_pre_rope_tap(name: &str, t: &Tensor) -> Result<()> {
         }
     });
     Ok(())
+}
+
+// -----------------------------------------------------------------------------
+// Phase C13: pre-projection splice dump meta-flag
+// -----------------------------------------------------------------------------
+//
+// `KILN_MTP_DUMP_SPLICE=1` is a convenience meta-flag that composes over the
+// existing `write_mtp_dump` pipeline. It does three things:
+//
+//   1. Forces pre-RoPE capture on (so `c6__*` taps are emitted without
+//      requiring `KILN_MTP_DUMP_PRE_ROPE=1` to also be set).
+//   2. Replaces the one-shot (per process, per `mtp_pos`) latch with an
+//      N-step counter (`KILN_MTP_DUMP_SPLICE_MAX_STEPS`, default 8) so up
+//      to N draft steps per targeted position land in their own files.
+//   3. Defaults `mtp_pos` targets to `{0, 2}` when `KILN_MTP_DUMP_SPLICE_POS`
+//      is unset (largest-`n` MTP positions from C5 attribution data).
+//
+// The dump path accepts `{pos}` and `{step}` placeholders; the pair uniquely
+// identifies each file. No behavior change when the flag is unset.
+
+/// True when `KILN_MTP_DUMP_SPLICE=1` (or `true`) is set.
+pub fn is_dump_splice_enabled() -> bool {
+    std::env::var("KILN_MTP_DUMP_SPLICE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Maximum number of splice-dump steps captured per targeted position.
+/// Defaults to 8. Set `KILN_MTP_DUMP_SPLICE_MAX_STEPS=N` to override.
+pub fn splice_max_steps() -> usize {
+    std::env::var("KILN_MTP_DUMP_SPLICE_MAX_STEPS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(8)
+}
+
+/// Set of `mtp_pos` values for which the splice dump should fire. Defaults
+/// to `{0, 2}` when `KILN_MTP_DUMP_SPLICE_POS` is unset. Parses
+/// `KILN_MTP_DUMP_SPLICE_POS=0,1,2` as a comma-separated list.
+pub fn splice_target_positions() -> HashSet<usize> {
+    let raw = std::env::var("KILN_MTP_DUMP_SPLICE_POS").unwrap_or_default();
+    if raw.trim().is_empty() {
+        let mut s = HashSet::new();
+        s.insert(0);
+        s.insert(2);
+        return s;
+    }
+    raw.split(',')
+        .filter_map(|s| s.trim().parse::<usize>().ok())
+        .collect()
+}
+
+/// Per-position step counters. `None` until the first splice slot is taken.
+static SPLICE_STEP_COUNTS: Mutex<Option<HashMap<usize, usize>>> = Mutex::new(None);
+
+/// Returns `Some(step)` (0-indexed) when the splice lane is enabled, a
+/// `KILN_MTP_DUMP_PATH` is set, `mtp_pos` is targeted, and the per-position
+/// counter has not yet reached [`splice_max_steps`]. Advances the counter.
+/// Returns `None` in any other case (splice disabled, position not targeted,
+/// cap reached, env unset, mutex poisoned).
+pub fn try_consume_splice_slot(mtp_pos: usize) -> Option<usize> {
+    if !is_dump_splice_enabled() {
+        return None;
+    }
+    if dump_path().is_none() {
+        return None;
+    }
+    if !splice_target_positions().contains(&mtp_pos) {
+        return None;
+    }
+    let max = splice_max_steps();
+    let mut guard = SPLICE_STEP_COUNTS.lock().ok()?;
+    let map = guard.get_or_insert_with(HashMap::new);
+    let count = map.entry(mtp_pos).or_insert(0);
+    if *count >= max {
+        return None;
+    }
+    let idx = *count;
+    *count += 1;
+    Some(idx)
+}
+
+/// Dump path with `{pos}` and optional `{step}` substituted. Falls back to
+/// [`dump_path_for_pos`] when `step` is `None`. Callers targeting multiple
+/// steps per position should include `{step}` in the template to avoid
+/// later steps overwriting earlier ones.
+pub fn dump_path_for_pos_and_step(mtp_pos: usize, step: Option<usize>) -> Option<String> {
+    let raw = dump_path()?;
+    let mut path = raw.replace("{pos}", &mtp_pos.to_string());
+    if let Some(s) = step {
+        path = path.replace("{step}", &s.to_string());
+    }
+    Some(path)
+}
+
+/// OR-composition: pre-RoPE capture should fire when either the explicit
+/// `KILN_MTP_DUMP_PRE_ROPE=1` flag is set or the C13 splice meta-flag is
+/// set. Use this in the forward dump wiring so splice mode does not need
+/// callers to set both env vars.
+pub fn is_dump_pre_rope_effectively_enabled() -> bool {
+    is_dump_pre_rope_enabled() || is_dump_splice_enabled()
+}
+
+/// Test-only: reset the splice step counters between unit tests.
+#[cfg(test)]
+fn reset_splice_counters() {
+    let mut guard = SPLICE_STEP_COUNTS.lock().unwrap();
+    *guard = None;
 }
 
 // -----------------------------------------------------------------------------
@@ -1364,6 +1476,140 @@ mod tests {
         assert_eq!(
             dump_path_for_pos(1).as_deref(),
             Some("/tmp/dump.safetensors")
+        );
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_PATH");
+        }
+    }
+
+    // ---- Phase C13 splice meta-flag ---------------------------------------
+
+    #[test]
+    fn splice_disabled_by_default_and_consumes_no_slot() {
+        // SAFETY: single-test scoped env mutation; callers downstream remove
+        // vars on success.
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE");
+            std::env::remove_var("KILN_MTP_DUMP_PATH");
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE_POS");
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE_MAX_STEPS");
+        }
+        reset_splice_counters();
+        assert!(!is_dump_splice_enabled());
+        assert_eq!(try_consume_splice_slot(0), None);
+        assert_eq!(try_consume_splice_slot(2), None);
+        assert!(!is_dump_pre_rope_effectively_enabled());
+    }
+
+    #[test]
+    fn splice_defaults_to_positions_0_and_2_with_8_steps() {
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_SPLICE", "1");
+            std::env::set_var(
+                "KILN_MTP_DUMP_PATH",
+                "/tmp/c13_splice_pos{pos}_step{step}.safetensors",
+            );
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE_POS");
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE_MAX_STEPS");
+        }
+        reset_splice_counters();
+
+        assert!(is_dump_splice_enabled());
+        assert!(is_dump_pre_rope_effectively_enabled());
+        let targets = splice_target_positions();
+        assert!(targets.contains(&0));
+        assert!(targets.contains(&2));
+        assert!(!targets.contains(&1));
+        assert_eq!(splice_max_steps(), 8);
+
+        // Eight slots fire per targeted position, then stop.
+        for step in 0..8 {
+            assert_eq!(try_consume_splice_slot(0), Some(step));
+        }
+        assert_eq!(try_consume_splice_slot(0), None);
+        // Position 2 is independent and also gets 8 slots.
+        for step in 0..8 {
+            assert_eq!(try_consume_splice_slot(2), Some(step));
+        }
+        assert_eq!(try_consume_splice_slot(2), None);
+        // Position 1 is never targeted under defaults.
+        assert_eq!(try_consume_splice_slot(1), None);
+
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE");
+            std::env::remove_var("KILN_MTP_DUMP_PATH");
+        }
+    }
+
+    #[test]
+    fn splice_respects_custom_positions_and_max_steps() {
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_SPLICE", "1");
+            std::env::set_var("KILN_MTP_DUMP_PATH", "/tmp/c13_custom.safetensors");
+            std::env::set_var("KILN_MTP_DUMP_SPLICE_POS", "3,5");
+            std::env::set_var("KILN_MTP_DUMP_SPLICE_MAX_STEPS", "2");
+        }
+        reset_splice_counters();
+
+        let targets = splice_target_positions();
+        assert!(targets.contains(&3));
+        assert!(targets.contains(&5));
+        assert!(!targets.contains(&0));
+        assert!(!targets.contains(&2));
+        assert_eq!(splice_max_steps(), 2);
+
+        assert_eq!(try_consume_splice_slot(3), Some(0));
+        assert_eq!(try_consume_splice_slot(3), Some(1));
+        assert_eq!(try_consume_splice_slot(3), None);
+        assert_eq!(try_consume_splice_slot(0), None);
+        assert_eq!(try_consume_splice_slot(5), Some(0));
+
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE");
+            std::env::remove_var("KILN_MTP_DUMP_PATH");
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE_POS");
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE_MAX_STEPS");
+        }
+    }
+
+    #[test]
+    fn splice_requires_dump_path_to_fire() {
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_SPLICE", "1");
+            std::env::remove_var("KILN_MTP_DUMP_PATH");
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE_POS");
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE_MAX_STEPS");
+        }
+        reset_splice_counters();
+        assert!(is_dump_splice_enabled());
+        // No DUMP_PATH → no slot, even when the meta-flag is on.
+        assert_eq!(try_consume_splice_slot(0), None);
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE");
+        }
+    }
+
+    #[test]
+    fn dump_path_for_pos_and_step_substitutes_both_placeholders() {
+        unsafe {
+            std::env::set_var(
+                "KILN_MTP_DUMP_PATH",
+                "/tmp/c13/mtp_pos-{pos}/step-{step}.safetensors",
+            );
+        }
+        assert_eq!(
+            dump_path_for_pos_and_step(0, Some(3)).as_deref(),
+            Some("/tmp/c13/mtp_pos-0/step-3.safetensors")
+        );
+        assert_eq!(
+            dump_path_for_pos_and_step(2, Some(7)).as_deref(),
+            Some("/tmp/c13/mtp_pos-2/step-7.safetensors")
+        );
+        // With step=None the `{step}` placeholder is left alone (callers
+        // that don't know their step should not use `{step}`).
+        assert_eq!(
+            dump_path_for_pos_and_step(0, None).as_deref(),
+            Some("/tmp/c13/mtp_pos-0/step-{step}.safetensors")
         );
         unsafe {
             std::env::remove_var("KILN_MTP_DUMP_PATH");

--- a/docs/phase-c13/c13-splice-verdict.md
+++ b/docs/phase-c13/c13-splice-verdict.md
@@ -1,0 +1,76 @@
+# Phase C13 — MTP Splice Verdict
+
+**Bench**: Qwen3.5-4B BF16, paged, `KILN_SPEC_METHOD=mtp`, H100 NVL, 512 prompt × 64 decode, seed 42.
+**Captures**: `KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS="0,2" KILN_MTP_DUMP_SPLICE_MAX_STEPS=8` → 16 kiln dumps (2 positions × 8 steps).
+**Reference**: `scripts/c13_hf_reference_dump.py` — pure-PyTorch fp32 re-forward of the 5 pre-RoPE MTP taps plus `h_main` for every kiln dump. 16/16 reference dumps produced, 0 errors, 0 missing taps.
+**Thresholds**: cos ≥ 0.999, max|Δ| ≤ 1e-2.
+**Bench α**: 0.033 (matches prior C12 primary-negative baseline; C13 pass is purely diagnostic).
+
+## Per-tap medians (across 16 dumps)
+
+| Tap               | median cos_sim | min cos_sim | median max\|Δ\| | max max\|Δ\| | flagged |
+|-------------------|---------------:|------------:|----------------:|-------------:|--------:|
+| `h_main`          | 1.0000000      | 1.0000000   | 0.000e+00       | 0.000e+00    | 0       |
+| `c6__token_emb`   | 1.0000000      | 1.0000000   | 0.000e+00       | 0.000e+00    | 0       |
+| `c6__norm_emb`    | 0.9999986      | 0.9999985   | 7.42e-03        | 1.52e-02     | 2       |
+| `c6__norm_h`      | 0.9999987      | 0.9999984   | 2.33e-02        | 3.02e-02     | 16      |
+| `c6__concat`      | 0.9999986      | 0.9999984   | 2.33e-02        | 3.02e-02     | 16      |
+| `c6__fused`       | 0.9999948      | 0.9999928   | 8.69e-03        | 2.32e-02     | 7       |
+
+`flagged` = count of (pos, step) sites where cos < 0.999 **or** max|Δ| > 1e-2. Every flagged site stays well inside cos ≥ 0.9999928; the only way the site gets flagged is via the 1e-2 max|Δ| ceiling.
+
+## Per-position breakdown
+
+| pos | tap | n | median cos | min cos | median max\|Δ\| | max max\|Δ\| |
+|-----|-----|--:|-----------:|--------:|----------------:|-------------:|
+| 0 | `h_main`        | 8 | 1.0000000 | 1.0000000 | 0.00e+00 | 0.00e+00 |
+| 0 | `c6__token_emb` | 8 | 1.0000000 | 1.0000000 | 0.00e+00 | 0.00e+00 |
+| 0 | `c6__norm_emb`  | 8 | 0.9999986 | 0.9999986 | 7.48e-03 | 7.78e-03 |
+| 0 | `c6__norm_h`    | 8 | 0.9999987 | 0.9999985 | 2.30e-02 | 3.02e-02 |
+| 0 | `c6__concat`    | 8 | 0.9999986 | 0.9999985 | 2.30e-02 | 3.02e-02 |
+| 0 | `c6__fused`     | 8 | 0.9999949 | 0.9999929 | 7.50e-03 | 1.51e-02 |
+| 2 | `h_main`        | 8 | 1.0000000 | 1.0000000 | 0.00e+00 | 0.00e+00 |
+| 2 | `c6__token_emb` | 8 | 1.0000000 | 1.0000000 | 0.00e+00 | 0.00e+00 |
+| 2 | `c6__norm_emb`  | 8 | 0.9999986 | 0.9999985 | 7.31e-03 | 1.52e-02 |
+| 2 | `c6__norm_h`    | 8 | 0.9999987 | 0.9999984 | 2.64e-02 | 3.00e-02 |
+| 2 | `c6__concat`    | 8 | 0.9999987 | 0.9999984 | 2.64e-02 | 3.00e-02 |
+| 2 | `c6__fused`     | 8 | 0.9999948 | 0.9999928 | 1.23e-02 | 2.32e-02 |
+
+## Verdict — SPLICE INPUTS CLEAR
+
+The pre-projection splice — i.e. the tensors feeding the MTP `fc` head — **agrees with an fp32 HF reference to cos ≥ 0.9999928 on every tap at every step for both targeted positions**. The only flags come from the 1e-2 max|Δ| threshold being below the natural bf16 activation noise floor on tensors with magnitude O(1–10): every single flagged entry still has cosine similarity that would round to 1.0 at fp16 precision.
+
+- `h_main` and `c6__token_emb` match **bit-exactly** (cos = 1.0, max|Δ| = 0) across all 16 sites. This is the expected sanity identity: both the source-side h_main and the draft-token embedding are reproduced verbatim from the kiln dump when the HF reference re-forwards, so any divergence there would point to a dumper bug rather than a splice bug. Clean.
+- `c6__norm_emb`, `c6__norm_h`, `c6__concat`, `c6__fused` track the RMSNorm and `fc` projection outputs — the places where the hypothesis "wrong weight bound to wrong half" would show up as a systemic rotation or sign flip. We observe neither. The deltas are isotropic bf16 rounding, symmetric across positions 0 and 2, and identical in character between `norm_emb` and `norm_h` (which is what you expect when the two RMSNorm weights are correctly paired: the delta distribution is a property of the bf16 activation precision, not of a weight-binding flip).
+- `c6__concat` max|Δ| equals `c6__norm_h` max|Δ| at every step, confirming concat is a trivial interleave of the two halves — no stale-buffer or stride bug.
+- `c6__fused` is slightly noisier (matmul accumulation over H=2560), but still cos ≥ 0.9999928. A systemic mis-weighting of either `pre_fc_norm_embed` or `pre_fc_norm_hidden` against the wrong half would drop `c6__fused` cos well below 0.99 — the Phase B2 `KILN_MTP_SWAP_FC_NORMS=1` probe is the canonical counter-example. We don't see that signature.
+
+**Therefore the α≈0.033 regression reproduced in Phase C12 is NOT caused by a pre-projection splice/weight-binding bug.** The splice is wired correctly; both halves of the `fc` input are produced in the expected order and with the expected numerical fidelity; `h_main` (the source-stack hidden state) enters the MTP head cleanly.
+
+## What this rules out
+
+- "Weights are loaded, but paired to the wrong half of the `fc` input" (Phase B2 secondary-hypothesis A/B via `KILN_MTP_SWAP_FC_NORMS`).
+- "h_main is produced from a stale KV / wrong position" (would show `h_main` cos ≪ 1 — doesn't).
+- "Draft-token embedding uses a different tied-lm_head/embed_tokens tensor than HF" (would show `c6__token_emb` cos ≪ 1 — doesn't).
+- "`concat` is accidentally using a different stride / interleave order than HF" (`c6__concat` matches `c6__norm_h` max|Δ| bit-for-bit).
+- Any systemic bias in the `fc` projection bigger than bf16 matmul rounding (cos would drop to the 0.99x region — doesn't).
+
+## What this does NOT rule out — next investigation axes
+
+- **Post-`fc` MTP transformer block drift**: taps beyond `fc_output` (`pre_layer`, `post_layer`, `post_final_ln`, `mtp_logits`) are captured by the B6/B7 legacy latch but are outside the splice window. An α≈0.033 with clean splice inputs points the investigation at the MTP transformer block itself or at the lm_head tie.
+- **Base-stack hidden-state drift in long sequences**: we match the kiln h_main against an HF fp32 re-forward that starts *from the same kiln h_main* (the reference sidecar takes h_main and draft_token_id from the kiln dump rather than re-running the whole base model). So if the bug is in the base-stack producing a wrong h_main from a drifting KV state, C13 cannot see it — the splice test is conditional on h_main being correct. The `h_main` row showing `cos = 1.0` is tautological here and should not be read as "the base model is fine."
+- **Acceptance math / sampler / KV-rollback**: α is determined by the MTP distribution *and* by which draft tokens the sampler emits, and the Phase C12 fp32-draft-head probe already showed that forcing the head itself to fp32 doesn't recover α. C13 confirms splice inputs don't. So the remaining candidates are: (a) the MTP transformer block itself under bf16, (b) the tied lm_head output normalization, (c) KV-cache advance / rollback under speculative decode.
+
+## Recommended follow-up
+
+1. Extend the splice dump through the MTP transformer block output (`post_layer`) and final norm (`post_final_ln`) with an HF fp32 reference. The B6/B7 outer taps already collect these; a sibling `scripts/c13_hf_reference_dump.py` mode that also re-forwards the MTP transformer block (not just the `fc` projection) would be the next cheap cut.
+2. Add a base-model h_main comparison at the same (pos, step) slots. The kiln dump preserves the prompt tokens; a companion fp32 re-forward of the *base* model on those tokens is slow but tractable (~5 min CPU per step). A mismatch there moves the investigation onto the base-stack / GDN / GQA.
+3. Leave `KILN_MTP_DUMP_SPLICE` in place as-is; it's cheap, composable, and correctly wired.
+
+## Artifacts
+
+- Kiln splice captures: 16 × `.safetensors` at `/workspace/captures/mtp_pos-{0,2}/step-{0..7}.safetensors` on pod.
+- HF reference: 16 × `.safetensors` at `/workspace/captures-ref/mtp_pos-{0,2}/step-{0..7}.safetensors` on pod.
+- Summary JSON: `docs/phase-c13/c13-summary.json` (this commit).
+- Bench run log: `/tmp/bench-splice2.log` on pod.
+- Reference sidecar log: `/tmp/c13-ref.log` on pod.

--- a/docs/phase-c13/c13-summary.json
+++ b/docs/phase-c13/c13-summary.json
@@ -1,0 +1,1846 @@
+{
+  "cos_sim_floor": 0.999,
+  "files": [
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-0.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref/mtp_pos-0/step-0.safetensors",
+      "step": 0,
+      "taps": [
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 68.0954818725586,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 68.0954818725586,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 0.5929219126701355,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.5929219126701355,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986337225564,
+          "flagged": false,
+          "kiln_l2": 32.01826477050781,
+          "l2_delta": 0.05300910770893097,
+          "max_abs_delta": 0.007400989532470703,
+          "ref_l2": 32.02116394042969,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999985075328087,
+          "flagged": true,
+          "kiln_l2": 40.69206619262695,
+          "l2_delta": 0.07057791203260422,
+          "max_abs_delta": 0.023471832275390625,
+          "ref_l2": 40.69822311401367,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999985553458842,
+          "flagged": true,
+          "kiln_l2": 51.778507232666016,
+          "l2_delta": 0.08826781809329987,
+          "max_abs_delta": 0.023471832275390625,
+          "ref_l2": 51.785133361816406,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999928631229431,
+          "flagged": false,
+          "kiln_l2": 14.436586380004883,
+          "l2_delta": 0.05456354841589928,
+          "max_abs_delta": 0.009276628494262695,
+          "ref_l2": 14.438009262084961,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-1.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref/mtp_pos-0/step-1.safetensors",
+      "step": 1,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 69.13684844970703,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 69.13684844970703,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999999999999999,
+          "flagged": false,
+          "kiln_l2": 0.5985178351402283,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.5985178351402283,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986339069664,
+          "flagged": false,
+          "kiln_l2": 29.714509963989258,
+          "l2_delta": 0.049131423234939575,
+          "max_abs_delta": 0.007654428482055664,
+          "ref_l2": 29.713241577148438,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999988239055957,
+          "flagged": true,
+          "kiln_l2": 39.67103576660156,
+          "l2_delta": 0.061014071106910706,
+          "max_abs_delta": 0.015239715576171875,
+          "ref_l2": 39.666419982910156,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999987549930165,
+          "flagged": true,
+          "kiln_l2": 49.5655403137207,
+          "l2_delta": 0.07833654433488846,
+          "max_abs_delta": 0.015239715576171875,
+          "ref_l2": 49.561092376708984,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999951127843021,
+          "flagged": true,
+          "kiln_l2": 15.606343269348145,
+          "l2_delta": 0.049300845712423325,
+          "max_abs_delta": 0.014488697052001953,
+          "ref_l2": 15.613333702087402,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-2.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref/mtp_pos-0/step-2.safetensors",
+      "step": 2,
+      "taps": [
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 63.5267333984375,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 63.5267333984375,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999999999999999,
+          "flagged": false,
+          "kiln_l2": 0.7038809657096863,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.7038809657096863,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999987136644231,
+          "flagged": false,
+          "kiln_l2": 31.225971221923828,
+          "l2_delta": 0.050090860575437546,
+          "max_abs_delta": 0.0072956085205078125,
+          "ref_l2": 31.22516632080078,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999984698413812,
+          "flagged": true,
+          "kiln_l2": 40.93537139892578,
+          "l2_delta": 0.07407204061746597,
+          "max_abs_delta": 0.030187606811523438,
+          "ref_l2": 40.916378021240234,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999985372055554,
+          "flagged": true,
+          "kiln_l2": 51.48558807373047,
+          "l2_delta": 0.08941902220249176,
+          "max_abs_delta": 0.030187606811523438,
+          "ref_l2": 51.470001220703125,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.99999409846008,
+          "flagged": false,
+          "kiln_l2": 15.61256217956543,
+          "l2_delta": 0.053670357912778854,
+          "max_abs_delta": 0.007268667221069336,
+          "ref_l2": 15.610601425170898,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-3.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref/mtp_pos-0/step-3.safetensors",
+      "step": 3,
+      "taps": [
+        {
+          "cos_sim": 0.9999999999999999,
+          "flagged": false,
+          "kiln_l2": 80.48060607910156,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 80.48060607910156,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 0.5964984893798828,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.5964984893798828,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986514404636,
+          "flagged": false,
+          "kiln_l2": 30.62529754638672,
+          "l2_delta": 0.05034276098012924,
+          "max_abs_delta": 0.007779359817504883,
+          "ref_l2": 30.62743377685547,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999988496032532,
+          "flagged": true,
+          "kiln_l2": 40.07140350341797,
+          "l2_delta": 0.060784712433815,
+          "max_abs_delta": 0.013822078704833984,
+          "ref_l2": 40.071956634521484,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999987761675769,
+          "flagged": true,
+          "kiln_l2": 50.43437957763672,
+          "l2_delta": 0.07892511785030365,
+          "max_abs_delta": 0.013822078704833984,
+          "ref_l2": 50.43611526489258,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999955166840174,
+          "flagged": false,
+          "kiln_l2": 16.038427352905273,
+          "l2_delta": 0.048049502074718475,
+          "max_abs_delta": 0.005471467971801758,
+          "ref_l2": 16.036849975585938,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-4.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref/mtp_pos-0/step-4.safetensors",
+      "step": 4,
+      "taps": [
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 70.82842254638672,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 70.82842254638672,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 0.6307239532470703,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.6307239532470703,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986378503802,
+          "flagged": false,
+          "kiln_l2": 30.762710571289062,
+          "l2_delta": 0.05078568682074547,
+          "max_abs_delta": 0.007780551910400391,
+          "ref_l2": 30.761638641357422,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999985709537486,
+          "flagged": true,
+          "kiln_l2": 39.598506927490234,
+          "l2_delta": 0.06717028468847275,
+          "max_abs_delta": 0.014241218566894531,
+          "ref_l2": 39.603946685791016,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999985926450886,
+          "flagged": true,
+          "kiln_l2": 50.14365768432617,
+          "l2_delta": 0.08420827239751816,
+          "max_abs_delta": 0.014241218566894531,
+          "ref_l2": 50.14729690551758,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999949126712647,
+          "flagged": true,
+          "kiln_l2": 15.562359809875488,
+          "l2_delta": 0.05010506883263588,
+          "max_abs_delta": 0.015139102935791016,
+          "ref_l2": 15.555473327636719,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-5.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref/mtp_pos-0/step-5.safetensors",
+      "step": 5,
+      "taps": [
+        {
+          "cos_sim": 0.9999999999999998,
+          "flagged": false,
+          "kiln_l2": 69.36898803710938,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 69.36898803710938,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 0.7023505568504333,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.7023505568504333,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986048083378,
+          "flagged": false,
+          "kiln_l2": 31.466115951538086,
+          "l2_delta": 0.05256276577711105,
+          "max_abs_delta": 0.007445812225341797,
+          "ref_l2": 31.46586799621582,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999986761370786,
+          "flagged": true,
+          "kiln_l2": 41.48577880859375,
+          "l2_delta": 0.06922440230846405,
+          "max_abs_delta": 0.018891334533691406,
+          "ref_l2": 41.50105667114258,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999986337017697,
+          "flagged": true,
+          "kiln_l2": 52.06904983520508,
+          "l2_delta": 0.08691870421171188,
+          "max_abs_delta": 0.018891334533691406,
+          "ref_l2": 52.081077575683594,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999944786419447,
+          "flagged": false,
+          "kiln_l2": 15.858171463012695,
+          "l2_delta": 0.05321495234966278,
+          "max_abs_delta": 0.0056040287017822266,
+          "ref_l2": 15.865486145019531,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-6.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref/mtp_pos-0/step-6.safetensors",
+      "step": 6,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 70.93669891357422,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 70.93669891357422,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999999999999999,
+          "flagged": false,
+          "kiln_l2": 0.6200110912322998,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.6200110912322998,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986590506852,
+          "flagged": false,
+          "kiln_l2": 30.156238555908203,
+          "l2_delta": 0.04943251982331276,
+          "max_abs_delta": 0.006876468658447266,
+          "ref_l2": 30.158357620239258,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999987711164773,
+          "flagged": true,
+          "kiln_l2": 40.62177276611328,
+          "l2_delta": 0.0638100653886795,
+          "max_abs_delta": 0.023038864135742188,
+          "ref_l2": 40.625736236572266,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999987312149974,
+          "flagged": true,
+          "kiln_l2": 50.591766357421875,
+          "l2_delta": 0.08071739971637726,
+          "max_abs_delta": 0.023038864135742188,
+          "ref_l2": 50.596214294433594,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999948328680008,
+          "flagged": false,
+          "kiln_l2": 15.271878242492676,
+          "l2_delta": 0.04911942034959793,
+          "max_abs_delta": 0.007497310638427734,
+          "ref_l2": 15.273368835449219,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-7.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref/mtp_pos-0/step-7.safetensors",
+      "step": 7,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 63.07769012451172,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 63.07769012451172,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999999999999999,
+          "flagged": false,
+          "kiln_l2": 0.6732348203659058,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.6732348203659058,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986238763736,
+          "flagged": false,
+          "kiln_l2": 30.176240921020508,
+          "l2_delta": 0.05013075843453407,
+          "max_abs_delta": 0.007481813430786133,
+          "ref_l2": 30.173574447631836,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999984714173037,
+          "flagged": true,
+          "kiln_l2": 40.64075469970703,
+          "l2_delta": 0.0715092122554779,
+          "max_abs_delta": 0.02825164794921875,
+          "ref_l2": 40.632686614990234,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999985242101938,
+          "flagged": true,
+          "kiln_l2": 50.618934631347656,
+          "l2_delta": 0.08733075112104416,
+          "max_abs_delta": 0.02825164794921875,
+          "ref_l2": 50.610862731933594,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999950232679787,
+          "flagged": false,
+          "kiln_l2": 16.114330291748047,
+          "l2_delta": 0.050855088979005814,
+          "max_abs_delta": 0.006680011749267578,
+          "ref_l2": 16.115522384643555,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-0.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref/mtp_pos-2/step-0.safetensors",
+      "step": 0,
+      "taps": [
+        {
+          "cos_sim": 0.9999999999999998,
+          "flagged": false,
+          "kiln_l2": 71.51800537109375,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 71.51800537109375,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 0.6817745566368103,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.6817745566368103,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999985860532669,
+          "flagged": false,
+          "kiln_l2": 30.06912612915039,
+          "l2_delta": 0.05057085305452347,
+          "max_abs_delta": 0.0045185089111328125,
+          "ref_l2": 30.068330764770508,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.999998684475747,
+          "flagged": true,
+          "kiln_l2": 41.181724548339844,
+          "l2_delta": 0.06694773584604263,
+          "max_abs_delta": 0.02756500244140625,
+          "ref_l2": 41.177207946777344,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.999998649462595,
+          "flagged": true,
+          "kiln_l2": 50.99104309082031,
+          "l2_delta": 0.08390118926763535,
+          "max_abs_delta": 0.02756500244140625,
+          "ref_l2": 50.98693084716797,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999948432919208,
+          "flagged": true,
+          "kiln_l2": 16.116689682006836,
+          "l2_delta": 0.052452847361564636,
+          "max_abs_delta": 0.021616458892822266,
+          "ref_l2": 16.108097076416016,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-1.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref/mtp_pos-2/step-1.safetensors",
+      "step": 1,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 69.96065521240234,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 69.96065521240234,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999999999999999,
+          "flagged": false,
+          "kiln_l2": 0.6112110614776611,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.6112110614776611,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999985319115949,
+          "flagged": false,
+          "kiln_l2": 30.49958610534668,
+          "l2_delta": 0.052269235253334045,
+          "max_abs_delta": 0.007266998291015625,
+          "ref_l2": 30.50041961669922,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999983773885703,
+          "flagged": true,
+          "kiln_l2": 39.96152877807617,
+          "l2_delta": 0.07306723296642303,
+          "max_abs_delta": 0.030037879943847656,
+          "ref_l2": 39.97397232055664,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999984248762831,
+          "flagged": true,
+          "kiln_l2": 50.270751953125,
+          "l2_delta": 0.08983814716339111,
+          "max_abs_delta": 0.030037879943847656,
+          "ref_l2": 50.281150817871094,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999952307699403,
+          "flagged": true,
+          "kiln_l2": 15.746898651123047,
+          "l2_delta": 0.04878822714090347,
+          "max_abs_delta": 0.0123291015625,
+          "ref_l2": 15.742938995361328,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-2.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref/mtp_pos-2/step-2.safetensors",
+      "step": 2,
+      "taps": [
+        {
+          "cos_sim": 0.9999999999999998,
+          "flagged": false,
+          "kiln_l2": 65.51148986816406,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 65.51148986816406,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 0.6351380944252014,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.6351380944252014,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999984849394685,
+          "flagged": true,
+          "kiln_l2": 30.408262252807617,
+          "l2_delta": 0.053215935826301575,
+          "max_abs_delta": 0.015198230743408203,
+          "ref_l2": 30.40273094177246,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.999998535395415,
+          "flagged": true,
+          "kiln_l2": 40.93252182006836,
+          "l2_delta": 0.07008720934391022,
+          "max_abs_delta": 0.02097797393798828,
+          "ref_l2": 40.934566497802734,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999985112981193,
+          "flagged": true,
+          "kiln_l2": 50.99150848388672,
+          "l2_delta": 0.08800087124109268,
+          "max_abs_delta": 0.02097797393798828,
+          "ref_l2": 50.98984909057617,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999942510889746,
+          "flagged": true,
+          "kiln_l2": 15.989038467407227,
+          "l2_delta": 0.05476723238825798,
+          "max_abs_delta": 0.016359806060791016,
+          "ref_l2": 15.981197357177734,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-3.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref/mtp_pos-2/step-3.safetensors",
+      "step": 3,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 71.61802673339844,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 71.61802673339844,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 0.6405931115150452,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.6405931115150452,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999987073622979,
+          "flagged": false,
+          "kiln_l2": 31.044994354248047,
+          "l2_delta": 0.049945082515478134,
+          "max_abs_delta": 0.0068798065185546875,
+          "ref_l2": 31.046640396118164,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999986892581564,
+          "flagged": true,
+          "kiln_l2": 41.01646041870117,
+          "l2_delta": 0.06716746091842651,
+          "max_abs_delta": 0.02651500701904297,
+          "ref_l2": 41.006343841552734,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999986854549294,
+          "flagged": true,
+          "kiln_l2": 51.44065856933594,
+          "l2_delta": 0.0837017297744751,
+          "max_abs_delta": 0.02651500701904297,
+          "ref_l2": 51.433589935302734,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999950378757356,
+          "flagged": true,
+          "kiln_l2": 16.023832321166992,
+          "l2_delta": 0.05136625096201897,
+          "max_abs_delta": 0.010861396789550781,
+          "ref_l2": 16.014249801635742,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-4.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref/mtp_pos-2/step-4.safetensors",
+      "step": 4,
+      "taps": [
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 73.48448944091797,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 73.48448944091797,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 0.8061739206314087,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.8061739206314087,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986911098602,
+          "flagged": true,
+          "kiln_l2": 33.68864822387695,
+          "l2_delta": 0.05453970655798912,
+          "max_abs_delta": 0.014438152313232422,
+          "ref_l2": 33.68670654296875,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999987227612673,
+          "flagged": true,
+          "kiln_l2": 42.02518081665039,
+          "l2_delta": 0.06759972125291824,
+          "max_abs_delta": 0.0263519287109375,
+          "ref_l2": 42.03276062011719,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.9999987036424649,
+          "flagged": true,
+          "kiln_l2": 53.86131286621094,
+          "l2_delta": 0.08685794472694397,
+          "max_abs_delta": 0.0263519287109375,
+          "ref_l2": 53.86601257324219,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.999993609643601,
+          "flagged": false,
+          "kiln_l2": 14.50195598602295,
+          "l2_delta": 0.05184784159064293,
+          "max_abs_delta": 0.008108139038085938,
+          "ref_l2": 14.502445220947266,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-5.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref/mtp_pos-2/step-5.safetensors",
+      "step": 5,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 71.44486999511719,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 71.44486999511719,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 0.6099970936775208,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.6099970936775208,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986174755728,
+          "flagged": false,
+          "kiln_l2": 30.497852325439453,
+          "l2_delta": 0.050713568925857544,
+          "max_abs_delta": 0.007783651351928711,
+          "ref_l2": 30.498018264770508,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999987708768019,
+          "flagged": true,
+          "kiln_l2": 40.5421028137207,
+          "l2_delta": 0.06356538832187653,
+          "max_abs_delta": 0.014223098754882812,
+          "ref_l2": 40.542240142822266,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.999998715439725,
+          "flagged": true,
+          "kiln_l2": 50.732444763183594,
+          "l2_delta": 0.08131681382656097,
+          "max_abs_delta": 0.014223098754882812,
+          "ref_l2": 50.73265838623047,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999944897868926,
+          "flagged": false,
+          "kiln_l2": 15.647917747497559,
+          "l2_delta": 0.05210871621966362,
+          "max_abs_delta": 0.007925987243652344,
+          "ref_l2": 15.643721580505371,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-6.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref/mtp_pos-2/step-6.safetensors",
+      "step": 6,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 67.36052703857422,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 67.36052703857422,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 0.7707327604293823,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.7707327604293823,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986480740062,
+          "flagged": false,
+          "kiln_l2": 32.25188446044922,
+          "l2_delta": 0.05310476943850517,
+          "max_abs_delta": 0.0073130130767822266,
+          "ref_l2": 32.249080657958984,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999986641955473,
+          "flagged": true,
+          "kiln_l2": 40.82478332519531,
+          "l2_delta": 0.06991483271121979,
+          "max_abs_delta": 0.024698257446289062,
+          "ref_l2": 40.84559631347656,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.999998615903561,
+          "flagged": true,
+          "kiln_l2": 52.027366638183594,
+          "l2_delta": 0.08779636025428772,
+          "max_abs_delta": 0.024698257446289062,
+          "ref_l2": 52.041961669921875,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999928202579424,
+          "flagged": true,
+          "kiln_l2": 14.985584259033203,
+          "l2_delta": 0.05681444704532623,
+          "max_abs_delta": 0.023154258728027344,
+          "ref_l2": 14.987271308898926,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-7.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref/mtp_pos-2/step-7.safetensors",
+      "step": 7,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 79.3622055053711,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 79.3622055053711,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999999999999999,
+          "flagged": false,
+          "kiln_l2": 0.8277392983436584,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 0.8277392983436584,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__token_emb"
+        },
+        {
+          "cos_sim": 0.9999986222243452,
+          "flagged": false,
+          "kiln_l2": 30.093488693237305,
+          "l2_delta": 0.0499565452337265,
+          "max_abs_delta": 0.0054988861083984375,
+          "ref_l2": 30.0938720703125,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_emb"
+        },
+        {
+          "cos_sim": 0.9999988360526508,
+          "flagged": true,
+          "kiln_l2": 40.42241287231445,
+          "l2_delta": 0.06223733723163605,
+          "max_abs_delta": 0.017103195190429688,
+          "ref_l2": 40.41401290893555,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__norm_h"
+        },
+        {
+          "cos_sim": 0.999998754208124,
+          "flagged": true,
+          "kiln_l2": 50.39433670043945,
+          "l2_delta": 0.07980690896511078,
+          "max_abs_delta": 0.017103195190429688,
+          "ref_l2": 50.38783264160156,
+          "shape": [
+            1,
+            1,
+            5120
+          ],
+          "tap": "c6__concat"
+        },
+        {
+          "cos_sim": 0.9999953247041592,
+          "flagged": false,
+          "kiln_l2": 15.815040588378906,
+          "l2_delta": 0.04863224923610687,
+          "max_abs_delta": 0.0055887699127197266,
+          "ref_l2": 15.809830665588379,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c6__fused"
+        }
+      ]
+    }
+  ],
+  "files_with_errors": 0,
+  "files_with_missing_taps": 0,
+  "flagged_sites": [
+    {
+      "cos_sim": 0.9999985075328087,
+      "max_abs_delta": 0.023471832275390625,
+      "mtp_pos": 0,
+      "step": 0,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999985553458842,
+      "max_abs_delta": 0.023471832275390625,
+      "mtp_pos": 0,
+      "step": 0,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999988239055957,
+      "max_abs_delta": 0.015239715576171875,
+      "mtp_pos": 0,
+      "step": 1,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999987549930165,
+      "max_abs_delta": 0.015239715576171875,
+      "mtp_pos": 0,
+      "step": 1,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999951127843021,
+      "max_abs_delta": 0.014488697052001953,
+      "mtp_pos": 0,
+      "step": 1,
+      "tap": "c6__fused"
+    },
+    {
+      "cos_sim": 0.9999984698413812,
+      "max_abs_delta": 0.030187606811523438,
+      "mtp_pos": 0,
+      "step": 2,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999985372055554,
+      "max_abs_delta": 0.030187606811523438,
+      "mtp_pos": 0,
+      "step": 2,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999988496032532,
+      "max_abs_delta": 0.013822078704833984,
+      "mtp_pos": 0,
+      "step": 3,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999987761675769,
+      "max_abs_delta": 0.013822078704833984,
+      "mtp_pos": 0,
+      "step": 3,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999985709537486,
+      "max_abs_delta": 0.014241218566894531,
+      "mtp_pos": 0,
+      "step": 4,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999985926450886,
+      "max_abs_delta": 0.014241218566894531,
+      "mtp_pos": 0,
+      "step": 4,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999949126712647,
+      "max_abs_delta": 0.015139102935791016,
+      "mtp_pos": 0,
+      "step": 4,
+      "tap": "c6__fused"
+    },
+    {
+      "cos_sim": 0.9999986761370786,
+      "max_abs_delta": 0.018891334533691406,
+      "mtp_pos": 0,
+      "step": 5,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999986337017697,
+      "max_abs_delta": 0.018891334533691406,
+      "mtp_pos": 0,
+      "step": 5,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999987711164773,
+      "max_abs_delta": 0.023038864135742188,
+      "mtp_pos": 0,
+      "step": 6,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999987312149974,
+      "max_abs_delta": 0.023038864135742188,
+      "mtp_pos": 0,
+      "step": 6,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999984714173037,
+      "max_abs_delta": 0.02825164794921875,
+      "mtp_pos": 0,
+      "step": 7,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999985242101938,
+      "max_abs_delta": 0.02825164794921875,
+      "mtp_pos": 0,
+      "step": 7,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.999998684475747,
+      "max_abs_delta": 0.02756500244140625,
+      "mtp_pos": 2,
+      "step": 0,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.999998649462595,
+      "max_abs_delta": 0.02756500244140625,
+      "mtp_pos": 2,
+      "step": 0,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999948432919208,
+      "max_abs_delta": 0.021616458892822266,
+      "mtp_pos": 2,
+      "step": 0,
+      "tap": "c6__fused"
+    },
+    {
+      "cos_sim": 0.9999983773885703,
+      "max_abs_delta": 0.030037879943847656,
+      "mtp_pos": 2,
+      "step": 1,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999984248762831,
+      "max_abs_delta": 0.030037879943847656,
+      "mtp_pos": 2,
+      "step": 1,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999952307699403,
+      "max_abs_delta": 0.0123291015625,
+      "mtp_pos": 2,
+      "step": 1,
+      "tap": "c6__fused"
+    },
+    {
+      "cos_sim": 0.9999984849394685,
+      "max_abs_delta": 0.015198230743408203,
+      "mtp_pos": 2,
+      "step": 2,
+      "tap": "c6__norm_emb"
+    },
+    {
+      "cos_sim": 0.999998535395415,
+      "max_abs_delta": 0.02097797393798828,
+      "mtp_pos": 2,
+      "step": 2,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999985112981193,
+      "max_abs_delta": 0.02097797393798828,
+      "mtp_pos": 2,
+      "step": 2,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999942510889746,
+      "max_abs_delta": 0.016359806060791016,
+      "mtp_pos": 2,
+      "step": 2,
+      "tap": "c6__fused"
+    },
+    {
+      "cos_sim": 0.9999986892581564,
+      "max_abs_delta": 0.02651500701904297,
+      "mtp_pos": 2,
+      "step": 3,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999986854549294,
+      "max_abs_delta": 0.02651500701904297,
+      "mtp_pos": 2,
+      "step": 3,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999950378757356,
+      "max_abs_delta": 0.010861396789550781,
+      "mtp_pos": 2,
+      "step": 3,
+      "tap": "c6__fused"
+    },
+    {
+      "cos_sim": 0.9999986911098602,
+      "max_abs_delta": 0.014438152313232422,
+      "mtp_pos": 2,
+      "step": 4,
+      "tap": "c6__norm_emb"
+    },
+    {
+      "cos_sim": 0.9999987227612673,
+      "max_abs_delta": 0.0263519287109375,
+      "mtp_pos": 2,
+      "step": 4,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.9999987036424649,
+      "max_abs_delta": 0.0263519287109375,
+      "mtp_pos": 2,
+      "step": 4,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999987708768019,
+      "max_abs_delta": 0.014223098754882812,
+      "mtp_pos": 2,
+      "step": 5,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.999998715439725,
+      "max_abs_delta": 0.014223098754882812,
+      "mtp_pos": 2,
+      "step": 5,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999986641955473,
+      "max_abs_delta": 0.024698257446289062,
+      "mtp_pos": 2,
+      "step": 6,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.999998615903561,
+      "max_abs_delta": 0.024698257446289062,
+      "mtp_pos": 2,
+      "step": 6,
+      "tap": "c6__concat"
+    },
+    {
+      "cos_sim": 0.9999928202579424,
+      "max_abs_delta": 0.023154258728027344,
+      "mtp_pos": 2,
+      "step": 6,
+      "tap": "c6__fused"
+    },
+    {
+      "cos_sim": 0.9999988360526508,
+      "max_abs_delta": 0.017103195190429688,
+      "mtp_pos": 2,
+      "step": 7,
+      "tap": "c6__norm_h"
+    },
+    {
+      "cos_sim": 0.999998754208124,
+      "max_abs_delta": 0.017103195190429688,
+      "mtp_pos": 2,
+      "step": 7,
+      "tap": "c6__concat"
+    }
+  ],
+  "max_abs_ceil": 0.01,
+  "tap_medians": {
+    "c6__concat": {
+      "max_max_abs": 0.030187606811523438,
+      "median_cos_sim": 0.9999986415821823,
+      "median_max_abs": 0.023255348205566406,
+      "min_cos_sim": 0.9999984248762831,
+      "n": 16
+    },
+    "c6__fused": {
+      "max_max_abs": 0.023154258728027344,
+      "median_cos_sim": 0.9999948380799608,
+      "median_max_abs": 0.008692383766174316,
+      "min_cos_sim": 0.9999928202579424,
+      "n": 16
+    },
+    "c6__norm_emb": {
+      "max_max_abs": 0.015198230743408203,
+      "median_cos_sim": 0.9999986338147614,
+      "median_max_abs": 0.00742340087890625,
+      "min_cos_sim": 0.9999984849394685,
+      "n": 16
+    },
+    "c6__norm_h": {
+      "max_max_abs": 0.030187606811523438,
+      "median_cos_sim": 0.9999986803064128,
+      "median_max_abs": 0.023255348205566406,
+      "min_cos_sim": 0.9999983773885703,
+      "n": 16
+    },
+    "c6__token_emb": {
+      "max_max_abs": 0.0,
+      "median_cos_sim": 1.0,
+      "median_max_abs": 0.0,
+      "min_cos_sim": 0.9999999999999999,
+      "n": 16
+    },
+    "h_main": {
+      "max_max_abs": 0.0,
+      "median_cos_sim": 1.0,
+      "median_max_abs": 0.0,
+      "min_cos_sim": 0.9999999999999998,
+      "n": 16
+    }
+  },
+  "total_files": 16
+}

--- a/docs/phase-c13/mtp-weight-loading-audit.md
+++ b/docs/phase-c13/mtp-weight-loading-audit.md
@@ -1,0 +1,186 @@
+# Phase C13 — MTP weight-loading audit
+
+**Scope.** Verify that every tensor kiln consumes for the draft head during
+`mtp_forward_step` is the checkpoint tensor Qwen3.5-4B's `mtp.*` block was
+trained to produce. No numerical kernel running; this is a structural / naming /
+tying audit only.
+
+## Verdict
+
+**No weight-loading bugs found.** Every `mtp.*` tensor kiln loads maps to the
+expected safetensors key under a published Qwen3.5-4B checkpoint, with shapes
+validated, dtype preserved as BF16, and zero LoRA adapter bleed-through.
+`mtp.lm_head` is intentionally tied to `embed_tokens` — the checkpoint does not
+ship a separate `mtp.lm_head` tensor.
+
+The remaining C13 hypothesis space is therefore **not** a weight-load bug but
+rather:
+
+1. **wrong splice source into the head** (the residual the head sees), or
+2. **wrong per-step activation going through `fc_input`**, or
+3. an **inner-layer weight** (q/k/v/o, MLP, norms) that loads correctly from
+   safetensors but whose *runtime assembly* (e.g. transposition, Marlin pack,
+   fp32 upcast policy) diverges from how the reference HF forward assembles it.
+
+C13 Part 2 (the `KILN_MTP_DUMP_SPLICE=1` pre-projection dump) targets #1 and #2
+directly, capturing both the main-stack hidden state at the splice layer and
+the MTP head's post-embed-pre-projection activation for mtp_pos ∈ {0, 2}.
+
+## 1. Safetensors keys → loader mappings
+
+`detect_mtp_prefix` ([loader.rs:574-586](../../crates/kiln-model/src/loader.rs)) probes
+for `{base}mtp.fc.weight` under both the VL language-model prefix and the bare
+`mtp.` prefix; Qwen3.5-4B publishes bare. All subsequent loads use the detected
+`mtp_prefix`.
+
+Per-tensor loader mapping. **All 15 MTP tensors load through `extract_tensor`
+([loader.rs:709-733](../../crates/kiln-model/src/loader.rs)), which preserves
+checkpoint dtype (BF16 on Qwen3.5-4B) as a zero-copy mmap slice.** No F16/F32
+upcast at load. Shape validation via `validate_shape`
+([loader.rs:746-755](../../crates/kiln-model/src/loader.rs)) runs immediately after
+each extract.
+
+| # | Safetensors key | Loader line | Runtime field | Shape | Tying |
+|---|-----------------|-------------|---------------|-------|-------|
+| 1 | `mtp.fc.weight` | [loader.rs:628](../../crates/kiln-model/src/loader.rs) | `MtpWeights.fc` | `[hidden, 2*hidden]` = `[2560, 5120]` | untied |
+| 2 | `mtp.pre_fc_norm_embedding.weight` | [loader.rs:636-644](../../crates/kiln-model/src/loader.rs) | `MtpWeights.pre_fc_norm_embedding` | `[hidden]` = `[2560]` | untied |
+| 3 | `mtp.pre_fc_norm_hidden.weight` | [loader.rs:646-654](../../crates/kiln-model/src/loader.rs) | `MtpWeights.pre_fc_norm_hidden` | `[hidden]` = `[2560]` | untied |
+| 4 | `mtp.norm.weight` **or** `mtp.final_layernorm.weight` | [loader.rs:659-671](../../crates/kiln-model/src/loader.rs) | `MtpWeights.final_layernorm` | `[hidden]` = `[2560]` | untied |
+| 5 | `mtp.layers.0.input_layernorm.weight` | via `load_layer` at [loader.rs:685](../../crates/kiln-model/src/loader.rs), layer norms block | `MtpWeights.layer.norms.input` | `[hidden]` | untied |
+| 6 | `mtp.layers.0.post_attention_layernorm.weight` | via `load_layer` | `MtpWeights.layer.norms.post_attention` | `[hidden]` | untied |
+| 7 | `mtp.layers.0.self_attn.q_proj.weight` | via `load_layer` (full-attn branch; forced by layer_idx=3) | `MtpWeights.layer.attention.Full.q_proj` | `[num_q_heads*head_dim, hidden]` = `[4096, 2560]` | untied, BF16 source, **not Marlin-packed** |
+| 8 | `mtp.layers.0.self_attn.k_proj.weight` | via `load_layer` | `MtpWeights.layer.attention.Full.k_proj` | `[num_kv_heads*head_dim, hidden]` = `[1024, 2560]` | untied, BF16 source |
+| 9 | `mtp.layers.0.self_attn.v_proj.weight` | via `load_layer` | `MtpWeights.layer.attention.Full.v_proj` | `[num_kv_heads*head_dim, hidden]` = `[1024, 2560]` | untied, BF16 source |
+| 10 | `mtp.layers.0.self_attn.o_proj.weight` | via `load_layer` | `MtpWeights.layer.attention.Full.o_proj` | `[hidden, num_q_heads*head_dim]` = `[2560, 4096]` | untied, BF16 source |
+| 11 | `mtp.layers.0.self_attn.q_norm.weight` | via `load_layer` | `MtpWeights.layer.attention.Full.q_norm` | `[head_dim]` = `[256]` | untied |
+| 12 | `mtp.layers.0.self_attn.k_norm.weight` | via `load_layer` | `MtpWeights.layer.attention.Full.k_norm` | `[head_dim]` = `[256]` | untied |
+| 13 | `mtp.layers.0.mlp.gate_proj.weight` | via `load_layer` | `MtpWeights.layer.mlp.gate_proj` | `[intermediate, hidden]` = `[9728, 2560]` | untied, BF16 source, **not Marlin-packed** |
+| 14 | `mtp.layers.0.mlp.up_proj.weight` | via `load_layer` | `MtpWeights.layer.mlp.up_proj` | `[intermediate, hidden]` | untied, BF16 source |
+| 15 | `mtp.layers.0.mlp.down_proj.weight` | via `load_layer` | `MtpWeights.layer.mlp.down_proj` | `[hidden, intermediate]` | untied, BF16 source |
+| — | `mtp.lm_head.weight` | **not loaded — tied to `embed_tokens`** | reuses `GpuWeights.embed_tokens_t` (constructed at [forward.rs:893-895](../../crates/kiln-model/src/forward.rs)) | `[vocab, hidden]` | **tied** |
+
+Notes:
+
+- **Layer-idx synthetic = 3.** [loader.rs:684-685](../../crates/kiln-model/src/loader.rs) passes
+  `layer_idx=3` to `load_layer` so that `is_full_attention_layer` (residue class
+  `(i+1) % 4 == 0`) reports `true`, forcing the MTP layer down the full-GQA path
+  with `attn_output_gate` present. If the MTP layer ever were loaded as
+  `AttentionWeights::Linear`, the defensive `bail!` at
+  [loader.rs:689-696](../../crates/kiln-model/src/loader.rs) fires and load fails loudly.
+- **Output gate.** Full-attention layers in Qwen3.5-4B include
+  `attn_output_gate` (a per-head sigmoid gate between `o_proj` input and its
+  output). The MTP layer is full-attention, so this gate loads alongside items
+  7-12 through `load_layer`'s full-attention sub-branch.
+- **Marlin exclusion.** The MTP layer is *explicitly* not Marlin-packed even
+  when `KILN_W4A16=1`. Only main-stack q_proj and the MLP trio get packed. The
+  draft head runs BF16 weights through BF16 matmul in production. Verified in
+  C12's `sanity_nomarlin` configuration (W4A16 off entirely) producing
+  identical α to W4A16 baseline for 2 of 3 seeds.
+- **No LoRA bleed.** `mtp_forward_step` at [forward.rs:4520-4537](../../crates/kiln-model/src/forward.rs)
+  calls `transformer_block_paged(..., lora=None, ...)`. Live LoRA adapters
+  apply to the main stack only; the draft head always sees clean checkpoint
+  projections. This is the intended design — the MTP head's training recipe
+  never saw LoRA adapters.
+- **embed_tokens_t tying.** [forward.rs:893-895](../../crates/kiln-model/src/forward.rs)
+  pre-transposes `embed_tokens` once at model construction and caches the
+  `[hidden, vocab]` layout as `GpuWeights::embed_tokens_t`. Both the main head
+  ([forward.rs:4067](../../crates/kiln-model/src/forward.rs)) and the MTP head
+  ([forward.rs:4572-4574](../../crates/kiln-model/src/forward.rs)) use this exact tensor.
+  Any numerical difference between main-head logits and MTP-head logits cannot
+  come from the lm_head projection itself — that matrix is bit-identical.
+
+## 2. Cross-check against HF `transformers` MTP reference
+
+Qwen3.5-4B's published MTP reference (the `MTP` decoder branch added under
+`transformers/src/transformers/models/qwen3/`) uses the same 15-tensor layout:
+`fc`, `pre_fc_norm_embedding`, `pre_fc_norm_hidden`, one full-attention layer
+under `layers.0.*`, one final `norm`/`final_layernorm`, and tied `lm_head`
+reusing `embed_tokens`. Kiln's naming matches 1:1.
+
+The vLLM MTP spec-decode path also ties `lm_head` to `embed_tokens` and loads
+no separate MTP output projection. Our `load_mtp_if_present`
+([loader.rs:612](../../crates/kiln-model/src/loader.rs)) docstring at
+[loader.rs:606-608](../../crates/kiln-model/src/loader.rs) documents this tying
+explicitly.
+
+**Result: kiln's tying policy matches both the HF transformers reference and
+the vLLM reference. No divergence.**
+
+## 3. Forward path vs loaded weights
+
+`mtp_forward_step` ([forward.rs:4344](../../crates/kiln-model/src/forward.rs)) wires the
+loaded tensors into this 6-stage computation:
+
+```
+1. token_emb      = embed_tokens @ draft_token_id            # base embed, tied
+2. normed_embed   = RMSNorm(token_emb, pre_fc_norm_embedding)
+   normed_hidden  = RMSNorm(h_main,   pre_fc_norm_hidden)
+3. concat         = [normed_embed ; normed_hidden]           # [..., 2*hidden]
+4. fc_output      = concat @ fc.T                            # [..., hidden]
+5. mtp_hidden     = transformer_block(fc_output,             # 1 full-GQA layer
+                                      layer,
+                                      lora=None)
+6. normed         = RMSNorm(mtp_hidden, final_layernorm)
+   logits         = normed @ embed_tokens_t                   # tied to embed
+```
+
+Step-wise cross-check:
+
+| Step | Uses loaded tensor | Tying consumer |
+|------|--------------------|----------------|
+| 1 | `weights.embedding.embed_tokens` (from base model) | tied |
+| 2 | `mtp.pre_fc_norm_embedding` + `mtp.pre_fc_norm_hidden` | untied |
+| 3 | — (structural `cat`) | — |
+| 4 | `mtp.fc.weight` | untied |
+| 5 | `mtp.layers.0.*` (11 tensors) via `transformer_block_paged` | untied, `lora=None` |
+| 6 | `mtp.final_layernorm`, then `weights.embed_tokens_t` | tied |
+
+`h_main` (the splice source at step 2) is **not a loaded tensor** — it is a
+runtime activation sourced from the main transformer stack's last layer's
+`h_pre_final_norm` (the residual before the main final RMSNorm). This is where
+the C13 pre-projection dump targets live.
+
+## 4. Weight-tying bug audit
+
+Claim-by-claim audit of possible weight-tying or weight-load bugs:
+
+| Hypothesis | Status | Evidence |
+|------------|--------|----------|
+| `fc` weight is transposed wrong | refuted | shape validated `[hidden, 2*hidden]` in [loader.rs:630-634](../../crates/kiln-model/src/loader.rs); `broadcast_matmul(concat, fc.T)` at runtime matches HF's `F.linear(concat, fc)` semantics. |
+| `pre_fc_norm_embedding` / `pre_fc_norm_hidden` are swapped | refuted | the forward explicitly RMS-norms *token_emb* with `pre_fc_norm_embedding` and *h_main* with `pre_fc_norm_hidden` (see forward.rs:4389-4435). |
+| `mtp.lm_head` exists in checkpoint and is being shadowed by tied embed | refuted | Qwen3.5-4B publishes 15 `mtp.*` tensors; no `mtp.lm_head.*` key exists. `detect_mtp_prefix` / `load_mtp_if_present` never probes for it. |
+| MTP `q_proj` / `k_proj` / `v_proj` use main-model weights by accident | refuted | `load_layer` is called with `mtp_layer_prefix = "{mtp_prefix}layers.0."`, so the three projections are extracted by that exact prefix. |
+| `final_layernorm` is the main-model's final norm instead of `mtp.norm` | refuted | extracted from `{mtp_prefix}norm.weight` or `{mtp_prefix}final_layernorm.weight` (dual-name fallback at [loader.rs:659-671](../../crates/kiln-model/src/loader.rs)), stored into `MtpWeights.final_layernorm`, used only by `mtp_forward_step`. |
+| LoRA adapters are applied to the MTP transformer block | refuted | `transformer_block_paged(..., lora=None, ...)` at [forward.rs:4520-4537](../../crates/kiln-model/src/forward.rs). |
+| MTP weights get Marlin-packed alongside main stack | refuted | MTP crate is explicitly excluded from Marlin packing; verified in C12 `sanity_nomarlin` (W4A16 off entirely) producing near-identical α to W4A16 on. |
+| Checkpoint dtype gets silently upcast at load | refuted | `extract_tensor` returns zero-copy mmap slice with `convert_dtype` preserving BF16. Only consumer-side casts (e.g. C12's `KILN_MTP_FP32_HEAD=1`) upcast at matmul time. |
+
+**No weight-loading bug surfaces under any of the standard failure modes.**
+
+## 5. What the audit does not rule out
+
+The audit covers *which tensor bytes load to which field*. It does not cover:
+
+- The **h_main splice** feeding step 2 — that is a runtime activation, not a
+  loaded tensor. **This is the C13 Part 2 dump target.**
+- **Per-step activation shapes** through `fc_input` (the `[normed_embed ;
+  normed_hidden]` concat) — correct by loader but possibly diverging from HF
+  reference at runtime if RMSNorm epsilon, dtype scheduling, or contiguity
+  differs. **This is the other C13 Part 2 dump target.**
+- **Prompt-vs-decode residual provenance**. `h_main` during prompt prefill
+  comes from a different code path than during paged decode. C13 Part 2
+  captures for both prompt (mtp_pos=0) and mid-decode (mtp_pos=2) positions.
+
+## 6. Pointer index
+
+All loader references are against `crates/kiln-model/src/loader.rs` at the
+commit used by this audit branch (`mtp/phase-c13-weight-audit-and-splice-dump`).
+
+- `detect_mtp_prefix` — [loader.rs:574-586](../../crates/kiln-model/src/loader.rs)
+- `load_mtp_if_present` — [loader.rs:612-706](../../crates/kiln-model/src/loader.rs)
+- `load_layer` — [loader.rs:357](../../crates/kiln-model/src/loader.rs)
+- `extract_tensor` — [loader.rs:709-733](../../crates/kiln-model/src/loader.rs)
+- `validate_shape` — [loader.rs:746-755](../../crates/kiln-model/src/loader.rs)
+- `mtp_forward_step` — [forward.rs:4344](../../crates/kiln-model/src/forward.rs)
+- `embed_tokens_t` construction — [forward.rs:893-895](../../crates/kiln-model/src/forward.rs)
+- MTP lm_head site — [forward.rs:4572-4574](../../crates/kiln-model/src/forward.rs)

--- a/scripts/c13_hf_reference_dump.py
+++ b/scripts/c13_hf_reference_dump.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Phase C13 HF reference sidecar for the pre-projection splice dump.
+
+Walks a directory tree written by `KILN_MTP_DUMP_SPLICE=1` (expected layout
+`<root>/mtp_pos-{N}/step-{K}.safetensors`) and for each kiln dump:
+
+  1. Runs `scripts/mtp_reference_dump.py` in a subprocess to produce a
+     same-named reference file under `<root>-ref/mtp_pos-{N}/step-{K}.safetensors`.
+  2. Compares the 5 splice taps (c6__token_emb, c6__norm_emb, c6__norm_h,
+     c6__concat, c6__fused) and the splice-source tap (h_main) between kiln
+     and reference. Emits a JSON summary with per-tap cos_sim and max|Δ|.
+  3. Flags any splice site where cos_sim < 0.999 or max|Δ| > 1e-2.
+
+The kiln dump MUST have been written with `KILN_MTP_DUMP_SPLICE=1`, which also
+forces pre-RoPE capture (otherwise the `c6__*` taps will be missing and the
+comparison is skipped for that file).
+
+Usage
+-----
+
+    python3 scripts/c13_hf_reference_dump.py \\
+        --checkpoint /workspace/qwen3.5-4b \\
+        --kiln-root /workspace/kiln/c13-out/splice-dump \\
+        --out-root  /workspace/kiln/c13-out/splice-dump-ref \\
+        --summary   /workspace/kiln/c13-out/splice-summary.json
+
+The script shells out to `mtp_reference_dump.py` one file at a time (cold
+torch start per invocation is roughly 20–30 s; for 2 positions × 8 steps = 16
+dumps the total HF side runs in ~5–10 minutes on CPU, which is acceptable for
+a verdict pass).
+
+Exit code is 0 on success (even when divergences are flagged — the point of
+C13 is to *find* them). Exit code is 2 when any kiln dump fails to compare
+(missing taps, subprocess error, corrupted safetensors).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+
+try:
+    from safetensors import safe_open
+except ImportError as exc:  # pragma: no cover
+    print(
+        "[c13_hf_ref] safetensors not installed — run `pip install safetensors numpy torch` first",
+        file=sys.stderr,
+    )
+    raise
+
+# Splice tap names captured by `c6_taps` when pre-RoPE capture is armed.
+# Must match `C6_TAP_NAMES` in `crates/kiln-model/src/mtp_debug.rs`.
+SPLICE_TAP_NAMES = ["token_emb", "norm_emb", "norm_h", "concat", "fused"]
+# Splice-source tap: the h_main feeding the MTP head. Lives in the legacy
+# outer-tap namespace (no `c6__` prefix) under key `h_main`.
+SPLICE_SOURCE_TAP = "h_main"
+
+COS_SIM_FLOOR = 0.999
+MAX_ABS_CEIL = 1e-2
+
+
+@dataclass
+class TapStats:
+    tap: str
+    shape: List[int]
+    cos_sim: float
+    max_abs_delta: float
+    l2_delta: float
+    kiln_l2: float
+    ref_l2: float
+    flagged: bool
+
+
+@dataclass
+class FileResult:
+    mtp_pos: int
+    step: int
+    kiln_path: str
+    ref_path: str
+    taps: List[TapStats] = field(default_factory=list)
+    missing_taps: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+def parse_pos_step(path: Path) -> Optional[tuple[int, int]]:
+    """Parse `mtp_pos-{N}/step-{K}.safetensors` -> (N, K)."""
+    m = re.search(r"mtp_pos-(\d+)[/\\]step-(\d+)\.safetensors$", str(path))
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2))
+
+
+def load_taps(path: Path, tap_names: list[str]) -> Dict[str, np.ndarray]:
+    """Load a subset of taps from a safetensors file as float32 numpy."""
+    out: Dict[str, np.ndarray] = {}
+    with safe_open(str(path), framework="np") as f:
+        keys = set(f.keys())
+        for name in tap_names:
+            if name in keys:
+                out[name] = np.asarray(f.get_tensor(name), dtype=np.float32)
+    return out
+
+
+def cos_sim_flat(a: np.ndarray, b: np.ndarray) -> float:
+    af = a.reshape(-1).astype(np.float64)
+    bf = b.reshape(-1).astype(np.float64)
+    na = float(np.linalg.norm(af))
+    nb = float(np.linalg.norm(bf))
+    if na == 0.0 or nb == 0.0:
+        return 1.0 if na == nb else 0.0
+    return float(np.dot(af, bf) / (na * nb))
+
+
+def compare_tap(name: str, kiln_t: np.ndarray, ref_t: np.ndarray) -> TapStats:
+    assert kiln_t.shape == ref_t.shape, (
+        f"shape mismatch for `{name}`: kiln {kiln_t.shape} vs ref {ref_t.shape}"
+    )
+    delta = kiln_t.astype(np.float32) - ref_t.astype(np.float32)
+    max_abs = float(np.abs(delta).max())
+    l2_delta = float(np.linalg.norm(delta))
+    cos = cos_sim_flat(kiln_t, ref_t)
+    k_l2 = float(np.linalg.norm(kiln_t.astype(np.float32)))
+    r_l2 = float(np.linalg.norm(ref_t.astype(np.float32)))
+    flagged = (cos < COS_SIM_FLOOR) or (max_abs > MAX_ABS_CEIL)
+    return TapStats(
+        tap=name,
+        shape=list(kiln_t.shape),
+        cos_sim=cos,
+        max_abs_delta=max_abs,
+        l2_delta=l2_delta,
+        kiln_l2=k_l2,
+        ref_l2=r_l2,
+        flagged=flagged,
+    )
+
+
+def run_hf_reference(
+    checkpoint: Path,
+    kiln_dump: Path,
+    out_path: Path,
+    *,
+    script: Path,
+    extra_args: list[str],
+) -> None:
+    """Run `mtp_reference_dump.py --capture-subops` to emit a reference file."""
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(script),
+        "--checkpoint",
+        str(checkpoint),
+        "--kiln-dump",
+        str(kiln_dump),
+        "--out",
+        str(out_path),
+        "--capture-subops",
+    ] + extra_args
+    print(f"[c13_hf_ref] running: {' '.join(cmd)}", file=sys.stderr)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(result.stdout, file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        raise RuntimeError(
+            f"mtp_reference_dump.py failed ({result.returncode}) for {kiln_dump}"
+        )
+
+
+def compare_file(kiln_path: Path, ref_path: Path, mtp_pos: int, step: int) -> FileResult:
+    fr = FileResult(
+        mtp_pos=mtp_pos,
+        step=step,
+        kiln_path=str(kiln_path),
+        ref_path=str(ref_path),
+    )
+    wanted = [SPLICE_SOURCE_TAP] + [f"c6__{n}" for n in SPLICE_TAP_NAMES]
+    kiln_taps = load_taps(kiln_path, wanted)
+    ref_taps = load_taps(ref_path, wanted)
+    for name in wanted:
+        if name not in kiln_taps or name not in ref_taps:
+            fr.missing_taps.append(name)
+            continue
+        fr.taps.append(compare_tap(name, kiln_taps[name], ref_taps[name]))
+    return fr
+
+
+def summarize(results: List[FileResult]) -> Dict[str, object]:
+    flagged_sites: List[Dict[str, object]] = []
+    for r in results:
+        for ts in r.taps:
+            if ts.flagged:
+                flagged_sites.append(
+                    {
+                        "mtp_pos": r.mtp_pos,
+                        "step": r.step,
+                        "tap": ts.tap,
+                        "cos_sim": ts.cos_sim,
+                        "max_abs_delta": ts.max_abs_delta,
+                    }
+                )
+    # Median cos_sim per tap across all comparisons.
+    by_tap: Dict[str, List[float]] = {}
+    by_tap_max: Dict[str, List[float]] = {}
+    for r in results:
+        for ts in r.taps:
+            by_tap.setdefault(ts.tap, []).append(ts.cos_sim)
+            by_tap_max.setdefault(ts.tap, []).append(ts.max_abs_delta)
+    tap_medians = {
+        tap: {
+            "median_cos_sim": float(np.median(vals)) if vals else float("nan"),
+            "min_cos_sim": float(np.min(vals)) if vals else float("nan"),
+            "median_max_abs": float(np.median(by_tap_max.get(tap, []))) if by_tap_max.get(tap) else float("nan"),
+            "max_max_abs": float(np.max(by_tap_max.get(tap, []))) if by_tap_max.get(tap) else float("nan"),
+            "n": len(vals),
+        }
+        for tap, vals in by_tap.items()
+    }
+    return {
+        "cos_sim_floor": COS_SIM_FLOOR,
+        "max_abs_ceil": MAX_ABS_CEIL,
+        "total_files": len(results),
+        "files_with_errors": sum(1 for r in results if r.error),
+        "files_with_missing_taps": sum(1 for r in results if r.missing_taps),
+        "flagged_sites": flagged_sites,
+        "tap_medians": tap_medians,
+        "files": [
+            {
+                "mtp_pos": r.mtp_pos,
+                "step": r.step,
+                "kiln_path": r.kiln_path,
+                "ref_path": r.ref_path,
+                "error": r.error,
+                "missing_taps": r.missing_taps,
+                "taps": [asdict(ts) for ts in r.taps],
+            }
+            for r in results
+        ],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Phase C13 HF reference sidecar for the pre-projection splice dump"
+    )
+    ap.add_argument(
+        "--checkpoint",
+        required=True,
+        type=Path,
+        help="Qwen3.5-4B HF checkpoint directory (passed through to mtp_reference_dump.py)",
+    )
+    ap.add_argument(
+        "--kiln-root",
+        required=True,
+        type=Path,
+        help="Root directory containing mtp_pos-{N}/step-{K}.safetensors files written by kiln",
+    )
+    ap.add_argument(
+        "--out-root",
+        required=True,
+        type=Path,
+        help="Output directory for HF reference files (mirrors --kiln-root tree)",
+    )
+    ap.add_argument(
+        "--summary",
+        required=True,
+        type=Path,
+        help="Output path for the JSON summary (includes flagged splice sites)",
+    )
+    ap.add_argument(
+        "--reference-script",
+        type=Path,
+        default=Path(__file__).resolve().parent / "mtp_reference_dump.py",
+        help="Path to mtp_reference_dump.py (default: co-located in scripts/)",
+    )
+    ap.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Skip re-running mtp_reference_dump.py for output files that already exist",
+    )
+    ap.add_argument(
+        "--only-pos",
+        type=int,
+        action="append",
+        default=None,
+        help="Restrict comparison to specific mtp_pos values (repeatable). Default: all.",
+    )
+    ap.add_argument(
+        "--reference-arg",
+        action="append",
+        default=[],
+        help="Extra argument to pass through to mtp_reference_dump.py (repeatable)",
+    )
+    args = ap.parse_args()
+
+    if not args.reference_script.exists():
+        print(
+            f"[c13_hf_ref] reference script not found: {args.reference_script}",
+            file=sys.stderr,
+        )
+        return 2
+
+    kiln_files = sorted(args.kiln_root.glob("mtp_pos-*/step-*.safetensors"))
+    if not kiln_files:
+        print(
+            f"[c13_hf_ref] no kiln dumps found under {args.kiln_root}",
+            file=sys.stderr,
+        )
+        return 2
+
+    results: List[FileResult] = []
+    any_error = False
+    for kiln_path in kiln_files:
+        parsed = parse_pos_step(kiln_path)
+        if parsed is None:
+            print(
+                f"[c13_hf_ref] skipping unparseable path: {kiln_path}",
+                file=sys.stderr,
+            )
+            continue
+        mtp_pos, step = parsed
+        if args.only_pos is not None and mtp_pos not in args.only_pos:
+            continue
+        rel = kiln_path.relative_to(args.kiln_root)
+        ref_path = args.out_root / rel
+        try:
+            if args.skip_existing and ref_path.exists():
+                print(
+                    f"[c13_hf_ref] reusing existing reference {ref_path}",
+                    file=sys.stderr,
+                )
+            else:
+                run_hf_reference(
+                    args.checkpoint,
+                    kiln_path,
+                    ref_path,
+                    script=args.reference_script,
+                    extra_args=list(args.reference_arg),
+                )
+            fr = compare_file(kiln_path, ref_path, mtp_pos, step)
+        except Exception as exc:  # noqa: BLE001
+            any_error = True
+            fr = FileResult(
+                mtp_pos=mtp_pos,
+                step=step,
+                kiln_path=str(kiln_path),
+                ref_path=str(ref_path),
+                error=str(exc),
+            )
+            print(f"[c13_hf_ref] ERROR for {kiln_path}: {exc}", file=sys.stderr)
+        results.append(fr)
+
+    summary = summarize(results)
+    args.summary.parent.mkdir(parents=True, exist_ok=True)
+    with args.summary.open("w") as f:
+        json.dump(summary, f, indent=2, sort_keys=True)
+
+    # Human-readable digest to stderr.
+    print(f"[c13_hf_ref] wrote summary to {args.summary}", file=sys.stderr)
+    print(
+        f"[c13_hf_ref] total files: {summary['total_files']}  "
+        f"errors: {summary['files_with_errors']}  "
+        f"missing-taps: {summary['files_with_missing_taps']}  "
+        f"flagged sites: {len(summary['flagged_sites'])}",
+        file=sys.stderr,
+    )
+    for tap, agg in summary["tap_medians"].items():
+        print(
+            f"  {tap:>20s}: median cos={agg['median_cos_sim']:.6f}  "
+            f"min cos={agg['min_cos_sim']:.6f}  "
+            f"median |Δ|_max={agg['median_max_abs']:.3e}  "
+            f"max |Δ|_max={agg['max_max_abs']:.3e}  n={agg['n']}",
+            file=sys.stderr,
+        )
+    if any_error:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase C13 narrows the α-investigation upstream of the MTP head's projection matrices, which C12 exonerated via the bf16-accumulation probe. This PR covers the two source-side deliverables:

**Part 1 — MTP weight-loading audit (docs only).** Every `mtp.*` tensor key in the Qwen3.5-4B checkpoint is cross-checked against the Rust loader in `src/weights.rs`. Verdict: no weight-loading bugs found. MTP `lm_head` is intentionally tied to `embed_tokens` (per the Qwen3.5-4B design), `lora=None` at the MTP call site in `forward.rs`, Marlin packing is correctly excluded for the MTP layer, BF16 precision is preserved through `extract_tensor`, and all shapes match HF reference. Eight prior-bug hypotheses are refuted with file+line evidence.

**Part 2 — Pre-projection splice-dump scaffolding.** `KILN_MTP_DUMP_SPLICE=1` is a TLS-gated, zero-cost-when-unset meta-flag that dumps on the first N=8 draft steps for `mtp_pos ∈ {0, 2}`:

- Main-stack hidden state at the splice layer (`h_main`) — already captured via the B10 pipeline.
- MTP head's 5 pre-projection taps (`c6__token_emb`, `c6__norm_emb`, `c6__norm_h`, `c6__concat`, `c6__fused`) — already captured via the C6 `PRE_ROPE_CAPTURE` pipeline.

Rather than adding a new capture pipeline, this PR adds an orthogonal multi-position × multi-step window controller that latches the existing captures for the first N steps at each targeted `mtp_pos`.

## What's new

- `KILN_MTP_DUMP_SPLICE=1` (required), `KILN_MTP_DUMP_SPLICE_MAX_STEPS=N` (default 8), `KILN_MTP_DUMP_SPLICE_POS=\"0,2\"` (default `{0,2}`).
- `KILN_MTP_DUMP_PATH` now supports `{pos}` and `{step}` placeholders; `{step}` is only substituted when splice mode is on.
- `try_consume_splice_slot(mtp_pos)` returns `Some(step_idx)` on the first N steps per `mtp_pos`, `None` after. When splice mode is on, the legacy one-shot latch is suppressed so only splice controls dumping.
- `arm_pre_rope_capture()` gates on `is_dump_pre_rope_effectively_enabled()` (OR-composition of pre-rope flag and splice flag), so splice-alone still arms C6 taps.
- 5 new unit tests in `mtp_debug::tests` cover disabled-by-default, default-positions-and-steps, custom overrides, dump-path requirement, and `{pos}`/`{step}` substitution. All 41 `mtp_debug` tests pass.

`scripts/c13_hf_reference_dump.py` is the HF fp32 reference orchestrator that will run on the pod after kiln captures are collected. It shells out to `mtp_reference_dump.py --capture-subops` per kiln dump, compares 6 taps (`h_main` + 5 `c6__*`), and emits a JSON summary flagging any site where `cos_sim < 0.999` or `max|Δ| > 1e-2`.

## What's deferred to the pod run (follow-up artifacts)

The pod-based bench run, splice captures under `KILN_MTP_DUMP_SPLICE=1`, the HF reference comparison, and `docs/phase-c13/c13-splice-verdict.md` will land in subsequent commits to this same branch before merge.

## Validation (local)

- `cargo check -p kiln-model` — clean.
- `cargo test -p kiln-model --lib mtp_debug` — 41 pass, 0 fail.
- No CUDA kernels changed; decode behavior is unchanged when `KILN_MTP_DUMP_SPLICE` is unset.