### PR TITLE
[codex] Gate Metal readiness prewarm

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -28,6 +28,35 @@ const DISABLE_METAL_RMSNORM: &str = "KILN_DISABLE_METAL_RMSNORM";
 #[derive(Debug)]
 pub struct MetalBackend {
     device: Device,
+    /// Cached at construction to keep env-var reads off per-token support gates.
+    disable: MetalKernelDisables,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MetalKernelDisables {
+    conv1d_prefill: bool,
+    conv1d_update: bool,
+    gdn_forward_substitution: bool,
+    gdn_recurrent: bool,
+    gdn_gates: bool,
+    gated_rms_norm: bool,
+}
+
+impl MetalKernelDisables {
+    fn from_env() -> Self {
+        let gdn_kernel = env_truthy(DISABLE_GDN_KERNEL);
+        Self {
+            conv1d_prefill: env_truthy(DISABLE_METAL_CONV1D_PREFILL),
+            conv1d_update: env_present(DISABLE_FUSED_CONV1D)
+                || env_truthy(DISABLE_METAL_FUSED_CONV1D),
+            gdn_forward_substitution: gdn_kernel
+                || env_truthy(DISABLE_METAL_GDN_FORWARD_SUBSTITUTION),
+            gdn_recurrent: gdn_kernel || env_truthy(DISABLE_METAL_GDN_RECURRENT),
+            gdn_gates: env_present(DISABLE_FUSED_GDN_GATES)
+                || env_truthy(DISABLE_METAL_GDN_GATES),
+            gated_rms_norm: env_truthy(DISABLE_METAL_GATED_RMSNORM),
+        }
+    }
 }
 
 impl MetalBackend {
@@ -36,7 +65,10 @@ impl MetalBackend {
             matches!(device, Device::Metal(_)),
             "MetalBackend created on non-Metal device"
         );
-        Self { device }
+        Self {
+            device,
+            disable: MetalKernelDisables::from_env(),
+        }
     }
 }
 
@@ -82,27 +114,27 @@ impl BackendRuntime for MetalBackend {
     }
 
     fn supports_causal_conv1d_prefill(&self) -> bool {
-        !metal_conv1d_prefill_disabled()
+        !self.disable.conv1d_prefill
     }
 
     fn supports_causal_conv1d_update(&self) -> bool {
-        !metal_conv1d_update_disabled()
+        !self.disable.conv1d_update
     }
 
     fn supports_gdn_forward_substitution(&self) -> bool {
-        !metal_gdn_forward_substitution_disabled()
+        !self.disable.gdn_forward_substitution
     }
 
     fn supports_gdn_recurrent_step(&self) -> bool {
-        !metal_gdn_recurrent_disabled()
+        !self.disable.gdn_recurrent
     }
 
     fn supports_gdn_gates(&self) -> bool {
-        !metal_gdn_gates_disabled()
+        !self.disable.gdn_gates
     }
 
     fn supports_gdn_gated_rms_norm(&self) -> bool {
-        !metal_gated_rms_norm_disabled()
+        !self.disable.gated_rms_norm
     }
 
     fn flash_attn_prefill(
@@ -242,7 +274,7 @@ impl BackendRuntime for MetalBackend {
         conv_state: &mut Tensor,
         kernel_size: usize,
     ) -> Result<Option<Tensor>> {
-        if metal_conv1d_prefill_disabled()
+        if self.disable.conv1d_prefill
             || !metal_conv1d_prefill_supports(x, weight, conv_state, kernel_size)
         {
             return Ok(None);
@@ -259,7 +291,7 @@ impl BackendRuntime for MetalBackend {
         conv_state: &mut Tensor,
         kernel_size: usize,
     ) -> Result<Option<Tensor>> {
-        if metal_conv1d_update_disabled()
+        if self.disable.conv1d_update
             || !metal_conv1d_update_supports(x, weight, conv_state, kernel_size)
         {
             return Ok(None);
@@ -275,7 +307,7 @@ impl BackendRuntime for MetalBackend {
         v_prime: &Tensor,
         beta: &Tensor,
     ) -> Result<Option<Tensor>> {
-        if metal_gdn_forward_substitution_disabled()
+        if self.disable.gdn_forward_substitution
             || !metal_gdn_forward_substitution_supports(a_strict, v_prime, beta)
         {
             return Ok(None);
@@ -294,8 +326,7 @@ impl BackendRuntime for MetalBackend {
         g: &Tensor,
         state: &mut Tensor,
     ) -> Result<Option<Tensor>> {
-        if metal_gdn_recurrent_disabled() || !metal_gdn_recurrent_supports(q, k, v, beta, g, state)
-        {
+        if self.disable.gdn_recurrent || !metal_gdn_recurrent_supports(q, k, v, beta, g, state) {
             return Ok(None);
         }
         let out = metal_gdn_recurrent_bf16(q, k, v, beta, g, state)
@@ -310,7 +341,7 @@ impl BackendRuntime for MetalBackend {
         a_log: &Tensor,
         dt_bias: &Tensor,
     ) -> Result<Option<(Tensor, Tensor)>> {
-        if metal_gdn_gates_disabled() || !metal_gdn_gates_supports(a, b, a_log, dt_bias) {
+        if self.disable.gdn_gates || !metal_gdn_gates_supports(a, b, a_log, dt_bias) {
             return Ok(None);
         }
         let out = metal_gdn_gates_bf16(a, b, a_log, dt_bias)
@@ -325,7 +356,7 @@ impl BackendRuntime for MetalBackend {
         weight: &Tensor,
         eps: f64,
     ) -> Result<Option<Tensor>> {
-        if metal_gated_rms_norm_disabled() || !metal_gated_rms_norm_supports(x, z, weight) {
+        if self.disable.gated_rms_norm || !metal_gated_rms_norm_supports(x, z, weight) {
             return Ok(None);
         }
         let out = metal_gated_rms_norm_bf16(x, z, weight, eps as f32)
@@ -342,38 +373,16 @@ fn metal_sdpa_supports_head_dim(head_dim: usize) -> bool {
     matches!(head_dim, 32 | 64 | 72 | 80 | 96 | 128 | 256 | 512)
 }
 
-fn metal_conv1d_prefill_disabled() -> bool {
-    env_truthy(DISABLE_METAL_CONV1D_PREFILL)
-}
-
-fn metal_conv1d_update_disabled() -> bool {
-    // Match the CUDA kill-switch contract for the shared env var: if it is
-    // present at all, the fused decode conv path is disabled.
-    std::env::var(DISABLE_FUSED_CONV1D).is_ok() || env_truthy(DISABLE_METAL_FUSED_CONV1D)
-}
-
-fn metal_gdn_recurrent_disabled() -> bool {
-    env_truthy(DISABLE_GDN_KERNEL) || env_truthy(DISABLE_METAL_GDN_RECURRENT)
-}
-
-fn metal_gdn_forward_substitution_disabled() -> bool {
-    env_truthy(DISABLE_GDN_KERNEL) || env_truthy(DISABLE_METAL_GDN_FORWARD_SUBSTITUTION)
-}
-
-fn metal_gdn_gates_disabled() -> bool {
-    std::env::var(DISABLE_FUSED_GDN_GATES).is_ok() || env_truthy(DISABLE_METAL_GDN_GATES)
-}
-
-fn metal_gated_rms_norm_disabled() -> bool {
-    env_truthy(DISABLE_METAL_GATED_RMSNORM)
-}
-
 fn metal_gdn_qk_norm_disabled() -> bool {
     env_truthy(DISABLE_METAL_GDN_QK_NORM)
 }
 
 fn metal_rms_norm_disabled() -> bool {
-    std::env::var(DISABLE_RMSNORM_KERNEL).is_ok() || env_truthy(DISABLE_METAL_RMSNORM)
+    env_present(DISABLE_RMSNORM_KERNEL) || env_truthy(DISABLE_METAL_RMSNORM)
+}
+
+fn env_present(var: &str) -> bool {
+    std::env::var(var).is_ok()
 }
 
 fn env_truthy(var: &str) -> bool {

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -10,6 +10,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
 use std::path::Path;
+use std::sync::atomic::Ordering;
 
 use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
@@ -233,6 +234,8 @@ async fn chat_completions_inner(
     state: &AppState,
     req: ChatCompletionRequest,
 ) -> Result<Response, ApiError> {
+    wait_for_inference_prewarm(state).await?;
+
     // Convert request messages to ChatMessage for template formatting
     let chat_messages: Vec<ChatMessage> = req
         .messages
@@ -323,6 +326,23 @@ async fn chat_completions_inner(
             }
         }
     }
+}
+
+async fn wait_for_inference_prewarm(state: &AppState) -> Result<(), ApiError> {
+    if state.inference_prewarm_complete.load(Ordering::Acquire) {
+        return Ok(());
+    }
+
+    let timeout = state.request_timeout;
+    let wait = async {
+        while !state.inference_prewarm_complete.load(Ordering::Acquire) {
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    };
+
+    tokio::time::timeout(timeout, wait)
+        .await
+        .map_err(|_| ApiError::request_timeout(timeout.as_secs()))
 }
 
 /// Ensure the correct LoRA adapter is active for the given request.

--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -4,6 +4,7 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
 use serde::Serialize;
+use std::sync::atomic::Ordering;
 
 use crate::state::{AppState, ModelBackend};
 
@@ -125,7 +126,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
     };
 
     // Training info
-    let (active_job, running_count) = {
+    let (active_job, _running_count) = {
         let jobs = state.training_jobs.read().unwrap();
         let active = jobs.values().find(|j| {
             j.state == kiln_train::TrainingState::Running
@@ -146,6 +147,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
 
     // Health checks
     let scheduler_responsive = scheduler_stats.is_some();
+    let inference_prewarm_complete = state.inference_prewarm_complete.load(Ordering::Acquire);
     let checks = vec![
         HealthCheck {
             name: "model_loaded",
@@ -154,6 +156,10 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
         HealthCheck {
             name: "scheduler_responsive",
             pass: scheduler_responsive,
+        },
+        HealthCheck {
+            name: "inference_prewarm_complete",
+            pass: inference_prewarm_complete,
         },
     ];
 

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -122,6 +123,7 @@ async fn main() -> Result<()> {
         vocab_size = tokenizer.vocab_size(),
         "tokenizer loaded successfully"
     );
+    warm_tokenizer(&tokenizer);
 
     let mut state = if let Some(mp) = model_path {
         // Real inference mode: load model weights and create ModelRunner.
@@ -254,9 +256,11 @@ fn spawn_backend_prewarm(state: AppState) {
 
     let runner = runner.clone();
     let gpu_lock = state.gpu_lock.clone();
+    let prewarm_complete = state.inference_prewarm_complete.clone();
 
     tokio::spawn(async move {
         tracing::info!("starting background inference prewarm");
+        let prewarm_start = std::time::Instant::now();
         let prewarm = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
             // Hold the exclusive GPU lock so prewarm never races real
             // generation. If a request starts first, this blocks until that
@@ -303,11 +307,34 @@ fn spawn_backend_prewarm(state: AppState) {
         .await;
 
         match prewarm {
-            Ok(Ok(())) => tracing::info!("background inference prewarm complete"),
+            Ok(Ok(())) => tracing::info!(
+                elapsed_ms = prewarm_start.elapsed().as_millis() as u64,
+                "background inference prewarm complete"
+            ),
             Ok(Err(err)) => tracing::warn!(error = %err, "background inference prewarm failed"),
             Err(err) => tracing::warn!(error = %err, "background inference prewarm task failed"),
         }
+        prewarm_complete.store(true, Ordering::Release);
     });
+}
+
+fn warm_tokenizer(tokenizer: &KilnTokenizer) {
+    let start = std::time::Instant::now();
+    let prompt = "Kiln tokenizer startup warmup.";
+    match tokenizer.encode(prompt) {
+        Ok(tokens) => {
+            if let Err(err) = tokenizer.decode(&tokens) {
+                tracing::warn!(error = %err, "tokenizer decode warmup failed");
+            } else {
+                tracing::info!(
+                    elapsed_ms = start.elapsed().as_millis() as u64,
+                    tokens = tokens.len(),
+                    "tokenizer warmup complete"
+                );
+            }
+        }
+        Err(err) => tracing::warn!(error = %err, "tokenizer encode warmup failed"),
+    }
 }
 
 #[cfg(feature = "metal")]

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -190,6 +191,8 @@ pub struct AppState {
     pub metrics: Arc<Metrics>,
     /// Server startup time — used to compute uptime in health checks.
     pub started_at: std::time::Instant,
+    /// True once startup inference prewarm has finished or was not needed.
+    pub inference_prewarm_complete: Arc<AtomicBool>,
     /// Server-level default for adapter checkpoint interval during training.
     /// Per-job config overrides this. None = only save at the end.
     pub checkpoint_interval: Option<usize>,
@@ -228,6 +231,7 @@ impl AppState {
             request_timeout: std::time::Duration::from_secs(request_timeout_secs),
             metrics: Arc::new(Metrics::new()),
             started_at: std::time::Instant::now(),
+            inference_prewarm_complete: Arc::new(AtomicBool::new(true)),
             checkpoint_interval: None,
             served_model_id,
         }
@@ -422,6 +426,10 @@ impl AppState {
             request_timeout: std::time::Duration::from_secs(request_timeout_secs),
             metrics: Arc::new(Metrics::new()),
             started_at: std::time::Instant::now(),
+            inference_prewarm_complete: Arc::new(AtomicBool::new(!matches!(
+                device,
+                candle_core::Device::Metal(_)
+            ))),
             checkpoint_interval: None,
             served_model_id,
         }

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -258,7 +258,16 @@ async fn test_real_model_streaming_chat_completion() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300, "qwen3.5-4b-kiln".to_string());
+    let state = AppState::new_real(
+        config,
+        runner,
+        state_tokenizer,
+        device.clone(),
+        std::path::PathBuf::from("/tmp/kiln-test-adapters"),
+        &kiln_server::config::MemoryConfig::default(),
+        300,
+        "qwen3.5-4b-kiln".to_string(),
+    );
 
     let app = api::router(state);
 
@@ -434,8 +443,14 @@ async fn test_health_with_real_backend() {
 
     assert_eq!(resp["status"], "ok");
     assert_eq!(resp["backend"], "model");
-    // scheduler should be null for real backend
-    assert!(resp["scheduler"].is_null());
+    let scheduler = &resp["scheduler"];
+    assert_eq!(scheduler["waiting"], 0);
+    assert_eq!(scheduler["running"], 0);
+    assert!(scheduler["blocks_total"].as_u64().unwrap() > 0);
+    let checks = resp["checks"].as_array().unwrap();
+    assert!(checks
+        .iter()
+        .any(|check| check["name"] == "inference_prewarm_complete" && check["pass"] == true));
 }
 
 /// End-to-end: HTTP → axum → ModelRunner → Metal → generate. Runs the tiny


### PR DESCRIPTION
## Summary
- add a startup prewarm readiness flag and expose it through `/health`
- make real chat completions wait for Metal inference prewarm instead of racing the first live request against lazy Metal/Candle setup
- warm tokenizer encode/decode during startup
- cache Metal backend env kill switches at backend construction so support gates stop reading env vars on the decode path
- update the real-backend health integration assertion for the scheduler stats now returned by health

## Validation
- `cargo check -p kiln-model -p kiln-server --features metal --locked`
- `cargo test -p kiln-server test_health_with_real_backend --features metal --locked`
- `cargo build -p kiln-server --bin kiln --bin kiln-bench --features metal --release --locked`
- `git diff --check`
- launched release server with desktop-style env on macOS Metal, verified `/health` returned `inference_prewarm_complete: true`, and verified a tiny `/v1/chat/completions` request returned `HTTP 200` in 3.20s after warmup