### PR TITLE
[codex] Hoist paged decode debug gates

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -6,6 +6,7 @@
 
 use anyhow::{Context, Result};
 use candle_core::{DType, Device, Tensor};
+use std::sync::OnceLock;
 
 use crate::backend::BackendRuntime;
 use crate::kv_cache::KvCache;
@@ -34,6 +35,11 @@ fn cuda_sigmoid(x: &Tensor) -> Result<Tensor> {
     let one_plus = (exp_neg_x + 1.0)?;
     let result = one_plus.recip()?;
     Ok(result)
+}
+
+fn fused_paged_decode_disabled() -> bool {
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| std::env::var("KILN_DISABLE_FUSED_PAGED_DECODE").is_ok())
 }
 
 /// CUDA-compatible SiLU (Swish): `x * sigmoid(x)`.
@@ -3296,7 +3302,7 @@ pub fn gqa_attention_paged(
         && !single_token_self_attn
         && !paged_cache.is_fp8()
         && (num_heads / num_kv_heads) > 1
-        && std::env::var("KILN_DISABLE_FUSED_PAGED_DECODE").is_err()
+        && !fused_paged_decode_disabled()
         && backend.supports_flash_attn_paged_decode()
         && !crate::mtp_debug::is_c7_sdpa_capture_armed()
     {

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -31,6 +31,7 @@ use anyhow::{Context, Result};
 use candle_core::{DType, Tensor};
 
 static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
+static C7_SDPA_CAPTURE_ARMED_THREADS: AtomicUsize = AtomicUsize::new(0);
 static MTP_FP32_HEAD_ARMED_THREADS: AtomicUsize = AtomicUsize::new(0);
 // Phase B7a: track which mtp_pos values have already been dumped so a single
 // process can capture multiple positions. Initialized lazily on first use.
@@ -898,6 +899,9 @@ pub fn is_dump_c7_sdpa_enabled() -> bool {
 /// bypass (so the grouped-decode Candle path runs and materializes scores
 /// / probs as real tensors the capture can see).
 pub fn is_c7_sdpa_capture_armed() -> bool {
+    if C7_SDPA_CAPTURE_ARMED_THREADS.load(Ordering::Acquire) == 0 {
+        return false;
+    }
     C7_SDPA_CAPTURE.with(|c| c.borrow().is_some())
 }
 
@@ -910,13 +914,29 @@ pub fn arm_c7_sdpa_capture() {
     if !is_dump_c7_sdpa_enabled() {
         return;
     }
-    C7_SDPA_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
+    let was_armed = C7_SDPA_CAPTURE.with(|c| {
+        let mut capture = c.borrow_mut();
+        let was_armed = capture.is_some();
+        *capture = Some(Vec::new());
+        was_armed
+    });
+    if !was_armed {
+        C7_SDPA_CAPTURE_ARMED_THREADS.fetch_add(1, Ordering::Release);
+    }
 }
 
 /// Drain the captured C7 SDPA taps and disarm. Returns whatever was
 /// recorded since the matching [`arm_c7_sdpa_capture`] call, in order.
 pub fn drain_c7_sdpa_capture() -> Vec<(String, Vec<usize>, Vec<f32>)> {
-    C7_SDPA_CAPTURE.with(|c| c.borrow_mut().take().unwrap_or_default())
+    let (was_armed, drained) = C7_SDPA_CAPTURE.with(|c| {
+        let mut capture = c.borrow_mut();
+        let was_armed = capture.is_some();
+        (was_armed, capture.take().unwrap_or_default())
+    });
+    if was_armed {
+        C7_SDPA_CAPTURE_ARMED_THREADS.fetch_sub(1, Ordering::Release);
+    }
+    drained
 }
 
 /// Phase C8: returns true when the current thread is executing inside an


### PR DESCRIPTION
## Summary
- cache `KILN_DISABLE_FUSED_PAGED_DECODE` with `OnceLock` instead of checking the environment in every full-attention decode layer
- add an armed-thread fast gate for C7 SDPA capture, matching the existing MTP fp32-head pattern so the default path avoids a TLS borrow when capture is disarmed

## Validation
- `cargo check -p kiln-model --features metal --locked`
- `cargo test -p kiln-model c7_sdpa --features metal --locked`
- `cargo build -p kiln-server --bin kiln-bench --features metal --release --locked`
- `git diff --check`
- direct default-path benchmark, Qwen3.5-4B, paged, prompt 8 / output 16: main `390.3ms` mean ITL, branch `382.5ms` mean ITL in the same harness