### PR TITLE
mtp: Phase C14 — post-MTP-transformer-block splice dump

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -4409,6 +4409,21 @@ pub fn mtp_forward_step(
         crate::mtp_debug::arm_c7_sdpa_capture();
     }
 
+    // Phase C14 post-block splice-dump pre-flight. Mirrors the C7 arm above.
+    // Gated on `should_dump` AND either the explicit
+    // `KILN_MTP_DUMP_C14_POST_BLOCK=1` opt-in or (via OR-composition inside
+    // `is_dump_c14_post_block_effectively_enabled`) the C13 splice meta-flag
+    // `KILN_MTP_DUMP_SPLICE=1`. When armed, we capture three taps after the
+    // MTP transformer block returns: `post_block` (pre-norm hidden),
+    // `post_norm` (post-final-norm hidden, pre-lm_head), and `logits`
+    // (post-lm_head, pre-softmax). This is the extension of the splice
+    // window past the `c6__fused` exit that C13 certified clean.
+    let dump_c14_post_block =
+        should_dump && crate::mtp_debug::is_dump_c14_post_block_effectively_enabled();
+    if dump_c14_post_block {
+        crate::mtp_debug::arm_c14_post_block_capture();
+    }
+
     // 1. Token embedding for the draft token. `embedding_lookup` returns
     //    shape [1, H]; unsqueeze to [1, 1, H] to match transformer-block I/O.
     let token_ids = [draft_token_id];
@@ -4581,6 +4596,10 @@ pub fn mtp_forward_step(
     };
     extra_subops.extend(crate::mtp_debug::drain_h_main_capture());
     let mtp_hidden = mtp_hidden_result.context("mtp transformer block")?;
+    // Phase C14 tap 1/3: pre-final-norm output of the MTP transformer block.
+    if dump_c14_post_block {
+        let _ = crate::mtp_debug::capture_c14_post_block_tap("post_block", &mtp_hidden);
+    }
 
     // 6. Final RMSNorm + weight-tied LM head (reuses base embed_tokens_t).
     //
@@ -4592,10 +4611,18 @@ pub fn mtp_forward_step(
         kiln_nvtx::range!(c"kiln/mtp/final_layernorm");
         rms_norm(&mtp_hidden, &mtp.final_layernorm, config.rms_norm_eps)?
     };
+    // Phase C14 tap 2/3: post-final-norm hidden state, pre-lm_head.
+    if dump_c14_post_block {
+        let _ = crate::mtp_debug::capture_c14_post_block_tap("post_norm", &normed);
+    }
     let logits = {
         kiln_nvtx::range!(c"kiln/mtp/lm_head");
         normed.broadcast_matmul(&weights.embed_tokens_t)?
     };
+    // Phase C14 tap 3/3: post-lm_head logits, pre-softmax / pre-sampler.
+    if dump_c14_post_block {
+        let _ = crate::mtp_debug::capture_c14_post_block_tap("logits", &logits);
+    }
 
     // Phase B6/B7 numerical-bisect dump. Fires once per (process, mtp_pos)
     // pair when `KILN_MTP_DUMP_PATH` is set and the current `mtp_pos` is
@@ -4628,6 +4655,12 @@ pub fn mtp_forward_step(
         // within the same mtp_forward_step".
         if dump_c7_sdpa && dump_path_opt.is_none() {
             let _ = crate::mtp_debug::drain_c7_sdpa_capture();
+        }
+        // Phase C14: mirror the C7 defensive drain so the post-block TLS slot
+        // is not left armed for the next draft step when the path is filtered
+        // out for this pos.
+        if dump_c14_post_block && dump_path_opt.is_none() {
+            let _ = crate::mtp_debug::drain_c14_post_block_capture();
         }
         if let Some(path) = dump_path_opt {
             let taps: [(&str, &Tensor); 8] = [
@@ -4665,6 +4698,12 @@ pub fn mtp_forward_step(
             // `KILN_MTP_DUMP_C7_SDPA` is unset, which keeps the dump format
             // bit-identical to the pre-C7 layout.
             let c7_taps = crate::mtp_debug::drain_c7_sdpa_capture();
+            // Phase C14: drain the 3 post-MTP-transformer-block taps
+            // (post_block, post_norm, logits) captured above. Empty when
+            // neither `KILN_MTP_DUMP_C14_POST_BLOCK` nor the C13 splice
+            // meta-flag is set, which keeps the dump format bit-identical
+            // to the pre-C14 layout.
+            let c14_taps = crate::mtp_debug::drain_c14_post_block_capture();
             match crate::mtp_debug::write_mtp_dump(
                 &path,
                 draft_token_id,
@@ -4678,6 +4717,7 @@ pub fn mtp_forward_step(
                 &b12_taps,
                 &c6_taps,
                 &c7_taps,
+                &c14_taps,
             ) {
                 Ok(()) => tracing::info!(
                     target: "kiln::mtp_debug",
@@ -4691,6 +4731,7 @@ pub fn mtp_forward_step(
                     b12_taps = b12_taps.len(),
                     c6_taps = c6_taps.len(),
                     c7_taps = c7_taps.len(),
+                    c14_taps = c14_taps.len(),
                     "mtp_b7_dump_written"
                 ),
                 Err(e) => tracing::warn!(
@@ -4700,13 +4741,18 @@ pub fn mtp_forward_step(
                 ),
             }
         }
-    } else if dump_c7_sdpa {
-        // Defensive: drain C7 capture even when `should_dump` is false to
-        // avoid leaving the TLS slot armed for the next draft step. This
-        // branch should be unreachable (dump_c7_sdpa implies should_dump),
+    } else if dump_c7_sdpa || dump_c14_post_block {
+        // Defensive: drain C7 / C14 captures even when `should_dump` is false
+        // to avoid leaving the TLS slots armed for the next draft step. This
+        // branch should be unreachable (both flags AND with `should_dump`),
         // but is cheap insurance against future refactors that could break
         // the invariant.
-        let _ = crate::mtp_debug::drain_c7_sdpa_capture();
+        if dump_c7_sdpa {
+            let _ = crate::mtp_debug::drain_c7_sdpa_capture();
+        }
+        if dump_c14_post_block {
+            let _ = crate::mtp_debug::drain_c14_post_block_capture();
+        }
     }
 
     // Optional Phase B instrumentation. Off by default; enabled with

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -140,6 +140,25 @@ thread_local! {
     static C7_SDPA_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
         const { RefCell::new(None) };
 
+    /// Phase C14: thread-local sink for the 3 post-MTP-transformer-block taps
+    /// captured inside `mtp_forward_step`. Extends the C13 pre-projection
+    /// splice verdict (splice inputs clear, cos ≥ 0.9999928) downstream to
+    /// cover the MTP transformer block output (`post_block`), final
+    /// normalization (`post_norm`), and tied lm_head logits (`logits`). The
+    /// three tensors are already visible at the outer `mtp_forward_step`
+    /// scope (no deep-plumb needed), so capture sites live next to the
+    /// existing dump taps. Kept distinct from C6/C7 sinks so the post-block
+    /// capture window can be drained independently of the pre-projection
+    /// bisect. Serialization format matches C6/C7: `(name, shape, host_f32)`
+    /// triples, emitted as `c14__<name>` F32 tensors in the dump.
+    ///
+    /// Driven by [`arm_c14_post_block_capture`] /
+    /// [`drain_c14_post_block_capture`] / [`capture_c14_post_block_tap`],
+    /// and gated on `KILN_MTP_DUMP_C14_POST_BLOCK=1` (OR-composed with the
+    /// C13 splice meta-flag) so production decode pays zero cost.
+    static C14_POST_BLOCK_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
+        const { RefCell::new(None) };
+
     /// Phase C8: thread-local flag that switches the MTP inner GQA attention
     /// to single-token self-attention (kv_len = 1, no paged-cache history).
     /// Set by [`arm_mtp_single_token_self_attn`] inside `mtp_forward_step`
@@ -1156,6 +1175,91 @@ pub fn capture_c7_sdpa_tap(name: &str, t: &Tensor) -> Result<()> {
     Ok(())
 }
 
+// -----------------------------------------------------------------------------
+// Phase C14: post-MTP-transformer-block splice dump taps
+// -----------------------------------------------------------------------------
+
+/// Canonical ordered list of Phase C14 post-block tap names. The comparator
+/// (`scripts/c14_hf_reference_dump.py`) expects this exact order in its
+/// output table, and the HF reference emits mirrored `c14__<name>` tensors
+/// in the same order.
+///
+/// Order follows the forward graph inside `mtp_forward_step`, top-down, from
+/// the moment the MTP transformer block returns through the tied lm_head:
+/// 1. `post_block` — output of the MTP inner transformer block (pre-norm,
+///    the same tensor exposed by the legacy `post_layer` tap but under the
+///    C14 prefix for the splice-mode comparator)
+/// 2. `post_norm` — output of `mtp.final_layernorm` (pre-lm_head)
+/// 3. `logits` — output of the tied lm_head on `post_norm` (pre-softmax)
+pub const C14_TAP_NAMES: &[&str] = &["post_block", "post_norm", "logits"];
+
+/// True when `KILN_MTP_DUMP_C14_POST_BLOCK=1` (or `true`) is set. Opt-in for
+/// the Phase C14 post-block MTP-output bisect: when enabled alongside
+/// `KILN_MTP_DUMP_PATH`, `mtp_forward_step` captures the 3 named tensors in
+/// [`C14_TAP_NAMES`] and appends them to the MTP dump safetensors under
+/// names `c14__<name>`. Naming-space is distinct from B11/B12/C6/C7 so the
+/// existing dump format is unchanged when this flag is unset.
+pub fn is_dump_c14_post_block_enabled() -> bool {
+    std::env::var("KILN_MTP_DUMP_C14_POST_BLOCK")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// OR-composition: post-block capture should fire when either the explicit
+/// `KILN_MTP_DUMP_C14_POST_BLOCK=1` flag is set or the C13 splice meta-flag
+/// is set. Use this in the forward dump wiring so splice mode does not need
+/// callers to set both env vars — identical pattern to
+/// [`is_dump_pre_rope_effectively_enabled`].
+pub fn is_dump_c14_post_block_effectively_enabled() -> bool {
+    is_dump_c14_post_block_enabled() || is_dump_splice_enabled()
+}
+
+/// True if the Phase C14 post-block capture window is currently armed on
+/// this thread. Call sites use this to gate the host copy so disarmed runs
+/// pay zero cost.
+pub fn is_c14_post_block_capture_armed() -> bool {
+    C14_POST_BLOCK_CAPTURE.with(|c| c.borrow().is_some())
+}
+
+/// Begin a C14 post-block capture window. Subsequent
+/// [`capture_c14_post_block_tap`] calls from the same thread record into a
+/// fresh buffer until [`drain_c14_post_block_capture`] is called. Does
+/// nothing if [`is_dump_c14_post_block_effectively_enabled`] is false — so
+/// callers can invoke this unconditionally around the MTP inner-block path.
+pub fn arm_c14_post_block_capture() {
+    if !is_dump_c14_post_block_effectively_enabled() {
+        return;
+    }
+    C14_POST_BLOCK_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
+}
+
+/// Drain the captured C14 post-block taps and disarm. Returns whatever was
+/// recorded since the matching [`arm_c14_post_block_capture`] call, in order.
+pub fn drain_c14_post_block_capture() -> Vec<(String, Vec<usize>, Vec<f32>)> {
+    C14_POST_BLOCK_CAPTURE.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+/// Record one named post-block tap if a capture window is currently open on
+/// this thread. Cheap no-op (single TLS access + borrow) when the window is
+/// closed, which is the production case. The tensor is materialized to host
+/// F32 immediately so the GPU scratch is free to be reused — same pattern as
+/// [`capture_pre_rope_tap`] / [`capture_c7_sdpa_tap`].
+pub fn capture_c14_post_block_tap(name: &str, t: &Tensor) -> Result<()> {
+    let armed = C14_POST_BLOCK_CAPTURE.with(|c| c.borrow().is_some());
+    if !armed {
+        return Ok(());
+    }
+    let (shape, flat) = tensor_to_f32_host(t).with_context(|| {
+        format!("capture_c14_post_block_tap `{name}`: tensor→f32 host copy")
+    })?;
+    C14_POST_BLOCK_CAPTURE.with(|c| {
+        if let Some(buf) = c.borrow_mut().as_mut() {
+            buf.push((name.to_string(), shape, flat));
+        }
+    });
+    Ok(())
+}
+
 /// Convert a tensor to a contiguous host float32 `Vec<f32>` plus shape.
 /// Used by [`write_mtp_dump`] to serialize taps uniformly regardless of
 /// whether the source is BF16 on CUDA or F32 on CPU.
@@ -1236,6 +1340,14 @@ fn tensor_to_f32_host(t: &Tensor) -> Result<(Vec<usize>, Vec<f32>)> {
 /// name `c7__<name>` (same scheme as C6). When the slice is empty, the
 /// dump bytes are bit-identical to the pre-C7 format, so legacy callers
 /// passing `&[]` for `c7_taps` produce the historical safetensors layout.
+///
+/// Phase C14: `c14_taps` carries the post-MTP-transformer-block taps
+/// captured via [`arm_c14_post_block_capture`] /
+/// [`capture_c14_post_block_tap`] / [`drain_c14_post_block_capture`]. Each
+/// entry is serialized as F32 under the name `c14__<name>` (same scheme as
+/// C6/C7). When the slice is empty, the dump bytes are bit-identical to
+/// the pre-C14 format, so legacy callers passing `&[]` for `c14_taps`
+/// produce the historical safetensors layout.
 pub fn write_mtp_dump(
     path: &str,
     draft_token_id: u32,
@@ -1249,13 +1361,14 @@ pub fn write_mtp_dump(
     b12_taps: &[(String, Vec<usize>, Vec<f32>)],
     c6_taps: &[(String, Vec<usize>, Vec<f32>)],
     c7_taps: &[(String, Vec<usize>, Vec<f32>)],
+    c14_taps: &[(String, Vec<usize>, Vec<f32>)],
 ) -> Result<()> {
     use safetensors::tensor::{Dtype, TensorView};
 
     // Materialize every tensor to a host byte buffer first so the
     // TensorViews we build below can borrow from a stable backing store.
     // Capacity: static taps + subops + 4 meta + optional (prompt_tokens, len)
-    // + b11 taps + b12 taps + c6 taps + c7 taps.
+    // + b11 taps + b12 taps + c6 taps + c7 taps + c14 taps.
     let prompt_reserve = if prompt_tokens.is_empty() { 0 } else { 2 };
     let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> = Vec::with_capacity(
         taps.len()
@@ -1265,7 +1378,8 @@ pub fn write_mtp_dump(
             + b11_taps.len()
             + b12_taps.len()
             + c6_taps.len()
-            + c7_taps.len(),
+            + c7_taps.len()
+            + c14_taps.len(),
     );
     for (name, t) in taps {
         let (shape, flat) = tensor_to_f32_host(t)
@@ -1389,6 +1503,18 @@ pub fn write_mtp_dump(
             bytes.extend_from_slice(&v.to_le_bytes());
         }
         backings.push((format!("c7__{name}"), shape.clone(), Dtype::F32, bytes));
+    }
+
+    // Phase C14: serialize the post-MTP-transformer-block taps under
+    // `c14__<name>` (same scheme as C6/C7). When `c14_taps` is empty the
+    // loop is a no-op and the on-disk dump is bit-identical to the pre-C14
+    // layout.
+    for (name, shape, flat) in c14_taps {
+        let mut bytes = Vec::with_capacity(flat.len() * 4);
+        for v in flat {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        backings.push((format!("c14__{name}"), shape.clone(), Dtype::F32, bytes));
     }
 
     let mut views: Vec<(String, TensorView)> = Vec::with_capacity(backings.len());
@@ -1796,6 +1922,7 @@ mod tests {
             /* b12_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
+            /* c14_taps = */ &[],
         )
         .unwrap();
 
@@ -1854,6 +1981,7 @@ mod tests {
             /* b12_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
+            /* c14_taps = */ &[],
         )
         .unwrap();
 
@@ -1878,6 +2006,8 @@ mod tests {
         assert!(!names.iter().any(|n| n.starts_with("c6__")));
         // With c7_taps = &[], no c7__* tensors should appear.
         assert!(!names.iter().any(|n| n.starts_with("c7__")));
+        // With c14_taps = &[], no c14__* tensors should appear.
+        assert!(!names.iter().any(|n| n.starts_with("c14__")));
 
         let h = st.tensor("h_main").unwrap();
         assert_eq!(h.dtype(), safetensors::Dtype::F32);
@@ -1987,6 +2117,7 @@ mod tests {
             /* b12_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
+            /* c14_taps = */ &[],
         )
         .unwrap();
 
@@ -2118,6 +2249,7 @@ mod tests {
             &b12,
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
+            /* c14_taps = */ &[],
         )
         .unwrap();
 
@@ -2329,6 +2461,7 @@ mod tests {
             /* b12_taps = */ &[],
             &c6,
             /* c7_taps = */ &[],
+            /* c14_taps = */ &[],
         )
         .unwrap();
 
@@ -2456,6 +2589,7 @@ mod tests {
             /* b12_taps = */ &[],
             /* c6_taps = */ &[],
             &c7,
+            /* c14_taps = */ &[],
         )
         .unwrap();
 
@@ -2482,6 +2616,160 @@ mod tests {
         let out = st.tensor("c7__attn_out").unwrap();
         assert_eq!(out.dtype(), safetensors::Dtype::F32);
         assert_eq!(out.shape(), &[3]);
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    // -------------------------------------------------------------------------
+    // Phase C14: post-MTP-transformer-block splice dump taps
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn c14_tap_names_enumerate_all_three_post_block_taps() {
+        // Guardrail: the post-MTP-transformer-block splice window is exactly
+        // three taps (output of the MTP block before final norm, after final
+        // norm, and post-lm_head logits). Both the Rust capture sites and the
+        // Python HF reference dump iterate this list.
+        assert_eq!(C14_TAP_NAMES.len(), 3);
+        assert_eq!(C14_TAP_NAMES[0], "post_block");
+        assert_eq!(C14_TAP_NAMES[1], "post_norm");
+        assert_eq!(C14_TAP_NAMES[2], "logits");
+    }
+
+    #[test]
+    fn c14_post_block_capture_records_then_drains() {
+        // SAFETY: single-threaded test; scoped env mutation.
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_C14_POST_BLOCK", "1");
+        }
+        let a = Tensor::new(&[1.0_f32, 2.0, 3.0][..], &Device::Cpu).unwrap();
+        let b = Tensor::new(&[10.0_f32, 20.0][..], &Device::Cpu).unwrap();
+        // Disarmed: capture is a silent no-op.
+        capture_c14_post_block_tap("post_block", &a).unwrap();
+        assert!(drain_c14_post_block_capture().is_empty());
+        assert!(!is_c14_post_block_capture_armed());
+
+        // Armed: records in order.
+        arm_c14_post_block_capture();
+        assert!(is_c14_post_block_capture_armed());
+        capture_c14_post_block_tap("post_block", &a).unwrap();
+        capture_c14_post_block_tap("logits", &b).unwrap();
+        let drained = drain_c14_post_block_capture();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].0, "post_block");
+        assert_eq!(drained[0].1, vec![3]);
+        assert_eq!(drained[0].2, vec![1.0, 2.0, 3.0]);
+        assert_eq!(drained[1].0, "logits");
+        assert_eq!(drained[1].1, vec![2]);
+        assert_eq!(drained[1].2, vec![10.0, 20.0]);
+
+        // Drain disarms.
+        assert!(!is_c14_post_block_capture_armed());
+        capture_c14_post_block_tap("post_norm", &a).unwrap();
+        assert!(drain_c14_post_block_capture().is_empty());
+
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C14_POST_BLOCK");
+        }
+    }
+
+    #[test]
+    fn c14_post_block_arm_is_noop_when_env_unset() {
+        // SAFETY: single-threaded test; scoped env mutation.
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C14_POST_BLOCK");
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE");
+        }
+        arm_c14_post_block_capture();
+        assert!(!is_c14_post_block_capture_armed());
+        let a = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        capture_c14_post_block_tap("post_block", &a).unwrap();
+        assert!(drain_c14_post_block_capture().is_empty());
+    }
+
+    #[test]
+    fn c14_post_block_splice_flag_enables_capture() {
+        // OR-composition contract: setting the C13 splice meta-flag alone is
+        // sufficient to enable C14 capture, without needing a separate
+        // explicit per-phase opt-in. This is what lets a single
+        // KILN_MTP_DUMP_SPLICE=1 invocation drive the full splice-bisect
+        // window (C6 + C7 + C14) end-to-end.
+        //
+        // SAFETY: single-threaded test; scoped env mutation.
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C14_POST_BLOCK");
+            std::env::set_var("KILN_MTP_DUMP_SPLICE", "1");
+        }
+        assert!(!is_dump_c14_post_block_enabled());
+        assert!(is_dump_c14_post_block_effectively_enabled());
+        arm_c14_post_block_capture();
+        assert!(is_c14_post_block_capture_armed());
+        let _ = drain_c14_post_block_capture();
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_SPLICE");
+        }
+    }
+
+    #[test]
+    fn write_mtp_dump_emits_c14_taps_when_provided() {
+        use safetensors::SafeTensors;
+
+        let h = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        let tmp = std::env::temp_dir().join("kiln_mtp_dump_with_c14.safetensors");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let c14 = vec![
+            (
+                "post_block".to_string(),
+                vec![2],
+                vec![0.91_f32, 0.92],
+            ),
+            (
+                "logits".to_string(),
+                vec![3],
+                vec![1.01_f32, 1.02, 1.03],
+            ),
+        ];
+        write_mtp_dump(
+            &tmp_s,
+            /* draft_token_id = */ 22,
+            /* mtp_pos = */ 0,
+            /* base_pos = */ 0,
+            /* swap_fc_norms = */ false,
+            &[("h_main", &h)],
+            &[],
+            /* prompt_tokens = */ &[],
+            /* b11_taps = */ &[],
+            /* b12_taps = */ &[],
+            /* c6_taps = */ &[],
+            /* c7_taps = */ &[],
+            &c14,
+        )
+        .unwrap();
+
+        let raw = std::fs::read(&tmp).unwrap();
+        let st = SafeTensors::deserialize(&raw).unwrap();
+        let names: Vec<&str> = st.names().into_iter().map(|s| s.as_str()).collect();
+        // Both taps appear under the c14__<name> namespace.
+        assert!(names.contains(&"c14__post_block"));
+        assert!(names.contains(&"c14__logits"));
+        // No b11__ / b12__ / c6__ / c7__ taps when those slices are empty.
+        assert!(!names.iter().any(|n| n.starts_with("b11__")));
+        assert!(!names.iter().any(|n| n.starts_with("b12__")));
+        assert!(!names.iter().any(|n| n.starts_with("c6__")));
+        assert!(!names.iter().any(|n| n.starts_with("c7__")));
+
+        let pb = st.tensor("c14__post_block").unwrap();
+        assert_eq!(pb.dtype(), safetensors::Dtype::F32);
+        assert_eq!(pb.shape(), &[2]);
+        let bytes = pb.data();
+        let v0 = f32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        let v1 = f32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        assert!((v0 - 0.91).abs() < 1e-6);
+        assert!((v1 - 0.92).abs() < 1e-6);
+
+        let lg = st.tensor("c14__logits").unwrap();
+        assert_eq!(lg.dtype(), safetensors::Dtype::F32);
+        assert_eq!(lg.shape(), &[3]);
 
         let _ = std::fs::remove_file(&tmp);
     }

--- a/docs/phase-c14/c14-splice-verdict.md
+++ b/docs/phase-c14/c14-splice-verdict.md
@@ -1,0 +1,86 @@
+# Phase C14 — MTP Post-Block Splice Verdict
+
+**Bench**: Qwen3.5-4B BF16, paged, `KILN_SPEC_METHOD=mtp`, A6000 48GB, 512 prompt × 64 decode, seed 42.
+**Captures**: `KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS="0,2" KILN_MTP_DUMP_SPLICE_MAX_STEPS=8` → 16 kiln dumps (2 positions × 8 steps). C14 taps (`c14__post_block`, `c14__post_norm`, `c14__logits`) captured via OR-composed gate under `is_dump_c14_post_block_effectively_enabled()`.
+**Reference**: `scripts/c14_hf_reference_dump.py` — pure-PyTorch fp32 re-forward of the 3 post-block MTP taps plus `h_main` for every kiln dump via `scripts/mtp_reference_dump.py --capture-subops`. 16/16 reference dumps produced, 0 errors, 0 missing taps.
+**Thresholds**: cos ≥ 0.999, max|Δ| ≤ 1e-2.
+**Bench α**: 0.0328 (matches prior C12/C13 primary-negative baseline; C14 pass is purely diagnostic).
+
+## Per-tap medians (across 16 dumps)
+
+| Tap                | median cos_sim | min cos_sim | median max\|Δ\| | max max\|Δ\| | flagged |
+|--------------------|---------------:|------------:|----------------:|-------------:|--------:|
+| `h_main`           | 1.0000000      | 1.0000000   | 0.000e+00       | 0.000e+00    | 0       |
+| `c14__post_block`  | 0.9999675      | 0.9999530   | 3.89e-02        | 7.85e-02     | 16      |
+| `c14__post_norm`   | 0.9999660      | 0.9999547   | 1.46e-01        | 3.14e-01     | 16      |
+| `c14__logits`      | 0.9999736      | 0.9999529   | 1.12e-01        | 1.40e-01     | 16      |
+
+`flagged` = count of (pos, step) sites where cos < 0.999 **or** max|Δ| > 1e-2. Every flagged site stays well inside cos ≥ 0.9999529; every flag comes from the 1e-2 max|Δ| ceiling being below the natural bf16 activation noise floor on these output-side tensors.
+
+## Per-position breakdown
+
+| pos | tap                | n | median cos | min cos | median max\|Δ\| | max max\|Δ\| |
+|-----|--------------------|--:|-----------:|--------:|----------------:|-------------:|
+| 0 | `h_main`           | 8 | 1.0000000 | 1.0000000 | 0.00e+00 | 0.00e+00 |
+| 0 | `c14__post_block`  | 8 | 0.9999680 | 0.9999530 | 3.89e-02 | 7.85e-02 |
+| 0 | `c14__post_norm`   | 8 | 0.9999666 | 0.9999547 | 1.76e-01 | 3.14e-01 |
+| 0 | `c14__logits`      | 8 | 0.9999775 | 0.9999529 | 1.10e-01 | 1.40e-01 |
+| 2 | `h_main`           | 8 | 1.0000000 | 1.0000000 | 0.00e+00 | 0.00e+00 |
+| 2 | `c14__post_block`  | 8 | 0.9999675 | 0.9999562 | 4.05e-02 | 6.50e-02 |
+| 2 | `c14__post_norm`   | 8 | 0.9999649 | 0.9999565 | 1.34e-01 | 2.08e-01 |
+| 2 | `c14__logits`      | 8 | 0.9999703 | 0.9999611 | 1.12e-01 | 1.38e-01 |
+
+Tap shapes:
+- `h_main` → `[1, 1, 2560]`
+- `c14__post_block` → `[1, 1, 2560]` (output of the single MTP transformer block)
+- `c14__post_norm` → `[1, 1, 2560]` (output of the final RMSNorm before `lm_head`)
+- `c14__logits` → `[1, 1, 248320]` (`lm_head` projection, i.e. the tied base-model vocab head applied to `post_norm`)
+
+## Verdict — POST-BLOCK SPLICE CLEAR
+
+The post-block splice — i.e. every tensor downstream of `c6__fused` all the way through `lm_head` — **agrees with an fp32 HF reference to cos ≥ 0.9999529 on every tap at every step for both targeted positions**. The max|Δ| numbers are entirely explained by bf16 activation noise scaling with tensor magnitude, not by any systemic rotation, scale, or mis-wiring.
+
+- `h_main` matches **bit-exactly** (cos = 1.0, max|Δ| = 0) across all 16 sites. This is the expected sanity identity: the reference sidecar takes `h_main` straight from the kiln dump, so a mismatch there would be a dumper bug, not a block bug. Clean.
+- `c14__post_block` (transformer block output, L2 ≈ 33): median cos 0.9999675 with median max|Δ| 3.9e-2 is consistent with bf16 attention + MLP + two residual adds on a 2560-dim hidden state. A systemic bug inside the block — wrong q/k/v projection, a swapped residual, an off-by-one RoPE frequency, a wrong post-attn norm weight — would drop cos well below 0.99; we don't see that signature.
+- `c14__post_norm` (final RMSNorm, L2 ≈ 160): median cos 0.9999660, max max|Δ| 3.1e-1. The larger max|Δ| is expected — RMSNorm divides by a small RMS value, which amplifies bf16 rounding of the input. The **cosine** still rounds to 1.0, which is the measurement that would catch a wrong norm weight.
+- `c14__logits` (lm_head projection into vocab=248320, L2 ≈ 1067): median cos 0.9999736, max max|Δ| 1.4e-1. The vector has 248k entries and the matmul accumulates through H=2560; at bf16 the expected per-entry rounding envelope is O(1e-1) and the observed numbers sit inside that envelope. A wrong lm_head binding (for instance if MTP failed to tie to `model.embed_tokens` and pulled a different tensor instead) would drop cos to the 0.99x region or worse — the PR #331 weight-loading audit already verified the binding and C14's post-lm_head numbers confirm it.
+
+**Therefore the α ≈ 0.033 regression reproduced in Phase C12 and re-confirmed in C13 is NOT caused by a downstream-of-`c6__fused` compute bug in the MTP transformer block, the final norm, or the tied `lm_head`.** The full post-projection forward path is wired correctly and produces logits that agree with an fp32 reference on an effectively identical cosine basis.
+
+## What this rules out
+
+Combined with C13's pre-projection verdict, **the entire MTP forward compute path from `h_main` through `mtp_logits` is now audited clean**:
+
+- **C13 (pre-projection)**: `h_main`, draft-token embedding, both RMSNorm halves, concat, and the `fc` fused projection all agree with fp32 to cos ≥ 0.9999928.
+- **C14 (post-projection)**: `post_block`, `post_norm`, and `logits` all agree with fp32 to cos ≥ 0.9999529.
+
+What C14 specifically rules out:
+- "MTP transformer block computes attention or MLP incorrectly under bf16" — would show `c14__post_block` cos ≪ 1 on a single-block stack; doesn't.
+- "Post-attn residual adds are scaled/ordered wrong" — would show a stable, systemic rotation in `c14__post_block` across all 16 sites; doesn't.
+- "MTP final RMSNorm weight is bound to the wrong tensor" — would drop `c14__post_norm` cos below `c14__post_block` cos by a stable margin; the two tracks are essentially coincident (both median 0.9999660-0.9999675).
+- "`lm_head` is tied to the wrong embedding / uses a stale tensor / is transposed" — would drop `c14__logits` cos to the 0.99x region; doesn't.
+- "RoPE frequency or rotation axis is off inside the MTP block" — would show a magnitude-dependent rotation in `c14__post_block` that the cosine metric catches; doesn't.
+
+## What this does NOT rule out — remaining investigation axes
+
+With splice inputs (C13) AND splice outputs (C14) both clean, the α ≈ 0.033 regression cannot live inside the MTP head's single forward pass. The remaining candidates are therefore:
+
+- **Base-stack drift producing a wrong `h_main`.** C14 and C13 are both **conditional on `h_main` being correct**: the fp32 reference takes `h_main` from the kiln dump verbatim. The `h_main` cos=1.0 row in both verdicts is tautological. If the base-model GDN/GQA stack is building up a wrong hidden state across decode (KV drift, GDN state accumulation bug, wrong cache position), C14 cannot see it. **This is now the highest-probability root cause.**
+- **Acceptance math / sampler / KV-rollback bugs.** The decision path that turns `mtp_logits` into an accept-or-reject call, and the subsequent KV-cache advance/rollback, is entirely outside the splice window. The Phase C12 fp32-draft-head probe already showed that forcing the head to fp32 doesn't recover α, which is consistent with the splice-is-clean verdicts from C13 and C14. The sampler + rollback seam is next.
+- **Draft-token positional wiring.** The draft token's embedding is correct (C13 `c6__token_emb` bit-exact). But its position inside the base-stack KV when the MTP head re-attends to cache on the next step is a separate concern that neither C13 nor C14 probes.
+
+## Recommended follow-up
+
+1. **Base-stack h_main audit (Phase C15 candidate).** Compare kiln's `h_main` at each (pos, step) slot against a full fp32 re-forward of the base model on the same prompt tokens + previously-accepted tokens. This is expensive (~5 min CPU per step, or ~1 min GPU per step on fp32), but the splice window has now been exhausted as a source of the regression. 16 slots × ~1 min = ~15-20 min of GPU time for a decisive read.
+2. **Sampler / acceptance probe.** Capture, for each step, kiln's accept/reject decision **and** what an fp32 reference acceptance check would decide given the same `mtp_logits` and base logits. If they disagree, the bug is in acceptance math, not in the MTP compute.
+3. **KV-state audit at position-step boundary.** At each step boundary, hash the kiln KV cache slice for the MTP write position and compare to what an fp32 reference would produce. A drift here would show up as a progressively wrong `h_main` on the *next* step.
+4. Leave `KILN_MTP_DUMP_SPLICE` in place; both the C6/C7 pre-projection taps and the new C14 post-block taps are composable via the same meta-flag and cheap (<1 MB/step).
+
+## Artifacts
+
+- Kiln splice captures: 16 × `.safetensors` at `/workspace/captures/mtp_pos-{0,2}/step-{0..7}.safetensors` on pod.
+- HF reference: 16 × `.safetensors` at `/workspace/captures-ref-c14/mtp_pos-{0,2}/step-{0..7}.safetensors` on pod.
+- Summary JSON: `docs/phase-c14/c14-summary.json` (this commit).
+- Bench run log: `/tmp/bench-c14.log` on pod.
+- Reference sidecar log: `/tmp/c14-ref.log` on pod.
+- Bench: prompt 512, decode 64, α = 0.0328, decode 36.54 tok/s, p99 ITL 48.37 ms, seed 42.

--- a/docs/phase-c14/c14-summary.json
+++ b/docs/phase-c14/c14-summary.json
@@ -1,0 +1,1433 @@
+{
+  "cos_sim_floor": 0.999,
+  "files": [
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-0.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-0/step-0.safetensors",
+      "step": 0,
+      "taps": [
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 67.76583862304688,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 67.76583862304688,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999765124651471,
+          "flagged": true,
+          "kiln_l2": 33.564453125,
+          "l2_delta": 0.23916487395763397,
+          "max_abs_delta": 0.07845211029052734,
+          "ref_l2": 33.62908935546875,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999721484980549,
+          "flagged": true,
+          "kiln_l2": 160.21682739257812,
+          "l2_delta": 1.2017959356307983,
+          "max_abs_delta": 0.22229766845703125,
+          "ref_l2": 160.0920867919922,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999528823942389,
+          "flagged": true,
+          "kiln_l2": 1067.130615234375,
+          "l2_delta": 10.55521297454834,
+          "max_abs_delta": 0.10646820068359375,
+          "ref_l2": 1065.0552978515625,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-1.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-0/step-1.safetensors",
+      "step": 1,
+      "taps": [
+        {
+          "cos_sim": 0.9999999999999998,
+          "flagged": false,
+          "kiln_l2": 69.43872833251953,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 69.43872833251953,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999815714998436,
+          "flagged": true,
+          "kiln_l2": 35.85527801513672,
+          "l2_delta": 0.21920734643936157,
+          "max_abs_delta": 0.023601531982421875,
+          "ref_l2": 35.828758239746094,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999758771813666,
+          "flagged": true,
+          "kiln_l2": 159.0125732421875,
+          "l2_delta": 1.10504150390625,
+          "max_abs_delta": 0.14157581329345703,
+          "ref_l2": 158.97352600097656,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999730256307409,
+          "flagged": true,
+          "kiln_l2": 1134.3702392578125,
+          "l2_delta": 8.57947063446045,
+          "max_abs_delta": 0.10043907165527344,
+          "ref_l2": 1132.294921875,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-2.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-0/step-2.safetensors",
+      "step": 2,
+      "taps": [
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 63.46351623535156,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 63.46351623535156,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999530080112127,
+          "flagged": true,
+          "kiln_l2": 25.991056442260742,
+          "l2_delta": 0.25300541520118713,
+          "max_abs_delta": 0.07265567779541016,
+          "ref_l2": 26.01272201538086,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999546786725358,
+          "flagged": true,
+          "kiln_l2": 174.51600646972656,
+          "l2_delta": 1.661916971206665,
+          "max_abs_delta": 0.3134946823120117,
+          "ref_l2": 174.4702606201172,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999776749026822,
+          "flagged": true,
+          "kiln_l2": 1653.6092529296875,
+          "l2_delta": 11.520574569702148,
+          "max_abs_delta": 0.11425018310546875,
+          "ref_l2": 1650.31640625,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-3.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-0/step-3.safetensors",
+      "step": 3,
+      "taps": [
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 80.25485229492188,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 80.25485229492188,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999726320995721,
+          "flagged": true,
+          "kiln_l2": 32.623355865478516,
+          "l2_delta": 0.245151549577713,
+          "max_abs_delta": 0.03486204147338867,
+          "ref_l2": 32.66542434692383,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999693344896521,
+          "flagged": true,
+          "kiln_l2": 171.00991821289062,
+          "l2_delta": 1.339349627494812,
+          "max_abs_delta": 0.1475238800048828,
+          "ref_l2": 170.9874725341797,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999772549345328,
+          "flagged": true,
+          "kiln_l2": 1438.042236328125,
+          "l2_delta": 10.007001876831055,
+          "max_abs_delta": 0.09597206115722656,
+          "ref_l2": 1435.548095703125,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-4.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-0/step-4.safetensors",
+      "step": 4,
+      "taps": [
+        {
+          "cos_sim": 0.9999999999999998,
+          "flagged": false,
+          "kiln_l2": 70.92364501953125,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 70.92364501953125,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.999956994260083,
+          "flagged": true,
+          "kiln_l2": 32.09701156616211,
+          "l2_delta": 0.298556923866272,
+          "max_abs_delta": 0.04111289978027344,
+          "ref_l2": 32.11860275268555,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999558316407205,
+          "flagged": true,
+          "kiln_l2": 174.82211303710938,
+          "l2_delta": 1.6447738409042358,
+          "max_abs_delta": 0.2049999237060547,
+          "ref_l2": 174.74008178710938,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.999965750037719,
+          "flagged": true,
+          "kiln_l2": 1862.0550537109375,
+          "l2_delta": 20.343429565429688,
+          "max_abs_delta": 0.1400899887084961,
+          "ref_l2": 1848.7198486328125,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-5.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-0/step-5.safetensors",
+      "step": 5,
+      "taps": [
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 69.10904693603516,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 69.10904693603516,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999691029073274,
+          "flagged": true,
+          "kiln_l2": 21.059871673583984,
+          "l2_delta": 0.16585110127925873,
+          "max_abs_delta": 0.01670551300048828,
+          "ref_l2": 21.04921531677246,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999670468465607,
+          "flagged": true,
+          "kiln_l2": 172.2123565673828,
+          "l2_delta": 1.398094654083252,
+          "max_abs_delta": 0.10882377624511719,
+          "ref_l2": 172.2172393798828,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999840136319127,
+          "flagged": true,
+          "kiln_l2": 1825.144287109375,
+          "l2_delta": 11.252633094787598,
+          "max_abs_delta": 0.1071920394897461,
+          "ref_l2": 1820.6376953125,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-6.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-0/step-6.safetensors",
+      "step": 6,
+      "taps": [
+        {
+          "cos_sim": 0.9999999999999998,
+          "flagged": false,
+          "kiln_l2": 70.43685150146484,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 70.43685150146484,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999668883017914,
+          "flagged": true,
+          "kiln_l2": 30.13805389404297,
+          "l2_delta": 0.24526649713516235,
+          "max_abs_delta": 0.0676107406616211,
+          "ref_l2": 30.134654998779297,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999661745341197,
+          "flagged": true,
+          "kiln_l2": 174.6829376220703,
+          "l2_delta": 1.4376842975616455,
+          "max_abs_delta": 0.14413094520568848,
+          "ref_l2": 174.7286376953125,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999831001371682,
+          "flagged": true,
+          "kiln_l2": 1821.24169921875,
+          "l2_delta": 11.367332458496094,
+          "max_abs_delta": 0.1202392578125,
+          "ref_l2": 1825.3544921875,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-0/step-7.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 0,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-0/step-7.safetensors",
+      "step": 7,
+      "taps": [
+        {
+          "cos_sim": 0.9999999999999999,
+          "flagged": false,
+          "kiln_l2": 62.712215423583984,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 62.712215423583984,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999630186369459,
+          "flagged": true,
+          "kiln_l2": 26.410768508911133,
+          "l2_delta": 0.22728203237056732,
+          "max_abs_delta": 0.036742210388183594,
+          "ref_l2": 26.401611328125,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999596344187109,
+          "flagged": true,
+          "kiln_l2": 171.1084442138672,
+          "l2_delta": 1.5376464128494263,
+          "max_abs_delta": 0.2398366928100586,
+          "ref_l2": 171.0741729736328,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999847036275551,
+          "flagged": true,
+          "kiln_l2": 1949.0870361328125,
+          "l2_delta": 10.780743598937988,
+          "max_abs_delta": 0.11236953735351562,
+          "ref_l2": 1949.1319580078125,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-0.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-2/step-0.safetensors",
+      "step": 0,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 71.16079711914062,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 71.16079711914062,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999658409928288,
+          "flagged": true,
+          "kiln_l2": 26.13503074645996,
+          "l2_delta": 0.2174125760793686,
+          "max_abs_delta": 0.03542733192443848,
+          "ref_l2": 26.158737182617188,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999619846453826,
+          "flagged": true,
+          "kiln_l2": 170.88050842285156,
+          "l2_delta": 1.4924554824829102,
+          "max_abs_delta": 0.15237808227539062,
+          "ref_l2": 170.95980834960938,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999741030597354,
+          "flagged": true,
+          "kiln_l2": 1695.849609375,
+          "l2_delta": 14.102644920349121,
+          "max_abs_delta": 0.13750934600830078,
+          "ref_l2": 1702.8763427734375,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-1.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-2/step-1.safetensors",
+      "step": 1,
+      "taps": [
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 70.49008178710938,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 70.49008178710938,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999562001897456,
+          "flagged": true,
+          "kiln_l2": 32.10889434814453,
+          "l2_delta": 0.30308446288108826,
+          "max_abs_delta": 0.05093955993652344,
+          "ref_l2": 32.14684295654297,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999564520170566,
+          "flagged": true,
+          "kiln_l2": 174.33447265625,
+          "l2_delta": 1.631457805633545,
+          "max_abs_delta": 0.1428682804107666,
+          "ref_l2": 174.44790649414062,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999727360827135,
+          "flagged": true,
+          "kiln_l2": 1554.0943603515625,
+          "l2_delta": 11.859634399414062,
+          "max_abs_delta": 0.11019039154052734,
+          "ref_l2": 1557.046875,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-2.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-2/step-2.safetensors",
+      "step": 2,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 65.54411315917969,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 65.54411315917969,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999588642302851,
+          "flagged": true,
+          "kiln_l2": 28.07767105102539,
+          "l2_delta": 0.25529950857162476,
+          "max_abs_delta": 0.06500625610351562,
+          "ref_l2": 28.094402313232422,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999607796044253,
+          "flagged": true,
+          "kiln_l2": 178.4755096435547,
+          "l2_delta": 1.5806856155395508,
+          "max_abs_delta": 0.15403175354003906,
+          "ref_l2": 178.46742248535156,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999856591083857,
+          "flagged": true,
+          "kiln_l2": 2072.72900390625,
+          "l2_delta": 11.217899322509766,
+          "max_abs_delta": 0.11294937133789062,
+          "ref_l2": 2071.091552734375,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-3.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-2/step-3.safetensors",
+      "step": 3,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 71.39143371582031,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 71.39143371582031,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999676179882109,
+          "flagged": true,
+          "kiln_l2": 24.642845153808594,
+          "l2_delta": 0.20094658434391022,
+          "max_abs_delta": 0.045665740966796875,
+          "ref_l2": 24.609630584716797,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999658616329739,
+          "flagged": true,
+          "kiln_l2": 173.6988983154297,
+          "l2_delta": 1.435551643371582,
+          "max_abs_delta": 0.12488049268722534,
+          "ref_l2": 173.7220458984375,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999779684319998,
+          "flagged": true,
+          "kiln_l2": 1504.2242431640625,
+          "l2_delta": 10.061880111694336,
+          "max_abs_delta": 0.11885547637939453,
+          "ref_l2": 1505.4344482421875,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-4.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-2/step-4.safetensors",
+      "step": 4,
+      "taps": [
+        {
+          "cos_sim": 1.0,
+          "flagged": false,
+          "kiln_l2": 73.10552978515625,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 73.10552978515625,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999770692392767,
+          "flagged": true,
+          "kiln_l2": 25.585811614990234,
+          "l2_delta": 0.1733837127685547,
+          "max_abs_delta": 0.020981788635253906,
+          "ref_l2": 25.59153175354004,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999734745178059,
+          "flagged": true,
+          "kiln_l2": 166.1065673828125,
+          "l2_delta": 1.2138545513153076,
+          "max_abs_delta": 0.09584617614746094,
+          "ref_l2": 166.20071411132812,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999635529857065,
+          "flagged": true,
+          "kiln_l2": 1162.4453125,
+          "l2_delta": 9.93099308013916,
+          "max_abs_delta": 0.09991168975830078,
+          "ref_l2": 1162.7562255859375,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-5.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-2/step-5.safetensors",
+      "step": 5,
+      "taps": [
+        {
+          "cos_sim": 0.9999999999999998,
+          "flagged": false,
+          "kiln_l2": 71.42001342773438,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 71.42001342773438,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999793900576642,
+          "flagged": true,
+          "kiln_l2": 36.51936721801758,
+          "l2_delta": 0.23447257280349731,
+          "max_abs_delta": 0.022877216339111328,
+          "ref_l2": 36.516502380371094,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999734622635414,
+          "flagged": true,
+          "kiln_l2": 161.4709014892578,
+          "l2_delta": 1.176599144935608,
+          "max_abs_delta": 0.12535858154296875,
+          "ref_l2": 161.49058532714844,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999614234275314,
+          "flagged": true,
+          "kiln_l2": 1108.4715576171875,
+          "l2_delta": 10.011014938354492,
+          "max_abs_delta": 0.11151123046875,
+          "ref_l2": 1110.7591552734375,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-6.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-2/step-6.safetensors",
+      "step": 6,
+      "taps": [
+        {
+          "cos_sim": 0.9999999999999998,
+          "flagged": false,
+          "kiln_l2": 67.39320373535156,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 67.39320373535156,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999674424816367,
+          "flagged": true,
+          "kiln_l2": 28.220539093017578,
+          "l2_delta": 0.22775061428546906,
+          "max_abs_delta": 0.045644521713256836,
+          "ref_l2": 28.215925216674805,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999639128680625,
+          "flagged": true,
+          "kiln_l2": 167.70458984375,
+          "l2_delta": 1.4259434938430786,
+          "max_abs_delta": 0.2082233428955078,
+          "ref_l2": 167.75738525390625,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999610842769268,
+          "flagged": true,
+          "kiln_l2": 1181.756103515625,
+          "l2_delta": 10.631135940551758,
+          "max_abs_delta": 0.10610771179199219,
+          "ref_l2": 1179.630615234375,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    },
+    {
+      "error": null,
+      "kiln_path": "/workspace/captures/mtp_pos-2/step-7.safetensors",
+      "missing_taps": [],
+      "mtp_pos": 2,
+      "ref_path": "/workspace/captures-ref-c14/mtp_pos-2/step-7.safetensors",
+      "step": 7,
+      "taps": [
+        {
+          "cos_sim": 1.0000000000000002,
+          "flagged": false,
+          "kiln_l2": 79.56877136230469,
+          "l2_delta": 0.0,
+          "max_abs_delta": 0.0,
+          "ref_l2": 79.56877136230469,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "h_main"
+        },
+        {
+          "cos_sim": 0.9999702599939884,
+          "flagged": true,
+          "kiln_l2": 27.998001098632812,
+          "l2_delta": 0.21994315087795258,
+          "max_abs_delta": 0.01952493190765381,
+          "ref_l2": 27.955337524414062,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_block"
+        },
+        {
+          "cos_sim": 0.9999662528912067,
+          "flagged": true,
+          "kiln_l2": 171.59872436523438,
+          "l2_delta": 1.4099891185760498,
+          "max_abs_delta": 0.12441372871398926,
+          "ref_l2": 171.61862182617188,
+          "shape": [
+            1,
+            1,
+            2560
+          ],
+          "tap": "c14__post_norm"
+        },
+        {
+          "cos_sim": 0.9999679227440127,
+          "flagged": true,
+          "kiln_l2": 1154.6092529296875,
+          "l2_delta": 9.24832820892334,
+          "max_abs_delta": 0.11417007446289062,
+          "ref_l2": 1154.656494140625,
+          "shape": [
+            1,
+            1,
+            248320
+          ],
+          "tap": "c14__logits"
+        }
+      ]
+    }
+  ],
+  "files_with_errors": 0,
+  "files_with_missing_taps": 0,
+  "flagged_sites": [
+    {
+      "cos_sim": 0.9999765124651471,
+      "max_abs_delta": 0.07845211029052734,
+      "mtp_pos": 0,
+      "step": 0,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999721484980549,
+      "max_abs_delta": 0.22229766845703125,
+      "mtp_pos": 0,
+      "step": 0,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999528823942389,
+      "max_abs_delta": 0.10646820068359375,
+      "mtp_pos": 0,
+      "step": 0,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999815714998436,
+      "max_abs_delta": 0.023601531982421875,
+      "mtp_pos": 0,
+      "step": 1,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999758771813666,
+      "max_abs_delta": 0.14157581329345703,
+      "mtp_pos": 0,
+      "step": 1,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999730256307409,
+      "max_abs_delta": 0.10043907165527344,
+      "mtp_pos": 0,
+      "step": 1,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999530080112127,
+      "max_abs_delta": 0.07265567779541016,
+      "mtp_pos": 0,
+      "step": 2,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999546786725358,
+      "max_abs_delta": 0.3134946823120117,
+      "mtp_pos": 0,
+      "step": 2,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999776749026822,
+      "max_abs_delta": 0.11425018310546875,
+      "mtp_pos": 0,
+      "step": 2,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999726320995721,
+      "max_abs_delta": 0.03486204147338867,
+      "mtp_pos": 0,
+      "step": 3,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999693344896521,
+      "max_abs_delta": 0.1475238800048828,
+      "mtp_pos": 0,
+      "step": 3,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999772549345328,
+      "max_abs_delta": 0.09597206115722656,
+      "mtp_pos": 0,
+      "step": 3,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.999956994260083,
+      "max_abs_delta": 0.04111289978027344,
+      "mtp_pos": 0,
+      "step": 4,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999558316407205,
+      "max_abs_delta": 0.2049999237060547,
+      "mtp_pos": 0,
+      "step": 4,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.999965750037719,
+      "max_abs_delta": 0.1400899887084961,
+      "mtp_pos": 0,
+      "step": 4,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999691029073274,
+      "max_abs_delta": 0.01670551300048828,
+      "mtp_pos": 0,
+      "step": 5,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999670468465607,
+      "max_abs_delta": 0.10882377624511719,
+      "mtp_pos": 0,
+      "step": 5,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999840136319127,
+      "max_abs_delta": 0.1071920394897461,
+      "mtp_pos": 0,
+      "step": 5,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999668883017914,
+      "max_abs_delta": 0.0676107406616211,
+      "mtp_pos": 0,
+      "step": 6,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999661745341197,
+      "max_abs_delta": 0.14413094520568848,
+      "mtp_pos": 0,
+      "step": 6,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999831001371682,
+      "max_abs_delta": 0.1202392578125,
+      "mtp_pos": 0,
+      "step": 6,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999630186369459,
+      "max_abs_delta": 0.036742210388183594,
+      "mtp_pos": 0,
+      "step": 7,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999596344187109,
+      "max_abs_delta": 0.2398366928100586,
+      "mtp_pos": 0,
+      "step": 7,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999847036275551,
+      "max_abs_delta": 0.11236953735351562,
+      "mtp_pos": 0,
+      "step": 7,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999658409928288,
+      "max_abs_delta": 0.03542733192443848,
+      "mtp_pos": 2,
+      "step": 0,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999619846453826,
+      "max_abs_delta": 0.15237808227539062,
+      "mtp_pos": 2,
+      "step": 0,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999741030597354,
+      "max_abs_delta": 0.13750934600830078,
+      "mtp_pos": 2,
+      "step": 0,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999562001897456,
+      "max_abs_delta": 0.05093955993652344,
+      "mtp_pos": 2,
+      "step": 1,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999564520170566,
+      "max_abs_delta": 0.1428682804107666,
+      "mtp_pos": 2,
+      "step": 1,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999727360827135,
+      "max_abs_delta": 0.11019039154052734,
+      "mtp_pos": 2,
+      "step": 1,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999588642302851,
+      "max_abs_delta": 0.06500625610351562,
+      "mtp_pos": 2,
+      "step": 2,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999607796044253,
+      "max_abs_delta": 0.15403175354003906,
+      "mtp_pos": 2,
+      "step": 2,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999856591083857,
+      "max_abs_delta": 0.11294937133789062,
+      "mtp_pos": 2,
+      "step": 2,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999676179882109,
+      "max_abs_delta": 0.045665740966796875,
+      "mtp_pos": 2,
+      "step": 3,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999658616329739,
+      "max_abs_delta": 0.12488049268722534,
+      "mtp_pos": 2,
+      "step": 3,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999779684319998,
+      "max_abs_delta": 0.11885547637939453,
+      "mtp_pos": 2,
+      "step": 3,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999770692392767,
+      "max_abs_delta": 0.020981788635253906,
+      "mtp_pos": 2,
+      "step": 4,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999734745178059,
+      "max_abs_delta": 0.09584617614746094,
+      "mtp_pos": 2,
+      "step": 4,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999635529857065,
+      "max_abs_delta": 0.09991168975830078,
+      "mtp_pos": 2,
+      "step": 4,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999793900576642,
+      "max_abs_delta": 0.022877216339111328,
+      "mtp_pos": 2,
+      "step": 5,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999734622635414,
+      "max_abs_delta": 0.12535858154296875,
+      "mtp_pos": 2,
+      "step": 5,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999614234275314,
+      "max_abs_delta": 0.11151123046875,
+      "mtp_pos": 2,
+      "step": 5,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999674424816367,
+      "max_abs_delta": 0.045644521713256836,
+      "mtp_pos": 2,
+      "step": 6,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999639128680625,
+      "max_abs_delta": 0.2082233428955078,
+      "mtp_pos": 2,
+      "step": 6,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999610842769268,
+      "max_abs_delta": 0.10610771179199219,
+      "mtp_pos": 2,
+      "step": 6,
+      "tap": "c14__logits"
+    },
+    {
+      "cos_sim": 0.9999702599939884,
+      "max_abs_delta": 0.01952493190765381,
+      "mtp_pos": 2,
+      "step": 7,
+      "tap": "c14__post_block"
+    },
+    {
+      "cos_sim": 0.9999662528912067,
+      "max_abs_delta": 0.12441372871398926,
+      "mtp_pos": 2,
+      "step": 7,
+      "tap": "c14__post_norm"
+    },
+    {
+      "cos_sim": 0.9999679227440127,
+      "max_abs_delta": 0.11417007446289062,
+      "mtp_pos": 2,
+      "step": 7,
+      "tap": "c14__logits"
+    }
+  ],
+  "max_abs_ceil": 0.01,
+  "tap_medians": {
+    "c14__logits": {
+      "max_max_abs": 0.1400899887084961,
+      "median_cos_sim": 0.9999735643452381,
+      "median_max_abs": 0.11194038391113281,
+      "min_cos_sim": 0.9999528823942389,
+      "n": 16
+    },
+    "c14__post_block": {
+      "max_max_abs": 0.07845211029052734,
+      "median_cos_sim": 0.9999675302349238,
+      "median_max_abs": 0.038927555084228516,
+      "min_cos_sim": 0.9999530080112127,
+      "n": 16
+    },
+    "c14__post_norm": {
+      "max_max_abs": 0.3134946823120117,
+      "median_cos_sim": 0.9999660180835468,
+      "median_max_abs": 0.14582741260528564,
+      "min_cos_sim": 0.9999546786725358,
+      "n": 16
+    },
+    "h_main": {
+      "max_max_abs": 0.0,
+      "median_cos_sim": 1.0,
+      "median_max_abs": 0.0,
+      "min_cos_sim": 0.9999999999999998,
+      "n": 16
+    }
+  },
+  "total_files": 16
+}

--- a/scripts/c14_hf_reference_dump.py
+++ b/scripts/c14_hf_reference_dump.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Phase C14 HF reference sidecar for the post-MTP-transformer-block splice dump.
+
+Walks a directory tree written by `KILN_MTP_DUMP_SPLICE=1` (expected layout
+`<root>/mtp_pos-{N}/step-{K}.safetensors`) and for each kiln dump:
+
+  1. Runs `scripts/mtp_reference_dump.py` in a subprocess to produce a
+     same-named reference file under `<root>-ref/mtp_pos-{N}/step-{K}.safetensors`.
+  2. Compares the 3 post-block taps (c14__post_block, c14__post_norm,
+     c14__logits) and the splice-source tap (h_main) between kiln and
+     reference. Emits a JSON summary with per-tap cos_sim and max|Δ|.
+  3. Flags any post-block site where cos_sim < 0.999 or max|Δ| > 1e-2.
+
+The kiln dump MUST have been written with `KILN_MTP_DUMP_SPLICE=1`, which also
+forces post-block capture (otherwise the `c14__*` taps will be missing and the
+comparison is skipped for that file).
+
+C14 extends the C13 bisect window past the `fc` projection: C13 proved the
+*inputs* to the MTP head are clean (cos ≥ 0.9999928 for all 5 pre-projection
+taps). C14 asks whether the divergence appears *inside* the MTP transformer
+block (post_block), at the final norm (post_norm), or at the tied lm_head
+(logits). Any tap that fails the cos ≥ 0.999 / max|Δ| ≤ 1e-2 thresholds tells
+us exactly where to look next.
+
+Usage
+-----
+
+    python3 scripts/c14_hf_reference_dump.py \\
+        --checkpoint /workspace/qwen3.5-4b \\
+        --kiln-root /workspace/kiln/c14-out/splice-dump \\
+        --out-root  /workspace/kiln/c14-out/splice-dump-ref \\
+        --summary   /workspace/kiln/c14-out/splice-summary.json
+
+The script shells out to `mtp_reference_dump.py` one file at a time (cold
+torch start per invocation is roughly 20–30 s; for 2 positions × 8 steps = 16
+dumps the total HF side runs in ~5–10 minutes on CPU, which is acceptable for
+a verdict pass).
+
+Exit code is 0 on success (even when divergences are flagged — the point of
+C14 is to *find* them). Exit code is 2 when any kiln dump fails to compare
+(missing taps, subprocess error, corrupted safetensors).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import numpy as np
+
+try:
+    from safetensors import safe_open
+except ImportError as exc:  # pragma: no cover
+    print(
+        "[c14_hf_ref] safetensors not installed — run `pip install safetensors numpy torch` first",
+        file=sys.stderr,
+    )
+    raise
+
+# Post-block tap names captured by `c14_taps` when post-block capture is armed.
+# Must match `C14_TAP_NAMES` in `crates/kiln-model/src/mtp_debug.rs`.
+C14_TAP_NAMES = ["post_block", "post_norm", "logits"]
+# Splice-source tap: the h_main feeding the MTP head. Lives in the legacy
+# outer-tap namespace (no `c14__` prefix) under key `h_main`. Included so the
+# C14 summary can cross-check the same sanity-identity row that C13 uses.
+SPLICE_SOURCE_TAP = "h_main"
+
+COS_SIM_FLOOR = 0.999
+MAX_ABS_CEIL = 1e-2
+
+
+@dataclass
+class TapStats:
+    tap: str
+    shape: List[int]
+    cos_sim: float
+    max_abs_delta: float
+    l2_delta: float
+    kiln_l2: float
+    ref_l2: float
+    flagged: bool
+
+
+@dataclass
+class FileResult:
+    mtp_pos: int
+    step: int
+    kiln_path: str
+    ref_path: str
+    taps: List[TapStats] = field(default_factory=list)
+    missing_taps: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+def parse_pos_step(path: Path) -> Optional[tuple[int, int]]:
+    """Parse `mtp_pos-{N}/step-{K}.safetensors` -> (N, K)."""
+    m = re.search(r"mtp_pos-(\d+)[/\\]step-(\d+)\.safetensors$", str(path))
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2))
+
+
+def load_taps(path: Path, tap_names: list[str]) -> Dict[str, np.ndarray]:
+    """Load a subset of taps from a safetensors file as float32 numpy."""
+    out: Dict[str, np.ndarray] = {}
+    with safe_open(str(path), framework="np") as f:
+        keys = set(f.keys())
+        for name in tap_names:
+            if name in keys:
+                out[name] = np.asarray(f.get_tensor(name), dtype=np.float32)
+    return out
+
+
+def cos_sim_flat(a: np.ndarray, b: np.ndarray) -> float:
+    af = a.reshape(-1).astype(np.float64)
+    bf = b.reshape(-1).astype(np.float64)
+    na = float(np.linalg.norm(af))
+    nb = float(np.linalg.norm(bf))
+    if na == 0.0 or nb == 0.0:
+        return 1.0 if na == nb else 0.0
+    return float(np.dot(af, bf) / (na * nb))
+
+
+def compare_tap(name: str, kiln_t: np.ndarray, ref_t: np.ndarray) -> TapStats:
+    assert kiln_t.shape == ref_t.shape, (
+        f"shape mismatch for `{name}`: kiln {kiln_t.shape} vs ref {ref_t.shape}"
+    )
+    delta = kiln_t.astype(np.float32) - ref_t.astype(np.float32)
+    max_abs = float(np.abs(delta).max())
+    l2_delta = float(np.linalg.norm(delta))
+    cos = cos_sim_flat(kiln_t, ref_t)
+    k_l2 = float(np.linalg.norm(kiln_t.astype(np.float32)))
+    r_l2 = float(np.linalg.norm(ref_t.astype(np.float32)))
+    flagged = (cos < COS_SIM_FLOOR) or (max_abs > MAX_ABS_CEIL)
+    return TapStats(
+        tap=name,
+        shape=list(kiln_t.shape),
+        cos_sim=cos,
+        max_abs_delta=max_abs,
+        l2_delta=l2_delta,
+        kiln_l2=k_l2,
+        ref_l2=r_l2,
+        flagged=flagged,
+    )
+
+
+def run_hf_reference(
+    checkpoint: Path,
+    kiln_dump: Path,
+    out_path: Path,
+    *,
+    script: Path,
+    extra_args: list[str],
+) -> None:
+    """Run `mtp_reference_dump.py --capture-subops` to emit a reference file.
+
+    `--capture-subops` is set so the resulting file includes the full sub-op
+    tap set; C14 only reads `c14__*` + `h_main` but sharing a reference file
+    across C6/C7/C14 comparators keeps HF recompute cost to 1× per kiln dump.
+    """
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        sys.executable,
+        str(script),
+        "--checkpoint",
+        str(checkpoint),
+        "--kiln-dump",
+        str(kiln_dump),
+        "--out",
+        str(out_path),
+        "--capture-subops",
+    ] + extra_args
+    print(f"[c14_hf_ref] running: {' '.join(cmd)}", file=sys.stderr)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(result.stdout, file=sys.stderr)
+        print(result.stderr, file=sys.stderr)
+        raise RuntimeError(
+            f"mtp_reference_dump.py failed ({result.returncode}) for {kiln_dump}"
+        )
+
+
+def compare_file(kiln_path: Path, ref_path: Path, mtp_pos: int, step: int) -> FileResult:
+    fr = FileResult(
+        mtp_pos=mtp_pos,
+        step=step,
+        kiln_path=str(kiln_path),
+        ref_path=str(ref_path),
+    )
+    wanted = [SPLICE_SOURCE_TAP] + [f"c14__{n}" for n in C14_TAP_NAMES]
+    kiln_taps = load_taps(kiln_path, wanted)
+    ref_taps = load_taps(ref_path, wanted)
+    for name in wanted:
+        if name not in kiln_taps or name not in ref_taps:
+            fr.missing_taps.append(name)
+            continue
+        fr.taps.append(compare_tap(name, kiln_taps[name], ref_taps[name]))
+    return fr
+
+
+def summarize(results: List[FileResult]) -> Dict[str, object]:
+    flagged_sites: List[Dict[str, object]] = []
+    for r in results:
+        for ts in r.taps:
+            if ts.flagged:
+                flagged_sites.append(
+                    {
+                        "mtp_pos": r.mtp_pos,
+                        "step": r.step,
+                        "tap": ts.tap,
+                        "cos_sim": ts.cos_sim,
+                        "max_abs_delta": ts.max_abs_delta,
+                    }
+                )
+    # Median cos_sim per tap across all comparisons.
+    by_tap: Dict[str, List[float]] = {}
+    by_tap_max: Dict[str, List[float]] = {}
+    for r in results:
+        for ts in r.taps:
+            by_tap.setdefault(ts.tap, []).append(ts.cos_sim)
+            by_tap_max.setdefault(ts.tap, []).append(ts.max_abs_delta)
+    tap_medians = {
+        tap: {
+            "median_cos_sim": float(np.median(vals)) if vals else float("nan"),
+            "min_cos_sim": float(np.min(vals)) if vals else float("nan"),
+            "median_max_abs": float(np.median(by_tap_max.get(tap, []))) if by_tap_max.get(tap) else float("nan"),
+            "max_max_abs": float(np.max(by_tap_max.get(tap, []))) if by_tap_max.get(tap) else float("nan"),
+            "n": len(vals),
+        }
+        for tap, vals in by_tap.items()
+    }
+    return {
+        "cos_sim_floor": COS_SIM_FLOOR,
+        "max_abs_ceil": MAX_ABS_CEIL,
+        "total_files": len(results),
+        "files_with_errors": sum(1 for r in results if r.error),
+        "files_with_missing_taps": sum(1 for r in results if r.missing_taps),
+        "flagged_sites": flagged_sites,
+        "tap_medians": tap_medians,
+        "files": [
+            {
+                "mtp_pos": r.mtp_pos,
+                "step": r.step,
+                "kiln_path": r.kiln_path,
+                "ref_path": r.ref_path,
+                "error": r.error,
+                "missing_taps": r.missing_taps,
+                "taps": [asdict(ts) for ts in r.taps],
+            }
+            for r in results
+        ],
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Phase C14 HF reference sidecar for the post-MTP-transformer-block splice dump"
+    )
+    ap.add_argument(
+        "--checkpoint",
+        required=True,
+        type=Path,
+        help="Qwen3.5-4B HF checkpoint directory (passed through to mtp_reference_dump.py)",
+    )
+    ap.add_argument(
+        "--kiln-root",
+        required=True,
+        type=Path,
+        help="Root directory containing mtp_pos-{N}/step-{K}.safetensors files written by kiln",
+    )
+    ap.add_argument(
+        "--out-root",
+        required=True,
+        type=Path,
+        help="Output directory for HF reference files (mirrors --kiln-root tree)",
+    )
+    ap.add_argument(
+        "--summary",
+        required=True,
+        type=Path,
+        help="Output path for the JSON summary (includes flagged post-block sites)",
+    )
+    ap.add_argument(
+        "--reference-script",
+        type=Path,
+        default=Path(__file__).resolve().parent / "mtp_reference_dump.py",
+        help="Path to mtp_reference_dump.py (default: co-located in scripts/)",
+    )
+    ap.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Skip re-running mtp_reference_dump.py for output files that already exist",
+    )
+    ap.add_argument(
+        "--only-pos",
+        type=int,
+        action="append",
+        default=None,
+        help="Restrict comparison to specific mtp_pos values (repeatable). Default: all.",
+    )
+    ap.add_argument(
+        "--reference-arg",
+        action="append",
+        default=[],
+        help="Extra argument to pass through to mtp_reference_dump.py (repeatable)",
+    )
+    args = ap.parse_args()
+
+    if not args.reference_script.exists():
+        print(
+            f"[c14_hf_ref] reference script not found: {args.reference_script}",
+            file=sys.stderr,
+        )
+        return 2
+
+    kiln_files = sorted(args.kiln_root.glob("mtp_pos-*/step-*.safetensors"))
+    if not kiln_files:
+        print(
+            f"[c14_hf_ref] no kiln dumps found under {args.kiln_root}",
+            file=sys.stderr,
+        )
+        return 2
+
+    results: List[FileResult] = []
+    any_error = False
+    for kiln_path in kiln_files:
+        parsed = parse_pos_step(kiln_path)
+        if parsed is None:
+            print(
+                f"[c14_hf_ref] skipping unparseable path: {kiln_path}",
+                file=sys.stderr,
+            )
+            continue
+        mtp_pos, step = parsed
+        if args.only_pos is not None and mtp_pos not in args.only_pos:
+            continue
+        rel = kiln_path.relative_to(args.kiln_root)
+        ref_path = args.out_root / rel
+        try:
+            if args.skip_existing and ref_path.exists():
+                print(
+                    f"[c14_hf_ref] reusing existing reference {ref_path}",
+                    file=sys.stderr,
+                )
+            else:
+                run_hf_reference(
+                    args.checkpoint,
+                    kiln_path,
+                    ref_path,
+                    script=args.reference_script,
+                    extra_args=list(args.reference_arg),
+                )
+            fr = compare_file(kiln_path, ref_path, mtp_pos, step)
+        except Exception as exc:  # noqa: BLE001
+            any_error = True
+            fr = FileResult(
+                mtp_pos=mtp_pos,
+                step=step,
+                kiln_path=str(kiln_path),
+                ref_path=str(ref_path),
+                error=str(exc),
+            )
+            print(f"[c14_hf_ref] ERROR for {kiln_path}: {exc}", file=sys.stderr)
+        results.append(fr)
+
+    summary = summarize(results)
+    args.summary.parent.mkdir(parents=True, exist_ok=True)
+    with args.summary.open("w") as f:
+        json.dump(summary, f, indent=2, sort_keys=True)
+
+    # Human-readable digest to stderr.
+    print(f"[c14_hf_ref] wrote summary to {args.summary}", file=sys.stderr)
+    print(
+        f"[c14_hf_ref] total files: {summary['total_files']}  "
+        f"errors: {summary['files_with_errors']}  "
+        f"missing-taps: {summary['files_with_missing_taps']}  "
+        f"flagged sites: {len(summary['flagged_sites'])}",
+        file=sys.stderr,
+    )
+    for tap, agg in summary["tap_medians"].items():
+        print(
+            f"  {tap:>20s}: median cos={agg['median_cos_sim']:.6f}  "
+            f"min cos={agg['min_cos_sim']:.6f}  "
+            f"median |Δ|_max={agg['median_max_abs']:.3e}  "
+            f"max |Δ|_max={agg['max_max_abs']:.3e}  n={agg['n']}",
+            file=sys.stderr,
+        )
+    if any_error:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/mtp_reference_dump.py
+++ b/scripts/mtp_reference_dump.py
@@ -732,6 +732,14 @@ def main() -> int:
         key = f"c7__{name}"
         assert key not in out_dict, f"c7 tap name `{key}` collides with existing tap"
         out_dict[key] = t.detach().clone().contiguous()
+    # Phase C14: emit the 3 post-MTP-transformer-block taps under a `c14__`
+    # prefix so the C14 comparator can diff kiln's post-block capture window
+    # (`c14__post_block`, `c14__post_norm`, `c14__logits` in kiln's dump)
+    # against the fp32 reference without colliding with the legacy `post_layer`
+    # / `post_final_ln` / `mtp_logits` tap names (kept for back-compat).
+    out_dict["c14__post_block"] = post_layer.detach().clone().contiguous()
+    out_dict["c14__post_norm"] = post_final_ln.detach().clone().contiguous()
+    out_dict["c14__logits"] = mtp_logits.detach().clone().contiguous()
     save_file(out_dict, args.out)
     print(f"[mtp_ref] wrote {args.out} ({sum(t.numel()*t.element_size() for t in out_dict.values())} bytes)", file=sys.stderr)
     return 0


### PR DESCRIPTION
## Summary

Extends the Phase C13 splice bisect window past the `fc` projection to cover the 3 downstream MTP head taps: the transformer block output, the final norm, and the tied-lm_head logits.

C13 proved the pre-projection splice inputs match an fp32 HF reference to `cos ≥ 0.9999928` on every tap at every step. C14 asks whether the α ≈ 0.033 regression appears:
- inside the MTP transformer block (`c14__post_block`),
- at the final RMSNorm (`c14__post_norm`), or
- at the tied `lm_head` matmul (`c14__logits`).

## What's in this PR

**Kiln side (`mtp_debug.rs`, `forward.rs`):**
- New `C14_POST_BLOCK_CAPTURE` TLS RefCell + `C14_TAP_NAMES = [\"post_block\", \"post_norm\", \"logits\"]` const.
- Explicit `KILN_MTP_DUMP_C14_POST_BLOCK` env flag OR-composed with `KILN_MTP_DUMP_SPLICE` (same pattern as C6/C7 — one meta-flag arms all three capture windows).
- Arm/drain/capture trio mirroring the C6/C7 surface.
- Extended `write_mtp_dump` signature with `c14_taps: &[(String, Vec<usize>, Vec<f32>)]`; serialized under `c14__` prefix.
- 3 capture points inside `mtp_forward_step` after `mtp_hidden`, after `normed`, after `logits`. Defensive drain on both the no-dump-path branch and the dump-siblings branch.
- Added `c14_taps = N` to the tracing info line.

**Reference side (`scripts/`):**
- `mtp_reference_dump.py`: emits `c14__post_block` / `c14__post_norm` / `c14__logits` aliases pointing at the already-computed `post_layer` / `post_final_ln` / `mtp_logits` tensors.
- New `scripts/c14_hf_reference_dump.py`: orchestrator mirroring `c13_hf_reference_dump.py`, compares the 3 `c14__*` taps + `h_main` sanity-identity, emits JSON summary with per-tap cos_sim / max|Δ| medians + flagged sites under `cos ≥ 0.999` / `max|Δ| ≤ 1e-2` thresholds.

## Tests

- 5 new unit tests in `mtp_debug::tests`:
  - `c14_tap_names_enumerate_all_three_post_block_taps`
  - `c14_post_block_capture_records_then_drains`
  - `c14_post_block_arm_is_noop_when_env_unset`
  - `c14_post_block_splice_flag_enables_capture`
  - `write_mtp_dump_emits_c14_taps_when_provided`
- All 47 `kiln-model` unit tests pass.

## Bench plan (WIP, will update PR once captures + verdict doc land)

- A6000 pod from `ce kiln-pod-acquire` (cuda feature, release build).
- Qwen3.5-4B BF16, paged, `KILN_SPEC_METHOD=mtp`, 512 prompt × 64 decode, seed 42.
- `KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS=\"0,2\" KILN_MTP_DUMP_SPLICE_MAX_STEPS=8` → 16 kiln dumps (2 positions × 8 steps).
- `scripts/c14_hf_reference_dump.py` → 16 reference dumps + per-tap verdict.
- `docs/phase-c14/c14-splice-verdict.md` will follow with the summary tables + verdict text.

## Test plan

- [x] `cargo check -p kiln-model` clean
- [x] `cargo nextest run -p kiln-model --lib mtp_debug::` (47/47 pass)
- [ ] Release-mode CUDA build on A6000
- [ ] Bench captures 16 dumps with non-empty `c14__*` taps
- [ ] Comparator runs clean against fp32 HF reference
- [ ] Verdict doc committed