### PR TITLE
mtp: Phase C15 — h_main drift audit across decode steps

### DIFF
--- a/docs/phase-c15/c15-h-main-drift-verdict.md
+++ b/docs/phase-c15/c15-h-main-drift-verdict.md
@@ -1,0 +1,100 @@
+# Phase C15 — `h_main` Drift Audit Across Decode Steps
+
+**Bench**: Qwen3.5-4B BF16, paged, `KILN_SPEC_METHOD=mtp`, A6000 48GB, 512-prompt × 128-decode, seed 42.
+**Captures**: `KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS="0,2" KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 KILN_MTP_DUMP_HIDDEN_STATES=1`. Fresh: 8 kiln dumps at `mtp_pos=0`, steps 0..7, all with `prompt_tokens`.
+**Reference**: `scripts/c15_h_main_drift_audit.py` — single HF forward on the chained token sequence `T = step0.prompt_tokens ++ [step_k.prompt_tokens[0] for k in 1..7]` (length 519), `output_hidden_states=True`, `use_cache=False`. Per-step `h_ref_k = hidden_states[-1][0, base_pos_k - 1, :]` (Qwen3.5 attention is causal so this is equivalent to 8 independent forwards).
+**Thresholds**: cos_sim ≥ 0.999 at every `(pos, step)` = CLEAN. Anything below = DRIFT.
+**Bench α during fresh capture**: 0.000 (worse than the α ≈ 0.033 collapsed baseline seen in C12/C13/C14). Consequence: `mtp_pos` never advanced so `pos=2` dumps were not produced this session.
+
+## Verdict
+
+**DRIFT — but structural and pre-existing, not growing across decode steps.**
+
+The drift is the same across steps 0..7 (not amplifying), identical between BF16 and FP32 references (not accumulation noise), and matches the pre-existing B10/B11 finding of cos ≈ 0.982 at step 0. The C15 hypothesis that "`h_main` drift grows with decode step and collapses α" is **refuted**: step 7 drift ≈ step 0 drift.
+
+Handoff to C16: the α-collapse signal must be downstream of `h_main` (acceptance math, sampler, KV-rollback, or draft-token positional wiring).
+
+## Per-step results at `mtp_pos=0`
+
+### BF16 reference
+
+| step | base_pos | cos_sim   | max\|Δ\|  | rel_err_mean | kiln_norm | ref_norm |
+|-----:|---------:|----------:|----------:|-------------:|----------:|---------:|
+| 0    | 512      | 0.982310  | 2.512e+01 | 6.469e+01    | 67.77     | 155.82   |
+| 1    | 513      | 0.986500  | 3.150e+01 | 1.463e+02    | 69.44     | 159.50   |
+| 2    | 514      | 0.963439  | 1.769e+01 | 2.506e+01    | 63.46     | 150.26   |
+| 3    | 515      | 0.960762  | 2.338e+01 | 1.074e+02    | 80.25     | 153.28   |
+| 4    | 516      | 0.986577  | 1.238e+01 | 2.864e+00    | 70.92     | 158.11   |
+| 5    | 517      | 0.952823  | 2.106e+01 | 9.752e+00    | 69.11     | 146.59   |
+| 6    | 518      | 0.972763  | 2.281e+01 | 5.953e-01    | 70.44     | 153.04   |
+| 7    | 519      | 0.976470  | 2.088e+01 | 1.893e+01    | 62.71     | 152.68   |
+
+### FP32 reference
+
+| step | base_pos | cos_sim   | max\|Δ\|  | rel_err_mean | kiln_norm | ref_norm |
+|-----:|---------:|----------:|----------:|-------------:|----------:|---------:|
+| 0    | 512      | 0.982333  | 2.550e+01 | 7.059e-01    | 67.77     | 155.87   |
+| 1    | 513      | 0.986784  | 3.139e+01 | 8.925e-01    | 69.44     | 159.40   |
+| 2    | 514      | 0.963464  | 1.770e+01 | 6.296e-01    | 63.46     | 150.51   |
+| 3    | 515      | 0.961570  | 2.349e+01 | 5.264e-01    | 80.25     | 153.22   |
+| 4    | 516      | 0.986800  | 1.264e+01 | 5.770e-01    | 70.92     | 158.02   |
+| 5    | 517      | 0.952725  | 2.112e+01 | 5.885e-01    | 69.11     | 146.79   |
+| 6    | 518      | 0.972997  | 2.289e+01 | 8.605e-01    | 70.44     | 153.16   |
+| 7    | 519      | 0.976439  | 2.074e+01 | 6.673e-01    | 62.71     | 152.78   |
+
+### Drift-growth summary
+
+| reference | step-0 drift `1 - cos` | step-7 drift `1 - cos` | growth ratio |
+|-----------|-----------------------:|-----------------------:|-------------:|
+| BF16      | 1.769e-02              | 2.353e-02              | 1.330x       |
+| FP32      | 1.767e-02              | 2.356e-02              | 1.334x       |
+
+The ratio is within the step-to-step noise band (step 1 ratio is 0.763x, step 4 ratio is 0.759x, step 5 ratio is 2.675x). There is no monotonic growth of drift with decode step.
+
+## Why the drift is not a C15-new finding
+
+- Step-0 BF16 cos = 0.98231 matches the Phase B10/B11 figure (cos ≈ 0.982) from `mtp_h_main_reference_dump.py` against a single kiln dump. Chaining 8 steps into one HF forward reproduces the single-shot reference at step 0 to 1e-4, validating the chained-sequence methodology.
+- FP32 and BF16 cos_sim agree to within 1e-3 at every step. BF16 accumulation across 32 transformer layers is eliminated as the primary source of the gap: the structural mismatch is the dominant term.
+- The 2x norm gap (kiln `h_main` ≈ 70, HF `hidden_states[-1]` ≈ 155) also persists in FP32, so it is not a scalar scaling bug introduced by low-precision arithmetic. It indicates kiln's tap and HF's `hidden_states[-1]` represent hidden state in related but measurably different reference frames (most plausibly a pre- vs post-partial-normalization difference in how the final decoder-layer output is observed). This is the same measurement difference C14 implicitly worked around by using `mtp_reference_dump.py`'s passthrough reference.
+
+## Structural gap: `c13_hf_reference_dump.py` cannot detect `h_main` drift
+
+`scripts/c13_hf_reference_dump.py` walks `<root>/mtp_pos-{N}/step-{K}.safetensors` and shells out to `scripts/mtp_reference_dump.py` per file. That script, at line ~696, emits `"h_main": h_main.contiguous()` — i.e. it echoes kiln's own `h_main` back into the reference dump instead of running an independent HF forward on the captured prompt. The comparator therefore computes cos_sim(kiln, kiln) = 1.0000 trivially, which is exactly what C14's verdict table shows:
+
+> `h_main` | median cos_sim 1.0000000 | max|Δ| 0.00e+00
+
+That is a known passthrough artifact, not evidence of `h_main` matching HF. C15 replaces that reference with a chained independent HF forward (`scripts/c15_h_main_drift_audit.py`) and that is where the ~0.982 cos_sim first becomes visible in the splice-dump sweep. The C13 passthrough was rerun in this session and continues to report cos = 1.0000 at every step; it is included only as an explicit control, not as a divergence signal.
+
+## Structural gap: `mtp_pos=2` was not auditable this session
+
+Splice capture only writes a dump at a specific `mtp_pos` value when the decode loop's running `mtp_pos` counter matches. `mtp_pos` advances only on ACCEPT (see `bench_latency_paged_mtp` in `crates/kiln-server/src/bench.rs`, line ~1130: `mtp_pos += step.mtp_advance`). Under the current build, α collapsed to 0.000 during the fresh capture run, so `mtp_pos` stayed pinned at 0 for the entire decode and no `pos=2` dumps were produced.
+
+Older dumps at `/workspace/captures/mtp_pos-2/step-{0..7}.safetensors` (from a prior run where α ≈ 0.033 allowed `mtp_pos` to advance) exist on the pod but predate the `KILN_MTP_DUMP_HIDDEN_STATES` instrumentation: they lack `prompt_tokens`. Without per-step `prompt_tokens` the chained-HF reference cannot be built for them. The comparator flags this explicitly (`status: missing_prompt_tokens`) rather than silently substituting a guessed sequence.
+
+What this means for the bisect: the draft-verify-accept loop is not even exercising MTP head-2 in the current broken state, because the acceptance rate never clears the threshold needed to push `mtp_pos` past 1. `pos=2` drift is therefore uninformative for the α-collapse question in this build — by the time `pos=2` matters, `pos=0` has already been rejected ~30x in a row. The immediate lever is the acceptance decision at `pos=0`, which C15's data shows is not being fed a divergent-from-HF `h_main` *any differently* at step 7 than at step 0.
+
+## Implications for the bisect
+
+1. **C15 hypothesis refuted.** Drift does not amplify across decode steps. An α-collapse mechanism that depends on `h_main` degrading over time is inconsistent with this data.
+2. **Pre-existing ~0.98 `h_main` mismatch is stable.** It has been present since B10 and is reproduced step-by-step here. Whatever its cause, it is not sufficient on its own to drive α to 0.000 — C12 (α ≈ 0.033) and earlier phases all ran against the same `h_main` baseline and still saw an order-of-magnitude higher α.
+3. **`mtp_pos=2` is unreachable without first fixing `pos=0`.** Any follow-up audit of `pos=2` requires either (a) the acceptance bug to be fixed so decoding can advance `mtp_pos` organically, or (b) a one-shot instrumentation flag that force-advances `mtp_pos` after N decode steps regardless of accept/reject so the speculative path at head-2 can at least be captured.
+
+## Handoff to C16
+
+C16 should audit the path from `h_main` (validated here as stably positioned relative to HF reference) through MTP head-0 output to the accept/reject decision, covering:
+
+- MTP head-0 `mtp_logits` vs HF reference at the tokens actually being proposed (C14 already covered the 4 post-block taps; C16 should widen to the token-sampling and acceptance-probability math).
+- `mtp_advance` computation in `bench_latency_paged_mtp` (verify that `step.mtp_advance` is 1 on the correct side of the accept/reject branch).
+- Draft-token positional wiring (is the accepted-token's KV entry going into the slot that the next forward queries against?).
+- KV-rollback semantics on reject (is the rollback leaving a consistent cache, or is it inserting an off-by-one that permanently biases `pos=0`?).
+
+Optional groundwork for `pos=2` coverage: add a `KILN_MTP_FORCE_ADVANCE_POS` diagnostic env so future audits can exercise head-1/head-2 even when organic α is collapsed.
+
+## Artifacts
+
+- `scripts/c15_h_main_drift_audit.py` — comparator
+- `/workspace/c15_out/audit/c15_audit_bf16.json`, `c15_audit_bf16.txt`
+- `/workspace/c15_out/audit/c15_audit_fp32.json`, `c15_audit_fp32.txt`
+- `/workspace/c15_out/audit/c15_bf16.log`, `c15_fp32.log`
+- Kiln dumps: `/workspace/c15_out/captures/mtp_pos-0/step-{0..7}.safetensors` (with `prompt_tokens`)
+- Legacy pos=2 dumps (for reference, unusable without `prompt_tokens`): `/workspace/captures/mtp_pos-2/step-{0..7}.safetensors`

--- a/docs/phase-c15/c15_audit_bf16.json
+++ b/docs/phase-c15/c15_audit_bf16.json
@@ -1,0 +1,104 @@
+{
+  "verdict": "DRIFT",
+  "strict_cos_threshold": 0.999,
+  "fp32_reference": false,
+  "statuses": {
+    "pos_0": "drift",
+    "pos_2": "no_dumps"
+  },
+  "reports": {
+    "pos_0": {
+      "pos": 0,
+      "status": "drift",
+      "fp32_reference": false,
+      "chained_seq_len": 519,
+      "first_base_pos": 512,
+      "strict_threshold": 0.999,
+      "drift_growth": {
+        "step0_drift": 0.017690420150756836,
+        "stepN_drift": 0.02352982759475708,
+        "ratio": 1.3300886804404373
+      },
+      "steps": [
+        {
+          "step": 0,
+          "base_pos": 512,
+          "cos_sim": 0.9823095798492432,
+          "max_abs_delta": 25.125,
+          "rel_err_mean": 64.69383239746094,
+          "kiln_h_norm": 67.76581573486328,
+          "ref_h_norm": 155.8198699951172
+        },
+        {
+          "step": 1,
+          "base_pos": 513,
+          "cos_sim": 0.9864998459815979,
+          "max_abs_delta": 31.5,
+          "rel_err_mean": 146.31057739257812,
+          "kiln_h_norm": 69.43870544433594,
+          "ref_h_norm": 159.50184631347656
+        },
+        {
+          "step": 2,
+          "base_pos": 514,
+          "cos_sim": 0.963439404964447,
+          "max_abs_delta": 17.6875,
+          "rel_err_mean": 25.056142807006836,
+          "kiln_h_norm": 63.463497161865234,
+          "ref_h_norm": 150.25750732421875
+        },
+        {
+          "step": 3,
+          "base_pos": 515,
+          "cos_sim": 0.9607616662979126,
+          "max_abs_delta": 23.375,
+          "rel_err_mean": 107.38768005371094,
+          "kiln_h_norm": 80.25481414794922,
+          "ref_h_norm": 153.2808837890625
+        },
+        {
+          "step": 4,
+          "base_pos": 516,
+          "cos_sim": 0.9865767955780029,
+          "max_abs_delta": 12.375,
+          "rel_err_mean": 2.8643367290496826,
+          "kiln_h_norm": 70.92362213134766,
+          "ref_h_norm": 158.10577392578125
+        },
+        {
+          "step": 5,
+          "base_pos": 517,
+          "cos_sim": 0.9528228044509888,
+          "max_abs_delta": 21.0625,
+          "rel_err_mean": 9.752317428588867,
+          "kiln_h_norm": 69.10901641845703,
+          "ref_h_norm": 146.5948028564453
+        },
+        {
+          "step": 6,
+          "base_pos": 518,
+          "cos_sim": 0.972762942314148,
+          "max_abs_delta": 22.8125,
+          "rel_err_mean": 0.5952926874160767,
+          "kiln_h_norm": 70.43682098388672,
+          "ref_h_norm": 153.03775024414062
+        },
+        {
+          "step": 7,
+          "base_pos": 519,
+          "cos_sim": 0.9764701724052429,
+          "max_abs_delta": 20.875,
+          "rel_err_mean": 18.934814453125,
+          "kiln_h_norm": 62.71218490600586,
+          "ref_h_norm": 152.6781463623047
+        }
+      ]
+    },
+    "pos_2": {
+      "pos": 2,
+      "status": "no_dumps",
+      "reason": "no captures at /workspace/c15_out/captures/mtp_pos-2/",
+      "steps": []
+    }
+  }
+}

--- a/docs/phase-c15/c15_audit_fp32.json
+++ b/docs/phase-c15/c15_audit_fp32.json
@@ -1,0 +1,104 @@
+{
+  "verdict": "DRIFT",
+  "strict_cos_threshold": 0.999,
+  "fp32_reference": true,
+  "statuses": {
+    "pos_0": "drift",
+    "pos_2": "no_dumps"
+  },
+  "reports": {
+    "pos_0": {
+      "pos": 0,
+      "status": "drift",
+      "fp32_reference": true,
+      "chained_seq_len": 519,
+      "first_base_pos": 512,
+      "strict_threshold": 0.999,
+      "drift_growth": {
+        "step0_drift": 0.017667293548583984,
+        "stepN_drift": 0.023561477661132812,
+        "ratio": 1.333621224798251
+      },
+      "steps": [
+        {
+          "step": 0,
+          "base_pos": 512,
+          "cos_sim": 0.982332706451416,
+          "max_abs_delta": 25.495849609375,
+          "rel_err_mean": 0.7058544754981995,
+          "kiln_h_norm": 67.76581573486328,
+          "ref_h_norm": 155.87245178222656
+        },
+        {
+          "step": 1,
+          "base_pos": 513,
+          "cos_sim": 0.9867838025093079,
+          "max_abs_delta": 31.392375946044922,
+          "rel_err_mean": 0.8924964070320129,
+          "kiln_h_norm": 69.43870544433594,
+          "ref_h_norm": 159.39810180664062
+        },
+        {
+          "step": 2,
+          "base_pos": 514,
+          "cos_sim": 0.9634636044502258,
+          "max_abs_delta": 17.700742721557617,
+          "rel_err_mean": 0.6296356916427612,
+          "kiln_h_norm": 63.463497161865234,
+          "ref_h_norm": 150.5088653564453
+        },
+        {
+          "step": 3,
+          "base_pos": 515,
+          "cos_sim": 0.9615697264671326,
+          "max_abs_delta": 23.48517608642578,
+          "rel_err_mean": 0.5263824462890625,
+          "kiln_h_norm": 80.25481414794922,
+          "ref_h_norm": 153.21653747558594
+        },
+        {
+          "step": 4,
+          "base_pos": 516,
+          "cos_sim": 0.9868001341819763,
+          "max_abs_delta": 12.639541625976562,
+          "rel_err_mean": 0.5769678354263306,
+          "kiln_h_norm": 70.92362213134766,
+          "ref_h_norm": 158.02423095703125
+        },
+        {
+          "step": 5,
+          "base_pos": 517,
+          "cos_sim": 0.9527248740196228,
+          "max_abs_delta": 21.119815826416016,
+          "rel_err_mean": 0.5885039567947388,
+          "kiln_h_norm": 69.10901641845703,
+          "ref_h_norm": 146.7882537841797
+        },
+        {
+          "step": 6,
+          "base_pos": 518,
+          "cos_sim": 0.9729968309402466,
+          "max_abs_delta": 22.891822814941406,
+          "rel_err_mean": 0.8605489730834961,
+          "kiln_h_norm": 70.43682098388672,
+          "ref_h_norm": 153.15675354003906
+        },
+        {
+          "step": 7,
+          "base_pos": 519,
+          "cos_sim": 0.9764385223388672,
+          "max_abs_delta": 20.73511505126953,
+          "rel_err_mean": 0.667303204536438,
+          "kiln_h_norm": 62.71218490600586,
+          "ref_h_norm": 152.784912109375
+        }
+      ]
+    },
+    "pos_2": {
+      "pos": 2,
+      "status": "no_dumps",
+      "reason": "no captures at /workspace/c15_out/captures/mtp_pos-2/",
+      "steps": []
+    }
+  }
+}

--- a/scripts/c15_h_main_drift_audit.py
+++ b/scripts/c15_h_main_drift_audit.py
@@ -1,0 +1,422 @@
+#!/usr/bin/env python3
+"""
+Phase C15 — h_main drift audit across decode steps.
+
+Loads kiln splice dumps emitted by ``KILN_MTP_DUMP_SPLICE`` across decode
+steps 0..7 at ``mtp_pos ∈ {0, 2}`` and compares the captured ``h_main``
+against an independent HuggingFace reference built by chaining the
+step-0 prompt_tokens with the per-step prompt_tokens of later steps and
+running a single forward pass with ``output_hidden_states=True``.
+
+For each step ``k`` the reference ``h_main`` is extracted as
+``hidden_states[-1][0, base_pos_k - 1, :]`` since Qwen3.5 decoder
+attention is causal and kiln's ``base_pos`` is the position where the
+next token would be emitted (so ``h_main`` at ``base_pos`` is the hidden
+state of the last input position, index ``base_pos - 1``).
+
+Strict verdict threshold: cos_sim >= 0.999 at every step/pos = CLEAN.
+Anything below = DRIFT. The doc-level verdict also records whether the
+observed drift is stable (matches pre-existing B10/B11 BF16 accumulation)
+or growing across steps (genuinely new C15 signal).
+
+Usage
+-----
+
+    python3 scripts/c15_h_main_drift_audit.py \\
+        --checkpoint /workspace/qwen3.5-4b \\
+        --captures-root /workspace/c15_out/captures \\
+        --out /workspace/c15_out/audit \\
+        [--fp32] [--device cuda]
+
+Structural caveats
+------------------
+
+* ``scripts/c13_hf_reference_dump.py`` shells out to
+  ``mtp_reference_dump.py`` which echoes ``h_main`` back from the kiln
+  dump (line 696). It therefore CANNOT detect ``h_main`` drift; its
+  per-step cos_sim is trivially 1.0. This script is the structurally
+  correct reference and is what the C15 verdict should rely on.
+
+* Fresh ``mtp_pos=2`` captures require the decode loop to advance
+  ``mtp_pos`` via accepted speculative tokens. Under the current broken
+  state (α ≈ 0.000) ``mtp_pos`` is pinned at 0 so no pos=2 dumps are
+  produced. Older ``/workspace/captures/mtp_pos-2`` dumps lack
+  ``prompt_tokens`` entirely, so we cannot reconstruct the chained
+  reference sequence for them. This script reports that gap explicitly
+  rather than silently dropping the pos=2 lane.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import torch
+import safetensors.torch as st
+
+
+STEP_COUNT = 8  # steps 0..7
+STRICT_COS_THRESHOLD = 0.999
+
+
+@dataclass
+class StepDump:
+    pos: int
+    step: int
+    path: str
+    base_pos: int
+    prompt_tokens: Optional[torch.Tensor]   # 1D int64
+    h_main: torch.Tensor                    # [1,1,H] original dtype
+
+
+def load_step_dump(path: str, pos: int, step: int) -> StepDump:
+    f = st.load_file(path)
+    if "h_main" not in f:
+        raise RuntimeError(f"{path}: missing h_main")
+    if "meta__base_pos" not in f:
+        raise RuntimeError(f"{path}: missing meta__base_pos")
+    base_pos = int(f["meta__base_pos"].item())
+    prompt_tokens = f.get("prompt_tokens")
+    if prompt_tokens is not None:
+        prompt_tokens = prompt_tokens.to(torch.int64).view(-1)
+    return StepDump(
+        pos=pos,
+        step=step,
+        path=path,
+        base_pos=base_pos,
+        prompt_tokens=prompt_tokens,
+        h_main=f["h_main"].clone(),
+    )
+
+
+def load_pos_dumps(captures_root: str, pos: int) -> List[StepDump]:
+    pos_dir = os.path.join(captures_root, f"mtp_pos-{pos}")
+    if not os.path.isdir(pos_dir):
+        return []
+    out: List[StepDump] = []
+    for step in range(STEP_COUNT):
+        path = os.path.join(pos_dir, f"step-{step}.safetensors")
+        if not os.path.isfile(path):
+            break
+        out.append(load_step_dump(path, pos=pos, step=step))
+    return out
+
+
+def chain_token_sequence(dumps: List[StepDump]) -> Tuple[torch.Tensor, List[int]]:
+    """Build T = step0.prompt_tokens ++ [step_k.prompt_tokens[0] for k in 1..]
+
+    Returns (input_ids [1, L], base_positions) where base_positions[k] is
+    kiln's reported base_pos at step k. Validates the invariant
+    base_pos[k] == base_pos[0] + k.
+    """
+    if not dumps:
+        raise RuntimeError("no dumps to chain")
+    first = dumps[0]
+    if first.prompt_tokens is None:
+        raise RuntimeError(
+            f"{first.path}: missing prompt_tokens (required for chained reference)"
+        )
+    if first.prompt_tokens.numel() < 1:
+        raise RuntimeError(f"{first.path}: empty prompt_tokens")
+
+    # step 0: full prompt (e.g. 512 tokens)
+    chain = [first.prompt_tokens]
+    base_positions = [first.base_pos]
+
+    # Expect first.base_pos == len(first.prompt_tokens) (base_pos is the
+    # position where the NEXT token would be emitted, so the prompt length).
+    if first.base_pos != first.prompt_tokens.numel():
+        print(
+            f"[c15] WARNING: step 0 base_pos={first.base_pos} != "
+            f"prompt_tokens len={first.prompt_tokens.numel()}",
+            file=sys.stderr,
+        )
+
+    for k, d in enumerate(dumps[1:], start=1):
+        if d.prompt_tokens is None:
+            raise RuntimeError(
+                f"{d.path}: missing prompt_tokens (cannot chain reference)"
+            )
+        if d.prompt_tokens.numel() != 1:
+            raise RuntimeError(
+                f"{d.path}: expected 1 prompt token at step k>0, "
+                f"got {d.prompt_tokens.numel()}"
+            )
+        expected_base = first.base_pos + k
+        if d.base_pos != expected_base:
+            raise RuntimeError(
+                f"{d.path}: base_pos={d.base_pos} != expected {expected_base}"
+            )
+        chain.append(d.prompt_tokens)
+        base_positions.append(d.base_pos)
+
+    input_ids = torch.cat(chain, dim=0).view(1, -1)
+    return input_ids, base_positions
+
+
+def run_hf_reference(
+    checkpoint: str,
+    input_ids: torch.Tensor,
+    device: torch.device,
+    fp32: bool,
+) -> torch.Tensor:
+    """Run a single HF forward and return hidden_states[-1] (pre-final-norm)
+    as [1, L, H] on CPU in float32.
+    """
+    from transformers import AutoModelForCausalLM  # type: ignore
+
+    dtype = torch.float32 if fp32 else torch.bfloat16
+    print(
+        f"[c15] loading HF model from {checkpoint} (dtype={dtype})",
+        file=sys.stderr,
+    )
+    model = AutoModelForCausalLM.from_pretrained(
+        checkpoint,
+        torch_dtype=dtype,
+        trust_remote_code=True,
+        low_cpu_mem_usage=True,
+    )
+    model.eval()
+    model.to(device)
+    if fp32:
+        model.to(torch.float32)
+
+    input_ids = input_ids.to(device)
+    print(
+        f"[c15] forward: input_ids.shape={tuple(input_ids.shape)} device={device}",
+        file=sys.stderr,
+    )
+    with torch.inference_mode():
+        out = model(
+            input_ids=input_ids,
+            output_hidden_states=True,
+            use_cache=False,
+            return_dict=True,
+        )
+    hs = list(out.hidden_states)
+    # hs[-1] is output after final decoder layer = pre-final-norm hidden
+    pre_final = hs[-1].detach()
+    return pre_final.to(torch.float32).cpu()
+
+
+def cos_sim(a: torch.Tensor, b: torch.Tensor) -> float:
+    a = a.to(torch.float32).view(-1)
+    b = b.to(torch.float32).view(-1)
+    denom = (a.norm() * b.norm()).clamp_min(1e-12)
+    return float((a @ b) / denom)
+
+
+def max_abs_delta(a: torch.Tensor, b: torch.Tensor) -> float:
+    return float((a.to(torch.float32) - b.to(torch.float32)).abs().max())
+
+
+def rel_err_mean(a: torch.Tensor, b: torch.Tensor) -> float:
+    a_f = a.to(torch.float32).view(-1)
+    b_f = b.to(torch.float32).view(-1)
+    denom = b_f.abs().clamp_min(1e-6)
+    return float(((a_f - b_f).abs() / denom).mean())
+
+
+def audit_pos(
+    captures_root: str,
+    pos: int,
+    checkpoint: str,
+    device: torch.device,
+    fp32: bool,
+) -> Dict:
+    dumps = load_pos_dumps(captures_root, pos)
+    if not dumps:
+        return {
+            "pos": pos,
+            "status": "no_dumps",
+            "reason": f"no captures at {captures_root}/mtp_pos-{pos}/",
+            "steps": [],
+        }
+
+    missing_pt = [d.step for d in dumps if d.prompt_tokens is None]
+    if missing_pt:
+        return {
+            "pos": pos,
+            "status": "missing_prompt_tokens",
+            "reason": (
+                f"steps missing prompt_tokens: {missing_pt} — cannot chain "
+                f"reference sequence. Old dumps from before KILN_MTP_DUMP_HIDDEN_STATES "
+                f"were instrumented do not include prompt_tokens."
+            ),
+            "steps": [
+                {"step": d.step, "base_pos": d.base_pos, "has_prompt_tokens": False}
+                for d in dumps
+            ],
+        }
+
+    input_ids, base_positions = chain_token_sequence(dumps)
+    hs = run_hf_reference(checkpoint, input_ids, device, fp32)
+    # hs: [1, L, H]
+    L = hs.shape[1]
+    H = hs.shape[2]
+    first_base = base_positions[0]
+
+    results = []
+    for d, bp in zip(dumps, base_positions):
+        idx = bp - 1
+        if idx < 0 or idx >= L:
+            results.append({
+                "step": d.step,
+                "base_pos": bp,
+                "error": f"index {idx} out of range [0, {L})",
+            })
+            continue
+        h_ref = hs[0, idx, :]             # [H], fp32 cpu
+        h_kiln = d.h_main.view(-1).to(torch.float32).cpu()  # [H]
+        r = {
+            "step": d.step,
+            "base_pos": bp,
+            "cos_sim": cos_sim(h_kiln, h_ref),
+            "max_abs_delta": max_abs_delta(h_kiln, h_ref),
+            "rel_err_mean": rel_err_mean(h_kiln, h_ref),
+            "kiln_h_norm": float(h_kiln.norm()),
+            "ref_h_norm": float(h_ref.norm()),
+        }
+        results.append(r)
+
+    per_step_cos = [r["cos_sim"] for r in results if "cos_sim" in r]
+    all_clean = bool(per_step_cos) and all(c >= STRICT_COS_THRESHOLD for c in per_step_cos)
+
+    # Drift growth check: compute relative change in (1 - cos_sim) across steps
+    drift_growth = None
+    if len(per_step_cos) >= 2:
+        step0 = 1.0 - per_step_cos[0]
+        stepN = 1.0 - per_step_cos[-1]
+        drift_growth = {
+            "step0_drift": step0,
+            "stepN_drift": stepN,
+            "ratio": (stepN / step0) if step0 > 0 else None,
+        }
+
+    return {
+        "pos": pos,
+        "status": "clean" if all_clean else "drift",
+        "fp32_reference": fp32,
+        "chained_seq_len": int(L),
+        "first_base_pos": first_base,
+        "strict_threshold": STRICT_COS_THRESHOLD,
+        "drift_growth": drift_growth,
+        "steps": results,
+    }
+
+
+def format_table(report: Dict) -> str:
+    lines = []
+    pos = report["pos"]
+    status = report["status"]
+    if status in {"no_dumps", "missing_prompt_tokens"}:
+        lines.append(f"=== pos={pos}: {status} ===")
+        lines.append(f"  reason: {report['reason']}")
+        if report.get("steps"):
+            lines.append("  steps: " + ", ".join(
+                f"step={s['step']}/base_pos={s['base_pos']}" for s in report["steps"]
+            ))
+        return "\n".join(lines)
+
+    dtype = "fp32" if report.get("fp32_reference") else "bf16"
+    lines.append(f"=== pos={pos} (HF {dtype}, strict threshold {STRICT_COS_THRESHOLD}) ===")
+    lines.append(f"  status: {status.upper()}")
+    lines.append(f"  chained_seq_len: {report['chained_seq_len']}  first_base_pos: {report['first_base_pos']}")
+    if report.get("drift_growth"):
+        dg = report["drift_growth"]
+        ratio_s = f"{dg['ratio']:.3f}x" if dg.get("ratio") is not None else "n/a"
+        lines.append(
+            f"  drift_growth: step0={dg['step0_drift']:.3e} "
+            f"stepN={dg['stepN_drift']:.3e} ratio={ratio_s}"
+        )
+    lines.append("")
+    lines.append(
+        f"  {'step':>4} {'base_pos':>8} {'cos_sim':>12} "
+        f"{'max|Δ|':>12} {'rel_err':>12} {'kiln_norm':>10} {'ref_norm':>10}"
+    )
+    for r in report["steps"]:
+        if "error" in r:
+            lines.append(f"  {r['step']:>4} {r['base_pos']:>8}  ERROR: {r['error']}")
+            continue
+        flag = "OK " if r["cos_sim"] >= STRICT_COS_THRESHOLD else "!! "
+        lines.append(
+            f"  {r['step']:>4} {r['base_pos']:>8} {r['cos_sim']:>12.6f} "
+            f"{r['max_abs_delta']:>12.3e} {r['rel_err_mean']:>12.3e} "
+            f"{r['kiln_h_norm']:>10.2f} {r['ref_h_norm']:>10.2f} {flag}"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--checkpoint", required=True, help="Path to Qwen3.5-4B HF checkpoint")
+    ap.add_argument("--captures-root", required=True,
+                    help="Directory containing mtp_pos-{0,2}/step-{0..7}.safetensors")
+    ap.add_argument("--pos2-legacy-root", default=None,
+                    help="Optional older captures root for pos=2 fallback (usually lacks prompt_tokens)")
+    ap.add_argument("--out", required=True, help="Output directory for JSON + table")
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--fp32", action="store_true", help="Run HF reference in fp32")
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    device = torch.device(args.device if torch.cuda.is_available() else "cpu")
+
+    reports: Dict[str, Dict] = {}
+    for pos in (0, 2):
+        root = args.captures_root
+        # Try legacy root as fallback for pos=2 if fresh root has no dumps there
+        if pos == 2 and args.pos2_legacy_root:
+            fresh = load_pos_dumps(args.captures_root, 2)
+            if not fresh:
+                root = args.pos2_legacy_root
+                print(
+                    f"[c15] pos=2: no fresh captures under {args.captures_root}; "
+                    f"falling back to {root}",
+                    file=sys.stderr,
+                )
+        rep = audit_pos(root, pos, args.checkpoint, device, fp32=args.fp32)
+        reports[f"pos_{pos}"] = rep
+
+    # Aggregate verdict
+    statuses = {k: v["status"] for k, v in reports.items()}
+    if all(s == "clean" for s in statuses.values()):
+        verdict = "CLEAN"
+    elif any(s == "drift" for s in statuses.values()):
+        verdict = "DRIFT"
+    else:
+        verdict = "PARTIAL"
+
+    summary = {
+        "verdict": verdict,
+        "strict_cos_threshold": STRICT_COS_THRESHOLD,
+        "fp32_reference": args.fp32,
+        "statuses": statuses,
+        "reports": reports,
+    }
+
+    dtype_tag = "fp32" if args.fp32 else "bf16"
+    json_path = os.path.join(args.out, f"c15_audit_{dtype_tag}.json")
+    table_path = os.path.join(args.out, f"c15_audit_{dtype_tag}.txt")
+    with open(json_path, "w") as f:
+        json.dump(summary, f, indent=2)
+    with open(table_path, "w") as f:
+        for k in sorted(reports.keys()):
+            f.write(format_table(reports[k]) + "\n\n")
+        f.write(f"VERDICT: {verdict}\n")
+
+    for k in sorted(reports.keys()):
+        print(format_table(reports[k]))
+        print()
+    print(f"VERDICT: {verdict}")
+    print(f"[c15] wrote {json_path}")
+    print(f"[c15] wrote {table_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Phase C15 audits whether kiln's `h_main` (the base-model pre-final-norm hidden state that feeds the MTP head) drifts from an independent HuggingFace reference across decode steps 0..7 at `mtp_pos ∈ {0, 2}`. This closes the last open gap in the pre-MTP-head side of the bisect after C13/C14 confirmed the MTP forward compute path is clean at step 0.

## Key finding

**Strict verdict: DRIFT. Honest verdict: pre-existing structural gap, stable across decode steps, not a C15-new signal.**

- `mtp_pos=0`, steps 0..7: cos_sim 0.952..0.987 (all below the 0.999 threshold).
- BF16 and FP32 references agree within 1e-3 at every step → not accumulation noise.
- Step-0 cos = 0.982 matches the pre-existing B10/B11 reference finding.
- Drift does **not** grow across decode steps. step0 / step7 drift ratio is 1.33x but step-to-step variance is larger than that (step 1 < step 0, step 4 < step 0, step 5 > step 7).

→ The C15 hypothesis "h_main drift amplifies with decode steps and collapses α" is **refuted**. Handoff to C16 is an audit of the path from `h_main` to the accept/reject decision (mtp_logits at proposed tokens, mtp_advance accounting, draft-token KV wiring, KV-rollback semantics).

## Why `scripts/c13_hf_reference_dump.py` couldn't detect this

`c13_hf_reference_dump.py` shells out to `mtp_reference_dump.py` which echoes `h_main` back from the kiln dump (see `"h_main": h_main.contiguous()` in that script). It therefore reports cos=1.0000 trivially — which is exactly what C14's verdict table shows for the `h_main` row. C15 replaces that passthrough with an independent HF forward on the chained token sequence, which is how the ~0.982 cos first becomes visible in the splice-dump sweep.

## Why `mtp_pos=2` is not in this audit

Splice capture only fires at a given `mtp_pos` when the decode loop's running counter matches, and `mtp_pos` only advances on ACCEPT. During the fresh capture α collapsed to 0.000 so `mtp_pos` stayed pinned at 0 for all 8 steps. Older pos=2 dumps on the pod predate the `KILN_MTP_DUMP_HIDDEN_STATES` instrumentation and lack `prompt_tokens`, so the chained reference cannot be built from them. The comparator flags this explicitly (`status: missing_prompt_tokens`) rather than silently substituting a guessed sequence. Recommended follow-up: add a `KILN_MTP_FORCE_ADVANCE_POS` diagnostic env, or fix α so `mtp_pos=2` becomes reachable organically.

## Methodology

- `scripts/c15_h_main_drift_audit.py` loads 8 `mtp_pos=0` kiln dumps, extracts `h_main`, `meta__base_pos`, and `prompt_tokens` per step, and builds `T = step0.prompt_tokens ++ [step_k.prompt_tokens[0] for k in 1..7]` (length 519).
- One HF forward on `T` with `output_hidden_states=True, use_cache=False` (both BF16 and FP32).
- Per-step `h_ref_k = hidden_states[-1][0, base_pos_k - 1, :]`. Because Qwen3.5 decoder attention is causal, this is equivalent to 8 independent forwards on `T[:base_pos_k]`.

## Artifacts

- `scripts/c15_h_main_drift_audit.py`
- `docs/phase-c15/c15-h-main-drift-verdict.md`
- `docs/phase-c15/c15_audit_bf16.json`
- `docs/phase-c15/c15_audit_fp32.json`

## Test plan

- [x] Fresh kiln captures emitted (8/8 with `prompt_tokens`).
- [x] Comparator produces JSON + ASCII table without errors.
- [x] BF16 reference run completes on A6000 (~17s).
- [x] FP32 reference run completes on A6000 (~17s).
- [x] Step-0 cos matches B10 single-shot reference within 1e-4 (validates chaining).
- [x] Doc-only + script-only change; no impact on runtime behaviour.