### PR TITLE
mtp: Phase C18 — fix h_prev reference frame (post-final-norm)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -4256,7 +4256,9 @@ pub fn model_forward_paged_with_last_hidden(
     // when `KILN_MTP_DUMP_HIDDEN_STATES=1`. The arm is a no-op when the env
     // var is unset, so production cost is a single TLS borrow + env lookup.
     // The inner forward pass fills the window with boundary-layer last-row
-    // slices plus `h_pre_final_norm`; the window is drained in
+    // slices plus `h_post_final_norm` (C18 — formerly `h_pre_final_norm`
+    // before kiln started returning post-final-norm `h_prev`); the window
+    // is drained in
     // `mtp_forward_step`'s dump block so the taps appear alongside the
     // standard 8 MTP taps in the same safetensors file. The next call to
     // this function re-arms the window, overwriting any stale buffer from
@@ -5033,38 +5035,44 @@ fn model_forward_paged_inner(
             Ok((Some(logits), None))
         }
         LmHeadMode::FullWithLastHidden => {
-            // Extract the last-row pre-final-norm hidden BEFORE normalising.
-            // MTP needs `h_prev` as the base model's output between the final
-            // transformer block and the final RMSNorm (matches vLLM's
-            // Qwen3-Next reference where `previous_hidden_states` is passed
-            // into the MTP head before `final_layernorm`). Logits are
-            // produced over every position so speculative verification can
-            // compare draft predictions at position 0 and sample a bonus at
-            // position 1 in a single pass.
-            let last_hidden = hidden.narrow(1, seq_len - 1, 1)?.contiguous()?;
-            // Phase B10: `h_pre_final_norm` is the same tensor the MTP head
-            // receives as `h_prev`. Captured under a distinct name so the
-            // comparator can verify the final-layer → h_main handoff
-            // independently from `h_layer_31`.
+            // Phase C18: `h_prev` must be returned POST-final-norm.
+            // vLLM (`Qwen3_5MultiTokenPredictor.forward`) and SGLang consume
+            // the base model's `last_hidden_state` (post-`model.norm`) as the
+            // input to `pre_fc_norm_hidden`. C17 cross-referenced the upstream
+            // contract and the C15 numerical fingerprint (2.0–2.4× kiln/HF
+            // magnitude ratio) confirmed kiln was one RMSNorm behind. We now
+            // apply `final_norm` ONCE and slice the last row from the normed
+            // tensor for both the logits projection and the returned h_prev.
+            let normed = {
+                kiln_nvtx::range!(c"kiln/final_norm");
+                rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?
+            };
+            let last_hidden = normed.narrow(1, seq_len - 1, 1)?.contiguous()?;
             if crate::mtp_debug::is_h_main_capture_armed() {
-                let _ = crate::mtp_debug::capture_h_main_tap("h_pre_final_norm", &last_hidden);
+                let _ = crate::mtp_debug::capture_h_main_tap("h_post_final_norm", &last_hidden);
             }
             let logits = {
                 kiln_nvtx::range!(c"kiln/lm_head");
-                let normed = rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?;
                 normed.broadcast_matmul(&weights.embed_tokens_t)?
             };
             Ok((Some(logits), Some(last_hidden)))
         }
         LmHeadMode::LastRowWithLastHidden => {
-            let last_hidden = hidden.narrow(1, seq_len - 1, 1)?.contiguous()?;
+            // Phase C18: same frame fix as `FullWithLastHidden`. For the
+            // single-row variant we still only materialise the last row before
+            // `final_norm` (cheap) — that row, once normed, is the canonical
+            // post-final-norm `h_prev` the MTP head expects.
+            let last_pre_norm = hidden.narrow(1, seq_len - 1, 1)?.contiguous()?;
+            let last_hidden = {
+                kiln_nvtx::range!(c"kiln/final_norm");
+                rms_norm(&last_pre_norm, &weights.final_norm, config.rms_norm_eps)?
+            };
             if crate::mtp_debug::is_h_main_capture_armed() {
-                let _ = crate::mtp_debug::capture_h_main_tap("h_pre_final_norm", &last_hidden);
+                let _ = crate::mtp_debug::capture_h_main_tap("h_post_final_norm", &last_hidden);
             }
             let logits = {
                 kiln_nvtx::range!(c"kiln/lm_head");
-                let normed = rms_norm(&last_hidden, &weights.final_norm, config.rms_norm_eps)?;
-                normed.broadcast_matmul(&weights.embed_tokens_t)?
+                last_hidden.broadcast_matmul(&weights.embed_tokens_t)?
             };
             Ok((Some(logits), Some(last_hidden)))
         }

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -50,7 +50,8 @@ thread_local! {
         const { RefCell::new(None) };
 
     /// Phase B10: separate thread-local sink for base-model per-layer hidden
-    /// states (`h_layer_*` + `h_pre_final_norm`). Kept distinct from
+    /// states (`h_layer_*` + `h_post_final_norm`, renamed from
+    /// `h_pre_final_norm` in Phase C18). Kept distinct from
     /// [`SUBOP_CAPTURE`] so the base-model forward can run while the MTP
     /// inner-block capture window is closed (and vice versa), and so each
     /// buffer can be drained without conflation.
@@ -431,17 +432,18 @@ pub fn capture_subop(name: &str, t: &Tensor) -> Result<()> {
 
 /// Boundary layer indices captured when `KILN_MTP_DUMP_HIDDEN_STATES=1`.
 /// Spans the full 32-layer Qwen3.5-4B stack: three GDN samples (0, 8, 16)
-/// plus two GQA samples (23, 31). Layer 31's output IS the pre-final-norm
-/// hidden state, but the comparator still writes a separate `h_pre_final_norm`
-/// tap so the final-layer → h_main handoff can be verified independently.
+/// plus two GQA samples (23, 31). Layer 31's output is still the
+/// pre-final-norm hidden state; the comparator also writes the
+/// `h_post_final_norm` tap (Phase C18) so the final-layer → final_norm →
+/// h_main handoff can be verified independently.
 pub const B10_BOUNDARY_LAYERS: [usize; 5] = [0, 8, 16, 23, 31];
 
 /// True when `KILN_MTP_DUMP_HIDDEN_STATES=1` (or `true`) is set. Phase B10
 /// opt-in: when enabled alongside `KILN_MTP_DUMP_PATH`, the base-model
 /// forward records the last-row hidden state at each boundary layer and at
-/// the pre-final-norm site, and appends them to the MTP dump safetensors
-/// under names `h_layer_0`, `h_layer_8`, `h_layer_16`, `h_layer_23`,
-/// `h_layer_31`, and `h_pre_final_norm`.
+/// the post-final-norm site (Phase C18), and appends them to the MTP dump
+/// safetensors under names `h_layer_0`, `h_layer_8`, `h_layer_16`,
+/// `h_layer_23`, `h_layer_31`, and `h_post_final_norm`.
 pub fn is_dump_hidden_states_enabled() -> bool {
     std::env::var("KILN_MTP_DUMP_HIDDEN_STATES")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
@@ -471,7 +473,7 @@ pub fn should_capture_hidden_state_for_layer(layer_idx: usize) -> bool {
 }
 
 /// True if the Phase B10 hidden-state capture window is currently armed on
-/// this thread. Used to gate `h_pre_final_norm` capture (which is not
+/// this thread. Used to gate `h_post_final_norm` capture (Phase C18; not
 /// indexed by layer).
 pub fn is_h_main_capture_armed() -> bool {
     H_MAIN_CAPTURE.with(|c| c.borrow().is_some())
@@ -1845,13 +1847,13 @@ mod tests {
         assert!(should_capture_hidden_state_for_layer(31));
         assert!(!should_capture_hidden_state_for_layer(5));
         capture_h_main_tap("h_layer_0", &a).unwrap();
-        capture_h_main_tap("h_pre_final_norm", &b).unwrap();
+        capture_h_main_tap("h_post_final_norm", &b).unwrap();
         let drained = drain_h_main_capture();
         assert_eq!(drained.len(), 2);
         assert_eq!(drained[0].0, "h_layer_0");
         assert_eq!(drained[0].1, vec![3]);
         assert_eq!(drained[0].2, vec![1.0, 2.0, 3.0]);
-        assert_eq!(drained[1].0, "h_pre_final_norm");
+        assert_eq!(drained[1].0, "h_post_final_norm");
         // Drain disarms.
         assert!(!is_h_main_capture_armed());
         capture_h_main_tap("h_layer_16", &a).unwrap();

--- a/docs/phase-c18/alpha-post.log
+++ b/docs/phase-c18/alpha-post.log
@@ -1,0 +1,474 @@
+=== seed=42 ===
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-22T00:58:40.358441Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-22T00:58:40.359864Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-22T00:58:40.360133Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-22T00:58:40.360148Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-22T00:58:40.360307Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-22T00:59:03.337138Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m21117 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 21117 ms (parallel)
+Model loaded in 23.70s (backend: cuda, VRAM: 18006 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (512 prompt tokens)...
+    Prefill (MTP): 326.1ms (1570 tok/s)
+    Decode (MTP): 128 tokens, mean ITL 23.6ms (42.4 tok/s), α = 0.114 (13/114)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-22T00:59:08.254975Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 2854.3ms (44.8 tok/s)
+  => 44.8 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 2866.6ms (44.7 tok/s)
+    Run 2/4: 128 tokens in 2833.1ms (45.2 tok/s)
+    Run 3/4: 128 tokens in 2835.2ms (45.1 tok/s)
+    Run 4/4: 128 tokens in 2853.2ms (44.9 tok/s)
+  => 45.0 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2878.7ms (44.5 tok/s)
+    Run 2/8: 128 tokens in 2880.4ms (44.4 tok/s)
+    Run 3/8: 128 tokens in 2881.7ms (44.4 tok/s)
+    Run 4/8: 128 tokens in 2858.8ms (44.8 tok/s)
+    Run 5/8: 128 tokens in 2865.8ms (44.7 tok/s)
+    Run 6/8: 128 tokens in 2872.8ms (44.6 tok/s)
+    Run 7/8: 128 tokens in 2861.9ms (44.7 tok/s)
+    Run 8/8: 128 tokens in 2879.8ms (44.4 tok/s)
+  => 44.6 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2841.9ms (45.0 tok/s)
+    Run 2/16: 128 tokens in 2827.4ms (45.3 tok/s)
+    Run 3/16: 128 tokens in 2829.6ms (45.2 tok/s)
+    Run 4/16: 128 tokens in 2835.9ms (45.1 tok/s)
+    Run 5/16: 128 tokens in 2842.7ms (45.0 tok/s)
+    Run 6/16: 128 tokens in 2871.4ms (44.6 tok/s)
+    Run 7/16: 128 tokens in 2860.4ms (44.7 tok/s)
+    Run 8/16: 128 tokens in 2865.6ms (44.7 tok/s)
+    Run 9/16: 128 tokens in 2886.5ms (44.3 tok/s)
+    Run 10/16: 128 tokens in 2894.3ms (44.2 tok/s)
+    Run 11/16: 128 tokens in 2915.0ms (43.9 tok/s)
+    Run 12/16: 128 tokens in 2930.9ms (43.7 tok/s)
+    Run 13/16: 128 tokens in 2898.5ms (44.2 tok/s)
+    Run 14/16: 128 tokens in 2903.3ms (44.1 tok/s)
+    Run 15/16: 128 tokens in 2887.9ms (44.3 tok/s)
+    Run 16/16: 128 tokens in 2873.4ms (44.5 tok/s)
+  => 44.6 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 23.70s (VRAM: 18006 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               512        128         44.8      18280
+4               512        512         45.0      18280
+8               512       1024         44.6      18280
+16              512       2048         44.6      18280
+
+--- Latency (single request) ---
+Prompt tokens:         512
+Prefill time:          326.1 ms (1570 tok/s)
+Time to first token:   326.1 ms
+Mean inter-token:      23.6 ms (42.4 tok/s)
+P50 inter-token:       23.5 ms
+P99 inter-token:       29.8 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.114
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.697459481,
+    "model_vram_mb": 18006
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 512,
+      "output_tokens": 128,
+      "total_time_secs": 2.854337466,
+      "tokens_per_sec": 44.84403176733553,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 512,
+      "output_tokens": 512,
+      "total_time_secs": 11.388278727,
+      "tokens_per_sec": 44.95850622149951,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 512,
+      "output_tokens": 1024,
+      "total_time_secs": 22.980300746,
+      "tokens_per_sec": 44.559904211794944,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 512,
+      "output_tokens": 2048,
+      "total_time_secs": 45.965480181,
+      "tokens_per_sec": 44.555174707965925,
+      "peak_vram_mb": 18280
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 512,
+    "prefill_time_ms": 326.080597,
+    "prefill_tokens_per_sec": 1570.1639555082143,
+    "time_to_first_token_ms": 326.080597,
+    "mean_inter_token_ms": 23.560055141732278,
+    "p50_inter_token_ms": 23.515658,
+    "p99_inter_token_ms": 29.838195000000002,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 42.44472239068257,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.11403508771929824
+  },
+  "training": null
+}
+=== seed=43 ===
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-22T01:00:33.253365Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-22T01:00:33.254547Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-22T01:00:33.254694Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-22T01:00:33.254709Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-22T01:00:33.254797Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-22T01:00:54.754560Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m19614 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 19614 ms (parallel)
+Model loaded in 22.10s (backend: cuda, VRAM: 18006 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (503 prompt tokens)...
+    Prefill (MTP): 319.5ms (1575 tok/s)
+    Decode (MTP): 128 tokens, mean ITL 23.3ms (42.8 tok/s), α = 0.153 (17/111)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-22T01:00:59.598943Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 2893.6ms (44.2 tok/s)
+  => 44.2 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 2959.5ms (43.3 tok/s)
+    Run 2/4: 128 tokens in 2813.7ms (45.5 tok/s)
+    Run 3/4: 128 tokens in 2912.3ms (44.0 tok/s)
+    Run 4/4: 128 tokens in 2892.6ms (44.3 tok/s)
+  => 44.2 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2889.3ms (44.3 tok/s)
+    Run 2/8: 128 tokens in 2883.6ms (44.4 tok/s)
+    Run 3/8: 128 tokens in 2913.3ms (43.9 tok/s)
+    Run 4/8: 128 tokens in 2823.6ms (45.3 tok/s)
+    Run 5/8: 128 tokens in 2794.6ms (45.8 tok/s)
+    Run 6/8: 128 tokens in 2937.0ms (43.6 tok/s)
+    Run 7/8: 128 tokens in 2879.3ms (44.5 tok/s)
+    Run 8/8: 128 tokens in 2938.2ms (43.6 tok/s)
+  => 44.4 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2949.9ms (43.4 tok/s)
+    Run 2/16: 128 tokens in 3043.4ms (42.1 tok/s)
+    Run 3/16: 128 tokens in 2863.4ms (44.7 tok/s)
+    Run 4/16: 128 tokens in 2837.7ms (45.1 tok/s)
+    Run 5/16: 128 tokens in 2979.8ms (43.0 tok/s)
+    Run 6/16: 128 tokens in 2912.5ms (43.9 tok/s)
+    Run 7/16: 128 tokens in 2907.4ms (44.0 tok/s)
+    Run 8/16: 128 tokens in 2859.5ms (44.8 tok/s)
+    Run 9/16: 128 tokens in 2936.5ms (43.6 tok/s)
+    Run 10/16: 128 tokens in 2903.5ms (44.1 tok/s)
+    Run 11/16: 128 tokens in 2862.9ms (44.7 tok/s)
+    Run 12/16: 128 tokens in 2856.7ms (44.8 tok/s)
+    Run 13/16: 128 tokens in 2871.2ms (44.6 tok/s)
+    Run 14/16: 128 tokens in 2880.5ms (44.4 tok/s)
+    Run 15/16: 128 tokens in 2842.8ms (45.0 tok/s)
+    Run 16/16: 128 tokens in 2900.6ms (44.1 tok/s)
+  => 44.1 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 22.10s (VRAM: 18006 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               503        128         44.2      18280
+4               503        512         44.2      18280
+8               503       1024         44.4      18280
+16              503       2048         44.1      18280
+
+--- Latency (single request) ---
+Prompt tokens:         503
+Prefill time:          319.5 ms (1575 tok/s)
+Time to first token:   319.5 ms
+Mean inter-token:      23.3 ms (42.8 tok/s)
+P50 inter-token:       23.1 ms
+P99 inter-token:       29.4 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.153
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 22.098084113,
+    "model_vram_mb": 18006
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 503,
+      "output_tokens": 128,
+      "total_time_secs": 2.893696448,
+      "tokens_per_sec": 44.23407993898882,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 503,
+      "output_tokens": 512,
+      "total_time_secs": 11.578200751,
+      "tokens_per_sec": 44.22103321673524,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 503,
+      "output_tokens": 1024,
+      "total_time_secs": 23.059300112,
+      "tokens_per_sec": 44.407245450919525,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 503,
+      "output_tokens": 2048,
+      "total_time_secs": 46.408901724,
+      "tokens_per_sec": 44.12946490696402,
+      "peak_vram_mb": 18280
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 503,
+    "prefill_time_ms": 319.462409,
+    "prefill_tokens_per_sec": 1574.5201495678948,
+    "time_to_first_token_ms": 319.462409,
+    "mean_inter_token_ms": 23.339917562992124,
+    "p50_inter_token_ms": 23.142224,
+    "p99_inter_token_ms": 29.364517,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 42.84505278568783,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.15315315315315314
+  },
+  "training": null
+}
+=== seed=44 ===
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-22T01:02:25.271882Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-22T01:02:25.272842Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-22T01:02:25.272965Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-22T01:02:25.272978Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-22T01:02:25.273063Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-22T01:02:47.361212Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m20258 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 20258 ms (parallel)
+Model loaded in 22.75s (backend: cuda, VRAM: 18006 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (498 prompt tokens)...
+    Prefill (MTP): 326.6ms (1525 tok/s)
+    Decode (MTP): 128 tokens, mean ITL 23.0ms (43.4 tok/s), α = 0.187 (20/107)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-22T01:02:52.178846Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 2841.7ms (45.0 tok/s)
+  => 45.0 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 2854.1ms (44.8 tok/s)
+    Run 2/4: 128 tokens in 2865.8ms (44.7 tok/s)
+    Run 3/4: 128 tokens in 2785.9ms (45.9 tok/s)
+    Run 4/4: 128 tokens in 2839.3ms (45.1 tok/s)
+  => 45.1 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2905.4ms (44.1 tok/s)
+    Run 2/8: 128 tokens in 2857.0ms (44.8 tok/s)
+    Run 3/8: 128 tokens in 2896.2ms (44.2 tok/s)
+    Run 4/8: 128 tokens in 2786.4ms (45.9 tok/s)
+    Run 5/8: 128 tokens in 2766.6ms (46.3 tok/s)
+    Run 6/8: 128 tokens in 2851.6ms (44.9 tok/s)
+    Run 7/8: 128 tokens in 3031.2ms (42.2 tok/s)
+    Run 8/8: 128 tokens in 2872.8ms (44.6 tok/s)
+  => 44.6 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2832.1ms (45.2 tok/s)
+    Run 2/16: 128 tokens in 2868.6ms (44.6 tok/s)
+    Run 3/16: 128 tokens in 2870.5ms (44.6 tok/s)
+    Run 4/16: 128 tokens in 2917.9ms (43.9 tok/s)
+    Run 5/16: 128 tokens in 2903.2ms (44.1 tok/s)
+    Run 6/16: 128 tokens in 2982.0ms (42.9 tok/s)
+    Run 7/16: 128 tokens in 2930.9ms (43.7 tok/s)
+    Run 8/16: 128 tokens in 2876.4ms (44.5 tok/s)
+    Run 9/16: 128 tokens in 2821.2ms (45.4 tok/s)
+    Run 10/16: 128 tokens in 2868.6ms (44.6 tok/s)
+    Run 11/16: 128 tokens in 2842.3ms (45.0 tok/s)
+    Run 12/16: 128 tokens in 2878.6ms (44.5 tok/s)
+    Run 13/16: 128 tokens in 2876.8ms (44.5 tok/s)
+    Run 14/16: 128 tokens in 2867.9ms (44.6 tok/s)
+    Run 15/16: 128 tokens in 2851.4ms (44.9 tok/s)
+    Run 16/16: 128 tokens in 2855.4ms (44.8 tok/s)
+  => 44.5 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 22.75s (VRAM: 18006 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               498        128         45.0      18280
+4               498        512         45.1      18280
+8               498       1024         44.6      18280
+16              498       2048         44.5      18280
+
+--- Latency (single request) ---
+Prompt tokens:         498
+Prefill time:          326.6 ms (1525 tok/s)
+Time to first token:   326.6 ms
+Mean inter-token:      23.0 ms (43.4 tok/s)
+P50 inter-token:       23.1 ms
+P99 inter-token:       26.0 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.187
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 22.753211165,
+    "model_vram_mb": 18006
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 498,
+      "output_tokens": 128,
+      "total_time_secs": 2.84176863,
+      "tokens_per_sec": 45.04237208079815,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 498,
+      "output_tokens": 512,
+      "total_time_secs": 11.345356887,
+      "tokens_per_sec": 45.128593582337786,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 498,
+      "output_tokens": 1024,
+      "total_time_secs": 22.967695983,
+      "tokens_per_sec": 44.58435886463902,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 498,
+      "output_tokens": 2048,
+      "total_time_secs": 46.044771911,
+      "tokens_per_sec": 44.47844814952243,
+      "peak_vram_mb": 18280
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 498,
+    "prefill_time_ms": 326.613755,
+    "prefill_tokens_per_sec": 1524.7367643778505,
+    "time_to_first_token_ms": 326.613755,
+    "mean_inter_token_ms": 23.01599359055118,
+    "p50_inter_token_ms": 23.125889,
+    "p99_inter_token_ms": 26.012389,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 43.448048248090096,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.18691588785046728
+  },
+  "training": null
+}

--- a/docs/phase-c18/alpha-pre.log
+++ b/docs/phase-c18/alpha-pre.log
@@ -1,0 +1,474 @@
+=== seed=42 ===
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-22T00:51:36.887703Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-22T00:51:36.889882Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-22T00:51:36.890172Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-22T00:51:36.890196Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-22T00:51:36.890342Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-22T00:52:00.853642Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m21958 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 21958 ms (parallel)
+Model loaded in 24.69s (backend: cuda, VRAM: 18006 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (512 prompt tokens)...
+    Prefill (MTP): 343.5ms (1491 tok/s)
+    Decode (MTP): 128 tokens, mean ITL 23.7ms (42.2 tok/s), α = 0.024 (3/124)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-22T00:52:05.813192Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 2847.7ms (44.9 tok/s)
+  => 44.9 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 2931.5ms (43.7 tok/s)
+    Run 2/4: 128 tokens in 2900.6ms (44.1 tok/s)
+    Run 3/4: 128 tokens in 2881.5ms (44.4 tok/s)
+    Run 4/4: 128 tokens in 2862.8ms (44.7 tok/s)
+  => 44.2 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2887.9ms (44.3 tok/s)
+    Run 2/8: 128 tokens in 2886.3ms (44.3 tok/s)
+    Run 3/8: 128 tokens in 2844.3ms (45.0 tok/s)
+    Run 4/8: 128 tokens in 2802.0ms (45.7 tok/s)
+    Run 5/8: 128 tokens in 2837.1ms (45.1 tok/s)
+    Run 6/8: 128 tokens in 2817.9ms (45.4 tok/s)
+    Run 7/8: 128 tokens in 2864.6ms (44.7 tok/s)
+    Run 8/8: 128 tokens in 2869.7ms (44.6 tok/s)
+  => 44.9 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2856.0ms (44.8 tok/s)
+    Run 2/16: 128 tokens in 2932.8ms (43.6 tok/s)
+    Run 3/16: 128 tokens in 2820.0ms (45.4 tok/s)
+    Run 4/16: 128 tokens in 2784.7ms (46.0 tok/s)
+    Run 5/16: 128 tokens in 2780.9ms (46.0 tok/s)
+    Run 6/16: 128 tokens in 2841.3ms (45.0 tok/s)
+    Run 7/16: 128 tokens in 2927.5ms (43.7 tok/s)
+    Run 8/16: 128 tokens in 2889.3ms (44.3 tok/s)
+    Run 9/16: 128 tokens in 2889.9ms (44.3 tok/s)
+    Run 10/16: 128 tokens in 2938.3ms (43.6 tok/s)
+    Run 11/16: 128 tokens in 2923.1ms (43.8 tok/s)
+    Run 12/16: 128 tokens in 2882.6ms (44.4 tok/s)
+    Run 13/16: 128 tokens in 2963.2ms (43.2 tok/s)
+    Run 14/16: 128 tokens in 2920.2ms (43.8 tok/s)
+    Run 15/16: 128 tokens in 2945.6ms (43.5 tok/s)
+    Run 16/16: 128 tokens in 2875.4ms (44.5 tok/s)
+  => 44.4 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 24.69s (VRAM: 18006 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               512        128         44.9      18280
+4               512        512         44.2      18280
+8               512       1024         44.9      18280
+16              512       2048         44.4      18280
+
+--- Latency (single request) ---
+Prompt tokens:         512
+Prefill time:          343.5 ms (1491 tok/s)
+Time to first token:   343.5 ms
+Mean inter-token:      23.7 ms (42.2 tok/s)
+P50 inter-token:       23.5 ms
+P99 inter-token:       25.7 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.024
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.687939108,
+    "model_vram_mb": 18006
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 512,
+      "output_tokens": 128,
+      "total_time_secs": 2.847719429,
+      "tokens_per_sec": 44.948248305820016,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 512,
+      "output_tokens": 512,
+      "total_time_secs": 11.576571956,
+      "tokens_per_sec": 44.22725500657701,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 512,
+      "output_tokens": 1024,
+      "total_time_secs": 22.810199785000002,
+      "tokens_per_sec": 44.892197773444444,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 512,
+      "output_tokens": 2048,
+      "total_time_secs": 46.171684207,
+      "tokens_per_sec": 44.35619005835414,
+      "peak_vram_mb": 18280
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 512,
+    "prefill_time_ms": 343.47159500000004,
+    "prefill_tokens_per_sec": 1490.6618406101384,
+    "time_to_first_token_ms": 343.47159500000004,
+    "mean_inter_token_ms": 23.682890842519694,
+    "p50_inter_token_ms": 23.541338,
+    "p99_inter_token_ms": 25.74476,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 42.224574974800966,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.024193548387096774
+  },
+  "training": null
+}
+=== seed=43 ===
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-22T00:53:31.006390Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-22T00:53:31.007543Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-22T00:53:31.007671Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-22T00:53:31.007685Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-22T00:53:31.007756Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-22T00:53:55.382988Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m22372 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 22372 ms (parallel)
+Model loaded in 25.13s (backend: cuda, VRAM: 18006 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (503 prompt tokens)...
+    Prefill (MTP): 334.2ms (1505 tok/s)
+    Decode (MTP): 128 tokens, mean ITL 23.9ms (41.8 tok/s), α = 0.033 (4/123)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-22T00:54:00.449341Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 2855.4ms (44.8 tok/s)
+  => 44.8 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 2875.1ms (44.5 tok/s)
+    Run 2/4: 128 tokens in 2873.4ms (44.5 tok/s)
+    Run 3/4: 128 tokens in 2847.3ms (45.0 tok/s)
+    Run 4/4: 128 tokens in 2856.1ms (44.8 tok/s)
+  => 44.7 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2830.0ms (45.2 tok/s)
+    Run 2/8: 128 tokens in 2834.4ms (45.2 tok/s)
+    Run 3/8: 128 tokens in 2834.9ms (45.2 tok/s)
+    Run 4/8: 128 tokens in 2821.4ms (45.4 tok/s)
+    Run 5/8: 128 tokens in 2860.8ms (44.7 tok/s)
+    Run 6/8: 128 tokens in 2847.1ms (45.0 tok/s)
+    Run 7/8: 128 tokens in 2837.3ms (45.1 tok/s)
+    Run 8/8: 128 tokens in 2867.0ms (44.6 tok/s)
+  => 45.0 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2869.3ms (44.6 tok/s)
+    Run 2/16: 128 tokens in 2872.3ms (44.6 tok/s)
+    Run 3/16: 128 tokens in 2858.5ms (44.8 tok/s)
+    Run 4/16: 128 tokens in 2906.1ms (44.0 tok/s)
+    Run 5/16: 128 tokens in 2833.4ms (45.2 tok/s)
+    Run 6/16: 128 tokens in 2825.4ms (45.3 tok/s)
+    Run 7/16: 128 tokens in 2786.5ms (45.9 tok/s)
+    Run 8/16: 128 tokens in 2783.6ms (46.0 tok/s)
+    Run 9/16: 128 tokens in 2763.7ms (46.3 tok/s)
+    Run 10/16: 128 tokens in 2791.7ms (45.9 tok/s)
+    Run 11/16: 128 tokens in 2730.6ms (46.9 tok/s)
+    Run 12/16: 128 tokens in 2753.0ms (46.5 tok/s)
+    Run 13/16: 128 tokens in 2860.7ms (44.7 tok/s)
+    Run 14/16: 128 tokens in 2818.6ms (45.4 tok/s)
+    Run 15/16: 128 tokens in 2831.5ms (45.2 tok/s)
+    Run 16/16: 128 tokens in 2840.7ms (45.1 tok/s)
+  => 45.4 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 25.13s (VRAM: 18006 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               503        128         44.8      18280
+4               503        512         44.7      18280
+8               503       1024         45.0      18280
+16              503       2048         45.4      18280
+
+--- Latency (single request) ---
+Prompt tokens:         503
+Prefill time:          334.2 ms (1505 tok/s)
+Time to first token:   334.2 ms
+Mean inter-token:      23.9 ms (41.8 tok/s)
+P50 inter-token:       23.8 ms
+P99 inter-token:       26.9 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.033
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.132563878,
+    "model_vram_mb": 18006
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 503,
+      "output_tokens": 128,
+      "total_time_secs": 2.855488182,
+      "tokens_per_sec": 44.825960340815726,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 503,
+      "output_tokens": 512,
+      "total_time_secs": 11.452109203,
+      "tokens_per_sec": 44.70792156486565,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 503,
+      "output_tokens": 1024,
+      "total_time_secs": 22.733185695,
+      "tokens_per_sec": 45.04428080333771,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 503,
+      "output_tokens": 2048,
+      "total_time_secs": 45.126355044,
+      "tokens_per_sec": 45.38367873946651,
+      "peak_vram_mb": 18280
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 503,
+    "prefill_time_ms": 334.229297,
+    "prefill_tokens_per_sec": 1504.954845415601,
+    "time_to_first_token_ms": 334.229297,
+    "mean_inter_token_ms": 23.939773330708658,
+    "p50_inter_token_ms": 23.770017,
+    "p99_inter_token_ms": 26.856946,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 41.7714899045119,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.032520325203252036
+  },
+  "training": null
+}
+=== seed=44 ===
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-22T00:55:24.408675Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-22T00:55:24.409844Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-22T00:55:24.409999Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-22T00:55:24.410007Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-22T00:55:24.410173Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-22T00:55:47.643973Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m21345 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 21345 ms (parallel)
+Model loaded in 23.90s (backend: cuda, VRAM: 18006 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (498 prompt tokens)...
+    Prefill (MTP): 333.1ms (1495 tok/s)
+    Decode (MTP): 128 tokens, mean ITL 23.7ms (42.3 tok/s), α = 0.104 (12/115)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-22T00:55:52.574817Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 2855.0ms (44.8 tok/s)
+  => 44.8 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 2875.4ms (44.5 tok/s)
+    Run 2/4: 128 tokens in 2889.0ms (44.3 tok/s)
+    Run 3/4: 128 tokens in 2916.4ms (43.9 tok/s)
+    Run 4/4: 128 tokens in 2868.4ms (44.6 tok/s)
+  => 44.3 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2917.6ms (43.9 tok/s)
+    Run 2/8: 128 tokens in 2859.1ms (44.8 tok/s)
+    Run 3/8: 128 tokens in 2904.2ms (44.1 tok/s)
+    Run 4/8: 128 tokens in 2877.3ms (44.5 tok/s)
+    Run 5/8: 128 tokens in 2963.0ms (43.2 tok/s)
+    Run 6/8: 128 tokens in 2901.3ms (44.1 tok/s)
+    Run 7/8: 128 tokens in 2871.7ms (44.6 tok/s)
+    Run 8/8: 128 tokens in 2863.4ms (44.7 tok/s)
+  => 44.2 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2833.9ms (45.2 tok/s)
+    Run 2/16: 128 tokens in 2838.1ms (45.1 tok/s)
+    Run 3/16: 128 tokens in 2850.7ms (44.9 tok/s)
+    Run 4/16: 128 tokens in 2844.1ms (45.0 tok/s)
+    Run 5/16: 128 tokens in 2858.6ms (44.8 tok/s)
+    Run 6/16: 128 tokens in 2950.6ms (43.4 tok/s)
+    Run 7/16: 128 tokens in 2889.0ms (44.3 tok/s)
+    Run 8/16: 128 tokens in 2898.1ms (44.2 tok/s)
+    Run 9/16: 128 tokens in 2897.8ms (44.2 tok/s)
+    Run 10/16: 128 tokens in 2843.3ms (45.0 tok/s)
+    Run 11/16: 128 tokens in 2898.9ms (44.2 tok/s)
+    Run 12/16: 128 tokens in 2887.2ms (44.3 tok/s)
+    Run 13/16: 128 tokens in 2915.0ms (43.9 tok/s)
+    Run 14/16: 128 tokens in 2912.2ms (44.0 tok/s)
+    Run 15/16: 128 tokens in 2955.9ms (43.3 tok/s)
+    Run 16/16: 128 tokens in 2941.8ms (43.5 tok/s)
+  => 44.3 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 23.90s (VRAM: 18006 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               498        128         44.8      18280
+4               498        512         44.3      18280
+8               498       1024         44.2      18280
+16              498       2048         44.3      18280
+
+--- Latency (single request) ---
+Prompt tokens:         498
+Prefill time:          333.1 ms (1495 tok/s)
+Time to first token:   333.1 ms
+Mean inter-token:      23.7 ms (42.3 tok/s)
+P50 inter-token:       23.5 ms
+P99 inter-token:       30.1 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.104
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.898506807,
+    "model_vram_mb": 18006
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 498,
+      "output_tokens": 128,
+      "total_time_secs": 2.855039464,
+      "tokens_per_sec": 44.83300550272184,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 498,
+      "output_tokens": 512,
+      "total_time_secs": 11.549365082,
+      "tokens_per_sec": 44.3314412839859,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 498,
+      "output_tokens": 1024,
+      "total_time_secs": 23.157990076,
+      "tokens_per_sec": 44.217999776294576,
+      "peak_vram_mb": 18280
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 498,
+      "output_tokens": 2048,
+      "total_time_secs": 46.216175531,
+      "tokens_per_sec": 44.31348930259887,
+      "peak_vram_mb": 18280
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 498,
+    "prefill_time_ms": 333.07733099999996,
+    "prefill_tokens_per_sec": 1495.1482843484177,
+    "time_to_first_token_ms": 333.07733099999996,
+    "mean_inter_token_ms": 23.657595740157486,
+    "p50_inter_token_ms": 23.467157,
+    "p99_inter_token_ms": 30.0930345,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 42.26972220607161,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.10434782608695652
+  },
+  "training": null
+}

--- a/docs/phase-c18/c18-h-prev-post-norm-fix.md
+++ b/docs/phase-c18/c18-h-prev-post-norm-fix.md
@@ -1,0 +1,154 @@
+# Phase C18 — Fix `h_prev` reference frame (post-final-norm)
+
+## Verdict
+
+**Partial recovery. C17's reference-frame hypothesis is directionally confirmed — α
+improved 4.7× (median 0.033 → 0.153) — but α is still below the 0.5 minimum floor,
+so additional bugs remain downstream. Ship C18 and hand off the residual α gap to
+Phase C19.**
+
+## Context
+
+Phase C17 ([PR #340](https://github.com/ericflo/kiln/pull/340)) established that
+`h_prev` was being returned to the MTP head in the **pre-final-norm** frame,
+whereas the vLLM / SGLang `last_hidden_state` contract requires the
+**post-final-norm** frame. C15 had already measured a 2.0–2.4× magnitude
+ratio between kiln's `h_main` and HF's `hs[-1]`, exactly the signature of one
+RMSNorm being missing.
+
+This task implements the fix and measures its α impact in isolation.
+
+## Change summary
+
+Branch: `ce/mtp-phase-c18-h-prev-post-norm` — commit `dd1cdef`.
+
+### `crates/kiln-model/src/forward.rs`
+
+Both `LmHeadMode::FullWithLastHidden` and `LmHeadMode::LastRowWithLastHidden`
+arms now compute the final RMSNorm once and return the post-norm last-row as
+`h_prev`. The math-cheaper variant is used: one `rms_norm(hidden)` call whose
+output both feeds `lm_head` and (sliced) becomes `last_hidden`.
+
+```rust
+LmHeadMode::FullWithLastHidden => {
+    let normed = rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?;
+    let last_hidden = normed.narrow(1, seq_len - 1, 1)?.contiguous()?;
+    // capture tap: "h_post_final_norm"
+    let logits = normed.broadcast_matmul(&weights.embed_tokens_t)?;
+    Ok((Some(logits), Some(last_hidden)))
+}
+LmHeadMode::LastRowWithLastHidden => {
+    let last_pre_norm = hidden.narrow(1, seq_len - 1, 1)?.contiguous()?;
+    let last_hidden = rms_norm(&last_pre_norm, &weights.final_norm, config.rms_norm_eps)?;
+    // capture tap: "h_post_final_norm"
+    let logits = last_hidden.broadcast_matmul(&weights.embed_tokens_t)?;
+    Ok((Some(logits), Some(last_hidden)))
+}
+```
+
+### `crates/kiln-model/src/mtp_debug.rs`
+
+Renamed the h_main tap from `h_pre_final_norm` → `h_post_final_norm` (docstrings
++ the `h_main_capture_records_then_drains` test).
+
+### `scripts/mtp_reference_dump.py`, `scripts/c15_h_main_drift_audit.py`
+
+Updated docstrings / inline comments to reflect the new contract. HF's
+`output_hidden_states[-1]` is already post-final-norm, so no reference-side
+conversion is required.
+
+## Call-site audit
+
+The two callers of `model_forward_paged_with_last_hidden` both consume `h_prev`
+as MTP context:
+
+- `crates/kiln-server/src/bench.rs:1034` — MTP bench path.
+- `crates/kiln-model/src/speculative.rs:585, 680` — production MTP decode.
+
+Neither depends on the pre-norm frame. No non-MTP callers exist.
+
+## α recovery benchmark
+
+A6000, `KILN_SPEC_METHOD=mtp`, `KILN_W4A16=1`, CUDA graphs ON, prompt 512 tok,
+decode 128 tok, 3 seeds. See `alpha-pre.log` and `alpha-post.log` in this
+directory for raw output.
+
+### Pre-fix (main merge `6b5aa07`)
+
+| seed | α (accepted / drafted) | decode tok/s |
+| --- | --- | --- |
+| 42 | 0.0242 (3/124) | 42.2 |
+| 43 | 0.0325 (4/123) | 42.2 |
+| 44 | 0.1043 (12/115) | 42.2 |
+| **median** | **0.0325** | **42.2** |
+
+### Post-fix (C18 branch `dd1cdef`)
+
+| seed | α (accepted / drafted) | decode tok/s |
+| --- | --- | --- |
+| 42 | 0.1140 (13/114) | 42.4 |
+| 43 | 0.1532 (17/111) | 42.8 |
+| 44 | 0.1869 (20/107) | 43.4 |
+| **median** | **0.1532** | **42.85** |
+
+### Recovery
+
+- **α: 0.0325 → 0.1532 (median)** — **4.7× multiplicative**, +0.12 absolute.
+- **Decode tok/s: 42.2 → 42.85** — essentially unchanged. The single extra
+  `rms_norm` call in the `LastRowWithLastHidden` arm is fully amortized under
+  CUDA graph replay. No measurable regression.
+- Every seed's post-fix α exceeds every seed's pre-fix α.
+
+## Interpretation vs. ship floors
+
+| Floor | Threshold | C18 median α | Status |
+| --- | --- | --- | --- |
+| Minimum (must-pass) | α ≥ 0.5 | 0.1532 | **below floor** |
+| Clean-ship | α ≥ 0.72 | 0.1532 | **below floor** |
+
+The 4.7× recovery confirms C17's directional analysis: `h_prev` reference-frame
+was the single largest pre-decoding bug. The remaining gap to 0.5+ means **at
+least one more bug still sits between `h_prev` and accepted draft tokens**.
+Candidates are tracked in the Phase C19 handoff below.
+
+## Phase C19 handoff — remaining hypotheses
+
+Per C17's first-divergence audit, the following were not disproven as
+secondary contributors. With `h_prev` now in the correct frame, these become
+the new head of the queue and should be tested one at a time, in the order
+that each has the highest math-ceiling × cheapest test cost.
+
+1. **`mtp.fc_norm` vs. `model.norm` reuse.** HF Transformers instantiates a
+   *separate* RMSNorm (`fc_norm`) inside the MTP head and applies it to
+   `h_main` before the `fc` projection. Kiln currently reuses the main
+   final-norm weights for both. Swap to the dedicated `fc_norm` tensors from
+   the checkpoint and re-bench α.
+2. **Dual-norm inversion inside the MTP block.** The MTP decoder block has its
+   own pre-attn / pre-MLP RMSNorms. If kiln's `MtpBlock` currently applies
+   these in the wrong order (or substitutes the main-model norms), token
+   logits will be subtly miscalibrated but still on-manifold — exactly the
+   α ≈ 0.15 shape.
+3. **Rotary `mtp_pos` offset.** MTP inner-block rotary should receive
+   `pos + 1` (the next position) relative to the main block's rotary at `pos`.
+   If kiln feeds the same position index to both, the rotary frequency is
+   off-by-one and draft tokens will consistently miss.
+4. **Gate / residual parameterization.** MTP splices
+   `h_prev` ⊕ `e(token_prev)` through an `fc` linear + residual gate. Check
+   the gate parameterization and the `fc` weight slicing against HF's reference.
+5. **Draft token sampling.** Confirm the draft-side sampler uses temperature
+   and top-p that match main-side semantics. A sampler mismatch (e.g. greedy
+   on draft + sampled on main) manifests as α < 0.2 with the full prefix
+   pipeline otherwise correct.
+
+The B6 inner-MTP splice parity harness already exists (`scripts/mtp_compare.py`
++ `scripts/mtp_h_main_reference_dump.py`) and can be retargeted at each
+hypothesis in turn without additional GPU time for the first two (CPU-only
+tensor comparisons against HF).
+
+## Cost / budget
+
+- Wall-clock on pod: ~35 min (build 12 min sccache-warm, bench 3×2 min pre-fix,
+  rebuild 5 min incremental, bench 3×2 min post-fix, wait-file polls).
+- Pod cost envelope: well under the 120 min / $50 cap.
+- No SSH polling loops used — all long-running commands supervised via
+  `runpod_api.py wait-file` per the kiln RunPod workflow.

--- a/scripts/c15_h_main_drift_audit.py
+++ b/scripts/c15_h_main_drift_audit.py
@@ -198,7 +198,10 @@ def run_hf_reference(
             return_dict=True,
         )
     hs = list(out.hidden_states)
-    # hs[-1] is output after final decoder layer = pre-final-norm hidden
+    # Phase C18: HF's `output_hidden_states` returns the **post-final-norm**
+    # hidden state as `hs[-1]` (equivalent to `last_hidden_state`). Variable
+    # name kept as `pre_final` for downstream compatibility — it is now the
+    # post-final-norm tensor despite the legacy name.
     pre_final = hs[-1].detach()
     return pre_final.to(torch.float32).cpu()
 

--- a/scripts/mtp_reference_dump.py
+++ b/scripts/mtp_reference_dump.py
@@ -18,9 +18,11 @@ Design
 The Qwen3.5-4B main model is a hybrid 24×GDN + 8×GQA stack that we do **not**
 re-implement here — doing so in a single script would be large, slow, and
 itself a new source of bugs. Instead, the reference script takes `h_main`
-(last-row pre-final-norm hidden state from the base model, `[1, 1, H]`) and
-`draft_token_id` **from the kiln dump itself**, and runs a *pure-tensor*
-reference implementation of every op that lives inside `mtp_forward_step`:
+(last-row **post-final-norm** hidden state from the base model, `[1, 1, H]`;
+Phase C18 — prior to the fix this was pre-final-norm, which broke the
+vLLM/SGLang MTP contract) and `draft_token_id` **from the kiln dump itself**,
+and runs a *pure-tensor* reference implementation of every op that lives
+inside `mtp_forward_step`:
 
     1. token_emb   = embed_tokens[draft_token_id]           # [1, 1, H]
     2. norm_emb    = rms_norm(token_emb, pre_fc_norm_embedding)
@@ -642,6 +644,11 @@ def main() -> int:
     print(f"[mtp_ref] rope_theta={rope_theta} rotary_frac={rotary_frac}", file=sys.stderr)
 
     # Pull `h_main` and run the full reference forward.
+    # Phase C18: `h_main` is the post-final-norm last-row hidden state (the
+    # vLLM/SGLang `last_hidden_state` contract). Prior to C18 the kiln dumps
+    # here were pre-final-norm; that was the root cause of α ≈ 0 and is fixed
+    # upstream in forward.rs. No frame-conversion is applied here — the kiln
+    # dump is treated as already post-final-norm.
     h_main = kiln["h_main"].to(torch.float32)  # expected shape [1, 1, H]
     assert h_main.ndim == 3, f"h_main expected 3-D, got {h_main.shape}"
 


### PR DESCRIPTION
## What

Fixes MTP `h_prev` reference-frame bug identified in Phase C17 ([#340](https://github.com/ericflo/kiln/pull/340)).

`model_forward_paged_with_last_hidden` now returns the **post-final-norm** last-row hidden state as `h_prev`, matching the vLLM/SGLang `last_hidden_state` contract consumed by the MTP head. Both `LmHeadMode::FullWithLastHidden` and `LmHeadMode::LastRowWithLastHidden` arms are updated. The math-cheaper variant is used — a single `rms_norm(hidden)` whose output feeds both the logits projection and (sliced) the returned `last_hidden`.

Also renames the debug tap `h_pre_final_norm` → `h_post_final_norm` across `mtp_debug.rs` + scripts, and updates `scripts/mtp_reference_dump.py` + `scripts/c15_h_main_drift_audit.py` comments to reflect the new contract.

## Why

C15 measured kiln's `h_main` at 2.0–2.4× the magnitude of HF's `hs[-1]` — the exact signature of one RMSNorm being skipped. C17 traced this to `h_prev` being returned *before* the final norm, while MTP expects `last_hidden_state` (post-norm).

## α-recovery bench (A6000, KILN_SPEC_METHOD=mtp, KILN_W4A16=1, 512×128, 3 seeds)

| | seed 42 | seed 43 | seed 44 | **median** |
| --- | --- | --- | --- | --- |
| **Pre-fix** (main `6b5aa07`) | 0.0242 | 0.0325 | 0.1043 | **0.0325** |
| **Post-fix** (this branch) | 0.1140 | 0.1532 | 0.1869 | **0.1532** |

**Recovery: 4.7× multiplicative, +0.12 absolute.**
Decode tok/s 42.2 → 42.85 (unchanged — CUDA graphs amortize the single extra `rms_norm`).

## Interpretation

The 4.7× α recovery directionally confirms C17's hypothesis that `h_prev` reference-frame was the single largest pre-decoding bug. However α = 0.153 is still below both ship-floors (0.5 minimum, 0.72 clean-ship), so at least one more bug remains downstream.

**Per task spec, this ships + hands off the residual α gap to Phase C19.** Remaining hypotheses (from the C17 first-divergence audit) are enumerated in `docs/phase-c18/c18-h-prev-post-norm-fix.md`:

1. `fc_norm` swap (HF uses a separate MTP norm; kiln reuses the main final-norm)
2. Dual-norm inversion inside `MtpBlock`
3. Rotary `mtp_pos` off-by-one (draft should use `pos + 1`)
4. Gate / residual parameterization in the MTP `fc` splice
5. Draft-side sampler parity

## Files touched

- `crates/kiln-model/src/forward.rs` — both `*WithLastHidden` arms return post-norm `h_prev`
- `crates/kiln-model/src/mtp_debug.rs` — tap renamed `h_pre_final_norm` → `h_post_final_norm` (+ test)
- `scripts/mtp_reference_dump.py` — docstring + inline comment updated; no reference-side conversion needed
- `scripts/c15_h_main_drift_audit.py` — line 201 comment updated to "post-final-norm"
- `docs/phase-c18/` — verdict doc + raw α-bench logs

## Call-site audit

Only `bench.rs:1034` and `speculative.rs:585,680` consume `h_prev`; both are MTP paths and both now receive the correct post-norm frame. No non-MTP callers exist.