### PR TITLE
[codex] Use head-major SDPA for Metal paged decode

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2930,16 +2930,34 @@ fn try_flash_attn_paged_decode(
         {
             let k_live = k_pool.narrow(0, start_slot, total_seq_len)?.unsqueeze(0)?;
             let v_live = v_pool.narrow(0, start_slot, total_seq_len)?.unsqueeze(0)?;
-            if let Some(attn_output) = flash_attention_forward(
-                backend,
-                &q_fa,
-                &k_live,
-                &v_live,
-                num_heads,
-                num_kv_heads,
-                head_dim,
-            )? {
-                // `flash_attention_forward` already reshapes to
+            let attn_output = if backend.supports_flash_attn_prefill_head_major() {
+                // Q is already head-major at the call site. Keep K/V grouped
+                // instead of routing through `flash_attention_forward`, which
+                // expands GQA K/V before Metal SDPA and defeats Candle's
+                // native vector-attention GQA path.
+                let k_head = k_live.transpose(1, 2)?.contiguous()?;
+                let v_head = v_live.transpose(1, 2)?.contiguous()?;
+                flash_attention_forward_head_major(
+                    backend, q, &k_head, &v_head, num_heads, head_dim,
+                )?
+            } else {
+                None
+            };
+            let attn_output = if attn_output.is_some() {
+                attn_output
+            } else {
+                flash_attention_forward(
+                    backend,
+                    &q_fa,
+                    &k_live,
+                    &v_live,
+                    num_heads,
+                    num_kv_heads,
+                    head_dim,
+                )?
+            };
+            if let Some(attn_output) = attn_output {
+                // The flash-attention helpers already reshape to
                 // [batch, seq_len, num_heads * head_dim].
                 let _ = crate::mtp_debug::capture_subop("post_attn_raw", &attn_output);
 


### PR DESCRIPTION
## Summary

This changes the contiguous-slot paged decode fast path to prefer the backend head-major SDPA entrypoint when it is available. On Metal, Q is already head-major and Candle's vector SDPA supports native GQA, so routing through the generic token-major helper was unnecessarily expanding grouped K/V to all query heads before dispatch.

The existing token-major helper remains as a fallback for backends that do not support the head-major path.

## Validation

- `CARGO_TARGET_DIR=/tmp/kiln-real-kv-prewarm/target cargo test -p kiln-model --features metal test_paged_decode_parity_with_direct_sdpa --locked -- --nocapture`
- `CARGO_TARGET_DIR=/tmp/kiln-real-kv-prewarm/target cargo check -p kiln-server --features metal --locked`
- Real Qwen desktop-path bench, patched: `mean_inter_token_ms=251.5`
- Same-session main baseline: `mean_inter_token_ms=255.3`

This is a small default-path decode cleanup, not the final llama.cpp gap closure.