### PR TITLE
[codex] Speed up macOS default MTP decode

### DIFF
--- a/crates/kiln-model/src/speculative.rs
+++ b/crates/kiln-model/src/speculative.rs
@@ -11,8 +11,8 @@
 
 use anyhow::{Context, Result};
 use candle_core::{DType, Tensor};
+use rand::Rng;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
 
 use kiln_core::block::BlockTable;
 use kiln_core::config::ModelConfig;
@@ -22,9 +22,8 @@ use kiln_core::token::TokenId;
 use crate::backend::BackendRuntime;
 use crate::c1_attr;
 use crate::forward::{
-    model_forward, model_forward_embed, model_forward_head,
-    model_forward_paged_with_last_hidden, model_forward_segment, mtp_forward_step, GpuWeights,
-    LinearAttentionState,
+    GpuWeights, LinearAttentionState, model_forward, model_forward_embed, model_forward_head,
+    model_forward_paged_with_last_hidden, model_forward_segment, mtp_forward_step,
 };
 use crate::kv_cache::KvCache;
 use crate::paged_kv_cache::PagedKvCache;
@@ -249,7 +248,14 @@ pub fn draft_forward_for_state_init(
     draft_layers: usize,
     linear_state: &mut LinearAttentionState,
 ) -> Result<()> {
-    let _ = draft_forward(backend, token_ids, weights, config, draft_layers, linear_state)?;
+    let _ = draft_forward(
+        backend,
+        token_ids,
+        weights,
+        config,
+        draft_layers,
+        linear_state,
+    )?;
     Ok(())
 }
 
@@ -371,12 +377,8 @@ pub fn speculative_decode_step(
                 // Target disagrees with EOS — accept target's token instead
                 accepted_tokens.push(target_token);
             } else {
-                let (accepted, resampled) = rejection_sample(
-                    draft_token,
-                    &draft_probs_list[i],
-                    &target_probs,
-                    rng,
-                )?;
+                let (accepted, resampled) =
+                    rejection_sample(draft_token, &draft_probs_list[i], &target_probs, rng)?;
                 if accepted {
                     hit_eos = true;
                     break;
@@ -408,12 +410,8 @@ pub fn speculative_decode_step(
             }
         } else {
             // Stochastic verification via rejection sampling
-            let (accepted, resampled) = rejection_sample(
-                draft_token,
-                &draft_probs_list[i],
-                &target_probs,
-                rng,
-            )?;
+            let (accepted, resampled) =
+                rejection_sample(draft_token, &draft_probs_list[i], &target_probs, rng)?;
 
             if accepted {
                 accepted_tokens.push(draft_token);
@@ -437,13 +435,7 @@ pub fn speculative_decode_step(
         let bonus_token = if temperature == 0.0 {
             greedy_sample(&bonus_logits)?
         } else {
-            sample_with_params(
-                &bonus_logits,
-                temperature,
-                params.top_p,
-                params.top_k,
-                None,
-            )?
+            sample_with_params(&bonus_logits, temperature, params.top_p, params.top_k, None)?
         };
 
         if eos_token_ids.contains(&bonus_token) {
@@ -469,7 +461,7 @@ pub fn speculative_decode_step(
 /// Result of one native MTP (Multi-Token Prediction) speculative decoding step.
 ///
 /// In addition to the accepted tokens and EOS flag produced by
-/// [`SpeculativeStepResult`], MTP also threads a new `h_prev` (pre-final-norm
+/// [`SpeculativeStepResult`], MTP also threads a new `h_prev` (post-final-norm
 /// hidden state from the base-model verify pass) and advances the MTP
 /// position counter independently of the base position counter.
 #[derive(Debug)]
@@ -479,16 +471,12 @@ pub struct MtpSpeculativeStepResult {
     pub accepted_tokens: Vec<TokenId>,
     /// Whether an EOS token was encountered in the accepted run.
     pub hit_eos: bool,
-    /// Pre-final-norm hidden state to feed into the NEXT MTP step.
+    /// Post-final-norm hidden state to feed into the NEXT MTP step.
     ///
     /// On ACCEPT this is the hidden at the draft token's position in the
-    /// verify pass (correctly predicts the bonus). On REJECT this is also the
-    /// draft position's hidden — a known approximation because the draft was
-    /// rejected, so the true h_prev for the corrected token is one position
-    /// earlier. The staleness typically costs <5% of acceptance rate for k=1
-    /// MTP; extracting both positions from the verify pass is a follow-up
-    /// optimisation that requires returning `[1, seq_len, H]` instead of only
-    /// the last row.
+    /// verify pass, which predicts the bonus. On REJECT this is the hidden
+    /// after replaying only `last_token`, so the next draft starts from exact
+    /// base-model GDN state.
     pub new_h_prev: Tensor,
     /// How many KV-cache slots the BASE model consumed this step
     /// (`= accepted_tokens.len()` when no EOS cut the step short, and
@@ -528,8 +516,8 @@ pub struct MtpSpeculativeStepResult {
 ///    KV slot; the base KV at `base_pos + 1` is also written but stale and is
 ///    overwritten on the next iteration when the corrected token is processed
 ///    as the new `last_token`).
-/// 5. Return the new `h_prev` (hidden at the draft position) so the caller
-///    can thread it into the next MTP step.
+/// 5. Return the new `h_prev`: the draft position on accept, or the replayed
+///    `last_token` position on reject.
 ///
 /// Greedy-only path (temperature == 0). The stochastic rejection-sampling
 /// variant is a follow-up; this implementation takes the minimum viable path
@@ -576,15 +564,18 @@ pub fn speculative_mtp_decode_step(
     .context("mtp draft step failed")?;
     let draft_token = greedy_sample(&mtp_logits).context("mtp draft sampling failed")?;
 
-    // 2. Verify the draft with a one-token base-model step. A single
-    // `[last_token, draft_token]` call is mathematically equivalent for
-    // greedy verification, but it misses Metal's single-token decode fast
-    // paths. Split verification keeps the base model on the normal decode
-    // path and lets us skip the second token entirely on rejection.
-    let verify_input0 = [last_token];
-    let (verify_logits0, hidden_after_last) = model_forward_paged_with_last_hidden(
+    // 2. Verify the draft with one two-token base-model pass. This is the only
+    // k=1 MTP shape that can amortize base-model overhead: on accept the pass
+    // both verifies `draft_token` and produces the bonus-token logits. On
+    // rejection we restore the GDN state snapshot and replay the one committed
+    // token so the base recurrent state remains exact.
+    let linear_state_snapshot = linear_state
+        .snapshot()
+        .context("snapshot linear attention state before MTP verify")?;
+    let verify_input = [last_token, draft_token];
+    let (verify_logits, hidden_after_draft) = model_forward_paged_with_last_hidden(
         backend,
-        &verify_input0,
+        &verify_input,
         weights,
         config,
         base_cache,
@@ -594,13 +585,11 @@ pub fn speculative_mtp_decode_step(
         None, // no LoRA on the verify pass — keep parity with scaffolding.
         None, // positions_gpu: let the forward pass build positions internally.
     )
-    .context("mtp verify position 0 forward failed")?;
+    .context("mtp two-token verify forward failed")?;
 
-    // Position 0 predicts what follows `last_token`; compare it with the MTP
-    // draft. If it rejects, `hidden_after_last` is the correct `h_prev` for
-    // the next MTP step because the accepted token will be consumed as the
-    // next loop's `last_token`.
-    let verify_pos0 = verify_logits0.squeeze(1)?;
+    // Position 0 predicts what follows `last_token`; position 1 predicts what
+    // follows the accepted draft token (the speculative bonus).
+    let verify_pos0 = verify_logits.narrow(1, 0, 1)?.squeeze(1)?;
     let target_at_0 = greedy_sample(&verify_pos0).context("verify pos-0 sampling failed")?;
 
     // 3. Accept / reject decision. Greedy compare.
@@ -666,7 +655,7 @@ pub fn speculative_mtp_decode_step(
         );
     }
 
-    let mut new_h_prev = hidden_after_last;
+    let mut new_h_prev = hidden_after_draft.clone();
     let (base_advance, mtp_advance) = if draft_accepted {
         // ACCEPT: draft_token matches target. Emit [draft, bonus].
         if eos_token_ids.contains(&draft_token) {
@@ -676,22 +665,7 @@ pub fn speculative_mtp_decode_step(
             (1, 1)
         } else {
             accepted_tokens.push(draft_token);
-            let verify_input1 = [draft_token];
-            let (verify_logits1, hidden_after_draft) = model_forward_paged_with_last_hidden(
-                backend,
-                &verify_input1,
-                weights,
-                config,
-                base_cache,
-                base_block_table,
-                base_pos + 1,
-                Some(linear_state),
-                None, // no LoRA on the verify pass — keep parity with scaffolding.
-                None, // positions_gpu: let the forward pass build positions internally.
-            )
-            .context("mtp verify bonus forward failed")?;
-            new_h_prev = hidden_after_draft;
-            let verify_pos1 = verify_logits1.squeeze(1)?;
+            let verify_pos1 = verify_logits.narrow(1, 1, 1)?.squeeze(1)?;
             let bonus = greedy_sample(&verify_pos1).context("bonus sampling failed")?;
             if eos_token_ids.contains(&bonus) {
                 hit_eos = true;
@@ -702,6 +676,29 @@ pub fn speculative_mtp_decode_step(
             (2, 1)
         }
     } else {
+        // Restore to the state before the optimistic two-token verifier, then
+        // replay exactly the committed token. The stale base KV written at
+        // `base_pos + 1` is outside the next attention window and will be
+        // overwritten if that slot becomes live later.
+        linear_state
+            .restore_from(&linear_state_snapshot)
+            .context("restore linear attention state after MTP rejection")?;
+        let verify_input0 = [last_token];
+        let (_verify_logits0, hidden_after_last) = model_forward_paged_with_last_hidden(
+            backend,
+            &verify_input0,
+            weights,
+            config,
+            base_cache,
+            base_block_table,
+            base_pos,
+            Some(linear_state),
+            None,
+            None,
+        )
+        .context("mtp rejection replay forward failed")?;
+        new_h_prev = hidden_after_last;
+
         // REJECT: emit the target's token at position 0.
         if eos_token_ids.contains(&target_at_0) {
             hit_eos = true;
@@ -727,6 +724,7 @@ pub fn speculative_mtp_decode_step(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::SeedableRng;
 
     fn make_rng(seed: u64) -> StdRng {
         StdRng::seed_from_u64(seed)
@@ -756,14 +754,20 @@ mod tests {
         // Token 0 should always be accepted (p_target/p_draft = 4.0, clamped to 1.0)
         for _ in 0..50 {
             let (accepted, _) = rejection_sample(0, &draft_probs, &target_probs, &mut rng).unwrap();
-            assert!(accepted, "token 0 should always be accepted when target concentrates on it");
+            assert!(
+                accepted,
+                "token 0 should always be accepted when target concentrates on it"
+            );
         }
 
         // Token 1 should always be rejected (p_target = 0)
         for _ in 0..50 {
             let (accepted, resampled) =
                 rejection_sample(1, &draft_probs, &target_probs, &mut rng).unwrap();
-            assert!(!accepted, "token 1 should always be rejected when target assigns 0 prob");
+            assert!(
+                !accepted,
+                "token 1 should always be rejected when target assigns 0 prob"
+            );
             // Resampled token should always be 0 (the only token with mass in adjusted dist)
             assert_eq!(resampled, Some(0), "resampled should be token 0");
         }
@@ -833,13 +837,10 @@ mod tests {
     fn test_logits_to_probs_2d() {
         let device = candle_core::Device::Cpu;
         // [seq_len=2, vocab_size=3]
-        let logits = Tensor::new(
-            &[1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0],
-            &device,
-        )
-        .unwrap()
-        .reshape((2, 3))
-        .unwrap();
+        let logits = Tensor::new(&[1.0_f32, 2.0, 3.0, 4.0, 5.0, 6.0], &device)
+            .unwrap()
+            .reshape((2, 3))
+            .unwrap();
 
         // Should extract last position (4.0, 5.0, 6.0)
         let probs = logits_to_probs(&logits, 1.0).unwrap();

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -149,6 +149,8 @@ enum ResolvedSpeculativeMode {
     Mtp,
 }
 
+const MTP_MAX_PROMPT_TOKENS_DEFAULT: usize = 128;
+
 fn resolve_skip_layer_config(
     model_config: &kiln_core::config::ModelConfig,
     speculative: &SpeculativeDecodingConfig,
@@ -165,6 +167,7 @@ fn resolve_speculative_mode_from_config(
     model_config: &kiln_core::config::ModelConfig,
     speculative: &SpeculativeDecodingConfig,
     sampling: &SamplingParams,
+    prompt_tokens: usize,
     mtp_supported: bool,
     has_active_lora: bool,
 ) -> ResolvedSpeculativeMode {
@@ -176,12 +179,14 @@ fn resolve_speculative_mode_from_config(
             .map(ResolvedSpeculativeMode::SkipLayer)
             .unwrap_or(ResolvedSpeculativeMode::Off),
         SpecMethod::Mtp => {
-            if mtp_supported && sampling.temperature == 0.0 && !has_active_lora {
+            if mtp_supported
+                && sampling.temperature == 0.0
+                && !has_active_lora
+                && prompt_tokens <= MTP_MAX_PROMPT_TOKENS_DEFAULT
+            {
                 ResolvedSpeculativeMode::Mtp
             } else {
-                skip_layer
-                    .map(ResolvedSpeculativeMode::SkipLayer)
-                    .unwrap_or(ResolvedSpeculativeMode::Off)
+                ResolvedSpeculativeMode::Off
             }
         }
     }
@@ -190,6 +195,7 @@ fn resolve_speculative_mode_from_config(
 fn resolve_speculative_mode(
     state: &AppState,
     sampling: &SamplingParams,
+    prompt_tokens: usize,
     mtp_supported: bool,
     has_active_lora: bool,
 ) -> ResolvedSpeculativeMode {
@@ -198,6 +204,7 @@ fn resolve_speculative_mode(
         &state.model_config,
         &speculative,
         sampling,
+        prompt_tokens,
         mtp_supported,
         has_active_lora,
     )
@@ -432,8 +439,13 @@ async fn generate_real(
         let guard = runner.read().unwrap();
         (guard.weights.mtp.is_some(), guard.active_lora().is_some())
     };
-    let speculative_mode =
-        resolve_speculative_mode(state, sampling, mtp_supported, has_active_lora);
+    let speculative_mode = resolve_speculative_mode(
+        state,
+        sampling,
+        prompt_token_count,
+        mtp_supported,
+        has_active_lora,
+    );
 
     // ModelRunner.generate_paged() is CPU-bound; run on a blocking thread to
     // avoid starving the tokio runtime.
@@ -536,8 +548,13 @@ async fn generate_real_streaming(
         let guard = runner.read().unwrap();
         (guard.weights.mtp.is_some(), guard.active_lora().is_some())
     };
-    let speculative_mode =
-        resolve_speculative_mode(state, sampling, mtp_supported, has_active_lora);
+    let speculative_mode = resolve_speculative_mode(
+        state,
+        sampling,
+        prompt_tokens.len(),
+        mtp_supported,
+        has_active_lora,
+    );
 
     let runner = runner.clone();
     let bm = block_manager.clone();
@@ -958,6 +975,7 @@ mod tests {
             &ModelConfig::qwen3_5_4b(),
             &cfg,
             &make_sampling(1.0),
+            16,
             false,
             false,
         );
@@ -984,6 +1002,7 @@ mod tests {
             &ModelConfig::qwen3_5_4b(),
             &cfg,
             &make_sampling(0.0),
+            16,
             true,
             false,
         );
@@ -993,19 +1012,31 @@ mod tests {
             &ModelConfig::qwen3_5_4b(),
             &cfg,
             &make_sampling(0.7),
+            16,
             true,
             false,
         );
-        assert!(matches!(sampled, ResolvedSpeculativeMode::SkipLayer(_)));
+        assert!(matches!(sampled, ResolvedSpeculativeMode::Off));
 
         let with_lora = resolve_speculative_mode_from_config(
             &ModelConfig::qwen3_5_4b(),
             &cfg,
             &make_sampling(0.0),
+            16,
             true,
             true,
         );
-        assert!(matches!(with_lora, ResolvedSpeculativeMode::SkipLayer(_)));
+        assert!(matches!(with_lora, ResolvedSpeculativeMode::Off));
+
+        let long_prompt = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &make_sampling(0.0),
+            MTP_MAX_PROMPT_TOKENS_DEFAULT + 1,
+            true,
+            false,
+        );
+        assert!(matches!(long_prompt, ResolvedSpeculativeMode::Off));
     }
 
     #[test]
@@ -1020,6 +1051,7 @@ mod tests {
             &ModelConfig::qwen3_5_4b(),
             &cfg,
             &make_sampling(1.0),
+            16,
             false,
             false,
         );

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -19,8 +19,8 @@ use kiln_model::ModelRunner;
 use kiln_model::backend as runtime_backend;
 use kiln_model::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
-    model_forward_paged_last_token, model_forward_paged_streaming,
-    model_forward_paged_with_last_hidden, streaming_prefill_enabled,
+    model_forward_paged_last_token, model_forward_paged_last_token_with_last_hidden,
+    model_forward_paged_streaming, streaming_prefill_enabled,
 };
 use kiln_model::kv_cache::KvCache;
 use kiln_model::paged_kv_cache::PagedKvCache;
@@ -1031,7 +1031,7 @@ fn bench_latency_paged_mtp(
     // Prefill: paged forward returning (logits, last-position hidden state)
     // so we can seed h_prev for the first MTP draft step.
     let prefill_start = Instant::now();
-    let (prefill_logits, mut h_prev) = model_forward_paged_with_last_hidden(
+    let (prefill_logits, mut h_prev) = model_forward_paged_last_token_with_last_hidden(
         &*backend,
         &prompt_token_ids,
         weights,
@@ -1045,10 +1045,8 @@ fn bench_latency_paged_mtp(
     )
     .context("MTP prefill (paged with last-hidden) failed")?;
 
-    // prefill_logits is [1, seq_len, V]; slice the last row before sampling.
-    let prefill_last = prefill_logits
-        .narrow(1, prompt_token_ids.len() - 1, 1)?
-        .squeeze(1)?;
+    // prefill_logits is already [1, 1, V].
+    let prefill_last = prefill_logits.squeeze(1)?;
     let mut last_token = greedy_sample(&prefill_last)?;
     let prefill_time = prefill_start.elapsed();
 
@@ -1119,7 +1117,7 @@ fn bench_latency_paged_mtp(
         }
 
         let per_token_ms = (step_time.as_secs_f64() * 1000.0) / step.accepted_tokens.len() as f64;
-        for &tok in &step.accepted_tokens {
+        for &_tok in &step.accepted_tokens {
             inter_token_ms.push(per_token_ms);
             num_tokens += 1;
             if num_tokens >= max_output_tokens {

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::sync::atomic::Ordering;
 
 use anyhow::Result;
 use clap::Parser;
@@ -302,6 +302,13 @@ fn spawn_backend_prewarm(state: AppState) {
                 &mut block_manager,
                 &mut paged_cache,
             )?;
+            if runner_guard.weights.mtp.is_some() {
+                let mtp_params = SamplingParams {
+                    max_tokens: 4,
+                    ..params.clone()
+                };
+                runner_guard.generate_from_tokens_mtp_speculative(&prompt_tokens, &mtp_params)?;
+            }
             Ok(())
         })
         .await;

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -522,7 +522,7 @@ textarea { resize: vertical; min-height: 80px; }
           <option value="">Base Model</option>
         </select>
         <label style="font-size:12px;color:var(--text2);margin-left:8px;">Temp:</label>
-        <input type="number" id="chat-temp" value="0.7" min="0" max="2" step="0.1" style="width:70px;">
+        <input type="number" id="chat-temp" value="0.0" min="0" max="2" step="0.1" style="width:70px;">
       </div>
       <div class="chat-messages" id="chat-messages"></div>
       <div class="chat-input-row">
@@ -921,7 +921,8 @@ async function sendChat() {
   renderChat();
 
   const adapter = document.getElementById('chat-adapter').value || undefined;
-  const temp = parseFloat(document.getElementById('chat-temp').value) || 0.7;
+  const parsedTemp = parseFloat(document.getElementById('chat-temp').value);
+  const temp = Number.isFinite(parsedTemp) ? parsedTemp : 0.0;
 
   const body = {
     messages: chatMessages.filter(m => m.content).map(m => ({ role: m.role, content: m.content })),

--- a/desktop/src/settings.rs
+++ b/desktop/src/settings.rs
@@ -37,7 +37,7 @@ impl Default for Settings {
             fp8_kv_cache: false,
             cuda_graphs: !cfg!(target_os = "macos"),
             prefix_cache: true,
-            speculative_decoding: false,
+            speculative_decoding: cfg!(target_os = "macos"),
             adapter_dir: None,
             served_model_id: None,
             auto_start: true,
@@ -171,6 +171,10 @@ pub fn apply_to_supervisor_config(s: &Settings, cfg: &mut SupervisorConfig) {
         "KILN_SPEC_ENABLED".to_string(),
         bool_env(s.speculative_decoding),
     ));
+    envs.push((
+        "KILN_SPEC_METHOD".to_string(),
+        if s.speculative_decoding { "mtp" } else { "off" }.to_string(),
+    ));
     if let Some(dir) = &s.adapter_dir {
         envs.push(("KILN_ADAPTER_DIR".to_string(), dir.display().to_string()));
     }
@@ -196,7 +200,11 @@ pub fn apply_to_supervisor_config(s: &Settings, cfg: &mut SupervisorConfig) {
 }
 
 fn bool_env(b: bool) -> String {
-    if b { "1".into() } else { "0".into() }
+    if b {
+        "1".into()
+    } else {
+        "0".into()
+    }
 }
 
 #[cfg(test)]
@@ -213,7 +221,7 @@ mod tests {
         assert!(!s.fp8_kv_cache);
         assert_eq!(s.cuda_graphs, !cfg!(target_os = "macos"));
         assert!(s.prefix_cache);
-        assert!(!s.speculative_decoding);
+        assert_eq!(s.speculative_decoding, cfg!(target_os = "macos"));
         assert!(s.auto_start);
         assert!(s.auto_restart);
         assert!(!s.launch_at_login);
@@ -254,7 +262,18 @@ mod tests {
             Some(if cfg!(target_os = "macos") { "0" } else { "1" })
         );
         assert_eq!(env_get("KILN_PREFIX_CACHE_ENABLED"), Some("1")); // default true
-        assert_eq!(env_get("KILN_SPEC_ENABLED"), Some("0")); // default false
+        assert_eq!(
+            env_get("KILN_SPEC_ENABLED"),
+            Some(if cfg!(target_os = "macos") { "1" } else { "0" })
+        );
+        assert_eq!(
+            env_get("KILN_SPEC_METHOD"),
+            Some(if cfg!(target_os = "macos") {
+                "mtp"
+            } else {
+                "off"
+            })
+        );
         assert_eq!(env_get("KILN_MODEL_PATH"), Some("/models/foo"));
         assert_eq!(env_get("KILN_ADAPTER_DIR"), Some("/adapters"));
         assert_eq!(env_get("KILN_SERVED_MODEL_ID"), Some("custom-id"));


### PR DESCRIPTION
## Summary

This makes the macOS default inference path use the fast native MTP route under the same default desktop-app conditions instead of hiding the speedup behind a manual flag.

- Reworks k=1 MTP verification to use one two-token base verifier pass, so accepted drafts amortize the base forward and reuse position-1 logits for the bonus token.
- Keeps rejection exact by snapshotting/restoring GDN linear state and replaying the committed token only on reject.
- Makes the desktop macOS default enable MTP via `KILN_SPEC_ENABLED=1` and `KILN_SPEC_METHOD=mtp`, warms the MTP path during server prewarm, and makes the built-in chat UI default to greedy temp `0.0` without treating `0` as falsy.
- Guards API MTP use to the measured fast envelope: MTP weights present, greedy sampling, no active LoRA, and prompt length <= 128 tokens. Ineligible requests now fall back to normal decode instead of silently using skip-layer speculation.
- Updates the MTP benchmark prefill to project only the final prompt row while still returning the last hidden state.

## Validation

- `cargo test -p kiln-server --features metal --locked api::completions::tests -- --nocapture`
- `cargo check -p kiln-server --features metal --locked`
- `cargo test -p kiln-model --features metal --locked test_rejection_sample_identical_distributions -- --nocapture`
- `cargo test --manifest-path desktop/Cargo.toml --locked settings -- --nocapture`
- `cargo check --manifest-path desktop/Cargo.toml --locked`
- `git diff --check -- crates/kiln-model/src/speculative.rs crates/kiln-server/src/api/completions.rs crates/kiln-server/src/bench.rs crates/kiln-server/src/main.rs crates/kiln-server/src/ui.html desktop/src/settings.rs`

## Benchmarks

Measured on the local macOS Metal desktop model path before the final resolver guard tweak, which does not affect the explicit MTP bench path:

- Short prompt, 15 input / 16 output, explicit MTP: mean ITL improved from ~425.1ms to ~170.4ms, throughput from ~2.35 tok/s to ~5.9 tok/s, acceptance alpha 1.000.
- Same short shape beats the local llama.cpp master comparison for this prompt shape (~4.26 tok/s).
- Long prompt, 512 input / 256 output, explicit MTP remains slower than non-MTP, so API/default routing limits MTP to prompts <= 128 tokens while the next patch targets long-context decode.