### PR TITLE
[codex] Route long macOS decode through paged skip-layer

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -387,6 +387,23 @@ impl LinearAttentionState {
         })
     }
 
+    /// Snapshot for decode rollback.
+    ///
+    /// Recurrent tensors are replaced on update, so Arc-cloning their handles
+    /// preserves the pre-step value without a device copy. Conv state is mutated
+    /// in-place by the Metal/CUDA update kernels, so it must still be copied.
+    pub fn snapshot_for_decode_rollback(&self) -> Result<Self> {
+        let recurrent_states = self.recurrent_states.clone();
+        let mut conv_states = Vec::with_capacity(self.conv_states.len());
+        for t in &self.conv_states {
+            conv_states.push(t.copy().context("snapshot conv state")?);
+        }
+        Ok(Self {
+            recurrent_states,
+            conv_states,
+        })
+    }
+
     /// Restore this state from a previously captured [`Self::snapshot`].
     ///
     /// Checks that the shapes/counts match — a mismatch indicates the caller
@@ -420,6 +437,29 @@ impl LinearAttentionState {
         for (dst, src) in self.conv_states.iter_mut().zip(snapshot.conv_states.iter()) {
             *dst = src.copy().context("restore conv state")?;
         }
+        Ok(())
+    }
+
+    /// Restore from [`Self::snapshot_for_decode_rollback`] without recopying
+    /// recurrent state. The snapshot owns fresh conv-state copies, so assigning
+    /// their tensor handles is enough to restore the old conv buffers as well.
+    pub fn restore_from_decode_rollback(&mut self, snapshot: &Self) -> Result<()> {
+        if self.recurrent_states.len() != snapshot.recurrent_states.len() {
+            anyhow::bail!(
+                "LinearAttentionState::restore_from_decode_rollback: recurrent_states len mismatch ({} vs {})",
+                self.recurrent_states.len(),
+                snapshot.recurrent_states.len()
+            );
+        }
+        if self.conv_states.len() != snapshot.conv_states.len() {
+            anyhow::bail!(
+                "LinearAttentionState::restore_from_decode_rollback: conv_states len mismatch ({} vs {})",
+                self.conv_states.len(),
+                snapshot.conv_states.len()
+            );
+        }
+        self.recurrent_states.clone_from(&snapshot.recurrent_states);
+        self.conv_states.clone_from(&snapshot.conv_states);
         Ok(())
     }
 }
@@ -902,8 +942,8 @@ impl GpuWeights {
                 .context("embed_tokens stub")?;
             (embed_tokens, embed_tokens_t)
         } else {
-            let embed_tokens =
-                weight_to_tensor(&weights.embedding.embed_tokens, device).context("embed_tokens")?;
+            let embed_tokens = weight_to_tensor(&weights.embedding.embed_tokens, device)
+                .context("embed_tokens")?;
             let embed_tokens_t =
                 cached_transpose_for_weight(&weights.embedding.embed_tokens, &embed_tokens, device)
                     .context("embed_tokens cached transpose")?;
@@ -1630,13 +1670,8 @@ fn gdn_qk_norm(q: &Tensor, k: &Tensor, input_dtype: DType, scale: f64) -> Result
     #[cfg(feature = "metal")]
     {
         if input_dtype == DType::BF16 && crate::backend::metal::metal_gdn_qk_norm_supports(q, k) {
-            return crate::backend::metal::metal_gdn_qk_norm_f32_bf16(
-                q,
-                k,
-                scale as f32,
-                1e-6,
-            )
-            .context("metal gdn qk_norm kernel failed");
+            return crate::backend::metal::metal_gdn_qk_norm_f32_bf16(q, k, scale as f32, 1e-6)
+                .context("metal gdn qk_norm kernel failed");
         }
     }
 
@@ -3480,8 +3515,7 @@ pub fn gqa_attention_paged(
             crate::mtp_debug::capture_c7_sdpa_tap("pre_sdpa_q", &q)?;
             crate::mtp_debug::capture_c7_sdpa_tap("pre_sdpa_k", &k)?;
             crate::mtp_debug::capture_c7_sdpa_tap("pre_sdpa_v", &v)?;
-            let empty_mask =
-                candle_core::Tensor::zeros((), candle_core::DType::F32, q.device())?;
+            let empty_mask = candle_core::Tensor::zeros((), candle_core::DType::F32, q.device())?;
             crate::mtp_debug::capture_c7_sdpa_tap("causal_mask", &empty_mask)?;
         }
 
@@ -4448,8 +4482,7 @@ pub fn mtp_forward_step(
     } else {
         crate::mtp_debug::try_consume_dump_slot_for_pos(mtp_pos)
     };
-    let dump_pre_rope =
-        should_dump && crate::mtp_debug::is_dump_pre_rope_effectively_enabled();
+    let dump_pre_rope = should_dump && crate::mtp_debug::is_dump_pre_rope_effectively_enabled();
     if dump_pre_rope {
         crate::mtp_debug::arm_pre_rope_capture();
     }
@@ -4545,9 +4578,7 @@ pub fn mtp_forward_step(
             let in_dtype = concat.dtype();
             let concat_f32 = concat.to_dtype(candle_core::DType::F32)?;
             let fc_t_f32 = mtp.fc_t.to_dtype(candle_core::DType::F32)?;
-            concat_f32
-                .broadcast_matmul(&fc_t_f32)?
-                .to_dtype(in_dtype)?
+            concat_f32.broadcast_matmul(&fc_t_f32)?.to_dtype(in_dtype)?
         } else {
             concat.broadcast_matmul(&mtp.fc_t)?
         }
@@ -4703,8 +4734,7 @@ pub fn mtp_forward_step(
         // can substitute `{step}` alongside `{pos}` so each of the up-to-8
         // per-position dumps lands in its own file. Falls back to the legacy
         // `{pos}`-only substitution when splice is off.
-        let dump_path_opt =
-            crate::mtp_debug::dump_path_for_pos_and_step(mtp_pos, splice_step);
+        let dump_path_opt = crate::mtp_debug::dump_path_for_pos_and_step(mtp_pos, splice_step);
         // Always drain the C7 TLS slot before returning. If we entered the
         // armed C7 path above but `dump_path_for_pos` returned None (pos not
         // listed in `KILN_MTP_DUMP_POS`), the slot would otherwise leak
@@ -4999,7 +5029,8 @@ fn model_forward_paged_inner(
                     config,
                     &mut state.recurrent_states[linear_attn_idx],
                     &mut state.conv_states[linear_attn_idx],
-                    /* capture_b11_taps = */ crate::mtp_debug::should_capture_b11_tap_for_layer(i),
+                    /* capture_b11_taps = */
+                    crate::mtp_debug::should_capture_b11_tap_for_layer(i),
                 )
                 .with_context(|| format!("gated deltanet layer {i} (linear attention, paged)"))?;
                 hidden = {
@@ -6151,8 +6182,7 @@ mod tests {
         for col in 0..cols {
             for row in 0..rows {
                 let got_offset = (col * rows + row) * 2;
-                let got =
-                    u16::from_le_bytes([transposed[got_offset], transposed[got_offset + 1]]);
+                let got = u16::from_le_bytes([transposed[got_offset], transposed[got_offset + 1]]);
                 assert_eq!(got, values[row * cols + col]);
             }
         }

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -24,7 +24,10 @@ use crate::kv_cache::KvCache;
 use crate::lora_loader::LoraWeights;
 use crate::paged_kv_cache::PagedKvCache;
 use crate::sampling::{greedy_sample, sample_with_params};
-use crate::speculative::{SpeculativeConfig, speculative_decode_step, speculative_mtp_decode_step};
+use crate::speculative::{
+    SpeculativeConfig, speculative_decode_step, speculative_decode_step_paged_greedy,
+    speculative_mtp_decode_step,
+};
 
 use kiln_core::block::{BlockManager, BlockTable};
 
@@ -772,6 +775,68 @@ impl ModelRunner {
         result
     }
 
+    pub fn generate_paged_speculative_shared_tokens(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+        spec_config: &SpeculativeConfig,
+    ) -> Result<GenerationOutput> {
+        anyhow::ensure!(
+            params.temperature == 0.0,
+            "paged skip-layer speculative decode is greedy-only"
+        );
+        spec_config
+            .validate(&self.config)
+            .context("invalid speculative config")?;
+
+        let max_spec_window = spec_config.num_speculative_tokens.min(params.max_tokens.max(1));
+        let max_total = prompt_tokens.len() + params.max_tokens + max_spec_window + 1;
+        let (reservation, block_table) = {
+            let mut bm_guard = lock_block_manager(block_manager)?;
+            let block_size = bm_guard.block_size();
+            let num_blocks = Self::blocks_needed(max_total, block_size);
+            let block_ids = bm_guard
+                .allocate(num_blocks)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let mut block_table = BlockTable::new();
+            for &block_id in &block_ids {
+                block_table.push(block_id);
+            }
+            (
+                SharedBlockReservation {
+                    block_manager,
+                    block_ids,
+                },
+                block_table,
+            )
+        };
+
+        let output = self.generate_from_tokens_paged_speculative_interleaved(
+            prompt_tokens,
+            params,
+            paged_cache,
+            &block_table,
+            spec_config,
+        );
+
+        drop(reservation);
+
+        let output = output?;
+        let text = self
+            .tokenizer
+            .decode(&output.token_ids)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("failed to decode output tokens")?;
+
+        Ok(GenerationOutput {
+            text,
+            token_ids: output.token_ids,
+            finish_reason: output.finish_reason,
+        })
+    }
+
     fn generate_from_tokens_paged_interleaved(
         &self,
         prompt_tokens: &[TokenId],
@@ -896,6 +961,195 @@ impl ModelRunner {
                     step_seed,
                 )?
             };
+        }
+
+        Ok(GenerationOutput {
+            text: String::new(),
+            token_ids: generated_tokens,
+            finish_reason: FinishReason::MaxTokens,
+        })
+    }
+
+    fn generate_from_tokens_paged_speculative_interleaved(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+        spec_config: &SpeculativeConfig,
+    ) -> Result<GenerationOutput> {
+        anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
+
+        let mut linear_state = self.new_linear_state()?;
+        let mut draft_linear_state = self.new_linear_state()?;
+
+        let logits = {
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            if streaming_prefill_enabled() {
+                model_forward_paged_streaming(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                )
+                .context("prefill forward pass (paged skip-layer, streaming) failed")?
+            } else {
+                model_forward_paged_last_token(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("prefill forward pass (paged skip-layer) failed")?
+            }
+        };
+
+        crate::speculative::draft_forward_for_state_init(
+            &*self.backend,
+            prompt_tokens,
+            &self.weights,
+            &self.config,
+            spec_config.draft_layers,
+            &mut draft_linear_state,
+        )
+        .context("draft state init for paged skip-layer failed")?;
+
+        let mut base_pos = prompt_tokens.len();
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
+        let mut last_token = greedy_sample(&logits)?;
+
+        loop {
+            if generated_tokens.len() >= params.max_tokens {
+                return Ok(GenerationOutput {
+                    text: String::new(),
+                    token_ids: generated_tokens,
+                    finish_reason: FinishReason::MaxTokens,
+                });
+            }
+
+            if self.eos_token_ids.contains(&last_token) {
+                return Ok(GenerationOutput {
+                    text: String::new(),
+                    token_ids: generated_tokens,
+                    finish_reason: FinishReason::Eos,
+                });
+            }
+
+            generated_tokens.push(last_token);
+            if !params.stop.is_empty() {
+                let decoded_so_far = self
+                    .tokenizer
+                    .decode(&generated_tokens)
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+                    .ok();
+                if let Some(text) = &decoded_so_far {
+                    for stop_seq in &params.stop {
+                        if text.contains(stop_seq.as_str()) {
+                            return Ok(GenerationOutput {
+                                text: String::new(),
+                                token_ids: generated_tokens,
+                                finish_reason: FinishReason::StopSequence(stop_seq.clone()),
+                            });
+                        }
+                    }
+                }
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                return Ok(GenerationOutput {
+                    text: String::new(),
+                    token_ids: generated_tokens,
+                    finish_reason: FinishReason::MaxTokens,
+                });
+            }
+
+            let remaining = params.max_tokens - generated_tokens.len();
+            let effective_config = SpeculativeConfig {
+                num_speculative_tokens: spec_config.num_speculative_tokens.min(remaining),
+                draft_layers: spec_config.draft_layers,
+            };
+
+            let result = {
+                let mut pc_guard = lock_paged_cache(paged_cache)?;
+                speculative_decode_step_paged_greedy(
+                    &*self.backend,
+                    last_token,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    base_pos,
+                    &mut linear_state,
+                    &mut draft_linear_state,
+                    &effective_config,
+                    params,
+                    &self.eos_token_ids,
+                    self.active_lora.as_ref(),
+                )
+                .context("paged skip-layer speculative decode step failed")?
+            };
+            base_pos += result.base_advance;
+
+            if result.accepted_tokens.is_empty() {
+                if result.hit_eos {
+                    return Ok(GenerationOutput {
+                        text: String::new(),
+                        token_ids: generated_tokens,
+                        finish_reason: FinishReason::Eos,
+                    });
+                }
+                break;
+            }
+
+            for &token in &result.accepted_tokens[..result.accepted_tokens.len() - 1] {
+                generated_tokens.push(token);
+                if !params.stop.is_empty() {
+                    let decoded_so_far = self
+                        .tokenizer
+                        .decode(&generated_tokens)
+                        .map_err(|e| anyhow::anyhow!("{e}"))
+                        .ok();
+                    if let Some(text) = &decoded_so_far {
+                        for stop_seq in &params.stop {
+                            if text.contains(stop_seq.as_str()) {
+                                return Ok(GenerationOutput {
+                                    text: String::new(),
+                                    token_ids: generated_tokens,
+                                    finish_reason: FinishReason::StopSequence(stop_seq.clone()),
+                                });
+                            }
+                        }
+                    }
+                }
+
+                if generated_tokens.len() >= params.max_tokens {
+                    return Ok(GenerationOutput {
+                        text: String::new(),
+                        token_ids: generated_tokens,
+                        finish_reason: FinishReason::MaxTokens,
+                    });
+                }
+            }
+
+            last_token = *result.accepted_tokens.last().unwrap();
+            if result.hit_eos {
+                return Ok(GenerationOutput {
+                    text: String::new(),
+                    token_ids: generated_tokens,
+                    finish_reason: FinishReason::Eos,
+                });
+            }
         }
 
         Ok(GenerationOutput {
@@ -1099,8 +1353,8 @@ impl ModelRunner {
         // Verification writes the full speculative window (`last_token + k`)
         // before the loop commits accepted tokens, so flat KV needs temporary
         // headroom beyond the user-visible max token budget.
-        let max_total =
-            prompt_tokens.len() + params.max_tokens + spec_config.num_speculative_tokens + 1;
+        let max_spec_window = spec_config.num_speculative_tokens.min(params.max_tokens.max(1));
+        let max_total = prompt_tokens.len() + params.max_tokens + max_spec_window + 1;
         let mut kv_cache = self.new_kv_cache(max_total)?;
         let mut linear_state = self.new_linear_state()?;
         let mut draft_linear_state = self.new_linear_state()?;
@@ -1728,6 +1982,10 @@ impl ModelRunner {
                 }
             }
 
+            if !matches!(finish_reason, FinishReason::MaxTokens) {
+                break;
+            }
+
             if generated_tokens.len() >= params.max_tokens {
                 break;
             }
@@ -1931,6 +2189,10 @@ impl ModelRunner {
                 }
             }
 
+            if !matches!(finish_reason, FinishReason::MaxTokens) {
+                break;
+            }
+
             if generated_tokens.len() >= params.max_tokens {
                 break;
             }
@@ -1993,6 +2255,56 @@ impl ModelRunner {
             block_manager,
             paged_cache,
         )
+    }
+
+    pub fn generate_streaming_paged_speculative_shared_tokens(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+        spec_config: &SpeculativeConfig,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        anyhow::ensure!(
+            params.temperature == 0.0,
+            "paged skip-layer speculative streaming is greedy-only"
+        );
+        spec_config
+            .validate(&self.config)
+            .context("invalid speculative config")?;
+
+        let max_total =
+            prompt_tokens.len() + params.max_tokens + spec_config.num_speculative_tokens + 1;
+        let (reservation, block_table) = {
+            let mut bm_guard = lock_block_manager(block_manager)?;
+            let block_size = bm_guard.block_size();
+            let num_blocks = Self::blocks_needed(max_total, block_size);
+            let block_ids = bm_guard
+                .allocate(num_blocks)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            let mut block_table = BlockTable::new();
+            for &block_id in &block_ids {
+                block_table.push(block_id);
+            }
+            (
+                SharedBlockReservation {
+                    block_manager,
+                    block_ids,
+                },
+                block_table,
+            )
+        };
+
+        let result = self.generate_from_tokens_streaming_paged_speculative_interleaved(
+            prompt_tokens,
+            params,
+            paged_cache,
+            &block_table,
+            spec_config,
+        );
+
+        drop(reservation);
+        result
     }
 
     fn generate_from_tokens_streaming_paged_shared(
@@ -2169,6 +2481,172 @@ impl ModelRunner {
                     step_seed,
                 )?
             };
+        }
+
+        let _ = tx.send(StreamEvent::Done(StreamDone {
+            finish_reason,
+            completion_tokens: generated_tokens.len(),
+        }));
+
+        Ok(rx)
+    }
+
+    fn generate_from_tokens_streaming_paged_speculative_interleaved(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+        spec_config: &SpeculativeConfig,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        let (tx, rx) = mpsc::channel();
+        let mut linear_state = self.new_linear_state()?;
+        let mut draft_linear_state = self.new_linear_state()?;
+
+        let logits = {
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            if streaming_prefill_enabled() {
+                model_forward_paged_streaming(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                )
+                .context("prefill forward pass (streaming paged skip-layer, streaming) failed")?
+            } else {
+                model_forward_paged_last_token(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("prefill forward pass (streaming paged skip-layer) failed")?
+            }
+        };
+
+        crate::speculative::draft_forward_for_state_init(
+            &*self.backend,
+            prompt_tokens,
+            &self.weights,
+            &self.config,
+            spec_config.draft_layers,
+            &mut draft_linear_state,
+        )
+        .context("draft state init for streaming paged skip-layer failed")?;
+
+        let mut base_pos = prompt_tokens.len();
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
+        let mut finish_reason = FinishReason::MaxTokens;
+        let mut last_token = greedy_sample(&logits)?;
+
+        loop {
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            if self.eos_token_ids.contains(&last_token) {
+                finish_reason = FinishReason::Eos;
+                break;
+            }
+
+            match emit_stream_token(
+                &tx,
+                &self.tokenizer,
+                &mut generated_tokens,
+                last_token,
+                &params.stop,
+            ) {
+                StreamTokenDisposition::Continue => {}
+                StreamTokenDisposition::Finished(reason) => {
+                    finish_reason = reason;
+                    break;
+                }
+                StreamTokenDisposition::ReceiverDropped => return Ok(rx),
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            let remaining = params.max_tokens - generated_tokens.len();
+            let effective_config = SpeculativeConfig {
+                num_speculative_tokens: spec_config.num_speculative_tokens.min(remaining),
+                draft_layers: spec_config.draft_layers,
+            };
+
+            let result = {
+                let mut pc_guard = lock_paged_cache(paged_cache)?;
+                speculative_decode_step_paged_greedy(
+                    &*self.backend,
+                    last_token,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    base_pos,
+                    &mut linear_state,
+                    &mut draft_linear_state,
+                    &effective_config,
+                    params,
+                    &self.eos_token_ids,
+                    self.active_lora.as_ref(),
+                )
+                .context("streaming paged skip-layer speculative decode step failed")?
+            };
+            base_pos += result.base_advance;
+
+            if result.accepted_tokens.is_empty() {
+                if result.hit_eos {
+                    finish_reason = FinishReason::Eos;
+                }
+                break;
+            }
+
+            for &token in &result.accepted_tokens[..result.accepted_tokens.len() - 1] {
+                match emit_stream_token(
+                    &tx,
+                    &self.tokenizer,
+                    &mut generated_tokens,
+                    token,
+                    &params.stop,
+                ) {
+                    StreamTokenDisposition::Continue => {}
+                    StreamTokenDisposition::Finished(reason) => {
+                        finish_reason = reason;
+                        break;
+                    }
+                    StreamTokenDisposition::ReceiverDropped => return Ok(rx),
+                }
+
+                if generated_tokens.len() >= params.max_tokens {
+                    break;
+                }
+            }
+
+            if !matches!(finish_reason, FinishReason::MaxTokens) {
+                break;
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            last_token = *result.accepted_tokens.last().unwrap();
+            if result.hit_eos {
+                finish_reason = FinishReason::Eos;
+                break;
+            }
         }
 
         let _ = tx.send(StreamEvent::Done(StreamDone {

--- a/crates/kiln-model/src/speculative.rs
+++ b/crates/kiln-model/src/speculative.rs
@@ -23,7 +23,8 @@ use crate::backend::BackendRuntime;
 use crate::c1_attr;
 use crate::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_embed, model_forward_head,
-    model_forward_paged_with_last_hidden, model_forward_segment, mtp_forward_step,
+    model_forward_paged, model_forward_paged_with_last_hidden, model_forward_segment,
+    mtp_forward_step,
 };
 use crate::kv_cache::KvCache;
 use crate::paged_kv_cache::PagedKvCache;
@@ -34,7 +35,8 @@ use crate::sampling::{greedy_sample, sample_with_params};
 pub struct SpeculativeConfig {
     /// Number of tokens the draft model proposes per speculation step.
     /// Higher values amortize verification cost but risk more rejections.
-    /// Typical range: 3-8. Default: 4.
+    /// Typical range depends on the verifier path. The paged greedy path uses
+    /// a large default window to amortize full-model verification.
     pub num_speculative_tokens: usize,
 
     /// Number of layers to use for the draft model (skip-layer approach).
@@ -46,7 +48,7 @@ pub struct SpeculativeConfig {
 impl Default for SpeculativeConfig {
     fn default() -> Self {
         Self {
-            num_speculative_tokens: 4,
+            num_speculative_tokens: 256,
             draft_layers: 8,
         }
     }
@@ -83,7 +85,7 @@ pub struct SpeculativeStepResult {
 ///
 /// This produces lower-quality logits but runs much faster since it skips
 /// most of the model's layers.
-fn draft_forward(
+fn draft_forward_hidden(
     backend: &dyn BackendRuntime,
     token_ids: &[u32],
     weights: &GpuWeights,
@@ -107,7 +109,25 @@ fn draft_forward(
         None, // no LoRA for draft (speed over quality)
     )?;
 
-    // Project to vocab
+    Ok(hidden)
+}
+
+fn draft_forward(
+    backend: &dyn BackendRuntime,
+    token_ids: &[u32],
+    weights: &GpuWeights,
+    config: &ModelConfig,
+    draft_layers: usize,
+    linear_state: &mut LinearAttentionState,
+) -> Result<Tensor> {
+    let hidden = draft_forward_hidden(
+        backend,
+        token_ids,
+        weights,
+        config,
+        draft_layers,
+        linear_state,
+    )?;
     model_forward_head(&hidden, weights, config)
 }
 
@@ -248,7 +268,7 @@ pub fn draft_forward_for_state_init(
     draft_layers: usize,
     linear_state: &mut LinearAttentionState,
 ) -> Result<()> {
-    let _ = draft_forward(
+    let _ = draft_forward_hidden(
         backend,
         token_ids,
         weights,
@@ -291,7 +311,11 @@ pub fn speculative_decode_step(
     // linear state but don't use a KV cache for the draft (it uses the segment
     // forward which doesn't need one).
     let mut draft_tokens: Vec<TokenId> = Vec::with_capacity(k);
-    let mut draft_probs_list: Vec<Vec<f32>> = Vec::with_capacity(k);
+    let mut draft_probs_list: Vec<Vec<f32>> = if temperature > 0.0 {
+        Vec::with_capacity(k)
+    } else {
+        Vec::new()
+    };
     let mut current_token = last_token;
 
     for _ in 0..k {
@@ -304,12 +328,6 @@ pub fn speculative_decode_step(
             draft_linear_state,
         )
         .context("draft forward pass failed")?;
-
-        let probs = if temperature > 0.0 {
-            logits_to_probs(&draft_logits, temperature)?
-        } else {
-            logits_to_probs(&draft_logits, 1.0)?
-        };
 
         // Sample from draft
         let draft_token = if temperature == 0.0 {
@@ -324,7 +342,9 @@ pub fn speculative_decode_step(
             )?
         };
 
-        draft_probs_list.push(probs);
+        if temperature > 0.0 {
+            draft_probs_list.push(logits_to_probs(&draft_logits, temperature)?);
+        }
         draft_tokens.push(draft_token);
         current_token = draft_token;
     }
@@ -357,12 +377,6 @@ pub fn speculative_decode_step(
     for i in 0..k {
         // Extract target probabilities for position i
         let pos_logits = verify_logits.narrow(1, i, 1)?.squeeze(1)?;
-        let target_probs = if temperature > 0.0 {
-            logits_to_probs(&pos_logits, temperature)?
-        } else {
-            logits_to_probs(&pos_logits, 1.0)?
-        };
-
         let draft_token = draft_tokens[i];
 
         // Check EOS before acceptance
@@ -377,6 +391,7 @@ pub fn speculative_decode_step(
                 // Target disagrees with EOS — accept target's token instead
                 accepted_tokens.push(target_token);
             } else {
+                let target_probs = logits_to_probs(&pos_logits, temperature)?;
                 let (accepted, resampled) =
                     rejection_sample(draft_token, &draft_probs_list[i], &target_probs, rng)?;
                 if accepted {
@@ -410,6 +425,7 @@ pub fn speculative_decode_step(
             }
         } else {
             // Stochastic verification via rejection sampling
+            let target_probs = logits_to_probs(&pos_logits, temperature)?;
             let (accepted, resampled) =
                 rejection_sample(draft_token, &draft_probs_list[i], &target_probs, rng)?;
 
@@ -455,6 +471,165 @@ pub fn speculative_decode_step(
     Ok(SpeculativeStepResult {
         accepted_tokens,
         hit_eos,
+    })
+}
+
+/// Result of one paged greedy skip-layer speculative decoding step.
+#[derive(Debug)]
+pub struct PagedSpeculativeStepResult {
+    pub accepted_tokens: Vec<TokenId>,
+    pub hit_eos: bool,
+    pub base_advance: usize,
+    pub accepted_draft_tokens: usize,
+    pub attempted_draft_tokens: usize,
+}
+
+/// Greedy-only skip-layer speculative decode on the production paged KV path.
+///
+/// This mirrors [`speculative_decode_step`] but avoids the flat `KvCache` path
+/// and skips probability-vector materialization that greedy acceptance does not
+/// use. On rejection it restores both base and draft linear-attention state,
+/// then replays only the committed prefix so the next step is exact.
+#[allow(clippy::too_many_arguments)]
+pub fn speculative_decode_step_paged_greedy(
+    backend: &dyn BackendRuntime,
+    last_token: TokenId,
+    weights: &GpuWeights,
+    config: &ModelConfig,
+    paged_cache: &mut PagedKvCache,
+    block_table: &BlockTable,
+    base_pos: usize,
+    linear_state: &mut LinearAttentionState,
+    draft_linear_state: &mut LinearAttentionState,
+    spec_config: &SpeculativeConfig,
+    params: &SamplingParams,
+    eos_token_ids: &[TokenId],
+    lora: Option<&crate::lora_loader::LoraWeights>,
+) -> Result<PagedSpeculativeStepResult> {
+    anyhow::ensure!(
+        params.temperature == 0.0,
+        "paged skip-layer speculative decode is greedy-only"
+    );
+
+    let k = spec_config.num_speculative_tokens;
+    let base_state_snapshot = linear_state
+        .snapshot_for_decode_rollback()
+        .context("snapshot base linear attention state before paged skip-layer verify")?;
+    let draft_state_snapshot = draft_linear_state
+        .snapshot_for_decode_rollback()
+        .context("snapshot draft linear attention state before paged skip-layer draft")?;
+
+    let mut draft_tokens: Vec<TokenId> = Vec::with_capacity(k);
+    let mut current_token = last_token;
+    for _ in 0..k {
+        let draft_logits = draft_forward(
+            backend,
+            &[current_token],
+            weights,
+            config,
+            spec_config.draft_layers,
+            draft_linear_state,
+        )
+        .context("paged skip-layer draft forward pass failed")?;
+        let draft_token = greedy_sample(&draft_logits)?;
+        draft_tokens.push(draft_token);
+        current_token = draft_token;
+    }
+
+    let mut verify_input: Vec<TokenId> = Vec::with_capacity(k + 1);
+    verify_input.push(last_token);
+    verify_input.extend_from_slice(&draft_tokens);
+    let verify_logits = model_forward_paged(
+        backend,
+        &verify_input,
+        weights,
+        config,
+        paged_cache,
+        block_table,
+        base_pos,
+        Some(linear_state),
+        lora,
+        None,
+    )
+    .context("paged skip-layer verification forward pass failed")?;
+
+    let mut accepted_tokens: Vec<TokenId> = Vec::with_capacity(k + 1);
+    let mut hit_eos = false;
+    let mut accepted_draft_tokens = 0usize;
+    let mut replay_input_len: Option<usize> = None;
+
+    for (i, &draft_token) in draft_tokens.iter().enumerate() {
+        let pos_logits = verify_logits.narrow(1, i, 1)?.squeeze(1)?;
+        let target_token = greedy_sample(&pos_logits)?;
+
+        if target_token == draft_token {
+            accepted_draft_tokens += 1;
+            if eos_token_ids.contains(&draft_token) {
+                hit_eos = true;
+                break;
+            }
+            accepted_tokens.push(draft_token);
+        } else {
+            replay_input_len = Some(i + 1);
+            if eos_token_ids.contains(&target_token) {
+                hit_eos = true;
+            } else {
+                accepted_tokens.push(target_token);
+            }
+            break;
+        }
+    }
+
+    if accepted_draft_tokens == k && !hit_eos {
+        let bonus_logits = verify_logits.narrow(1, k, 1)?.squeeze(1)?;
+        let bonus_token = greedy_sample(&bonus_logits)?;
+        if eos_token_ids.contains(&bonus_token) {
+            hit_eos = true;
+        } else {
+            accepted_tokens.push(bonus_token);
+        }
+    }
+
+    if let Some(replay_len) = replay_input_len {
+        linear_state
+            .restore_from_decode_rollback(&base_state_snapshot)
+            .context("restore base linear attention state after paged skip-layer rejection")?;
+        draft_linear_state
+            .restore_from_decode_rollback(&draft_state_snapshot)
+            .context("restore draft linear attention state after paged skip-layer rejection")?;
+
+        let committed_prefix = &verify_input[..replay_len];
+        let _ = model_forward_paged(
+            backend,
+            committed_prefix,
+            weights,
+            config,
+            paged_cache,
+            block_table,
+            base_pos,
+            Some(linear_state),
+            lora,
+            None,
+        )
+        .context("replay base prefix after paged skip-layer rejection failed")?;
+        draft_forward_for_state_init(
+            backend,
+            committed_prefix,
+            weights,
+            config,
+            spec_config.draft_layers,
+            draft_linear_state,
+        )
+        .context("replay draft prefix after paged skip-layer rejection failed")?;
+    }
+
+    let base_advance = accepted_tokens.len();
+    Ok(PagedSpeculativeStepResult {
+        accepted_tokens,
+        hit_eos,
+        base_advance,
+        accepted_draft_tokens,
+        attempted_draft_tokens: k,
     })
 }
 
@@ -570,7 +745,7 @@ pub fn speculative_mtp_decode_step(
     // rejection we restore the GDN state snapshot and replay the one committed
     // token so the base recurrent state remains exact.
     let linear_state_snapshot = linear_state
-        .snapshot()
+        .snapshot_for_decode_rollback()
         .context("snapshot linear attention state before MTP verify")?;
     let verify_input = [last_token, draft_token];
     let (verify_logits, hidden_after_draft) = model_forward_paged_with_last_hidden(
@@ -681,7 +856,7 @@ pub fn speculative_mtp_decode_step(
         // `base_pos + 1` is outside the next attention window and will be
         // overwritten if that slot becomes live later.
         linear_state
-            .restore_from(&linear_state_snapshot)
+            .restore_from_decode_rollback(&linear_state_snapshot)
             .context("restore linear attention state after MTP rejection")?;
         let verify_input0 = [last_token];
         let (_verify_logits0, hidden_after_last) = model_forward_paged_with_last_hidden(

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -150,6 +150,7 @@ enum ResolvedSpeculativeMode {
 }
 
 const MTP_MAX_PROMPT_TOKENS_DEFAULT: usize = 128;
+const LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS_DEFAULT: usize = 32;
 
 fn resolve_skip_layer_config(
     model_config: &kiln_core::config::ModelConfig,
@@ -179,12 +180,19 @@ fn resolve_speculative_mode_from_config(
             .map(ResolvedSpeculativeMode::SkipLayer)
             .unwrap_or(ResolvedSpeculativeMode::Off),
         SpecMethod::Mtp => {
+            let greedy_without_lora = sampling.temperature == 0.0 && !has_active_lora;
             if mtp_supported
-                && sampling.temperature == 0.0
-                && !has_active_lora
+                && greedy_without_lora
                 && prompt_tokens <= MTP_MAX_PROMPT_TOKENS_DEFAULT
             {
                 ResolvedSpeculativeMode::Mtp
+            } else if greedy_without_lora
+                && prompt_tokens > MTP_MAX_PROMPT_TOKENS_DEFAULT
+                && sampling.max_tokens >= LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS_DEFAULT
+            {
+                skip_layer
+                    .map(ResolvedSpeculativeMode::SkipLayer)
+                    .unwrap_or(ResolvedSpeculativeMode::Off)
             } else {
                 ResolvedSpeculativeMode::Off
             }
@@ -471,7 +479,21 @@ async fn generate_real(
                 pc.as_ref(),
             ),
             ResolvedSpeculativeMode::SkipLayer(spec_config) => {
-                runner_guard.generate_speculative(&prompt, &params, &spec_config)
+                if params.temperature == 0.0 {
+                    runner_guard.generate_paged_speculative_shared_tokens(
+                        &prompt_tokens,
+                        &params,
+                        bm.as_ref(),
+                        pc.as_ref(),
+                        &spec_config,
+                    )
+                } else {
+                    let flat_spec_config = SpeculativeConfig {
+                        num_speculative_tokens: spec_config.num_speculative_tokens.min(4),
+                        draft_layers: spec_config.draft_layers,
+                    };
+                    runner_guard.generate_speculative(&prompt, &params, &flat_spec_config)
+                }
             }
             ResolvedSpeculativeMode::Mtp => {
                 let output = runner_guard.generate_mtp_speculative(&prompt, &params)?;
@@ -628,7 +650,25 @@ async fn generate_real_streaming(
                     match tokio::task::spawn_blocking(move || {
                         let _gpu_guard = gpu_lock.read().unwrap();
                         let runner_guard = runner.read().unwrap();
-                        runner_guard.generate_streaming_speculative(&prompt, &params, &spec_config)
+                        if params.temperature == 0.0 {
+                            runner_guard.generate_streaming_paged_speculative_shared_tokens(
+                                &prompt_tokens,
+                                &params,
+                                bm.as_ref(),
+                                pc.as_ref(),
+                                &spec_config,
+                            )
+                        } else {
+                            let flat_spec_config = SpeculativeConfig {
+                                num_speculative_tokens: spec_config.num_speculative_tokens.min(4),
+                                draft_layers: spec_config.draft_layers,
+                            };
+                            runner_guard.generate_streaming_speculative(
+                                &prompt,
+                                &params,
+                                &flat_spec_config,
+                            )
+                        }
                     })
                     .await
                     {
@@ -1036,7 +1076,22 @@ mod tests {
             true,
             false,
         );
-        assert!(matches!(long_prompt, ResolvedSpeculativeMode::Off));
+        assert!(matches!(long_prompt, ResolvedSpeculativeMode::SkipLayer(_)));
+
+        let mut short_output_sampling = make_sampling(0.0);
+        short_output_sampling.max_tokens = LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS_DEFAULT - 1;
+        let long_prompt_short_output = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &short_output_sampling,
+            MTP_MAX_PROMPT_TOKENS_DEFAULT + 1,
+            true,
+            false,
+        );
+        assert!(matches!(
+            long_prompt_short_output,
+            ResolvedSpeculativeMode::Off
+        ));
     }
 
     #[test]

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -26,7 +26,8 @@ use kiln_model::kv_cache::KvCache;
 use kiln_model::paged_kv_cache::PagedKvCache;
 use kiln_model::sampling::greedy_sample;
 use kiln_model::speculative::{
-    SpeculativeConfig, speculative_decode_step, speculative_mtp_decode_step,
+    SpeculativeConfig, speculative_decode_step, speculative_decode_step_paged_greedy,
+    speculative_mtp_decode_step,
 };
 use kiln_server::config::SpecMethod;
 
@@ -112,6 +113,10 @@ struct BenchArgs {
     /// non-paged contiguous KvCache + model_forward path so prior numbers stay
     /// comparable.
     paged: bool,
+    /// When true, stop after latency and emit JSON with empty throughput
+    /// results and no training result. This keeps rapid decode-path iteration
+    /// from paying unrelated benchmark costs.
+    latency_only: bool,
     /// RNG seed threaded through `SamplingParams` and `StdRng` sites so bench
     /// runs are fully reproducible. Phase B3 multi-prompt A/B relies on varying
     /// this across {0..=7} to get independent prompt/sampling trajectories.
@@ -126,6 +131,7 @@ fn parse_args() -> Result<BenchArgs> {
     let mut training_steps = 10;
     let mut skip_training = false;
     let mut paged = false;
+    let mut latency_only = false;
     let mut seed: u64 = 42;
 
     let mut i = 1;
@@ -153,6 +159,9 @@ fn parse_args() -> Result<BenchArgs> {
             "--paged" => {
                 paged = true;
             }
+            "--latency-only" => {
+                latency_only = true;
+            }
             "--seed" => {
                 i += 1;
                 seed = args.get(i).and_then(|s| s.parse().ok()).unwrap_or(42);
@@ -175,6 +184,9 @@ fn parse_args() -> Result<BenchArgs> {
                     "                            (matches the HTTP/scheduler production path)"
                 );
                 eprintln!(
+                    "  --latency-only            Stop after latency and skip training/throughput"
+                );
+                eprintln!(
                     "  --seed <u64>              RNG seed + prompt selector from 8-prompt pool (default: 42)"
                 );
                 std::process::exit(0);
@@ -195,6 +207,7 @@ fn parse_args() -> Result<BenchArgs> {
         training_steps,
         skip_training,
         paged,
+        latency_only,
         seed,
     })
 }
@@ -748,7 +761,7 @@ fn read_spec_method_from_env() -> SpecMethod {
 /// each step's wall time is divided across the tokens emitted that step,
 /// giving a per-emitted-token ITL distribution comparable to the `Off` arm.
 ///
-/// Reads `KILN_SPEC_NUM_TOKENS` (default 4) and `KILN_SPEC_DRAFT_LAYERS`
+/// Reads `KILN_SPEC_NUM_TOKENS` (default 256) and `KILN_SPEC_DRAFT_LAYERS`
 /// (default 8). Greedy-only (`temperature = 0`) since the bench harness is
 /// deterministic.
 fn bench_latency_skiplayer(
@@ -764,7 +777,7 @@ fn bench_latency_skiplayer(
     let num_speculative_tokens = std::env::var("KILN_SPEC_NUM_TOKENS")
         .ok()
         .and_then(|v| v.parse().ok())
-        .unwrap_or(4usize);
+        .unwrap_or(256usize);
     let draft_layers = std::env::var("KILN_SPEC_DRAFT_LAYERS")
         .ok()
         .and_then(|v| v.parse().ok())
@@ -949,6 +962,252 @@ fn bench_latency_skiplayer(
         decode_tokens_per_sec: decode_tok_per_sec,
         spec_method: "skip_layer".to_string(),
         acceptance_rate: None,
+    })
+}
+
+/// Benchmark latency along the PAGED SKIP-LAYER speculative path.
+///
+/// This is benchmark-only scaffolding for the production-style paged
+/// self-speculative implementation. It keeps the paged prefill/cache/block-table
+/// setup in this harness and delegates each decode iteration to
+/// `speculative_decode_step_paged_greedy`, which is expected to verify against
+/// `PagedKvCache` at the caller-provided `base_pos`.
+///
+/// Enable with `KILN_SPEC_METHOD=skip_layer --paged`. Without `--paged`, the
+/// legacy flat-KV skip-layer benchmark remains available for comparisons.
+fn bench_latency_paged_skiplayer(
+    weights: &GpuWeights,
+    config: &ModelConfig,
+    tokenizer: &KilnTokenizer,
+    prompt_tokens: usize,
+    max_output_tokens: usize,
+    seed: u64,
+) -> Result<LatencyResult> {
+    let num_speculative_tokens = std::env::var("KILN_SPEC_NUM_TOKENS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(256usize);
+    let draft_layers = std::env::var("KILN_SPEC_DRAFT_LAYERS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(8usize);
+
+    let prompt = build_prompt(tokenizer, prompt_tokens, seed);
+    let prompt_token_ids = tokenizer
+        .encode(&prompt)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let actual_prompt_tokens = prompt_token_ids.len();
+
+    let device = weights.embed_tokens.device();
+    let dtype = match config.dtype {
+        kiln_core::config::DType::BF16 => candle_core::DType::BF16,
+        kiln_core::config::DType::FP16 => candle_core::DType::F16,
+        kiln_core::config::DType::FP32 => candle_core::DType::F32,
+    };
+
+    // Verification writes `[last_token, draft_0, ..., draft_k-1]` starting at
+    // `base_pos`. Reserve headroom so late-generation verify windows do not
+    // run off the allocated paged cache before stale speculative slots are
+    // overwritten by the next committed step.
+    let max_total = actual_prompt_tokens + max_output_tokens + num_speculative_tokens + 1;
+    let num_blocks = (max_total + PAGED_BLOCK_SIZE - 1) / PAGED_BLOCK_SIZE;
+
+    let mut paged_cache = PagedKvCache::new(
+        config.num_full_attention_layers,
+        num_blocks,
+        PAGED_BLOCK_SIZE,
+        config.num_kv_heads,
+        config.head_dim,
+        dtype,
+        device,
+    )?;
+    let mut linear_state = LinearAttentionState::new(config, device)?;
+    let mut draft_linear_state = LinearAttentionState::new(config, device)?;
+    let backend = runtime_backend::for_device(device);
+
+    let mut block_table = BlockTable::new();
+    for i in 0..num_blocks as u32 {
+        block_table.push(i);
+    }
+
+    let eos_token_ids = tokenizer.eos_token_ids();
+
+    eprintln!(
+        "  Measuring latency [SKIP-LAYER, paged, k={num_speculative_tokens}, \
+         draft_layers={draft_layers}, blocks={num_blocks}] ({actual_prompt_tokens} prompt tokens)..."
+    );
+
+    let prefill_start = Instant::now();
+    let logits = if streaming_prefill_enabled() {
+        model_forward_paged_streaming(
+            &*backend,
+            &prompt_token_ids,
+            weights,
+            config,
+            &mut paged_cache,
+            &block_table,
+            0,
+            Some(&mut linear_state),
+            None,
+        )
+        .context("paged skip-layer prefill forward pass (streaming) failed")?
+    } else {
+        model_forward_paged_last_token(
+            &*backend,
+            &prompt_token_ids,
+            weights,
+            config,
+            &mut paged_cache,
+            &block_table,
+            0,
+            Some(&mut linear_state),
+            None,
+            None,
+        )
+        .context("paged skip-layer prefill forward pass failed")?
+    };
+
+    kiln_model::speculative::draft_forward_for_state_init(
+        &*backend,
+        &prompt_token_ids,
+        weights,
+        config,
+        draft_layers,
+        &mut draft_linear_state,
+    )
+    .context("paged skip-layer draft state init failed")?;
+
+    let mut last_token = greedy_sample(&logits)?;
+    let prefill_time = prefill_start.elapsed();
+
+    eprintln!(
+        "    Prefill (skip-layer paged): {:.1}ms ({:.0} tok/s)",
+        prefill_time.as_secs_f64() * 1000.0,
+        actual_prompt_tokens as f64 / prefill_time.as_secs_f64()
+    );
+
+    let mut inter_token_ms: Vec<f64> = Vec::new();
+    let mut num_tokens = 1usize; // counting the first token from prefill
+    let mut base_pos = actual_prompt_tokens;
+    let mut accepted_draft_tokens = 0usize;
+    let mut attempted_draft_tokens = 0usize;
+    let params = SamplingParams {
+        temperature: 0.0,
+        top_p: 1.0,
+        top_k: 0,
+        max_tokens: max_output_tokens,
+        repetition_penalty: 1.0,
+        stop: vec![],
+        seed: Some(seed),
+    };
+
+    while num_tokens < max_output_tokens {
+        if eos_token_ids.contains(&last_token) {
+            break;
+        }
+
+        let remaining = max_output_tokens - num_tokens;
+        let effective_config = SpeculativeConfig {
+            num_speculative_tokens: num_speculative_tokens.min(remaining.max(1)),
+            draft_layers,
+        };
+
+        let step_start = Instant::now();
+        let step = speculative_decode_step_paged_greedy(
+            &*backend,
+            last_token,
+            weights,
+            config,
+            &mut paged_cache,
+            &block_table,
+            base_pos,
+            &mut linear_state,
+            &mut draft_linear_state,
+            &effective_config,
+            &params,
+            &eos_token_ids,
+            None,
+        )
+        .context("skip-layer speculative_decode_step_paged_greedy failed")?;
+        let step_time = step_start.elapsed();
+
+        if step.accepted_tokens.is_empty() {
+            break;
+        }
+        accepted_draft_tokens += step.accepted_draft_tokens;
+        attempted_draft_tokens += step.attempted_draft_tokens;
+
+        let accepted_len = step.accepted_tokens.len();
+        let per_token_ms = (step_time.as_secs_f64() * 1000.0) / accepted_len as f64;
+        for &tok in &step.accepted_tokens {
+            inter_token_ms.push(per_token_ms);
+            num_tokens += 1;
+            if num_tokens >= max_output_tokens {
+                break;
+            }
+            if eos_token_ids.contains(&tok) {
+                break;
+            }
+        }
+
+        last_token = *step.accepted_tokens.last().unwrap();
+        base_pos += step.base_advance;
+
+        if step.hit_eos {
+            break;
+        }
+    }
+
+    let mean_itl = if inter_token_ms.is_empty() {
+        0.0
+    } else {
+        inter_token_ms.iter().sum::<f64>() / inter_token_ms.len() as f64
+    };
+    let mut sorted = inter_token_ms.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let p50 = if sorted.is_empty() {
+        0.0
+    } else {
+        sorted[sorted.len() / 2]
+    };
+    let p99 = if sorted.is_empty() {
+        0.0
+    } else {
+        let idx = ((sorted.len() as f64 * 0.99) as usize).min(sorted.len() - 1);
+        sorted[idx]
+    };
+    let decode_tok_per_sec = if inter_token_ms.is_empty() {
+        0.0
+    } else {
+        let total_decode_ms: f64 = inter_token_ms.iter().sum();
+        inter_token_ms.len() as f64 / (total_decode_ms / 1000.0)
+    };
+
+    eprintln!(
+        "    Decode (skip-layer paged): {num_tokens} tokens, mean ITL {:.1}ms ({:.1} tok/s)",
+        mean_itl, decode_tok_per_sec
+    );
+    let acceptance_rate = if attempted_draft_tokens > 0 {
+        Some(accepted_draft_tokens as f64 / attempted_draft_tokens as f64)
+    } else {
+        None
+    };
+    if let Some(rate) = acceptance_rate {
+        eprintln!("    Acceptance (skip-layer paged): {:.3}", rate);
+    }
+
+    Ok(LatencyResult {
+        prompt_tokens: actual_prompt_tokens,
+        prefill_time_ms: prefill_time.as_secs_f64() * 1000.0,
+        prefill_tokens_per_sec: actual_prompt_tokens as f64 / prefill_time.as_secs_f64(),
+        time_to_first_token_ms: prefill_time.as_secs_f64() * 1000.0,
+        mean_inter_token_ms: mean_itl,
+        p50_inter_token_ms: p50,
+        p99_inter_token_ms: p99,
+        num_tokens_generated: num_tokens,
+        decode_tokens_per_sec: decode_tok_per_sec,
+        spec_method: "skip_layer_paged".to_string(),
+        acceptance_rate,
     })
 }
 
@@ -1435,7 +1694,9 @@ fn main() -> Result<()> {
     // Latency benchmark (uses model_forward directly — must run before runner takes ownership).
     // Dispatch order:
     //   * KILN_SPEC_METHOD=mtp        → bench_latency_paged_mtp (paged + MTP)
-    //   * KILN_SPEC_METHOD=skip_layer → bench_latency_skiplayer (flat KV + skip-layer)
+    //   * KILN_SPEC_METHOD=skip_layer → bench_latency_paged_skiplayer when
+    //                                   --paged, else bench_latency_skiplayer
+    //                                   (flat KV + skip-layer)
     //   * default / off               → bench_latency_paged (paged Off) when
     //                                   --paged, else bench_latency (flat Off).
     let latency = match spec_method {
@@ -1452,16 +1713,29 @@ fn main() -> Result<()> {
             .context("MTP latency benchmark failed")?
         }
         SpecMethod::SkipLayer => {
-            eprintln!("--- Latency Benchmark (SKIP-LAYER — self-speculative, flat KV) ---");
-            bench_latency_skiplayer(
-                &gpu_weights,
-                &model_config,
-                &tokenizer,
-                args.prompt_tokens,
-                args.max_output_tokens,
-                args.seed,
-            )
-            .context("skip-layer latency benchmark failed")?
+            if args.paged {
+                eprintln!("--- Latency Benchmark (SKIP-LAYER — self-speculative, paged) ---");
+                bench_latency_paged_skiplayer(
+                    &gpu_weights,
+                    &model_config,
+                    &tokenizer,
+                    args.prompt_tokens,
+                    args.max_output_tokens,
+                    args.seed,
+                )
+                .context("paged skip-layer latency benchmark failed")?
+            } else {
+                eprintln!("--- Latency Benchmark (SKIP-LAYER — self-speculative, flat KV) ---");
+                bench_latency_skiplayer(
+                    &gpu_weights,
+                    &model_config,
+                    &tokenizer,
+                    args.prompt_tokens,
+                    args.max_output_tokens,
+                    args.seed,
+                )
+                .context("skip-layer latency benchmark failed")?
+            }
         }
         SpecMethod::Off => {
             if args.paged {
@@ -1487,6 +1761,24 @@ fn main() -> Result<()> {
             }
         }
     };
+
+    if args.latency_only {
+        let results = BenchmarkResults {
+            backend: backend_name.to_string(),
+            gpu_info,
+            model_load,
+            inference: Vec::new(),
+            latency,
+            training: None,
+        };
+
+        print_summary(&results);
+
+        let json = serde_json::to_string_pretty(&results)?;
+        println!("{json}");
+
+        return Ok(());
+    }
 
     // Training benchmark (borrows gpu_weights — must run before runner takes ownership)
     let training = if args.skip_training {

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -172,7 +172,7 @@ pub struct SpeculativeDecodingConfig {
     pub enabled: bool,
     /// Which speculative-decoding method to use. Default: `Off`.
     pub method: SpecMethod,
-    /// Number of tokens the draft proposes per step (default: 4).
+    /// Number of tokens the draft proposes per step (default: 256).
     /// Ignored by `Mtp` when the checkpoint has fewer MTP layers than this.
     pub num_speculative_tokens: usize,
     /// Number of layers to use for the `SkipLayer` draft (default: 8).
@@ -291,7 +291,7 @@ impl Default for SpeculativeDecodingConfig {
         Self {
             enabled: false,
             method: SpecMethod::Off,
-            num_speculative_tokens: 4,
+            num_speculative_tokens: 256,
             draft_layers: 8,
         }
     }
@@ -382,8 +382,8 @@ impl KilnConfig {
             toml::from_str(&contents)
                 .with_context(|| format!("failed to parse config file: {p}"))?
         } else if Path::new("kiln.toml").exists() {
-            let contents = std::fs::read_to_string("kiln.toml")
-                .context("failed to read kiln.toml")?;
+            let contents =
+                std::fs::read_to_string("kiln.toml").context("failed to read kiln.toml")?;
             toml::from_str(&contents).context("failed to parse kiln.toml")?
         } else {
             Self::default()
@@ -548,9 +548,7 @@ impl KilnConfig {
 
         let f = self.memory.inference_memory_fraction;
         if !(0.0..=1.0).contains(&f) {
-            anyhow::bail!(
-                "memory.inference_memory_fraction must be between 0.0 and 1.0, got {f}"
-            );
+            anyhow::bail!("memory.inference_memory_fraction must be between 0.0 and 1.0, got {f}");
         }
 
         let valid_levels = ["trace", "debug", "info", "warn", "error"];
@@ -572,9 +570,7 @@ impl KilnConfig {
             }
         }
 
-        if self.streaming_prefill.tile_tokens == 0
-            || self.streaming_prefill.tile_tokens % 64 != 0
-        {
+        if self.streaming_prefill.tile_tokens == 0 || self.streaming_prefill.tile_tokens % 64 != 0 {
             anyhow::bail!(
                 "streaming_prefill.tile_tokens must be a positive multiple of 64, got {}",
                 self.streaming_prefill.tile_tokens
@@ -611,7 +607,7 @@ mod tests {
         assert!(config.prefix_cache.enabled);
         assert!(config.prefix_cache.max_blocks.is_none());
         assert!(!config.speculative.enabled);
-        assert_eq!(config.speculative.num_speculative_tokens, 4);
+        assert_eq!(config.speculative.num_speculative_tokens, 256);
         assert_eq!(config.speculative.draft_layers, 8);
         assert!(!config.streaming_prefill.enabled);
         assert_eq!(config.streaming_prefill.tile_tokens, 8192);

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -1573,9 +1573,9 @@ mod tests {
                 let in_proj_z = Tensor::randn(0.0f32, 0.02, (v_dim, h), device)?;
                 let out_proj = Tensor::randn(0.0f32, 0.02, (h, v_dim), device)?;
                 let in_proj_a =
-                    Tensor::randn(0.0f32, 0.02, (config.linear_num_key_heads, h), device)?;
+                    Tensor::randn(0.0f32, 0.02, (config.linear_num_value_heads, h), device)?;
                 let in_proj_b =
-                    Tensor::randn(0.0f32, 0.02, (config.linear_num_key_heads, h), device)?;
+                    Tensor::randn(0.0f32, 0.02, (config.linear_num_value_heads, h), device)?;
                 let in_proj_qkv_t = in_proj_qkv.t()?.contiguous()?;
                 let in_proj_z_t = in_proj_z.t()?.contiguous()?;
                 let in_proj_a_t = in_proj_a.t()?.contiguous()?;
@@ -1594,8 +1594,8 @@ mod tests {
                         device,
                     )?,
                     norm: Tensor::zeros(config.linear_key_head_dim, DType::F32, device)?,
-                    a_log: Tensor::randn(0.0f32, 0.5, (config.linear_num_key_heads,), device)?,
-                    dt_bias: Tensor::zeros(config.linear_num_key_heads, DType::F32, device)?,
+                    a_log: Tensor::randn(0.0f32, 0.5, (config.linear_num_value_heads,), device)?,
+                    dt_bias: Tensor::zeros(config.linear_num_value_heads, DType::F32, device)?,
                     in_proj_qkv_t,
                     in_proj_z_t,
                     in_proj_a_t,


### PR DESCRIPTION
## Summary

This moves the macOS desktop default long greedy path onto a production paged self-speculative decode path instead of the old flat skip-layer path or paged Off fallback.

- Add greedy-only paged skip-layer decode using `PagedKvCache`/`BlockTable` for verifier passes.
- Route desktop-default `KILN_SPEC_METHOD=mtp` long prompts (`>128` prompt tokens, `max_tokens >= 32`, greedy, no LoRA) to paged skip-layer, while short prompts still use native MTP when available.
- Use paged skip-layer for explicit skip-layer greedy streaming and non-streaming API requests; sampled skip-layer requests fall back to the older flat path with a capped small window.
- Increase the default skip-layer speculative window to 256, matching the measured high-acceptance macOS path.
- Avoid unused draft LM-head work during state initialization and skip full-vocab probability vectors on greedy speculative decode.
- Add lightweight decode rollback snapshots that copy conv state only and shallow-clone recurrent state handles.
- Add `kiln-bench --latency-only` and paged skip-layer latency benchmarking.

## Validation

- `cargo check -p kiln-server --features metal --locked`
- `cargo test -p kiln-model --features metal --locked speculative::tests -- --nocapture`
- `cargo test -p kiln-server --features metal --locked api::completions::tests -- --nocapture`
- `cargo test -p kiln-server --features metal --locked config::tests -- --nocapture --test-threads=1`
- `cargo test -p kiln-train --features metal --locked --no-run`
- `git diff --check -- crates/kiln-model/src/forward.rs crates/kiln-model/src/speculative.rs crates/kiln-model/src/generate.rs crates/kiln-server/src/api/completions.rs crates/kiln-server/src/bench.rs crates/kiln-server/src/config.rs crates/kiln-train/src/trainer.rs`
- Release benchmark against the desktop model directory: `KILN_SPEC_METHOD=skip_layer ./target/release/kiln-bench --model-path '/Users/ericflo/Library/Application Support/com.eflorenzano.kiln.desktop/models/Qwen__Qwen3.5-4B' --prompt-tokens 512 --max-output-tokens 256 --skip-training --paged --latency-only`

Benchmark result: 512 prompt / 256 output, paged skip-layer default `k=256`: prefill 7332.9 ms, mean ITL 94.6 ms, 10.57 tok/s, draft acceptance alpha 1.000. This is materially faster than the previous paged Off path (~4.1 tok/s) and the local llama.cpp 512/256 comparison (~5.89 tok/s).