### PR TITLE
[codex] Speed up macOS startup and skip-layer prefill

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -16,6 +16,7 @@ use crate::lora_loader::{
     LoraLayerWeights, LoraProjectionWeights, LoraWeights, linear_with_lora_t,
 };
 use crate::paged_kv_cache::{PagedKvCache, contiguous_slot_run_start};
+use crate::transposed_weight_cache::transposed_weight_bytes_2d_cached;
 use crate::weights::{ModelWeights, TensorDType, WeightTensor};
 
 use kiln_core::block::BlockTable;
@@ -609,7 +610,7 @@ fn transpose_weight_bytes_generic(
     }
 }
 
-fn transposed_weight_bytes_2d(w: &WeightTensor) -> Result<(Vec<u8>, [usize; 2])> {
+pub(crate) fn transposed_weight_bytes_2d(w: &WeightTensor) -> Result<(Vec<u8>, [usize; 2])> {
     anyhow::ensure!(
         w.shape.len() == 2,
         "direct transposed weight upload requires a rank-2 tensor, got shape {:?}",
@@ -645,7 +646,7 @@ fn transposed_weight_bytes_2d(w: &WeightTensor) -> Result<(Vec<u8>, [usize; 2])>
 }
 
 fn weight_to_transposed_tensor_2d(w: &WeightTensor, device: &Device) -> Result<Tensor> {
-    let (data, shape) = transposed_weight_bytes_2d(w)?;
+    let (data, shape) = transposed_weight_bytes_2d_cached(w)?;
     Tensor::from_raw_buffer(&data, weight_dtype(w), &shape, device)
         .context("failed to create transposed tensor from raw buffer")
 }
@@ -750,7 +751,7 @@ fn projection_tensors_for_load_batch(
     let transposed: Result<Vec<(Vec<u8>, [usize; 2])>> = weights
         .par_iter()
         .map(|(name, w)| {
-            transposed_weight_bytes_2d(w)
+            transposed_weight_bytes_2d_cached(w)
                 .with_context(|| format!("{name} transposed projection bytes"))
         })
         .collect();
@@ -6105,6 +6106,7 @@ mod tests {
             data: crate::weights::WeightData::owned(bytes),
             shape: vec![2, 3],
             dtype: TensorDType::F32,
+            source: None,
         };
 
         let t = weight_to_tensor(&wt, &device)?;
@@ -6127,6 +6129,7 @@ mod tests {
             data: crate::weights::WeightData::owned(bytes),
             shape: vec![2, 3],
             dtype: TensorDType::F32,
+            source: None,
         };
 
         let direct = weight_to_transposed_tensor_2d(&wt, &device)?;
@@ -6150,6 +6153,7 @@ mod tests {
             data: crate::weights::WeightData::owned(bytes),
             shape: vec![2, 3],
             dtype: TensorDType::BF16,
+            source: None,
         };
 
         let (transposed, shape) = transposed_weight_bytes_2d(&wt)?;
@@ -6174,6 +6178,7 @@ mod tests {
             data: crate::weights::WeightData::owned(bytes),
             shape: vec![rows, cols],
             dtype: TensorDType::BF16,
+            source: None,
         };
 
         let (transposed, shape) = transposed_weight_bytes_2d(&wt)?;
@@ -6202,6 +6207,7 @@ mod tests {
             data: crate::weights::WeightData::owned(bytes),
             shape: vec![2, 3],
             dtype: TensorDType::F32,
+            source: None,
         };
 
         let direct = weight_to_transposed_tensor_2d(&wt, &device)?.to_device(&cpu)?;

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -791,7 +791,9 @@ impl ModelRunner {
             .validate(&self.config)
             .context("invalid speculative config")?;
 
-        let max_spec_window = spec_config.num_speculative_tokens.min(params.max_tokens.max(1));
+        let max_spec_window = spec_config
+            .num_speculative_tokens
+            .min(params.max_tokens.max(1));
         let max_total = prompt_tokens.len() + params.max_tokens + max_spec_window + 1;
         let (reservation, block_table) = {
             let mut bm_guard = lock_block_manager(block_manager)?;
@@ -981,7 +983,6 @@ impl ModelRunner {
         anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
 
         let mut linear_state = self.new_linear_state()?;
-        let mut draft_linear_state = self.new_linear_state()?;
 
         let logits = {
             let mut pc_guard = lock_paged_cache(paged_cache)?;
@@ -1015,15 +1016,9 @@ impl ModelRunner {
             }
         };
 
-        crate::speculative::draft_forward_for_state_init(
-            &*self.backend,
-            prompt_tokens,
-            &self.weights,
-            &self.config,
-            spec_config.draft_layers,
-            &mut draft_linear_state,
-        )
-        .context("draft state init for paged skip-layer failed")?;
+        let mut draft_linear_state = linear_state
+            .snapshot_for_decode_rollback()
+            .context("clone draft state from paged skip-layer prefill")?;
 
         let mut base_pos = prompt_tokens.len();
         let mut generated_tokens: Vec<TokenId> = Vec::new();
@@ -1353,11 +1348,12 @@ impl ModelRunner {
         // Verification writes the full speculative window (`last_token + k`)
         // before the loop commits accepted tokens, so flat KV needs temporary
         // headroom beyond the user-visible max token budget.
-        let max_spec_window = spec_config.num_speculative_tokens.min(params.max_tokens.max(1));
+        let max_spec_window = spec_config
+            .num_speculative_tokens
+            .min(params.max_tokens.max(1));
         let max_total = prompt_tokens.len() + params.max_tokens + max_spec_window + 1;
         let mut kv_cache = self.new_kv_cache(max_total)?;
         let mut linear_state = self.new_linear_state()?;
-        let mut draft_linear_state = self.new_linear_state()?;
 
         // Prefill: full model forward pass on all prompt tokens
         let logits = model_forward(
@@ -1372,16 +1368,9 @@ impl ModelRunner {
         .context("prefill forward pass failed")?;
         kv_cache.advance(prompt_tokens.len());
 
-        // Also run draft layers on prompt to initialize draft linear state
-        // (we don't need the output, just the state update)
-        let _ = crate::speculative::draft_forward_for_state_init(
-            &*self.backend,
-            prompt_tokens,
-            &self.weights,
-            &self.config,
-            spec_config.draft_layers,
-            &mut draft_linear_state,
-        );
+        let mut draft_linear_state = linear_state
+            .snapshot_for_decode_rollback()
+            .context("clone draft state from skip-layer prefill")?;
 
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut rng = match params.seed {
@@ -1848,11 +1837,12 @@ impl ModelRunner {
         // Verification writes the full speculative window (`last_token + k`)
         // before the loop commits accepted tokens, so flat KV needs temporary
         // headroom beyond the user-visible max token budget.
-        let max_total =
-            prompt_tokens.len() + params.max_tokens + spec_config.num_speculative_tokens + 1;
+        let max_spec_window = spec_config
+            .num_speculative_tokens
+            .min(params.max_tokens.max(1));
+        let max_total = prompt_tokens.len() + params.max_tokens + max_spec_window + 1;
         let mut kv_cache = self.new_kv_cache(max_total)?;
         let mut linear_state = self.new_linear_state()?;
-        let mut draft_linear_state = self.new_linear_state()?;
 
         let logits = model_forward(
             &*self.backend,
@@ -1866,14 +1856,9 @@ impl ModelRunner {
         .context("prefill forward pass failed")?;
         kv_cache.advance(prompt_tokens.len());
 
-        let _ = crate::speculative::draft_forward_for_state_init(
-            &*self.backend,
-            &prompt_tokens,
-            &self.weights,
-            &self.config,
-            spec_config.draft_layers,
-            &mut draft_linear_state,
-        );
+        let mut draft_linear_state = linear_state
+            .snapshot_for_decode_rollback()
+            .context("clone draft state from streaming skip-layer prefill")?;
 
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut finish_reason = FinishReason::MaxTokens;
@@ -2273,8 +2258,10 @@ impl ModelRunner {
             .validate(&self.config)
             .context("invalid speculative config")?;
 
-        let max_total =
-            prompt_tokens.len() + params.max_tokens + spec_config.num_speculative_tokens + 1;
+        let max_spec_window = spec_config
+            .num_speculative_tokens
+            .min(params.max_tokens.max(1));
+        let max_total = prompt_tokens.len() + params.max_tokens + max_spec_window + 1;
         let (reservation, block_table) = {
             let mut bm_guard = lock_block_manager(block_manager)?;
             let block_size = bm_guard.block_size();
@@ -2501,7 +2488,6 @@ impl ModelRunner {
     ) -> Result<mpsc::Receiver<StreamEvent>> {
         let (tx, rx) = mpsc::channel();
         let mut linear_state = self.new_linear_state()?;
-        let mut draft_linear_state = self.new_linear_state()?;
 
         let logits = {
             let mut pc_guard = lock_paged_cache(paged_cache)?;
@@ -2535,15 +2521,9 @@ impl ModelRunner {
             }
         };
 
-        crate::speculative::draft_forward_for_state_init(
-            &*self.backend,
-            prompt_tokens,
-            &self.weights,
-            &self.config,
-            spec_config.draft_layers,
-            &mut draft_linear_state,
-        )
-        .context("draft state init for streaming paged skip-layer failed")?;
+        let mut draft_linear_state = linear_state
+            .snapshot_for_decode_rollback()
+            .context("clone draft state from streaming paged skip-layer prefill")?;
 
         let mut base_pos = prompt_tokens.len();
         let mut generated_tokens: Vec<TokenId> = Vec::new();

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -16,6 +16,7 @@ pub mod paged_kv_cache;
 pub mod quantized;
 pub mod sampling;
 pub mod speculative;
+mod transposed_weight_cache;
 pub mod weights;
 
 pub use backend::{BackendRuntime, for_device as backend_for_device};

--- a/crates/kiln-model/src/loader.rs
+++ b/crates/kiln-model/src/loader.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 use std::sync::Arc;
+use std::time::UNIX_EPOCH;
 
 use anyhow::{Context, Result, bail};
 use memmap2::Mmap;
@@ -18,6 +19,28 @@ const LM_PREFIX: &str = "model.language_model.";
 
 /// Safetensors index file for sharded checkpoints.
 const INDEX_FILENAME: &str = "model.safetensors.index.json";
+
+#[derive(Debug)]
+struct ShardMetadata {
+    path: std::path::PathBuf,
+    size_bytes: u64,
+    modified_ns: u128,
+}
+
+#[derive(Debug)]
+struct LoadedShard {
+    meta: Arc<ShardMetadata>,
+    mmap: Arc<Mmap>,
+}
+
+#[derive(Debug)]
+struct TensorMapEntry<'a> {
+    shard: Arc<ShardMetadata>,
+    mmap: Arc<Mmap>,
+    view: &'a safetensors::tensor::TensorView<'a>,
+}
+
+type TensorMap<'a> = HashMap<&'a str, TensorMapEntry<'a>>;
 
 /// Optional loader toggles for startup-sensitive callers.
 #[derive(Debug, Clone, Copy)]
@@ -83,10 +106,12 @@ fn load_model_dense(
     );
 
     // Memory-map all shards and parse safetensors headers.
-    let mmaps = mmap_shards(&shards)?;
-    let parsed: Vec<SafeTensors<'_>> = mmaps
+    let loaded_shards = mmap_shards(&shards)?;
+    let parsed: Vec<SafeTensors<'_>> = loaded_shards
         .iter()
-        .map(|mmap| SafeTensors::deserialize(&mmap[..]).context("Failed to parse safetensors file"))
+        .map(|shard| {
+            SafeTensors::deserialize(&shard.mmap[..]).context("Failed to parse safetensors file")
+        })
         .collect::<Result<Vec<_>>>()?;
 
     // Build a unified name -> (shard_idx, tensor_view) lookup.
@@ -97,10 +122,16 @@ fn load_model_dense(
             all_tensors.push((name, shard_idx, view));
         }
     }
-    let mut tensor_map: HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)> =
-        HashMap::new();
+    let mut tensor_map: TensorMap<'_> = HashMap::new();
     for (name, shard_idx, view) in &all_tensors {
-        tensor_map.insert(name.as_str(), (Arc::clone(&mmaps[*shard_idx]), view));
+        tensor_map.insert(
+            name.as_str(),
+            TensorMapEntry {
+                shard: Arc::clone(&loaded_shards[*shard_idx].meta),
+                mmap: Arc::clone(&loaded_shards[*shard_idx].mmap),
+                view,
+            },
+        );
     }
 
     // Auto-detect prefix: try "model.language_model." first, fall back to "model.".
@@ -184,10 +215,12 @@ fn load_model_gptq(
         if shards.len() == 1 { "" } else { "s" }
     );
 
-    let mmaps = mmap_shards(&shards)?;
-    let parsed: Vec<SafeTensors<'_>> = mmaps
+    let loaded_shards = mmap_shards(&shards)?;
+    let parsed: Vec<SafeTensors<'_>> = loaded_shards
         .iter()
-        .map(|mmap| SafeTensors::deserialize(&mmap[..]).context("Failed to parse safetensors file"))
+        .map(|shard| {
+            SafeTensors::deserialize(&shard.mmap[..]).context("Failed to parse safetensors file")
+        })
         .collect::<Result<Vec<_>>>()?;
 
     let mut all_tensors: Vec<(String, usize, safetensors::tensor::TensorView<'_>)> = Vec::new();
@@ -196,10 +229,16 @@ fn load_model_gptq(
             all_tensors.push((name, shard_idx, view));
         }
     }
-    let mut tensor_map: HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)> =
-        HashMap::new();
+    let mut tensor_map: TensorMap<'_> = HashMap::new();
     for (name, shard_idx, view) in &all_tensors {
-        tensor_map.insert(name.as_str(), (Arc::clone(&mmaps[*shard_idx]), view));
+        tensor_map.insert(
+            name.as_str(),
+            TensorMapEntry {
+                shard: Arc::clone(&loaded_shards[*shard_idx].meta),
+                mmap: Arc::clone(&loaded_shards[*shard_idx].mmap),
+                view,
+            },
+        );
     }
 
     let prefix = detect_prefix(&tensor_map);
@@ -318,25 +357,40 @@ fn discover_shards(model_dir: &Path) -> Result<Vec<std::path::PathBuf>> {
 }
 
 /// Memory-map all shard files.
-fn mmap_shards(paths: &[std::path::PathBuf]) -> Result<Vec<Arc<Mmap>>> {
+fn mmap_shards(paths: &[std::path::PathBuf]) -> Result<Vec<LoadedShard>> {
     paths
         .iter()
         .map(|path| {
             let file = fs::File::open(path)
                 .with_context(|| format!("Failed to open {}", path.display()))?;
+            let meta = file
+                .metadata()
+                .with_context(|| format!("Failed to stat {}", path.display()))?;
+            let modified_ns = meta
+                .modified()
+                .ok()
+                .and_then(|mtime| mtime.duration_since(UNIX_EPOCH).ok())
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let shard_meta = Arc::new(ShardMetadata {
+                path: path.clone(),
+                size_bytes: meta.len(),
+                modified_ns,
+            });
             // SAFETY: We assume the file is not modified while mapped.
             // This is standard practice for model weight loading.
             let mmap = unsafe { Mmap::map(&file) }
                 .with_context(|| format!("Failed to mmap {}", path.display()))?;
-            Ok(Arc::new(mmap))
+            Ok(LoadedShard {
+                meta: shard_meta,
+                mmap: Arc::new(mmap),
+            })
         })
         .collect()
 }
 
 /// Detect the weight name prefix by checking which keys exist.
-fn detect_prefix(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
-) -> String {
+fn detect_prefix(tensor_map: &TensorMap<'_>) -> String {
     // Try the VL model prefix first (Qwen3.5-4B ships as VL).
     if tensor_map.contains_key(&format!("{LM_PREFIX}embed_tokens.weight") as &str) {
         return LM_PREFIX.to_string();
@@ -355,7 +409,7 @@ fn detect_prefix(
 
 /// Load one transformer layer's weights.
 fn load_layer(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -397,7 +451,7 @@ fn load_layer(
 
 /// Load full GQA attention weights.
 fn load_full_attention(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -439,7 +493,7 @@ fn load_full_attention(
 
 /// Load Gated DeltaNet linear attention weights.
 fn load_linear_attention(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -528,7 +582,7 @@ fn load_linear_attention(
 
 /// Load FFN/MLP weights.
 fn load_ffn(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -571,10 +625,7 @@ fn load_ffn(
 /// prefix (e.g. `model.language_model.mtp.`). Probe both by checking for
 /// `{candidate}fc.weight`, which is always present when MTP is shipped.
 /// Returns `None` if no MTP tensors are present (checkpoint is MTP-less).
-fn detect_mtp_prefix(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
-    base_prefix: &str,
-) -> Option<String> {
+fn detect_mtp_prefix(tensor_map: &TensorMap<'_>, base_prefix: &str) -> Option<String> {
     let prefixed = format!("{base_prefix}mtp.");
     if tensor_map.contains_key(format!("{prefixed}fc.weight").as_str()) {
         return Some(prefixed);
@@ -610,7 +661,7 @@ fn detect_mtp_prefix(
 /// Returns `Ok(Some(..))` when detected, `Ok(None)` when absent (so older
 /// or MTP-less checkpoints continue to load unchanged).
 fn load_mtp_if_present(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     prefix: &str,
     config: &ModelConfig,
 ) -> Result<Option<MtpWeights>> {
@@ -706,30 +757,45 @@ fn load_mtp_if_present(
 }
 
 /// Extract a tensor by name from the unified tensor map.
-fn extract_tensor(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
-    name: &str,
-) -> Result<WeightTensor> {
-    let (mmap, view) = tensor_map
+fn extract_tensor(tensor_map: &TensorMap<'_>, name: &str) -> Result<WeightTensor> {
+    let entry = tensor_map
         .get(name)
         .with_context(|| format!("Weight tensor not found: {name}"))?;
 
-    let dtype = convert_dtype(view.dtype())
-        .with_context(|| format!("Unsupported dtype {:?} for tensor {name}", view.dtype()))?;
+    let dtype = convert_dtype(entry.view.dtype()).with_context(|| {
+        format!(
+            "Unsupported dtype {:?} for tensor {name}",
+            entry.view.dtype()
+        )
+    })?;
 
-    let shape: Vec<usize> = view.shape().to_vec();
-    let view_data = view.data();
-    let mmap_start = mmap.as_ptr() as usize;
-    let mmap_end = mmap_start + mmap.len();
+    let shape: Vec<usize> = entry.view.shape().to_vec();
+    let view_data = entry.view.data();
+    let mmap_start = entry.mmap.as_ptr() as usize;
+    let mmap_end = mmap_start + entry.mmap.len();
     let data_start = view_data.as_ptr() as usize;
     let data_end = data_start + view_data.len();
     anyhow::ensure!(
         data_start >= mmap_start && data_end <= mmap_end,
         "tensor {name} data does not point into its safetensors mmap"
     );
-    let data = WeightData::mmap_slice(Arc::clone(mmap), data_start - mmap_start, view_data.len());
+    let data = WeightData::mmap_slice(
+        Arc::clone(&entry.mmap),
+        data_start - mmap_start,
+        view_data.len(),
+    );
 
-    Ok(WeightTensor { data, shape, dtype })
+    Ok(WeightTensor {
+        data,
+        shape,
+        dtype,
+        source: Some(WeightSource {
+            shard_path: entry.shard.path.clone(),
+            shard_size: entry.shard.size_bytes,
+            shard_mtime_ns: entry.shard.modified_ns,
+            tensor_name: name.to_owned(),
+        }),
+    })
 }
 
 /// Convert safetensors dtype to our dtype enum.
@@ -763,7 +829,7 @@ fn validate_shape(tensor: &WeightTensor, expected: &[usize], name: &str) -> Resu
 /// loaded from packed INT4 (qweight + scales + qzeros) and dequantized to BF16.
 /// Non-linear weights (norms, conv1d, a_log, dt_bias) are loaded as-is.
 fn load_layer_gptq(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -819,7 +885,7 @@ fn load_layer_gptq(
 /// Looks for `{name}.qweight`, `{name}.scales`, `{name}.qzeros` in the tensor map.
 /// Returns a dense BF16 `WeightTensor` with shape `[out_features, in_features]`.
 fn load_gptq_linear(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     name: &str,
     gptq_config: &GptqConfig,
     ctx: &str,
@@ -844,6 +910,12 @@ fn load_gptq_linear(
         &qzeros.0,
         &qzeros.1,
         gptq_config.group_size,
+        qweight.3.as_ref().map(|source| WeightSource {
+            shard_path: source.shard_path.clone(),
+            shard_size: source.shard_size,
+            shard_mtime_ns: source.shard_mtime_ns,
+            tensor_name: name.to_owned(),
+        }),
     )
     .with_context(|| format!("dequantizing {ctx}"))
 }
@@ -851,18 +923,33 @@ fn load_gptq_linear(
 /// Extract raw tensor data (bytes, shape, dtype) without dtype conversion.
 /// Used for GPTQ tensors which may be I32 (not supported by our TensorDType).
 fn extract_raw_tensor(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     name: &str,
-) -> Result<(Vec<u8>, Vec<usize>, safetensors::Dtype)> {
-    let (_mmap, view) = tensor_map
+) -> Result<(
+    Vec<u8>,
+    Vec<usize>,
+    safetensors::Dtype,
+    Option<WeightSource>,
+)> {
+    let entry = tensor_map
         .get(name)
         .with_context(|| format!("Weight tensor not found: {name}"))?;
-    Ok((view.data().to_vec(), view.shape().to_vec(), view.dtype()))
+    Ok((
+        entry.view.data().to_vec(),
+        entry.view.shape().to_vec(),
+        entry.view.dtype(),
+        Some(WeightSource {
+            shard_path: entry.shard.path.clone(),
+            shard_size: entry.shard.size_bytes,
+            shard_mtime_ns: entry.shard.modified_ns,
+            tensor_name: name.to_owned(),
+        }),
+    ))
 }
 
 /// Load GPTQ-quantized full GQA attention weights.
 fn load_full_attention_gptq(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -926,7 +1013,7 @@ fn load_full_attention_gptq(
 
 /// Load GPTQ-quantized Gated DeltaNet linear attention weights.
 fn load_linear_attention_gptq(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -1042,7 +1129,7 @@ fn load_linear_attention_gptq(
 
 /// Load GPTQ-quantized FFN/MLP weights.
 fn load_ffn_gptq(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     prefix: &str,
     layer_idx: usize,
     config: &ModelConfig,
@@ -1099,7 +1186,7 @@ fn load_ffn_gptq(
 /// Some small projections (e.g., GDN's in_proj_a/b) may not be quantized
 /// in certain GPTQ models. This function handles both cases gracefully.
 fn load_gptq_or_dense(
-    tensor_map: &HashMap<&str, (Arc<Mmap>, &safetensors::tensor::TensorView<'_>)>,
+    tensor_map: &TensorMap<'_>,
     name: &str,
     gptq_config: &GptqConfig,
     ctx: &str,

--- a/crates/kiln-model/src/quantized.rs
+++ b/crates/kiln-model/src/quantized.rs
@@ -22,7 +22,7 @@ use anyhow::{Context, Result, bail};
 use serde::Deserialize;
 use std::path::Path;
 
-use crate::weights::{TensorDType, WeightTensor};
+use crate::weights::{TensorDType, WeightSource, WeightTensor};
 
 /// GPTQ quantization configuration from `quantize_config.json`.
 #[derive(Debug, Clone, Deserialize)]
@@ -76,6 +76,7 @@ pub fn dequantize_gptq_weight(
     qzeros_data: &[u8],
     qzeros_shape: &[usize],
     group_size: usize,
+    source: Option<WeightSource>,
 ) -> Result<WeightTensor> {
     let pack_factor = 8usize; // 32 / 4 bits
 
@@ -157,6 +158,7 @@ pub fn dequantize_gptq_weight(
         data: crate::weights::WeightData::owned(output_bytes),
         shape: vec![out_features, in_features],
         dtype: TensorDType::BF16,
+        source,
     })
 }
 
@@ -345,6 +347,7 @@ mod tests {
             &qzeros_bytes,
             &[num_groups, out_features / pack_factor],
             group_size,
+            None,
         )
         .unwrap();
 
@@ -394,6 +397,7 @@ mod tests {
             &qzeros_bytes,
             &[1, 1],
             group_size,
+            None,
         )
         .unwrap();
 

--- a/crates/kiln-model/src/transposed_weight_cache.rs
+++ b/crates/kiln-model/src/transposed_weight_cache.rs
@@ -1,0 +1,261 @@
+use std::env;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+use anyhow::{Context, Result};
+
+use crate::forward::transposed_weight_bytes_2d;
+use crate::weights::WeightTensor;
+
+const CACHE_VERSION: u32 = 1;
+const CACHE_MAGIC: &[u8; 8] = b"KILNTRP1";
+
+struct CacheKey {
+    file_path: PathBuf,
+    key_bytes: Vec<u8>,
+    expected_len: usize,
+    shape: [usize; 2],
+}
+
+pub(crate) fn transposed_weight_bytes_2d_cached(
+    weight: &WeightTensor,
+) -> Result<(Vec<u8>, [usize; 2])> {
+    let Some(cache_key) = cache_key(weight) else {
+        return transposed_weight_bytes_2d(weight);
+    };
+
+    if let Some(bytes) = try_read_cached(&cache_key)? {
+        tracing::debug!(
+            tensor = %weight
+                .source
+                .as_ref()
+                .map(|s| s.tensor_name.as_str())
+                .unwrap_or("<unknown>"),
+            path = %weight
+                .source
+                .as_ref()
+                .map(|s| s.shard_path.display().to_string())
+                .unwrap_or_else(|| "<unknown>".to_string()),
+            "loaded transposed weight from disk cache"
+        );
+        return Ok((bytes, cache_key.shape));
+    }
+
+    let result = transposed_weight_bytes_2d(weight)?;
+    if let Err(err) = try_write_cached(&cache_key, &result.0) {
+        tracing::debug!(error = %err, "failed to write transposed weight cache entry");
+    }
+    Ok(result)
+}
+
+fn cache_key(weight: &WeightTensor) -> Option<CacheKey> {
+    let source = weight.source.as_ref()?;
+    let [rows, cols]: [usize; 2] = weight.shape.as_slice().try_into().ok()?;
+    let elem_size = weight.dtype.size_bytes();
+    let expected_len = rows.checked_mul(cols)?.checked_mul(elem_size)?;
+    let key_bytes = format!(
+        "version={CACHE_VERSION}\npath={}\nsize={}\nmtime_ns={}\ntensor={}\ndtype={}\nshape={},{}\n",
+        source.shard_path.display(),
+        source.shard_size,
+        source.shard_mtime_ns,
+        source.tensor_name,
+        weight.dtype,
+        rows,
+        cols
+    )
+    .into_bytes();
+    let file_path = cache_root_dir()
+        .join(format!("v{CACHE_VERSION}"))
+        .join(format!("{:016x}.bin", fnv1a64(&key_bytes)));
+    Some(CacheKey {
+        file_path,
+        key_bytes,
+        expected_len,
+        shape: [cols, rows],
+    })
+}
+
+fn try_read_cached(cache_key: &CacheKey) -> Result<Option<Vec<u8>>> {
+    let bytes = match fs::read(&cache_key.file_path) {
+        Ok(bytes) => bytes,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!(
+                    "reading transposed weight cache {}",
+                    cache_key.file_path.display()
+                )
+            });
+        }
+    };
+
+    match parse_cached_bytes(cache_key, &bytes) {
+        Ok(payload) => Ok(Some(payload)),
+        Err(err) => {
+            tracing::debug!(
+                path = %cache_key.file_path.display(),
+                error = %err,
+                "ignoring invalid transposed weight cache entry"
+            );
+            let _ = fs::remove_file(&cache_key.file_path);
+            Ok(None)
+        }
+    }
+}
+
+fn parse_cached_bytes(cache_key: &CacheKey, bytes: &[u8]) -> Result<Vec<u8>> {
+    let mut cursor = 0usize;
+    let magic = take_chunk(bytes, &mut cursor, CACHE_MAGIC.len())?;
+    anyhow::ensure!(magic == CACHE_MAGIC, "cache entry magic mismatch");
+
+    let version = u32::from_le_bytes(take_chunk(bytes, &mut cursor, 4)?.try_into().unwrap());
+    anyhow::ensure!(version == CACHE_VERSION, "cache entry version mismatch");
+
+    let key_len =
+        u32::from_le_bytes(take_chunk(bytes, &mut cursor, 4)?.try_into().unwrap()) as usize;
+    let cached_key = take_chunk(bytes, &mut cursor, key_len)?;
+    anyhow::ensure!(
+        cached_key == cache_key.key_bytes.as_slice(),
+        "cache key mismatch"
+    );
+
+    let data_len =
+        u64::from_le_bytes(take_chunk(bytes, &mut cursor, 8)?.try_into().unwrap()) as usize;
+    anyhow::ensure!(
+        data_len == cache_key.expected_len,
+        "cache payload length mismatch: expected {}, got {}",
+        cache_key.expected_len,
+        data_len
+    );
+
+    let payload = take_chunk(bytes, &mut cursor, data_len)?;
+    anyhow::ensure!(cursor == bytes.len(), "cache entry contains trailing bytes");
+    Ok(payload.to_vec())
+}
+
+fn take_chunk<'a>(bytes: &'a [u8], cursor: &mut usize, n: usize) -> Result<&'a [u8]> {
+    let start = *cursor;
+    let end = start
+        .checked_add(n)
+        .context("cache entry length overflow")?;
+    anyhow::ensure!(end <= bytes.len(), "cache entry truncated");
+    *cursor = end;
+    Ok(&bytes[start..end])
+}
+
+fn try_write_cached(cache_key: &CacheKey, data: &[u8]) -> Result<()> {
+    anyhow::ensure!(
+        data.len() == cache_key.expected_len,
+        "cache payload length mismatch: expected {}, got {}",
+        cache_key.expected_len,
+        data.len()
+    );
+
+    if let Some(parent) = cache_key.file_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!("creating transposed weight cache dir {}", parent.display())
+        })?;
+    }
+
+    let mut temp_path = cache_key.file_path.clone();
+    let suffix = format!(".{}.{}", std::process::id(), unique_nanos());
+    let temp_name = temp_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .map(|name| format!("{name}{suffix}"))
+        .unwrap_or_else(|| format!("cache{suffix}"));
+    temp_path.set_file_name(temp_name);
+
+    let mut file = match fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temp_path)
+    {
+        Ok(file) => file,
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => return Ok(()),
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!(
+                    "creating transposed weight cache temp file {}",
+                    temp_path.display()
+                )
+            });
+        }
+    };
+
+    file.write_all(CACHE_MAGIC)
+        .context("writing transposed weight cache magic")?;
+    file.write_all(&CACHE_VERSION.to_le_bytes())
+        .context("writing transposed weight cache version")?;
+    file.write_all(&(cache_key.key_bytes.len() as u32).to_le_bytes())
+        .context("writing transposed weight cache key length")?;
+    file.write_all(&cache_key.key_bytes)
+        .context("writing transposed weight cache key")?;
+    file.write_all(&(data.len() as u64).to_le_bytes())
+        .context("writing transposed weight cache payload length")?;
+    file.write_all(data)
+        .context("writing transposed weight cache payload")?;
+    match fs::rename(&temp_path, &cache_key.file_path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {
+            let _ = fs::remove_file(&temp_path);
+            Ok(())
+        }
+        Err(err) => {
+            let _ = fs::remove_file(&temp_path);
+            Err(err).with_context(|| {
+                format!(
+                    "renaming transposed weight cache {} -> {}",
+                    temp_path.display(),
+                    cache_key.file_path.display()
+                )
+            })
+        }
+    }
+}
+
+fn cache_root_dir() -> &'static PathBuf {
+    static CACHE_ROOT: OnceLock<PathBuf> = OnceLock::new();
+    CACHE_ROOT.get_or_init(|| {
+        if let Some(dir) = env::var_os("XDG_CACHE_HOME") {
+            return PathBuf::from(dir).join("kiln");
+        }
+
+        if let Some(home) = env::var_os("HOME") {
+            #[cfg(target_os = "macos")]
+            {
+                return PathBuf::from(home)
+                    .join("Library")
+                    .join("Caches")
+                    .join("kiln");
+            }
+            #[cfg(not(target_os = "macos"))]
+            {
+                return PathBuf::from(home).join(".cache").join("kiln");
+            }
+        }
+
+        env::temp_dir().join("kiln")
+    })
+}
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const PRIME: u64 = 0x100000001b3;
+
+    let mut hash = OFFSET_BASIS;
+    for &byte in bytes {
+        hash ^= byte as u64;
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+fn unique_nanos() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default()
+}

--- a/crates/kiln-model/src/weights.rs
+++ b/crates/kiln-model/src/weights.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::ops::Deref;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use memmap2::Mmap;
@@ -90,6 +91,18 @@ impl fmt::Debug for WeightData {
     }
 }
 
+/// Provenance for a loaded weight tensor.
+///
+/// This is used by the persistent transpose cache to key entries by the exact
+/// checkpoint shard that supplied the bytes.
+#[derive(Debug, Clone)]
+pub struct WeightSource {
+    pub shard_path: PathBuf,
+    pub shard_size: u64,
+    pub shard_mtime_ns: u128,
+    pub tensor_name: String,
+}
+
 /// A loaded tensor: raw bytes with shape and dtype metadata.
 ///
 /// This is a CPU-side representation. The forward pass will convert these
@@ -98,6 +111,7 @@ pub struct WeightTensor {
     pub data: WeightData,
     pub shape: Vec<usize>,
     pub dtype: TensorDType,
+    pub source: Option<WeightSource>,
 }
 
 impl WeightTensor {
@@ -119,13 +133,14 @@ impl WeightTensor {
 
 impl fmt::Debug for WeightTensor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "WeightTensor({:?}, {}, {} bytes)",
-            self.shape,
-            self.dtype,
-            self.data.len()
-        )
+        let mut ds = f.debug_struct("WeightTensor");
+        ds.field("shape", &self.shape)
+            .field("dtype", &self.dtype)
+            .field("bytes", &self.data.len());
+        if let Some(source) = &self.source {
+            ds.field("source", source);
+        }
+        ds.finish()
     }
 }
 

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -800,7 +800,8 @@ fn bench_latency_skiplayer(
     // forward pass. Near the end of generation those speculative KV writes can
     // extend past the committed token budget before stale slots are overwritten
     // or ignored, so reserve headroom for the verify window.
-    let max_total = actual_prompt_tokens + max_output_tokens + num_speculative_tokens + 1;
+    let max_spec_window = num_speculative_tokens.min(max_output_tokens.max(1));
+    let max_total = actual_prompt_tokens + max_output_tokens + max_spec_window + 1;
     let mut kv_cache = KvCache::new(
         config.num_full_attention_layers,
         config.num_kv_heads,
@@ -810,7 +811,6 @@ fn bench_latency_skiplayer(
         device,
     )?;
     let mut linear_state = LinearAttentionState::new(config, device)?;
-    let mut draft_linear_state = LinearAttentionState::new(config, device)?;
     let backend = runtime_backend::for_device(device);
 
     let eos_token_ids = tokenizer.eos_token_ids();
@@ -834,15 +834,9 @@ fn bench_latency_skiplayer(
     .context("skip-layer prefill forward pass failed")?;
     kv_cache.advance(actual_prompt_tokens);
 
-    // Initialize draft linear state from the prompt (mirrors generate.rs).
-    let _ = kiln_model::speculative::draft_forward_for_state_init(
-        &*backend,
-        &prompt_token_ids,
-        weights,
-        config,
-        draft_layers,
-        &mut draft_linear_state,
-    );
+    let mut draft_linear_state = linear_state
+        .snapshot_for_decode_rollback()
+        .context("clone draft state from skip-layer prefill")?;
 
     let mut last_token = greedy_sample(&logits)?;
     let prefill_time = prefill_start.elapsed();
@@ -1009,7 +1003,8 @@ fn bench_latency_paged_skiplayer(
     // `base_pos`. Reserve headroom so late-generation verify windows do not
     // run off the allocated paged cache before stale speculative slots are
     // overwritten by the next committed step.
-    let max_total = actual_prompt_tokens + max_output_tokens + num_speculative_tokens + 1;
+    let max_spec_window = num_speculative_tokens.min(max_output_tokens.max(1));
+    let max_total = actual_prompt_tokens + max_output_tokens + max_spec_window + 1;
     let num_blocks = (max_total + PAGED_BLOCK_SIZE - 1) / PAGED_BLOCK_SIZE;
 
     let mut paged_cache = PagedKvCache::new(
@@ -1022,7 +1017,6 @@ fn bench_latency_paged_skiplayer(
         device,
     )?;
     let mut linear_state = LinearAttentionState::new(config, device)?;
-    let mut draft_linear_state = LinearAttentionState::new(config, device)?;
     let backend = runtime_backend::for_device(device);
 
     let mut block_table = BlockTable::new();
@@ -1067,15 +1061,9 @@ fn bench_latency_paged_skiplayer(
         .context("paged skip-layer prefill forward pass failed")?
     };
 
-    kiln_model::speculative::draft_forward_for_state_init(
-        &*backend,
-        &prompt_token_ids,
-        weights,
-        config,
-        draft_layers,
-        &mut draft_linear_state,
-    )
-    .context("paged skip-layer draft state init failed")?;
+    let mut draft_linear_state = linear_state
+        .snapshot_for_decode_rollback()
+        .context("clone draft state from paged skip-layer prefill")?;
 
     let mut last_token = greedy_sample(&logits)?;
     let prefill_time = prefill_start.elapsed();


### PR DESCRIPTION
## Summary

This PR speeds up the default macOS inference path under the desktop-style settings by removing redundant work and caching launch-time transposes.

- Initialize skip-layer draft linear state from the already-computed base prefill state instead of rerunning the prompt through draft layers.
- Clamp speculative KV headroom to the actual remaining max-token window for flat, paged, streaming, and benchmark paths.
- Add a persistent transposed-weight cache keyed by shard path, size, mtime, tensor name, dtype, shape, and cache version so warm macOS launches skip repeated CPU transposition.
- Carry weight provenance through dense and GPTQ loading so cache keys are tied to the exact checkpoint bytes.

## Benchmarks

Model: `Qwen__Qwen3.5-4B`, Metal, paged skip-layer, `KILN_SPEC_METHOD=skip_layer`.

- Warm-cache `512/256`: load `4.25s`, prefill `5824.0ms`, decode `89.0ms/token` (`11.2 tok/s`), acceptance `1.000`.
- Warm-cache `512/1`: load `4.61s`, prefill `7684.7ms` in the last run; best warm run in this patch was load `4.40s`, prefill `5231.0ms`.
- Cold-cache `512/1`: load `19.58s`, prefill `6112.8ms`; cache creation is a one-time cost and warm launch is the target path.
- llama.cpp master comparison (`ca7f7b7`, Metal, BF16 GGUF, `-pg 512,256 -fa 1`): `43.02s`, `17.85 combined tok/s`.
- Current Kiln warm `512/256` total request time is about `28.61s`, or `26.8 combined tok/s`.

A candidate Metal `gdn_chunk_prep` kernel was prototyped and rejected before this PR because it regressed 512-token prefill to `51.3s`.

## Validation

- `cargo check -p kiln-server --features metal --locked`
- `cargo build -p kiln-server --features metal --locked --release --bin kiln-bench`
- `cargo test -p kiln-model --features metal --locked -- --nocapture --test-threads=1`
- `cargo test -p kiln-server --features metal --locked api::completions::tests -- --nocapture`
- `cargo test -p kiln-server --features metal --locked config::tests -- --nocapture --test-threads=1`
- `git diff --check`