### PR TITLE
[codex] Make prewarm opportunistic and batch verifier argmax

### DIFF
--- a/crates/kiln-model/src/sampling.rs
+++ b/crates/kiln-model/src/sampling.rs
@@ -55,6 +55,20 @@ pub fn greedy_sample(logits: &Tensor) -> Result<u32> {
     Ok(idx)
 }
 
+/// Greedy sampling for every row in a `[..., vocab_size]` logits tensor.
+///
+/// This runs one on-device argmax over the vocab dimension and transfers only
+/// the resulting token IDs. It is useful for batched verification paths where
+/// repeatedly narrowing rows and scalar-sampling would add one device op and
+/// one synchronization per verified position.
+pub fn greedy_sample_rows(logits: &Tensor) -> Result<Vec<u32>> {
+    let dims = logits.dims();
+    anyhow::ensure!(!dims.is_empty(), "logits tensor must have at least one dim");
+    let vocab_dim = dims.len() - 1;
+    let ids = logits.argmax(vocab_dim)?.flatten_all()?;
+    Ok(ids.to_vec1::<u32>()?)
+}
+
 /// Parameterized sampling with temperature, top-k, and top-p (nucleus) filtering.
 ///
 /// `logits`: tensor of shape `[..., vocab_size]`. Only the last position is sampled.
@@ -304,6 +318,39 @@ mod tests {
         .reshape((1, 2, 3))?;
         let token = greedy_sample(&logits)?;
         assert_eq!(token, 0); // index of 7.0 in last row
+        Ok(())
+    }
+
+    #[test]
+    fn test_greedy_sample_rows_2d() -> Result<()> {
+        let device = Device::Cpu;
+        let logits = Tensor::new(
+            &[
+                0.1_f32, 0.9, 0.2, // max index 1
+                3.0, 1.0, 2.0, // max index 0
+                -1.0, -0.5, -0.25, // max index 2
+            ],
+            &device,
+        )?
+        .reshape((3, 3))?;
+        assert_eq!(greedy_sample_rows(&logits)?, vec![1, 0, 2]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_greedy_sample_rows_3d_flattens_prefix_dims() -> Result<()> {
+        let device = Device::Cpu;
+        let logits = Tensor::new(
+            &[
+                0.1_f32, 0.9, 0.2, // max index 1
+                3.0, 1.0, 2.0, // max index 0
+                -1.0, -0.5, -0.25, // max index 2
+                4.0, 5.0, 1.0, // max index 1
+            ],
+            &device,
+        )?
+        .reshape((2, 2, 3))?;
+        assert_eq!(greedy_sample_rows(&logits)?, vec![1, 0, 2, 1]);
         Ok(())
     }
 

--- a/crates/kiln-model/src/speculative.rs
+++ b/crates/kiln-model/src/speculative.rs
@@ -28,7 +28,7 @@ use crate::forward::{
 };
 use crate::kv_cache::KvCache;
 use crate::paged_kv_cache::PagedKvCache;
-use crate::sampling::{greedy_sample, sample_with_params};
+use crate::sampling::{greedy_sample, greedy_sample_rows, sample_with_params};
 
 /// Configuration for speculative decoding.
 #[derive(Debug, Clone)]
@@ -370,20 +370,31 @@ pub fn speculative_decode_step(
     // The verify_logits has shape [1, K+1, vocab_size].
     // Position i gives logits for predicting token at position i+1.
     // So verify_logits[0] predicts what should follow last_token (i.e., verifies draft_tokens[0]).
+    let greedy_target_tokens = if temperature == 0.0 {
+        let tokens = greedy_sample_rows(&verify_logits)
+            .context("batched verification greedy sampling failed")?;
+        anyhow::ensure!(
+            tokens.len() == k + 1,
+            "verifier returned {} target tokens for window {}",
+            tokens.len(),
+            k + 1
+        );
+        Some(tokens)
+    } else {
+        None
+    };
 
     let mut accepted_tokens: Vec<TokenId> = Vec::new();
     let mut hit_eos = false;
 
     for i in 0..k {
-        // Extract target probabilities for position i
-        let pos_logits = verify_logits.narrow(1, i, 1)?.squeeze(1)?;
         let draft_token = draft_tokens[i];
 
         // Check EOS before acceptance
         if eos_token_ids.contains(&draft_token) {
             // If draft proposed EOS, check if target agrees
             if temperature == 0.0 {
-                let target_token = greedy_sample(&pos_logits)?;
+                let target_token = greedy_target_tokens.as_ref().expect("greedy tokens")[i];
                 if eos_token_ids.contains(&target_token) {
                     hit_eos = true;
                     break;
@@ -391,6 +402,7 @@ pub fn speculative_decode_step(
                 // Target disagrees with EOS — accept target's token instead
                 accepted_tokens.push(target_token);
             } else {
+                let pos_logits = verify_logits.narrow(1, i, 1)?.squeeze(1)?;
                 let target_probs = logits_to_probs(&pos_logits, temperature)?;
                 let (accepted, resampled) =
                     rejection_sample(draft_token, &draft_probs_list[i], &target_probs, rng)?;
@@ -411,7 +423,7 @@ pub fn speculative_decode_step(
 
         if temperature == 0.0 {
             // Greedy verification: accept if target agrees
-            let target_token = greedy_sample(&pos_logits)?;
+            let target_token = greedy_target_tokens.as_ref().expect("greedy tokens")[i];
             if target_token == draft_token {
                 accepted_tokens.push(draft_token);
             } else {
@@ -425,6 +437,7 @@ pub fn speculative_decode_step(
             }
         } else {
             // Stochastic verification via rejection sampling
+            let pos_logits = verify_logits.narrow(1, i, 1)?.squeeze(1)?;
             let target_probs = logits_to_probs(&pos_logits, temperature)?;
             let (accepted, resampled) =
                 rejection_sample(draft_token, &draft_probs_list[i], &target_probs, rng)?;
@@ -447,10 +460,10 @@ pub fn speculative_decode_step(
     // Bonus token: if ALL K draft tokens were accepted, sample one more from
     // the last verification position (position K).
     if accepted_tokens.len() == k && !hit_eos {
-        let bonus_logits = verify_logits.narrow(1, k, 1)?.squeeze(1)?;
         let bonus_token = if temperature == 0.0 {
-            greedy_sample(&bonus_logits)?
+            greedy_target_tokens.as_ref().expect("greedy tokens")[k]
         } else {
+            let bonus_logits = verify_logits.narrow(1, k, 1)?.squeeze(1)?;
             sample_with_params(&bonus_logits, temperature, params.top_p, params.top_k, None)?
         };
 
@@ -552,6 +565,14 @@ pub fn speculative_decode_step_paged_greedy(
         None,
     )
     .context("paged skip-layer verification forward pass failed")?;
+    let target_tokens = greedy_sample_rows(&verify_logits)
+        .context("paged skip-layer batched verification greedy sampling failed")?;
+    anyhow::ensure!(
+        target_tokens.len() == k + 1,
+        "paged skip-layer verifier returned {} target tokens for window {}",
+        target_tokens.len(),
+        k + 1
+    );
 
     let mut accepted_tokens: Vec<TokenId> = Vec::with_capacity(k + 1);
     let mut hit_eos = false;
@@ -559,8 +580,7 @@ pub fn speculative_decode_step_paged_greedy(
     let mut replay_input_len: Option<usize> = None;
 
     for (i, &draft_token) in draft_tokens.iter().enumerate() {
-        let pos_logits = verify_logits.narrow(1, i, 1)?.squeeze(1)?;
-        let target_token = greedy_sample(&pos_logits)?;
+        let target_token = target_tokens[i];
 
         if target_token == draft_token {
             accepted_draft_tokens += 1;
@@ -581,8 +601,7 @@ pub fn speculative_decode_step_paged_greedy(
     }
 
     if accepted_draft_tokens == k && !hit_eos {
-        let bonus_logits = verify_logits.narrow(1, k, 1)?.squeeze(1)?;
-        let bonus_token = greedy_sample(&bonus_logits)?;
+        let bonus_token = target_tokens[k];
         if eos_token_ids.contains(&bonus_token) {
             hit_eos = true;
         } else {

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -10,7 +10,6 @@ use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
 use std::path::Path;
-use std::sync::atomic::Ordering;
 
 use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
@@ -249,8 +248,6 @@ async fn chat_completions_inner(
     state: &AppState,
     req: ChatCompletionRequest,
 ) -> Result<Response, ApiError> {
-    wait_for_inference_prewarm(state).await?;
-
     // Convert request messages to ChatMessage for template formatting
     let chat_messages: Vec<ChatMessage> = req
         .messages
@@ -341,23 +338,6 @@ async fn chat_completions_inner(
             }
         }
     }
-}
-
-async fn wait_for_inference_prewarm(state: &AppState) -> Result<(), ApiError> {
-    if state.inference_prewarm_complete.load(Ordering::Acquire) {
-        return Ok(());
-    }
-
-    let timeout = state.request_timeout;
-    let wait = async {
-        while !state.inference_prewarm_complete.load(Ordering::Acquire) {
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
-    };
-
-    tokio::time::timeout(timeout, wait)
-        .await
-        .map_err(|_| ApiError::request_timeout(timeout.as_secs()))
 }
 
 /// Ensure the correct LoRA adapter is active for the given request.

--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -63,11 +63,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
     let uptime_seconds = state.started_at.elapsed().as_secs();
 
     // Adapter info
-    let active_adapter = state
-        .active_adapter_name
-        .read()
-        .unwrap()
-        .clone();
+    let active_adapter = state.active_adapter_name.read().unwrap().clone();
 
     let adapters_loaded = std::fs::read_dir(&state.adapter_dir)
         .map(|entries| {
@@ -128,9 +124,9 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
     // Training info
     let (active_job, _running_count) = {
         let jobs = state.training_jobs.read().unwrap();
-        let active = jobs.values().find(|j| {
-            j.state == kiln_train::TrainingState::Running
-        });
+        let active = jobs
+            .values()
+            .find(|j| j.state == kiln_train::TrainingState::Running);
         let active_info = active.map(|j| ActiveJobInfo {
             job_id: j.job_id.clone(),
             progress: j.progress,
@@ -140,10 +136,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
     };
     let queued = state.training_queue.lock().unwrap().len();
 
-    let training = TrainingInfo {
-        active_job,
-        queued,
-    };
+    let training = TrainingInfo { active_job, queued };
 
     // Health checks
     let scheduler_responsive = scheduler_stats.is_some();
@@ -163,8 +156,8 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
         },
     ];
 
-    let all_pass = checks.iter().all(|c| c.pass);
-    let status = if all_pass { "ok" } else { "degraded" };
+    let serving_ready = model_loaded && scheduler_responsive;
+    let status = if serving_ready { "ok" } else { "degraded" };
 
     let response = HealthResponse {
         status,
@@ -186,7 +179,7 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
         checks,
     };
 
-    if all_pass {
+    if serving_ready {
         (StatusCode::OK, Json(response)).into_response()
     } else {
         (StatusCode::SERVICE_UNAVAILABLE, Json(response)).into_response()
@@ -240,7 +233,12 @@ mod tests {
         let app = routes().with_state(state);
 
         let resp = app
-            .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
 
@@ -285,12 +283,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_health_ok_while_inference_prewarm_is_running() {
+        let state = make_test_state();
+        state
+            .inference_prewarm_complete
+            .store(false, Ordering::Release);
+        let app = routes().with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(json["status"], "ok");
+        let checks = json["checks"].as_array().unwrap();
+        let prewarm = checks
+            .iter()
+            .find(|c| c["name"] == "inference_prewarm_complete")
+            .unwrap();
+        assert_eq!(prewarm["pass"], false);
+    }
+
+    #[tokio::test]
     async fn test_health_scheduler_stats_present() {
         let state = make_test_state();
         let app = routes().with_state(state);
 
         let resp = app
-            .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+            .oneshot(
+                Request::builder()
+                    .uri("/health")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
             .await
             .unwrap();
 

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -261,11 +261,14 @@ fn spawn_backend_prewarm(state: AppState) {
     tokio::spawn(async move {
         tracing::info!("starting background inference prewarm");
         let prewarm_start = std::time::Instant::now();
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
         let prewarm = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-            // Hold the exclusive GPU lock so prewarm never races real
-            // generation. If a request starts first, this blocks until that
-            // request is done, then still warms the backend for the next one.
-            let _gpu_guard = gpu_lock.write().unwrap();
+            // Prewarm is opportunistic. If a live request or training job has
+            // the GPU first, skip prewarm rather than sitting in front of it.
+            let Ok(_gpu_guard) = gpu_lock.try_write() else {
+                tracing::info!("skipping inference prewarm because GPU is already busy");
+                return Ok(());
+            };
 
             let runner_guard = runner.read().unwrap();
             let params = SamplingParams {
@@ -302,13 +305,6 @@ fn spawn_backend_prewarm(state: AppState) {
                 &mut block_manager,
                 &mut paged_cache,
             )?;
-            if runner_guard.weights.mtp.is_some() {
-                let mtp_params = SamplingParams {
-                    max_tokens: 4,
-                    ..params.clone()
-                };
-                runner_guard.generate_from_tokens_mtp_speculative(&prompt_tokens, &mtp_params)?;
-            }
             Ok(())
         })
         .await;


### PR DESCRIPTION
## Summary

This PR continues the macOS inference latency work after #361.

- Stop chat completions from waiting on the inference prewarm flag before serving the request.
- Make Metal inference prewarm opportunistic: delay briefly, use `try_write`, and skip if a real request or training job already owns the GPU.
- Stop prewarm from running a second MTP speculative pass after the normal paged warmup.
- Keep `/health` serving-ready when model and scheduler are ready even if inference prewarm is still running; the prewarm check remains visible but no longer gates desktop health success.
- Add `greedy_sample_rows` and use it in greedy speculative verification so skip-layer verification does one batched argmax/readback instead of per-row `narrow + argmax + scalar` sampling.

## Benchmarks / impact

- The batched verifier argmax is correctness/overhead cleanup; the direct `512/256` Metal bench stayed essentially flat at about `88.9 ms/token`, so the bigger decode win still needs LM-head+argmax fusion under the projection instead of after logits materialization.
- The startup change targets perceived desktop latency: first requests are no longer forced to wait for background prewarm, and prewarm will not take the GPU lock if real work arrives first.

## Validation

- `cargo check -p kiln-server --features metal --locked`
- `cargo build -p kiln-server --features metal --locked --release --bin kiln --bin kiln-bench`
- `cargo test -p kiln-model --features metal --locked greedy_sample_rows -- --nocapture`
- `cargo test -p kiln-model --features metal --locked speculative::tests -- --nocapture`
- `cargo test -p kiln-server --features metal --locked api::health::tests -- --nocapture`
- `cargo test -p kiln-server --features metal --locked api::completions::tests -- --nocapture`
- `git diff --check`