### PR TITLE
Route Metal prefix attention through head-major SDPA

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3451,6 +3451,42 @@ pub fn gqa_attention_paged(
         (k, v, total_seq_len)
     };
 
+    // Multi-token append / speculative verify with prefix history. `read`
+    // already returns head-major K/V; on Metal, keep Q/K/V in that layout and
+    // avoid token-major transposes plus GQA K/V expansion.
+    if seq_len > 1
+        && backend.supports_flash_attn_prefill_head_major()
+        && !crate::mtp_debug::is_c7_sdpa_capture_armed()
+    {
+        kiln_nvtx::range!(c"kiln/attn/full/prefill_head_major");
+        if let Some(attn_output) =
+            flash_attention_forward_head_major(backend, &q, &k, &v, num_heads, head_dim)?
+        {
+            let attn_output = if let Some(ref gate) = gate {
+                let sigmoid_gate = cuda_sigmoid(gate)?;
+                (attn_output * sigmoid_gate)?
+            } else {
+                attn_output
+            };
+            if crate::mtp_debug::current_b12_layer_is_31() {
+                crate::mtp_debug::capture_b12_gqa_tap("attn_out", &attn_output)?;
+            }
+            let out = {
+                kiln_nvtx::range!(c"kiln/proj/o");
+                linear_with_lora_t(
+                    &attn_output,
+                    &attn_weights.o_proj_t,
+                    lora_layer.and_then(|l| l.o_proj.as_ref()),
+                    lora_scale,
+                )?
+            };
+            if crate::mtp_debug::current_b12_layer_is_31() {
+                crate::mtp_debug::capture_b12_gqa_tap("o_proj", &out)?;
+            }
+            return Ok(out);
+        }
+    }
+
     // Fused-attention path for prefill with existing prefix history
     // (`start_pos > 0`). Initial prefill is special-cased above so we do not
     // materialize the same K/V we just produced.


### PR DESCRIPTION
## Summary

Use the existing Metal head-major SDPA path for multi-token full-attention prefix work after paged KV reads. `PagedKvCache::read` already returns K/V as `[batch, heads, kv_len, head_dim]`; keeping Q/K/V in that layout avoids transposing back to token-major and avoids the token-major helper's GQA K/V expansion before Metal immediately consumes head-major tensors again.

This targets skip-layer verification and multi-token append with prefix history under the default macOS Metal path. Initial prefill and the existing single-token paged decode fast path are unchanged.

## Validation

- `cargo check -p kiln-server --features metal --locked`
- `cargo test -p kiln-model --features metal --locked test_model_forward_hybrid_layers -- --nocapture`
- `cargo test -p kiln-model --features metal --locked test_paged_decode_parity_with_direct_sdpa -- --nocapture`
- `cargo build -p kiln-server --features metal --locked --release --bin kiln-bench`
- `git diff --check`

## Benchmark

Qwen3.5-4B, Metal, `KILN_SPEC_METHOD=skip_layer`, `--paged --latency-only`:

- `8192/128`: prefill `88437.0ms`, mean ITL `117.1ms`, acceptance `1.000`
- Prior post-PR #365 reference: prefill about `88117.5ms`, mean ITL about `142.1ms`, acceptance `1.000`