### PR TITLE
Enable tiled prefill by default on Metal

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -822,33 +822,65 @@ fn marlin_bf16_drop_disabled() -> bool {
 /// `GDN_CHUNK_SIZE` (64) so the chunkwise kernel never sees a partial tail
 /// chunk from a tile boundary.
 pub const STREAMING_PREFILL_DEFAULT_TILE: usize = 8192;
+pub const STREAMING_PREFILL_METAL_DEFAULT_TILE: usize = 4096;
+pub const STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD: usize = 8192;
+
+fn streaming_prefill_env_override() -> Option<bool> {
+    std::env::var("KILN_STREAMING_PREFILL")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+        .map(str::to_ascii_lowercase)
+        .and_then(|v| match v.as_str() {
+            "1" | "true" | "yes" => Some(true),
+            "0" | "false" | "no" => Some(false),
+            _ => None,
+        })
+}
 
 /// Read `KILN_STREAMING_PREFILL` and return whether the streaming prefill
-/// dispatch should be used at all. Defaults to false.
+/// dispatch was explicitly enabled. Defaults to false for compatibility with
+/// tests and non-device-aware callers.
 pub fn streaming_prefill_enabled() -> bool {
-    matches!(
-        std::env::var("KILN_STREAMING_PREFILL")
-            .ok()
-            .as_deref()
-            .map(str::trim)
-            .map(str::to_ascii_lowercase)
-            .as_deref(),
-        Some("1") | Some("true") | Some("yes")
-    )
+    streaming_prefill_env_override().unwrap_or(false)
+}
+
+/// Device-aware streaming prefill policy for production prefill dispatch.
+///
+/// Env overrides win. Without an override, long Metal prompts use tiled
+/// prefill by default because it reduces peak intermediates and improves TTFT
+/// on the macOS desktop path.
+pub fn streaming_prefill_enabled_for(device: &Device, seq_len: usize) -> bool {
+    if let Some(enabled) = streaming_prefill_env_override() {
+        return enabled;
+    }
+    matches!(device, Device::Metal(_)) && seq_len >= STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD
+}
+
+fn streaming_tile_tokens_env_override() -> Option<usize> {
+    std::env::var("KILN_STREAMING_TILE_TOKENS")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|&n| n > 0 && n % GDN_CHUNK_SIZE == 0)
 }
 
 /// Read `KILN_STREAMING_TILE_TOKENS` (positive multiple of `GDN_CHUNK_SIZE`).
 /// Falls back to `STREAMING_PREFILL_DEFAULT_TILE` when unset, malformed, zero,
-/// or not a multiple of 64. The fallback path matches the documented default
-/// so misconfiguration cannot silently change the tile boundary.
+/// or not a multiple of 64.
 pub fn streaming_tile_tokens() -> usize {
-    match std::env::var("KILN_STREAMING_TILE_TOKENS")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-    {
-        Some(n) if n > 0 && n % GDN_CHUNK_SIZE == 0 => n,
-        _ => STREAMING_PREFILL_DEFAULT_TILE,
-    }
+    streaming_tile_tokens_env_override().unwrap_or(STREAMING_PREFILL_DEFAULT_TILE)
+}
+
+/// Device-aware tile-size default. Env overrides win; otherwise Metal uses a
+/// smaller tile because it measured faster for long desktop TTFT.
+pub fn streaming_tile_tokens_for(device: &Device) -> usize {
+    streaming_tile_tokens_env_override().unwrap_or_else(|| {
+        if matches!(device, Device::Metal(_)) {
+            STREAMING_PREFILL_METAL_DEFAULT_TILE
+        } else {
+            STREAMING_PREFILL_DEFAULT_TILE
+        }
+    })
 }
 
 /// Read `KILN_STREAMING_LAST_TOKEN_LM_HEAD`. Defaults to true: in streaming
@@ -5217,7 +5249,7 @@ pub fn model_forward_paged_streaming(
         start_pos,
         linear_state,
         lora,
-        streaming_tile_tokens(),
+        streaming_tile_tokens_for(weights.embed_tokens.device()),
         streaming_last_token_lm_head(),
     )
 }
@@ -8894,23 +8926,53 @@ mod tests {
             std::env::remove_var("KILN_STREAMING_LAST_TOKEN_LM_HEAD");
         }
         assert!(!streaming_prefill_enabled(), "default must be disabled");
+        assert!(!streaming_prefill_enabled_for(
+            &Device::Cpu,
+            STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD
+        ));
         assert_eq!(streaming_tile_tokens(), STREAMING_PREFILL_DEFAULT_TILE);
+        assert_eq!(
+            streaming_tile_tokens_for(&Device::Cpu),
+            STREAMING_PREFILL_DEFAULT_TILE
+        );
         assert!(streaming_last_token_lm_head(), "default must be true");
+
+        #[cfg(feature = "metal")]
+        if let Some(device) = crate::backend::metal::try_new_metal() {
+            assert!(!streaming_prefill_enabled_for(
+                &device,
+                STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD - 1
+            ));
+            assert!(streaming_prefill_enabled_for(
+                &device,
+                STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD
+            ));
+            assert_eq!(
+                streaming_tile_tokens_for(&device),
+                STREAMING_PREFILL_METAL_DEFAULT_TILE
+            );
+        }
 
         unsafe {
             std::env::set_var("KILN_STREAMING_PREFILL", "1");
         }
         assert!(streaming_prefill_enabled());
+        assert!(streaming_prefill_enabled_for(&Device::Cpu, 1));
 
         unsafe {
             std::env::set_var("KILN_STREAMING_PREFILL", "0");
         }
         assert!(!streaming_prefill_enabled());
+        assert!(!streaming_prefill_enabled_for(
+            &Device::Cpu,
+            STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD
+        ));
 
         unsafe {
             std::env::set_var("KILN_STREAMING_TILE_TOKENS", "256");
         }
         assert_eq!(streaming_tile_tokens(), 256);
+        assert_eq!(streaming_tile_tokens_for(&Device::Cpu), 256);
 
         // Bad value (not a multiple of GDN_CHUNK_SIZE) falls back to default.
         unsafe {

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -18,7 +18,7 @@ use crate::cuda_graph::CudaGraphRunner;
 use crate::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
     model_forward_paged_last_token, model_forward_paged_last_token_with_last_hidden,
-    model_forward_paged_streaming, streaming_prefill_enabled,
+    model_forward_paged_streaming, streaming_prefill_enabled_for,
 };
 use crate::kv_cache::KvCache;
 use crate::lora_loader::LoraWeights;
@@ -850,7 +850,7 @@ impl ModelRunner {
 
         let logits = {
             let mut pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled() {
+            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming(
                     &*self.backend,
                     prompt_tokens,
@@ -986,7 +986,7 @@ impl ModelRunner {
 
         let logits = {
             let mut pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled() {
+            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming(
                     &*self.backend,
                     prompt_tokens,
@@ -1165,9 +1165,9 @@ impl ModelRunner {
         let mut linear_state = self.new_linear_state()?;
 
         // Prefill: forward pass on all prompt tokens (never uses CUDA graphs).
-        // When KILN_STREAMING_PREFILL=1, iterate in tiles to cap peak activation
-        // memory for long contexts; otherwise use the monolithic path.
-        let logits = if streaming_prefill_enabled() {
+        // Long Metal prompts use tiled streaming prefill by default; env
+        // overrides can force either path.
+        let logits = if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
             model_forward_paged_streaming(
                 &*self.backend,
                 prompt_tokens,
@@ -2363,7 +2363,7 @@ impl ModelRunner {
 
         let logits = {
             let mut pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled() {
+            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming(
                     &*self.backend,
                     prompt_tokens,
@@ -2491,7 +2491,7 @@ impl ModelRunner {
 
         let logits = {
             let mut pc_guard = lock_paged_cache(paged_cache)?;
-            if streaming_prefill_enabled() {
+            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
                 model_forward_paged_streaming(
                     &*self.backend,
                     prompt_tokens,
@@ -2687,9 +2687,9 @@ impl ModelRunner {
         let (tx, rx) = mpsc::channel();
         let mut linear_state = self.new_linear_state()?;
 
-        // Prefill. When KILN_STREAMING_PREFILL=1, use the tiled streaming path
-        // to cap peak activation memory for long contexts.
-        let prefill_result = if streaming_prefill_enabled() {
+        // Prefill. Long Metal prompts use tiled streaming prefill by default;
+        // env overrides can force either path.
+        let prefill_result = if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
             model_forward_paged_streaming(
                 &*self.backend,
                 &prompt_tokens,

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -20,7 +20,7 @@ use kiln_model::backend as runtime_backend;
 use kiln_model::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
     model_forward_paged_last_token, model_forward_paged_last_token_with_last_hidden,
-    model_forward_paged_streaming, streaming_prefill_enabled,
+    model_forward_paged_streaming, streaming_prefill_enabled_for,
 };
 use kiln_model::kv_cache::KvCache;
 use kiln_model::paged_kv_cache::PagedKvCache;
@@ -597,11 +597,11 @@ fn bench_latency_paged(
          ({actual_prompt_tokens} prompt tokens)..."
     );
 
-    // Prefill: forward pass on all prompt tokens via paged path.
-    // KILN_STREAMING_PREFILL=1 opts into the tiled path that caps peak
-    // activation memory for long contexts.
+    // Prefill: forward pass on all prompt tokens via paged path. Long Metal
+    // prompts use tiled streaming prefill by default; env overrides can force
+    // either path.
     let prefill_start = Instant::now();
-    let logits = if streaming_prefill_enabled() {
+    let logits = if streaming_prefill_enabled_for(device, actual_prompt_tokens) {
         model_forward_paged_streaming(
             &*backend,
             &prompt_token_ids,
@@ -1049,7 +1049,7 @@ fn bench_latency_paged_skiplayer(
     );
 
     let prefill_start = Instant::now();
-    let logits = if streaming_prefill_enabled() {
+    let logits = if streaming_prefill_enabled_for(device, actual_prompt_tokens) {
         model_forward_paged_streaming(
             &*backend,
             &prompt_token_ids,


### PR DESCRIPTION
## Summary

Make tiled/streaming prefill the default for long Metal prompts instead of requiring `KILN_STREAMING_PREFILL=1`. Env overrides still win: `KILN_STREAMING_PREFILL=0` forces monolithic, and `KILN_STREAMING_TILE_TOKENS` still overrides tile size.

The default policy is intentionally scoped to macOS Metal long prompts: `seq_len >= 8192`, with a 4096-token Metal default tile. CPU/CUDA keep the existing 8192-token explicit streaming tile default unless env opts in.

## Why

The streaming implementation already existed and is exact-safe; it just was not on the desktop default path. After #366 removed redundant token-major/GQA layout work for prefix attention, two 4096-token tiles are faster than one 8192-token monolithic prefill on the local macOS path.

## Validation

- `cargo check -p kiln-server --features metal --locked`
- `cargo test -p kiln-model --features metal --locked test_streaming_prefill_env_helpers -- --nocapture`
- `cargo test -p kiln-model --features metal --locked test_streaming_matches_monolithic_cpu_small -- --nocapture`
- `cargo test -p kiln-model --features metal --locked test_streaming_tile_invariance_cpu -- --nocapture`
- `cargo build -p kiln-server --features metal --locked --release --bin kiln-bench`
- `git diff --check`

## Benchmark

Qwen3.5-4B, Metal, default env with only `KILN_SPEC_METHOD=skip_layer`, `--paged --latency-only`:

- `8192/1`: prefill `85308.2ms`
- `8192/128`: prefill `84307.1ms`, mean ITL `91.8ms`, acceptance `1.000`

For reference, before #366 plus this change the long-context run was about `88117.5ms` prefill and `142.1ms` mean ITL; after #366 alone it was `88437.0ms` prefill and `117.1ms` mean ITL.