### PR TITLE
PROFILING-MTP-C40a: HumanEval + chat-template OFF α re-bench (hypothesis inverted)

### DIFF
--- a/PROFILING-MTP-C40a.md
+++ b/PROFILING-MTP-C40a.md
@@ -1,0 +1,246 @@
+# Phase C40a — HumanEval + chat-template OFF N=20 α re-bench
+
+## TL;DR
+
+Removing `--chat-template` **catastrophically lowers** HumanEval MTP α.
+N=20 median **0.2814**, bootstrap 95% CI **[0.2562, 0.3026]** — far
+**below** the 0.72 paper floor and sharply below the C39 chat-template-ON
+baseline median of 0.6933.
+
+- **Hypothesis pre-test (from C39/C40 synthesis):** chat-template wraps
+  Python in a natural-language user turn, potentially shifting the MTP
+  draft off its training distribution. If α rose to ≥ 0.72 with
+  chat-template off, the paper floor would be reachable via prompt
+  framing alone.
+- **Result:** the hypothesis is **inverted**. Chat-template framing is
+  *critical* to MTP draft acceptance on code. Stripping it drops α by
+  **~0.412** absolute (median). **Every seed is below C39.**
+- **Decision input for C40b/c:** chat-template is not the bottleneck.
+  The HumanEval α gap at C35 Cell D is not a framing artifact; it is
+  a combination of a code-distribution weakness in the MTP head and,
+  possibly, other anchor-level effects (sampling temperature, W4A16).
+  C40b (temperature=0.1) and C40c (BF16) remain open as distinct
+  interventions, but C40a rules out the cheapest hypothesis.
+
+## Anchor
+
+Cell D, identical to C35/C37/C38/C39 **except** chat-template off:
+
+| Knob | Value | vs C39 |
+| --- | --- | --- |
+| Quantization | `KILN_W4A16=1` | same |
+| Argmax dtype | `KILN_MTP_ARGMAX_FP32=1` (FP32) | same |
+| Prompt framing | **`--chat-template` OFF (raw PROMPT_POOL strings)** | **flipped** |
+| KV path | `--paged` | same |
+| Prompt tokens | 512 | same |
+| Decode tokens | 128 | same |
+| Sampling | `temperature=0` (greedy) | same |
+| CUDA graphs | `KILN_CUDA_GRAPHS=true` | same |
+| Spec method | `KILN_SPEC_METHOD=mtp` | same |
+| Prompt subset | `--prompt-subset humaneval` | same |
+
+### Why chat-template is the only knob
+
+C40 synthesis (PR #372) identified chat-template as the single highest-
+leverage empirical intervention: it requires no code change (a CLI
+flag flip), it is orthogonal to numerical knobs (W4A16, FP32 argmax),
+and the pre-test hypothesis (natural-language framing shifting code
+tokens off the MTP training distribution) pointed at a *rise* in α.
+
+N=20 matches C39 exactly for direct seed-vs-seed comparison.
+
+## GPU note
+
+C39 ran on NVIDIA A6000 (sm_86). C40a ran on NVIDIA L40S (sm_89) because
+A6000 supply was constrained on RunPod at task time. MTP α is computed
+on CPU from argmax comparison of two token IDs per decode step with
+`KILN_MTP_ARGMAX_FP32=1`; GPU arch cannot materially affect the
+measurement at greedy temperature=0 given identical weights. Throughput
+numbers (decode tps, ITL) are not directly comparable to C39 across the
+arch boundary; α is.
+
+## Per-seed results (N=20, HumanEval subset, chat-template OFF)
+
+| seed | α      | decode_tps | mean_itl_ms | vs C39 α |
+| ---- | ------ | ---------- | ----------- | -------- |
+|    0 | 0.3368 |      27.06 |      36.954 | -0.3794 |
+|    1 | 0.1869 |      21.77 |      45.930 | -0.5293 |
+|    2 | 0.2451 |      23.38 |      42.765 | -0.4260 |
+|    3 | 0.2800 |      23.72 |      42.152 | -0.3694 |
+|    4 | 0.3229 |      25.40 |      39.376 | -0.4168 |
+|    5 | 0.2959 |      23.73 |      42.139 | -0.4819 |
+|    6 | 0.2959 |      23.43 |      42.683 | -0.3974 |
+|    7 | 0.2700 |      22.77 |      43.911 | -0.4233 |
+|    8 | 0.3093 |      27.99 |      35.733 | -0.3840 |
+|    9 | 0.1852 |      23.85 |      41.932 | -0.3827 |
+|   10 | 0.3368 |      25.71 |      38.892 | -0.4166 |
+|   11 | 0.1651 |      21.08 |      47.437 | -0.5646 |
+|   12 | 0.2451 |      23.01 |      43.455 | -0.4711 |
+|   13 | 0.2673 |      23.46 |      42.623 | -0.3821 |
+|   14 | 0.3229 |      25.27 |      39.577 | -0.3053 |
+|   15 | 0.2959 |      24.74 |      40.427 | -0.4108 |
+|   16 | 0.2828 |      24.13 |      41.436 | -0.3375 |
+|   17 | 0.2700 |      23.52 |      42.509 | -0.4011 |
+|   18 | 0.3093 |      25.04 |      39.932 | -0.3840 |
+|   19 | 0.1852 |      19.98 |      50.050 | -0.4642 |
+
+Every single seed is below the matching C39 seed by a large margin.
+Per-seed deltas range from −0.31 (seed 14) to −0.56 (seed 11).
+
+## Summary statistics
+
+| Metric | C40a (chat-off) | C39 (chat-on) | Δ |
+| --- | --- | --- | --- |
+| N | 20 | 20 | — |
+| median α | **0.2814** | 0.6933 | **-0.4119** |
+| mean α | 0.2704 | 0.6868 | -0.4164 |
+| stdev α | 0.0530 | 0.0499 | +0.0031 |
+| min α | 0.1651 (seed 11) | 0.5679 (seed 9) | -0.4028 |
+| max α | 0.3368 (seeds 0,10) | 0.7778 (seed 5) | -0.4410 |
+| 95% CI | **[0.2562, 0.3026]** | [0.6602, 0.7162] | — |
+| median ITL | ≈ 42.1 ms | ≈ 24.0 ms | +18.1 ms |
+| median decode tps | ≈ 23.7 tok/s | ≈ 41.6 tok/s | -17.9 tok/s |
+
+ITL / tps deltas reflect both the lower α (more verifier-only steps)
+**and** the L40S vs A6000 arch change; do not attribute them solely
+to the chat-template flip.
+
+## Floor check (Qwen3.5 paper, α ≥ 0.72)
+
+| Bound | Value | vs 0.72 | Verdict |
+| --- | --- | --- | --- |
+| CI lo | 0.2562 | < 0.72 | fail (by 0.464) |
+| median | 0.2814 | < 0.72 | fail (by 0.439) |
+| CI hi | 0.3026 | < 0.72 | fail (by 0.417) |
+
+The entire 95% CI sits ~0.42–0.46 below the paper floor. The CI
+upper bound is still further from 0.72 than the C39 lower bound was —
+chat-template OFF makes the gap *worse*, not better.
+
+## Cross-phase α comparison (Cell D anchor variants)
+
+| Phase | N | pool / subset | chat-template | median α | 95% CI | verdict vs 0.72 |
+| --- | --- | --- | --- | --- | --- | --- |
+| C37 | 10 | 8-prose | on | 0.6779 | [0.63, 0.72] | below (N small) |
+| C38 (full) | 30 | 30-domain | on | 0.7297 | [0.6996, 0.7760] | straddled |
+| C38 (GSM8K slice) | 10 | 30-domain slice | on | 0.789 | n/a | above |
+| C38 (HumanEval slice) | 10 | 30-domain slice | on | 0.6888 | n/a | below |
+| C38 (C4 slice) | 10 | 30-domain slice | on | 0.716 | n/a | borderline |
+| C39 | 20 | 10-HumanEval | **on** | 0.6933 | [0.6602, 0.7162] | below, CI clean |
+| **C40a** | **20** | **10-HumanEval** | **off** | **0.2814** | **[0.2562, 0.3026]** | **far below, ~0.43 gap** |
+
+## Interpretation
+
+1. **Chat-template is load-bearing for HumanEval MTP α.** Stripping the
+   Qwen ChatML wrapper around the Python prompts drops median α by
+   ~0.412 absolute — a direction and magnitude that completely
+   contradict the C40 pre-test hypothesis. The natural-language framing
+   is *helping*, not hurting, MTP draft acceptance on code tokens.
+2. **C40 hypothesis inversion.** The C40 synthesis suggested that
+   chat-template might be shifting code tokens off the MTP training
+   distribution. Empirically, the opposite holds: the bare code prompt,
+   without any framing, is what looks foreign to the MTP draft head.
+   One plausible cause: the MTP draft head was distilled / trained on
+   chat-formatted sequences at scale, so the ChatML preamble tokens
+   drive hidden states that the head predicts well; stripping them
+   exposes a much narrower code-only distribution that the head
+   underperforms on.
+3. **Domain ordering likely stable.** C40a does not re-measure GSM8K
+   or C4 with chat-template off, but the same mechanism that drops
+   HumanEval α by ~0.41 would be expected to drop GSM8K and C4 as
+   well. The conclusion that chat-template is the MTP's default
+   high-α regime is consistent with the C38 cross-domain ordering
+   (GSM8K > C4 > HumanEval, all at chat-template ON).
+4. **Anchor is still not suspect, but the anchor's default is now
+   justified.** C39 showed that the same Cell D anchor that scores 0.789
+   on GSM8K drops to 0.69 on HumanEval. C40a adds: removing chat-template
+   is the wrong way to close that gap.
+
+## Per-domain floor implications (update to C40 proposal)
+
+C40 (PR #372) proposed per-domain floors derived from C38/C39 data:
+GSM8K ≥ 0.78, C4 ≥ 0.70, HumanEval ≥ 0.65. C40a does not change those
+floors — it only strengthens the claim that those floors hold at the
+chat-template-ON default, and that turning chat-template off would
+violate the HumanEval floor catastrophically (observed 0.2814 vs the
+0.65 proposed floor — a 0.37 shortfall). Net effect: if kiln codifies
+per-domain floors, the default-anchor **must** include `--chat-template`
+(or the tokenizer's chat_template application) on every MTP code path;
+that framing is not a nice-to-have but a load-bearing part of reaching
+paper-floor compliance even under the lower domain-specific bar.
+
+## What C40a rules out
+
+1. Chat-template stripping as a path to α ≥ 0.72 on HumanEval. This was
+   the highest-leverage / cheapest / single-knob hypothesis coming out
+   of C40. **Dead.**
+2. Framing-drift as the dominant cause of the HumanEval code gap. The
+   gap is *not* that chat-template confuses the MTP head on code; the
+   gap is that, even *with* chat-template smoothing things, pure-code
+   content still underperforms natural language prose (GSM8K /
+   C4 prose).
+
+## Remaining open questions (C40b+)
+
+C40a pushes the highest-leverage empirical knob off the table. The
+remaining hypotheses in the C40 queue are all unchanged:
+
+1. **C40b — greedy vs temperature=0.1 on HumanEval.** Tests whether
+   greedy decoding is uniquely harmful for low-entropy code tokens;
+   MTP heads are trained over sampled distributions.
+2. **C40c — W4A16 vs BF16 on HumanEval.** Tests whether Marlin's W4
+   quantization is specifically hurting code α (vs. natural language,
+   where C37/C38 GSM8K α was ≥ 0.78 under the same W4A16 path).
+3. **Per-domain floors (C40 documentation proposal).** Still stands;
+   C40a confirms those floors are dependent on chat-template ON, so
+   any MTP bench or gate should default chat-template on.
+
+A new question surfaces from C40a:
+
+4. **Does chat-template ON also raise GSM8K α above its current
+   0.789 ceiling, or is GSM8K already saturated?** If the ChatML
+   wrapper helps code because it brings the prompt closer to the
+   MTP training distribution, GSM8K prose should be near-saturated
+   (no further α headroom), while code has residual headroom. A tiny
+   10-seed GSM8K-vs-HumanEval A/B at chat-template-on (already measured)
+   vs. an alternate framing (e.g. ChatML without system turn) could
+   probe whether "chat-template" specifically or just "any preamble"
+   is the key.
+
+## Artifacts
+
+- Branch: `ce/mtp-c40a-humaneval-no-chat-template`
+- Raw per-seed JSON: `docs/phase-c40a/seed-{0..19}.json`
+- Analysis script: `docs/phase-c40a/analyze_c40a.py` (ships with PR for
+  reproducibility)
+
+## Reproduction
+
+```bash
+cd /workspace/kiln
+for seed in $(seq 0 19); do
+  KILN_W4A16=1 \
+  KILN_SPEC_ENABLED=1 \
+  KILN_SPEC_METHOD=mtp \
+  KILN_MTP_ARGMAX_FP32=1 \
+  KILN_CUDA_GRAPHS=true \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --skip-training \
+    --prompt-tokens 512 --max-output-tokens 128 \
+    --prompt-subset humaneval \
+    --seed $seed
+done
+```
+
+Note the **absence** of `--chat-template`. All other flags match C39 to
+enable direct chat-template ON vs OFF comparison.
+
+## Cost & environment
+
+- GPU: NVIDIA L40S ($0.86/hr; A6000 supply-constrained at task time)
+- Pod: `hlxekl8ah1gjqa` on RunPod, on-demand
+- Image: `ghcr.io/ericflo/kiln-runpod:latest`
+- Build: cached via sccache + B2 (incremental ~2 min)
+- Bench run: ~38 min wall for N=20 × (model load 25s + bench 60s) per seed
+- Total pod cost: ≈ $0.75–1.00

--- a/docs/phase-c40a/analyze_c40a.py
+++ b/docs/phase-c40a/analyze_c40a.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Phase C40a analysis — HumanEval + chat-template OFF.
+
+Reads /workspace/c40a-results/seed-{0..19}.json, computes median α,
+95% bootstrap CI (rng=12345, 10_000 resamples), writes per-seed table
+and summary to stdout. Same methodology as C39 (analyze_c39.py).
+"""
+
+import json
+import random
+import statistics
+import sys
+from pathlib import Path
+
+RESULTS_DIR = Path("/workspace/c40a-results")
+N = 20
+BOOTSTRAP_RESAMPLES = 10_000
+RNG_SEED = 12345
+
+
+def main() -> int:
+    rows = []
+    for seed in range(N):
+        f = RESULTS_DIR / f"seed-{seed}.json"
+        if not f.exists():
+            print(f"MISSING: {f}", file=sys.stderr)
+            continue
+        data = json.loads(f.read_text())
+        lat = data.get("latency") or {}
+        alpha = lat.get("acceptance_rate")
+        tps = lat.get("decode_tokens_per_sec")
+        itl = lat.get("mean_inter_token_ms")
+        if alpha is None:
+            print(f"NO ALPHA: seed={seed}", file=sys.stderr)
+            continue
+        rows.append(
+            {
+                "seed": seed,
+                "alpha": alpha,
+                "decode_tps": tps,
+                "mean_itl_ms": itl,
+            }
+        )
+
+    alphas = [r["alpha"] for r in rows]
+    n = len(alphas)
+
+    # Bootstrap CI
+    rng = random.Random(RNG_SEED)
+    resample_medians = []
+    for _ in range(BOOTSTRAP_RESAMPLES):
+        sample = [rng.choice(alphas) for _ in range(n)]
+        resample_medians.append(statistics.median(sample))
+    resample_medians.sort()
+    lo = resample_medians[int(0.025 * BOOTSTRAP_RESAMPLES)]
+    hi = resample_medians[int(0.975 * BOOTSTRAP_RESAMPLES)]
+
+    median = statistics.median(alphas)
+    mean = statistics.fmean(alphas)
+    stdev = statistics.stdev(alphas) if n > 1 else 0.0
+    min_alpha = min(alphas)
+    max_alpha = max(alphas)
+    min_seed = rows[alphas.index(min_alpha)]["seed"]
+    max_seed = rows[alphas.index(max_alpha)]["seed"]
+
+    itls = [r["mean_itl_ms"] for r in rows if r["mean_itl_ms"] is not None]
+    tps = [r["decode_tps"] for r in rows if r["decode_tps"] is not None]
+    median_itl = statistics.median(itls) if itls else None
+    median_tps = statistics.median(tps) if tps else None
+
+    # Per-seed table
+    print("| seed | α      | decode_tps | mean_itl_ms |")
+    print("| ---- | ------ | ---------- | ----------- |")
+    for r in rows:
+        a = f"{r['alpha']:.4f}"
+        t = f"{r['decode_tps']:.2f}" if r["decode_tps"] is not None else "n/a"
+        i = f"{r['mean_itl_ms']:.3f}" if r["mean_itl_ms"] is not None else "n/a"
+        print(f"| {r['seed']:>4} | {a} | {t:>10} | {i:>11} |")
+
+    print()
+    print("## Summary statistics")
+    print(f"N = {n}")
+    print(f"median α = {median:.4f}")
+    print(f"mean α = {mean:.4f}")
+    print(f"stdev α = {stdev:.4f}")
+    print(f"min α = {min_alpha:.4f} (seed {min_seed})")
+    print(f"max α = {max_alpha:.4f} (seed {max_seed})")
+    print(f"95% CI (bootstrap {BOOTSTRAP_RESAMPLES} resamples, rng={RNG_SEED}): [{lo:.4f}, {hi:.4f}]")
+    print(f"median ITL ≈ {median_itl:.3f} ms" if median_itl else "median ITL: n/a")
+    print(f"median decode tps ≈ {median_tps:.2f} tok/s" if median_tps else "median tps: n/a")
+    print()
+    print("## Floor check vs 0.72")
+    print(f"CI lo = {lo:.4f}  {'PASS' if lo >= 0.72 else 'fail'}  vs 0.72")
+    print(f"median = {median:.4f}  {'PASS' if median >= 0.72 else 'fail'}  vs 0.72")
+    print(f"CI hi = {hi:.4f}  {'PASS' if hi >= 0.72 else 'fail'}  vs 0.72")
+    print()
+    if lo >= 0.72:
+        print("VERDICT: CI fully ≥ 0.72 — CHAT-TEMPLATE IS THE BUG. Flag removal unlocks paper floor.")
+    elif hi >= 0.72 and lo < 0.72:
+        print("VERDICT: CI straddles 0.72 — partial gap-closer. Queue C40b/c.")
+    else:
+        print(f"VERDICT: CI fully < 0.72 — chat-template is NOT the bottleneck. Gap confirmed structural.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/phase-c40a/seed-0.json
+++ b/docs/phase-c40a/seed-0.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 21.711267128,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 494,
+      "output_tokens": 128,
+      "total_time_secs": 2.821474561,
+      "tokens_per_sec": 45.366349131510034,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 494,
+      "output_tokens": 512,
+      "total_time_secs": 11.137407139,
+      "tokens_per_sec": 45.97120259769647,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 494,
+      "output_tokens": 1024,
+      "total_time_secs": 22.739446566,
+      "tokens_per_sec": 45.031878723516684,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 494,
+      "output_tokens": 2048,
+      "total_time_secs": 45.254478262,
+      "tokens_per_sec": 45.25518973267442,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 488,
+    "prefill_time_ms": 285.925915,
+    "prefill_tokens_per_sec": 1706.7358165138687,
+    "time_to_first_token_ms": 285.925915,
+    "mean_inter_token_ms": 36.954475094488174,
+    "p50_inter_token_ms": 31.746865,
+    "p99_inter_token_ms": 59.005837,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 27.06032212453619,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.3368421052631579,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-1.json
+++ b/docs/phase-c40a/seed-1.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 22.108585913,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 508,
+      "output_tokens": 128,
+      "total_time_secs": 2.8806473759999998,
+      "tokens_per_sec": 44.43445631923816,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 508,
+      "output_tokens": 512,
+      "total_time_secs": 11.466063488,
+      "tokens_per_sec": 44.653511690027024,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 508,
+      "output_tokens": 1024,
+      "total_time_secs": 23.025626919,
+      "tokens_per_sec": 44.4721876021985,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 508,
+      "output_tokens": 2048,
+      "total_time_secs": 46.632324378,
+      "tokens_per_sec": 43.91803383848043,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 507,
+    "prefill_time_ms": 282.93511,
+    "prefill_tokens_per_sec": 1791.9303122189397,
+    "time_to_first_token_ms": 282.93511,
+    "mean_inter_token_ms": 45.929649992125974,
+    "p50_inter_token_ms": 57.214765,
+    "p99_inter_token_ms": 62.130401,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 21.772428054022548,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.18691588785046728,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-10.json
+++ b/docs/phase-c40a/seed-10.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.375407554,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 488,
+      "output_tokens": 128,
+      "total_time_secs": 3.019569903,
+      "tokens_per_sec": 42.39014300441582,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 488,
+      "output_tokens": 512,
+      "total_time_secs": 11.514890796,
+      "tokens_per_sec": 44.4641646256738,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 488,
+      "output_tokens": 1024,
+      "total_time_secs": 23.247096843,
+      "tokens_per_sec": 44.04851095668488,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 488,
+      "output_tokens": 2048,
+      "total_time_secs": 46.030493035,
+      "tokens_per_sec": 44.492245573880155,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 488,
+    "prefill_time_ms": 280.36107,
+    "prefill_tokens_per_sec": 1740.612560795263,
+    "time_to_first_token_ms": 280.36107,
+    "mean_inter_token_ms": 38.892342590551195,
+    "p50_inter_token_ms": 31.4355075,
+    "p99_inter_token_ms": 61.977122,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 25.71200224495985,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.3368421052631579,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-11.json
+++ b/docs/phase-c40a/seed-11.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.448336051,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 507,
+      "output_tokens": 128,
+      "total_time_secs": 2.901403394,
+      "tokens_per_sec": 44.11658174271785,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 507,
+      "output_tokens": 512,
+      "total_time_secs": 11.543299311,
+      "tokens_per_sec": 44.35473656237068,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 507,
+      "output_tokens": 1024,
+      "total_time_secs": 23.212362976,
+      "tokens_per_sec": 44.11442303649767,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 507,
+      "output_tokens": 2048,
+      "total_time_secs": 45.797171884,
+      "tokens_per_sec": 44.718918565264126,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 507,
+    "prefill_time_ms": 289.509756,
+    "prefill_tokens_per_sec": 1751.2363210309222,
+    "time_to_first_token_ms": 289.509756,
+    "mean_inter_token_ms": 47.437202944881875,
+    "p50_inter_token_ms": 57.455999,
+    "p99_inter_token_ms": 67.240691,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 21.080500913216106,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.1651376146788991,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-12.json
+++ b/docs/phase-c40a/seed-12.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.449742635,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 502,
+      "output_tokens": 128,
+      "total_time_secs": 2.893522263,
+      "tokens_per_sec": 44.236742753549706,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 502,
+      "output_tokens": 512,
+      "total_time_secs": 11.547027132,
+      "tokens_per_sec": 44.34041716080381,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 502,
+      "output_tokens": 1024,
+      "total_time_secs": 23.049628963,
+      "tokens_per_sec": 44.425877815376445,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 502,
+      "output_tokens": 2048,
+      "total_time_secs": 46.376534041,
+      "tokens_per_sec": 44.16026428774149,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 502,
+    "prefill_time_ms": 300.707131,
+    "prefill_tokens_per_sec": 1669.3983888263692,
+    "time_to_first_token_ms": 300.707131,
+    "mean_inter_token_ms": 43.455426409448854,
+    "p50_inter_token_ms": 57.134116,
+    "p99_inter_token_ms": 66.103332,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 23.012085776761868,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.24509803921568626,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-13.json
+++ b/docs/phase-c40a/seed-13.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.482396202,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 486,
+      "output_tokens": 128,
+      "total_time_secs": 2.885269744,
+      "tokens_per_sec": 44.36326976574014,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 486,
+      "output_tokens": 512,
+      "total_time_secs": 11.457751312,
+      "tokens_per_sec": 44.685906165878215,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 486,
+      "output_tokens": 1024,
+      "total_time_secs": 23.031316078,
+      "tokens_per_sec": 44.46120215327801,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 486,
+      "output_tokens": 2048,
+      "total_time_secs": 46.076015933,
+      "tokens_per_sec": 44.448287433923,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 486,
+    "prefill_time_ms": 294.881156,
+    "prefill_tokens_per_sec": 1648.121591058874,
+    "time_to_first_token_ms": 294.881156,
+    "mean_inter_token_ms": 42.62290024015749,
+    "p50_inter_token_ms": 56.744059,
+    "p99_inter_token_ms": 65.13692999999999,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 23.461566302751084,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.26732673267326734,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-14.json
+++ b/docs/phase-c40a/seed-14.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.11849126,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 494,
+      "output_tokens": 128,
+      "total_time_secs": 2.930824325,
+      "tokens_per_sec": 43.67371967953078,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 494,
+      "output_tokens": 512,
+      "total_time_secs": 11.692190854,
+      "tokens_per_sec": 43.78991126584633,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 494,
+      "output_tokens": 1024,
+      "total_time_secs": 23.386429083,
+      "tokens_per_sec": 43.786077659216616,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 494,
+      "output_tokens": 2048,
+      "total_time_secs": 46.450719008,
+      "tokens_per_sec": 44.08973733317846,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 292.33171400000003,
+    "prefill_tokens_per_sec": 1689.861128101893,
+    "time_to_first_token_ms": 292.33171400000003,
+    "mean_inter_token_ms": 39.57652451968503,
+    "p50_inter_token_ms": 55.095769000000004,
+    "p99_inter_token_ms": 64.49142400000001,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 25.26750421206411,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.3229166666666667,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-15.json
+++ b/docs/phase-c40a/seed-15.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 22.649268146,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 502,
+      "output_tokens": 128,
+      "total_time_secs": 2.987433297,
+      "tokens_per_sec": 42.84614492599331,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 502,
+      "output_tokens": 512,
+      "total_time_secs": 11.630850653,
+      "tokens_per_sec": 44.02085584926133,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 502,
+      "output_tokens": 1024,
+      "total_time_secs": 23.425615448,
+      "tokens_per_sec": 43.7128323169595,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 502,
+      "output_tokens": 2048,
+      "total_time_secs": 46.143100307,
+      "tokens_per_sec": 44.38366703524935,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 502,
+    "prefill_time_ms": 296.255829,
+    "prefill_tokens_per_sec": 1694.4814274017203,
+    "time_to_first_token_ms": 296.255829,
+    "mean_inter_token_ms": 40.427175992126,
+    "p50_inter_token_ms": 55.175889,
+    "p99_inter_token_ms": 68.59464999999999,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 24.73583611664515,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.29591836734693877,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-16.json
+++ b/docs/phase-c40a/seed-16.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.40353252,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 507,
+      "output_tokens": 128,
+      "total_time_secs": 2.944612631,
+      "tokens_per_sec": 43.46921515327834,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 507,
+      "output_tokens": 512,
+      "total_time_secs": 11.477548655,
+      "tokens_per_sec": 44.60882853909366,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 507,
+      "output_tokens": 1024,
+      "total_time_secs": 23.243555533,
+      "tokens_per_sec": 44.0552220397683,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 507,
+      "output_tokens": 2048,
+      "total_time_secs": 46.866652276,
+      "tokens_per_sec": 43.69844869523063,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 507,
+    "prefill_time_ms": 288.57228499999997,
+    "prefill_tokens_per_sec": 1756.9254788276014,
+    "time_to_first_token_ms": 288.57228499999997,
+    "mean_inter_token_ms": 41.43570089763779,
+    "p50_inter_token_ms": 56.109201999999996,
+    "p99_inter_token_ms": 67.377632,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 24.13377783738682,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.2828282828282828,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-17.json
+++ b/docs/phase-c40a/seed-17.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.075130843,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 510,
+      "output_tokens": 128,
+      "total_time_secs": 2.914163543,
+      "tokens_per_sec": 43.92340996354301,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 510,
+      "output_tokens": 512,
+      "total_time_secs": 11.611588192,
+      "tokens_per_sec": 44.093882036976744,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 510,
+      "output_tokens": 1024,
+      "total_time_secs": 22.925791178,
+      "tokens_per_sec": 44.665852185840755,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 510,
+      "output_tokens": 2048,
+      "total_time_secs": 45.285796791,
+      "tokens_per_sec": 45.22389237075354,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 510,
+    "prefill_time_ms": 281.30060000000003,
+    "prefill_tokens_per_sec": 1813.0071532019483,
+    "time_to_first_token_ms": 281.30060000000003,
+    "mean_inter_token_ms": 42.508970086614134,
+    "p50_inter_token_ms": 57.578959999999995,
+    "p99_inter_token_ms": 66.576958,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 23.52444667472419,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.27,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-18.json
+++ b/docs/phase-c40a/seed-18.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 22.925385288,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 497,
+      "output_tokens": 128,
+      "total_time_secs": 2.922683804,
+      "tokens_per_sec": 43.79536363968574,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 497,
+      "output_tokens": 512,
+      "total_time_secs": 11.667643428,
+      "tokens_per_sec": 43.88204037597711,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 497,
+      "output_tokens": 1024,
+      "total_time_secs": 22.511686208,
+      "tokens_per_sec": 45.48748550146813,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 497,
+      "output_tokens": 2048,
+      "total_time_secs": 45.211816788,
+      "tokens_per_sec": 45.29789213300481,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 497,
+    "prefill_time_ms": 276.637193,
+    "prefill_tokens_per_sec": 1796.5769338904477,
+    "time_to_first_token_ms": 276.637193,
+    "mean_inter_token_ms": 39.932393992126,
+    "p50_inter_token_ms": 55.61591,
+    "p99_inter_token_ms": 69.927382,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 25.042325291020198,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.30927835051546393,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-19.json
+++ b/docs/phase-c40a/seed-19.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.298567548,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 507,
+      "output_tokens": 128,
+      "total_time_secs": 3.186997053,
+      "tokens_per_sec": 40.16319998774721,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 507,
+      "output_tokens": 512,
+      "total_time_secs": 12.586395224,
+      "tokens_per_sec": 40.67884337714962,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 507,
+      "output_tokens": 1024,
+      "total_time_secs": 24.741728393,
+      "tokens_per_sec": 41.38756936195747,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 507,
+      "output_tokens": 2048,
+      "total_time_secs": 49.330454045,
+      "tokens_per_sec": 41.515936547670584,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 507,
+    "prefill_time_ms": 281.08058200000005,
+    "prefill_tokens_per_sec": 1803.7532027025616,
+    "time_to_first_token_ms": 281.08058200000005,
+    "mean_inter_token_ms": 50.05042474409453,
+    "p50_inter_token_ms": 61.940743,
+    "p99_inter_token_ms": 74.007073,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 19.979850423107358,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.18518518518518517,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-2.json
+++ b/docs/phase-c40a/seed-2.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 22.585324644,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 501,
+      "output_tokens": 128,
+      "total_time_secs": 2.895552832,
+      "tokens_per_sec": 44.205720781681805,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 501,
+      "output_tokens": 512,
+      "total_time_secs": 11.455358684,
+      "tokens_per_sec": 44.69523950525651,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 501,
+      "output_tokens": 1024,
+      "total_time_secs": 23.350843948,
+      "tokens_per_sec": 43.85280473289727,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 501,
+      "output_tokens": 2048,
+      "total_time_secs": 46.533313169,
+      "tokens_per_sec": 44.01148038958799,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 502,
+    "prefill_time_ms": 290.776072,
+    "prefill_tokens_per_sec": 1726.4144073037758,
+    "time_to_first_token_ms": 290.776072,
+    "mean_inter_token_ms": 42.765270055118094,
+    "p50_inter_token_ms": 56.583196,
+    "p99_inter_token_ms": 66.685565,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 23.383460427378296,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.24509803921568626,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-3.json
+++ b/docs/phase-c40a/seed-3.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.331571572,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 496,
+      "output_tokens": 128,
+      "total_time_secs": 2.969648682,
+      "tokens_per_sec": 43.10274167306367,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 496,
+      "output_tokens": 512,
+      "total_time_secs": 11.924397288,
+      "tokens_per_sec": 42.93718060830179,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 496,
+      "output_tokens": 1024,
+      "total_time_secs": 23.971834855,
+      "tokens_per_sec": 42.71679686573579,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 496,
+      "output_tokens": 2048,
+      "total_time_secs": 47.146716869,
+      "tokens_per_sec": 43.438867772924496,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 486,
+    "prefill_time_ms": 309.582341,
+    "prefill_tokens_per_sec": 1569.8569835415774,
+    "time_to_first_token_ms": 309.582341,
+    "mean_inter_token_ms": 42.15202655511809,
+    "p50_inter_token_ms": 56.339991,
+    "p99_inter_token_ms": 65.115527,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 23.723651784390427,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.28,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-4.json
+++ b/docs/phase-c40a/seed-4.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.032976469,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 512,
+      "output_tokens": 128,
+      "total_time_secs": 2.88456302,
+      "tokens_per_sec": 44.374138860034336,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 512,
+      "output_tokens": 512,
+      "total_time_secs": 11.522432030000001,
+      "tokens_per_sec": 44.4350635930807,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 512,
+      "output_tokens": 1024,
+      "total_time_secs": 22.975920062,
+      "tokens_per_sec": 44.5684001875337,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 512,
+      "output_tokens": 2048,
+      "total_time_secs": 45.921125401,
+      "tokens_per_sec": 44.59821012913159,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 284.999115,
+    "prefill_tokens_per_sec": 1733.3387158061876,
+    "time_to_first_token_ms": 284.999115,
+    "mean_inter_token_ms": 39.376478165354335,
+    "p50_inter_token_ms": 55.197265,
+    "p99_inter_token_ms": 64.80825499999999,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 25.395872017824512,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.3229166666666667,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-5.json
+++ b/docs/phase-c40a/seed-5.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.085275632,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 496,
+      "output_tokens": 128,
+      "total_time_secs": 3.041775452,
+      "tokens_per_sec": 42.08068676333048,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 496,
+      "output_tokens": 512,
+      "total_time_secs": 12.080617443,
+      "tokens_per_sec": 42.38193969933827,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 496,
+      "output_tokens": 1024,
+      "total_time_secs": 23.706265208,
+      "tokens_per_sec": 43.19533216284265,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 496,
+      "output_tokens": 2048,
+      "total_time_secs": 46.595746303,
+      "tokens_per_sec": 43.95250988539575,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 502,
+    "prefill_time_ms": 291.33082,
+    "prefill_tokens_per_sec": 1723.1269935669698,
+    "time_to_first_token_ms": 291.33082,
+    "mean_inter_token_ms": 42.13857999999998,
+    "p50_inter_token_ms": 58.438708,
+    "p99_inter_token_ms": 70.32825199999999,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 23.731222077250834,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.29591836734693877,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-6.json
+++ b/docs/phase-c40a/seed-6.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.285441001,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 512,
+      "output_tokens": 128,
+      "total_time_secs": 3.049398276,
+      "tokens_per_sec": 41.97549431552181,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 512,
+      "output_tokens": 512,
+      "total_time_secs": 12.265295902,
+      "tokens_per_sec": 41.7437951836541,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 512,
+      "output_tokens": 1024,
+      "total_time_secs": 24.474535204,
+      "tokens_per_sec": 41.83940538460736,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 512,
+      "output_tokens": 2048,
+      "total_time_secs": 48.325463647,
+      "tokens_per_sec": 42.37931403948647,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 507,
+    "prefill_time_ms": 292.651846,
+    "prefill_tokens_per_sec": 1732.4339720720573,
+    "time_to_first_token_ms": 292.651846,
+    "mean_inter_token_ms": 42.683140220472474,
+    "p50_inter_token_ms": 58.770676,
+    "p99_inter_token_ms": 68.199824,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 23.428454299160528,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.29591836734693877,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-7.json
+++ b/docs/phase-c40a/seed-7.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.651873755,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 498,
+      "output_tokens": 128,
+      "total_time_secs": 3.038340141,
+      "tokens_per_sec": 42.12826545413436,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 498,
+      "output_tokens": 512,
+      "total_time_secs": 12.032931753,
+      "tokens_per_sec": 42.549896443346015,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 498,
+      "output_tokens": 1024,
+      "total_time_secs": 24.091890992,
+      "tokens_per_sec": 42.503927995524776,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 498,
+      "output_tokens": 2048,
+      "total_time_secs": 47.934932946,
+      "tokens_per_sec": 42.7245825566738,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 510,
+    "prefill_time_ms": 294.081957,
+    "prefill_tokens_per_sec": 1734.2104398468757,
+    "time_to_first_token_ms": 294.081957,
+    "mean_inter_token_ms": 43.91073137795276,
+    "p50_inter_token_ms": 59.443918,
+    "p99_inter_token_ms": 67.795848,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 22.77347629199573,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.27,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-8.json
+++ b/docs/phase-c40a/seed-8.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.652051476,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 512,
+      "output_tokens": 128,
+      "total_time_secs": 2.571419235,
+      "tokens_per_sec": 49.77795851324881,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 512,
+      "output_tokens": 512,
+      "total_time_secs": 10.298528176,
+      "tokens_per_sec": 49.71584203587268,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 512,
+      "output_tokens": 1024,
+      "total_time_secs": 20.566040197,
+      "tokens_per_sec": 49.790819729574025,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 512,
+      "output_tokens": 2048,
+      "total_time_secs": 41.398111283,
+      "tokens_per_sec": 49.47085595281746,
+      "peak_vram_mb": 18898
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 497,
+    "prefill_time_ms": 281.69227,
+    "prefill_tokens_per_sec": 1764.336664261323,
+    "time_to_first_token_ms": 281.69227,
+    "mean_inter_token_ms": 35.73282706299211,
+    "p50_inter_token_ms": 49.600678,
+    "p99_inter_token_ms": 65.19515,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 27.985471125392237,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.30927835051546393,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40a/seed-9.json
+++ b/docs/phase-c40a/seed-9.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA L40S",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.144168924,
+    "model_vram_mb": 18173
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 509,
+      "output_tokens": 128,
+      "total_time_secs": 2.615096862,
+      "tokens_per_sec": 48.946561735425306,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 509,
+      "output_tokens": 512,
+      "total_time_secs": 10.337809408,
+      "tokens_per_sec": 49.52693358844326,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 509,
+      "output_tokens": 1024,
+      "total_time_secs": 20.629547266,
+      "tokens_per_sec": 49.63754108591983,
+      "peak_vram_mb": 18469
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 509,
+      "output_tokens": 2048,
+      "total_time_secs": 41.584276378,
+      "tokens_per_sec": 49.24938410335034,
+      "peak_vram_mb": 18469
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 507,
+    "prefill_time_ms": 292.058836,
+    "prefill_tokens_per_sec": 1735.9515875082102,
+    "time_to_first_token_ms": 292.058836,
+    "mean_inter_token_ms": 41.93231563385826,
+    "p50_inter_token_ms": 51.59219,
+    "p99_inter_token_ms": 64.291312,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 23.84795556562466,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.18518518518518517,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}


### PR DESCRIPTION
## TL;DR

Removing `--chat-template` **catastrophically lowers** HumanEval MTP α.
N=20 median **0.2814**, bootstrap 95% CI **[0.2562, 0.3026]** — far below
the 0.72 paper floor and sharply below the C39 chat-template-ON baseline
median of 0.6933. **Every seed is below C39** (-0.31 to -0.56 absolute).

The C40 pre-test hypothesis (chat-template framing might be shifting
code tokens off the MTP training distribution, so removing it could
raise α toward 0.72) is **inverted**. Chat-template framing is
*load-bearing* for MTP draft acceptance on code; stripping it widens
the gap, not closes it.

## What this rules out

- **Chat-template stripping as a path to α ≥ 0.72 on HumanEval.** This was
  the cheapest, highest-leverage, single-knob hypothesis from C40. Dead.
- **Framing-drift as the dominant cause of the HumanEval code gap.** The
  gap is structural in the MTP head's code distribution, not a ChatML
  artifact.

## What's still open (C40b+)

- **C40b** — greedy vs temperature=0.1 on HumanEval (low-entropy code
  tokens may be uniquely hurt by greedy decoding).
- **C40c** — W4A16 vs BF16 on HumanEval (Marlin W4 may be specifically
  hurting code α even though GSM8K hits 0.789 under W4A16).
- **Per-domain floors** (C40 documentation proposal). Still stands; this
  result strengthens the claim that those floors require chat-template ON.

## Anchor

Cell D, identical to C35/C37/C38/C39 **except** `--chat-template` removed.
Same `KILN_W4A16=1`, `KILN_MTP_ARGMAX_FP32=1`, `--paged`, prompt=512,
decode=128, greedy, CUDA graphs ON, `--prompt-subset humaneval`.

## GPU note

Ran on NVIDIA L40S (sm_89) instead of A6000 (sm_86) because A6000 was
supply-constrained on RunPod at task time. α is computed on CPU from
argmax comparison with `KILN_MTP_ARGMAX_FP32=1`; GPU arch cannot
materially affect the measurement at greedy temperature=0 given identical
weights. Throughput numbers (ITL, decode tps) reflect both the lower α
and the arch change and are not directly cross-comparable to C39.

## Cost

≈ \$0.75–1.00 of RunPod L40S time; well under the 75-min / \$25 task cap.

## Files

- `PROFILING-MTP-C40a.md` — full writeup (TL;DR, anchor, per-seed table,
  cross-phase comparison, interpretation, remaining open questions,
  reproduction).
- `docs/phase-c40a/seed-{0..19}.json` — raw kiln-bench output for every
  seed.
- `docs/phase-c40a/analyze_c40a.py` — bootstrap CI + summary stats
  script (rng=12345, 10k resamples, matches C39 methodology).