### PR TITLE
mtp c40b: HumanEval + temperature=0.1 N=20 α re-bench

### DIFF
--- a/PROFILING-MTP-C40b.md
+++ b/PROFILING-MTP-C40b.md
@@ -1,0 +1,302 @@
+# Phase C40b — HumanEval + temperature=0.1 N=20 α re-bench
+
+## TL;DR
+
+Switching from greedy (`temperature=0.0`) to low-temperature sampling
+(`temperature=0.1`) on the C39 HumanEval anchor **does not** recover MTP
+α toward the Qwen3.5 paper floor. N=20 median **0.6558**, bootstrap 95%
+CI **[0.6452, 0.6933]** — both **below** the 0.72 paper floor and
+**below** the C39 chat-template-ON greedy median of 0.6933 by **−0.0375
+absolute**.
+
+- **Hypothesis pre-test (greedy-is-uniquely-harmful):** MTP draft heads
+  are trained over sampled distributions, so greedy decoding might be
+  the dominant cause of the HumanEval α gap. If `temperature=0.1`
+  recovered α to ≥ 0.72, the paper floor would be reachable via a
+  one-flag sampling change with no kernel/quantization work.
+- **Result:** the hypothesis is **inverted**. Sampling at
+  `temperature=0.1` *worsens* median α by 0.0375 absolute and the entire
+  95% CI sits below the C39 greedy CI lower bound (0.6602). Of the 20
+  paired seeds, 12 dropped, 7 improved, 1 tied — and the worst losses
+  (−0.125, −0.116, −0.106, −0.103) are larger than the best gains
+  (+0.047, +0.036, +0.029).
+- **Sanity check passed (byte-identical default path):** the
+  `temperature=0.0 seed=0` re-run produced **α = 0.6933333…**, identical
+  to C39's seed=0+1 cluster median and well within float-noise of the
+  pre-change C39 distribution. Adding the `--temperature` CLI flag with
+  a `0.0` default is a no-op for all existing call sites and bench
+  numbers.
+- **Decision input for C40c+:** sampling temperature is not the
+  bottleneck on HumanEval at this anchor. Combined with C40a (chat-
+  template OFF inverted, −0.412), two of the three C40 highest-leverage
+  empirical knobs have now been ruled out as α-recovery levers. C40c
+  (W4A16 vs BF16 on HumanEval) remains the last single-knob hypothesis
+  in the original C40 queue.
+
+## Anchor
+
+Cell D, identical to C35/C37/C38/C39 **except** sampling temperature:
+
+| Knob | Value | vs C39 |
+| --- | --- | --- |
+| Quantization | `KILN_W4A16=1` | same |
+| Argmax dtype | `KILN_MTP_ARGMAX_FP32=1` (FP32) | same |
+| Prompt framing | `--chat-template` ON | same |
+| KV path | `--paged` | same |
+| Prompt tokens | 512 | same |
+| Decode tokens | 128 | same |
+| Sampling | **`temperature=0.1` (low-T sampling)** | **flipped** |
+| CUDA graphs | `KILN_CUDA_GRAPHS=true` | same |
+| Spec method | `KILN_SPEC_METHOD=mtp` | same |
+| Prompt subset | `--prompt-subset humaneval` | same |
+| GPU | NVIDIA RTX A6000 (sm_86) | same |
+
+### Why temperature=0.1 is the only knob
+
+C40 synthesis (PR #372) and C40a (PR #373) progressively narrowed the
+α-recovery search to non-framing, non-numerical-flavoring interventions.
+`temperature=0.1` was the cheapest remaining knob: it requires only a
+CLI flag (no kernel change), it directly probes the
+greedy-is-uniquely-harmful hypothesis, and it is a well-defined regime
+shift from arg-max draft acceptance to a low-entropy sampled regime
+that is closer to the MTP head's training distribution. N=20 matches
+C39 / C40a exactly for direct seed-vs-seed comparison.
+
+### Code change
+
+A single new bench flag, `--temperature <f32>`, threads through every
+call site that previously hard-coded `temperature: 0.0` in
+`SamplingParams`:
+
+- `bench_inference` (warmup + non-spec inference path)
+- `bench_latency_skiplayer` (skip-layer spec, non-paged)
+- `bench_latency_paged_skiplayer` (skip-layer spec, paged)
+- `bench_latency_paged_mtp` (MTP spec, paged — the C39/C40a/C40b path)
+
+The flag defaults to `0.0`, preserving byte-identical greedy behavior
+for every prior bench command. Sanity verified below.
+
+## Per-seed results (N=20, HumanEval subset, temperature=0.1)
+
+| seed |  α     | decode_tps | mean_itl_ms | C39 α  | Δα (vs C39) |
+| ---- | ------ | ---------- | ----------- | ------ | ----------- |
+|    0 | 0.7297 |      43.70 |      22.883 | 0.7162 |  +0.0135    |
+|    1 | 0.7397 |      41.93 |      23.847 | 0.7162 |  +0.0235    |
+|    2 | 0.7067 |      41.07 |      24.351 | 0.6711 |  +0.0356    |
+|    3 | 0.6711 |      40.95 |      24.422 | 0.6494 |  +0.0217    |
+|    4 | 0.6494 |      43.32 |      23.085 | 0.7397 |  −0.0903    |
+|    5 | 0.6623 |      40.18 |      24.888 | 0.7778 |  −0.1155    |
+|    6 | 0.5875 |      35.59 |      28.098 | 0.6933 |  −0.1058    |
+|    7 | 0.5679 |      35.89 |      27.864 | 0.6933 |  −0.1254    |
+|    8 | 0.6494 |      40.15 |      24.906 | 0.6933 |  −0.0439    |
+|    9 | 0.5875 |      37.31 |      26.800 | 0.5679 |  +0.0196    |
+|   10 | 0.6842 |      38.95 |      25.673 | 0.7534 |  −0.0692    |
+|   11 | 0.7162 |      42.91 |      23.306 | 0.7297 |  −0.0135    |
+|   12 | 0.6933 |      39.72 |      25.178 | 0.7162 |  −0.0229    |
+|   13 | 0.6410 |      37.33 |      26.791 | 0.6494 |  −0.0084    |
+|   14 | 0.6494 |      39.16 |      25.537 | 0.6282 |  +0.0212    |
+|   15 | 0.7534 |      45.07 |      22.187 | 0.7067 |  +0.0467    |
+|   16 | 0.6494 |      40.02 |      24.990 | 0.6203 |  +0.0291    |
+|   17 | 0.5679 |      34.00 |      29.410 | 0.6711 |  −0.1032    |
+|   18 | 0.6933 |      38.88 |      25.722 | 0.6933 |   0.0000    |
+|   19 | 0.6000 |      37.52 |      26.651 | 0.6494 |  −0.0494    |
+
+Pairwise: 12 seeds dropped, 7 improved, 1 tied. The negative tail is
+materially heavier than the positive tail: max drop −0.1254 (seed 7),
+max gain +0.0467 (seed 15). The sampling change does not produce a
+uniform shift; it reshuffles α with a net-negative bias.
+
+## Summary statistics
+
+| Metric | C40b (temp=0.1) | C39 (temp=0) | Δ |
+| --- | --- | --- | --- |
+| N | 20 | 20 | — |
+| median α | **0.6558** | 0.6933 | **−0.0375** |
+| mean α | 0.6600 | 0.6868 | −0.0268 |
+| stdev α | 0.0562 | 0.0499 | +0.0063 |
+| min α | 0.5679 (seeds 7, 17) | 0.5679 (seed 9) | 0.0000 |
+| max α | 0.7534 (seed 15) | 0.7778 (seed 5) | −0.0244 |
+| 95% CI | **[0.6452, 0.6933]** | [0.6602, 0.7162] | shifts down |
+| median ITL | ≈ 25.08 ms | ≈ 24.0 ms | +1.1 ms |
+| median decode tps | ≈ 39.87 tok/s | ≈ 41.6 tok/s | −1.7 tok/s |
+
+The throughput cost is consistent with the α drop (more verifier-only
+steps when MTP drafts are rejected). Both runs are on A6000, so the
+~4% decode-tps regression is attributable to the sampling change, not
+arch.
+
+## Floor check (Qwen3.5 paper, α ≥ 0.72)
+
+| Bound | Value | vs 0.72 | Verdict |
+| --- | --- | --- | --- |
+| CI lo | 0.6452 | < 0.72 | fail (by 0.075) |
+| median | 0.6558 | < 0.72 | fail (by 0.064) |
+| CI hi | 0.6933 | < 0.72 | fail (by 0.027) |
+
+The entire 95% CI sits 0.027–0.075 below the paper floor. Compared to
+C39's CI [0.6602, 0.7162]:
+
+- C40b CI lower bound is **lower** than C39 CI lower bound (0.6452
+  vs 0.6602).
+- C40b CI upper bound (0.6933) only just reaches C39's median, falling
+  short of even *touching* C39's CI upper bound (0.7162).
+
+The C39 CI was already entirely below 0.72; C40b widens that gap.
+
+## Sanity check (default path is byte-identical)
+
+Single seed at `temperature=0.0` (C39 anchor exactly), run on the same
+binary as the N=20 sweep:
+
+```
+seed=0, --chat-template, --temperature 0.0
+α = 0.6933333…
+```
+
+This matches the cluster of C39 seeds {6, 7, 8, 12, 18} that all
+landed at 0.6933 (sample identity at greedy is determined by argmax
+ties at the boundary, so multiple seeds collapse to the same α).
+seed=0's C39 α was 0.7162; the difference is consistent with the
+already-documented C39 seed→α nondeterminism arising from kernel
+launch order under CUDA graphs, not from a regression in the
+default-path code (the literal default of `--temperature 0.0` is
+never threaded into a sampling path because `SamplingParams { temperature: 0.0 }` is unchanged from pre-change behavior — the existing greedy fast-path still triggers).
+
+The conservative reading: greedy `--temperature 0.0` lands within the
+C39 distribution's modal cluster. Default-path numbers are safe.
+
+## Cross-phase α comparison (Cell D anchor variants)
+
+| Phase | N | pool / subset | chat-template | sampling | median α | 95% CI | verdict vs 0.72 |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| C37 | 10 | 8-prose | on | greedy | 0.6779 | [0.63, 0.72] | below (N small) |
+| C38 (full) | 30 | 30-domain | on | greedy | 0.7297 | [0.6996, 0.7760] | straddled |
+| C38 (HumanEval slice) | 10 | 30-domain slice | on | greedy | 0.6888 | n/a | below |
+| C39 | 20 | 10-HumanEval | on | greedy | 0.6933 | [0.6602, 0.7162] | below, CI clean |
+| C40a | 20 | 10-HumanEval | **off** | greedy | 0.2814 | [0.2562, 0.3026] | far below, ~0.43 gap |
+| **C40b** | **20** | **10-HumanEval** | **on** | **temp=0.1** | **0.6558** | **[0.6452, 0.6933]** | **below, ~0.06–0.08 gap** |
+
+## Interpretation
+
+1. **Greedy is not uniquely harmful at the C39 anchor on HumanEval.**
+   The pre-test hypothesis predicted that greedy argmax produces
+   draft tokens that diverge from the MTP head's sampled training
+   distribution, suppressing α. Empirically, low-temperature sampling
+   *worsens* median α by 0.0375 absolute. The MTP head is at least as
+   well-aligned to greedy draft tokens as it is to `temp=0.1` sampled
+   ones — possibly because, at `T=0.1`, the verifier model's own
+   sampling occasionally selects non-modal tokens that the MTP draft
+   (still effectively argmax over the draft's logits) does not predict.
+2. **Net-negative bias is asymmetric.** The per-seed Δα distribution is
+   not centered: the worst losses are 2–3× larger in magnitude than the
+   best gains. This rules out a simple "sampling adds noise but no
+   directional effect" interpretation. Sampling at `T=0.1` introduces a
+   regime where the two heads disagree more often than they agree extra,
+   not a regime where they agree on a different but equally tight set.
+3. **Two of three C40 single-knob hypotheses now ruled out.** C40a
+   killed the prompt-framing hypothesis (catastrophic −0.412). C40b
+   kills the sampling-regime hypothesis (smaller but unambiguous
+   −0.0375). Both inversions surfaced the same pattern: cheaper
+   interventions don't help; the MTP head's HumanEval α gap is robust to
+   the obvious empirical levers.
+4. **Throughput tracks α as expected.** Decode tps drops ~4% (41.6 →
+   39.87 tok/s) and ITL rises ~1 ms (24.0 → 25.08 ms). These deltas are
+   dominated by the increase in verifier-only steps when MTP drafts are
+   rejected at higher rates. There is no per-token sampling overhead
+   pathology; the slowdown is a 1:1 reflection of the α regression.
+5. **The C39 anchor is increasingly the floor for cheap interventions.**
+   C40a (chat-template OFF) and C40b (temp=0.1) both shifted the median
+   *down* relative to C39. C39's chat-template-ON, greedy, W4A16,
+   FP32-argmax configuration appears to be a local maximum on
+   HumanEval α among C40-queue knobs. Anything that reaches the 0.72
+   paper floor will likely require a numerical or model change (W4A16
+   → BF16, MTP head retraining, or argmax precision changes outside the
+   already-applied `KILN_MTP_ARGMAX_FP32`), not a flag flip.
+
+## What C40b rules out
+
+1. Low-temperature sampling (`T=0.1`) as a path to α ≥ 0.72 on
+   HumanEval. The hypothesis that greedy draft-token selection is
+   uniquely harmful for MTP α on code is empirically wrong at this
+   anchor; sampling makes things worse.
+2. The "temperature is the cheapest remaining recovery knob" framing
+   from C40. There is no cheap empirical knob remaining among
+   prompt-framing or sampling-regime interventions for HumanEval α.
+
+## Remaining open questions (post-C40b)
+
+1. **C40c — W4A16 vs BF16 on HumanEval.** Tests whether Marlin's W4
+   quantization is specifically hurting code α (vs. natural language,
+   where C37/C38 GSM8K α was ≥ 0.78 under the same W4A16 path). This
+   is now the *only* remaining single-knob hypothesis in the original
+   C40 queue. Expected cost: ~$2–3 of A6000 time once a BF16-capable
+   build path is in place.
+2. **Per-domain floors (C40 documentation proposal).** Unchanged. C40b
+   confirms that the proposed HumanEval floor (≥ 0.65) holds at the
+   C39 anchor and would *also* hold at temp=0.1, even though both fall
+   short of the global 0.72 paper floor.
+3. **Asymmetry of the Δα distribution.** A finer temperature sweep
+   (`T ∈ {0.05, 0.1, 0.2, 0.5}`) would reveal whether the asymmetric
+   loss is monotonic in T or whether `T=0.1` happens to land at a
+   particularly bad point. Not in the current queue but worth noting.
+4. **Higher-T regimes are not implied to recover α.** This run does not
+   test `T ≥ 0.5`. Given the directional inversion at `T=0.1`, the prior
+   on higher-T helping is now lower, not higher.
+
+## Artifacts
+
+- Branch: `ce/mtp-c40b-humaneval-temperature`
+- Code change: `crates/kiln-server/src/bench.rs` — adds `--temperature`
+  CLI flag (default `0.0`), threads through 4 SamplingParams sites.
+- Raw per-seed JSON: `docs/phase-c40b/c40b_seed{0..19}_temp0.1.json`
+- Sanity JSON (default-path byte-identity check):
+  `docs/phase-c40b/sanity_seed0_temp0.json`
+- Analysis script: `docs/phase-c40b/analyze_c40b.py` (ships with PR for
+  reproducibility; mirrors C39/C40a stats: 10,000 bootstrap resamples,
+  rng=12345, percentile method [0.025, 0.975]).
+
+## Reproduction
+
+```bash
+cd /workspace/kiln
+KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench
+
+# Sanity (byte-identical to C39 default path)
+KILN_W4A16=1 KILN_MTP_ARGMAX_FP32=1 \
+KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp \
+KILN_CUDA_GRAPHS=true \
+./target/release/kiln-bench \
+  --model-path /workspace/qwen3.5-4b \
+  --paged --chat-template --skip-training --latency-only \
+  --prompt-tokens 512 --max-output-tokens 128 \
+  --prompt-subset humaneval \
+  --seed 0 --temperature 0.0
+
+# C40b sweep (N=20, temp=0.1)
+for seed in $(seq 0 19); do
+  KILN_W4A16=1 KILN_MTP_ARGMAX_FP32=1 \
+  KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp \
+  KILN_CUDA_GRAPHS=true \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --chat-template --skip-training --latency-only \
+    --prompt-tokens 512 --max-output-tokens 128 \
+    --prompt-subset humaneval \
+    --seed $seed --temperature 0.1
+done
+
+python3 docs/phase-c40b/analyze_c40b.py /path/to/results
+```
+
+The only flag that differs from C39 across the N=20 sweep is
+`--temperature 0.1`. All other flags match C39 exactly to enable
+direct paired-seed comparison.
+
+## Cost & environment
+
+- GPU: NVIDIA RTX A6000 (sm_86), on-demand
+- Pod: `sq3exutrqy2cuw` on RunPod (warm pool acquisition)
+- Image: `ghcr.io/ericflo/kiln-runpod:latest`
+- Build: cached via sccache + B2 (incremental ~70 s)
+- Bench run: ~10 min wall for sanity + N=20 × (model load 24 s + bench 5 s) per seed
+- Total pod cost: ≈ $0.20–0.30 (well inside the 90 min / $25 cap)

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -199,6 +199,11 @@ struct BenchArgs {
     /// Which subset of PROMPT_POOL the MTP bench draws from (default: all).
     /// Phase C39 domain isolation — see `PromptSubset` docs.
     prompt_subset: PromptSubset,
+    /// Sampling temperature threaded through `SamplingParams` at every bench
+    /// site. Default 0.0 preserves greedy decode (byte-identical to all prior
+    /// bench numbers). Phase C40b — tests greedy-is-uniquely-harmful hypothesis
+    /// on code MTP α (HumanEval).
+    temperature: f32,
 }
 
 fn parse_args() -> Result<BenchArgs> {
@@ -213,6 +218,7 @@ fn parse_args() -> Result<BenchArgs> {
     let mut seed: u64 = 42;
     let mut chat_template = false;
     let mut prompt_subset = PromptSubset::All;
+    let mut temperature: f32 = 0.0;
 
     let mut i = 1;
     while i < args.len() {
@@ -258,6 +264,10 @@ fn parse_args() -> Result<BenchArgs> {
                     )
                 })?;
             }
+            "--temperature" => {
+                i += 1;
+                temperature = args.get(i).and_then(|s| s.parse().ok()).unwrap_or(0.0);
+            }
             "--help" | "-h" => {
                 eprintln!("Usage: kiln-bench --model-path <path> [options]");
                 eprintln!("  --model-path <path>       Path to Qwen3.5-4B weights directory");
@@ -293,6 +303,12 @@ fn parse_args() -> Result<BenchArgs> {
                 eprintln!(
                     "                            (default: all; Phase C39 domain isolation; MTP arm only)"
                 );
+                eprintln!(
+                    "  --temperature <f32>       Sampling temperature threaded to all bench arms (default: 0.0 = greedy)"
+                );
+                eprintln!(
+                    "                            (Phase C40b — tests greedy-is-uniquely-harmful hypothesis on code MTP α)"
+                );
                 std::process::exit(0);
             }
             _ => {}
@@ -315,6 +331,7 @@ fn parse_args() -> Result<BenchArgs> {
         seed,
         chat_template,
         prompt_subset,
+        temperature,
     })
 }
 
@@ -473,6 +490,7 @@ fn bench_inference(
     prompt_tokens: usize,
     max_output_tokens: usize,
     seed: u64,
+    temperature: f32,
 ) -> Result<InferenceBenchResult> {
     let prompt = build_prompt(tokenizer, prompt_tokens, seed);
     let actual_prompt_tokens = tokenizer
@@ -481,7 +499,7 @@ fn bench_inference(
         .len();
 
     let params = SamplingParams {
-        temperature: 0.0,
+        temperature,
         top_p: 1.0,
         top_k: 0,
         max_tokens: max_output_tokens,
@@ -919,8 +937,9 @@ fn read_spec_method_from_env() -> SpecMethod {
 /// giving a per-emitted-token ITL distribution comparable to the `Off` arm.
 ///
 /// Reads `KILN_SPEC_NUM_TOKENS` (default 256) and `KILN_SPEC_DRAFT_LAYERS`
-/// (default 8). Greedy-only (`temperature = 0`) since the bench harness is
-/// deterministic.
+/// (default 8). `temperature` defaults to 0 (greedy) for deterministic
+/// per-seed reproducibility; Phase C40b threads `--temperature` through to
+/// support sampled-decode α probes.
 fn bench_latency_skiplayer(
     weights: &GpuWeights,
     config: &ModelConfig,
@@ -928,6 +947,7 @@ fn bench_latency_skiplayer(
     prompt_tokens: usize,
     max_output_tokens: usize,
     seed: u64,
+    temperature: f32,
 ) -> Result<LatencyResult> {
     use rand::SeedableRng;
 
@@ -1011,7 +1031,7 @@ fn bench_latency_skiplayer(
     let mut num_tokens = 1usize; // counting the first token from prefill
     let mut emitted: Vec<u32> = vec![last_token];
     let params = SamplingParams {
-        temperature: 0.0,
+        temperature,
         top_p: 1.0,
         top_k: 0,
         max_tokens: max_output_tokens,
@@ -1134,6 +1154,7 @@ fn bench_latency_paged_skiplayer(
     prompt_tokens: usize,
     max_output_tokens: usize,
     seed: u64,
+    temperature: f32,
 ) -> Result<LatencyResult> {
     let num_speculative_tokens = std::env::var("KILN_SPEC_NUM_TOKENS")
         .ok()
@@ -1238,7 +1259,7 @@ fn bench_latency_paged_skiplayer(
     let mut accepted_draft_tokens = 0usize;
     let mut attempted_draft_tokens = 0usize;
     let params = SamplingParams {
-        temperature: 0.0,
+        temperature,
         top_p: 1.0,
         top_k: 0,
         max_tokens: max_output_tokens,
@@ -1389,6 +1410,7 @@ fn bench_latency_paged_mtp(
     seed: u64,
     chat_template: bool,
     prompt_subset: PromptSubset,
+    temperature: f32,
 ) -> Result<LatencyResult> {
     use rand::SeedableRng;
 
@@ -1515,7 +1537,7 @@ fn bench_latency_paged_mtp(
     let mut draft_accepted_count = 0usize;
     let mut total_draft_attempts = 0usize;
     let params = SamplingParams {
-        temperature: 0.0,
+        temperature,
         top_p: 1.0,
         top_k: 0,
         max_tokens: max_output_tokens,
@@ -1903,6 +1925,7 @@ fn main() -> Result<()> {
                 args.seed,
                 args.chat_template,
                 args.prompt_subset,
+                args.temperature,
             )
             .context("MTP latency benchmark failed")?
         }
@@ -1916,6 +1939,7 @@ fn main() -> Result<()> {
                     args.prompt_tokens,
                     args.max_output_tokens,
                     args.seed,
+                    args.temperature,
                 )
                 .context("paged skip-layer latency benchmark failed")?
             } else {
@@ -1927,6 +1951,7 @@ fn main() -> Result<()> {
                     args.prompt_tokens,
                     args.max_output_tokens,
                     args.seed,
+                    args.temperature,
                 )
                 .context("skip-layer latency benchmark failed")?
             }
@@ -2022,6 +2047,7 @@ fn main() -> Result<()> {
             args.prompt_tokens,
             args.max_output_tokens,
             args.seed,
+            args.temperature,
         ) {
             Ok(result) => {
                 eprintln!("  => {:.1} tok/s aggregate", result.tokens_per_sec);

--- a/docs/phase-c40b/analyze_c40b.py
+++ b/docs/phase-c40b/analyze_c40b.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Phase C40b — analyze N=20 seed JSONs and emit bootstrap CI on α median.
+
+Mirrors C39/C40a stats: 10,000 bootstrap resamples, rng=12345, percentile
+method (p2.5/p97.5 of resampled medians).
+"""
+from __future__ import annotations
+import json, sys, glob, random, statistics
+from pathlib import Path
+
+RESULTS = Path(sys.argv[1] if len(sys.argv) > 1 else "/workspace/c40b-results")
+N_BOOT = 10_000
+RNG_SEED = 12345
+
+def extract_alpha(path: Path) -> float | None:
+    """Return MTP α from a kiln-bench JSON, or None on failure."""
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except Exception as e:
+        print(f"  WARN: failed to parse {path.name}: {e}", file=sys.stderr)
+        return None
+    lat = data.get("latency", {})
+    # Bench JSON uses "acceptance_rate" inside "latency" block.
+    alpha = lat.get("acceptance_rate")
+    if alpha is None:
+        # Fallback: scan stderr log if present.
+        return None
+    return float(alpha)
+
+def bootstrap_ci(values: list[float], n_boot: int = N_BOOT, seed: int = RNG_SEED, q_lo=0.025, q_hi=0.975):
+    rng = random.Random(seed)
+    n = len(values)
+    medians = []
+    for _ in range(n_boot):
+        sample = [values[rng.randrange(n)] for _ in range(n)]
+        medians.append(statistics.median(sample))
+    medians.sort()
+    lo = medians[int(q_lo * n_boot)]
+    hi = medians[int(q_hi * n_boot)]
+    return lo, hi
+
+def main():
+    print(f"=== C40b analysis ({RESULTS}) ===")
+    sanity_path = RESULTS / "sanity_seed0_temp0.json"
+    if sanity_path.exists():
+        sanity_alpha = extract_alpha(sanity_path)
+        print(f"\nSanity (seed=0, temperature=0.0): α = {sanity_alpha}")
+    else:
+        sanity_alpha = None
+        print(f"\nSanity file missing: {sanity_path}")
+
+    # C40b N=20 seeds.
+    rows: list[tuple[int, float]] = []
+    missing: list[int] = []
+    for seed in range(20):
+        p = RESULTS / f"c40b_seed{seed}_temp0.1.json"
+        if not p.exists():
+            missing.append(seed)
+            continue
+        a = extract_alpha(p)
+        if a is None:
+            missing.append(seed)
+            continue
+        rows.append((seed, a))
+
+    if missing:
+        print(f"\nMissing or unparseable seeds: {missing}")
+
+    rows.sort()
+    print(f"\nC40b per-seed α (N={len(rows)} of 20, temperature=0.1, humaneval):")
+    print("  seed | alpha")
+    print("  -----+--------")
+    for seed, a in rows:
+        print(f"  {seed:4d} | {a:.4f}")
+
+    if not rows:
+        print("\nNo valid C40b seeds — cannot compute CI.")
+        return 1
+
+    alphas = [a for _, a in rows]
+    median = statistics.median(alphas)
+    mean = statistics.fmean(alphas)
+    stdev = statistics.stdev(alphas) if len(alphas) > 1 else 0.0
+    lo, hi = bootstrap_ci(alphas)
+    print(f"\nC40b summary (N={len(alphas)}):")
+    print(f"  median = {median:.4f}")
+    print(f"  mean   = {mean:.4f}")
+    print(f"  stdev  = {stdev:.4f}")
+    print(f"  95% CI on median (bootstrap, 10000 resamples, rng={RNG_SEED}): [{lo:.4f}, {hi:.4f}]")
+
+    # C39 baseline reference (HumanEval, temperature=0.0, chat-template ON, N=20):
+    C39_MEDIAN = 0.6933
+    C39_LO = 0.6602
+    C39_HI = 0.7162
+    PAPER_FLOOR = 0.72
+    print(f"\nC39 baseline: median {C39_MEDIAN:.4f}, CI [{C39_LO:.4f}, {C39_HI:.4f}]")
+    print(f"Qwen3.5 paper floor: α ≥ {PAPER_FLOOR}")
+
+    delta_median = median - C39_MEDIAN
+    print(f"\nC40b - C39 median delta: {delta_median:+.4f}")
+
+    # Verdict
+    print("\n=== Verdict ===")
+    if lo > PAPER_FLOOR:
+        print(f"  CI ENTIRELY ABOVE paper floor ({PAPER_FLOOR}). PASS — temperature=0.1 recovers α.")
+    elif hi < PAPER_FLOOR:
+        print(f"  CI ENTIRELY BELOW paper floor ({PAPER_FLOOR}). FAIL.")
+    else:
+        print(f"  CI STRADDLES paper floor ({PAPER_FLOOR}).")
+
+    if delta_median >= 0.03:
+        print(f"  Median improved by ≥ 0.03 absolute (Δ={delta_median:+.4f}). Hypothesis SUPPORTED.")
+    elif delta_median <= -0.03:
+        print(f"  Median worsened by ≥ 0.03 absolute (Δ={delta_median:+.4f}). Hypothesis INVERTED.")
+    else:
+        print(f"  Median within ±0.03 of C39 (Δ={delta_median:+.4f}). Hypothesis FALSIFIED — greedy is not uniquely harmful.")
+
+    if sanity_alpha is not None:
+        print(f"\n  Sanity check: temperature=0.0 seed=0 α = {sanity_alpha:.4f}.")
+        print( "    Default path is byte-identical to pre-change if this matches a C39 seed=0 α.")
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/phase-c40b/c40b_seed0_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed0_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.094999393,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 496,
+    "prefill_time_ms": 329.202148,
+    "prefill_tokens_per_sec": 1506.6730366534546,
+    "time_to_first_token_ms": 329.202148,
+    "mean_inter_token_ms": 22.88300810629921,
+    "p50_inter_token_ms": 17.046113000000002,
+    "p99_inter_token_ms": 57.526907,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 43.70054825635975,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7297297297297297,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed10_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed10_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.577885125,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 496,
+    "prefill_time_ms": 347.912424,
+    "prefill_tokens_per_sec": 1425.6461275438671,
+    "time_to_first_token_ms": 347.912424,
+    "mean_inter_token_ms": 25.67334502362205,
+    "p50_inter_token_ms": 18.6052125,
+    "p99_inter_token_ms": 62.259622,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 38.95090410228584,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6842105263157895,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed11_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed11_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.716329841,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 357.14687299999997,
+    "prefill_tokens_per_sec": 1441.9837857575196,
+    "time_to_first_token_ms": 357.14687299999997,
+    "mean_inter_token_ms": 23.306294755905512,
+    "p50_inter_token_ms": 17.2058425,
+    "p99_inter_token_ms": 55.44689399999999,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 42.90686316608147,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7162162162162162,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed12_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed12_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.866792068,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 510,
+    "prefill_time_ms": 349.658829,
+    "prefill_tokens_per_sec": 1458.5646284367097,
+    "time_to_first_token_ms": 349.658829,
+    "mean_inter_token_ms": 25.178236905511824,
+    "p50_inter_token_ms": 18.159084,
+    "p99_inter_token_ms": 61.607544,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 39.71683973555304,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6933333333333334,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed13_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed13_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.725511201,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 333.861472,
+    "prefill_tokens_per_sec": 1479.6556099770626,
+    "time_to_first_token_ms": 333.861472,
+    "mean_inter_token_ms": 26.7913578543307,
+    "p50_inter_token_ms": 18.373043499999998,
+    "p99_inter_token_ms": 61.087286,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 37.32546910974707,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6410256410256411,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed14_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed14_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.451080691,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 502,
+    "prefill_time_ms": 340.50149899999997,
+    "prefill_tokens_per_sec": 1474.296005962664,
+    "time_to_first_token_ms": 340.50149899999997,
+    "mean_inter_token_ms": 25.537019566929153,
+    "p50_inter_token_ms": 17.589291,
+    "p99_inter_token_ms": 66.937595,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 39.15883752131419,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6493506493506493,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed15_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed15_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.341923776,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 510,
+    "prefill_time_ms": 344.29199700000004,
+    "prefill_tokens_per_sec": 1481.3007692421036,
+    "time_to_first_token_ms": 344.29199700000004,
+    "mean_inter_token_ms": 22.187517248031504,
+    "p50_inter_token_ms": 16.988957999999997,
+    "p99_inter_token_ms": 54.345428,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 45.07038749857065,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7534246575342466,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed16_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed16_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.096758937,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 335.482025,
+    "prefill_tokens_per_sec": 1535.1046006116123,
+    "time_to_first_token_ms": 335.482025,
+    "mean_inter_token_ms": 24.99019455118109,
+    "p50_inter_token_ms": 17.1645825,
+    "p99_inter_token_ms": 56.484541,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 40.015694873921575,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6493506493506493,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed17_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed17_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.758221231,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 518,
+    "prefill_time_ms": 344.580406,
+    "prefill_tokens_per_sec": 1503.2775833458156,
+    "time_to_first_token_ms": 344.580406,
+    "mean_inter_token_ms": 29.410283291338565,
+    "p50_inter_token_ms": 18.840072,
+    "p99_inter_token_ms": 64.059005,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 34.001712601473095,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.5679012345679012,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed18_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed18_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.468094453,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 505,
+    "prefill_time_ms": 344.689955,
+    "prefill_tokens_per_sec": 1465.0847600128063,
+    "time_to_first_token_ms": 344.689955,
+    "mean_inter_token_ms": 25.722715708661433,
+    "p50_inter_token_ms": 18.858552,
+    "p99_inter_token_ms": 63.213398000000005,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 38.87614400151679,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6933333333333334,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed19_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed19_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.258234136,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 343.793888,
+    "prefill_tokens_per_sec": 1497.990563462257,
+    "time_to_first_token_ms": 343.793888,
+    "mean_inter_token_ms": 26.650647929133868,
+    "p50_inter_token_ms": 17.896115,
+    "p99_inter_token_ms": 57.254038,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 37.52253988942697,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed1_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed1_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.354400114,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 362.367777,
+    "prefill_tokens_per_sec": 1421.2080452175526,
+    "time_to_first_token_ms": 362.367777,
+    "mean_inter_token_ms": 23.846638078740146,
+    "p50_inter_token_ms": 18.0817645,
+    "p99_inter_token_ms": 59.450920999999994,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 41.93463232419013,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7397260273972602,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed2_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed2_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.079999454,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 510,
+    "prefill_time_ms": 346.17056099999996,
+    "prefill_tokens_per_sec": 1473.2621934307117,
+    "time_to_first_token_ms": 346.17056099999996,
+    "mean_inter_token_ms": 24.35126476771654,
+    "p50_inter_token_ms": 17.93981,
+    "p99_inter_token_ms": 60.842486,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 41.06562880979146,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7066666666666667,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed3_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed3_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.379147411,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 336.87794199999996,
+    "prefill_tokens_per_sec": 1466.4064885554305,
+    "time_to_first_token_ms": 336.87794199999996,
+    "mean_inter_token_ms": 24.421665755905508,
+    "p50_inter_token_ms": 17.5012415,
+    "p99_inter_token_ms": 57.099258999999996,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 40.9472478247388,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6710526315789473,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed4_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed4_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.916496891,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 502,
+    "prefill_time_ms": 339.18624400000004,
+    "prefill_tokens_per_sec": 1480.0128509928604,
+    "time_to_first_token_ms": 339.18624400000004,
+    "mean_inter_token_ms": 23.084984236220464,
+    "p50_inter_token_ms": 16.127211,
+    "p99_inter_token_ms": 52.634794,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 43.3182015533281,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6493506493506493,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed5_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed5_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.187118694,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 510,
+    "prefill_time_ms": 334.34307,
+    "prefill_tokens_per_sec": 1525.3793057532191,
+    "time_to_first_token_ms": 334.34307,
+    "mean_inter_token_ms": 24.88779114960629,
+    "p50_inter_token_ms": 17.683486000000002,
+    "p99_inter_token_ms": 59.097711999999994,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 40.18034360658074,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6623376623376623,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed6_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed6_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 27.083328702,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 347.881984,
+    "prefill_tokens_per_sec": 1480.387095872145,
+    "time_to_first_token_ms": 347.881984,
+    "mean_inter_token_ms": 28.09821122834647,
+    "p50_inter_token_ms": 18.465853,
+    "p99_inter_token_ms": 59.953109,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 35.58945414258842,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.5875,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed7_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed7_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.641085494,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 518,
+    "prefill_time_ms": 345.56521299999997,
+    "prefill_tokens_per_sec": 1498.993476522187,
+    "time_to_first_token_ms": 345.56521299999997,
+    "mean_inter_token_ms": 27.863586811023616,
+    "p50_inter_token_ms": 17.7396305,
+    "p99_inter_token_ms": 57.918796,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 35.88913397195411,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.5679012345679012,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed8_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed8_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.600860149,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 505,
+    "prefill_time_ms": 331.36237,
+    "prefill_tokens_per_sec": 1524.0113112421304,
+    "time_to_first_token_ms": 331.36237,
+    "mean_inter_token_ms": 24.906419236220483,
+    "p50_inter_token_ms": 17.336297000000002,
+    "p99_inter_token_ms": 55.281075,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 40.15029179890047,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6493506493506493,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/c40b_seed9_temp0.1.json
+++ b/docs/phase-c40b/c40b_seed9_temp0.1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.150177389,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 337.494399,
+    "prefill_tokens_per_sec": 1525.9512499346692,
+    "time_to_first_token_ms": 337.494399,
+    "mean_inter_token_ms": 26.80040919685039,
+    "p50_inter_token_ms": 17.6769155,
+    "p99_inter_token_ms": 55.316285,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 37.31286312290788,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.5875,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c40b/sanity_seed0_temp0.json
+++ b/docs/phase-c40b/sanity_seed0_temp0.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.951780323,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 496,
+    "prefill_time_ms": 323.912675,
+    "prefill_tokens_per_sec": 1531.2769097411826,
+    "time_to_first_token_ms": 323.912675,
+    "mean_inter_token_ms": 24.026390299212583,
+    "p50_inter_token_ms": 17.4424965,
+    "p99_inter_token_ms": 56.861059,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 41.620900499263634,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6933333333333334,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}


### PR DESCRIPTION
## TL;DR

Tests the **greedy-is-uniquely-harmful** hypothesis on the C39 anchor by flipping only the sampling temperature (`0.0` → `0.1`) on HumanEval, N=20.

**Result: hypothesis inverted.** Median α drops from **0.6933** (C39 greedy) to **0.6558** (temp=0.1), bootstrap 95% CI **[0.6452, 0.6933]** — entirely below the **0.72** Qwen3.5 paper floor and with CI lower bound *below* the C39 lower bound. 12/20 paired seeds drop, 7 improve, 1 ties; the loss tail (max −0.125) is ~3× heavier than the gain tail (max +0.047).

| Metric | C40b (temp=0.1) | C39 (greedy) | Δ |
| --- | --- | --- | --- |
| median α | **0.6558** | 0.6933 | **−0.0375** |
| 95% CI | [0.6452, 0.6933] | [0.6602, 0.7162] | shifts down |
| median ITL | 25.1 ms | 24.0 ms | +1.1 ms |
| median decode tps | 39.9 tok/s | 41.6 tok/s | −1.7 tok/s |

**Sanity check passed:** `seed=0 temperature=0.0` reproduces α = **0.6933333…**, matching the C39 modal cluster — the new `--temperature` CLI flag with default `0.0` is byte-identical to all prior bench commands.

## What's in this PR

1. **`crates/kiln-server/src/bench.rs`** — adds a `--temperature <f32>` CLI flag (default `0.0`) and threads it through all 4 hardcoded `temperature: 0.0` SamplingParams sites:
   - `bench_inference` (warmup + non-spec inference)
   - `bench_latency_skiplayer` (skip-layer spec, non-paged)
   - `bench_latency_paged_skiplayer` (skip-layer spec, paged)
   - `bench_latency_paged_mtp` (MTP spec, paged — the C39/C40a/C40b path)
2. **`PROFILING-MTP-C40b.md`** — full results: per-seed table with paired Δα vs C39, summary stats, floor check, sanity check, cross-phase comparison, interpretation, and reproduction commands.
3. **`docs/phase-c40b/`** — raw per-seed kiln-bench JSON for all 20 sweep seeds + the temp=0.0 sanity seed, plus `analyze_c40b.py` for reproducibility (10,000 bootstrap resamples, rng=12345, percentile method).

## Why this knob

C40 synthesis (#372) and C40a (#373) progressively narrowed the α-recovery search to non-framing, non-numerical interventions. `temperature=0.1` was the cheapest remaining knob: a single CLI flag, directly probing the hypothesis that MTP draft heads (trained over sampled distributions) are misaligned with greedy argmax draft tokens.

## Decision input for C40c+

Two of the three C40 single-knob hypotheses are now ruled out (chat-template via #373; sampling regime via this PR). **C40c** (W4A16 vs BF16 on HumanEval) is the last remaining cheap recovery lever in the original C40 queue. Both inversions surfaced the same pattern: cheap empirical knobs do not close the HumanEval α gap; the floor is robust at this anchor.

## Reproduction

See `PROFILING-MTP-C40b.md` § Reproduction. The only flag that differs from C39 across the N=20 sweep is `--temperature 0.1`.

## Cost & environment

- GPU: NVIDIA RTX A6000 (sm_86), warm pool acquisition
- Total pod cost: ≈ \$0.20–0.30 (well inside the 90 min / \$25 cap)