### PR TITLE
mtp c40c: abort BF16 sweep after sanity regression

### DIFF
--- a/PROFILING-MTP-C40c.md
+++ b/PROFILING-MTP-C40c.md
@@ -1,0 +1,142 @@
+# Phase C40c — HumanEval + BF16 (W4A16 off) N=20 α re-bench
+
+## TL;DR
+
+This run was **aborted before the BF16 sweep** because the required
+default-path sanity check failed on current `origin/main`
+(`8870dd838a1182ce7f9d484ec321007f2bdebae3`, PR #374 merged).
+
+The task contract required the C39 anchor to reproduce
+`α = 0.6933333` for:
+
+- `KILN_W4A16=1`
+- `KILN_MTP_ARGMAX_FP32=1`
+- `KILN_SPEC_ENABLED=1`
+- `KILN_SPEC_METHOD=mtp`
+- `KILN_CUDA_GRAPHS=true`
+- `--paged --chat-template --skip-training --latency-only`
+- `--prompt-tokens 512 --max-output-tokens 128`
+- `--prompt-subset humaneval`
+- `--seed 0 --temperature 0.0`
+
+Two consecutive runs on the same pod and same current-main commit did
+not reproduce that anchor:
+
+| run | observed α | expected α | Δ vs expected |
+| --- | --- | --- | --- |
+| sanity #1 | `0.6710526316` | `0.6933333333` | `-0.0222807018` |
+| sanity #2 | `0.6623376623` | `0.6933333333` | `-0.0309956710` |
+
+Because the default `W4A16=1` path was already off-anchor before any
+`KILN_W4A16=0` change, the planned N=20 BF16 sweep was **not run**. Any
+BF16-vs-W4A16 comparison would have been confounded by an unexplained
+regression in the baseline path.
+
+## Preflight
+
+All pre-pod gates passed:
+
+1. No existing C40c PR was in flight.
+2. `origin/main:crates/kiln-server/src/bench.rs` includes the
+   `--temperature` flag from PR #374.
+3. `origin/main:PROFILING-MTP-C40b.md` ends with the "Remaining open
+   questions" section listing C40c as item 1.
+4. Static code reading confirms dense BF16 is the default weight-loader
+   path and that MTP loading is independent of `KILN_W4A16`:
+   - dense checkpoint load in
+     `crates/kiln-model/src/loader.rs:75-91` and `:94-182`
+   - MTP dense load in `crates/kiln-model/src/loader.rs:663-750`
+   - `KILN_W4A16` only toggles Marlin packing during GPU upload in
+     `crates/kiln-model/src/forward.rs:998-1199`
+   - MTP bench requires loaded MTP weights in
+     `crates/kiln-server/src/bench.rs:1404-1421`
+5. The pod did not already have `/workspace/qwen3.5-4b`, but the public
+   HF repo `Qwen/Qwen3.5-4B` was reachable and downloaded successfully
+   to the pod in under 5 minutes.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| Date | 2026-04-22 |
+| Commit under test | `8870dd838a1182ce7f9d484ec321007f2bdebae3` |
+| GPU | NVIDIA RTX A6000 |
+| Pod | `sl53yvx5seviyx` |
+| Image | `ghcr.io/ericflo/kiln-runpod:latest` |
+| Checkpoint source | HF `Qwen/Qwen3.5-4B` |
+| Build | `cargo build --release --features cuda --bin kiln-bench` |
+
+## Sanity Runs
+
+Command used for both runs:
+
+```bash
+KILN_W4A16=1 \
+KILN_MTP_ARGMAX_FP32=1 \
+KILN_SPEC_ENABLED=1 \
+KILN_SPEC_METHOD=mtp \
+KILN_CUDA_GRAPHS=true \
+./target/release/kiln-bench \
+  --model-path /workspace/qwen3.5-4b \
+  --paged --chat-template --skip-training --latency-only \
+  --prompt-tokens 512 --max-output-tokens 128 \
+  --prompt-subset humaneval \
+  --seed 0 --temperature 0.0
+```
+
+Observed metrics:
+
+| run | α | draft accepted | attempts | decode tok/s | mean ITL ms | prefill tok/s |
+| --- | --- | --- | --- | --- | --- | --- |
+| sanity #1 | `0.6710526316` | 51 | 76 | 44.81 | 22.32 | 68.48 |
+| sanity #2 | `0.6623376623` | 51 | 77 | 35.46 | 28.20 | 1464.91 |
+
+Notes:
+
+- Both runs loaded the same two-shard dense checkpoint and reported
+  "Native MTP head detected and loaded (k=1 draft depth)".
+- Both runs used Marlin on the default path:
+  `marlin batch pack: 104/104 projections`.
+- The acceptance-rate miss is larger than trivial float noise and moves
+  in the wrong direction on rerun.
+- Prefill throughput differed sharply between the two sanity runs, but
+  that does not explain the contract failure: both α values remain below
+  the required `0.6933333` anchor.
+
+## Why The BF16 Sweep Was Skipped
+
+The C40c method required a byte-identity check for the unchanged
+`KILN_W4A16=1` path before flipping the single knob to `KILN_W4A16=0`.
+That gate failed twice on current main, so the experiment could no
+longer isolate "W4A16 off" as the only changing variable.
+
+Running the planned `KILN_W4A16=0` N=20 sweep in this state would not
+answer the C40c hypothesis cleanly. A BF16 result could improve or
+worsen for reasons unrelated to quantization if the anchor itself has
+already drifted.
+
+## Verdict
+
+`C40c` is **blocked by baseline drift on current main**. The code-path
+preflight says BF16 + MTP is supported, and the checkpoint is available,
+but the unchanged `W4A16=1` sanity anchor no longer reproduces the C39 /
+C40b expectation. The next task should diagnose why current `main`
+misses `α = 0.6933333` on the seed-0 HumanEval anchor before resuming
+the BF16-vs-W4A16 comparison.
+
+## Artifacts
+
+- Sanity JSON:
+  `docs/phase-c40c/sanity_seed0_temp0.json`
+- Sanity rerun JSON:
+  `docs/phase-c40c/sanity_seed0_temp0_rerun.json`
+- Sanity stderr log:
+  `docs/phase-c40c/sanity_seed0_temp0.log`
+- Sanity rerun stderr log:
+  `docs/phase-c40c/sanity_seed0_temp0_rerun.log`
+
+## Cost Summary
+
+- Wall-clock: about 7 minutes from pod acquire to abort decision
+- GPU cost: about `$0.06` at `$0.49/hr`
+- Status: stopped well inside the 90 min / $25 cap

--- a/docs/phase-c40c/sanity_seed0_temp0.json
+++ b/docs/phase-c40c/sanity_seed0_temp0.json
@@ -1,0 +1,29 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.061032494,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 496,
+    "prefill_time_ms": 7243.097799,
+    "prefill_tokens_per_sec": 68.47898699759087,
+    "time_to_first_token_ms": 7243.097799,
+    "mean_inter_token_ms": 22.318932566929135,
+    "p50_inter_token_ms": 16.1666825,
+    "p99_inter_token_ms": 50.112598,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 44.80501014110955,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6710526315789473,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}
+

--- a/docs/phase-c40c/sanity_seed0_temp0.log
+++ b/docs/phase-c40c/sanity_seed0_temp0.log
@@ -1,0 +1,40 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-22T16:15:52.763947Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-22T16:15:52.765110Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-22T16:15:52.765301Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-22T16:15:52.765316Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-22T16:15:52.765391Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-22T16:16:17.313074Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m21425 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 21425 ms (parallel)
+Model loaded in 25.06s (backend: cuda, VRAM: 18006 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=47] (496 prompt tokens)...
+    Prefill (MTP): 7243.1ms (68 tok/s)
+    Decode (MTP): 128 tokens, mean ITL 22.3ms (44.8 tok/s), α = 0.671 (51/76)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 25.06s (VRAM: 18006 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         496
+Prefill time:          7243.1 ms (68 tok/s)
+Time to first token:   7243.1 ms
+Mean inter-token:      22.3 ms (44.8 tok/s)
+P50 inter-token:       16.2 ms
+P99 inter-token:       50.1 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.671
+
+

--- a/docs/phase-c40c/sanity_seed0_temp0_rerun.json
+++ b/docs/phase-c40c/sanity_seed0_temp0_rerun.json
@@ -1,0 +1,29 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 27.316449966,
+    "model_vram_mb": 18006
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 496,
+    "prefill_time_ms": 338.586979,
+    "prefill_tokens_per_sec": 1464.9116202427854,
+    "time_to_first_token_ms": 338.586979,
+    "mean_inter_token_ms": 28.199511692913383,
+    "p50_inter_token_ms": 19.651886,
+    "p99_inter_token_ms": 64.53866,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 35.46160695581487,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6623376623376623,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}
+

--- a/docs/phase-c40c/sanity_seed0_temp0_rerun.log
+++ b/docs/phase-c40c/sanity_seed0_temp0_rerun.log
@@ -1,0 +1,40 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-22T16:17:38.446312Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-22T16:17:38.447818Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-22T16:17:38.448158Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-22T16:17:38.448178Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-22T16:17:38.448334Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-22T16:18:04.913507Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m24623 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 24623 ms (parallel)
+Model loaded in 27.32s (backend: cuda, VRAM: 18006 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=47] (496 prompt tokens)...
+    Prefill (MTP): 338.6ms (1465 tok/s)
+    Decode (MTP): 128 tokens, mean ITL 28.2ms (35.5 tok/s), α = 0.662 (51/77)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 27.32s (VRAM: 18006 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         496
+Prefill time:          338.6 ms (1465 tok/s)
+Time to first token:   338.6 ms
+Mean inter-token:      28.2 ms (35.5 tok/s)
+P50 inter-token:       19.7 ms
+P99 inter-token:       64.5 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.662
+
+


### PR DESCRIPTION
## Summary
- abort the planned C40c BF16 (`KILN_W4A16=0`) HumanEval N=20 sweep because the required current-main sanity anchor failed before the knob flip
- add `PROFILING-MTP-C40c.md` documenting preflight, the two failed sanity runs, and why the BF16 comparison would have been confounded
- commit the raw sanity JSON/log artifacts under `docs/phase-c40c/`

## Sanity failure
The unchanged C39/C40b anchor command on current `main` commit `8870dd838a1182ce7f9d484ec321007f2bdebae3` was expected to reproduce `α = 0.6933333` with:
- `KILN_W4A16=1`
- `KILN_MTP_ARGMAX_FP32=1`
- `KILN_SPEC_ENABLED=1`
- `KILN_SPEC_METHOD=mtp`
- `KILN_CUDA_GRAPHS=true`
- `--paged --chat-template --skip-training --latency-only`
- `--prompt-tokens 512 --max-output-tokens 128`
- `--prompt-subset humaneval`
- `--seed 0 --temperature 0.0`

Observed instead:
- sanity #1: `α = 0.6710526316`
- sanity #2: `α = 0.6623376623`

Because the default `W4A16=1` path was already off-anchor before any BF16 change, this PR stops the experiment here rather than producing a confounded BF16-vs-W4A16 result.

## Cost
- Wall-clock: about 7 minutes (`2026-04-22T16:12Z` to `2026-04-22T16:19Z`)
- GPU: NVIDIA RTX A6000 warm pool pod `sl53yvx5seviyx`
- Estimated pod cost: about `$0.06` at `$0.49/hr`
- Pod lease released; no ongoing spend

## Validation
- static preflight confirms BF16 dense load + MTP load are supported on current main
- downloaded public HF checkpoint `Qwen/Qwen3.5-4B`
- ran the required sanity command twice and captured JSON + stderr logs
