### PR TITLE
[codex] Tune Metal streaming prefill defaults

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -822,8 +822,8 @@ fn marlin_bf16_drop_disabled() -> bool {
 /// `GDN_CHUNK_SIZE` (64) so the chunkwise kernel never sees a partial tail
 /// chunk from a tile boundary.
 pub const STREAMING_PREFILL_DEFAULT_TILE: usize = 8192;
-pub const STREAMING_PREFILL_METAL_DEFAULT_TILE: usize = 4096;
-pub const STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD: usize = 8192;
+pub const STREAMING_PREFILL_METAL_DEFAULT_TILE: usize = 512;
+pub const STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD: usize = 4096;
 
 fn streaming_prefill_env_override() -> Option<bool> {
     std::env::var("KILN_STREAMING_PREFILL")

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -191,13 +191,15 @@ pub struct SpeculativeDecodingConfig {
 ///
 /// Dispatch is driven by reading these environment variables directly from
 /// `kiln-model` helpers; this struct is the documentation / TOML-config
-/// mirror. Defaults keep streaming OFF.
+/// mirror. The generic config default keeps streaming OFF, while the runtime
+/// Metal policy enables streaming by default for long desktop prompts.
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct StreamingPrefillConfig {
     /// Enable tiled/streaming prefill (default: false).
     pub enabled: bool,
-    /// Tile size in tokens (default: 8192). Must be a positive multiple of 64.
+    /// Tile size in tokens (generic default: 8192). Must be a positive
+    /// multiple of 64.
     pub tile_tokens: usize,
     /// On the final tile, compute the LM head only for the last row instead
     /// of the full hidden state. Safe for inference because RMSNorm is


### PR DESCRIPTION
## Summary

Tune the macOS Metal streaming prefill defaults so real 8k-ish desktop prompts take the tiled path by default and use the faster measured tile size.

## Details

The previous Metal threshold was 8192 real tokens. The desktop/bench 8192 prompt tokenizes to 8174 tokens, so the default path missed streaming entirely. This lowers the Metal threshold to 4096 and changes the Metal default tile from 4096 to 512, preserving all env overrides.

## Validation

- `cargo test -p kiln-model --features metal --locked test_streaming_prefill_env_helpers -- --nocapture`
- `cargo test -p kiln-server --features metal --locked test_env_var_overrides -- --nocapture`
- `cargo build -p kiln-server --features metal --locked --release --bin kiln-bench`
- Default-condition benchmark, env unset: `8192/1` skip-layer paged prefill `82269.8ms` vs clean-main baseline `88646.8ms`
- Default-condition benchmark, env unset: `8192/128` skip-layer paged prefill `82639.8ms`, mean ITL `92.9ms`, acceptance `1.000`