### PR TITLE
docs: reconcile C40 synthesis after C40f

### DIFF
--- a/PROFILING-MTP-C39.md
+++ b/PROFILING-MTP-C39.md
@@ -132,47 +132,38 @@ paper floor is ~0.027 in the median, and ~0.06 at the CI upper bound.
 
 ## C40 recommendation
 
-Two credible directions; both assume the anchor stays at Cell D.
+The original C40 queue from this phase is now complete enough to close
+the "easy gap-closer" branch and keep only the documentation update.
 
-### (1) Accept domain-specific α targets (documentation-only)
+### What the completed C40 work says
 
-The Qwen3.5 paper floor of 0.72 is reported as a single number, but the
-distribution C39 and C38 surface is clearly heterogeneous. A
-documentation-only phase could:
+- **C40a falsified the prompt-framing hypothesis.** Removing
+  `--chat-template` collapsed HumanEval α from the C39 anchor rather
+  than recovering it, so chat-template is load-bearing for code.
+- **C40b falsified the low-temperature hypothesis.**
+  `temperature=0.1` did not rescue HumanEval α, so there is no cheap
+  sampler knob that closes the gap.
+- **C40e found a real paired seed-0 BF16 win.** On the same binary/pod
+  and flags, BF16 beat W4A16 materially for that one HumanEval seed.
+- **C40f showed that C40e does not generalize distributionally.** The
+  BF16 N=20 HumanEval distribution on current `main` landed at median
+  `0.6888`, mean `0.6939`, bootstrap 95% CI `[0.6517, 0.7232]`, with
+  only `6/20` seeds at or above `0.72`. That does not materially beat
+  the C39 W4A16 HumanEval distribution.
 
-- Replace the single floor gate with per-domain floors derived from the
-  observed distribution (e.g. GSM8K ≥ 0.78, C4 ≥ 0.70, HumanEval ≥ 0.65).
-- Note in MTP_PHASE_B12.md / PROFILING.md that the published 0.85 α in
-  the paper is an aggregate over a heavily natural-language-weighted
-  eval, and our code-heavy workloads should expect lower acceptance.
-- Cost: $0. Ship as a writeup PR.
+### Updated recommendation
 
-### (2) Investigate the HumanEval-specific α gap (bench + single knob)
-
-The open question: is the HumanEval gap a systematic MTP-head weakness
-on token-level Python (less training exposure?) or a prompt-framing
-issue (the chat-template wraps code in a natural-language user turn,
-which may confuse the MTP head)?
-
-Minimal sequential experiment:
-
-- **C40a:** HumanEval + `--chat-template` off (raw prose). If α rises
-  significantly, the paper floor is reachable via prompt framing, and
-  we should stop applying chat-template to code workloads.
-- **C40b:** HumanEval + temperature=0.1 sampling instead of greedy.
-  Tests whether greedy decoding is uniquely harmful for code (MTP
-  heads are trained over sampled distributions, and greedy can land
-  off-manifold for low-entropy tokens like Python keywords).
-- **C40c:** HumanEval + non-W4A16 (full-precision bench). If α rises
-  more than the C39 stdev, Marlin's W4 quantization is non-trivially
-  hurting code α and we should document a "use BF16 for code" mode.
-
-Each sub-cell: N=20, same Cell D otherwise. Estimated cost ≈ $5–8
-total on A6000. Budget 60–90 min per cell.
-
-**Recommended:** ship **(1)** first as a cheap documentation PR, then
-queue **C40a** as the single highest-leverage follow-up (flag-flip,
-no code change, directly actionable).
+- Keep the documentation conclusion from C39/C40: the paper's `0.72`
+  reference is an aggregate, prose-heavy benchmark anchor, while the
+  current-main HumanEval code distribution sits lower.
+- Do **not** present C40a/C40b/C40c as still-pending next steps. Those
+  branches are now either falsified or superseded by C40d/C40e/C40f.
+- Do **not** treat BF16 as the resolved HumanEval load-mode winner.
+  C40e remains an important paired single-seed result, but C40f is the
+  correct distributional readout for the BF16 question on current
+  `main`.
+- Keep the code-domain issue open as a modeling / implementation
+  investigation, not as an unresolved queue of cheap benchmark toggles.
 
 ## Artifacts
 

--- a/PROFILING.md
+++ b/PROFILING.md
@@ -3424,7 +3424,7 @@ Existing speculative decoding infrastructure:
 
 3. **Marlin W4A16 compatibility for MTP layer.** `mtp.layers.0` has q_proj / o_proj / gate_proj / up_proj / down_proj shapes that match the main model's layers. Marlin packing in the loader operates per-projection and should pick these up transparently (PR #146 path). Need to verify in implementation that the existing pack loop covers `mtp.*` prefixes — this is a 1-line check in the loader, not a design risk.
 
-4. **Acceptance rate below the 1.5× target.** At α=0.70, ceiling is 1.467× — below target. Qwen3.5-4B does not have published MTP acceptance numbers (Qwen3.5-4B isn't flagged as MTP-enabled in the model card text even though the weights are there). Risk: measured α could be <0.70 on kiln's typical workloads, giving a below-target speedup even with perfect implementation. Mitigation: A/B against skip-layer self-spec and against baseline in the same implementation PR. If α measurement on a representative workload comes back <0.72, pivot early — don't ship a below-target kernel just to cash the preflight.
+4. **Acceptance rate below the 1.5× target.** At α=0.70, ceiling is 1.467× — below target. Qwen3.5-4B does not have published MTP acceptance numbers (Qwen3.5-4B isn't flagged as MTP-enabled in the model card text even though the weights are there). Risk: measured α could be <0.70 on kiln's typical workloads, giving a below-target speedup even with perfect implementation. Mitigation: A/B against skip-layer self-spec and against baseline in the same implementation PR. Treat `0.72` here as the aggregate paper-reference gate for the standard workload, not as a blanket floor for every domain; current-main HumanEval later measured materially lower in C39/C40f.
 
 5. **Prefix cache interaction.** kiln has `KILN_PREFIX_CACHE_ENABLED=true` by default. MTP reads the target model's last hidden state, which for a prefix-cache hit was computed before the current request started. Need to verify the hidden state is cached alongside the KV for the last verified position, not just the KV. If it isn't, MTP can't run on the first step of a prefix-cache-hit request and must fall back to one synchronous target step to materialize `hidden_states`. Mitigation: small (one step), well-defined; probably worth it to avoid architectural coupling of MTP into prefix cache serialization.
 
@@ -3436,7 +3436,7 @@ Existing speculative decoding infrastructure:
 
 ### Recommendation
 
-**GREENLIGHT a follow-up implementation task** titled along the lines of "Phase X — native MTP spec-decode on Qwen3.5-4B (GREEN-after-preflight)". Scope: the 6-7 files listed in Check 4 (~800-1000 LOC). Gate behind `KILN_SPEC_METHOD=mtp`, default off. Ship with A/B bench (off / skip-layer / MTP) on A6000 warm pod, median-of-3 rule. Target: **≥1.5× decode tok/s vs. baseline Arm B on the standard 512p/128d workload**, with α reported separately. If measured α < 0.72 on the standard workload, stop at the A/B numbers — don't force-ship a below-ceiling path.
+**GREENLIGHT a follow-up implementation task** titled along the lines of "Phase X — native MTP spec-decode on Qwen3.5-4B (GREEN-after-preflight)". Scope: the 6-7 files listed in Check 4 (~800-1000 LOC). Gate behind `KILN_SPEC_METHOD=mtp`, default off. Ship with A/B bench (off / skip-layer / MTP) on A6000 warm pod, median-of-3 rule. Target: **≥1.5× decode tok/s vs. baseline Arm B on the standard 512p/128d workload**, with α reported separately. If measured α stays below the aggregate paper-reference band on that standard workload, stop at the A/B numbers — don't force-ship a below-ceiling path. Later C39/C40f evidence shows HumanEval code prompts need to be reported separately rather than judged by a blanket `0.72` gate.
 
 ## Phase X — native MTP spec-decode results (2026-04-21)
 
@@ -3524,7 +3524,7 @@ Minimal follow-up fix PR, narrow scope:
 2. Thread the snapshotted state into `speculative_mtp_decode_step`: take a snapshot before the draft step, pass the live `&mut LinearAttentionState` to `model_forward_paged_with_last_hidden`, and restore from the snapshot on rejected tokens.
 3. Re-run the 3× Mtp sweep. Keep the same `KILN_W4A16=1 KILN_CUDA_GRAPHS=true --paged --prompt-tokens 512 --max-output-tokens 128` workload. Median-of-3, reporting α alongside decode tok/s.
 
-Preflight Check 2 in the section above math-ceilings α=0.75 at 1.571× on Qwen3.5-4B's MTP (k=1, ~86% overhead). The ≥1.5× target stands; α<0.72 is the stop-ship threshold.
+Preflight Check 2 in the section above math-ceilings α=0.75 at 1.571× on Qwen3.5-4B's MTP (k=1, ~86% overhead). The ≥1.5× target stands; use `0.72` here as the aggregate standard-workload reference from the paper/preflight math, not as a universal per-domain floor.
 
 ### Cost
 
@@ -3566,7 +3566,7 @@ With that change the Mtp bench no longer fails at `linear attention state requir
 #### Findings
 
 1. **State threading is correct.** The bench path that previously crashed at decode step 0 now completes all three runs with 128 tokens each, stable tok/s across runs, and sane α.
-2. **α = 0.411 is well below the 0.72 stop-ship floor.** Preflight Check 2 math-ceilings α=0.75 at 1.571× and sets ≥1.5× as the target. At α=0.411 with k=1, mean accepted tokens per verify call is 1.411; the verify-pass overhead (two-token forward + draft-head forward + snapshot/restore dToD) is larger than the 0.411-token savings, so:
+2. **α = 0.411 is well below the aggregate paper-reference band and far below what the speed target needs.** Preflight Check 2 math-ceilings α=0.75 at 1.571× and sets ≥1.5× as the target. At α=0.411 with k=1, mean accepted tokens per verify call is 1.411; the verify-pass overhead (two-token forward + draft-head forward + snapshot/restore dToD) is larger than the 0.411-token savings, so:
 3. **Mtp is 15.7% SLOWER than Off on Qwen3.5-4B at this α** (41.16 vs 48.87 tok/s median decode). p99 ITL also widens from 23.13 → 39.31 ms.
 4. **The MTP path is functional but not yet shippable.** This PR unblocks the measurement path; the low-α investigation is a separate follow-up.
 
@@ -3580,7 +3580,7 @@ With that change the Mtp bench no longer fails at `linear attention state requir
 #### Next steps
 
 - Open a dedicated `mtp: debug low-α root cause` task. Instrument α per-step, log the top-5 draft tokens + base-verify probs for the first 16 verify calls, compare against HF reference on the same prompt tokens, confirm weight-tensor byte-equality after loader.
-- Revisit shadow-slot ping-pong snapshot rewrite (zero-copy) only after α clears 0.72 — at α=0.411 it would not move the needle.
+- Revisit shadow-slot ping-pong snapshot rewrite (zero-copy) only after α clears the aggregate-paper range needed for the speed target — at α=0.411 it would not move the needle.
 - Consider gating MTP on the new `KILN_SPEC_METHOD=mtp` flag with a startup warning until α ships above floor.
 
 #### Cost (follow-up)
@@ -3591,7 +3591,7 @@ With that change the Mtp bench no longer fails at `linear attention state requir
 
 ## MTP low-α root cause — Phase A static audit + Phase B instrumentation (2026-04-21)
 
-Follow-up to "Phase X — native MTP spec-decode results" above. PR #257 unblocked the MTP measurement path; Mtp arm now runs to completion at α=0.411, well below the 0.72 stop-ship floor. This update lands the Phase B instrumentation patch and records the Phase A static-audit findings.
+Follow-up to "Phase X — native MTP spec-decode results" above. PR #257 unblocked the MTP measurement path; Mtp arm now runs to completion at α=0.411, well below both the aggregate paper-reference band and the α needed to hit the decode-speed target. This update lands the Phase B instrumentation patch and records the Phase A static-audit findings.
 
 ### Tier classification
 
@@ -4493,7 +4493,8 @@ gate → mlp_up → mlp_gate → mlp_down` and dump each one.
 ### Goal
 
 Test whether forcing the MTP draft head's q/k/v/o + fc projections to fp32
-(`KILN_MTP_FP32_HEAD=1`) recovers α toward the 0.72 ship floor. Hypothesis
+(`KILN_MTP_FP32_HEAD=1`) recovers α toward the aggregate paper-reference
+band. Hypothesis
 from C9/C11 audit: bf16 matmul accumulation noise on W4A16-dequanted weights
 shifts the draft head's top-1 enough to explain α == 0.058-0.124 observed
 in C5 after the C3 RoPE fix landed.


### PR DESCRIPTION
## Summary
- replace the stale C40a/b/c follow-up queue in `PROFILING-MTP-C39.md` with a post-C40f synthesis
- update native-MTP planning/results text in `PROFILING.md` so `0.72` is described as the aggregate paper-reference gate, not a blanket per-domain stop-ship floor
- keep the HumanEval code-domain issue open without overstating BF16 as the resolved winner

## Validation
- `rg -n "0\.6888|0\.6939|\[0\.6517, 0\.7232\]|6/20|distributionally|0\.72 stop-ship floor|0\.72 ship floor|Remaining open questions|C40 recommendation|C40a|C40b|C40c" PROFILING-MTP-C39.md PROFILING-MTP-C40f.md PROFILING.md`
- `git diff -- PROFILING-MTP-C39.md PROFILING.md`
- `markdownlint PROFILING-MTP-C39.md PROFILING.md` *(not available in the session)*