### PR TITLE
[codex] Prewarm macOS speculative path

### DIFF
--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 use std::sync::atomic::Ordering;
+use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use clap::Parser;
@@ -19,6 +19,7 @@ use kiln_model::ModelRunner;
 use kiln_model::engine::MockEngine;
 use kiln_model::forward::GpuWeights;
 use kiln_model::paged_kv_cache::PagedKvCache;
+use kiln_model::speculative::SpeculativeConfig;
 use kiln_scheduler::{Scheduler, SchedulerConfig};
 use state::{AppState, ModelBackend};
 
@@ -288,22 +289,62 @@ fn spawn_backend_prewarm(state: AppState) {
             // on the first live request.
             let prompt_tokens = [1_u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
             let num_blocks = 2;
-            let mut block_manager = BlockManager::new(num_blocks, 16);
-            let mut paged_cache = PagedKvCache::new_uninit(
-                runner_guard.config.num_full_attention_layers,
-                num_blocks,
-                16,
-                runner_guard.config.num_kv_heads,
-                runner_guard.config.head_dim,
-                prewarm_kv_dtype(&runner_guard.config),
-                runner_guard.weights.embed_tokens.device(),
-            )?;
-            runner_guard.generate_from_tokens_paged(
-                &prompt_tokens,
-                &params,
-                &mut block_manager,
-                &mut paged_cache,
-            )?;
+            let spec_method =
+                kiln_server::config::SpeculativeDecodingConfig::from_env().effective_method();
+            let prewarm_result = if matches!(spec_method, kiln_server::config::SpecMethod::Mtp)
+                && runner_guard.weights.mtp.is_some()
+            {
+                runner_guard
+                    .generate_from_tokens_mtp_speculative(&prompt_tokens, &params)
+                    .map(|_| ())
+            } else {
+                let block_manager = Mutex::new(BlockManager::new(num_blocks, 16));
+                let paged_cache = Mutex::new(PagedKvCache::new_uninit(
+                    runner_guard.config.num_full_attention_layers,
+                    num_blocks,
+                    16,
+                    runner_guard.config.num_kv_heads,
+                    runner_guard.config.head_dim,
+                    prewarm_kv_dtype(&runner_guard.config),
+                    runner_guard.weights.embed_tokens.device(),
+                )?);
+                let spec_config = SpeculativeConfig {
+                    num_speculative_tokens: 4,
+                    draft_layers: 8,
+                };
+                runner_guard
+                    .generate_paged_speculative_shared_tokens(
+                        &prompt_tokens,
+                        &params,
+                        &block_manager,
+                        &paged_cache,
+                        &spec_config,
+                    )
+                    .map(|_| ())
+            };
+
+            if let Err(err) = prewarm_result {
+                tracing::warn!(
+                    error = %err,
+                    "speculative inference prewarm failed; falling back to base paged prewarm"
+                );
+                let mut block_manager = BlockManager::new(num_blocks, 16);
+                let mut paged_cache = PagedKvCache::new_uninit(
+                    runner_guard.config.num_full_attention_layers,
+                    num_blocks,
+                    16,
+                    runner_guard.config.num_kv_heads,
+                    runner_guard.config.head_dim,
+                    prewarm_kv_dtype(&runner_guard.config),
+                    runner_guard.weights.embed_tokens.device(),
+                )?;
+                runner_guard.generate_from_tokens_paged(
+                    &prompt_tokens,
+                    &params,
+                    &mut block_manager,
+                    &mut paged_cache,
+                )?;
+            }
             Ok(())
         })
         .await;


### PR DESCRIPTION
## Summary

This updates the Metal startup prewarm to compile the same speculative path the desktop can hit first, instead of only warming base paged generation:

- If desktop/env speculative mode is MTP and the checkpoint has MTP weights, prewarm a tiny MTP speculative request.
- Otherwise prewarm a tiny paged skip-layer speculative request using the shared-cache path.
- If speculative prewarm fails, fall back to the existing base paged prewarm so startup remains robust.

This builds on #385, which removed the fixed 250 ms prewarm delay.

## Validation

- `cargo test -p kiln-server --features metal --locked test_env_var_overrides -- --nocapture`
- `cargo build -p kiln-server --features metal --locked --release --bin kiln-bench`

## Notes

I also tested and rejected two GDN prefill knobs on this branch before reverting them:

- Per-call GDN mask reuse: `83800.0ms` on 8192/1, worse than merged main.
- `GDN_CHUNK_SIZE=32`: `84174.0ms` on 8192/1, worse than merged main.
