### PR TITLE
phase6: reconfirm FlashInfer paged decode is sub-floor

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -130,6 +130,38 @@ current-main evidence, not stale queue shape:
 - the prompt-heavy profile says the next materially new win is in **GDN
   prefill kernel vendoring**, not another hand-rolled candle experiment.
 
+### Remaining-work preflight — FlashInfer-style paged GQA decode (2026-04-22)
+
+Task brief checked against fresh `main` after PR #384:
+
+- **PR #384 merged:** yes (`930363e`, on `main` before current HEAD
+  `234c17a`).
+- **No open overlap:** yes. GitHub search over open PRs for
+  `flashinfer`, `paged decode`, and `flash_attn_paged_decode` returned no
+  active implementation PR.
+- **Decode call path still present:** yes.
+  `crates/kiln-model/src/forward.rs` still routes single-token paged
+  full-attention decode through `try_flash_attn_paged_decode(...)`, and
+  `crates/kiln-model/src/backend/cuda.rs` still implements
+  `flash_attn_paged_decode(...)` via
+  `kiln_flash_attn::flash_attn_paged_decode(...)`.
+
+**Decision: no implementation follow-up.** The fresh current-main profile
+above still leaves full-attention at sub-floor share on Qwen3.5-4B:
+
+- decode top-3 remain GDN-only (`gates` 18.0%, `gated_norm` 17.5%,
+  `qk_norm` 15.0%);
+- full-attention projections remain only ~3.8% of decode wall-clock
+  (`:kiln/proj/qkv` 3.0% + `:kiln/proj/o` 0.8%);
+- the inner `:kiln/attn/full/*` kernel region a FlashInfer-class paged
+  decode kernel would replace stays below the reporting floor.
+
+That keeps the overall Amdahl ceiling in the same ~`<=1.038x` range already
+documented by PR #163 and the later frontier audits, still well below the
+Phase 6 reopen bar. Replacing the current CUDA paged-decode backend on this
+model would be redoing a known sub-floor slice, not landing the next queued
+win.
+
 
 ## Phase 7 design: streaming/tiled GDN prefill — 2026-04-20
 


### PR DESCRIPTION
## Summary
- add a short current-main preflight note to `PROFILING.md` for the requested FlashInfer-style paged GQA decode slice
- record that the task brief's structural preconditions still hold on fresh `main` after PR #384, but that the implementation remains mathematically sub-floor on Qwen3.5-4B
- redirect the next optimization pick back to the already-profiled GDN prefill work instead of redoing the paged full-attention decode backend

## Remaining-work preflight
Checked on fresh `main` (`234c17a`, 2026-04-22):
- PR #384 is merged (`930363e` is on `main`)
- no open PR covering FlashInfer paged GQA decode vendoring turned up in open-PR search
- `crates/kiln-model/src/forward.rs` still routes the single-token paged full-attention decode fast path through `try_flash_attn_paged_decode(...)`
- `crates/kiln-model/src/backend/cuda.rs` still implements `flash_attn_paged_decode(...)` by calling `kiln_flash_attn::flash_attn_paged_decode(...)`

## Why this is a no-op PR
The fresh current-main profile at the top of `PROFILING.md` still does not justify this kernel class:
- decode top-3 remain GDN-only: `:kiln/gdn/gates` 18.0%, `:kiln/gdn/gated_norm` 17.5%, `:kiln/gdn/qk_norm` 15.0%
- full-attention projections remain only ~3.8% of decode (`:kiln/proj/qkv` 3.0% + `:kiln/proj/o` 0.8%`)
- the inner `:kiln/attn/full/*` region a FlashInfer-class paged decode kernel would replace is still below the reporting floor

So the Amdahl ceiling stays in the same ~`<=1.038x` range already captured by PR #163 and later frontier audits. Replacing the current CUDA paged-decode backend on this model would still be redoing a known sub-floor slice.

## Validation
- no pod launched
- no source or CUDA files changed
- no build/test commands run because this is a docs-only redirect PR

## Files changed
- `PROFILING.md`
