### PR TITLE
phase6: add fused full-chunk GDN prefill path

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -2,6 +2,31 @@
 
 ## Phase 6 post-#384 current-main re-profile — 2026-04-22
 
+### Post-change note — 2026-04-23 (`ce/phase6-fused-gdn-full-chunk`)
+
+Follow-up A6000 validation for the next minimal fused full-chunk CUDA prefill
+step (`gdn_full_chunk_forward`: fused chunk body + in-kernel state update,
+tail fallback unchanged) showed that correctness is acceptable on the focused
+CUDA parity test, but end-to-end prompt-heavy prefill did **not** improve on
+the `#389` baseline.
+
+- Validation environment: RunPod A6000, `ghcr.io/ericflo/kiln-runpod:latest`,
+  `KILN_W4A16=1`, `KILN_CUDA_GRAPHS=true`, `--paged --prompt-tokens 8192
+  --max-output-tokens 1 --skip-training --latency-only`
+- New focused CUDA parity test:
+  `test_gdn_full_chunk_forward_matches_fallback` — passed
+- Bench runs on the fused branch:
+  - run 1: **3239.3 ms** prefill (**2525 tok/s**)
+  - run 2: **3651.1 ms** prefill (**2240 tok/s**)
+  - run 3: **3254.9 ms** prefill (**2513 tok/s**)
+  - median: **3254.9 ms** (**2513 tok/s**)
+
+Compared with the post-`#384` baseline already recorded in this file
+(**2831.2 ms / 2889 tok/s** uncaptured, **2947.8 ms / 2775 tok/s** profiled),
+this minimal fused full-chunk step is a regression rather than a win. The
+fused path did exercise on the benchmark's full 64-token chunks, but the final
+short tail chunk still fell back by design.
+
 **Scope:** refresh the current-`main` performance source of truth after PR
 [#384](https://github.com/ericflo/kiln/pull/384) and name the next real
 Phase 6 hotspot from fresh evidence instead of the pre-`#384` queue shape.

--- a/crates/kiln-gdn-kernel/build.rs
+++ b/crates/kiln-gdn-kernel/build.rs
@@ -45,6 +45,7 @@ fn main() {
     build.file(csrc_dir.join("gdn_gates.cu"));
     build.file(csrc_dir.join("gdn_chunk_prep.cu"));
     build.file(csrc_dir.join("gdn_chunk_scan.cu"));
+    build.file(csrc_dir.join("gdn_full_chunk_forward.cu"));
 
     build.compile("kiln_gdn_kernel");
 

--- a/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
+++ b/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
@@ -1,0 +1,219 @@
+// Kiln GDN fused full-chunk prefill kernel.
+//
+// Scope is intentionally tight:
+// - CUDA only
+// - bf16 only
+// - full 64-token prefill chunks only
+// - Qwen3.5-4B GDN envelope (dk <= 128, dv <= 128)
+//
+// The four GEMMs surrounding the chunk path stay on cuBLAS in Rust
+// (`kkt`, `qkt`, `ks_entry`, `q_s`). This kernel owns the remaining hot
+// chunk-local orchestration:
+//   1. big_g / p / decay / strict+causal masking
+//   2. forward substitution for W
+//   3. intra-chunk output accumulation
+//   4. recurrent state update
+
+#include <cuda.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <stdint.h>
+
+#include "gdn_full_chunk_forward.h"
+
+namespace {
+
+constexpr int kChunkSize = 64;
+constexpr int kMaxDv = 128;
+
+__device__ __forceinline__ float bf16_to_f32(__nv_bfloat16 v) {
+    return __bfloat162float(v);
+}
+
+__device__ __forceinline__ __nv_bfloat16 f32_to_bf16(float v) {
+    return __float2bfloat16(v);
+}
+
+__global__ void gdn_full_chunk_forward_kernel(
+    const __nv_bfloat16 *__restrict__ g,
+    const __nv_bfloat16 *__restrict__ v,
+    const __nv_bfloat16 *__restrict__ kkt,
+    const __nv_bfloat16 *__restrict__ qkt,
+    const __nv_bfloat16 *__restrict__ ks_entry,
+    const __nv_bfloat16 *__restrict__ q_s,
+    const __nv_bfloat16 *__restrict__ beta,
+    const __nv_bfloat16 *__restrict__ k_t,
+    __nv_bfloat16 *__restrict__ state,
+    __nv_bfloat16 *__restrict__ out_chunk,
+    int dk,
+    int dv
+) {
+    const int bh = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (tid >= dv) {
+        return;
+    }
+
+    extern __shared__ __nv_bfloat16 smem[];
+    __nv_bfloat16 *s_a = smem;                                       // [C, C]
+    __nv_bfloat16 *s_b = s_a + (size_t)kChunkSize * kChunkSize;      // [C, C]
+    __nv_bfloat16 *s_w = s_b + (size_t)kChunkSize * kChunkSize;      // [C, dv]
+
+    __shared__ float s_big_g[kChunkSize];
+    __shared__ float s_p[kChunkSize];
+    __shared__ float s_decay_last[kChunkSize];
+    __shared__ float s_p_last;
+
+    const __nv_bfloat16 *g_base = g + (size_t)bh * kChunkSize;
+    const __nv_bfloat16 *v_base = v + (size_t)bh * kChunkSize * dv;
+    const __nv_bfloat16 *kkt_base = kkt + (size_t)bh * kChunkSize * kChunkSize;
+    const __nv_bfloat16 *qkt_base = qkt + (size_t)bh * kChunkSize * kChunkSize;
+    const __nv_bfloat16 *ks_base = ks_entry + (size_t)bh * kChunkSize * dv;
+    const __nv_bfloat16 *qs_base = q_s + (size_t)bh * kChunkSize * dv;
+    const __nv_bfloat16 *beta_base = beta + (size_t)bh * kChunkSize;
+    const __nv_bfloat16 *kt_base = k_t + (size_t)bh * dk * kChunkSize;
+    __nv_bfloat16 *state_base = state + (size_t)bh * dk * dv;
+    __nv_bfloat16 *out_base = out_chunk + (size_t)bh * kChunkSize * dv;
+
+    for (int i = tid; i < kChunkSize; i += blockDim.x) {
+        s_big_g[i] = bf16_to_f32(g_base[i]);
+    }
+    __syncthreads();
+
+    if (tid == 0) {
+        float acc = 0.0f;
+        for (int i = 0; i < kChunkSize; ++i) {
+            acc += s_big_g[i];
+            s_big_g[i] = acc;
+        }
+        s_p_last = __expf(s_big_g[kChunkSize - 1]);
+    }
+    __syncthreads();
+
+    for (int i = tid; i < kChunkSize; i += blockDim.x) {
+        const float p = __expf(s_big_g[i]);
+        s_p[i] = p;
+        s_decay_last[i] = __expf(s_big_g[kChunkSize - 1] - s_big_g[i]);
+    }
+
+    const int total_cc = kChunkSize * kChunkSize;
+    for (int idx = tid; idx < total_cc; idx += blockDim.x) {
+        const int t = idx / kChunkSize;
+        const int i = idx % kChunkSize;
+        const float decay = __expf(s_big_g[t] - s_big_g[i]);
+        const float a_val = (i < t) ? bf16_to_f32(kkt_base[idx]) * decay : 0.0f;
+        const float b_val = (i <= t) ? bf16_to_f32(qkt_base[idx]) * decay : 0.0f;
+        s_a[idx] = f32_to_bf16(a_val);
+        s_b[idx] = f32_to_bf16(b_val);
+    }
+    __syncthreads();
+
+    for (int t = 0; t < kChunkSize; ++t) {
+        const float beta_t = bf16_to_f32(beta_base[t]);
+        const float p_t = bf16_to_f32(f32_to_bf16(s_p[t]));
+
+        const __nv_bfloat16 *a_row = s_a + (size_t)t * kChunkSize;
+        const __nv_bfloat16 *b_row = s_b + (size_t)t * kChunkSize;
+        __nv_bfloat16 *w_row = s_w + (size_t)t * dv;
+
+        float acc_a = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < kChunkSize; ++i) {
+            if (i < t) {
+                acc_a += bf16_to_f32(a_row[i]) * bf16_to_f32(s_w[(size_t)i * dv + tid]);
+            }
+        }
+
+        const size_t td = (size_t)t * dv + tid;
+        const float vp = bf16_to_f32(f32_to_bf16(
+            bf16_to_f32(v_base[td]) - bf16_to_f32(ks_base[td]) * p_t
+        ));
+        const float w_val = beta_t * (vp - acc_a);
+        w_row[tid] = f32_to_bf16(w_val);
+        __syncthreads();
+
+        float acc_b = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < kChunkSize; ++i) {
+            if (i <= t) {
+                acc_b += bf16_to_f32(b_row[i]) * bf16_to_f32(s_w[(size_t)i * dv + tid]);
+            }
+        }
+
+        const float qss = bf16_to_f32(f32_to_bf16(bf16_to_f32(qs_base[td]) * p_t));
+        const float out_val = qss + acc_b;
+        out_base[td] = f32_to_bf16(out_val);
+        __syncthreads();
+    }
+
+    const float p_last = bf16_to_f32(f32_to_bf16(s_p_last));
+    for (int k_idx = 0; k_idx < dk; ++k_idx) {
+        float delta = 0.0f;
+        #pragma unroll
+        for (int t = 0; t < kChunkSize; ++t) {
+            const float kt = bf16_to_f32(kt_base[(size_t)k_idx * kChunkSize + t]);
+            const float w = bf16_to_f32(s_w[(size_t)t * dv + tid]);
+            const float decay_last = bf16_to_f32(f32_to_bf16(s_decay_last[t]));
+            const float w_weighted = bf16_to_f32(f32_to_bf16(w * decay_last));
+            delta += kt * w_weighted;
+        }
+        const size_t state_idx = (size_t)k_idx * dv + tid;
+        const float prev = bf16_to_f32(state_base[state_idx]);
+        state_base[state_idx] = f32_to_bf16(prev * p_last + delta);
+    }
+}
+
+} // namespace
+
+extern "C" kiln_gdn_full_chunk_forward_status_t kiln_gdn_full_chunk_forward(
+    const void *g,
+    const void *v,
+    const void *kkt,
+    const void *qkt,
+    const void *ks_entry,
+    const void *q_s,
+    const void *beta,
+    const void *k_t,
+    void *state,
+    void *out_chunk,
+    int batch_heads,
+    int chunk_size,
+    int dk,
+    int dv,
+    void *stream
+) {
+    if (batch_heads <= 0 || chunk_size != kChunkSize || dk <= 0 || dv <= 0) {
+        return -1;
+    }
+    if (dk > 128 || dv > kMaxDv) {
+        return -2;
+    }
+
+    const int blocks = batch_heads;
+    const int threads = 128;
+    const size_t smem_bytes =
+        ((size_t)kChunkSize * kChunkSize * 2 + (size_t)kChunkSize * dv) *
+        sizeof(__nv_bfloat16);
+
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+    gdn_full_chunk_forward_kernel<<<blocks, threads, smem_bytes, s>>>(
+        reinterpret_cast<const __nv_bfloat16 *>(g),
+        reinterpret_cast<const __nv_bfloat16 *>(v),
+        reinterpret_cast<const __nv_bfloat16 *>(kkt),
+        reinterpret_cast<const __nv_bfloat16 *>(qkt),
+        reinterpret_cast<const __nv_bfloat16 *>(ks_entry),
+        reinterpret_cast<const __nv_bfloat16 *>(q_s),
+        reinterpret_cast<const __nv_bfloat16 *>(beta),
+        reinterpret_cast<const __nv_bfloat16 *>(k_t),
+        reinterpret_cast<__nv_bfloat16 *>(state),
+        reinterpret_cast<__nv_bfloat16 *>(out_chunk),
+        dk,
+        dv
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return (int)err;
+    }
+    return 0;
+}

--- a/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.h
+++ b/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.h
@@ -1,0 +1,46 @@
+// Kiln Gated DeltaNet (GDN) fused full-chunk prefill C-ABI wrapper.
+//
+// This is the next minimal CUDA step past the split `gdn_chunk_prep` +
+// `gdn_chunk_scan` path. It keeps the four GEMMs on cuBLAS (KKT, QKT,
+// ks_entry, q_s) but collapses the remaining full-chunk prefill work into one
+// supported CUDA entrypoint:
+//
+//   1. chunk-prep algebra on-chip (big_g / p / decay / masks)
+//   2. chunk-local forward substitution + intra-chunk output accumulation
+//   3. final recurrent-state update
+//
+// This entrypoint is intentionally narrow to kiln's prompt-heavy CUDA hot
+// path: full chunks only (`chunk_size == 64`), bf16, CUDA, Qwen3.5-4B GDN
+// envelope (`dk <= 128`, `dv <= 128`).
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int kiln_gdn_full_chunk_forward_status_t;
+
+kiln_gdn_full_chunk_forward_status_t kiln_gdn_full_chunk_forward(
+    const void *g,         // [B*H, C] bf16
+    const void *v,         // [B*H, C, dv] bf16
+    const void *kkt,       // [B*H, C, C] bf16
+    const void *qkt,       // [B*H, C, C] bf16
+    const void *ks_entry,  // [B*H, C, dv] bf16
+    const void *q_s,       // [B*H, C, dv] bf16
+    const void *beta,      // [B*H, C] bf16
+    const void *k_t,       // [B*H, dk, C] bf16
+    void *state,           // [B*H, dk, dv] bf16, mutated in place
+    void *out_chunk,       // [B*H, C, dv] bf16
+    int batch_heads,
+    int chunk_size,
+    int dk,
+    int dv,
+    void *stream
+);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -124,6 +124,24 @@ unsafe extern "C" {
         dv: i32,
         stream: *mut core::ffi::c_void,
     ) -> i32;
+
+    fn kiln_gdn_full_chunk_forward(
+        g: *const core::ffi::c_void,
+        v: *const core::ffi::c_void,
+        kkt: *const core::ffi::c_void,
+        qkt: *const core::ffi::c_void,
+        ks_entry: *const core::ffi::c_void,
+        q_s: *const core::ffi::c_void,
+        beta: *const core::ffi::c_void,
+        k_t: *const core::ffi::c_void,
+        state: *mut core::ffi::c_void,
+        out_chunk: *mut core::ffi::c_void,
+        batch_heads: i32,
+        chunk_size: i32,
+        dk: i32,
+        dv: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
 }
 
 /// Run the fused GDN forward-substitution kernel.
@@ -1062,4 +1080,241 @@ pub fn gdn_chunk_scan(
     }
 
     Ok((out_chunk, w_weighted))
+}
+
+pub fn gdn_full_chunk_forward_supports(
+    g: &Tensor,
+    v: &Tensor,
+    kkt: &Tensor,
+    qkt: &Tensor,
+    ks_entry: &Tensor,
+    q_s: &Tensor,
+    beta: &Tensor,
+    k_t: &Tensor,
+    state: &Tensor,
+) -> bool {
+    if !matches!(g.device(), candle_core::Device::Cuda(_)) {
+        return false;
+    }
+    if g.dtype() != DType::BF16
+        || v.dtype() != DType::BF16
+        || kkt.dtype() != DType::BF16
+        || qkt.dtype() != DType::BF16
+        || ks_entry.dtype() != DType::BF16
+        || q_s.dtype() != DType::BF16
+        || beta.dtype() != DType::BF16
+        || k_t.dtype() != DType::BF16
+        || state.dtype() != DType::BF16
+    {
+        return false;
+    }
+
+    let Ok((b, h, c)) = g.dims3() else {
+        return false;
+    };
+    if c != 64 {
+        return false;
+    }
+    let Ok((b_v, h_v, c_v, dv)) = v.dims4() else {
+        return false;
+    };
+    if (b_v, h_v, c_v) != (b, h, c) || dv == 0 || dv > 128 {
+        return false;
+    }
+    let Ok((b_kkt, h_kkt, c1, c2)) = kkt.dims4() else {
+        return false;
+    };
+    if (b_kkt, h_kkt, c1, c2) != (b, h, c, c) {
+        return false;
+    }
+    let Ok((b_qkt, h_qkt, cq1, cq2)) = qkt.dims4() else {
+        return false;
+    };
+    if (b_qkt, h_qkt, cq1, cq2) != (b, h, c, c) {
+        return false;
+    }
+    let Ok((b_ks, h_ks, c_ks, dv_ks)) = ks_entry.dims4() else {
+        return false;
+    };
+    if (b_ks, h_ks, c_ks, dv_ks) != (b, h, c, dv) {
+        return false;
+    }
+    let Ok((b_qs, h_qs, c_qs, dv_qs)) = q_s.dims4() else {
+        return false;
+    };
+    if (b_qs, h_qs, c_qs, dv_qs) != (b, h, c, dv) {
+        return false;
+    }
+    let Ok((b_beta, h_beta, c_beta)) = beta.dims3() else {
+        return false;
+    };
+    if (b_beta, h_beta, c_beta) != (b, h, c) {
+        return false;
+    }
+    let Ok((b_kt, h_kt, dk, c_kt)) = k_t.dims4() else {
+        return false;
+    };
+    if (b_kt, h_kt, c_kt) != (b, h, c) || dk == 0 || dk > 128 {
+        return false;
+    }
+    let Ok((b_state, h_state, dk_state, dv_state)) = state.dims4() else {
+        return false;
+    };
+    (b_state, h_state, dk_state, dv_state) == (b, h, dk, dv)
+}
+
+pub fn gdn_full_chunk_forward(
+    g: &Tensor,
+    v: &Tensor,
+    kkt: &Tensor,
+    qkt: &Tensor,
+    ks_entry: &Tensor,
+    q_s: &Tensor,
+    beta: &Tensor,
+    k_t: &Tensor,
+    state: &mut Tensor,
+) -> Result<Tensor> {
+    if !gdn_full_chunk_forward_supports(g, v, kkt, qkt, ks_entry, q_s, beta, k_t, state) {
+        candle_core::bail!(
+            "kiln-gdn-kernel: gdn_full_chunk_forward: envelope violation \
+             (g={:?}, v={:?}, kkt={:?}, qkt={:?}, ks_entry={:?}, q_s={:?}, beta={:?}, k_t={:?}, state={:?})",
+            g.shape(),
+            v.shape(),
+            kkt.shape(),
+            qkt.shape(),
+            ks_entry.shape(),
+            q_s.shape(),
+            beta.shape(),
+            k_t.shape(),
+            state.shape()
+        );
+    }
+
+    let (b, h, c) = g.dims3()?;
+    let dk = k_t.dim(2)?;
+    let dv = v.dim(3)?;
+    let device = g.device();
+
+    let g_c = g.contiguous()?;
+    let v_c = v.contiguous()?;
+    let kkt_c = kkt.contiguous()?;
+    let qkt_c = qkt.contiguous()?;
+    let ks_c = ks_entry.contiguous()?;
+    let qs_c = q_s.contiguous()?;
+    let beta_c = beta.contiguous()?;
+    let kt_c = k_t.contiguous()?;
+    let state_c = state.contiguous()?;
+
+    let out_chunk = Tensor::zeros((b, h, c, dv), DType::BF16, device)?;
+
+    {
+        let (g_storage, g_layout) = g_c.storage_and_layout();
+        let (v_storage, v_layout) = v_c.storage_and_layout();
+        let (kkt_storage, kkt_layout) = kkt_c.storage_and_layout();
+        let (qkt_storage, qkt_layout) = qkt_c.storage_and_layout();
+        let (ks_storage, ks_layout) = ks_c.storage_and_layout();
+        let (qs_storage, qs_layout) = qs_c.storage_and_layout();
+        let (beta_storage, beta_layout) = beta_c.storage_and_layout();
+        let (kt_storage, kt_layout) = kt_c.storage_and_layout();
+        let (state_storage, state_layout) = state_c.storage_and_layout();
+        let (out_storage, out_layout) = out_chunk.storage_and_layout();
+
+        let g_cuda = match &*g_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: g must be on CUDA"),
+        };
+        let v_cuda = match &*v_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: v must be on CUDA"),
+        };
+        let kkt_cuda = match &*kkt_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: kkt must be on CUDA"),
+        };
+        let qkt_cuda = match &*qkt_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: qkt must be on CUDA"),
+        };
+        let ks_cuda = match &*ks_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: ks_entry must be on CUDA"),
+        };
+        let qs_cuda = match &*qs_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: q_s must be on CUDA"),
+        };
+        let beta_cuda = match &*beta_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: beta must be on CUDA"),
+        };
+        let kt_cuda = match &*kt_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: k_t must be on CUDA"),
+        };
+        let state_cuda = match &*state_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: state must be on CUDA"),
+        };
+        let out_cuda = match &*out_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: out_chunk must be on CUDA"),
+        };
+
+        let stream = g_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let g_slice = g_cuda.as_cuda_slice::<bf16>()?.slice(g_layout.start_offset()..);
+        let v_slice = v_cuda.as_cuda_slice::<bf16>()?.slice(v_layout.start_offset()..);
+        let kkt_slice = kkt_cuda.as_cuda_slice::<bf16>()?.slice(kkt_layout.start_offset()..);
+        let qkt_slice = qkt_cuda.as_cuda_slice::<bf16>()?.slice(qkt_layout.start_offset()..);
+        let ks_slice = ks_cuda.as_cuda_slice::<bf16>()?.slice(ks_layout.start_offset()..);
+        let qs_slice = qs_cuda.as_cuda_slice::<bf16>()?.slice(qs_layout.start_offset()..);
+        let beta_slice = beta_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(beta_layout.start_offset()..);
+        let kt_slice = kt_cuda.as_cuda_slice::<bf16>()?.slice(kt_layout.start_offset()..);
+        let state_slice = state_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(state_layout.start_offset()..);
+        let out_slice = out_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(out_layout.start_offset()..);
+
+        unsafe {
+            let (g_ptr, _g1) = g_slice.device_ptr(&stream);
+            let (v_ptr, _g2) = v_slice.device_ptr(&stream);
+            let (kkt_ptr, _g3) = kkt_slice.device_ptr(&stream);
+            let (qkt_ptr, _g4) = qkt_slice.device_ptr(&stream);
+            let (ks_ptr, _g5) = ks_slice.device_ptr(&stream);
+            let (qs_ptr, _g6) = qs_slice.device_ptr(&stream);
+            let (beta_ptr, _g7) = beta_slice.device_ptr(&stream);
+            let (kt_ptr, _g8) = kt_slice.device_ptr(&stream);
+            let (state_ptr, _g9) = state_slice.device_ptr(&stream);
+            let (out_ptr, _g10) = out_slice.device_ptr(&stream);
+
+            let status = kiln_gdn_full_chunk_forward(
+                g_ptr as *const _,
+                v_ptr as *const _,
+                kkt_ptr as *const _,
+                qkt_ptr as *const _,
+                ks_ptr as *const _,
+                qs_ptr as *const _,
+                beta_ptr as *const _,
+                kt_ptr as *const _,
+                state_ptr as *mut _,
+                out_ptr as *mut _,
+                (b * h) as i32,
+                c as i32,
+                dk as i32,
+                dv as i32,
+                raw_stream,
+            );
+            if status != 0 {
+                candle_core::bail!("kiln_gdn_full_chunk_forward failed with status {status}");
+            }
+        }
+    }
+
+    *state = state_c;
+    Ok(out_chunk)
 }

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -72,6 +72,10 @@ impl BackendRuntime for CudaBackend {
         self.gdn_enabled
     }
 
+    fn supports_gdn_full_chunk_forward(&self) -> bool {
+        self.gdn_enabled
+    }
+
     fn flash_attn_prefill(
         &self,
         q: &Tensor,
@@ -193,6 +197,30 @@ impl BackendRuntime for CudaBackend {
             decay_last_col,
         )
         .context("gdn_chunk_scan kernel failed")?;
+        Ok(Some(out))
+    }
+
+    fn gdn_full_chunk_forward(
+        &self,
+        g: &Tensor,
+        v: &Tensor,
+        kkt: &Tensor,
+        qkt: &Tensor,
+        ks_entry: &Tensor,
+        q_s: &Tensor,
+        beta: &Tensor,
+        k_t: &Tensor,
+        state: &mut Tensor,
+    ) -> Result<Option<Tensor>> {
+        if !kiln_gdn_kernel::gdn_full_chunk_forward_supports(
+            g, v, kkt, qkt, ks_entry, q_s, beta, k_t, state,
+        ) {
+            return Ok(None);
+        }
+        let out = kiln_gdn_kernel::gdn_full_chunk_forward(
+            g, v, kkt, qkt, ks_entry, q_s, beta, k_t, state,
+        )
+        .context("gdn_full_chunk_forward kernel failed")?;
         Ok(Some(out))
     }
 

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -66,6 +66,10 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         false
     }
 
+    fn supports_gdn_full_chunk_forward(&self) -> bool {
+        false
+    }
+
     /// FlashAttention-2 forward for prefill (no KV cache, seq_len > 1).
     ///
     /// `q`, `k`, `v`: `[batch, seq_len, num_heads, head_dim]` bf16 contiguous.
@@ -201,6 +205,21 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         _beta: &Tensor,
         _decay_last_col: &Tensor,
     ) -> Result<Option<(Tensor, Tensor)>> {
+        Ok(None)
+    }
+
+    fn gdn_full_chunk_forward(
+        &self,
+        _g: &Tensor,
+        _v: &Tensor,
+        _kkt: &Tensor,
+        _qkt: &Tensor,
+        _ks_entry: &Tensor,
+        _q_s: &Tensor,
+        _beta: &Tensor,
+        _k_t: &Tensor,
+        _state: &mut Tensor,
+    ) -> Result<Option<Tensor>> {
         Ok(None)
     }
 

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2260,6 +2260,16 @@ fn gdn_chunkwise_recurrence(
         let qkt = q_c.matmul(&k_t_mat)?; // [B, nv, C, C]
         let q_s = q_c.matmul(&*state)?; // [B, nv, C, dv]
 
+        if !is_tail && c == 64 && backend.supports_gdn_full_chunk_forward() && dtype == DType::BF16
+        {
+            if let Some(out_chunk) = backend.gdn_full_chunk_forward(
+                &g_c, &v_c, &kkt, &qkt, &ks_entry, &q_s, &beta_c, &k_t_mat, state,
+            )? {
+                out_chunks.push(out_chunk);
+                continue;
+            }
+        }
+
         // Fused prep: cumsum + decay + exp + masked scales + v_prime +
         // q_s_scaled + decay_last_col + p_last in a single CUDA launch.
         // Falls back to the candle-op chain when the backend declines
@@ -8261,6 +8271,109 @@ mod tests {
 
         check("out_chunk", &out_kernel, &out_ref)?;
         check("w_weighted", &ww_kernel, &ww_ref)?;
+        Ok(())
+    }
+
+    /// Parity check for the fused full-chunk CUDA prefill path.
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn test_gdn_full_chunk_forward_matches_fallback() -> Result<()> {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let device = match Device::new_cuda(0) {
+            Ok(d) => d,
+            Err(_) => {
+                eprintln!(
+                    "CUDA not available, skipping test_gdn_full_chunk_forward_matches_fallback"
+                );
+                return Ok(());
+            }
+        };
+
+        let b = 1usize;
+        let nv = 32usize;
+        let c = 64usize;
+        let dk = 128usize;
+        let dv = 128usize;
+
+        let mut rng = StdRng::seed_from_u64(0x5EED_CAFE_u64);
+        let n_c = b * nv * c;
+        let n_cdv = b * nv * c * dv;
+        let n_cc = b * nv * c * c;
+        let n_dkc = b * nv * dk * c;
+        let n_dkdv = b * nv * dk * dv;
+
+        let g_data: Vec<f32> = (0..n_c).map(|_| rng.gen_range(-0.15f32..0.0f32)).collect();
+        let v_data: Vec<f32> = (0..n_cdv).map(|_| rng.gen_range(-1.0f32..1.0f32)).collect();
+        let kkt_data: Vec<f32> = (0..n_cc).map(|_| rng.gen_range(-0.5f32..0.5f32)).collect();
+        let qkt_data: Vec<f32> = (0..n_cc).map(|_| rng.gen_range(-0.5f32..0.5f32)).collect();
+        let ks_data: Vec<f32> = (0..n_cdv).map(|_| rng.gen_range(-0.5f32..0.5f32)).collect();
+        let qs_data: Vec<f32> = (0..n_cdv).map(|_| rng.gen_range(-0.5f32..0.5f32)).collect();
+        let beta_data: Vec<f32> = (0..n_c).map(|_| rng.gen_range(0.3f32..1.1f32)).collect();
+        let kt_data: Vec<f32> = (0..n_dkc).map(|_| rng.gen_range(-0.5f32..0.5f32)).collect();
+        let state_data: Vec<f32> =
+            (0..n_dkdv).map(|_| rng.gen_range(-0.25f32..0.25f32)).collect();
+
+        let g = Tensor::from_slice(&g_data, (b, nv, c), &device)?.to_dtype(DType::BF16)?;
+        let v = Tensor::from_slice(&v_data, (b, nv, c, dv), &device)?.to_dtype(DType::BF16)?;
+        let kkt = Tensor::from_slice(&kkt_data, (b, nv, c, c), &device)?.to_dtype(DType::BF16)?;
+        let qkt = Tensor::from_slice(&qkt_data, (b, nv, c, c), &device)?.to_dtype(DType::BF16)?;
+        let ks_entry =
+            Tensor::from_slice(&ks_data, (b, nv, c, dv), &device)?.to_dtype(DType::BF16)?;
+        let q_s = Tensor::from_slice(&qs_data, (b, nv, c, dv), &device)?.to_dtype(DType::BF16)?;
+        let beta =
+            Tensor::from_slice(&beta_data, (b, nv, c), &device)?.to_dtype(DType::BF16)?;
+        let k_t = Tensor::from_slice(&kt_data, (b, nv, dk, c), &device)?.to_dtype(DType::BF16)?;
+        let mut state_kernel =
+            Tensor::from_slice(&state_data, (b, nv, dk, dv), &device)?.to_dtype(DType::BF16)?;
+        let state_ref = state_kernel.clone();
+
+        let out_kernel = kiln_gdn_kernel::gdn_full_chunk_forward(
+            &g,
+            &v,
+            &kkt,
+            &qkt,
+            &ks_entry,
+            &q_s,
+            &beta,
+            &k_t,
+            &mut state_kernel,
+        )?;
+
+        let (a_strict, b_mask, v_prime, q_s_scaled, decay_last_col, p_last) =
+            kiln_gdn_kernel::gdn_chunk_prep(&g, &v, &kkt, &qkt, &ks_entry, &q_s)?;
+        let (out_ref, ww_ref) = compute_chunk_body_reference(
+            &a_strict,
+            &b_mask,
+            &v_prime,
+            &q_s_scaled,
+            &beta,
+            &decay_last_col.unsqueeze(3)?,
+        )?;
+        let p_last_u = p_last.unsqueeze(2)?.unsqueeze(3)?;
+        let state_expected =
+            (state_ref.broadcast_mul(&p_last_u)? + k_t.matmul(&ww_ref)?)?.contiguous()?;
+
+        let check = |name: &str, got: &Tensor, want: &Tensor, max_tol: f32, mean_tol: f32| -> Result<()> {
+            let diff = (got.to_dtype(DType::F32)? - want.to_dtype(DType::F32)?)?;
+            let abs = diff.abs()?;
+            let max = abs.flatten_all()?.max(0)?.to_scalar::<f32>()?;
+            let mean = abs.flatten_all()?.mean(0)?.to_scalar::<f32>()?;
+            eprintln!("gdn-full-chunk {name}: max={max:e} mean={mean:e}");
+            assert!(
+                max < max_tol,
+                "full-chunk {name} max_abs_diff {max:e} exceeds {max_tol:e}"
+            );
+            assert!(
+                mean < mean_tol,
+                "full-chunk {name} mean_abs_diff {mean:e} exceeds {mean_tol:e}"
+            );
+            Ok(())
+        };
+
+        check("out_chunk", &out_kernel, &out_ref, 2e-2, 2e-3)?;
+        check("state", &state_kernel, &state_expected, 3.5e-2, 4e-3)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add a CUDA-only `gdn_full_chunk_forward` entrypoint that fuses the full-chunk prefill body and recurrent state update for the supported 64-token BF16 path
- route `gdn_chunkwise_recurrence` through that fused full-chunk path on CUDA while keeping decode and tail chunks on the existing fallback path
- add a focused CUDA parity test and record the post-change measurement note in `PROFILING.md`

## Preflight
- PR #389 is merged on current `main` (`9eeebd0`)
- no newer merged or open PR already landed a fused full-chunk GDN prefill forward path
- `PROFILING.md` still points at GDN prefill chunk work as the next Phase 6 target
- `crates/kiln-model/src/forward.rs` still had the split `chunk_prep` -> `chunk` -> Rust-side state update path before this change
- `git log --all --grep='full-chunk\|gdn_full_chunk_forward\|chunk_gla_fwd'` did not show an already-landed equivalent beyond the current split kernels

## Validation
RunPod only, `ghcr.io/ericflo/kiln-runpod:latest`, RTX A6000.

- `cargo build --release --features cuda,nvtx --bin kiln-bench`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo test -p kiln-model -p kiln-server --features cuda --no-run`
- `CARGO_PROFILE_DEV_DEBUG=0 cargo test -p kiln-model test_gdn_full_chunk_forward_matches_fallback --features cuda -- --nocapture`
- `KILN_W4A16=1 KILN_CUDA_GRAPHS=true ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 8192 --max-output-tokens 1 --skip-training --latency-only` x3

## Bench result
Prompt-heavy prefill did not improve on the `#389` baseline.

New branch runs:
- run 1: `3239.3 ms` prefill (`2525 tok/s`)
- run 2: `3651.1 ms` prefill (`2240 tok/s`)
- run 3: `3254.9 ms` prefill (`2513 tok/s`)
- median: `3254.9 ms` (`2513 tok/s`)

Baseline already recorded in `PROFILING.md`:
- uncaptured: `2831.2 ms` / `2889 tok/s`
- profiled: `2947.8 ms` / `2775 tok/s`

So this minimal fused full-chunk step is a regression, not a win.

## Exercised vs fallback
On the `8192/1` benchmark arm the prompt tokenized to `8180`, so the fused path exercised on the first `127` full `64`-token chunks. The final `52`-token tail chunk still fell back by design.
