### PR TITLE
phase6: port one vLLM fused-GDN win into full-chunk prefill kernel

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -179,6 +179,27 @@ direction:
   ceiling;
 - decode full attention remains far below the >5% reopen bar.
 
+### Follow-up blocked on RunPod infra — 2026-04-23
+
+Attempted follow-up task `phase6: port one vLLM fused-GDN win into full-chunk
+prefill kernel` stopped before validation because the required RunPod GPU
+environment never became reachable.
+
+- Requested on-demand `NVIDIA RTX A6000` with
+  `ghcr.io/ericflo/kiln-runpod:latest` failed immediately with
+  `SUPPLY_CONSTRAINT`.
+- Fallback launch on on-demand `A40` succeeded at pod creation
+  (`gx9qu9cmmoxrrm`, `$0.44/hr`) but remained `runtime: null` / unreachable for
+  more than 5 minutes and was terminated per task policy.
+- Second launch on on-demand `A100 PCIe` (`i3rgpq7yiehyzo`, `$1.39/hr`) also
+  remained `runtime: null` / unreachable and was terminated. Per the task
+  brief's second-launch rule, this attempt stopped cleanly with a doc-only
+  PR instead of shipping unvalidated CUDA changes.
+
+No parity tests, `8192/1` timing runs, or post-change kernel-share captures
+were executed in this attempt, so the post-`#392` profile above remains the
+current source of truth.
+
 ## Phase 6 post-#384 current-main re-profile — 2026-04-22
 
 ### Post-change note — 2026-04-23 (`ce/phase6-fused-gdn-full-chunk`)

--- a/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
+++ b/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
@@ -54,15 +54,10 @@ __global__ void gdn_full_chunk_forward_kernel(
         return;
     }
 
-    extern __shared__ unsigned char smem_raw[];
-    unsigned char *smem = smem_raw;
-    __nv_bfloat16 *s_a = reinterpret_cast<__nv_bfloat16 *>(smem);    // [C, C]
-    smem += (size_t)kChunkSize * kChunkSize * sizeof(__nv_bfloat16);
-    __nv_bfloat16 *s_b = reinterpret_cast<__nv_bfloat16 *>(smem);    // [C, C]
-    smem += (size_t)kChunkSize * kChunkSize * sizeof(__nv_bfloat16);
-    uintptr_t smem_aligned = (reinterpret_cast<uintptr_t>(smem) + alignof(float) - 1) &
-        ~(uintptr_t)(alignof(float) - 1);
-    float *s_w = reinterpret_cast<float *>(smem_aligned);            // [C, dv]
+    extern __shared__ __nv_bfloat16 smem[];
+    __nv_bfloat16 *s_a = smem;                                       // [C, C]
+    __nv_bfloat16 *s_b = s_a + (size_t)kChunkSize * kChunkSize;      // [C, C]
+    __nv_bfloat16 *s_w = s_b + (size_t)kChunkSize * kChunkSize;      // [C, dv]
 
     __shared__ float s_big_g[kChunkSize];
     __shared__ float s_p[kChunkSize];
@@ -115,49 +110,52 @@ __global__ void gdn_full_chunk_forward_kernel(
 
     for (int t = 0; t < kChunkSize; ++t) {
         const float beta_t = bf16_to_f32(beta_base[t]);
-        const float p_t = s_p[t];
+        const float p_t = bf16_to_f32(f32_to_bf16(s_p[t]));
 
         const __nv_bfloat16 *a_row = s_a + (size_t)t * kChunkSize;
         const __nv_bfloat16 *b_row = s_b + (size_t)t * kChunkSize;
-        float *w_row = s_w + (size_t)t * dv;
+        __nv_bfloat16 *w_row = s_w + (size_t)t * dv;
 
         float acc_a = 0.0f;
         #pragma unroll
         for (int i = 0; i < kChunkSize; ++i) {
             if (i < t) {
-                acc_a += bf16_to_f32(a_row[i]) * s_w[(size_t)i * dv + tid];
+                acc_a += bf16_to_f32(a_row[i]) * bf16_to_f32(s_w[(size_t)i * dv + tid]);
             }
         }
 
         const size_t td = (size_t)t * dv + tid;
-        const float vp = bf16_to_f32(v_base[td]) - bf16_to_f32(ks_base[td]) * p_t;
+        const float vp = bf16_to_f32(f32_to_bf16(
+            bf16_to_f32(v_base[td]) - bf16_to_f32(ks_base[td]) * p_t
+        ));
         const float w_val = beta_t * (vp - acc_a);
-        w_row[tid] = w_val;
+        w_row[tid] = f32_to_bf16(w_val);
         __syncthreads();
 
         float acc_b = 0.0f;
         #pragma unroll
         for (int i = 0; i < kChunkSize; ++i) {
             if (i <= t) {
-                acc_b += bf16_to_f32(b_row[i]) * s_w[(size_t)i * dv + tid];
+                acc_b += bf16_to_f32(b_row[i]) * bf16_to_f32(s_w[(size_t)i * dv + tid]);
             }
         }
 
-        const float qss = bf16_to_f32(qs_base[td]) * p_t;
+        const float qss = bf16_to_f32(f32_to_bf16(bf16_to_f32(qs_base[td]) * p_t));
         const float out_val = qss + acc_b;
         out_base[td] = f32_to_bf16(out_val);
         __syncthreads();
     }
 
-    const float p_last = s_p_last;
+    const float p_last = bf16_to_f32(f32_to_bf16(s_p_last));
     for (int k_idx = 0; k_idx < dk; ++k_idx) {
         float delta = 0.0f;
         #pragma unroll
         for (int t = 0; t < kChunkSize; ++t) {
             const float kt = bf16_to_f32(kt_base[(size_t)k_idx * kChunkSize + t]);
-            const float w = s_w[(size_t)t * dv + tid];
-            const float decay_last = s_decay_last[t];
-            delta += kt * (w * decay_last);
+            const float w = bf16_to_f32(s_w[(size_t)t * dv + tid]);
+            const float decay_last = bf16_to_f32(f32_to_bf16(s_decay_last[t]));
+            const float w_weighted = bf16_to_f32(f32_to_bf16(w * decay_last));
+            delta += kt * w_weighted;
         }
         const size_t state_idx = (size_t)k_idx * dv + tid;
         const float prev = bf16_to_f32(state_base[state_idx]);
@@ -194,9 +192,8 @@ extern "C" kiln_gdn_full_chunk_forward_status_t kiln_gdn_full_chunk_forward(
     const int blocks = batch_heads;
     const int threads = 128;
     const size_t smem_bytes =
-        (size_t)kChunkSize * kChunkSize * 2 * sizeof(__nv_bfloat16) +
-        (size_t)kChunkSize * dv * sizeof(float) +
-        alignof(float);
+        ((size_t)kChunkSize * kChunkSize * 2 + (size_t)kChunkSize * dv) *
+        sizeof(__nv_bfloat16);
 
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
     gdn_full_chunk_forward_kernel<<<blocks, threads, smem_bytes, s>>>(

--- a/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
+++ b/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
@@ -54,10 +54,15 @@ __global__ void gdn_full_chunk_forward_kernel(
         return;
     }
 
-    extern __shared__ __nv_bfloat16 smem[];
-    __nv_bfloat16 *s_a = smem;                                       // [C, C]
-    __nv_bfloat16 *s_b = s_a + (size_t)kChunkSize * kChunkSize;      // [C, C]
-    __nv_bfloat16 *s_w = s_b + (size_t)kChunkSize * kChunkSize;      // [C, dv]
+    extern __shared__ unsigned char smem_raw[];
+    unsigned char *smem = smem_raw;
+    __nv_bfloat16 *s_a = reinterpret_cast<__nv_bfloat16 *>(smem);    // [C, C]
+    smem += (size_t)kChunkSize * kChunkSize * sizeof(__nv_bfloat16);
+    __nv_bfloat16 *s_b = reinterpret_cast<__nv_bfloat16 *>(smem);    // [C, C]
+    smem += (size_t)kChunkSize * kChunkSize * sizeof(__nv_bfloat16);
+    uintptr_t smem_aligned = (reinterpret_cast<uintptr_t>(smem) + alignof(float) - 1) &
+        ~(uintptr_t)(alignof(float) - 1);
+    float *s_w = reinterpret_cast<float *>(smem_aligned);            // [C, dv]
 
     __shared__ float s_big_g[kChunkSize];
     __shared__ float s_p[kChunkSize];
@@ -110,52 +115,49 @@ __global__ void gdn_full_chunk_forward_kernel(
 
     for (int t = 0; t < kChunkSize; ++t) {
         const float beta_t = bf16_to_f32(beta_base[t]);
-        const float p_t = bf16_to_f32(f32_to_bf16(s_p[t]));
+        const float p_t = s_p[t];
 
         const __nv_bfloat16 *a_row = s_a + (size_t)t * kChunkSize;
         const __nv_bfloat16 *b_row = s_b + (size_t)t * kChunkSize;
-        __nv_bfloat16 *w_row = s_w + (size_t)t * dv;
+        float *w_row = s_w + (size_t)t * dv;
 
         float acc_a = 0.0f;
         #pragma unroll
         for (int i = 0; i < kChunkSize; ++i) {
             if (i < t) {
-                acc_a += bf16_to_f32(a_row[i]) * bf16_to_f32(s_w[(size_t)i * dv + tid]);
+                acc_a += bf16_to_f32(a_row[i]) * s_w[(size_t)i * dv + tid];
             }
         }
 
         const size_t td = (size_t)t * dv + tid;
-        const float vp = bf16_to_f32(f32_to_bf16(
-            bf16_to_f32(v_base[td]) - bf16_to_f32(ks_base[td]) * p_t
-        ));
+        const float vp = bf16_to_f32(v_base[td]) - bf16_to_f32(ks_base[td]) * p_t;
         const float w_val = beta_t * (vp - acc_a);
-        w_row[tid] = f32_to_bf16(w_val);
+        w_row[tid] = w_val;
         __syncthreads();
 
         float acc_b = 0.0f;
         #pragma unroll
         for (int i = 0; i < kChunkSize; ++i) {
             if (i <= t) {
-                acc_b += bf16_to_f32(b_row[i]) * bf16_to_f32(s_w[(size_t)i * dv + tid]);
+                acc_b += bf16_to_f32(b_row[i]) * s_w[(size_t)i * dv + tid];
             }
         }
 
-        const float qss = bf16_to_f32(f32_to_bf16(bf16_to_f32(qs_base[td]) * p_t));
+        const float qss = bf16_to_f32(qs_base[td]) * p_t;
         const float out_val = qss + acc_b;
         out_base[td] = f32_to_bf16(out_val);
         __syncthreads();
     }
 
-    const float p_last = bf16_to_f32(f32_to_bf16(s_p_last));
+    const float p_last = s_p_last;
     for (int k_idx = 0; k_idx < dk; ++k_idx) {
         float delta = 0.0f;
         #pragma unroll
         for (int t = 0; t < kChunkSize; ++t) {
             const float kt = bf16_to_f32(kt_base[(size_t)k_idx * kChunkSize + t]);
-            const float w = bf16_to_f32(s_w[(size_t)t * dv + tid]);
-            const float decay_last = bf16_to_f32(f32_to_bf16(s_decay_last[t]));
-            const float w_weighted = bf16_to_f32(f32_to_bf16(w * decay_last));
-            delta += kt * w_weighted;
+            const float w = s_w[(size_t)t * dv + tid];
+            const float decay_last = s_decay_last[t];
+            delta += kt * (w * decay_last);
         }
         const size_t state_idx = (size_t)k_idx * dv + tid;
         const float prev = bf16_to_f32(state_base[state_idx]);
@@ -192,8 +194,9 @@ extern "C" kiln_gdn_full_chunk_forward_status_t kiln_gdn_full_chunk_forward(
     const int blocks = batch_heads;
     const int threads = 128;
     const size_t smem_bytes =
-        ((size_t)kChunkSize * kChunkSize * 2 + (size_t)kChunkSize * dv) *
-        sizeof(__nv_bfloat16);
+        (size_t)kChunkSize * kChunkSize * 2 * sizeof(__nv_bfloat16) +
+        (size_t)kChunkSize * dv * sizeof(float) +
+        alignof(float);
 
     cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
     gdn_full_chunk_forward_kernel<<<blocks, threads, smem_bytes, s>>>(


### PR DESCRIPTION
## Summary
- no-op / doc-only PR due to RunPod infra blocker during required GPU validation
- record the exact failed launch attempts and stop per task policy instead of shipping unvalidated CUDA changes
- leave the post-#392 profile as the current source of truth

## What happened
I started from fresh `main`, confirmed PR #396 was merged, confirmed there was no newer PR already modifying `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu` for this same goal, and confirmed `PROFILING.md` still shows the post-#392 section with `gdn_full_chunk_forward_kernel` at 34.6% and the old chunkwise pair collapsed to ~0.1% / 0.1%.

I then attempted the required RunPod validation workflow with the kiln image only:
- `NVIDIA RTX A6000` on-demand: launch failed immediately with `SUPPLY_CONSTRAINT`
- fallback `A40` on-demand pod `gx9qu9cmmoxrrm`: remained `runtime: null` / unreachable for more than 5 minutes, then terminated per task policy
- second launch `A100 PCIe` on-demand pod `i3rgpq7yiehyzo`: also remained `runtime: null` / unreachable and was terminated

Per the task brief: after the second unreachable launch, stop cleanly with a doc-only / no-op PR rather than duplicating work or shipping unvalidated CUDA edits.

## Files changed
- `PROFILING.md`

## Validation
Not run. No parity tests, `8192/1` timing runs, or post-change kernel-share captures were possible because the required pod environment never became reachable.

## Current source of truth
`PROFILING.md` remains unchanged on the actual performance conclusion: `gdn_full_chunk_forward_kernel` is still the current Phase 6 prompt-heavy prefill frontier based on the merged post-#392 profile.
