### PR TITLE
phase6: retry vLLM full-chunk GDN win after #397 blocker

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -200,6 +200,49 @@ No parity tests, `8192/1` timing runs, or post-change kernel-share captures
 were executed in this attempt, so the post-`#392` profile above remains the
 current source of truth.
 
+### Follow-up parity retry — 2026-04-23
+
+Retried the same Phase 6 frontier on fresh `main` after `#397`, this time on a
+reachable on-demand A40 fallback pod (same `sm_86` envelope as A6000) with the
+required kiln image. Preflight still passed:
+
+- `#397` is merged on `main` and remains doc-only (`PROFILING.md` only);
+- no newer open or merged PR already modifies
+  `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu` for this exact goal;
+- the post-`#392` section above still shows
+  `gdn_full_chunk_forward_kernel` at **34.6%** of refined prompt-heavy prefill
+  kernel time.
+
+The upstream idea attempted here was the smallest vLLM-style cleanup available
+inside kiln's fused full-chunk kernel: stop redundant bf16 round-trips in the
+final recurrent-state update path while leaving the chunk body and launch
+envelope unchanged.
+
+Validation command on the pod:
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+export KILN_CUDA_ARCHS=86
+export CARGO_PROFILE_DEV_DEBUG=0
+cargo test -p kiln-model --features cuda \
+  forward::tests::test_gdn_full_chunk_forward_matches_fallback \
+  -- --exact --nocapture
+```
+
+Result: **fail**. The kernel launched and the output chunk stayed within the
+existing tolerance, but the recurrent-state parity regressed past the test bar:
+
+- `out_chunk` max abs diff: **1.5625e-2**
+- `state` max abs diff: **3.90625e-2**
+- test threshold for `state`: **3.5e-2**
+
+Because the focused CUDA parity check failed, this retry did **not** run the
+`8192/1` timing arm or a new Nsight capture, and it does **not** ship a kernel
+change. The current source of truth therefore remains the post-`#392` profile
+above, and the next Phase 6 retry on this frontier needs a different upstream
+idea than this scalar round-trip cleanup.
+
 ## Phase 6 post-#384 current-main re-profile — 2026-04-22
 
 ### Post-change note — 2026-04-23 (`ce/phase6-fused-gdn-full-chunk`)


### PR DESCRIPTION
## Summary
- document the post-#397 retry on fresh `main` and the exact reason no kernel change ships
- record the smallest vLLM-inspired fused-GDN idea attempted and its focused parity failure
- leave the post-#392 profile as the current Phase 6 source of truth because no validated `8192/1` rerun was justified

## Upstream idea attempted
Port the smallest concrete win from vLLM's newer fused GDN path into kiln's vendored `gdn_full_chunk_forward_kernel`: remove redundant bf16<->f32 round-trips in the final recurrent-state update path while keeping the full-chunk CUDA envelope fixed (`chunk_size=64`, bf16, `dk<=128`, `dv<=128`).

## Files changed
- `PROFILING.md`

## Preflight
Confirmed on fresh `main` before editing:
- PR #397 is merged on `main`
- no newer open or merged PR already modifies `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu` for this same goal
- `PROFILING.md` still shows the post-#392 section with `gdn_full_chunk_forward_kernel` at 34.6% of refined prompt-heavy prefill kernel time, and #397 remains a doc-only infra note

## Validation
RunPod fallback used the required kiln image on an on-demand A40 after the requested A6000 returned `SUPPLY_CONSTRAINT`.

Focused parity command:
```bash
source /root/.kiln-build-env
cd /workspace/kiln
export KILN_CUDA_ARCHS=86
export CARGO_PROFILE_DEV_DEBUG=0
cargo test -p kiln-model --features cuda \
  forward::tests::test_gdn_full_chunk_forward_matches_fallback \
  -- --exact --nocapture
```

Result: failed parity, so no benchmark/profile rerun was executed.
- `out_chunk` max abs diff: `1.5625e-2`
- `state` max abs diff: `3.90625e-2`
- state threshold in the test: `3.5e-2`

I also confirmed the bare task command with `test_gdn_full_chunk_forward_matches_fallback -- --exact` does not match Cargo's fully qualified unit-test name on this target; the rerun above used the exact discovered harness path.

## 8192/1 before/after
No new `8192/1` before/after numbers were taken in this retry because the kernel idea failed the focused CUDA parity gate first. The current validated prompt-heavy prefill source of truth therefore remains the merged post-#392 numbers already recorded in `PROFILING.md`:
- prefill time: `3277.7 ms`
- prefill throughput: `2495.6 tok/s`

## Post-change kernel share
No post-change kernel-share capture was taken because no parity-preserving kernel change survived validation.

## Frontier status
Yes: `gdn_full_chunk_forward_kernel` still remains the Phase 6 prompt-heavy prefill frontier from the last validated profile. The next retry on this path needs a different upstream idea than this scalar round-trip cleanup.
