### PR TITLE
phase6: port one different vLLM full-chunk GDN win after #401

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -339,6 +339,80 @@ end-to-end bar, so the next retry on this path should target a different
 kernel-internal bottleneck than both `#399`'s scalar round-trip cleanup and
 this shared-`W` weighting hoist.
 
+### Post-#401 bounded shared-`k_t` row staging — 2026-04-23
+
+Fresh-`main` preflight passed again before editing:
+
+- PR `#401` is merged and remains doc-only (`PROFILING.md` plus a capture-note
+  CSV only).
+- No newer open or merged PR already changes
+  `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu` for this post-`#401`
+  follow-up scope.
+- The validated post-`#392` refined prefill capture above still shows
+  `gdn_full_chunk_forward_kernel` at **34.6%** of prompt-heavy prefill kernel
+  time, so the frontier still exists on the current source of truth.
+
+This retry ported one different bounded vLLM-style idea into the fused
+full-chunk kernel's recurrent-state update: stage each `k_t[k_idx, :]` row
+into shared memory once per `dk` iteration, then let all `dv` lanes reuse that
+staged row instead of reloading the same 64 bf16 `k_t` scalars from global
+memory in every thread. The motivating upstream pattern is the current vLLM
+`fused_recurrent_gated_delta_rule_fwd_kernel`, which loads `b_k` once per
+program tile and reuses it across all value lanes.
+
+**Attempted code path**
+
+- `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu`
+
+**Parity**
+
+RunPod on-demand RTX A6000, `ghcr.io/ericflo/kiln-runpod:latest`.
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+export KILN_CUDA_ARCHS=86
+export KILN_W4A16=1
+export KILN_CUDA_GRAPHS=true
+export CARGO_PROFILE_DEV_DEBUG=0
+cargo test -p kiln-model --features cuda \
+  forward::tests::test_gdn_full_chunk_forward_matches_fallback \
+  -- --exact --nocapture
+```
+
+Result: **pass**.
+
+- `out_chunk` max abs diff: **1.5625e-2**
+- `state` max abs diff: **3.125e-2**
+
+**8192/1 prompt-heavy prefill**
+
+To avoid cross-pod noise, I measured both arms on the same A6000 pod after the
+branch benchmark looked much slower than the historical post-`#392` number.
+
+Same-pod control on fresh `main`:
+
+- before: **3272.4 ms**, **2499.7 tok/s**
+
+Branch with shared-`k_t` row staging:
+
+- after: **4704.0 ms**, **1739.0 tok/s**
+
+That is a clear regression on the required prompt-heavy arm, so the kernel
+change was reverted before opening the PR. This section documents the failed
+attempt; it does **not** land a source change in
+`gdn_full_chunk_forward.cu`.
+
+**Kernel-share capture note**
+
+Unlike the post-`#399` retry, I did **not** keep a new Nsight kernel-share
+capture for this attempt. Once the same-pod control showed the branch at
+**4704.0 ms** versus `main` at **3272.4 ms**, the code no longer met the keep
+bar, so I reverted it immediately instead of burning more pod time on a
+post-change profile for a change that was already disqualified. The capture
+note for this decision is recorded in
+`profiling-artifacts/post401_20260423_prefill_kern.csv`.
+
 ## Phase 6 post-#384 current-main re-profile — 2026-04-22
 
 ### Post-change note — 2026-04-23 (`ce/phase6-fused-gdn-full-chunk`)

--- a/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
+++ b/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
@@ -63,7 +63,6 @@ __global__ void gdn_full_chunk_forward_kernel(
     __shared__ float s_p[kChunkSize];
     __shared__ float s_decay_last[kChunkSize];
     __shared__ float s_p_last;
-    __shared__ __nv_bfloat16 s_kt_row[kChunkSize];
 
     const __nv_bfloat16 *g_base = g + (size_t)bh * kChunkSize;
     const __nv_bfloat16 *v_base = v + (size_t)bh * kChunkSize * dv;
@@ -149,15 +148,10 @@ __global__ void gdn_full_chunk_forward_kernel(
 
     const float p_last = bf16_to_f32(f32_to_bf16(s_p_last));
     for (int k_idx = 0; k_idx < dk; ++k_idx) {
-        if (tid < kChunkSize) {
-            s_kt_row[tid] = kt_base[(size_t)k_idx * kChunkSize + tid];
-        }
-        __syncthreads();
-
         float delta = 0.0f;
         #pragma unroll
         for (int t = 0; t < kChunkSize; ++t) {
-            const float kt = bf16_to_f32(s_kt_row[t]);
+            const float kt = bf16_to_f32(kt_base[(size_t)k_idx * kChunkSize + t]);
             const float w = bf16_to_f32(s_w[(size_t)t * dv + tid]);
             const float decay_last = bf16_to_f32(f32_to_bf16(s_decay_last[t]));
             const float w_weighted = bf16_to_f32(f32_to_bf16(w * decay_last));
@@ -166,7 +160,6 @@ __global__ void gdn_full_chunk_forward_kernel(
         const size_t state_idx = (size_t)k_idx * dv + tid;
         const float prev = bf16_to_f32(state_base[state_idx]);
         state_base[state_idx] = f32_to_bf16(prev * p_last + delta);
-        __syncthreads();
     }
 }
 

--- a/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
+++ b/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
@@ -63,6 +63,7 @@ __global__ void gdn_full_chunk_forward_kernel(
     __shared__ float s_p[kChunkSize];
     __shared__ float s_decay_last[kChunkSize];
     __shared__ float s_p_last;
+    __shared__ __nv_bfloat16 s_kt_row[kChunkSize];
 
     const __nv_bfloat16 *g_base = g + (size_t)bh * kChunkSize;
     const __nv_bfloat16 *v_base = v + (size_t)bh * kChunkSize * dv;
@@ -148,10 +149,15 @@ __global__ void gdn_full_chunk_forward_kernel(
 
     const float p_last = bf16_to_f32(f32_to_bf16(s_p_last));
     for (int k_idx = 0; k_idx < dk; ++k_idx) {
+        if (tid < kChunkSize) {
+            s_kt_row[tid] = kt_base[(size_t)k_idx * kChunkSize + tid];
+        }
+        __syncthreads();
+
         float delta = 0.0f;
         #pragma unroll
         for (int t = 0; t < kChunkSize; ++t) {
-            const float kt = bf16_to_f32(kt_base[(size_t)k_idx * kChunkSize + t]);
+            const float kt = bf16_to_f32(s_kt_row[t]);
             const float w = bf16_to_f32(s_w[(size_t)t * dv + tid]);
             const float decay_last = bf16_to_f32(f32_to_bf16(s_decay_last[t]));
             const float w_weighted = bf16_to_f32(f32_to_bf16(w * decay_last));
@@ -160,6 +166,7 @@ __global__ void gdn_full_chunk_forward_kernel(
         const size_t state_idx = (size_t)k_idx * dv + tid;
         const float prev = bf16_to_f32(state_base[state_idx]);
         state_base[state_idx] = f32_to_bf16(prev * p_last + delta);
+        __syncthreads();
     }
 }
 

--- a/profiling-artifacts/post401_20260423_prefill_kern.csv
+++ b/profiling-artifacts/post401_20260423_prefill_kern.csv
@@ -1,0 +1,3 @@
+attempt,graphs_setting,nsys_args,bench_prefill_ms,bench_prefill_tok_s,artifact,error_status,error_excerpt
+post401-main-control,true,"",3272.444408,2499.660492,not-run,control_only,"Fresh-main same-pod control on the A6000 before deciding whether to keep the kernel change"
+post401-shared-kt-row,true,"",4703.982696,1738.951975,not-run,capture_skipped_after_regression,"Skipped Nsight capture after same-pod control showed the branch regressed badly enough to require immediate revert"


### PR DESCRIPTION
## Summary
- document the post-#401 full-chunk GDN retry on fresh `main`
- record one different bounded vLLM-inspired kernel idea, its parity result, and the same-pod `8192/1` control vs branch numbers
- keep this PR doc-only because the measured kernel change was reverted before opening the PR

## Upstream idea attempted
Attempted one different bounded win inside `gdn_full_chunk_forward_kernel`: stage each `k_t[k_idx, :]` row into shared memory once per `dk` iteration, then reuse that staged row across all `dv` lanes in the recurrent-state update instead of having every thread reload the same 64 bf16 scalars from global memory.

This is materially different from PR #401's reverted shared-`W` `decay_last` hoist. The idea is closer to the current vLLM `fused_recurrent_gated_delta_rule_fwd_kernel`, which loads `b_k` once per tile and reuses it across value lanes.

## Files changed
- `PROFILING.md`
- `profiling-artifacts/post401_20260423_prefill_kern.csv`

## Preflight
Confirmed on fresh `main` before editing:
- PR #401 is merged and doc-only
- no newer open or merged PR already modifies `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu` for the same post-#401 follow-up scope
- `PROFILING.md` still shows `gdn_full_chunk_forward_kernel` at 34.6% of refined prompt-heavy prefill kernel time in the validated post-#392 section

## Validation
RunPod on-demand RTX A6000 with `ghcr.io/ericflo/kiln-runpod:latest`.

Parity:
```bash
source /root/.kiln-build-env
cd /workspace/kiln
export KILN_CUDA_ARCHS=86
export KILN_W4A16=1
export KILN_CUDA_GRAPHS=true
export CARGO_PROFILE_DEV_DEBUG=0
cargo test -p kiln-model --features cuda \
  forward::tests::test_gdn_full_chunk_forward_matches_fallback \
  -- --exact --nocapture
```

Result: passed.
- `out_chunk` max abs diff: `1.5625e-2`
- `state` max abs diff: `3.125e-2`

Prompt-heavy prefill (`8192/1`) on the same pod:
- before, fresh `main` control: `3272.4 ms`, `2499.7 tok/s`
- after, shared-`k_t` row staging branch: `4704.0 ms`, `1739.0 tok/s`

So the bounded kernel idea is parity-safe but materially slower on prompt-heavy prefill. The kernel diff was reverted before opening the PR.

## Kernel-share capture note
I did not keep a new Nsight kernel-share export for this attempt. Once the same-pod control showed the branch at `4704.0 ms` versus `main` at `3272.4 ms`, the code no longer met the keep bar, so I reverted it immediately instead of spending more pod budget on a post-change capture for a disqualified kernel diff. `profiling-artifacts/post401_20260423_prefill_kern.csv` records that control/regression decision.
