### PR TITLE
phase6: document fused-recurrent vLLM audit supersession

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -492,6 +492,72 @@ warm-`main` rerun showed parity with the branch. The measurement record for the
 control, branch, and warm-control sanity rerun is stored in
 `profiling-artifacts/post403_20260423_prefill_kern.csv`.
 
+### Post-#405 vLLM fused-recurrent audit — 2026-04-23
+
+Fresh-`main` remaining-work preflight passed before deciding whether to edit
+the kernel:
+
+- PR `#405` is merged and doc-only.
+- The recent `#401` / `#403` / `#405` loop did **not** land any source change
+  under `crates/kiln-gdn-kernel/`; `git diff --stat 57f67ae..4ecd7ce -- \
+  crates/kiln-gdn-kernel` is empty on fresh `main`.
+- No newer open or merged PR already audits or edits
+  `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu` for the same
+  frontier; `gh pr list -R ericflo/kiln --state all --limit 20` tops out at
+  `#405` plus unrelated `#404`.
+
+I then audited the current vLLM upstream source at:
+
+- `vllm/model_executor/layers/fla/ops/fused_recurrent.py`
+- commit `ccaf5ffaa3e1fb2a081b2c9e403ac0e4dfc142c8`
+
+and its recent commits touching the fused recurrent GDN path:
+
+- `22dffca9822987f0e912bfd9635e94bbdd05def3` — raise decode `BV` tile cap from
+  8 to 32
+- `824058076c56164a3772a5f5829bd9662507e5a3` — change recurrent-state layout
+  from `[N, HV, K, V]` to `[N, HV, V, K]`
+- `9e19f8338b4098047175ca3119d5ae0368bcf24a` — add packed recurrent decode fast
+  path
+- `d4cb783c10ffc091af7f09a3b052dceadc06d075` — guard NULL-block decode padding
+
+**Audit verdict:** no single bounded full-chunk prefill win remains to port
+from the current vLLM fused recurrent kernel into
+`crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu`.
+
+Why each upstream change does **not** qualify as the requested one-diff port:
+
+- `22dffca9` is decode-only tile sizing. kiln's full-chunk prefill kernel
+  already runs one thread per `dv` lane (`dv <= 128`) and has no analogous
+  `BV=8 -> 32` knob to raise.
+- `82405807` is a cross-cutting recurrent-state ABI/layout refactor, not a
+  narrow kernel diff. Porting it would require coordinated state-layout changes
+  across decode, prefill, bindings, and parity tests.
+- `9e19f833` is a packed **decode** fast path built around mixed-QKV inputs and
+  scalar gate inputs. kiln's full-chunk prefill path consumes chunk matrices
+  (`kkt`, `qkt`, `ks_entry`, `q_s`) instead, so there is no thin plumbing-only
+  transplant.
+- `d4cb783c` fixes continuous-batching decode padding (`NULL_BLOCK_ID=0`).
+  kiln's full-chunk prefill kernel has no equivalent state-index input.
+
+This upstream audit also explains why the recent direct reuse attempts already
+failed to produce a keepable prefill win:
+
+- `#401` weighted-`W` / `decay_last` hoist: parity-safe but slower
+  (`3277.7 ms` baseline vs `3566.0 ms` / `3686.3 ms` branch reruns).
+- `#403` shared-`k_t` row staging: same-pod regression
+  (`3272.4 ms` control vs `4704.0 ms` branch).
+- `#405` front-half triangular packing: warm-arm artifact only
+  (`4785.1 ms` cold control, `3348.3 ms` branch, `3347.1 ms` warm-`main` rerun).
+
+So the current kiln full-chunk code does predate some newer vLLM
+`fused_recurrent_gated_delta_rule` commits, but the remaining diffs are either
+decode-only or too wide to fit this task's "exactly one bounded win" scope. The
+correct outcome for this cycle is therefore doc-only: do **not** make another
+`gdn_full_chunk_forward.cu` edit off the current vLLM fused recurrent frontier.
+See `profiling-artifacts/vllm_audit_20260423.md` for the detailed portability
+table used for this decision.
+
 ## Phase 6 post-#384 current-main re-profile — 2026-04-22
 
 ### Post-change note — 2026-04-23 (`ce/phase6-fused-gdn-full-chunk`)

--- a/profiling-artifacts/vllm_audit_20260423.md
+++ b/profiling-artifacts/vllm_audit_20260423.md
@@ -1,0 +1,68 @@
+# vLLM fused-recurrent GDN audit — 2026-04-23
+
+## Scope
+
+Task: audit vLLM's current fused recurrent GDN kernel for one bounded win that
+could be ported into kiln's fused full-chunk prefill kernel.
+
+Kiln target path:
+
+- `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu`
+
+Audited upstream source:
+
+- repo: `vllm-project/vllm`
+- file: `vllm/model_executor/layers/fla/ops/fused_recurrent.py`
+- current commit inspected: `ccaf5ffaa3e1fb2a081b2c9e403ac0e4dfc142c8`
+
+## Fresh-main preflight
+
+- kiln `main` at `4ecd7ce` (`phase6: document failed post-403 front-half full-chunk retry (#405)`)
+- PR `#405` is merged and doc-only
+- `git diff --stat 57f67ae..4ecd7ce -- crates/kiln-gdn-kernel` is empty
+- `gh pr list -R ericflo/kiln --state all --limit 20` shows no newer open or
+  merged PR changing `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu`
+  after `#405`
+
+## Upstream commit audit
+
+| Commit | Upstream change | Why it is not the requested one-diff full-chunk port |
+| --- | --- | --- |
+| `22dffca9822987f0e912bfd9635e94bbdd05def3` | Raise decode `BV` cap from 8 to 32 | Decode-only tile size knob. kiln full-chunk prefill already runs one thread per `dv` lane and has no equivalent `BV` cap. |
+| `824058076c56164a3772a5f5829bd9662507e5a3` | Change recurrent state layout `[N, HV, K, V] -> [N, HV, V, K]` | Cross-cutting state ABI/layout refactor. Would touch decode + prefill kernels, Rust tensor layout assumptions, and tests. Not bounded to one kernel diff. |
+| `9e19f8338b4098047175ca3119d5ae0368bcf24a` | Add packed recurrent decode fast path | Decode-only path with mixed-QKV and scalar gate inputs. kiln full-chunk prefill consumes chunk matrices (`kkt`, `qkt`, `ks_entry`, `q_s`), so this does not map to a thin port. |
+| `d4cb783c10ffc091af7f09a3b052dceadc06d075` | Guard NULL-block decode padding | Continuous-batching decode bugfix. No equivalent state-index input exists in kiln's full-chunk prefill kernel. |
+
+## Why the direct reuse frontier is exhausted
+
+The last three bounded attempts already covered the only obvious "reuse the
+same loaded data more aggressively" ideas from the fused recurrent mental model:
+
+1. `#401` weighted-`W` / `decay_last` hoist
+   - control: `3277.7 ms`
+   - branch: `3566.0 ms`, `3686.3 ms`
+   - verdict: slower, reverted
+2. `#403` shared-`k_t` row staging
+   - same-pod control: `3272.4 ms`
+   - same-pod branch: `4704.0 ms`
+   - verdict: slower, reverted
+3. `#405` front-half triangular packing
+   - same-pod cold control: `4785.1 ms`
+   - same-pod branch: `3348.3 ms`
+   - same-pod warm-`main` rerun: `3347.1 ms`
+   - verdict: warm-arm artifact, reverted
+
+## Conclusion
+
+No single bounded win remains from the current vLLM
+`fused_recurrent_gated_delta_rule` frontier that cleanly ports into kiln's
+full-chunk prefill kernel.
+
+The remaining upstream differences are either:
+
+- decode-specific,
+- bugfix-only, or
+- wide state-layout refactors that exceed this task's allowed scope.
+
+Correct outcome: doc-only PR, no edit to
+`crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu`.


### PR DESCRIPTION
## Summary
- document the fresh-main preflight after `#405` and record that `#401` / `#403` / `#405` did not land any `crates/kiln-gdn-kernel/` source change
- audit vLLM's current fused recurrent GDN source and recent commits against kiln's fused full-chunk prefill kernel
- conclude doc-only that no single bounded full-chunk prefill win remains to port from the current upstream fused recurrent frontier

## Fresh-main preflight
Confirmed on fresh `main` before editing:
- PR `#405` is merged and doc-only
- the recent `#401` / `#403` / `#405` loop did not land any source change under `crates/kiln-gdn-kernel/`
- no newer open or merged PR already audits or edits `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu` for the same frontier

## Exact upstream source audited
- repo: `vllm-project/vllm`
- file: `vllm/model_executor/layers/fla/ops/fused_recurrent.py`
- current commit audited: `ccaf5ffaa3e1fb2a081b2c9e403ac0e4dfc142c8`

Recent upstream commits reviewed as the relevant diff frontier:
- `22dffca9822987f0e912bfd9635e94bbdd05def3` — raise decode `BV` tile cap from 8 to 32
- `824058076c56164a3772a5f5829bd9662507e5a3` — recurrent state layout `[N, HV, K, V] -> [N, HV, V, K]`
- `9e19f8338b4098047175ca3119d5ae0368bcf24a` — packed recurrent decode fast path
- `d4cb783c10ffc091af7f09a3b052dceadc06d075` — NULL-block decode padding guard

## Audit result
No single bounded full-chunk prefill win remains to port into `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu` from the current vLLM fused recurrent frontier.

Why the current upstream diffs do not qualify:
- `22dffca9` is decode-only tile sizing; kiln's full-chunk prefill kernel has no analogous `BV=8 -> 32` knob
- `82405807` is a cross-cutting state-layout ABI refactor, not a narrow one-file kernel diff
- `9e19f833` is a packed decode path built around mixed-QKV inputs, not kiln's chunk-matrix full-chunk prefill path
- `d4cb783c` is a decode padding bugfix with no equivalent state-index input on the full-chunk prefill kernel

## Same-pod timing evidence carried forward
This audit also explains why the direct reuse attempts from the same frontier were already exhausted:
- `#401` weighted-`W` / `decay_last` hoist: `3277.7 ms` baseline vs `3566.0 ms` / `3686.3 ms` branch reruns
- `#403` shared-`k_t` row staging: same-pod `3272.4 ms` control vs `4704.0 ms` branch
- `#405` triangular packing: same-pod `4785.1 ms` cold control, `3348.3 ms` branch, `3347.1 ms` warm-`main` sanity rerun

So the current cycle ships as doc-only rather than forcing another generic full-chunk retry.

## Validation
- `git diff --check`

## Final status
- kernel diff shipped: **no**
- kernel diff reverted: **not applicable** (no kernel edit attempted)
