### PR TITLE
phase6: tile full-chunk GDN recurrent state update

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -552,6 +552,128 @@ there was no remaining one-diff candidate to validate. Re-running another
 micro-port on RunPod would have been a duplicate spend against the same
 already-failed frontier.
 
+### Post-#406 tiled recurrent-state update — 2026-04-23
+
+Fresh-`main` preflight passed again before editing:
+
+- PR `#406` is merged and remains doc-only (`PROFILING.md` plus
+  `profiling-artifacts/post405_20260423_vllm_recurrent_audit.csv` only); there
+  is still **no** source change in
+  `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu` after `#392`.
+- No newer open or merged PR already changes
+  `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu` for this same
+  recurrent/full-chunk frontier. `#407` was a closed doc-only duplicate and
+  `#408` only touches `crates/kiln-model/`.
+- The validated post-`#392` refined prefill capture above still shows
+  `gdn_full_chunk_forward_kernel` at **34.6%** of prompt-heavy prefill kernel
+  time, so the frontier still exists on fresh `main`.
+
+This retry takes the larger structural step `#406` called out: keep the chunk
+body unchanged, but replace the scalar-thread `(k_idx, dv)` recurrent-state
+epilogue with a cooperative tiled update. The kernel now:
+
+- precomputes the existing bf16-rounded `w * decay_last` rows once after the
+  chunk body, preserving the established parity surface;
+- stages `k_t` in shared memory in `4 x 64` tiles; and
+- maps the final state update over `32 x 4` `(dv, dk)` tiles so each staged
+  `k_t` row is reused across all 32 value lanes before the next tile load.
+
+**Changed code**
+
+- `crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu`
+
+**Validation commands**
+
+Baseline on fresh `main`:
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+export KILN_CUDA_ARCHS=86
+export CARGO_PROFILE_DEV_DEBUG=0
+
+cargo test -p kiln-model --features cuda \
+  forward::tests::test_gdn_full_chunk_forward_matches_fallback \
+  -- --exact --nocapture
+
+cargo build --release --features cuda,nvtx --bin kiln-bench
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
+  --prompt-tokens 8192 --max-output-tokens 1 --skip-training --latency-only
+```
+
+Changed branch (`ce/gdn-recurrent-tile`) on the same A6000 pod:
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+export KILN_CUDA_ARCHS=86
+export CARGO_PROFILE_DEV_DEBUG=0
+
+cargo test -p kiln-model --features cuda \
+  forward::tests::test_gdn_full_chunk_forward_matches_fallback \
+  -- --exact --nocapture
+
+cargo build --release --features cuda,nvtx --bin kiln-bench
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
+  --prompt-tokens 8192 --max-output-tokens 1 --skip-training --latency-only
+```
+
+**Parity**
+
+Passed on both fresh `main` and the changed branch.
+
+- `out_chunk` max abs diff: **1.5625e-2**
+- `state` max abs diff: **3.125e-2**
+
+So the tiled update stayed inside the existing fallback test bar while
+rewriting only the recurrent-state epilogue.
+
+**8192/1 prompt-heavy prefill**
+
+Same on-demand RunPod A6000, same checkpoint at `/workspace/qwen3.5-4b`,
+same `--paged --skip-training --latency-only` arm:
+
+- fresh `main`: **4698.8 ms**, **1741 tok/s**
+- tiled recurrent-state branch: **2905.5 ms**, **2815 tok/s**
+
+That is a **1.62x speedup** on prompt-heavy prefill, or a **38.2% latency
+reduction**, comfortably above the 3% ship floor.
+
+**Refined Nsight attempt**
+
+The requested refined kernel capture hit the same importer failure already seen
+on this pod image's baked `nsys 2023.4.4`.
+
+First, the exact task command with `--delay=26` produced no `.nsys-rep` because
+the workload exits before the delay expires on current `main`. I reran with a
+reduced delay matched to the measured startup envelope:
+
+```bash
+nsys profile -t cuda,nvtx --sample=none --cpuctxsw=none --delay=2 --duration=4 \
+  -o /workspace/phase6-profile/post406-prefill-refined \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
+  --prompt-tokens 8192 --max-output-tokens 1 --skip-training --latency-only
+nsys stats --report cuda_gpu_kern_sum --format csv \
+  --output /workspace/phase6-profile/post406-prefill-refined \
+  /workspace/phase6-profile/post406-prefill-refined.nsys-rep
+```
+
+That run produced `post406-prefill-refined.qdstrm`, but `nsys stats` failed to
+import it with the same `Wrong event order has been detected` exception seen in
+earlier Phase 6 retries. So there is **no post-change kernel-share CSV** from
+this pod image, despite the refined capture attempt completing.
+
+**Verdict**
+
+Ship the kernel change. This is the first recurrent/full-chunk follow-up after
+`#406` that clears both required gates:
+
+- parity remains within the existing fallback tolerance; and
+- prompt-heavy prefill on `8192/1` improves far above the 3% threshold.
+
+The concise measurement record for this verdict is committed in
+`profiling-artifacts/post406_20260423_recurrent_tile.csv`.
+
 ## Phase 6 post-#384 current-main re-profile — 2026-04-22
 
 ### Post-change note — 2026-04-23 (`ce/phase6-fused-gdn-full-chunk`)

--- a/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
+++ b/crates/kiln-gdn-kernel/csrc/gdn_full_chunk_forward.cu
@@ -25,6 +25,8 @@ namespace {
 
 constexpr int kChunkSize = 64;
 constexpr int kMaxDv = 128;
+constexpr int kStateVTile = 32;
+constexpr int kStateKTile = 4;
 
 __device__ __forceinline__ float bf16_to_f32(__nv_bfloat16 v) {
     return __bfloat162float(v);
@@ -50,9 +52,7 @@ __global__ void gdn_full_chunk_forward_kernel(
 ) {
     const int bh = blockIdx.x;
     const int tid = threadIdx.x;
-    if (tid >= dv) {
-        return;
-    }
+    const bool active_dv = tid < dv;
 
     extern __shared__ __nv_bfloat16 smem[];
     __nv_bfloat16 *s_a = smem;                                       // [C, C]
@@ -109,57 +109,94 @@ __global__ void gdn_full_chunk_forward_kernel(
     __syncthreads();
 
     for (int t = 0; t < kChunkSize; ++t) {
-        const float beta_t = bf16_to_f32(beta_base[t]);
-        const float p_t = bf16_to_f32(f32_to_bf16(s_p[t]));
+        if (active_dv) {
+            const float beta_t = bf16_to_f32(beta_base[t]);
+            const float p_t = bf16_to_f32(f32_to_bf16(s_p[t]));
 
-        const __nv_bfloat16 *a_row = s_a + (size_t)t * kChunkSize;
-        const __nv_bfloat16 *b_row = s_b + (size_t)t * kChunkSize;
-        __nv_bfloat16 *w_row = s_w + (size_t)t * dv;
+            const __nv_bfloat16 *a_row = s_a + (size_t)t * kChunkSize;
+            const __nv_bfloat16 *b_row = s_b + (size_t)t * kChunkSize;
+            __nv_bfloat16 *w_row = s_w + (size_t)t * dv;
 
-        float acc_a = 0.0f;
-        #pragma unroll
-        for (int i = 0; i < kChunkSize; ++i) {
-            if (i < t) {
-                acc_a += bf16_to_f32(a_row[i]) * bf16_to_f32(s_w[(size_t)i * dv + tid]);
+            float acc_a = 0.0f;
+            #pragma unroll
+            for (int i = 0; i < kChunkSize; ++i) {
+                if (i < t) {
+                    acc_a += bf16_to_f32(a_row[i]) * bf16_to_f32(s_w[(size_t)i * dv + tid]);
+                }
             }
-        }
 
-        const size_t td = (size_t)t * dv + tid;
-        const float vp = bf16_to_f32(f32_to_bf16(
-            bf16_to_f32(v_base[td]) - bf16_to_f32(ks_base[td]) * p_t
-        ));
-        const float w_val = beta_t * (vp - acc_a);
-        w_row[tid] = f32_to_bf16(w_val);
+            const size_t td = (size_t)t * dv + tid;
+            const float vp = bf16_to_f32(f32_to_bf16(
+                bf16_to_f32(v_base[td]) - bf16_to_f32(ks_base[td]) * p_t
+            ));
+            const float w_val = beta_t * (vp - acc_a);
+            w_row[tid] = f32_to_bf16(w_val);
+        }
         __syncthreads();
 
-        float acc_b = 0.0f;
-        #pragma unroll
-        for (int i = 0; i < kChunkSize; ++i) {
-            if (i <= t) {
-                acc_b += bf16_to_f32(b_row[i]) * bf16_to_f32(s_w[(size_t)i * dv + tid]);
+        if (active_dv) {
+            const float p_t = bf16_to_f32(f32_to_bf16(s_p[t]));
+            const __nv_bfloat16 *b_row = s_b + (size_t)t * kChunkSize;
+            float acc_b = 0.0f;
+            #pragma unroll
+            for (int i = 0; i < kChunkSize; ++i) {
+                if (i <= t) {
+                    acc_b += bf16_to_f32(b_row[i]) * bf16_to_f32(s_w[(size_t)i * dv + tid]);
+                }
             }
-        }
 
-        const float qss = bf16_to_f32(f32_to_bf16(bf16_to_f32(qs_base[td]) * p_t));
-        const float out_val = qss + acc_b;
-        out_base[td] = f32_to_bf16(out_val);
+            const size_t td = (size_t)t * dv + tid;
+            const float qss = bf16_to_f32(f32_to_bf16(bf16_to_f32(qs_base[td]) * p_t));
+            const float out_val = qss + acc_b;
+            out_base[td] = f32_to_bf16(out_val);
+        }
         __syncthreads();
     }
 
     const float p_last = bf16_to_f32(f32_to_bf16(s_p_last));
-    for (int k_idx = 0; k_idx < dk; ++k_idx) {
-        float delta = 0.0f;
+    if (active_dv) {
         #pragma unroll
         for (int t = 0; t < kChunkSize; ++t) {
-            const float kt = bf16_to_f32(kt_base[(size_t)k_idx * kChunkSize + t]);
-            const float w = bf16_to_f32(s_w[(size_t)t * dv + tid]);
             const float decay_last = bf16_to_f32(f32_to_bf16(s_decay_last[t]));
+            const float w = bf16_to_f32(s_w[(size_t)t * dv + tid]);
             const float w_weighted = bf16_to_f32(f32_to_bf16(w * decay_last));
-            delta += kt * w_weighted;
+            s_w[(size_t)t * dv + tid] = f32_to_bf16(w_weighted);
         }
-        const size_t state_idx = (size_t)k_idx * dv + tid;
-        const float prev = bf16_to_f32(state_base[state_idx]);
-        state_base[state_idx] = f32_to_bf16(prev * p_last + delta);
+    }
+    __syncthreads();
+
+    __nv_bfloat16 *s_k_tile = s_a; // [kStateKTile, C]
+    const int state_v_lane = tid % kStateVTile;
+    const int state_k_lane = tid / kStateVTile;
+
+    for (int k0 = 0; k0 < dk; k0 += kStateKTile) {
+        for (int idx = tid; idx < kStateKTile * kChunkSize; idx += blockDim.x) {
+            const int k_local = idx / kChunkSize;
+            const int t = idx % kChunkSize;
+            const int k_idx = k0 + k_local;
+            s_k_tile[idx] = (k_idx < dk)
+                ? kt_base[(size_t)k_idx * kChunkSize + t]
+                : f32_to_bf16(0.0f);
+        }
+        __syncthreads();
+
+        for (int dv0 = 0; dv0 < dv; dv0 += kStateVTile) {
+            const int k_idx = k0 + state_k_lane;
+            const int dv_idx = dv0 + state_v_lane;
+            if (k_idx < dk && dv_idx < dv) {
+                float delta = 0.0f;
+                #pragma unroll
+                for (int t = 0; t < kChunkSize; ++t) {
+                    const float kt = bf16_to_f32(s_k_tile[(size_t)state_k_lane * kChunkSize + t]);
+                    const float w_weighted = bf16_to_f32(s_w[(size_t)t * dv + dv_idx]);
+                    delta += kt * w_weighted;
+                }
+                const size_t state_idx = (size_t)k_idx * dv + dv_idx;
+                const float prev = bf16_to_f32(state_base[state_idx]);
+                state_base[state_idx] = f32_to_bf16(prev * p_last + delta);
+            }
+        }
+        __syncthreads();
     }
 }
 

--- a/profiling-artifacts/post406_20260423_recurrent_tile.csv
+++ b/profiling-artifacts/post406_20260423_recurrent_tile.csv
@@ -1,0 +1,4 @@
+arm,commit_or_branch,parity_out_max_abs,parity_state_max_abs,prompt_tokens,max_output_tokens,prefill_ms,prefill_tok_per_s,notes
+baseline_main,main,0.015625,0.03125,8180,1,4698.835811,1740.8567417594322,"fresh main on same A6000 pod"
+tiled_recurrent_update,ce/gdn-recurrent-tile,0.015625,0.03125,8180,1,2905.500699,2815.349520588775,"accepted run on same A6000 pod; 1.62x faster than baseline"
+postchange_nsys_attempt,ce/gdn-recurrent-tile,0.015625,0.03125,8180,1,3034.576945,2695.5981503378885,"nsys profile with --delay=2 produced qdstrm only; importer failed with Wrong event order"


### PR DESCRIPTION
## What
- replace the scalar-thread recurrent-state epilogue in `gdn_full_chunk_forward.cu` with a cooperative tiled `(dv, dk)` update
- precompute the existing bf16-rounded `w * decay_last` rows once and reuse them across the tiled state update
- record fresh preflight, parity, and 8192/1 prompt-heavy prefill numbers in `PROFILING.md`
- add `profiling-artifacts/post406_20260423_recurrent_tile.csv` with the acceptance measurements

## Why
`#406` established that the remaining port-worthy win on the full-chunk GDN frontier was the larger recurrent-state update structure, not another micro-cleanup. This change takes that bounded structural step while leaving the rest of the chunk body unchanged.

## Validation
- RunPod on-demand RTX A6000 with `ghcr.io/ericflo/kiln-runpod:latest`
- `cargo test -p kiln-model --features cuda forward::tests::test_gdn_full_chunk_forward_matches_fallback -- --exact --nocapture`
- `cargo build --release --features cuda,nvtx --bin kiln-bench`
- `./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 8192 --max-output-tokens 1 --skip-training --latency-only`

Results on the same pod:
- fresh `main`: `4698.8 ms` prefill, `1741 tok/s`
- this branch: `2905.5 ms` prefill, `2815 tok/s`
- parity stayed within the existing tolerance (`out_chunk` max `1.5625e-2`, `state` max `3.125e-2`)

## Notes
- The requested refined Nsight capture was attempted twice. The exact task command with `--delay=26` produced no `.nsys-rep` because the workload exits before the delay fires on current `main`; a rerun with `--delay=2` produced `.qdstrm` only, but the pod image's baked `nsys 2023.4.4` importer failed with the same `Wrong event order` exception already documented in prior Phase 6 retries.
