### PR TITLE
Align skip-layer bench draft state with production

### DIFF
--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -1113,9 +1113,10 @@ fn bench_latency_skiplayer(
     .context("skip-layer prefill forward pass failed")?;
     kv_cache.advance(actual_prompt_tokens);
 
+    let draft_linear_layers = weights.linear_attention_layers_in_prefix(draft_layers);
     let mut draft_linear_state = linear_state
-        .snapshot_for_decode_rollback()
-        .context("clone draft state from skip-layer prefill")?;
+        .snapshot_for_decode_rollback_prefix(draft_linear_layers)
+        .context("clone draft linear-attention prefix from skip-layer prefill")?;
 
     let mut last_token = greedy_sample(&logits)?;
     let prefill_time = prefill_start.elapsed();
@@ -1342,9 +1343,10 @@ fn bench_latency_paged_skiplayer(
         .context("paged skip-layer prefill forward pass failed")?
     };
 
+    let draft_linear_layers = weights.linear_attention_layers_in_prefix(draft_layers);
     let mut draft_linear_state = linear_state
-        .snapshot_for_decode_rollback()
-        .context("clone draft state from paged skip-layer prefill")?;
+        .snapshot_for_decode_rollback_prefix(draft_linear_layers)
+        .context("clone draft linear-attention prefix from paged skip-layer prefill")?;
 
     let mut last_token = greedy_sample(&logits)?;
     let prefill_time = prefill_start.elapsed();


### PR DESCRIPTION
## Summary
- initialize skip-layer benchmark draft GDN state from only the draft-layer prefix, matching the production desktop path
- applies to both flat and paged skip-layer benchmark arms

## Validation
- `cargo test -p kiln-server --locked bench_mtp -- --nocapture`
- `cargo build --release --locked --features metal --target-dir /private/tmp/kiln-perf-graph-target`
- `git diff --check`

## macOS desktop-env benchmark
Command env: `KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp KILN_INFERENCE_MEMORY_FRACTION=0.7 KILN_KV_CACHE_FP8=0 KILN_CUDA_GRAPHS=0`

8192 prompt / 64 decode / paged / latency-only:
- before anchor after #408: prefill 58809.1 ms, decode mean ITL 96.7 ms, peak footprint 11518452992
- this PR: prefill 56777.8 ms, decode mean ITL 88.5 ms, peak footprint 11518584128

Rejected A/B:
- `KILN_SPEC_NUM_TOKENS=4`: decode regressed to 157.2 ms ITL
- `KILN_STREAMING_TILE_TOKENS=8192`: prefill regressed to 70647.9 ms and peak footprint rose to 14939296640