### PR TITLE
[codex] Reduce macOS startup and KV prefill overhead

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3672,6 +3672,13 @@ fn gqa_attention_paged_with_rope_tables(
         crate::mtp_debug::capture_b12_gqa_tap("rope_k", &k)?;
     }
 
+    // Keep the cache-native token-major K/V views for paged writes. Attention
+    // still wants head-major tensors, but the cache pool stores
+    // `[slot, kv_head, dim]`, so using these avoids a transpose back during
+    // prefill.
+    let k_cache_token_major = k.clone();
+    let v_cache_token_major = v.clone();
+
     // Transpose to [batch, heads, seq_len, head_dim]
     let (q, k, v) = {
         kiln_nvtx::range!(c"kiln/attn/qkv_transpose");
@@ -3719,9 +3726,17 @@ fn gqa_attention_paged_with_rope_tables(
         if let Some(attn_output) = attn_output {
             {
                 kiln_nvtx::range!(c"kiln/kv/copy");
-                paged_cache
-                    .write(full_attn_layer_idx, block_table, start_pos, &k, &v)
-                    .context("paged KV cache write failed")?;
+                if !paged_cache.write_token_major_native(
+                    full_attn_layer_idx,
+                    block_table,
+                    start_pos,
+                    &k_cache_token_major,
+                    &v_cache_token_major,
+                )? {
+                    paged_cache
+                        .write(full_attn_layer_idx, block_table, start_pos, &k, &v)
+                        .context("paged KV cache write failed")?;
+                }
             }
 
             // Phase B12 layer-31 GQA tap: attn_out. Captured AFTER the gate
@@ -3766,9 +3781,17 @@ fn gqa_attention_paged_with_rope_tables(
     // Write new K/V into paged cache.
     if !single_token_self_attn {
         kiln_nvtx::range!(c"kiln/kv/copy");
-        paged_cache
-            .write(full_attn_layer_idx, block_table, start_pos, &k, &v)
-            .context("paged KV cache write failed")?;
+        if !paged_cache.write_token_major_native(
+            full_attn_layer_idx,
+            block_table,
+            start_pos,
+            &k_cache_token_major,
+            &v_cache_token_major,
+        )? {
+            paged_cache
+                .write(full_attn_layer_idx, block_table, start_pos, &k, &v)
+                .context("paged KV cache write failed")?;
+        }
     }
 
     // Fast path: fused paged-decode flash-attention kernel.

--- a/crates/kiln-model/src/paged_kv_cache.rs
+++ b/crates/kiln-model/src/paged_kv_cache.rs
@@ -198,6 +198,66 @@ impl PagedKvCache {
         }
     }
 
+    /// Write cache-native token-major K/V values without the head-major
+    /// transpose required by [`Self::write`].
+    ///
+    /// Returns `false` when the cache is FP8-backed so callers can fall back to
+    /// [`Self::write`], which owns quantization.
+    ///
+    /// - `k`: `[1, new_len, num_kv_heads, head_dim]`
+    /// - `v`: `[1, new_len, num_kv_heads, head_dim]`
+    pub fn write_token_major_native(
+        &mut self,
+        layer_idx: usize,
+        block_table: &BlockTable,
+        start_pos: usize,
+        k: &Tensor,
+        v: &Tensor,
+    ) -> Result<bool> {
+        if self.fp8 {
+            return Ok(false);
+        }
+
+        let new_len = k.dim(1)?;
+        let (k_pool, v_pool) = &mut self.layers[layer_idx];
+
+        if new_len == 1 {
+            let slot = block_table
+                .slot_for(start_pos, self.block_size)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no slot for position {start_pos} in block table")
+                })?;
+            k_pool.slice_set(&k.squeeze(1)?, 0, slot)?;
+            v_pool.slice_set(&v.squeeze(1)?, 0, slot)?;
+            return Ok(true);
+        }
+
+        let k_flat = k.squeeze(0)?.contiguous()?;
+        let v_flat = v.squeeze(0)?.contiguous()?;
+
+        if let Some(start_slot) =
+            contiguous_slot_run_start(block_table, self.block_size, start_pos, new_len)
+        {
+            k_pool.slice_set(&k_flat, 0, start_slot)?;
+            v_pool.slice_set(&v_flat, 0, start_slot)?;
+            return Ok(true);
+        }
+
+        for i in 0..new_len {
+            let pos = start_pos + i;
+            let slot = block_table
+                .slot_for(pos, self.block_size)
+                .ok_or_else(|| anyhow::anyhow!("no slot for position {pos} in block table"))?;
+
+            let k_row = k_flat.narrow(0, i, 1)?;
+            let v_row = v_flat.narrow(0, i, 1)?;
+            k_pool.slice_set(&k_row, 0, slot)?;
+            v_pool.slice_set(&v_row, 0, slot)?;
+        }
+
+        Ok(true)
+    }
+
     fn write_native(
         &mut self,
         layer_idx: usize,
@@ -547,6 +607,43 @@ mod tests {
         let v_orig = v.flatten_all()?.to_vec1::<f32>()?;
         let v_read = v_out.flatten_all()?.to_vec1::<f32>()?;
         assert_eq!(v_orig, v_read, "V roundtrip failed");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_token_major_native_then_read_roundtrip() -> Result<()> {
+        let device = Device::Cpu;
+        let mut cache = PagedKvCache::new(1, 4, 4, 2, 3, DType::F32, &device)?;
+
+        let mut bt = BlockTable::new();
+        bt.push(1);
+        bt.push(2);
+
+        // Shape: [1, new_len=3, num_kv_heads=2, head_dim=3].
+        let k = Tensor::new(
+            &[[
+                [[1.0_f32, 2.0, 3.0], [4.0, 5.0, 6.0]],
+                [[7.0, 8.0, 9.0], [10.0, 11.0, 12.0]],
+                [[13.0, 14.0, 15.0], [16.0, 17.0, 18.0]],
+            ]],
+            &device,
+        )?;
+        let v = (k.clone() + 100.0)?;
+
+        assert!(cache.write_token_major_native(0, &bt, 0, &k, &v)?);
+        let (k_out, v_out) = cache.read(0, &bt, 3)?;
+        let k_expected = k.squeeze(0)?.transpose(0, 1)?.contiguous()?.unsqueeze(0)?;
+        let v_expected = v.squeeze(0)?.transpose(0, 1)?.contiguous()?.unsqueeze(0)?;
+
+        assert_eq!(
+            k_out.flatten_all()?.to_vec1::<f32>()?,
+            k_expected.flatten_all()?.to_vec1::<f32>()?
+        );
+        assert_eq!(
+            v_out.flatten_all()?.to_vec1::<f32>()?,
+            v_expected.flatten_all()?.to_vec1::<f32>()?
+        );
 
         Ok(())
     }

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -1,6 +1,6 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
-use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use clap::Parser;
@@ -19,7 +19,6 @@ use kiln_model::ModelRunner;
 use kiln_model::engine::MockEngine;
 use kiln_model::forward::GpuWeights;
 use kiln_model::paged_kv_cache::PagedKvCache;
-use kiln_model::speculative::SpeculativeConfig;
 use kiln_scheduler::{Scheduler, SchedulerConfig};
 use state::{AppState, ModelBackend};
 
@@ -289,41 +288,11 @@ fn spawn_backend_prewarm(state: AppState) {
             // on the first live request.
             let prompt_tokens = [1_u32, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
             let num_blocks = 2;
-            // Warm the base paged/speculative path used by long desktop
-            // prompts. Native MTP is only selected for a narrow short-prompt
-            // subset, so exercising it during startup makes readiness slower
-            // without warming the common long-prompt route.
+            // Warm the base paged path used by every desktop request. The
+            // previous speculative-first prewarm made readiness wait on
+            // skip-layer draft/verify work; live greedy requests can still
+            // compile speculative kernels on demand without blocking startup.
             let prewarm_result = {
-                let block_manager = Mutex::new(BlockManager::new(num_blocks, 16));
-                let paged_cache = Mutex::new(PagedKvCache::new_uninit(
-                    runner_guard.config.num_full_attention_layers,
-                    num_blocks,
-                    16,
-                    runner_guard.config.num_kv_heads,
-                    runner_guard.config.head_dim,
-                    prewarm_kv_dtype(&runner_guard.config),
-                    runner_guard.weights.embed_tokens.device(),
-                )?);
-                let spec_config = SpeculativeConfig {
-                    num_speculative_tokens: 4,
-                    draft_layers: 8,
-                };
-                runner_guard
-                    .generate_paged_speculative_shared_tokens(
-                        &prompt_tokens,
-                        &params,
-                        &block_manager,
-                        &paged_cache,
-                        &spec_config,
-                    )
-                    .map(|_| ())
-            };
-
-            if let Err(err) = prewarm_result {
-                tracing::warn!(
-                    error = %err,
-                    "speculative inference prewarm failed; falling back to base paged prewarm"
-                );
                 let mut block_manager = BlockManager::new(num_blocks, 16);
                 let mut paged_cache = PagedKvCache::new_uninit(
                     runner_guard.config.num_full_attention_layers,
@@ -339,7 +308,11 @@ fn spawn_backend_prewarm(state: AppState) {
                     &params,
                     &mut block_manager,
                     &mut paged_cache,
-                )?;
+                )
+            };
+
+            if let Err(err) = prewarm_result {
+                anyhow::bail!("base paged inference prewarm failed: {err}");
             }
             Ok(())
         })

--- a/desktop/src/poller.rs
+++ b/desktop/src/poller.rs
@@ -6,14 +6,15 @@ use tokio::task::JoinHandle;
 
 use crate::supervisor::ServerState;
 
-const POLL_INTERVAL_SECS: u64 = 2;
+const STEADY_POLL_INTERVAL_SECS: u64 = 2;
+const STARTING_POLL_INTERVAL_MS: u64 = 500;
 const REQUEST_TIMEOUT_SECS: u64 = 1;
 const MAX_CONSECUTIVE_FAILURES: u32 = 3;
 
 /// Spawn a background task that polls `/v1/health` and `/v1/train/status` on
-/// the managed kiln server every `POLL_INTERVAL_SECS` seconds and drives
-/// `state` transitions accordingly. Exits when `shutdown` changes or when the
-/// observed state is `Stopped`.
+/// the managed kiln server and drives `state` transitions accordingly. Polling
+/// is faster while the server is starting so the tray does not sit stale after
+/// kiln becomes ready, then returns to the steady cadence once running.
 pub fn spawn_health_poller(
     state: Arc<Mutex<ServerState>>,
     host: String,
@@ -29,8 +30,7 @@ pub fn spawn_health_poller(
             Err(_) => return,
         };
 
-        let mut interval = tokio::time::interval(Duration::from_secs(POLL_INTERVAL_SECS));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut next_delay = Duration::ZERO;
         let mut consecutive_failures: u32 = 0;
 
         loop {
@@ -38,7 +38,7 @@ pub fn spawn_health_poller(
                 _ = shutdown.changed() => {
                     return;
                 }
-                _ = interval.tick() => {
+                _ = tokio::time::sleep(next_delay) => {
                     {
                         let s = state.lock().await;
                         if matches!(*s, ServerState::Stopped) {
@@ -90,6 +90,7 @@ pub fn spawn_health_poller(
                         train_status.as_ref(),
                         &s,
                     );
+                    next_delay = poll_delay_for(&new_state);
                     *s = new_state;
                 }
             }
@@ -139,27 +140,20 @@ pub fn derive_state(
     ServerState::Running
 }
 
+fn poll_delay_for(state: &ServerState) -> Duration {
+    if matches!(state, ServerState::Starting) {
+        Duration::from_millis(STARTING_POLL_INTERVAL_MS)
+    } else {
+        Duration::from_secs(STEADY_POLL_INTERVAL_SECS)
+    }
+}
+
 fn health_response_ready(status_success: bool, body: Option<&serde_json::Value>) -> bool {
     if !status_success {
         return false;
     }
 
-    let Some(body) = body else {
-        return false;
-    };
-
-    inference_prewarm_complete(body).unwrap_or(true)
-}
-
-fn inference_prewarm_complete(body: &serde_json::Value) -> Option<bool> {
-    body.get("checks")?
-        .as_array()?
-        .iter()
-        .find(|check| {
-            check.get("name").and_then(|name| name.as_str()) == Some("inference_prewarm_complete")
-        })?
-        .get("pass")?
-        .as_bool()
+    body.is_some()
 }
 
 fn has_running_job(status: &serde_json::Value) -> bool {
@@ -190,7 +184,7 @@ mod tests {
     }
 
     #[test]
-    fn health_ready_waits_for_inference_prewarm() {
+    fn health_ready_does_not_wait_for_inference_prewarm() {
         let health = json!({
             "status": "ok",
             "checks": [
@@ -199,7 +193,7 @@ mod tests {
                 {"name": "inference_prewarm_complete", "pass": false}
             ]
         });
-        assert!(!health_response_ready(true, Some(&health)));
+        assert!(health_response_ready(true, Some(&health)));
     }
 
     #[test]
@@ -232,6 +226,18 @@ mod tests {
         let health = json!({"status": "degraded", "checks": []});
         assert!(!health_response_ready(false, Some(&health)));
         assert!(!health_response_ready(true, None));
+    }
+
+    #[test]
+    fn poll_delay_is_short_only_while_starting() {
+        assert_eq!(
+            poll_delay_for(&ServerState::Starting),
+            Duration::from_millis(STARTING_POLL_INTERVAL_MS)
+        );
+        assert_eq!(
+            poll_delay_for(&ServerState::Running),
+            Duration::from_secs(STEADY_POLL_INTERVAL_SECS)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR tightens the macOS desktop default path in two places:

- Startup/readiness: desktop no longer waits for inference prewarm before showing the server as running, and the server prewarm now warms the base paged path instead of speculative skip-layer work.
- Long-prompt prefill: full-attention K/V cache writes can now consume token-major K/V directly, avoiding a transpose back from head-major layout for the native BF16 paged cache path.

## Validation

- `cargo check -p kiln-server --locked --features metal`
- `cargo test -p kiln-model --locked test_write_token_major_native_then_read_roundtrip -- --nocapture`
- `cargo test --locked health_ready -- --nocapture` from `desktop/`
- `cargo test --locked poll_delay -- --nocapture` from `desktop/`
- `cargo build --release --locked --features metal --target-dir /private/tmp/kiln-perf-graph-target`
- `git diff --check`

## Benchmark Notes

Under the desktop env envelope (`KILN_INFERENCE_MEMORY_FRACTION=0.7`, `KILN_KV_CACHE_FP8=0`, `KILN_CUDA_GRAPHS=0`):

- Base paged 8192-ish prompt improved from `58728.8ms` / `139 tok/s` to `58212.7ms` / `141 tok/s` after the token-major cache write.
- A larger strided-SDPA experiment reached `57090.7ms` / `143 tok/s`, but it collapsed speculative acceptance, so it was reverted and is not included here.