### PR TITLE
Avoid zeroing Metal GDN recurrent prefill outputs

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -3940,7 +3940,9 @@ fn metal_gdn_recurrent_prefill_head_last_bf16(
     if !state.is_contiguous() {
         *state = state.contiguous()?;
     }
-    let out = Tensor::zeros((batch, seq_len, value_heads, dv), DType::BF16, q.device())?;
+    // SAFETY: the kernel dispatch covers every (batch, token, value-head, dv)
+    // output element exactly once via `gid=batch_head*dv+d` and the token loop.
+    let out = unsafe { Tensor::empty((batch, seq_len, value_heads, dv), DType::BF16, q.device())? };
 
     let Device::Metal(device) = q.device() else {
         anyhow::bail!("metal gdn recurrent prefill requires a Metal tensor");
@@ -4074,7 +4076,9 @@ fn metal_gdn_recurrent_prefill_native_head_last_bf16(
     if !state.is_contiguous() {
         *state = state.contiguous()?;
     }
-    let out = Tensor::zeros((batch, seq_len, value_heads, dv), DType::BF16, q.device())?;
+    // SAFETY: the kernel dispatch covers every (batch, token, value-head, dv)
+    // output element exactly once via `gid=batch_head*dv+d` and the token loop.
+    let out = unsafe { Tensor::empty((batch, seq_len, value_heads, dv), DType::BF16, q.device())? };
 
     let Device::Metal(device) = q.device() else {
         anyhow::bail!("metal gdn recurrent native prefill requires a Metal tensor");


### PR DESCRIPTION
## Summary
- Allocate Metal GDN recurrent prefill output tensors uninitialized instead of zero-filled.
- Keep the change narrow to the recurrent head-last kernels where the dispatch writes every output element exactly once.

## Validation
- `cargo test -p kiln-model --locked test_gdn_recurrent_prefill_head_last_matches_sequential --features metal -- --nocapture`
- `cargo test -p kiln-model --locked test_gdn_full_chunk_forward_matches_fallback_prefill_shape --features metal -- --nocapture`
- `cargo check -p kiln-server --locked --features metal`
- `cargo build --release --locked --features metal --target-dir /private/tmp/kiln-perf-graph-target`
- Desktop-default bench x2:
  - prefill `53271.1ms` (`153.44 tok/s`), decode `88.7ms` (`11.28 tok/s`), acceptance `1.000`
  - prefill `53271.5ms` (`153.44 tok/s`), decode `87.7ms` (`11.40 tok/s`), acceptance `1.000`