### PR TITLE
phase6: capture post-#420 seed-split h_main drift artifact

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -189,6 +189,69 @@ as the front-door verdict, then bisect why standard-workload seeds 1 and 2
 stay trapped in the identity-biased reject regime while seed 0 escapes it on
 the same current `main`.
 
+## Phase C37 post-#420 seed0-vs-seed1 `h_main` drift audit (2026-04-23)
+
+**Scope:** reuse the existing splice dump path plus
+`scripts/c15_h_main_drift_audit.py` to test whether the post-#420 seed split
+is already visible in the base-model hidden-state path on the standard native
+MTP workload.
+
+**Preflight outcome:** proceed. Fresh `origin/main` was still `59ea3b5`
+(PR #419 merged, PR #420 already present), with no newer open or merged PR
+landing a post-#420 seed0-vs-seed1 `h_main` drift artifact. A fresh rerun of
+the standard workload also reproduced the split before the audit:
+
+| Seed | prompt tokens | mean ITL ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 24.9 | 40.1 | 0.740 |
+| 1 | 508 | 43.7 | 22.9 | 0.309 |
+
+**Hardware note:** RunPod A6000 capacity was unavailable on 2026-04-23
+(both pool resume and direct launch returned supply-constraint failures), so
+this run used the project-policy fallback `A40` on the same kiln image.
+
+**Commands run:** build `kiln-bench`, rerun the standard workload with
+`KILN_MTP_DUMP_SPLICE=1`, `KILN_MTP_DUMP_HIDDEN_STATES=1`, and a dump path
+template rooted at
+`profiling-artifacts/post420_20260423_seed${seed}_captures/mtp_pos-{pos}/step-{step}.safetensors`,
+then run `scripts/c15_h_main_drift_audit.py` twice per seed (default BF16 and
+`--fp32`). The committed source-of-truth artifacts are the FP32 outputs:
+
+- `profiling-artifacts/post420_20260423_hmain_seed0.json`
+- `profiling-artifacts/post420_20260423_hmain_seed1.json`
+
+### Verdict at `mtp_pos=0`
+
+Yes, the split is already visible in `h_main`.
+
+- **Seed 0 (escaping case):** FP32 audit is `clean` at `mtp_pos=0`. Minimum
+  cosine is **0.999067**, last-step cosine **0.999675**, and drift shrinks
+  across the captured window (ratio **0.348x**).
+- **Seed 1 (trapped case):** FP32 audit is `drift` at `mtp_pos=0`. Minimum
+  cosine falls to **0.990691** at step 6, last-step cosine is **0.998943**,
+  and drift grows **3.425x** from step 0 to step 7.
+
+So the low-α seed is not merely failing farther downstream on identical
+hidden-state quality. By the late `mtp_pos=0` steps, it is already feeding the
+MTP head a materially worse `h_main` than the escaping seed.
+
+### Caveat
+
+The existing C15 script's `pos=2` output is not usable on these per-seed
+roots: it builds a 4-token chained sequence from the isolated `pos=2` files
+and then indexes with `base_pos` values around 502/520, producing the
+committed `index out of range` errors. No new instrumentation was added in
+this task, so the source-of-truth verdict is intentionally limited to
+`mtp_pos=0`.
+
+### Recommendation
+
+Do **not** queue another decode-kernel retry off this result. The next narrow
+task should bisect the first seed1-only divergence upstream of the `h_main`
+tap on the standard workload, using the existing hidden-state dump path and a
+layer/sub-op comparator. Seed 1's failure is already visible before the
+accept/reject seam.
+
 ## Phase 6 post-#412 preflight — tiled recurrent-state retry is obsolete (2026-04-23)
 
 **Scope:** re-check the queued "prototype vLLM-style block-tiled

--- a/docs/phase-c37/c37-post420-seed-split-h-main-drift.md
+++ b/docs/phase-c37/c37-post420-seed-split-h-main-drift.md
@@ -1,0 +1,118 @@
+# Phase C37 — post-#420 seed0-vs-seed1 `h_main` drift audit
+
+**Date:** 2026-04-23  
+**Current main:** `59ea3b5` (PR #419 merged; PR #420 already on `main`)  
+**Hardware:** RunPod `NVIDIA A40` via `ghcr.io/ericflo/kiln-runpod:latest`  
+**A6000 note:** direct A6000 allocation and pool resume both failed on 2026-04-23 with RunPod supply-constraint errors, so this rerun used the project-policy fallback order (`A6000 -> A40`) rather than stalling the task indefinitely.
+
+## Preflight
+
+1. **No newer open or merged PR already lands this artifact:** satisfied. Fresh `origin/main` was still `59ea3b5`, and recent PR history after #420 contains no post-#420 seed0-vs-seed1 `h_main` drift artifact for the standard native-MTP workload.
+2. **Current main still shows the post-#420 seed split:** satisfied on a fresh rerun of the standard native-MTP bench. Seed 0 stayed near the paper floor while seed 1 stayed in the low-α regime.
+
+## Commands run
+
+Build:
+
+```bash
+source /root/.kiln-build-env
+export KILN_CUDA_ARCHS=86
+cd /workspace/kiln
+cargo build --release --features cuda --bin kiln-bench
+hf download Qwen/Qwen3.5-4B --local-dir /workspace/qwen3.5-4b
+```
+
+Per-seed standard workload capture:
+
+```bash
+for seed in 0 1; do
+  rm -rf profiling-artifacts/post420_20260423_seed${seed}_captures
+  mkdir -p \
+    profiling-artifacts/post420_20260423_seed${seed}_captures/mtp_pos-0 \
+    profiling-artifacts/post420_20260423_seed${seed}_captures/mtp_pos-2
+
+  KILN_SPEC_METHOD=mtp \
+  KILN_BENCH_FORCE_MTP=1 \
+  KILN_MTP_DUMP_SPLICE=1 \
+  KILN_MTP_DUMP_SPLICE_POS=0,2 \
+  KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+  KILN_MTP_DUMP_HIDDEN_STATES=1 \
+  KILN_MTP_DUMP_PATH=/workspace/kiln/profiling-artifacts/post420_20260423_seed${seed}_captures/mtp_pos-{pos}/step-{step}.safetensors \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+    --seed ${seed} \
+    > profiling-artifacts/post420_20260423_seed${seed}.bench.json \
+    2> profiling-artifacts/post420_20260423_seed${seed}.bench.stderr
+done
+```
+
+Audit (existing tooling only):
+
+```bash
+python3 scripts/c15_h_main_drift_audit.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --captures-root /workspace/kiln/profiling-artifacts/post420_20260423_seed0_captures \
+  --out /workspace/kiln/profiling-artifacts/post420_20260423_seed0_audit_manual
+
+python3 scripts/c15_h_main_drift_audit.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --captures-root /workspace/kiln/profiling-artifacts/post420_20260423_seed0_captures \
+  --out /workspace/kiln/profiling-artifacts/post420_20260423_seed0_audit_manual \
+  --fp32
+
+python3 scripts/c15_h_main_drift_audit.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --captures-root /workspace/kiln/profiling-artifacts/post420_20260423_seed1_captures \
+  --out /workspace/kiln/profiling-artifacts/post420_20260423_seed1_audit_manual
+
+python3 scripts/c15_h_main_drift_audit.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --captures-root /workspace/kiln/profiling-artifacts/post420_20260423_seed1_captures \
+  --out /workspace/kiln/profiling-artifacts/post420_20260423_seed1_audit_manual \
+  --fp32
+```
+
+The committed artifacts are the FP32 audit outputs copied verbatim from the existing script:
+
+- [`profiling-artifacts/post420_20260423_hmain_seed0.json`](../../profiling-artifacts/post420_20260423_hmain_seed0.json)
+- [`profiling-artifacts/post420_20260423_hmain_seed1.json`](../../profiling-artifacts/post420_20260423_hmain_seed1.json)
+
+## Fresh seed split
+
+| Seed | blocks | actual prompt tokens | mean ITL ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 0 | 47 | 494 | 24.9 | 40.1 | 0.740 |
+| 1 | 48 | 508 | 43.7 | 22.9 | 0.309 |
+
+This reproduces the post-#420 split on fresh current `main`: seed 0 escapes, seed 1 stays trapped.
+
+## Audit summary at `mtp_pos=0`
+
+FP32 is the source-of-truth verdict here because C15 already established that BF16-only thresholds can overstate harmless noise. BF16 is listed only as a corroborating cross-check.
+
+| Seed | FP32 status | FP32 min cos | FP32 last-step cos | FP32 drift ratio | BF16 min cos |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 0 | `clean` | 0.999067 | 0.999675 | 0.348x | 0.998639 |
+| 1 | `drift` | 0.990691 | 0.998943 | 3.425x | 0.985204 |
+
+### Readout
+
+- **Seed 0:** the escaped case stays effectively aligned in the base hidden-state path. The FP32 audit is `clean` at `mtp_pos=0`, with every captured step above the strict `0.999` bar and the drift ratio shrinking across steps.
+- **Seed 1:** the trapped case shows a real late-step `h_main` divergence at `mtp_pos=0`. FP32 cosine falls from `0.999691` at step 0 to `0.990691` at step 6, and the drift ratio grows `3.425x` from step 0 to step 7.
+
+## Pos-2 caveat
+
+The existing `scripts/c15_h_main_drift_audit.py` output for `mtp_pos=2` is not usable on these per-seed roots. It builds a chained sequence of length 4 from the isolated `pos=2` files, then indexes with `base_pos` values around `502` / `520`, which produces the committed `index out of range` errors in both seeds. I did not add new instrumentation or patch the script in this task. The honest source-of-truth verdict is therefore limited to `mtp_pos=0`, which is also the critical path for distinguishing the escaping seed from the trapped one.
+
+## Verdict
+
+**Yes: the post-#420 seed split is already visible in the base-model hidden-state path at `mtp_pos=0`.** The escaping seed 0 does **not** show materially growing `h_main` drift under the FP32 audit, while seed 1 does. That means the current split is not solely a downstream accept/reject artifact layered on top of identical `h_main` quality; by step 5-6 the low-α seed is feeding the MTP head a measurably worse base hidden state than the escaping seed.
+
+The next recommendation should stay on the base-stack / `h_main` production side for the low-α branch, not on another decode-kernel retry. The narrow follow-up is to bisect the first seed1-only divergence upstream of the `h_main` tap on the standard workload, using the existing hidden-state dump path and a layer/sub-op comparator, rather than reopening speculative acceptance math in isolation.
+
+## Validation
+
+- `python3 -m py_compile scripts/c15_h_main_drift_audit.py`
+- Fresh RunPod GPU rerun of the standard native-MTP workload for seeds 0 and 1 with splice dumps enabled
+- Re-copied the script outputs and verified the committed JSON files match the generated FP32 audit JSON contents (newline-normalized locally)

--- a/profiling-artifacts/post420_20260423_hmain_seed0.json
+++ b/profiling-artifacts/post420_20260423_hmain_seed0.json
@@ -1,0 +1,88 @@
+{
+  "verdict": "DRIFT",
+  "strict_cos_threshold": 0.999,
+  "fp32_reference": true,
+  "statuses": {
+    "pos_0": "clean",
+    "pos_2": "drift"
+  },
+  "reports": {
+    "pos_0": {
+      "pos": 0,
+      "status": "clean",
+      "fp32_reference": true,
+      "chained_seq_len": 497,
+      "first_base_pos": 494,
+      "strict_threshold": 0.999,
+      "drift_growth": {
+        "step0_drift": 0.000933229923248291,
+        "stepN_drift": 0.0003248453140258789,
+        "ratio": 0.3480871175831896
+      },
+      "steps": [
+        {
+          "step": 0,
+          "base_pos": 494,
+          "cos_sim": 0.9990667700767517,
+          "max_abs_delta": 0.5034294128417969,
+          "rel_err_mean": 0.23379573225975037,
+          "kiln_h_norm": 155.5940399169922,
+          "ref_h_norm": 155.47438049316406
+        },
+        {
+          "step": 1,
+          "base_pos": 495,
+          "cos_sim": 0.9995455741882324,
+          "max_abs_delta": 0.38419994711875916,
+          "rel_err_mean": 0.1570529341697693,
+          "kiln_h_norm": 153.85545349121094,
+          "ref_h_norm": 153.7520294189453
+        },
+        {
+          "step": 2,
+          "base_pos": 496,
+          "cos_sim": 0.9996705055236816,
+          "max_abs_delta": 0.3817846179008484,
+          "rel_err_mean": 0.1432987004518509,
+          "kiln_h_norm": 158.5428466796875,
+          "ref_h_norm": 158.5140838623047
+        },
+        {
+          "step": 3,
+          "base_pos": 497,
+          "cos_sim": 0.9996751546859741,
+          "max_abs_delta": 0.22802484035491943,
+          "rel_err_mean": 0.20240747928619385,
+          "kiln_h_norm": 143.873046875,
+          "ref_h_norm": 144.04019165039062
+        }
+      ]
+    },
+    "pos_2": {
+      "pos": 2,
+      "status": "drift",
+      "fp32_reference": true,
+      "chained_seq_len": 4,
+      "first_base_pos": 502,
+      "strict_threshold": 0.999,
+      "drift_growth": null,
+      "steps": [
+        {
+          "step": 0,
+          "base_pos": 502,
+          "error": "index 501 out of range [0, 4)"
+        },
+        {
+          "step": 1,
+          "base_pos": 503,
+          "error": "index 502 out of range [0, 4)"
+        },
+        {
+          "step": 2,
+          "base_pos": 504,
+          "error": "index 503 out of range [0, 4)"
+        }
+      ]
+    }
+  }
+}

--- a/profiling-artifacts/post420_20260423_hmain_seed1.json
+++ b/profiling-artifacts/post420_20260423_hmain_seed1.json
@@ -1,0 +1,124 @@
+{
+  "verdict": "DRIFT",
+  "strict_cos_threshold": 0.999,
+  "fp32_reference": true,
+  "statuses": {
+    "pos_0": "drift",
+    "pos_2": "drift"
+  },
+  "reports": {
+    "pos_0": {
+      "pos": 0,
+      "status": "drift",
+      "fp32_reference": true,
+      "chained_seq_len": 515,
+      "first_base_pos": 508,
+      "strict_threshold": 0.999,
+      "drift_growth": {
+        "step0_drift": 0.00030875205993652344,
+        "stepN_drift": 0.001057446002960205,
+        "ratio": 3.424903474903475
+      },
+      "steps": [
+        {
+          "step": 0,
+          "base_pos": 508,
+          "cos_sim": 0.9996912479400635,
+          "max_abs_delta": 0.3220195770263672,
+          "rel_err_mean": 0.11739611625671387,
+          "kiln_h_norm": 151.390869140625,
+          "ref_h_norm": 151.2965087890625
+        },
+        {
+          "step": 1,
+          "base_pos": 509,
+          "cos_sim": 0.9996362328529358,
+          "max_abs_delta": 0.28461742401123047,
+          "rel_err_mean": 0.16680875420570374,
+          "kiln_h_norm": 145.27593994140625,
+          "ref_h_norm": 145.20553588867188
+        },
+        {
+          "step": 2,
+          "base_pos": 510,
+          "cos_sim": 0.999565601348877,
+          "max_abs_delta": 0.3911733627319336,
+          "rel_err_mean": 0.15470924973487854,
+          "kiln_h_norm": 146.93910217285156,
+          "ref_h_norm": 146.929443359375
+        },
+        {
+          "step": 3,
+          "base_pos": 511,
+          "cos_sim": 0.9998300075531006,
+          "max_abs_delta": 0.20960819721221924,
+          "rel_err_mean": 0.10993325710296631,
+          "kiln_h_norm": 154.83447265625,
+          "ref_h_norm": 154.85389709472656
+        },
+        {
+          "step": 4,
+          "base_pos": 512,
+          "cos_sim": 0.9995660185813904,
+          "max_abs_delta": 0.4242873787879944,
+          "rel_err_mean": 0.365508496761322,
+          "kiln_h_norm": 143.19345092773438,
+          "ref_h_norm": 142.9138641357422
+        },
+        {
+          "step": 5,
+          "base_pos": 513,
+          "cos_sim": 0.9983517527580261,
+          "max_abs_delta": 0.9210567474365234,
+          "rel_err_mean": 0.4823400378227234,
+          "kiln_h_norm": 144.96435546875,
+          "ref_h_norm": 145.06552124023438
+        },
+        {
+          "step": 6,
+          "base_pos": 514,
+          "cos_sim": 0.9906905293464661,
+          "max_abs_delta": 2.8576908111572266,
+          "rel_err_mean": 4.102612495422363,
+          "kiln_h_norm": 157.52906799316406,
+          "ref_h_norm": 155.68226623535156
+        },
+        {
+          "step": 7,
+          "base_pos": 515,
+          "cos_sim": 0.9989425539970398,
+          "max_abs_delta": 0.6552934646606445,
+          "rel_err_mean": 0.3692258596420288,
+          "kiln_h_norm": 135.88922119140625,
+          "ref_h_norm": 135.4033203125
+        }
+      ]
+    },
+    "pos_2": {
+      "pos": 2,
+      "status": "drift",
+      "fp32_reference": true,
+      "chained_seq_len": 4,
+      "first_base_pos": 520,
+      "strict_threshold": 0.999,
+      "drift_growth": null,
+      "steps": [
+        {
+          "step": 0,
+          "base_pos": 520,
+          "error": "index 519 out of range [0, 4)"
+        },
+        {
+          "step": 1,
+          "base_pos": 521,
+          "error": "index 520 out of range [0, 4)"
+        },
+        {
+          "step": 2,
+          "base_pos": 522,
+          "error": "index 521 out of range [0, 4)"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- capture fresh standard-workload native-MTP seed 0 / seed 1 reruns on current `main` after PR #420 and confirm the seed split still holds
- reuse `scripts/c15_h_main_drift_audit.py` on the fresh splice dumps, then commit the FP32 per-seed audit JSONs as the source-of-truth artifacts
- record the preflight, exact commands, per-seed bench context, audit summary, and verdict in `docs/phase-c37/c37-post420-seed-split-h-main-drift.md` and `PROFILING.md`

## Preflight
- fresh `origin/main` is still `59ea3b5` (PR #419 merged; PR #420 already present)
- recent PR history contains no newer open or merged post-#420 seed0-vs-seed1 `h_main` drift artifact for the standard native-MTP workload
- fresh rerun still shows the post-#420 split on current `main`:
  - seed 0: `494` prompt tokens, `40.1 tok/s`, `α=0.740`
  - seed 1: `508` prompt tokens, `22.9 tok/s`, `α=0.309`

## Audit verdict
At `mtp_pos=0`, the split is already visible in the base-model hidden-state path:
- seed 0 FP32 audit: `clean`, min cos `0.999067`, last-step cos `0.999675`, drift ratio `0.348x`
- seed 1 FP32 audit: `drift`, min cos `0.990691` at step 6, last-step cos `0.998943`, drift ratio `3.425x`

That means the low-α seed is not only failing in downstream acceptance math; by the late `mtp_pos=0` steps it is already feeding the MTP head a materially worse `h_main` than the escaping seed.

## Pos-2 caveat
The existing C15 script's `pos=2` path is not usable on these per-seed roots: it constructs a 4-token chained sequence from the isolated `pos=2` files and then indexes with `base_pos` values around `502/520`, producing the committed `index out of range` errors. I did not add instrumentation or patch the script here, so the source-of-truth verdict is intentionally limited to `mtp_pos=0`.

## Hardware note
A6000 capacity was unavailable on 2026-04-23: both pool resume and direct RunPod launch returned supply-constraint failures. Per the repo policy's fallback order (`A6000 -> A40 -> A100`), this rerun used an A40 on the same kiln image.

## Validation
- `python3 -m py_compile scripts/c15_h_main_drift_audit.py`
- fresh RunPod GPU rerun of the standard native-MTP workload for seeds 0 and 1 with splice dumps enabled
- content-validated the committed JSON artifacts against the generated FP32 audit outputs
