### PR TITLE
phase6: bisect post-#422 seed1 upstream blocker

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -252,6 +252,82 @@ tap on the standard workload, using the existing hidden-state dump path and a
 layer/sub-op comparator. Seed 1's failure is already visible before the
 accept/reject seam.
 
+## Phase C38 post-#422 seed1 upstream base-stack bisect (2026-04-23)
+
+**Scope:** use the existing B10/B11/B12 hidden-state dump + HF reference +
+comparator path on fresh `main` after PR #422 to localize the first
+seed1-only divergence upstream of `h_main`.
+
+**Preflight outcome:** proceed. Fresh `origin/main` was `c66cf41`
+(PR #422 on `main`), with no newer open or merged PR already landing a
+post-#422 upstream base-stack bisect artifact. A fresh standard-workload rerun
+still reproduced the split:
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 5602.8 | 49.98 | 0.7162 |
+| 1 | 508 | 377.2 | 30.82 | 0.2828 |
+
+**Hardware note:** the pod-pool A6000 could not resume (`not enough free GPUs
+on the host machine`). Direct A6000 launch hit `SUPPLY_CONSTRAINT`, and direct
+A40 launch failed with a RunPod internal error, so the fresh rerun used the
+documented fallback `A100 PCIe` on the kiln image.
+
+**Commands run:** rebuilt `kiln-bench`, reran the standard workload for seeds
+0/1 with `KILN_MTP_DUMP_HIDDEN_STATES=1`, `KILN_MTP_DUMP_B11_TAPS=1`, and
+`KILN_MTP_DUMP_B12_GQA_TAPS=1`, generated matched HF reference dumps with
+`scripts/mtp_h_main_reference_dump.py` in both bf16 and fp32, then ran
+`scripts/mtp_compare.py --b10`, `--b11`, and `--b12` for both seeds. The
+committed source-of-truth artifacts are:
+
+- `profiling-artifacts/post422_20260423_seed0_compare_bf16.txt`
+- `profiling-artifacts/post422_20260423_seed1_compare_bf16.txt`
+- `profiling-artifacts/post422_20260423_seed0_compare_fp32.txt`
+- `profiling-artifacts/post422_20260423_seed1_compare_fp32.txt`
+
+### Verdict
+
+**Blocked by the existing reference contract.** The current B10/B11/B12 path
+cannot honestly localize a **seed1-only** first divergence beyond the initial
+`mtp_pos=0` dump.
+
+Why:
+
+- `mtp_h_main_reference_dump.py` forwards the `prompt_tokens` tensor embedded
+  in each splice dump.
+- Only the first `mtp_pos=0` dump (`0_s0`) contains the full prompt
+  (`494` tokens for seed 0, `508` for seed 1).
+- Every later `mtp_pos=0` dump carries `prompt_tokens` length `1`, and the
+  `mtp_pos=2` path carries lengths `2` then `1`.
+- So every later comparator row is an under-conditioned HF replay on the wrong
+  sequence length. Both seeds then look "divergent" for the same reason.
+
+On the **only** fully-contexted row (`0_s0`), seed 0 and seed 1 do not
+separate in a way that makes the next fix target obvious:
+
+- `h_layer_0`: seed 0 `1.00`, seed 1 `1.00`
+- `h_layer_24`: seed 0 `0.985`, seed 1 `0.976`
+- `h_layer_31`: seed 0 `0.958`, seed 1 `0.957`
+- B11 `gdn_conv`: seed 0 `1.00`, seed 1 `1.00`
+
+The mechanically-generated full reports do produce the same nominal
+localization for **both** seeds:
+
+- B10: `DIVERGENCE AT LAYER 0`
+- B11: first below-bar sub-op = `gdn_conv`
+- B12: first below-bar late-stack layer = `h_layer_24`
+
+But those are **not** seed1-only findings; they are artifacts of the
+incomplete-history replay on every row after `0_s0`.
+
+### Recommendation
+
+Do **not** queue a fix from this task. The next narrow task should keep the
+same B10/B11/B12 comparator stack but fix the replay contract first, either
+by serializing the full chained prompt history into every splice dump or by
+teaching the HF reference side to reconstruct the chained history C15-style
+before re-running the existing comparators.
+
 ## Phase 6 post-#412 preflight — tiled recurrent-state retry is obsolete (2026-04-23)
 
 **Scope:** re-check the queued "prototype vLLM-style block-tiled

--- a/docs/phase-c38/c38-post422-seed1-upstream-bisect.md
+++ b/docs/phase-c38/c38-post422-seed1-upstream-bisect.md
@@ -1,0 +1,180 @@
+# Phase C38 — post-#422 seed1 upstream base-stack bisect
+
+**Date:** 2026-04-23  
+**Current main:** `c66cf41` (PR #422 on `main`)  
+**Hardware:** RunPod `NVIDIA A100 PCIe` via `ghcr.io/ericflo/kiln-runpod:latest`  
+**A6000 note:** `ce kiln-pod-acquire --gpu-type 'NVIDIA RTX A6000'` failed because the hibernated pool pod could not resume (`There are not enough free GPUs on the host machine to start this pod`). Direct A6000 launch returned `SUPPLY_CONSTRAINT`, and direct A40 launch returned a RunPod internal error. Per project fallback order, the fresh rerun used `A100 PCIe`.
+
+## Preflight
+
+1. **No newer PR already lands this artifact:** satisfied. Fresh `origin/main` is `c66cf41` (PR #422), and recent PR history contains no newer open or merged PR that already commits a post-#422 seed1-only upstream base-stack bisect artifact for the standard native-MTP workload.
+2. **Current `main` still reproduces the seed split:** satisfied on a fresh standard-workload rerun. Seed 0 stayed near the paper floor while seed 1 remained trapped in the low-α regime.
+3. **Current `PROFILING.md` still recommends an upstream `h_main` bisect, not another decode-kernel retry:** satisfied. The Phase C37 section still says the next narrow task should bisect the first seed1-only divergence upstream of the `h_main` tap.
+
+## Commands run
+
+Build and model download:
+
+```bash
+source /root/.kiln-build-env
+export KILN_CUDA_ARCHS=80
+cd /workspace/kiln
+cargo build --release --features cuda --bin kiln-bench
+hf download Qwen/Qwen3.5-4B --local-dir /workspace/qwen3.5-4b
+python3 -m pip install --upgrade numpy transformers sentencepiece safetensors
+```
+
+Fresh per-seed capture on the standard workload:
+
+```bash
+for seed in 0 1; do
+  root=/workspace/kiln/profiling-artifacts/post422_20260423_seed${seed}_captures
+  rm -rf "$root"
+  mkdir -p "$root"/mtp_pos-0 "$root"/mtp_pos-2
+
+  KILN_W4A16=1 \
+  KILN_CUDA_GRAPHS=true \
+  KILN_SPEC_METHOD=mtp \
+  KILN_BENCH_FORCE_MTP=1 \
+  KILN_MTP_DUMP_SPLICE=1 \
+  KILN_MTP_DUMP_SPLICE_POS=0,2 \
+  KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+  KILN_MTP_DUMP_HIDDEN_STATES=1 \
+  KILN_MTP_DUMP_B11_TAPS=1 \
+  KILN_MTP_DUMP_B12_GQA_TAPS=1 \
+  KILN_MTP_DUMP_PATH=$root/mtp_pos-{pos}/step-{step}.safetensors \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+    --seed ${seed} \
+    > /workspace/kiln/profiling-artifacts/post422_20260423_seed${seed}.bench.json \
+    2> /workspace/kiln/profiling-artifacts/post422_20260423_seed${seed}.bench.stderr
+done
+```
+
+Matched HF reference dumps with the existing script:
+
+```bash
+for seed in 0 1; do
+  root=/workspace/kiln/profiling-artifacts/post422_20260423_seed${seed}_captures
+  while IFS= read -r dump; do
+    rel=${dump#${root}/}
+    out_bf16=/workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed${seed}/${rel}
+    out_fp32=/workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed${seed}/${rel}
+    mkdir -p "$(dirname "$out_bf16")" "$(dirname "$out_fp32")"
+
+    python3 scripts/mtp_h_main_reference_dump.py \
+      --checkpoint /workspace/qwen3.5-4b \
+      --kiln-dump "$dump" \
+      --out "$out_bf16" \
+      --device cuda \
+      --b11-taps \
+      --b12-taps
+
+    python3 scripts/mtp_h_main_reference_dump.py \
+      --checkpoint /workspace/qwen3.5-4b \
+      --kiln-dump "$dump" \
+      --out "$out_fp32" \
+      --device cuda \
+      --b11-taps \
+      --b12-taps \
+      --fp32
+  done < <(find "$root" -type f -name '*.safetensors' | sort)
+done
+```
+
+Comparator pass (mechanically reproduced for both seeds and both reference dtypes):
+
+```bash
+python3 scripts/mtp_compare.py --b10 ...
+python3 scripts/mtp_compare.py --b11 ...
+python3 scripts/mtp_compare.py --b12 ...
+```
+
+Committed comparator outputs:
+
+- [`profiling-artifacts/post422_20260423_seed0_compare_bf16.txt`](../../profiling-artifacts/post422_20260423_seed0_compare_bf16.txt)
+- [`profiling-artifacts/post422_20260423_seed1_compare_bf16.txt`](../../profiling-artifacts/post422_20260423_seed1_compare_bf16.txt)
+- [`profiling-artifacts/post422_20260423_seed0_compare_fp32.txt`](../../profiling-artifacts/post422_20260423_seed0_compare_fp32.txt)
+- [`profiling-artifacts/post422_20260423_seed1_compare_fp32.txt`](../../profiling-artifacts/post422_20260423_seed1_compare_fp32.txt)
+
+Supporting bench artifacts:
+
+- [`profiling-artifacts/post422_20260423_seed0.bench.json`](../../profiling-artifacts/post422_20260423_seed0.bench.json)
+- [`profiling-artifacts/post422_20260423_seed1.bench.json`](../../profiling-artifacts/post422_20260423_seed1.bench.json)
+
+## Fresh workload check
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 5602.8 | 49.98 | 0.7162 |
+| 1 | 508 | 377.2 | 30.82 | 0.2828 |
+
+Condition 2 still holds on fresh `main`: seed 0 escapes, seed 1 does not.
+
+## What the comparator outputs actually prove
+
+The existing B10/B11/B12 path is only trustworthy on the **first** `mtp_pos=0` dump (`0_s0`) for each seed.
+
+Why:
+
+- `mtp_h_main_reference_dump.py` forwards the `prompt_tokens` tensor embedded in each kiln dump.
+- On the standard splice dumps, only the first `mtp_pos=0` capture carries the full prompt (`494` tokens for seed 0, `508` for seed 1).
+- Every later `mtp_pos=0` capture carries `prompt_tokens` length `1`, and the `mtp_pos=2` captures carry lengths `2` then `1`.
+- So the comparator's later rows are comparing a late-step kiln hidden state against an HF forward on an under-conditioned 1-token or 2-token sequence. That is not the same absolute position and cannot localize a seed-specific upstream bug.
+
+This is visible directly in the committed reports:
+
+- seed 0 fp32: `0_s0` has `prompt_tokens 494`, then `0_s1/0_s2/0_s3/2_s1/2_s2` all drop to `1`, with `2_s0` at `2`
+- seed 1 fp32: `0_s0` has `prompt_tokens 508`, then every later `0_s*` row drops to `1`, with `2_s0` at `2`
+
+That makes the later B10/B11/B12 medians **mechanically generated but not source-of-truth** for this task.
+
+## Valid step-0 readout
+
+On the only fully-contexted comparison (`mtp_pos=0`, `step=0`), seed 0 and seed 1 do **not** separate cleanly:
+
+| Surface | Seed 0 fp32 (`0_s0`) | Seed 1 fp32 (`0_s0`) | Seed-specific? |
+| --- | ---: | ---: | --- |
+| `h_layer_0` | `1.00` | `1.00` | no |
+| `h_layer_24` | `0.985` | `0.976` | no clear split |
+| `h_layer_31` | `0.958` | `0.957` | no |
+| B11 `gdn_conv` | `1.00` | `1.00` | no |
+
+The same story holds in bf16: the control and failing seed are materially similar at the only valid comparator row.
+
+## Mechanical full-report outputs
+
+If you ignore the context problem and let the existing comparators consume every splice file verbatim, they produce the same nominal localization for **both** seeds:
+
+- B10: `DIVERGENCE AT LAYER 0`
+- B11: first sub-op below the bar is `gdn_conv`
+- B12: first below-bar late-stack layer is `h_layer_24`
+
+Those are not seed1-only findings. They are the product of feeding the same under-conditioned later-step inputs into the HF reference path on both seeds.
+
+## Verdict
+
+**The existing B10/B11/B12 dump/reference/comparator path is structurally insufficient to localize a first seed1-only upstream divergence after PR #422.**
+
+Fresh `main` still reproduces the seed split, and the current handoff is still correctly pointed upstream of `h_main`, but the existing reference dumper only has one valid fully-contexted row per seed (`0_s0`). That valid row does **not** expose a seed1-only first divergent layer or sub-op. Everything later in the comparator reports is contaminated by incomplete history (`prompt_tokens` length `1` or `2`) and cannot be used as a source-of-truth localization verdict.
+
+## Next recommendation
+
+Do **not** queue a kernel fix from this task.
+
+The next narrow task should keep the same B10/B11/B12 comparator stack but fix the input contract first, either by:
+
+1. serializing the full chained prompt history into every splice dump, or
+2. teaching the HF reference side to reconstruct the chained history C15-style before re-running the existing comparators.
+
+Until one of those happens, the honest result is: **seed 1 is still the failing branch, but the current base-stack comparator path cannot isolate its first upstream-only divergence beyond step 0.**
+
+## Validation
+
+- `python3 -m py_compile scripts/mtp_compare.py scripts/mtp_h_main_reference_dump.py scripts/c15_h_main_drift_audit.py`
+- fresh RunPod rerun on `c66cf41` of the standard native-MTP workload for seeds `0` and `1`
+- fresh kiln hidden-state dumps with `KILN_MTP_DUMP_HIDDEN_STATES=1`, `KILN_MTP_DUMP_B11_TAPS=1`, and `KILN_MTP_DUMP_B12_GQA_TAPS=1`
+- fresh HF reference dumps from `scripts/mtp_h_main_reference_dump.py` in both bf16 and fp32
+- fresh B10/B11/B12 comparator runs for both seeds against both reference dtypes
+

--- a/profiling-artifacts/post422_20260423_seed0.bench.json
+++ b/profiling-artifacts/post422_20260423_seed0.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA A100 80GB PCIe",
+    "total_vram_mb": 81920,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 16.587838174,
+    "model_vram_mb": 17683
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 494,
+      "output_tokens": 128,
+      "total_time_secs": 2.44474172,
+      "tokens_per_sec": 52.35726905335423,
+      "peak_vram_mb": 18021
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 494,
+      "output_tokens": 512,
+      "total_time_secs": 9.798856512,
+      "tokens_per_sec": 52.25099473321076,
+      "peak_vram_mb": 18021
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 494,
+      "output_tokens": 1024,
+      "total_time_secs": 19.523927207,
+      "tokens_per_sec": 52.44846434547557,
+      "peak_vram_mb": 18021
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 494,
+      "output_tokens": 2048,
+      "total_time_secs": 39.135942367,
+      "tokens_per_sec": 52.33041230474889,
+      "peak_vram_mb": 18021
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 5602.7667870000005,
+    "prefill_tokens_per_sec": 88.17072328375677,
+    "time_to_first_token_ms": 5602.7667870000005,
+    "mean_inter_token_ms": 20.009870511811034,
+    "p50_inter_token_ms": 13.594859000000001,
+    "p99_inter_token_ms": 46.209988,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 49.97533589284047,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7162162162162162,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post422_20260423_seed0_compare_bf16.txt
+++ b/profiling-artifacts/post422_20260423_seed0_compare_bf16.txt
@@ -1,0 +1,1312 @@
+# seed 0 compare vs bf16 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   7.81e-03     7.50e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   9.81e-02     1.91e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   3.44e-01     4.20e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   6.88e-01     7.07e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.51e+01     1.33e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.91e-03     2.32e-08    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   1.56e-02     5.89e-07    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.23e-02     8.21e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.83e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   3.91e-03     9.98e-05    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   3.91e-03     8.63e-04    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.55e-02     7.51e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   5.86e-03     4.22e-06    
+b11__gdn_gated_norm    1x494x4096             True     True     1.00e+00   2.34e-02     5.06e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.56e-02     6.51e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   6.25e-01     7.41e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   5.31e-01     7.55e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   6.25e-01     8.01e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.78e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.87e-01   5.16e-01     1.14e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.09e-01     1.28e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.56e-01     1.57e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.93e-01   3.75e-01     1.62e-02    
+h_layer_8              1x1x2560               True     False    4.39e-02   1.55e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    6.13e-04   1.35e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.78e-01   1.03e+01     3.31e-01    
+h_layer_31             1x1x2560               True     False    2.13e-01   4.80e+01     2.33e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.06e-06    
+b11__gdn_conv          1x1x8192               True     False    5.62e-01   1.83e+01     3.94e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.84e-01   8.52e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.17e-01   8.59e-01     5.63e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.77e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.77e-03     7.78e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.43e-01   4.39e-01     1.16e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.31e-01   9.65e-01     5.34e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.62e-01   3.44e-01     9.01e-03    
+h_layer_24             1x1x2560               True     False    4.07e-01   9.38e+00     3.63e-01    
+h_layer_25             1x1x2560               True     False    4.56e-01   8.56e+00     3.82e-01    
+h_layer_26             1x1x2560               True     False    4.75e-01   7.19e+00     4.17e-01    
+h_layer_27             1x1x2560               True     False    4.15e-01   8.31e+00     5.59e-01    
+h_layer_28             1x1x2560               True     False    4.67e-01   8.38e+00     6.21e-01    
+h_layer_29             1x1x2560               True     False    4.47e-01   1.29e+01     6.93e-01    
+h_layer_30             1x1x2560               True     False    3.82e-01   9.67e+00     8.46e-01    
+b12__post_input_norm   1x1x2560               True     False    3.24e-01   2.02e+01     1.04e+00    
+b12__q_proj            1x1x8192               True     False    5.90e-01   1.03e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    4.74e-01   6.50e+00     8.05e-01    
+b12__v_proj            1x1x1024               True     False    9.01e-01   1.11e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.49e-01   8.17e+00     1.00e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.95e-01   8.36e+00     1.07e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.88e-01   1.02e+01     9.82e-01    
+b12__mlp_gate          1x1x9216               True     False    8.11e-01   1.19e+01     9.39e-01    
+b12__mlp_up            1x1x9216               True     False    6.44e-01   6.88e+00     7.12e-01    
+b12__mlp_down          1x1x2560               True     False    4.14e-01   5.62e+00     7.63e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.88e-01   1.05e+00     2.11e-02    
+h_layer_8              1x1x2560               True     False    5.23e-02   1.56e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -2.52e-02  1.37e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.05e-01   1.15e+01     3.23e-01    
+h_layer_31             1x1x2560               True     False    2.35e-01   2.88e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.20e-06    
+b11__gdn_conv          1x1x8192               True     False    7.34e-01   4.09e+00     3.10e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.63e-01   7.68e-01     4.15e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.09e-01   8.96e-01     5.76e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     7.93e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.38e-03     4.83e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.36e-01   5.36e-01     1.53e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.49e-01   1.60e+00     8.09e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   9.53e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    4.43e-01   1.08e+01     3.39e-01    
+h_layer_25             1x1x2560               True     False    5.02e-01   9.50e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.30e-01   6.30e+00     3.78e-01    
+h_layer_27             1x1x2560               True     False    4.13e-01   8.44e+00     5.61e-01    
+h_layer_28             1x1x2560               True     False    4.72e-01   7.00e+00     6.22e-01    
+h_layer_29             1x1x2560               True     False    4.59e-01   9.62e+00     6.91e-01    
+h_layer_30             1x1x2560               True     False    3.75e-01   9.07e+00     8.34e-01    
+b12__post_input_norm   1x1x2560               True     False    3.24e-01   1.97e+01     1.03e+00    
+b12__q_proj            1x1x8192               True     False    6.18e-01   1.21e+01     1.37e+00    
+b12__k_proj            1x1x1024               True     False    4.32e-01   8.48e+00     8.16e-01    
+b12__v_proj            1x1x1024               True     False    8.93e-01   1.19e+01     1.08e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.35e-01   8.27e+00     1.00e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.66e-01   9.52e+00     1.09e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.08e-01   1.08e+01     9.76e-01    
+b12__mlp_gate          1x1x9216               True     False    8.71e-01   1.24e+01     7.51e-01    
+b12__mlp_up            1x1x9216               True     False    7.17e-01   7.27e+00     6.65e-01    
+b12__mlp_down          1x1x2560               True     False    4.45e-01   9.25e+00     7.57e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.98e-01   1.23e+00     2.09e-02    
+h_layer_8              1x1x2560               True     False    3.74e-02   1.64e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -5.19e-02  1.40e+01     1.86e-01    
+h_layer_23             1x1x2560               True     False    4.22e-01   9.19e+00     3.22e-01    
+h_layer_31             1x1x2560               True     False    3.79e-01   3.00e+01     2.07e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     7.37e-07    
+b11__gdn_conv          1x1x8192               True     False    7.39e-01   3.49e+00     2.57e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.81e-01   7.83e-01     4.06e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.90e-01   8.49e-01     5.81e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.16e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.64e-03     5.78e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.50e-01   5.16e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.41e-01   1.55e+00     8.01e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.54e-01   8.05e-01     1.04e-02    
+h_layer_24             1x1x2560               True     False    4.70e-01   7.62e+00     3.40e-01    
+h_layer_25             1x1x2560               True     False    5.35e-01   6.22e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.64e-01   6.86e+00     3.75e-01    
+h_layer_27             1x1x2560               True     False    4.93e-01   8.56e+00     4.98e-01    
+h_layer_28             1x1x2560               True     False    5.41e-01   7.14e+00     5.45e-01    
+h_layer_29             1x1x2560               True     False    5.37e-01   7.62e+00     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.14e-01   9.38e+00     7.86e-01    
+b12__post_input_norm   1x1x2560               True     False    3.46e-01   1.87e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    6.01e-01   1.25e+01     1.36e+00    
+b12__k_proj            1x1x1024               True     False    3.61e-01   6.55e+00     8.66e-01    
+b12__v_proj            1x1x1024               True     False    8.88e-01   1.12e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.15e-01   8.95e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.96e-01   8.33e+00     1.18e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.66e-01   1.01e+01     9.13e-01    
+b12__mlp_gate          1x1x9216               True     False    8.66e-01   1.27e+01     7.54e-01    
+b12__mlp_up            1x1x9216               True     False    7.38e-01   7.36e+00     6.11e-01    
+b12__mlp_down          1x1x2560               True     False    4.52e-01   2.95e+01     6.57e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    9.78e-01   1.64e-01     6.09e-03    
+h_layer_8              1x1x2560               True     False    5.02e-01   2.20e+00     1.05e-01    
+h_layer_16             1x1x2560               True     False    3.47e-01   2.93e+00     1.54e-01    
+h_layer_23             1x1x2560               True     False    6.82e-02   7.50e+00     4.64e-01    
+h_layer_31             1x1x2560               True     False    1.60e-01   6.28e+01     1.99e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   1.56e-02     7.50e-07    
+b11__gdn_conv          1x2x8192               True     False    9.38e-01   3.47e+00     1.79e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.44e-01   9.52e-01     3.60e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.93e-01   6.56e-01     3.34e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   3.91e-03     1.01e-03    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.53e-02     7.90e-04    
+b11__gdn_recur_out     1x2x32x128             True     False    6.58e-01   5.87e-01     1.26e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    9.34e-01   1.23e+00     4.76e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.50e-01   8.83e-01     7.36e-03    
+h_layer_24             1x1x2560               True     False    6.08e-02   1.16e+01     4.86e-01    
+h_layer_25             1x1x2560               True     False    4.30e-02   2.10e+01     5.88e-01    
+h_layer_26             1x1x2560               True     False    7.21e-02   9.86e+01     7.00e-01    
+h_layer_27             1x1x2560               True     False    1.80e-01   2.20e+01     5.35e-01    
+h_layer_28             1x1x2560               True     False    2.29e-01   2.37e+01     6.29e-01    
+h_layer_29             1x1x2560               True     False    3.24e-01   1.78e+01     6.90e-01    
+h_layer_30             1x1x2560               True     False    1.95e-01   2.75e+01     8.40e-01    
+b12__post_input_norm   1x2x2560               True     False    2.39e-01   2.46e+01     1.07e+00    
+b12__q_proj            1x2x8192               True     False    5.89e-01   1.16e+01     1.35e+00    
+b12__k_proj            1x2x1024               True     False    3.85e-01   6.99e+00     8.97e-01    
+b12__v_proj            1x2x1024               True     False    9.00e-01   1.16e+01     1.04e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.64e-01   8.67e+00     1.01e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.98e-01   8.05e+00     1.20e+00    
+b12__o_proj            1x2x2560               True     False    2.85e-01   5.83e+00     3.28e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.12e-01   1.96e+01     1.02e+00    
+b12__mlp_gate          1x2x9216               True     False    7.86e-01   1.25e+01     9.05e-01    
+b12__mlp_up            1x2x9216               True     False    6.01e-01   8.54e+00     8.09e-01    
+b12__mlp_down          1x2x2560               True     False    2.86e-01   3.23e+01     8.29e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.39e-01   1.05e+00     2.07e-02    
+h_layer_8              1x1x2560               True     False    3.74e-02   1.63e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -2.61e-02  1.43e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    3.81e-01   1.09e+01     3.31e-01    
+h_layer_31             1x1x2560               True     False    2.73e-01   2.27e+01     2.32e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   9.77e-04     9.46e-08    
+b11__gdn_conv          1x1x8192               True     False    5.76e-01   1.34e+01     3.76e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.90e-01   8.38e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   7.91e-01     5.72e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.31e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.59e-03     6.52e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.56e-01   5.40e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.27e-01   1.58e+00     6.81e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.53e-01   7.34e-01     1.06e-02    
+h_layer_24             1x1x2560               True     False    4.28e-01   8.25e+00     3.55e-01    
+h_layer_25             1x1x2560               True     False    4.81e-01   6.56e+00     3.72e-01    
+h_layer_26             1x1x2560               True     False    4.83e-01   6.76e+00     4.05e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   7.38e+00     5.51e-01    
+h_layer_28             1x1x2560               True     False    4.98e-01   8.25e+00     6.01e-01    
+h_layer_29             1x1x2560               True     False    4.77e-01   1.32e+01     6.88e-01    
+h_layer_30             1x1x2560               True     False    4.20e-01   9.34e+00     8.18e-01    
+b12__post_input_norm   1x1x2560               True     False    3.50e-01   1.82e+01     9.92e-01    
+b12__q_proj            1x1x8192               True     False    5.61e-01   1.17e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.48e-01   8.39e+00     8.58e-01    
+b12__v_proj            1x1x1024               True     False    8.88e-01   1.17e+01     1.12e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.35e-01   8.12e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    3.73e-01   9.25e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.43e-01   8.97e+00     9.34e-01    
+b12__mlp_gate          1x1x9216               True     False    8.53e-01   1.30e+01     7.86e-01    
+b12__mlp_up            1x1x9216               True     False    6.95e-01   7.21e+00     6.90e-01    
+b12__mlp_down          1x1x2560               True     False    4.31e-01   1.16e+01     7.10e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    6.85e-01   1.48e+00     2.33e-02    
+h_layer_8              1x1x2560               True     False    1.52e-02   1.63e+01     1.73e-01    
+h_layer_16             1x1x2560               True     False    -6.17e-02  1.41e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    2.57e-01   1.29e+01     3.69e-01    
+h_layer_31             1x1x2560               True     False    2.02e-01   2.78e+01     2.40e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   4.88e-04     1.91e-07    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     5.24e-06    
+b11__gdn_conv          1x1x8192               True     False    7.26e-01   3.70e+00     2.77e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.31e-01   7.01e-01     3.93e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.65e-01   8.20e-01     5.37e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.01e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.54e-03     1.18e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    6.23e-01   4.43e-01     1.45e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.15e-01   1.50e+00     7.96e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.40e-01   1.10e+00     1.05e-02    
+h_layer_24             1x1x2560               True     False    2.70e-01   1.28e+01     4.03e-01    
+h_layer_25             1x1x2560               True     False    3.12e-01   1.29e+01     4.20e-01    
+h_layer_26             1x1x2560               True     False    3.47e-01   6.37e+00     4.58e-01    
+h_layer_27             1x1x2560               True     False    3.41e-01   1.29e+01     5.51e-01    
+h_layer_28             1x1x2560               True     False    3.75e-01   9.19e+00     5.96e-01    
+h_layer_29             1x1x2560               True     False    3.69e-01   1.26e+01     6.96e-01    
+h_layer_30             1x1x2560               True     False    2.66e-01   8.54e+00     8.75e-01    
+b12__post_input_norm   1x1x2560               True     False    2.27e-01   1.89e+01     1.13e+00    
+b12__q_proj            1x1x8192               True     False    4.87e-01   1.46e+01     1.65e+00    
+b12__k_proj            1x1x1024               True     False    3.40e-01   6.15e+00     8.98e-01    
+b12__v_proj            1x1x1024               True     False    8.67e-01   1.32e+01     1.18e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.59e-01   9.50e+00     1.11e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.52e-01   8.25e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.09e-01   9.51e+00     1.07e+00    
+b12__mlp_gate          1x1x9216               True     False    7.80e-01   1.24e+01     9.12e-01    
+b12__mlp_up            1x1x9216               True     False    6.62e-01   6.98e+00     6.64e-01    
+b12__mlp_down          1x1x2560               True     False    1.77e-01   2.64e+01     7.58e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=7.81e-03   ok    cos=8.93e-01   max|Δ|=3.75e-01   DIV   cos=7.88e-01   max|Δ|=1.05e+00   DIV   cos=7.98e-01   max|Δ|=1.23e+00   DIV   cos=9.78e-01   max|Δ|=1.64e-01   DIV   cos=8.39e-01   max|Δ|=1.05e+00   DIV   cos=6.85e-01   max|Δ|=1.48e+00   DIV  
+  h_layer_8             cos=9.80e-01   max|Δ|=9.81e-02   DIV   cos=4.39e-02   max|Δ|=1.55e+01   DIV   cos=5.23e-02   max|Δ|=1.56e+01   DIV   cos=3.74e-02   max|Δ|=1.64e+01   DIV   cos=5.02e-01   max|Δ|=2.20e+00   DIV   cos=3.74e-02   max|Δ|=1.63e+01   DIV   cos=1.52e-02   max|Δ|=1.63e+01   DIV  
+  h_layer_16            cos=9.66e-01   max|Δ|=3.44e-01   DIV   cos=6.13e-04   max|Δ|=1.35e+01   DIV   cos=-2.52e-02  max|Δ|=1.37e+01   DIV   cos=-5.19e-02  max|Δ|=1.40e+01   DIV   cos=3.47e-01   max|Δ|=2.93e+00   DIV   cos=-2.61e-02  max|Δ|=1.43e+01   DIV   cos=-6.17e-02  max|Δ|=1.41e+01   DIV  
+  h_layer_23            cos=9.84e-01   max|Δ|=6.88e-01   DIV   cos=3.78e-01   max|Δ|=1.03e+01   DIV   cos=4.05e-01   max|Δ|=1.15e+01   DIV   cos=4.22e-01   max|Δ|=9.19e+00   DIV   cos=6.82e-02   max|Δ|=7.50e+00   DIV   cos=3.81e-01   max|Δ|=1.09e+01   DIV   cos=2.57e-01   max|Δ|=1.29e+01   DIV  
+  h_layer_31            cos=9.59e-01   max|Δ|=2.51e+01   DIV   cos=2.13e-01   max|Δ|=4.80e+01   DIV   cos=2.35e-01   max|Δ|=2.88e+01   DIV   cos=3.79e-01   max|Δ|=3.00e+01   DIV   cos=1.60e-01   max|Δ|=6.28e+01   DIV   cos=2.73e-01   max|Δ|=2.27e+01   DIV   cos=2.02e-01   max|Δ|=2.78e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_0' (pos=0_s1)
+Phase B10 verdict: DIVERGENCE AT LAYER 0
+  -> Input-path bug: embedding lookup, rotary_inv_freq build, first
+     block's Q/K/V proj or GDN sub-op, OR prompt-token construction
+     mismatch between kiln and reference. Verify `prompt_tokens` meta
+     matches exactly, then narrow to layer 0's sub-ops.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   7.81e-03     7.50e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   9.81e-02     1.91e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   3.44e-01     4.20e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   6.88e-01     7.07e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.51e+01     1.33e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.91e-03     2.32e-08    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   1.56e-02     5.89e-07    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.23e-02     8.21e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.83e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   3.91e-03     9.98e-05    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   3.91e-03     8.63e-04    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.55e-02     7.51e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   5.86e-03     4.22e-06    
+b11__gdn_gated_norm    1x494x4096             True     True     1.00e+00   2.34e-02     5.06e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.56e-02     6.51e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   6.25e-01     7.41e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   5.31e-01     7.55e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   6.25e-01     8.01e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.78e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.87e-01   5.16e-01     1.14e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.09e-01     1.28e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.56e-01     1.57e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.93e-01   3.75e-01     1.62e-02    
+h_layer_8              1x1x2560               True     False    4.39e-02   1.55e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    6.13e-04   1.35e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.78e-01   1.03e+01     3.31e-01    
+h_layer_31             1x1x2560               True     False    2.13e-01   4.80e+01     2.33e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.06e-06    
+b11__gdn_conv          1x1x8192               True     False    5.62e-01   1.83e+01     3.94e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.84e-01   8.52e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.17e-01   8.59e-01     5.63e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.77e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.77e-03     7.78e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.43e-01   4.39e-01     1.16e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.31e-01   9.65e-01     5.34e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.62e-01   3.44e-01     9.01e-03    
+h_layer_24             1x1x2560               True     False    4.07e-01   9.38e+00     3.63e-01    
+h_layer_25             1x1x2560               True     False    4.56e-01   8.56e+00     3.82e-01    
+h_layer_26             1x1x2560               True     False    4.75e-01   7.19e+00     4.17e-01    
+h_layer_27             1x1x2560               True     False    4.15e-01   8.31e+00     5.59e-01    
+h_layer_28             1x1x2560               True     False    4.67e-01   8.38e+00     6.21e-01    
+h_layer_29             1x1x2560               True     False    4.47e-01   1.29e+01     6.93e-01    
+h_layer_30             1x1x2560               True     False    3.82e-01   9.67e+00     8.46e-01    
+b12__post_input_norm   1x1x2560               True     False    3.24e-01   2.02e+01     1.04e+00    
+b12__q_proj            1x1x8192               True     False    5.90e-01   1.03e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    4.74e-01   6.50e+00     8.05e-01    
+b12__v_proj            1x1x1024               True     False    9.01e-01   1.11e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.49e-01   8.17e+00     1.00e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.95e-01   8.36e+00     1.07e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.88e-01   1.02e+01     9.82e-01    
+b12__mlp_gate          1x1x9216               True     False    8.11e-01   1.19e+01     9.39e-01    
+b12__mlp_up            1x1x9216               True     False    6.44e-01   6.88e+00     7.12e-01    
+b12__mlp_down          1x1x2560               True     False    4.14e-01   5.62e+00     7.63e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.88e-01   1.05e+00     2.11e-02    
+h_layer_8              1x1x2560               True     False    5.23e-02   1.56e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -2.52e-02  1.37e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.05e-01   1.15e+01     3.23e-01    
+h_layer_31             1x1x2560               True     False    2.35e-01   2.88e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.20e-06    
+b11__gdn_conv          1x1x8192               True     False    7.34e-01   4.09e+00     3.10e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.63e-01   7.68e-01     4.15e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.09e-01   8.96e-01     5.76e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     7.93e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.38e-03     4.83e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.36e-01   5.36e-01     1.53e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.49e-01   1.60e+00     8.09e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   9.53e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    4.43e-01   1.08e+01     3.39e-01    
+h_layer_25             1x1x2560               True     False    5.02e-01   9.50e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.30e-01   6.30e+00     3.78e-01    
+h_layer_27             1x1x2560               True     False    4.13e-01   8.44e+00     5.61e-01    
+h_layer_28             1x1x2560               True     False    4.72e-01   7.00e+00     6.22e-01    
+h_layer_29             1x1x2560               True     False    4.59e-01   9.62e+00     6.91e-01    
+h_layer_30             1x1x2560               True     False    3.75e-01   9.07e+00     8.34e-01    
+b12__post_input_norm   1x1x2560               True     False    3.24e-01   1.97e+01     1.03e+00    
+b12__q_proj            1x1x8192               True     False    6.18e-01   1.21e+01     1.37e+00    
+b12__k_proj            1x1x1024               True     False    4.32e-01   8.48e+00     8.16e-01    
+b12__v_proj            1x1x1024               True     False    8.93e-01   1.19e+01     1.08e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.35e-01   8.27e+00     1.00e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.66e-01   9.52e+00     1.09e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.08e-01   1.08e+01     9.76e-01    
+b12__mlp_gate          1x1x9216               True     False    8.71e-01   1.24e+01     7.51e-01    
+b12__mlp_up            1x1x9216               True     False    7.17e-01   7.27e+00     6.65e-01    
+b12__mlp_down          1x1x2560               True     False    4.45e-01   9.25e+00     7.57e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.98e-01   1.23e+00     2.09e-02    
+h_layer_8              1x1x2560               True     False    3.74e-02   1.64e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -5.19e-02  1.40e+01     1.86e-01    
+h_layer_23             1x1x2560               True     False    4.22e-01   9.19e+00     3.22e-01    
+h_layer_31             1x1x2560               True     False    3.79e-01   3.00e+01     2.07e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     7.37e-07    
+b11__gdn_conv          1x1x8192               True     False    7.39e-01   3.49e+00     2.57e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.81e-01   7.83e-01     4.06e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.90e-01   8.49e-01     5.81e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.16e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.64e-03     5.78e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.50e-01   5.16e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.41e-01   1.55e+00     8.01e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.54e-01   8.05e-01     1.04e-02    
+h_layer_24             1x1x2560               True     False    4.70e-01   7.62e+00     3.40e-01    
+h_layer_25             1x1x2560               True     False    5.35e-01   6.22e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.64e-01   6.86e+00     3.75e-01    
+h_layer_27             1x1x2560               True     False    4.93e-01   8.56e+00     4.98e-01    
+h_layer_28             1x1x2560               True     False    5.41e-01   7.14e+00     5.45e-01    
+h_layer_29             1x1x2560               True     False    5.37e-01   7.62e+00     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.14e-01   9.38e+00     7.86e-01    
+b12__post_input_norm   1x1x2560               True     False    3.46e-01   1.87e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    6.01e-01   1.25e+01     1.36e+00    
+b12__k_proj            1x1x1024               True     False    3.61e-01   6.55e+00     8.66e-01    
+b12__v_proj            1x1x1024               True     False    8.88e-01   1.12e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.15e-01   8.95e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.96e-01   8.33e+00     1.18e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.66e-01   1.01e+01     9.13e-01    
+b12__mlp_gate          1x1x9216               True     False    8.66e-01   1.27e+01     7.54e-01    
+b12__mlp_up            1x1x9216               True     False    7.38e-01   7.36e+00     6.11e-01    
+b12__mlp_down          1x1x2560               True     False    4.52e-01   2.95e+01     6.57e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    9.78e-01   1.64e-01     6.09e-03    
+h_layer_8              1x1x2560               True     False    5.02e-01   2.20e+00     1.05e-01    
+h_layer_16             1x1x2560               True     False    3.47e-01   2.93e+00     1.54e-01    
+h_layer_23             1x1x2560               True     False    6.82e-02   7.50e+00     4.64e-01    
+h_layer_31             1x1x2560               True     False    1.60e-01   6.28e+01     1.99e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   1.56e-02     7.50e-07    
+b11__gdn_conv          1x2x8192               True     False    9.38e-01   3.47e+00     1.79e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.44e-01   9.52e-01     3.60e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.93e-01   6.56e-01     3.34e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   3.91e-03     1.01e-03    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.53e-02     7.90e-04    
+b11__gdn_recur_out     1x2x32x128             True     False    6.58e-01   5.87e-01     1.26e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    9.34e-01   1.23e+00     4.76e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.50e-01   8.83e-01     7.36e-03    
+h_layer_24             1x1x2560               True     False    6.08e-02   1.16e+01     4.86e-01    
+h_layer_25             1x1x2560               True     False    4.30e-02   2.10e+01     5.88e-01    
+h_layer_26             1x1x2560               True     False    7.21e-02   9.86e+01     7.00e-01    
+h_layer_27             1x1x2560               True     False    1.80e-01   2.20e+01     5.35e-01    
+h_layer_28             1x1x2560               True     False    2.29e-01   2.37e+01     6.29e-01    
+h_layer_29             1x1x2560               True     False    3.24e-01   1.78e+01     6.90e-01    
+h_layer_30             1x1x2560               True     False    1.95e-01   2.75e+01     8.40e-01    
+b12__post_input_norm   1x2x2560               True     False    2.39e-01   2.46e+01     1.07e+00    
+b12__q_proj            1x2x8192               True     False    5.89e-01   1.16e+01     1.35e+00    
+b12__k_proj            1x2x1024               True     False    3.85e-01   6.99e+00     8.97e-01    
+b12__v_proj            1x2x1024               True     False    9.00e-01   1.16e+01     1.04e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.64e-01   8.67e+00     1.01e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.98e-01   8.05e+00     1.20e+00    
+b12__o_proj            1x2x2560               True     False    2.85e-01   5.83e+00     3.28e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.12e-01   1.96e+01     1.02e+00    
+b12__mlp_gate          1x2x9216               True     False    7.86e-01   1.25e+01     9.05e-01    
+b12__mlp_up            1x2x9216               True     False    6.01e-01   8.54e+00     8.09e-01    
+b12__mlp_down          1x2x2560               True     False    2.86e-01   3.23e+01     8.29e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.39e-01   1.05e+00     2.07e-02    
+h_layer_8              1x1x2560               True     False    3.74e-02   1.63e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -2.61e-02  1.43e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    3.81e-01   1.09e+01     3.31e-01    
+h_layer_31             1x1x2560               True     False    2.73e-01   2.27e+01     2.32e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   9.77e-04     9.46e-08    
+b11__gdn_conv          1x1x8192               True     False    5.76e-01   1.34e+01     3.76e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.90e-01   8.38e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   7.91e-01     5.72e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.31e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.59e-03     6.52e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.56e-01   5.40e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.27e-01   1.58e+00     6.81e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.53e-01   7.34e-01     1.06e-02    
+h_layer_24             1x1x2560               True     False    4.28e-01   8.25e+00     3.55e-01    
+h_layer_25             1x1x2560               True     False    4.81e-01   6.56e+00     3.72e-01    
+h_layer_26             1x1x2560               True     False    4.83e-01   6.76e+00     4.05e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   7.38e+00     5.51e-01    
+h_layer_28             1x1x2560               True     False    4.98e-01   8.25e+00     6.01e-01    
+h_layer_29             1x1x2560               True     False    4.77e-01   1.32e+01     6.88e-01    
+h_layer_30             1x1x2560               True     False    4.20e-01   9.34e+00     8.18e-01    
+b12__post_input_norm   1x1x2560               True     False    3.50e-01   1.82e+01     9.92e-01    
+b12__q_proj            1x1x8192               True     False    5.61e-01   1.17e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.48e-01   8.39e+00     8.58e-01    
+b12__v_proj            1x1x1024               True     False    8.88e-01   1.17e+01     1.12e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.35e-01   8.12e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    3.73e-01   9.25e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.43e-01   8.97e+00     9.34e-01    
+b12__mlp_gate          1x1x9216               True     False    8.53e-01   1.30e+01     7.86e-01    
+b12__mlp_up            1x1x9216               True     False    6.95e-01   7.21e+00     6.90e-01    
+b12__mlp_down          1x1x2560               True     False    4.31e-01   1.16e+01     7.10e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    6.85e-01   1.48e+00     2.33e-02    
+h_layer_8              1x1x2560               True     False    1.52e-02   1.63e+01     1.73e-01    
+h_layer_16             1x1x2560               True     False    -6.17e-02  1.41e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    2.57e-01   1.29e+01     3.69e-01    
+h_layer_31             1x1x2560               True     False    2.02e-01   2.78e+01     2.40e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   4.88e-04     1.91e-07    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     5.24e-06    
+b11__gdn_conv          1x1x8192               True     False    7.26e-01   3.70e+00     2.77e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.31e-01   7.01e-01     3.93e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.65e-01   8.20e-01     5.37e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.01e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.54e-03     1.18e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    6.23e-01   4.43e-01     1.45e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.15e-01   1.50e+00     7.96e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.40e-01   1.10e+00     1.05e-02    
+h_layer_24             1x1x2560               True     False    2.70e-01   1.28e+01     4.03e-01    
+h_layer_25             1x1x2560               True     False    3.12e-01   1.29e+01     4.20e-01    
+h_layer_26             1x1x2560               True     False    3.47e-01   6.37e+00     4.58e-01    
+h_layer_27             1x1x2560               True     False    3.41e-01   1.29e+01     5.51e-01    
+h_layer_28             1x1x2560               True     False    3.75e-01   9.19e+00     5.96e-01    
+h_layer_29             1x1x2560               True     False    3.69e-01   1.26e+01     6.96e-01    
+h_layer_30             1x1x2560               True     False    2.66e-01   8.54e+00     8.75e-01    
+b12__post_input_norm   1x1x2560               True     False    2.27e-01   1.89e+01     1.13e+00    
+b12__q_proj            1x1x8192               True     False    4.87e-01   1.46e+01     1.65e+00    
+b12__k_proj            1x1x1024               True     False    3.40e-01   6.15e+00     8.98e-01    
+b12__v_proj            1x1x1024               True     False    8.67e-01   1.32e+01     1.18e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.59e-01   9.50e+00     1.11e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.52e-01   8.25e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.09e-01   9.51e+00     1.07e+00    
+b12__mlp_gate          1x1x9216               True     False    7.80e-01   1.24e+01     9.12e-01    
+b12__mlp_up            1x1x9216               True     False    6.62e-01   6.98e+00     6.64e-01    
+b12__mlp_down          1x1x2560               True     False    1.77e-01   2.64e+01     7.58e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok 
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=2.32e-08   rel_l2=7.56e-06   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=4.88e-04   mean|Δ|=1.91e-07   rel_l2=8.49e-06   ok 
+  gdn_in_proj               cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=5.89e-07   rel_l2=3.73e-05   ok  cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=1.06e-06   rel_l2=5.84e-05   ok  cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=1.20e-06   rel_l2=7.64e-05   ok  cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=7.37e-07   rel_l2=6.63e-05   ok  cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=7.50e-07   rel_l2=5.98e-05   ok  cos=1.00e+00   max|Δ|=9.77e-04   mean|Δ|=9.46e-08   rel_l2=7.60e-06   ok  cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=5.24e-06   rel_l2=1.48e-04   ok 
+  gdn_conv                  cos=1.00e+00   max|Δ|=6.23e-02   mean|Δ|=8.21e-05   rel_l2=2.27e-03   ok  cos=5.62e-01   max|Δ|=1.83e+01   mean|Δ|=3.94e-02   rel_l2=3.60e+00   DIV cos=7.34e-01   max|Δ|=4.09e+00   mean|Δ|=3.10e-02   rel_l2=2.42e+00   DIV cos=7.39e-01   max|Δ|=3.49e+00   mean|Δ|=2.57e-02   rel_l2=1.79e+00   DIV cos=9.38e-01   max|Δ|=3.47e+00   mean|Δ|=1.79e-02   rel_l2=4.41e-01   DIV cos=5.76e-01   max|Δ|=1.34e+01   mean|Δ|=3.76e-02   rel_l2=3.98e+00   DIV cos=7.26e-01   max|Δ|=3.70e+00   mean|Δ|=2.77e-02   rel_l2=2.07e+00   DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.83e-01   mean|Δ|=4.04e-02   rel_l2=9.12e-01   ok  cos=6.84e-01   max|Δ|=8.52e-01   mean|Δ|=3.88e-02   rel_l2=9.42e-01   DIV cos=6.63e-01   max|Δ|=7.68e-01   mean|Δ|=4.15e-02   rel_l2=9.44e-01   DIV cos=6.81e-01   max|Δ|=7.83e-01   mean|Δ|=4.06e-02   rel_l2=9.42e-01   DIV cos=8.44e-01   max|Δ|=9.52e-01   mean|Δ|=3.60e-02   rel_l2=9.27e-01   DIV cos=6.90e-01   max|Δ|=8.38e-01   mean|Δ|=3.88e-02   rel_l2=9.41e-01   DIV cos=7.31e-01   max|Δ|=7.01e-01   mean|Δ|=3.93e-02   rel_l2=9.37e-01   DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.98e-05   rel_l2=3.20e-03   ok  cos=3.17e-01   max|Δ|=8.59e-01   mean|Δ|=5.63e-02   rel_l2=1.17e+00   DIV cos=3.09e-01   max|Δ|=8.96e-01   mean|Δ|=5.76e-02   rel_l2=1.18e+00   DIV cos=3.90e-01   max|Δ|=8.49e-01   mean|Δ|=5.81e-02   rel_l2=1.10e+00   DIV cos=6.93e-01   max|Δ|=6.56e-01   mean|Δ|=3.34e-02   rel_l2=7.83e-01   DIV cos=2.97e-01   max|Δ|=7.91e-01   mean|Δ|=5.72e-02   rel_l2=1.19e+00   DIV cos=3.65e-01   max|Δ|=8.20e-01   mean|Δ|=5.37e-02   rel_l2=1.13e+00   DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=8.63e-04   rel_l2=2.93e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.77e-04   rel_l2=2.90e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=7.93e-04   rel_l2=3.11e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.16e-04   rel_l2=3.09e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=1.01e-03   rel_l2=3.20e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.31e-04   rel_l2=3.21e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=1.01e-03   rel_l2=3.32e-03   ok 
+  gdn_gate_g                cos=1.00e+00   max|Δ|=1.55e-02   mean|Δ|=7.51e-04   rel_l2=1.63e-03   ok  cos=1.00e+00   max|Δ|=6.77e-03   mean|Δ|=7.78e-04   rel_l2=1.61e-03   ok  cos=1.00e+00   max|Δ|=5.38e-03   mean|Δ|=4.83e-04   rel_l2=1.27e-03   ok  cos=1.00e+00   max|Δ|=5.64e-03   mean|Δ|=5.78e-04   rel_l2=1.38e-03   ok  cos=1.00e+00   max|Δ|=1.53e-02   mean|Δ|=7.90e-04   rel_l2=1.80e-03   ok  cos=1.00e+00   max|Δ|=6.59e-03   mean|Δ|=6.52e-04   rel_l2=1.48e-03   ok  cos=1.00e+00   max|Δ|=7.54e-03   mean|Δ|=1.18e-03   rel_l2=2.13e-03   ok 
+  gdn_recur_out             cos=1.00e+00   max|Δ|=5.86e-03   mean|Δ|=4.22e-06   rel_l2=4.41e-03   ok  cos=5.43e-01   max|Δ|=4.39e-01   mean|Δ|=1.16e-03   rel_l2=6.41e+00   DIV cos=4.36e-01   max|Δ|=5.36e-01   mean|Δ|=1.53e-03   rel_l2=1.27e+01   DIV cos=4.50e-01   max|Δ|=5.16e-01   mean|Δ|=1.62e-03   rel_l2=1.34e+01   DIV cos=6.58e-01   max|Δ|=5.87e-01   mean|Δ|=1.26e-03   rel_l2=5.68e+00   DIV cos=3.56e-01   max|Δ|=5.40e-01   mean|Δ|=1.62e-03   rel_l2=8.63e+00   DIV cos=6.23e-01   max|Δ|=4.43e-01   mean|Δ|=1.45e-03   rel_l2=1.87e+01   DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=2.34e-02   mean|Δ|=5.06e-05   rel_l2=5.04e-03   ok  cos=9.31e-01   max|Δ|=9.65e-01   mean|Δ|=5.34e-03   rel_l2=4.73e-01   DIV cos=8.49e-01   max|Δ|=1.60e+00   mean|Δ|=8.09e-03   rel_l2=9.77e-01   DIV cos=8.41e-01   max|Δ|=1.55e+00   mean|Δ|=8.01e-03   rel_l2=9.66e-01   DIV cos=9.34e-01   max|Δ|=1.23e+00   mean|Δ|=4.76e-03   rel_l2=4.98e-01   DIV cos=8.27e-01   max|Δ|=1.58e+00   mean|Δ|=6.81e-03   rel_l2=8.20e-01   DIV cos=8.15e-01   max|Δ|=1.50e+00   mean|Δ|=7.96e-03   rel_l2=1.23e+00   DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=6.51e-05   rel_l2=3.01e-03   ok  cos=9.62e-01   max|Δ|=3.44e-01   mean|Δ|=9.01e-03   rel_l2=3.33e-01   ok  cos=9.46e-01   max|Δ|=9.53e-01   mean|Δ|=1.07e-02   rel_l2=7.03e-01   DIV cos=9.54e-01   max|Δ|=8.05e-01   mean|Δ|=1.04e-02   rel_l2=5.39e-01   ok  cos=9.50e-01   max|Δ|=8.83e-01   mean|Δ|=7.36e-03   rel_l2=4.82e-01   ok  cos=9.53e-01   max|Δ|=7.34e-01   mean|Δ|=1.06e-02   rel_l2=4.72e-01   ok  cos=9.40e-01   max|Δ|=1.10e+00   mean|Δ|=1.05e-02   rel_l2=7.92e-01   DIV
+
+  first sub-op with MEDIAN cos_sim < 0.95: 'gdn_conv' (median cos_sim = 0.733807)
+Phase B11b verdict: B12 TARGET = 'gdn_conv'.
+    Most-likely cause: causal_conv1d: kernel packing, stride/pad, SiLU activation, or bias
+  -> Queue B12 task to investigate this sub-op in isolation.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   7.81e-03     7.50e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   9.81e-02     1.91e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   3.44e-01     4.20e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   6.88e-01     7.07e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.51e+01     1.33e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.91e-03     2.32e-08    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   1.56e-02     5.89e-07    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.23e-02     8.21e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.83e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   3.91e-03     9.98e-05    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   3.91e-03     8.63e-04    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.55e-02     7.51e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   5.86e-03     4.22e-06    
+b11__gdn_gated_norm    1x494x4096             True     True     1.00e+00   2.34e-02     5.06e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.56e-02     6.51e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   6.25e-01     7.41e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   5.31e-01     7.55e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   6.25e-01     8.01e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.78e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.87e-01   5.16e-01     1.14e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.09e-01     1.28e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.56e-01     1.57e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.93e-01   3.75e-01     1.62e-02    
+h_layer_8              1x1x2560               True     False    4.39e-02   1.55e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    6.13e-04   1.35e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.78e-01   1.03e+01     3.31e-01    
+h_layer_31             1x1x2560               True     False    2.13e-01   4.80e+01     2.33e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.06e-06    
+b11__gdn_conv          1x1x8192               True     False    5.62e-01   1.83e+01     3.94e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.84e-01   8.52e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.17e-01   8.59e-01     5.63e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.77e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.77e-03     7.78e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.43e-01   4.39e-01     1.16e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.31e-01   9.65e-01     5.34e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.62e-01   3.44e-01     9.01e-03    
+h_layer_24             1x1x2560               True     False    4.07e-01   9.38e+00     3.63e-01    
+h_layer_25             1x1x2560               True     False    4.56e-01   8.56e+00     3.82e-01    
+h_layer_26             1x1x2560               True     False    4.75e-01   7.19e+00     4.17e-01    
+h_layer_27             1x1x2560               True     False    4.15e-01   8.31e+00     5.59e-01    
+h_layer_28             1x1x2560               True     False    4.67e-01   8.38e+00     6.21e-01    
+h_layer_29             1x1x2560               True     False    4.47e-01   1.29e+01     6.93e-01    
+h_layer_30             1x1x2560               True     False    3.82e-01   9.67e+00     8.46e-01    
+b12__post_input_norm   1x1x2560               True     False    3.24e-01   2.02e+01     1.04e+00    
+b12__q_proj            1x1x8192               True     False    5.90e-01   1.03e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    4.74e-01   6.50e+00     8.05e-01    
+b12__v_proj            1x1x1024               True     False    9.01e-01   1.11e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.49e-01   8.17e+00     1.00e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.95e-01   8.36e+00     1.07e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.88e-01   1.02e+01     9.82e-01    
+b12__mlp_gate          1x1x9216               True     False    8.11e-01   1.19e+01     9.39e-01    
+b12__mlp_up            1x1x9216               True     False    6.44e-01   6.88e+00     7.12e-01    
+b12__mlp_down          1x1x2560               True     False    4.14e-01   5.62e+00     7.63e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.88e-01   1.05e+00     2.11e-02    
+h_layer_8              1x1x2560               True     False    5.23e-02   1.56e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -2.52e-02  1.37e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.05e-01   1.15e+01     3.23e-01    
+h_layer_31             1x1x2560               True     False    2.35e-01   2.88e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.20e-06    
+b11__gdn_conv          1x1x8192               True     False    7.34e-01   4.09e+00     3.10e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.63e-01   7.68e-01     4.15e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.09e-01   8.96e-01     5.76e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     7.93e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.38e-03     4.83e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.36e-01   5.36e-01     1.53e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.49e-01   1.60e+00     8.09e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   9.53e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    4.43e-01   1.08e+01     3.39e-01    
+h_layer_25             1x1x2560               True     False    5.02e-01   9.50e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.30e-01   6.30e+00     3.78e-01    
+h_layer_27             1x1x2560               True     False    4.13e-01   8.44e+00     5.61e-01    
+h_layer_28             1x1x2560               True     False    4.72e-01   7.00e+00     6.22e-01    
+h_layer_29             1x1x2560               True     False    4.59e-01   9.62e+00     6.91e-01    
+h_layer_30             1x1x2560               True     False    3.75e-01   9.07e+00     8.34e-01    
+b12__post_input_norm   1x1x2560               True     False    3.24e-01   1.97e+01     1.03e+00    
+b12__q_proj            1x1x8192               True     False    6.18e-01   1.21e+01     1.37e+00    
+b12__k_proj            1x1x1024               True     False    4.32e-01   8.48e+00     8.16e-01    
+b12__v_proj            1x1x1024               True     False    8.93e-01   1.19e+01     1.08e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.35e-01   8.27e+00     1.00e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.66e-01   9.52e+00     1.09e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.08e-01   1.08e+01     9.76e-01    
+b12__mlp_gate          1x1x9216               True     False    8.71e-01   1.24e+01     7.51e-01    
+b12__mlp_up            1x1x9216               True     False    7.17e-01   7.27e+00     6.65e-01    
+b12__mlp_down          1x1x2560               True     False    4.45e-01   9.25e+00     7.57e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.98e-01   1.23e+00     2.09e-02    
+h_layer_8              1x1x2560               True     False    3.74e-02   1.64e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -5.19e-02  1.40e+01     1.86e-01    
+h_layer_23             1x1x2560               True     False    4.22e-01   9.19e+00     3.22e-01    
+h_layer_31             1x1x2560               True     False    3.79e-01   3.00e+01     2.07e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     7.37e-07    
+b11__gdn_conv          1x1x8192               True     False    7.39e-01   3.49e+00     2.57e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.81e-01   7.83e-01     4.06e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.90e-01   8.49e-01     5.81e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.16e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.64e-03     5.78e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.50e-01   5.16e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.41e-01   1.55e+00     8.01e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.54e-01   8.05e-01     1.04e-02    
+h_layer_24             1x1x2560               True     False    4.70e-01   7.62e+00     3.40e-01    
+h_layer_25             1x1x2560               True     False    5.35e-01   6.22e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.64e-01   6.86e+00     3.75e-01    
+h_layer_27             1x1x2560               True     False    4.93e-01   8.56e+00     4.98e-01    
+h_layer_28             1x1x2560               True     False    5.41e-01   7.14e+00     5.45e-01    
+h_layer_29             1x1x2560               True     False    5.37e-01   7.62e+00     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.14e-01   9.38e+00     7.86e-01    
+b12__post_input_norm   1x1x2560               True     False    3.46e-01   1.87e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    6.01e-01   1.25e+01     1.36e+00    
+b12__k_proj            1x1x1024               True     False    3.61e-01   6.55e+00     8.66e-01    
+b12__v_proj            1x1x1024               True     False    8.88e-01   1.12e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.15e-01   8.95e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.96e-01   8.33e+00     1.18e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.66e-01   1.01e+01     9.13e-01    
+b12__mlp_gate          1x1x9216               True     False    8.66e-01   1.27e+01     7.54e-01    
+b12__mlp_up            1x1x9216               True     False    7.38e-01   7.36e+00     6.11e-01    
+b12__mlp_down          1x1x2560               True     False    4.52e-01   2.95e+01     6.57e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    9.78e-01   1.64e-01     6.09e-03    
+h_layer_8              1x1x2560               True     False    5.02e-01   2.20e+00     1.05e-01    
+h_layer_16             1x1x2560               True     False    3.47e-01   2.93e+00     1.54e-01    
+h_layer_23             1x1x2560               True     False    6.82e-02   7.50e+00     4.64e-01    
+h_layer_31             1x1x2560               True     False    1.60e-01   6.28e+01     1.99e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   1.56e-02     7.50e-07    
+b11__gdn_conv          1x2x8192               True     False    9.38e-01   3.47e+00     1.79e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.44e-01   9.52e-01     3.60e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.93e-01   6.56e-01     3.34e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   3.91e-03     1.01e-03    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.53e-02     7.90e-04    
+b11__gdn_recur_out     1x2x32x128             True     False    6.58e-01   5.87e-01     1.26e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    9.34e-01   1.23e+00     4.76e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.50e-01   8.83e-01     7.36e-03    
+h_layer_24             1x1x2560               True     False    6.08e-02   1.16e+01     4.86e-01    
+h_layer_25             1x1x2560               True     False    4.30e-02   2.10e+01     5.88e-01    
+h_layer_26             1x1x2560               True     False    7.21e-02   9.86e+01     7.00e-01    
+h_layer_27             1x1x2560               True     False    1.80e-01   2.20e+01     5.35e-01    
+h_layer_28             1x1x2560               True     False    2.29e-01   2.37e+01     6.29e-01    
+h_layer_29             1x1x2560               True     False    3.24e-01   1.78e+01     6.90e-01    
+h_layer_30             1x1x2560               True     False    1.95e-01   2.75e+01     8.40e-01    
+b12__post_input_norm   1x2x2560               True     False    2.39e-01   2.46e+01     1.07e+00    
+b12__q_proj            1x2x8192               True     False    5.89e-01   1.16e+01     1.35e+00    
+b12__k_proj            1x2x1024               True     False    3.85e-01   6.99e+00     8.97e-01    
+b12__v_proj            1x2x1024               True     False    9.00e-01   1.16e+01     1.04e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.64e-01   8.67e+00     1.01e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.98e-01   8.05e+00     1.20e+00    
+b12__o_proj            1x2x2560               True     False    2.85e-01   5.83e+00     3.28e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.12e-01   1.96e+01     1.02e+00    
+b12__mlp_gate          1x2x9216               True     False    7.86e-01   1.25e+01     9.05e-01    
+b12__mlp_up            1x2x9216               True     False    6.01e-01   8.54e+00     8.09e-01    
+b12__mlp_down          1x2x2560               True     False    2.86e-01   3.23e+01     8.29e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.39e-01   1.05e+00     2.07e-02    
+h_layer_8              1x1x2560               True     False    3.74e-02   1.63e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -2.61e-02  1.43e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    3.81e-01   1.09e+01     3.31e-01    
+h_layer_31             1x1x2560               True     False    2.73e-01   2.27e+01     2.32e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   9.77e-04     9.46e-08    
+b11__gdn_conv          1x1x8192               True     False    5.76e-01   1.34e+01     3.76e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.90e-01   8.38e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   7.91e-01     5.72e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.31e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.59e-03     6.52e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.56e-01   5.40e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.27e-01   1.58e+00     6.81e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.53e-01   7.34e-01     1.06e-02    
+h_layer_24             1x1x2560               True     False    4.28e-01   8.25e+00     3.55e-01    
+h_layer_25             1x1x2560               True     False    4.81e-01   6.56e+00     3.72e-01    
+h_layer_26             1x1x2560               True     False    4.83e-01   6.76e+00     4.05e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   7.38e+00     5.51e-01    
+h_layer_28             1x1x2560               True     False    4.98e-01   8.25e+00     6.01e-01    
+h_layer_29             1x1x2560               True     False    4.77e-01   1.32e+01     6.88e-01    
+h_layer_30             1x1x2560               True     False    4.20e-01   9.34e+00     8.18e-01    
+b12__post_input_norm   1x1x2560               True     False    3.50e-01   1.82e+01     9.92e-01    
+b12__q_proj            1x1x8192               True     False    5.61e-01   1.17e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.48e-01   8.39e+00     8.58e-01    
+b12__v_proj            1x1x1024               True     False    8.88e-01   1.17e+01     1.12e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.35e-01   8.12e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    3.73e-01   9.25e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.43e-01   8.97e+00     9.34e-01    
+b12__mlp_gate          1x1x9216               True     False    8.53e-01   1.30e+01     7.86e-01    
+b12__mlp_up            1x1x9216               True     False    6.95e-01   7.21e+00     6.90e-01    
+b12__mlp_down          1x1x2560               True     False    4.31e-01   1.16e+01     7.10e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    6.85e-01   1.48e+00     2.33e-02    
+h_layer_8              1x1x2560               True     False    1.52e-02   1.63e+01     1.73e-01    
+h_layer_16             1x1x2560               True     False    -6.17e-02  1.41e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    2.57e-01   1.29e+01     3.69e-01    
+h_layer_31             1x1x2560               True     False    2.02e-01   2.78e+01     2.40e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   4.88e-04     1.91e-07    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     5.24e-06    
+b11__gdn_conv          1x1x8192               True     False    7.26e-01   3.70e+00     2.77e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.31e-01   7.01e-01     3.93e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.65e-01   8.20e-01     5.37e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.01e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.54e-03     1.18e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    6.23e-01   4.43e-01     1.45e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.15e-01   1.50e+00     7.96e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.40e-01   1.10e+00     1.05e-02    
+h_layer_24             1x1x2560               True     False    2.70e-01   1.28e+01     4.03e-01    
+h_layer_25             1x1x2560               True     False    3.12e-01   1.29e+01     4.20e-01    
+h_layer_26             1x1x2560               True     False    3.47e-01   6.37e+00     4.58e-01    
+h_layer_27             1x1x2560               True     False    3.41e-01   1.29e+01     5.51e-01    
+h_layer_28             1x1x2560               True     False    3.75e-01   9.19e+00     5.96e-01    
+h_layer_29             1x1x2560               True     False    3.69e-01   1.26e+01     6.96e-01    
+h_layer_30             1x1x2560               True     False    2.66e-01   8.54e+00     8.75e-01    
+b12__post_input_norm   1x1x2560               True     False    2.27e-01   1.89e+01     1.13e+00    
+b12__q_proj            1x1x8192               True     False    4.87e-01   1.46e+01     1.65e+00    
+b12__k_proj            1x1x1024               True     False    3.40e-01   6.15e+00     8.98e-01    
+b12__v_proj            1x1x1024               True     False    8.67e-01   1.32e+01     1.18e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.59e-01   9.50e+00     1.11e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.52e-01   8.25e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.09e-01   9.51e+00     1.07e+00    
+b12__mlp_gate          1x1x9216               True     False    7.80e-01   1.24e+01     9.12e-01    
+b12__mlp_up            1x1x9216               True     False    6.62e-01   6.98e+00     6.64e-01    
+b12__mlp_down          1x1x2560               True     False    1.77e-01   2.64e+01     7.58e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.85e-01   max|Δ|=6.25e-01   DIV   cos=4.07e-01   max|Δ|=9.38e+00   DIV   cos=4.43e-01   max|Δ|=1.08e+01   DIV   cos=4.70e-01   max|Δ|=7.62e+00   DIV   cos=6.08e-02   max|Δ|=1.16e+01   DIV   cos=4.28e-01   max|Δ|=8.25e+00   DIV   cos=2.70e-01   max|Δ|=1.28e+01   DIV  
+  h_layer_25            cos=9.86e-01   max|Δ|=5.31e-01   DIV   cos=4.56e-01   max|Δ|=8.56e+00   DIV   cos=5.02e-01   max|Δ|=9.50e+00   DIV   cos=5.35e-01   max|Δ|=6.22e+00   DIV   cos=4.30e-02   max|Δ|=2.10e+01   DIV   cos=4.81e-01   max|Δ|=6.56e+00   DIV   cos=3.12e-01   max|Δ|=1.29e+01   DIV  
+  h_layer_26            cos=9.86e-01   max|Δ|=6.25e-01   DIV   cos=4.75e-01   max|Δ|=7.19e+00   DIV   cos=4.30e-01   max|Δ|=6.30e+00   DIV   cos=4.64e-01   max|Δ|=6.86e+00   DIV   cos=7.21e-02   max|Δ|=9.86e+01   DIV   cos=4.83e-01   max|Δ|=6.76e+00   DIV   cos=3.47e-01   max|Δ|=6.37e+00   DIV  
+  h_layer_27            cos=9.87e-01   max|Δ|=5.78e-01   DIV   cos=4.15e-01   max|Δ|=8.31e+00   DIV   cos=4.13e-01   max|Δ|=8.44e+00   DIV   cos=4.93e-01   max|Δ|=8.56e+00   DIV   cos=1.80e-01   max|Δ|=2.20e+01   DIV   cos=4.48e-01   max|Δ|=7.38e+00   DIV   cos=3.41e-01   max|Δ|=1.29e+01   DIV  
+  h_layer_28            cos=9.87e-01   max|Δ|=5.16e-01   DIV   cos=4.67e-01   max|Δ|=8.38e+00   DIV   cos=4.72e-01   max|Δ|=7.00e+00   DIV   cos=5.41e-01   max|Δ|=7.14e+00   DIV   cos=2.29e-01   max|Δ|=2.37e+01   DIV   cos=4.98e-01   max|Δ|=8.25e+00   DIV   cos=3.75e-01   max|Δ|=9.19e+00   DIV  
+  h_layer_29            cos=9.86e-01   max|Δ|=6.09e-01   DIV   cos=4.47e-01   max|Δ|=1.29e+01   DIV   cos=4.59e-01   max|Δ|=9.62e+00   DIV   cos=5.37e-01   max|Δ|=7.62e+00   DIV   cos=3.24e-01   max|Δ|=1.78e+01   DIV   cos=4.77e-01   max|Δ|=1.32e+01   DIV   cos=3.69e-01   max|Δ|=1.26e+01   DIV  
+  h_layer_30            cos=9.82e-01   max|Δ|=6.56e-01   DIV   cos=3.82e-01   max|Δ|=9.67e+00   DIV   cos=3.75e-01   max|Δ|=9.07e+00   DIV   cos=4.14e-01   max|Δ|=9.38e+00   DIV   cos=1.95e-01   max|Δ|=2.75e+01   DIV   cos=4.20e-01   max|Δ|=9.34e+00   DIV   cos=2.66e-01   max|Δ|=8.54e+00   DIV  
+  h_layer_31            cos=9.59e-01   max|Δ|=2.51e+01   DIV   cos=2.13e-01   max|Δ|=4.80e+01   DIV   cos=2.35e-01   max|Δ|=2.88e+01   DIV   cos=3.79e-01   max|Δ|=3.00e+01   DIV   cos=1.60e-01   max|Δ|=6.28e+01   DIV   cos=2.73e-01   max|Δ|=2.27e+01   DIV   cos=2.02e-01   max|Δ|=2.78e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=4.28e-01     DIV
+    h_layer_25             median=4.81e-01     DIV
+    h_layer_26             median=4.64e-01     DIV
+    h_layer_27             median=4.15e-01     DIV
+    h_layer_28             median=4.72e-01     DIV
+    h_layer_29             median=4.59e-01     DIV
+    h_layer_30             median=3.82e-01     DIV
+    h_layer_31             median=2.35e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=3.24e-01   max|Δ|=2.02e+01   mean|Δ|=1.04e+00   rel_l2=1.13e+00   DIV cos=3.24e-01   max|Δ|=1.97e+01   mean|Δ|=1.03e+00   rel_l2=1.13e+00   DIV cos=3.46e-01   max|Δ|=1.87e+01   mean|Δ|=1.00e+00   rel_l2=1.12e+00   DIV cos=2.39e-01   max|Δ|=2.46e+01   mean|Δ|=1.07e+00   rel_l2=1.23e+00   DIV cos=3.50e-01   max|Δ|=1.82e+01   mean|Δ|=9.92e-01   rel_l2=1.11e+00   DIV cos=2.27e-01   max|Δ|=1.89e+01   mean|Δ|=1.13e+00   rel_l2=1.21e+00   DIV
+  q_proj              <missing>                                            cos=5.90e-01   max|Δ|=1.03e+01   mean|Δ|=1.54e+00   rel_l2=8.22e-01   DIV cos=6.18e-01   max|Δ|=1.21e+01   mean|Δ|=1.37e+00   rel_l2=8.05e-01   DIV cos=6.01e-01   max|Δ|=1.25e+01   mean|Δ|=1.36e+00   rel_l2=8.27e-01   DIV cos=5.89e-01   max|Δ|=1.16e+01   mean|Δ|=1.35e+00   rel_l2=8.37e-01   DIV cos=5.61e-01   max|Δ|=1.17e+01   mean|Δ|=1.52e+00   rel_l2=8.49e-01   DIV cos=4.87e-01   max|Δ|=1.46e+01   mean|Δ|=1.65e+00   rel_l2=9.05e-01   DIV
+  k_proj              <missing>                                            cos=4.74e-01   max|Δ|=6.50e+00   mean|Δ|=8.05e-01   rel_l2=9.34e-01   DIV cos=4.32e-01   max|Δ|=8.48e+00   mean|Δ|=8.16e-01   rel_l2=9.70e-01   DIV cos=3.61e-01   max|Δ|=6.55e+00   mean|Δ|=8.66e-01   rel_l2=1.04e+00   DIV cos=3.85e-01   max|Δ|=6.99e+00   mean|Δ|=8.97e-01   rel_l2=1.00e+00   DIV cos=3.48e-01   max|Δ|=8.39e+00   mean|Δ|=8.58e-01   rel_l2=1.00e+00   DIV cos=3.40e-01   max|Δ|=6.15e+00   mean|Δ|=8.98e-01   rel_l2=1.01e+00   DIV
+  v_proj              <missing>                                            cos=9.01e-01   max|Δ|=1.11e+01   mean|Δ|=1.07e+00   rel_l2=4.35e-01   DIV cos=8.93e-01   max|Δ|=1.19e+01   mean|Δ|=1.08e+00   rel_l2=4.52e-01   DIV cos=8.88e-01   max|Δ|=1.12e+01   mean|Δ|=1.03e+00   rel_l2=4.64e-01   DIV cos=9.00e-01   max|Δ|=1.16e+01   mean|Δ|=1.04e+00   rel_l2=4.35e-01   DIV cos=8.88e-01   max|Δ|=1.17e+01   mean|Δ|=1.12e+00   rel_l2=4.61e-01   DIV cos=8.67e-01   max|Δ|=1.32e+01   mean|Δ|=1.18e+00   rel_l2=4.99e-01   DIV
+  qk_norm_q           <missing>                                            cos=4.49e-01   max|Δ|=8.17e+00   mean|Δ|=1.00e+00   rel_l2=1.02e+00   DIV cos=4.35e-01   max|Δ|=8.27e+00   mean|Δ|=1.00e+00   rel_l2=1.03e+00   DIV cos=4.15e-01   max|Δ|=8.95e+00   mean|Δ|=1.04e+00   rel_l2=1.06e+00   DIV cos=4.64e-01   max|Δ|=8.67e+00   mean|Δ|=1.01e+00   rel_l2=1.05e+00   DIV cos=4.35e-01   max|Δ|=8.12e+00   mean|Δ|=9.94e-01   rel_l2=1.03e+00   DIV cos=3.59e-01   max|Δ|=9.50e+00   mean|Δ|=1.11e+00   rel_l2=1.13e+00   DIV
+  qk_norm_k           <missing>                                            cos=4.95e-01   max|Δ|=8.36e+00   mean|Δ|=1.07e+00   rel_l2=9.98e-01   DIV cos=4.66e-01   max|Δ|=9.52e+00   mean|Δ|=1.09e+00   rel_l2=1.03e+00   DIV cos=3.96e-01   max|Δ|=8.33e+00   mean|Δ|=1.18e+00   rel_l2=1.09e+00   DIV cos=3.98e-01   max|Δ|=8.05e+00   mean|Δ|=1.20e+00   rel_l2=1.10e+00   DIV cos=3.73e-01   max|Δ|=9.25e+00   mean|Δ|=1.19e+00   rel_l2=1.12e+00   DIV cos=3.52e-01   max|Δ|=8.25e+00   mean|Δ|=1.21e+00   rel_l2=1.14e+00   DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=2.85e-01   max|Δ|=5.83e+00   mean|Δ|=3.28e-01   rel_l2=1.40e+00   DIV <missing>                                            <missing>                                           
+  post_attn_norm      <missing>                                            cos=3.88e-01   max|Δ|=1.02e+01   mean|Δ|=9.82e-01   rel_l2=1.11e+00   DIV cos=4.08e-01   max|Δ|=1.08e+01   mean|Δ|=9.76e-01   rel_l2=1.11e+00   DIV cos=4.66e-01   max|Δ|=1.01e+01   mean|Δ|=9.13e-01   rel_l2=1.05e+00   DIV cos=3.12e-01   max|Δ|=1.96e+01   mean|Δ|=1.02e+00   rel_l2=1.21e+00   DIV cos=4.43e-01   max|Δ|=8.97e+00   mean|Δ|=9.34e-01   rel_l2=1.06e+00   DIV cos=3.09e-01   max|Δ|=9.51e+00   mean|Δ|=1.07e+00   rel_l2=1.19e+00   DIV
+  mlp_gate            <missing>                                            cos=8.11e-01   max|Δ|=1.19e+01   mean|Δ|=9.39e-01   rel_l2=8.22e-01   DIV cos=8.71e-01   max|Δ|=1.24e+01   mean|Δ|=7.51e-01   rel_l2=6.48e-01   DIV cos=8.66e-01   max|Δ|=1.27e+01   mean|Δ|=7.54e-01   rel_l2=6.57e-01   DIV cos=7.86e-01   max|Δ|=1.25e+01   mean|Δ|=9.05e-01   rel_l2=7.64e-01   DIV cos=8.53e-01   max|Δ|=1.30e+01   mean|Δ|=7.86e-01   rel_l2=7.11e-01   DIV cos=7.80e-01   max|Δ|=1.24e+01   mean|Δ|=9.12e-01   rel_l2=8.05e-01   DIV
+  mlp_up              <missing>                                            cos=6.44e-01   max|Δ|=6.88e+00   mean|Δ|=7.12e-01   rel_l2=1.06e+00   DIV cos=7.17e-01   max|Δ|=7.27e+00   mean|Δ|=6.65e-01   rel_l2=9.18e-01   DIV cos=7.38e-01   max|Δ|=7.36e+00   mean|Δ|=6.11e-01   rel_l2=8.82e-01   DIV cos=6.01e-01   max|Δ|=8.54e+00   mean|Δ|=8.09e-01   rel_l2=1.17e+00   DIV cos=6.95e-01   max|Δ|=7.21e+00   mean|Δ|=6.90e-01   rel_l2=1.10e+00   DIV cos=6.62e-01   max|Δ|=6.98e+00   mean|Δ|=6.64e-01   rel_l2=9.20e-01   DIV
+  mlp_down            <missing>                                            cos=4.14e-01   max|Δ|=5.62e+00   mean|Δ|=7.63e-01   rel_l2=1.15e+00   DIV cos=4.45e-01   max|Δ|=9.25e+00   mean|Δ|=7.57e-01   rel_l2=9.94e-01   DIV cos=4.52e-01   max|Δ|=2.95e+01   mean|Δ|=6.57e-01   rel_l2=9.40e-01   DIV cos=2.86e-01   max|Δ|=3.23e+01   mean|Δ|=8.29e-01   rel_l2=1.04e+00   DIV cos=4.31e-01   max|Δ|=1.16e+01   mean|Δ|=7.10e-01   rel_l2=1.15e+00   DIV cos=1.77e-01   max|Δ|=2.64e+01   mean|Δ|=7.58e-01   rel_l2=1.35e+00   DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=3.24e-01     DIV
+    q_proj               median=5.89e-01     DIV
+    k_proj               median=3.73e-01     DIV
+    v_proj               median=8.91e-01     DIV
+    qk_norm_q            median=4.35e-01     DIV
+    qk_norm_k            median=3.97e-01     DIV
+    o_proj               median=2.85e-01     DIV
+    post_attn_norm       median=3.98e-01     DIV
+    mlp_gate             median=8.32e-01     DIV
+    mlp_up               median=6.78e-01     DIV
+    mlp_down             median=4.22e-01     DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.428088)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/profiling-artifacts/post422_20260423_seed0_compare_fp32.txt
+++ b/profiling-artifacts/post422_20260423_seed0_compare_fp32.txt
@@ -1,0 +1,1312 @@
+# seed 0 compare vs fp32 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.28e-02     7.47e-04    
+h_layer_8              1x1x2560               True     False    9.79e-01   9.85e-02     1.93e-02    
+h_layer_16             1x1x2560               True     False    9.65e-01   3.73e-01     4.28e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   6.05e-01     7.15e-02    
+h_layer_31             1x1x2560               True     False    9.58e-01   2.52e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.00e-02     1.28e-03    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   6.66e-02     1.77e-03    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.20e-02     7.08e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.84e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   5.43e-03     1.33e-04    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   5.17e-03     1.17e-03    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.73e-02     8.34e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   5.50e-03     3.71e-06    
+b11__gdn_gated_norm    1x494x4096             True     False    1.00e+00   1.93e-02     5.08e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.20e-02     6.04e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   5.23e-01     7.52e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   5.11e-01     7.66e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   7.83e-01     8.17e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   5.50e-01     9.89e-02    
+h_layer_28             1x1x2560               True     False    9.86e-01   4.96e-01     1.16e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.28e-01     1.30e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.86e-01     1.59e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.93e-01   3.75e-01     1.62e-02    
+h_layer_8              1x1x2560               True     False    4.37e-02   1.56e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    6.65e-04   1.35e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.78e-01   1.03e+01     3.30e-01    
+h_layer_31             1x1x2560               True     False    2.12e-01   4.78e+01     2.33e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   7.90e-03     1.28e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.44e-02     1.78e-03    
+b11__gdn_conv          1x1x8192               True     False    5.62e-01   1.83e+01     3.94e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.84e-01   8.52e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.17e-01   8.59e-01     5.62e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   5.06e-03     1.38e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.30e-03     9.43e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.44e-01   4.39e-01     1.16e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.31e-01   9.58e-01     5.33e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.62e-01   3.42e-01     8.98e-03    
+h_layer_24             1x1x2560               True     False    4.06e-01   9.39e+00     3.63e-01    
+h_layer_25             1x1x2560               True     False    4.55e-01   8.64e+00     3.82e-01    
+h_layer_26             1x1x2560               True     False    4.75e-01   7.16e+00     4.17e-01    
+h_layer_27             1x1x2560               True     False    4.14e-01   8.40e+00     5.59e-01    
+h_layer_28             1x1x2560               True     False    4.65e-01   8.49e+00     6.21e-01    
+h_layer_29             1x1x2560               True     False    4.45e-01   1.31e+01     6.93e-01    
+h_layer_30             1x1x2560               True     False    3.82e-01   9.63e+00     8.45e-01    
+b12__post_input_norm   1x1x2560               True     False    3.24e-01   2.02e+01     1.04e+00    
+b12__q_proj            1x1x8192               True     False    5.89e-01   1.03e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    4.74e-01   6.51e+00     8.05e-01    
+b12__v_proj            1x1x1024               True     False    9.01e-01   1.11e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.49e-01   8.16e+00     1.00e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.95e-01   8.37e+00     1.07e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.87e-01   1.02e+01     9.83e-01    
+b12__mlp_gate          1x1x9216               True     False    8.10e-01   1.19e+01     9.42e-01    
+b12__mlp_up            1x1x9216               True     False    6.44e-01   6.88e+00     7.13e-01    
+b12__mlp_down          1x1x2560               True     False    4.11e-01   5.60e+00     7.64e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.88e-01   1.05e+00     2.12e-02    
+h_layer_8              1x1x2560               True     False    5.24e-02   1.57e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -2.43e-02  1.38e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.03e-01   1.15e+01     3.23e-01    
+h_layer_31             1x1x2560               True     False    2.34e-01   2.87e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.34e-02     1.29e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   2.12e-02     1.56e-03    
+b11__gdn_conv          1x1x8192               True     False    7.33e-01   4.11e+00     3.10e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.63e-01   7.68e-01     4.15e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.09e-01   8.96e-01     5.76e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.16e-03     1.14e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   2.65e-03     4.90e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.38e-01   5.36e-01     1.53e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.47e-01   1.60e+00     8.09e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   9.49e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    4.41e-01   1.09e+01     3.39e-01    
+h_layer_25             1x1x2560               True     False    5.00e-01   9.60e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.28e-01   6.23e+00     3.79e-01    
+h_layer_27             1x1x2560               True     False    4.11e-01   8.55e+00     5.61e-01    
+h_layer_28             1x1x2560               True     False    4.70e-01   7.16e+00     6.22e-01    
+h_layer_29             1x1x2560               True     False    4.57e-01   9.86e+00     6.91e-01    
+h_layer_30             1x1x2560               True     False    3.74e-01   9.07e+00     8.35e-01    
+b12__post_input_norm   1x1x2560               True     False    3.23e-01   1.99e+01     1.03e+00    
+b12__q_proj            1x1x8192               True     False    6.17e-01   1.21e+01     1.37e+00    
+b12__k_proj            1x1x1024               True     False    4.30e-01   8.48e+00     8.15e-01    
+b12__v_proj            1x1x1024               True     False    8.93e-01   1.20e+01     1.08e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.34e-01   8.27e+00     1.01e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.65e-01   9.51e+00     1.10e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.07e-01   1.08e+01     9.77e-01    
+b12__mlp_gate          1x1x9216               True     False    8.70e-01   1.24e+01     7.52e-01    
+b12__mlp_up            1x1x9216               True     False    7.19e-01   7.29e+00     6.64e-01    
+b12__mlp_down          1x1x2560               True     False    4.43e-01   9.13e+00     7.57e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.98e-01   1.23e+00     2.09e-02    
+h_layer_8              1x1x2560               True     False    3.73e-02   1.66e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -5.10e-02  1.42e+01     1.87e-01    
+h_layer_23             1x1x2560               True     False    4.20e-01   9.33e+00     3.22e-01    
+h_layer_31             1x1x2560               True     False    3.79e-01   2.98e+01     2.07e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.53e-02     1.28e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.51e-02     1.56e-03    
+b11__gdn_conv          1x1x8192               True     False    7.39e-01   3.49e+00     2.57e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.81e-01   7.84e-01     4.06e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.90e-01   8.45e-01     5.81e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.52e-03     1.23e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.83e-03     6.27e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.51e-01   5.16e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.41e-01   1.55e+00     8.00e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.54e-01   8.01e-01     1.04e-02    
+h_layer_24             1x1x2560               True     False    4.69e-01   7.77e+00     3.39e-01    
+h_layer_25             1x1x2560               True     False    5.34e-01   6.17e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.64e-01   6.80e+00     3.74e-01    
+h_layer_27             1x1x2560               True     False    4.93e-01   8.63e+00     4.97e-01    
+h_layer_28             1x1x2560               True     False    5.42e-01   7.08e+00     5.45e-01    
+h_layer_29             1x1x2560               True     False    5.37e-01   7.80e+00     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.14e-01   9.20e+00     7.85e-01    
+b12__post_input_norm   1x1x2560               True     False    3.46e-01   1.90e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    6.01e-01   1.26e+01     1.36e+00    
+b12__k_proj            1x1x1024               True     False    3.61e-01   6.54e+00     8.66e-01    
+b12__v_proj            1x1x1024               True     False    8.87e-01   1.12e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.14e-01   9.01e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.96e-01   8.34e+00     1.18e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.66e-01   1.01e+01     9.13e-01    
+b12__mlp_gate          1x1x9216               True     False    8.66e-01   1.27e+01     7.54e-01    
+b12__mlp_up            1x1x9216               True     False    7.39e-01   7.33e+00     6.11e-01    
+b12__mlp_down          1x1x2560               True     False    4.51e-01   2.94e+01     6.55e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    9.79e-01   1.64e-01     6.06e-03    
+h_layer_8              1x1x2560               True     False    5.02e-01   2.21e+00     1.06e-01    
+h_layer_16             1x1x2560               True     False    3.45e-01   2.91e+00     1.54e-01    
+h_layer_23             1x1x2560               True     False    6.91e-02   7.51e+00     4.63e-01    
+h_layer_31             1x1x2560               True     False    1.59e-01   6.28e+01     1.99e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   2.63e-02     1.26e-03    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   6.66e-02     1.98e-03    
+b11__gdn_conv          1x2x8192               True     False    9.38e-01   3.49e+00     1.79e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.44e-01   9.51e-01     3.60e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.93e-01   6.57e-01     3.34e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   4.67e-03     1.28e-03    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.37e-02     8.23e-04    
+b11__gdn_recur_out     1x2x32x128             True     False    6.58e-01   5.86e-01     1.26e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    9.34e-01   1.24e+00     4.76e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.50e-01   8.85e-01     7.36e-03    
+h_layer_24             1x1x2560               True     False    6.15e-02   1.15e+01     4.85e-01    
+h_layer_25             1x1x2560               True     False    4.36e-02   2.09e+01     5.84e-01    
+h_layer_26             1x1x2560               True     False    7.22e-02   9.76e+01     6.95e-01    
+h_layer_27             1x1x2560               True     False    1.80e-01   2.16e+01     5.35e-01    
+h_layer_28             1x1x2560               True     False    2.28e-01   2.34e+01     6.29e-01    
+h_layer_29             1x1x2560               True     False    3.23e-01   1.75e+01     6.90e-01    
+h_layer_30             1x1x2560               True     False    1.95e-01   2.74e+01     8.41e-01    
+b12__post_input_norm   1x2x2560               True     False    2.38e-01   2.44e+01     1.07e+00    
+b12__q_proj            1x2x8192               True     False    5.89e-01   1.17e+01     1.35e+00    
+b12__k_proj            1x2x1024               True     False    3.85e-01   7.02e+00     8.97e-01    
+b12__v_proj            1x2x1024               True     False    9.00e-01   1.16e+01     1.04e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.64e-01   8.64e+00     1.01e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.98e-01   8.03e+00     1.20e+00    
+b12__o_proj            1x2x2560               True     False    2.85e-01   5.83e+00     3.28e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.11e-01   1.96e+01     1.02e+00    
+b12__mlp_gate          1x2x9216               True     False    7.86e-01   1.25e+01     9.06e-01    
+b12__mlp_up            1x2x9216               True     False    6.01e-01   8.52e+00     8.09e-01    
+b12__mlp_down          1x2x2560               True     False    2.84e-01   3.21e+01     8.29e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.41e-01   1.03e+00     2.07e-02    
+h_layer_8              1x1x2560               True     False    3.71e-02   1.64e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -2.62e-02  1.44e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    3.77e-01   1.10e+01     3.31e-01    
+h_layer_31             1x1x2560               True     False    2.74e-01   2.28e+01     2.32e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.74e-02     1.30e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.17e-02     1.64e-03    
+b11__gdn_conv          1x1x8192               True     False    5.76e-01   1.34e+01     3.76e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.90e-01   8.40e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   7.91e-01     5.72e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   5.17e-03     1.37e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   8.53e-03     7.45e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.57e-01   5.40e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.26e-01   1.58e+00     6.81e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.53e-01   7.27e-01     1.06e-02    
+h_layer_24             1x1x2560               True     False    4.26e-01   8.34e+00     3.55e-01    
+h_layer_25             1x1x2560               True     False    4.80e-01   6.62e+00     3.72e-01    
+h_layer_26             1x1x2560               True     False    4.83e-01   6.73e+00     4.05e-01    
+h_layer_27             1x1x2560               True     False    4.47e-01   7.36e+00     5.51e-01    
+h_layer_28             1x1x2560               True     False    5.00e-01   8.09e+00     6.01e-01    
+h_layer_29             1x1x2560               True     False    4.79e-01   1.31e+01     6.88e-01    
+h_layer_30             1x1x2560               True     False    4.21e-01   9.29e+00     8.18e-01    
+b12__post_input_norm   1x1x2560               True     False    3.51e-01   1.81e+01     9.91e-01    
+b12__q_proj            1x1x8192               True     False    5.62e-01   1.17e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.48e-01   8.36e+00     8.57e-01    
+b12__v_proj            1x1x1024               True     False    8.88e-01   1.17e+01     1.12e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.36e-01   8.09e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    3.72e-01   9.26e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.44e-01   8.91e+00     9.32e-01    
+b12__mlp_gate          1x1x9216               True     False    8.53e-01   1.29e+01     7.86e-01    
+b12__mlp_up            1x1x9216               True     False    6.94e-01   7.18e+00     6.91e-01    
+b12__mlp_down          1x1x2560               True     False    4.32e-01   1.17e+01     7.09e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    6.85e-01   1.49e+00     2.32e-02    
+h_layer_8              1x1x2560               True     False    1.50e-02   1.61e+01     1.74e-01    
+h_layer_16             1x1x2560               True     False    -6.40e-02  1.39e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    2.58e-01   1.28e+01     3.69e-01    
+h_layer_31             1x1x2560               True     False    2.04e-01   2.79e+01     2.39e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   8.93e-03     1.27e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.45e-02     1.56e-03    
+b11__gdn_conv          1x1x8192               True     False    7.27e-01   3.69e+00     2.77e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.31e-01   6.99e-01     3.93e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.65e-01   8.17e-01     5.37e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.50e-03     1.39e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   8.07e-03     1.23e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    6.22e-01   4.43e-01     1.45e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.16e-01   1.50e+00     7.96e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.40e-01   1.10e+00     1.05e-02    
+h_layer_24             1x1x2560               True     False    2.73e-01   1.27e+01     4.03e-01    
+h_layer_25             1x1x2560               True     False    3.17e-01   1.27e+01     4.19e-01    
+h_layer_26             1x1x2560               True     False    3.49e-01   6.47e+00     4.57e-01    
+h_layer_27             1x1x2560               True     False    3.45e-01   1.27e+01     5.51e-01    
+h_layer_28             1x1x2560               True     False    3.79e-01   8.89e+00     5.95e-01    
+h_layer_29             1x1x2560               True     False    3.73e-01   1.23e+01     6.95e-01    
+h_layer_30             1x1x2560               True     False    2.68e-01   8.59e+00     8.75e-01    
+b12__post_input_norm   1x1x2560               True     False    2.28e-01   1.89e+01     1.13e+00    
+b12__q_proj            1x1x8192               True     False    4.87e-01   1.45e+01     1.65e+00    
+b12__k_proj            1x1x1024               True     False    3.40e-01   6.16e+00     8.99e-01    
+b12__v_proj            1x1x1024               True     False    8.68e-01   1.32e+01     1.18e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.61e-01   9.48e+00     1.11e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.52e-01   8.28e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.12e-01   9.53e+00     1.07e+00    
+b12__mlp_gate          1x1x9216               True     False    7.80e-01   1.24e+01     9.11e-01    
+b12__mlp_up            1x1x9216               True     False    6.63e-01   6.97e+00     6.63e-01    
+b12__mlp_down          1x1x2560               True     False    1.79e-01   2.68e+01     7.58e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=1.28e-02   ok    cos=8.93e-01   max|Δ|=3.75e-01   DIV   cos=7.88e-01   max|Δ|=1.05e+00   DIV   cos=7.98e-01   max|Δ|=1.23e+00   DIV   cos=9.79e-01   max|Δ|=1.64e-01   DIV   cos=8.41e-01   max|Δ|=1.03e+00   DIV   cos=6.85e-01   max|Δ|=1.49e+00   DIV  
+  h_layer_8             cos=9.79e-01   max|Δ|=9.85e-02   DIV   cos=4.37e-02   max|Δ|=1.56e+01   DIV   cos=5.24e-02   max|Δ|=1.57e+01   DIV   cos=3.73e-02   max|Δ|=1.66e+01   DIV   cos=5.02e-01   max|Δ|=2.21e+00   DIV   cos=3.71e-02   max|Δ|=1.64e+01   DIV   cos=1.50e-02   max|Δ|=1.61e+01   DIV  
+  h_layer_16            cos=9.65e-01   max|Δ|=3.73e-01   DIV   cos=6.65e-04   max|Δ|=1.35e+01   DIV   cos=-2.43e-02  max|Δ|=1.38e+01   DIV   cos=-5.10e-02  max|Δ|=1.42e+01   DIV   cos=3.45e-01   max|Δ|=2.91e+00   DIV   cos=-2.62e-02  max|Δ|=1.44e+01   DIV   cos=-6.40e-02  max|Δ|=1.39e+01   DIV  
+  h_layer_23            cos=9.83e-01   max|Δ|=6.05e-01   DIV   cos=3.78e-01   max|Δ|=1.03e+01   DIV   cos=4.03e-01   max|Δ|=1.15e+01   DIV   cos=4.20e-01   max|Δ|=9.33e+00   DIV   cos=6.91e-02   max|Δ|=7.51e+00   DIV   cos=3.77e-01   max|Δ|=1.10e+01   DIV   cos=2.58e-01   max|Δ|=1.28e+01   DIV  
+  h_layer_31            cos=9.58e-01   max|Δ|=2.52e+01   DIV   cos=2.12e-01   max|Δ|=4.78e+01   DIV   cos=2.34e-01   max|Δ|=2.87e+01   DIV   cos=3.79e-01   max|Δ|=2.98e+01   DIV   cos=1.59e-01   max|Δ|=6.28e+01   DIV   cos=2.74e-01   max|Δ|=2.28e+01   DIV   cos=2.04e-01   max|Δ|=2.79e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_0' (pos=0_s1)
+Phase B10 verdict: DIVERGENCE AT LAYER 0
+  -> Input-path bug: embedding lookup, rotary_inv_freq build, first
+     block's Q/K/V proj or GDN sub-op, OR prompt-token construction
+     mismatch between kiln and reference. Verify `prompt_tokens` meta
+     matches exactly, then narrow to layer 0's sub-ops.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.28e-02     7.47e-04    
+h_layer_8              1x1x2560               True     False    9.79e-01   9.85e-02     1.93e-02    
+h_layer_16             1x1x2560               True     False    9.65e-01   3.73e-01     4.28e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   6.05e-01     7.15e-02    
+h_layer_31             1x1x2560               True     False    9.58e-01   2.52e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.00e-02     1.28e-03    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   6.66e-02     1.77e-03    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.20e-02     7.08e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.84e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   5.43e-03     1.33e-04    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   5.17e-03     1.17e-03    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.73e-02     8.34e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   5.50e-03     3.71e-06    
+b11__gdn_gated_norm    1x494x4096             True     False    1.00e+00   1.93e-02     5.08e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.20e-02     6.04e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   5.23e-01     7.52e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   5.11e-01     7.66e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   7.83e-01     8.17e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   5.50e-01     9.89e-02    
+h_layer_28             1x1x2560               True     False    9.86e-01   4.96e-01     1.16e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.28e-01     1.30e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.86e-01     1.59e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.93e-01   3.75e-01     1.62e-02    
+h_layer_8              1x1x2560               True     False    4.37e-02   1.56e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    6.65e-04   1.35e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.78e-01   1.03e+01     3.30e-01    
+h_layer_31             1x1x2560               True     False    2.12e-01   4.78e+01     2.33e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   7.90e-03     1.28e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.44e-02     1.78e-03    
+b11__gdn_conv          1x1x8192               True     False    5.62e-01   1.83e+01     3.94e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.84e-01   8.52e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.17e-01   8.59e-01     5.62e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   5.06e-03     1.38e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.30e-03     9.43e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.44e-01   4.39e-01     1.16e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.31e-01   9.58e-01     5.33e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.62e-01   3.42e-01     8.98e-03    
+h_layer_24             1x1x2560               True     False    4.06e-01   9.39e+00     3.63e-01    
+h_layer_25             1x1x2560               True     False    4.55e-01   8.64e+00     3.82e-01    
+h_layer_26             1x1x2560               True     False    4.75e-01   7.16e+00     4.17e-01    
+h_layer_27             1x1x2560               True     False    4.14e-01   8.40e+00     5.59e-01    
+h_layer_28             1x1x2560               True     False    4.65e-01   8.49e+00     6.21e-01    
+h_layer_29             1x1x2560               True     False    4.45e-01   1.31e+01     6.93e-01    
+h_layer_30             1x1x2560               True     False    3.82e-01   9.63e+00     8.45e-01    
+b12__post_input_norm   1x1x2560               True     False    3.24e-01   2.02e+01     1.04e+00    
+b12__q_proj            1x1x8192               True     False    5.89e-01   1.03e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    4.74e-01   6.51e+00     8.05e-01    
+b12__v_proj            1x1x1024               True     False    9.01e-01   1.11e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.49e-01   8.16e+00     1.00e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.95e-01   8.37e+00     1.07e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.87e-01   1.02e+01     9.83e-01    
+b12__mlp_gate          1x1x9216               True     False    8.10e-01   1.19e+01     9.42e-01    
+b12__mlp_up            1x1x9216               True     False    6.44e-01   6.88e+00     7.13e-01    
+b12__mlp_down          1x1x2560               True     False    4.11e-01   5.60e+00     7.64e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.88e-01   1.05e+00     2.12e-02    
+h_layer_8              1x1x2560               True     False    5.24e-02   1.57e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -2.43e-02  1.38e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.03e-01   1.15e+01     3.23e-01    
+h_layer_31             1x1x2560               True     False    2.34e-01   2.87e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.34e-02     1.29e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   2.12e-02     1.56e-03    
+b11__gdn_conv          1x1x8192               True     False    7.33e-01   4.11e+00     3.10e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.63e-01   7.68e-01     4.15e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.09e-01   8.96e-01     5.76e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.16e-03     1.14e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   2.65e-03     4.90e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.38e-01   5.36e-01     1.53e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.47e-01   1.60e+00     8.09e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   9.49e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    4.41e-01   1.09e+01     3.39e-01    
+h_layer_25             1x1x2560               True     False    5.00e-01   9.60e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.28e-01   6.23e+00     3.79e-01    
+h_layer_27             1x1x2560               True     False    4.11e-01   8.55e+00     5.61e-01    
+h_layer_28             1x1x2560               True     False    4.70e-01   7.16e+00     6.22e-01    
+h_layer_29             1x1x2560               True     False    4.57e-01   9.86e+00     6.91e-01    
+h_layer_30             1x1x2560               True     False    3.74e-01   9.07e+00     8.35e-01    
+b12__post_input_norm   1x1x2560               True     False    3.23e-01   1.99e+01     1.03e+00    
+b12__q_proj            1x1x8192               True     False    6.17e-01   1.21e+01     1.37e+00    
+b12__k_proj            1x1x1024               True     False    4.30e-01   8.48e+00     8.15e-01    
+b12__v_proj            1x1x1024               True     False    8.93e-01   1.20e+01     1.08e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.34e-01   8.27e+00     1.01e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.65e-01   9.51e+00     1.10e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.07e-01   1.08e+01     9.77e-01    
+b12__mlp_gate          1x1x9216               True     False    8.70e-01   1.24e+01     7.52e-01    
+b12__mlp_up            1x1x9216               True     False    7.19e-01   7.29e+00     6.64e-01    
+b12__mlp_down          1x1x2560               True     False    4.43e-01   9.13e+00     7.57e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.98e-01   1.23e+00     2.09e-02    
+h_layer_8              1x1x2560               True     False    3.73e-02   1.66e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -5.10e-02  1.42e+01     1.87e-01    
+h_layer_23             1x1x2560               True     False    4.20e-01   9.33e+00     3.22e-01    
+h_layer_31             1x1x2560               True     False    3.79e-01   2.98e+01     2.07e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.53e-02     1.28e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.51e-02     1.56e-03    
+b11__gdn_conv          1x1x8192               True     False    7.39e-01   3.49e+00     2.57e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.81e-01   7.84e-01     4.06e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.90e-01   8.45e-01     5.81e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.52e-03     1.23e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.83e-03     6.27e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.51e-01   5.16e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.41e-01   1.55e+00     8.00e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.54e-01   8.01e-01     1.04e-02    
+h_layer_24             1x1x2560               True     False    4.69e-01   7.77e+00     3.39e-01    
+h_layer_25             1x1x2560               True     False    5.34e-01   6.17e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.64e-01   6.80e+00     3.74e-01    
+h_layer_27             1x1x2560               True     False    4.93e-01   8.63e+00     4.97e-01    
+h_layer_28             1x1x2560               True     False    5.42e-01   7.08e+00     5.45e-01    
+h_layer_29             1x1x2560               True     False    5.37e-01   7.80e+00     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.14e-01   9.20e+00     7.85e-01    
+b12__post_input_norm   1x1x2560               True     False    3.46e-01   1.90e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    6.01e-01   1.26e+01     1.36e+00    
+b12__k_proj            1x1x1024               True     False    3.61e-01   6.54e+00     8.66e-01    
+b12__v_proj            1x1x1024               True     False    8.87e-01   1.12e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.14e-01   9.01e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.96e-01   8.34e+00     1.18e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.66e-01   1.01e+01     9.13e-01    
+b12__mlp_gate          1x1x9216               True     False    8.66e-01   1.27e+01     7.54e-01    
+b12__mlp_up            1x1x9216               True     False    7.39e-01   7.33e+00     6.11e-01    
+b12__mlp_down          1x1x2560               True     False    4.51e-01   2.94e+01     6.55e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    9.79e-01   1.64e-01     6.06e-03    
+h_layer_8              1x1x2560               True     False    5.02e-01   2.21e+00     1.06e-01    
+h_layer_16             1x1x2560               True     False    3.45e-01   2.91e+00     1.54e-01    
+h_layer_23             1x1x2560               True     False    6.91e-02   7.51e+00     4.63e-01    
+h_layer_31             1x1x2560               True     False    1.59e-01   6.28e+01     1.99e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   2.63e-02     1.26e-03    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   6.66e-02     1.98e-03    
+b11__gdn_conv          1x2x8192               True     False    9.38e-01   3.49e+00     1.79e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.44e-01   9.51e-01     3.60e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.93e-01   6.57e-01     3.34e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   4.67e-03     1.28e-03    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.37e-02     8.23e-04    
+b11__gdn_recur_out     1x2x32x128             True     False    6.58e-01   5.86e-01     1.26e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    9.34e-01   1.24e+00     4.76e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.50e-01   8.85e-01     7.36e-03    
+h_layer_24             1x1x2560               True     False    6.15e-02   1.15e+01     4.85e-01    
+h_layer_25             1x1x2560               True     False    4.36e-02   2.09e+01     5.84e-01    
+h_layer_26             1x1x2560               True     False    7.22e-02   9.76e+01     6.95e-01    
+h_layer_27             1x1x2560               True     False    1.80e-01   2.16e+01     5.35e-01    
+h_layer_28             1x1x2560               True     False    2.28e-01   2.34e+01     6.29e-01    
+h_layer_29             1x1x2560               True     False    3.23e-01   1.75e+01     6.90e-01    
+h_layer_30             1x1x2560               True     False    1.95e-01   2.74e+01     8.41e-01    
+b12__post_input_norm   1x2x2560               True     False    2.38e-01   2.44e+01     1.07e+00    
+b12__q_proj            1x2x8192               True     False    5.89e-01   1.17e+01     1.35e+00    
+b12__k_proj            1x2x1024               True     False    3.85e-01   7.02e+00     8.97e-01    
+b12__v_proj            1x2x1024               True     False    9.00e-01   1.16e+01     1.04e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.64e-01   8.64e+00     1.01e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.98e-01   8.03e+00     1.20e+00    
+b12__o_proj            1x2x2560               True     False    2.85e-01   5.83e+00     3.28e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.11e-01   1.96e+01     1.02e+00    
+b12__mlp_gate          1x2x9216               True     False    7.86e-01   1.25e+01     9.06e-01    
+b12__mlp_up            1x2x9216               True     False    6.01e-01   8.52e+00     8.09e-01    
+b12__mlp_down          1x2x2560               True     False    2.84e-01   3.21e+01     8.29e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.41e-01   1.03e+00     2.07e-02    
+h_layer_8              1x1x2560               True     False    3.71e-02   1.64e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -2.62e-02  1.44e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    3.77e-01   1.10e+01     3.31e-01    
+h_layer_31             1x1x2560               True     False    2.74e-01   2.28e+01     2.32e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.74e-02     1.30e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.17e-02     1.64e-03    
+b11__gdn_conv          1x1x8192               True     False    5.76e-01   1.34e+01     3.76e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.90e-01   8.40e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   7.91e-01     5.72e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   5.17e-03     1.37e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   8.53e-03     7.45e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.57e-01   5.40e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.26e-01   1.58e+00     6.81e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.53e-01   7.27e-01     1.06e-02    
+h_layer_24             1x1x2560               True     False    4.26e-01   8.34e+00     3.55e-01    
+h_layer_25             1x1x2560               True     False    4.80e-01   6.62e+00     3.72e-01    
+h_layer_26             1x1x2560               True     False    4.83e-01   6.73e+00     4.05e-01    
+h_layer_27             1x1x2560               True     False    4.47e-01   7.36e+00     5.51e-01    
+h_layer_28             1x1x2560               True     False    5.00e-01   8.09e+00     6.01e-01    
+h_layer_29             1x1x2560               True     False    4.79e-01   1.31e+01     6.88e-01    
+h_layer_30             1x1x2560               True     False    4.21e-01   9.29e+00     8.18e-01    
+b12__post_input_norm   1x1x2560               True     False    3.51e-01   1.81e+01     9.91e-01    
+b12__q_proj            1x1x8192               True     False    5.62e-01   1.17e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.48e-01   8.36e+00     8.57e-01    
+b12__v_proj            1x1x1024               True     False    8.88e-01   1.17e+01     1.12e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.36e-01   8.09e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    3.72e-01   9.26e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.44e-01   8.91e+00     9.32e-01    
+b12__mlp_gate          1x1x9216               True     False    8.53e-01   1.29e+01     7.86e-01    
+b12__mlp_up            1x1x9216               True     False    6.94e-01   7.18e+00     6.91e-01    
+b12__mlp_down          1x1x2560               True     False    4.32e-01   1.17e+01     7.09e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    6.85e-01   1.49e+00     2.32e-02    
+h_layer_8              1x1x2560               True     False    1.50e-02   1.61e+01     1.74e-01    
+h_layer_16             1x1x2560               True     False    -6.40e-02  1.39e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    2.58e-01   1.28e+01     3.69e-01    
+h_layer_31             1x1x2560               True     False    2.04e-01   2.79e+01     2.39e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   8.93e-03     1.27e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.45e-02     1.56e-03    
+b11__gdn_conv          1x1x8192               True     False    7.27e-01   3.69e+00     2.77e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.31e-01   6.99e-01     3.93e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.65e-01   8.17e-01     5.37e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.50e-03     1.39e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   8.07e-03     1.23e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    6.22e-01   4.43e-01     1.45e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.16e-01   1.50e+00     7.96e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.40e-01   1.10e+00     1.05e-02    
+h_layer_24             1x1x2560               True     False    2.73e-01   1.27e+01     4.03e-01    
+h_layer_25             1x1x2560               True     False    3.17e-01   1.27e+01     4.19e-01    
+h_layer_26             1x1x2560               True     False    3.49e-01   6.47e+00     4.57e-01    
+h_layer_27             1x1x2560               True     False    3.45e-01   1.27e+01     5.51e-01    
+h_layer_28             1x1x2560               True     False    3.79e-01   8.89e+00     5.95e-01    
+h_layer_29             1x1x2560               True     False    3.73e-01   1.23e+01     6.95e-01    
+h_layer_30             1x1x2560               True     False    2.68e-01   8.59e+00     8.75e-01    
+b12__post_input_norm   1x1x2560               True     False    2.28e-01   1.89e+01     1.13e+00    
+b12__q_proj            1x1x8192               True     False    4.87e-01   1.45e+01     1.65e+00    
+b12__k_proj            1x1x1024               True     False    3.40e-01   6.16e+00     8.99e-01    
+b12__v_proj            1x1x1024               True     False    8.68e-01   1.32e+01     1.18e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.61e-01   9.48e+00     1.11e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.52e-01   8.28e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.12e-01   9.53e+00     1.07e+00    
+b12__mlp_gate          1x1x9216               True     False    7.80e-01   1.24e+01     9.11e-01    
+b12__mlp_up            1x1x9216               True     False    6.63e-01   6.97e+00     6.63e-01    
+b12__mlp_down          1x1x2560               True     False    1.79e-01   2.68e+01     7.58e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok 
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.00e-02   mean|Δ|=1.28e-03   rel_l2=1.65e-03   ok  cos=1.00e+00   max|Δ|=7.90e-03   mean|Δ|=1.28e-03   rel_l2=1.66e-03   ok  cos=1.00e+00   max|Δ|=1.34e-02   mean|Δ|=1.29e-03   rel_l2=1.65e-03   ok  cos=1.00e+00   max|Δ|=1.53e-02   mean|Δ|=1.28e-03   rel_l2=1.66e-03   ok  cos=1.00e+00   max|Δ|=2.63e-02   mean|Δ|=1.26e-03   rel_l2=1.63e-03   ok  cos=1.00e+00   max|Δ|=1.74e-02   mean|Δ|=1.30e-03   rel_l2=1.69e-03   ok  cos=1.00e+00   max|Δ|=8.93e-03   mean|Δ|=1.27e-03   rel_l2=1.66e-03   ok 
+  gdn_in_proj               cos=1.00e+00   max|Δ|=6.66e-02   mean|Δ|=1.77e-03   rel_l2=1.95e-03   ok  cos=1.00e+00   max|Δ|=3.44e-02   mean|Δ|=1.78e-03   rel_l2=1.94e-03   ok  cos=1.00e+00   max|Δ|=2.12e-02   mean|Δ|=1.56e-03   rel_l2=2.06e-03   ok  cos=1.00e+00   max|Δ|=3.51e-02   mean|Δ|=1.56e-03   rel_l2=2.07e-03   ok  cos=1.00e+00   max|Δ|=6.66e-02   mean|Δ|=1.98e-03   rel_l2=1.80e-03   ok  cos=1.00e+00   max|Δ|=3.17e-02   mean|Δ|=1.64e-03   rel_l2=2.01e-03   ok  cos=1.00e+00   max|Δ|=3.45e-02   mean|Δ|=1.56e-03   rel_l2=2.06e-03   ok 
+  gdn_conv                  cos=1.00e+00   max|Δ|=6.20e-02   mean|Δ|=7.08e-05   rel_l2=1.58e-03   ok  cos=5.62e-01   max|Δ|=1.83e+01   mean|Δ|=3.94e-02   rel_l2=3.60e+00   DIV cos=7.33e-01   max|Δ|=4.11e+00   mean|Δ|=3.10e-02   rel_l2=2.42e+00   DIV cos=7.39e-01   max|Δ|=3.49e+00   mean|Δ|=2.57e-02   rel_l2=1.78e+00   DIV cos=9.38e-01   max|Δ|=3.49e+00   mean|Δ|=1.79e-02   rel_l2=4.41e-01   DIV cos=5.76e-01   max|Δ|=1.34e+01   mean|Δ|=3.76e-02   rel_l2=3.98e+00   DIV cos=7.27e-01   max|Δ|=3.69e+00   mean|Δ|=2.77e-02   rel_l2=2.06e+00   DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.84e-01   mean|Δ|=4.04e-02   rel_l2=9.12e-01   ok  cos=6.84e-01   max|Δ|=8.52e-01   mean|Δ|=3.88e-02   rel_l2=9.42e-01   DIV cos=6.63e-01   max|Δ|=7.68e-01   mean|Δ|=4.15e-02   rel_l2=9.44e-01   DIV cos=6.81e-01   max|Δ|=7.84e-01   mean|Δ|=4.06e-02   rel_l2=9.42e-01   DIV cos=8.44e-01   max|Δ|=9.51e-01   mean|Δ|=3.60e-02   rel_l2=9.27e-01   DIV cos=6.90e-01   max|Δ|=8.40e-01   mean|Δ|=3.88e-02   rel_l2=9.41e-01   DIV cos=7.31e-01   max|Δ|=6.99e-01   mean|Δ|=3.93e-02   rel_l2=9.37e-01   DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=5.43e-03   mean|Δ|=1.33e-04   rel_l2=2.69e-03   ok  cos=3.17e-01   max|Δ|=8.59e-01   mean|Δ|=5.62e-02   rel_l2=1.17e+00   DIV cos=3.09e-01   max|Δ|=8.96e-01   mean|Δ|=5.76e-02   rel_l2=1.18e+00   DIV cos=3.90e-01   max|Δ|=8.45e-01   mean|Δ|=5.81e-02   rel_l2=1.10e+00   DIV cos=6.93e-01   max|Δ|=6.57e-01   mean|Δ|=3.34e-02   rel_l2=7.83e-01   DIV cos=2.97e-01   max|Δ|=7.91e-01   mean|Δ|=5.72e-02   rel_l2=1.19e+00   DIV cos=3.65e-01   max|Δ|=8.17e-01   mean|Δ|=5.37e-02   rel_l2=1.13e+00   DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=5.17e-03   mean|Δ|=1.17e-03   rel_l2=2.71e-03   ok  cos=1.00e+00   max|Δ|=5.06e-03   mean|Δ|=1.38e-03   rel_l2=2.93e-03   ok  cos=1.00e+00   max|Δ|=3.16e-03   mean|Δ|=1.14e-03   rel_l2=2.81e-03   ok  cos=1.00e+00   max|Δ|=4.52e-03   mean|Δ|=1.23e-03   rel_l2=2.93e-03   ok  cos=1.00e+00   max|Δ|=4.67e-03   mean|Δ|=1.28e-03   rel_l2=2.94e-03   ok  cos=1.00e+00   max|Δ|=5.17e-03   mean|Δ|=1.37e-03   rel_l2=3.15e-03   ok  cos=1.00e+00   max|Δ|=4.50e-03   mean|Δ|=1.39e-03   rel_l2=3.31e-03   ok 
+  gdn_gate_g                cos=1.00e+00   max|Δ|=1.73e-02   mean|Δ|=8.34e-04   rel_l2=1.77e-03   ok  cos=1.00e+00   max|Δ|=7.30e-03   mean|Δ|=9.43e-04   rel_l2=1.97e-03   ok  cos=1.00e+00   max|Δ|=2.65e-03   mean|Δ|=4.90e-04   rel_l2=9.85e-04   ok  cos=1.00e+00   max|Δ|=6.83e-03   mean|Δ|=6.27e-04   rel_l2=1.61e-03   ok  cos=1.00e+00   max|Δ|=1.37e-02   mean|Δ|=8.23e-04   rel_l2=1.67e-03   ok  cos=1.00e+00   max|Δ|=8.53e-03   mean|Δ|=7.45e-04   rel_l2=1.74e-03   ok  cos=1.00e+00   max|Δ|=8.07e-03   mean|Δ|=1.23e-03   rel_l2=2.26e-03   ok 
+  gdn_recur_out             cos=1.00e+00   max|Δ|=5.50e-03   mean|Δ|=3.71e-06   rel_l2=3.34e-03   ok  cos=5.44e-01   max|Δ|=4.39e-01   mean|Δ|=1.16e-03   rel_l2=6.42e+00   DIV cos=4.38e-01   max|Δ|=5.36e-01   mean|Δ|=1.53e-03   rel_l2=1.28e+01   DIV cos=4.51e-01   max|Δ|=5.16e-01   mean|Δ|=1.62e-03   rel_l2=1.33e+01   DIV cos=6.58e-01   max|Δ|=5.86e-01   mean|Δ|=1.26e-03   rel_l2=5.68e+00   DIV cos=3.57e-01   max|Δ|=5.40e-01   mean|Δ|=1.62e-03   rel_l2=8.67e+00   DIV cos=6.22e-01   max|Δ|=4.43e-01   mean|Δ|=1.45e-03   rel_l2=1.87e+01   DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=1.93e-02   mean|Δ|=5.08e-05   rel_l2=4.18e-03   ok  cos=9.31e-01   max|Δ|=9.58e-01   mean|Δ|=5.33e-03   rel_l2=4.72e-01   DIV cos=8.47e-01   max|Δ|=1.60e+00   mean|Δ|=8.09e-03   rel_l2=9.78e-01   DIV cos=8.41e-01   max|Δ|=1.55e+00   mean|Δ|=8.00e-03   rel_l2=9.63e-01   DIV cos=9.34e-01   max|Δ|=1.24e+00   mean|Δ|=4.76e-03   rel_l2=5.00e-01   DIV cos=8.26e-01   max|Δ|=1.58e+00   mean|Δ|=6.81e-03   rel_l2=8.22e-01   DIV cos=8.16e-01   max|Δ|=1.50e+00   mean|Δ|=7.96e-03   rel_l2=1.23e+00   DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.20e-02   mean|Δ|=6.04e-05   rel_l2=2.43e-03   ok  cos=9.62e-01   max|Δ|=3.42e-01   mean|Δ|=8.98e-03   rel_l2=3.32e-01   ok  cos=9.46e-01   max|Δ|=9.49e-01   mean|Δ|=1.07e-02   rel_l2=7.00e-01   DIV cos=9.54e-01   max|Δ|=8.01e-01   mean|Δ|=1.04e-02   rel_l2=5.37e-01   ok  cos=9.50e-01   max|Δ|=8.85e-01   mean|Δ|=7.36e-03   rel_l2=4.83e-01   ok  cos=9.53e-01   max|Δ|=7.27e-01   mean|Δ|=1.06e-02   rel_l2=4.69e-01   ok  cos=9.40e-01   max|Δ|=1.10e+00   mean|Δ|=1.05e-02   rel_l2=7.95e-01   DIV
+
+  first sub-op with MEDIAN cos_sim < 0.95: 'gdn_conv' (median cos_sim = 0.733474)
+Phase B11b verdict: B12 TARGET = 'gdn_conv'.
+    Most-likely cause: causal_conv1d: kernel packing, stride/pad, SiLU activation, or bias
+  -> Queue B12 task to investigate this sub-op in isolation.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.28e-02     7.47e-04    
+h_layer_8              1x1x2560               True     False    9.79e-01   9.85e-02     1.93e-02    
+h_layer_16             1x1x2560               True     False    9.65e-01   3.73e-01     4.28e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   6.05e-01     7.15e-02    
+h_layer_31             1x1x2560               True     False    9.58e-01   2.52e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.00e-02     1.28e-03    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   6.66e-02     1.77e-03    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.20e-02     7.08e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.84e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   5.43e-03     1.33e-04    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   5.17e-03     1.17e-03    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.73e-02     8.34e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   5.50e-03     3.71e-06    
+b11__gdn_gated_norm    1x494x4096             True     False    1.00e+00   1.93e-02     5.08e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.20e-02     6.04e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   5.23e-01     7.52e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   5.11e-01     7.66e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   7.83e-01     8.17e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   5.50e-01     9.89e-02    
+h_layer_28             1x1x2560               True     False    9.86e-01   4.96e-01     1.16e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.28e-01     1.30e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.86e-01     1.59e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.93e-01   3.75e-01     1.62e-02    
+h_layer_8              1x1x2560               True     False    4.37e-02   1.56e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    6.65e-04   1.35e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.78e-01   1.03e+01     3.30e-01    
+h_layer_31             1x1x2560               True     False    2.12e-01   4.78e+01     2.33e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   7.90e-03     1.28e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.44e-02     1.78e-03    
+b11__gdn_conv          1x1x8192               True     False    5.62e-01   1.83e+01     3.94e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.84e-01   8.52e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.17e-01   8.59e-01     5.62e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   5.06e-03     1.38e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.30e-03     9.43e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.44e-01   4.39e-01     1.16e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.31e-01   9.58e-01     5.33e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.62e-01   3.42e-01     8.98e-03    
+h_layer_24             1x1x2560               True     False    4.06e-01   9.39e+00     3.63e-01    
+h_layer_25             1x1x2560               True     False    4.55e-01   8.64e+00     3.82e-01    
+h_layer_26             1x1x2560               True     False    4.75e-01   7.16e+00     4.17e-01    
+h_layer_27             1x1x2560               True     False    4.14e-01   8.40e+00     5.59e-01    
+h_layer_28             1x1x2560               True     False    4.65e-01   8.49e+00     6.21e-01    
+h_layer_29             1x1x2560               True     False    4.45e-01   1.31e+01     6.93e-01    
+h_layer_30             1x1x2560               True     False    3.82e-01   9.63e+00     8.45e-01    
+b12__post_input_norm   1x1x2560               True     False    3.24e-01   2.02e+01     1.04e+00    
+b12__q_proj            1x1x8192               True     False    5.89e-01   1.03e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    4.74e-01   6.51e+00     8.05e-01    
+b12__v_proj            1x1x1024               True     False    9.01e-01   1.11e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.49e-01   8.16e+00     1.00e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.95e-01   8.37e+00     1.07e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.87e-01   1.02e+01     9.83e-01    
+b12__mlp_gate          1x1x9216               True     False    8.10e-01   1.19e+01     9.42e-01    
+b12__mlp_up            1x1x9216               True     False    6.44e-01   6.88e+00     7.13e-01    
+b12__mlp_down          1x1x2560               True     False    4.11e-01   5.60e+00     7.64e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.88e-01   1.05e+00     2.12e-02    
+h_layer_8              1x1x2560               True     False    5.24e-02   1.57e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -2.43e-02  1.38e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.03e-01   1.15e+01     3.23e-01    
+h_layer_31             1x1x2560               True     False    2.34e-01   2.87e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.34e-02     1.29e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   2.12e-02     1.56e-03    
+b11__gdn_conv          1x1x8192               True     False    7.33e-01   4.11e+00     3.10e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.63e-01   7.68e-01     4.15e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.09e-01   8.96e-01     5.76e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.16e-03     1.14e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   2.65e-03     4.90e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.38e-01   5.36e-01     1.53e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.47e-01   1.60e+00     8.09e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   9.49e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    4.41e-01   1.09e+01     3.39e-01    
+h_layer_25             1x1x2560               True     False    5.00e-01   9.60e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.28e-01   6.23e+00     3.79e-01    
+h_layer_27             1x1x2560               True     False    4.11e-01   8.55e+00     5.61e-01    
+h_layer_28             1x1x2560               True     False    4.70e-01   7.16e+00     6.22e-01    
+h_layer_29             1x1x2560               True     False    4.57e-01   9.86e+00     6.91e-01    
+h_layer_30             1x1x2560               True     False    3.74e-01   9.07e+00     8.35e-01    
+b12__post_input_norm   1x1x2560               True     False    3.23e-01   1.99e+01     1.03e+00    
+b12__q_proj            1x1x8192               True     False    6.17e-01   1.21e+01     1.37e+00    
+b12__k_proj            1x1x1024               True     False    4.30e-01   8.48e+00     8.15e-01    
+b12__v_proj            1x1x1024               True     False    8.93e-01   1.20e+01     1.08e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.34e-01   8.27e+00     1.01e+00    
+b12__qk_norm_k         1x1x4x256              True     False    4.65e-01   9.51e+00     1.10e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.07e-01   1.08e+01     9.77e-01    
+b12__mlp_gate          1x1x9216               True     False    8.70e-01   1.24e+01     7.52e-01    
+b12__mlp_up            1x1x9216               True     False    7.19e-01   7.29e+00     6.64e-01    
+b12__mlp_down          1x1x2560               True     False    4.43e-01   9.13e+00     7.57e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.98e-01   1.23e+00     2.09e-02    
+h_layer_8              1x1x2560               True     False    3.73e-02   1.66e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -5.10e-02  1.42e+01     1.87e-01    
+h_layer_23             1x1x2560               True     False    4.20e-01   9.33e+00     3.22e-01    
+h_layer_31             1x1x2560               True     False    3.79e-01   2.98e+01     2.07e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.53e-02     1.28e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.51e-02     1.56e-03    
+b11__gdn_conv          1x1x8192               True     False    7.39e-01   3.49e+00     2.57e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.81e-01   7.84e-01     4.06e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.90e-01   8.45e-01     5.81e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.52e-03     1.23e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.83e-03     6.27e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.51e-01   5.16e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.41e-01   1.55e+00     8.00e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.54e-01   8.01e-01     1.04e-02    
+h_layer_24             1x1x2560               True     False    4.69e-01   7.77e+00     3.39e-01    
+h_layer_25             1x1x2560               True     False    5.34e-01   6.17e+00     3.49e-01    
+h_layer_26             1x1x2560               True     False    4.64e-01   6.80e+00     3.74e-01    
+h_layer_27             1x1x2560               True     False    4.93e-01   8.63e+00     4.97e-01    
+h_layer_28             1x1x2560               True     False    5.42e-01   7.08e+00     5.45e-01    
+h_layer_29             1x1x2560               True     False    5.37e-01   7.80e+00     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.14e-01   9.20e+00     7.85e-01    
+b12__post_input_norm   1x1x2560               True     False    3.46e-01   1.90e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    6.01e-01   1.26e+01     1.36e+00    
+b12__k_proj            1x1x1024               True     False    3.61e-01   6.54e+00     8.66e-01    
+b12__v_proj            1x1x1024               True     False    8.87e-01   1.12e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.14e-01   9.01e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.96e-01   8.34e+00     1.18e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.66e-01   1.01e+01     9.13e-01    
+b12__mlp_gate          1x1x9216               True     False    8.66e-01   1.27e+01     7.54e-01    
+b12__mlp_up            1x1x9216               True     False    7.39e-01   7.33e+00     6.11e-01    
+b12__mlp_down          1x1x2560               True     False    4.51e-01   2.94e+01     6.55e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    9.79e-01   1.64e-01     6.06e-03    
+h_layer_8              1x1x2560               True     False    5.02e-01   2.21e+00     1.06e-01    
+h_layer_16             1x1x2560               True     False    3.45e-01   2.91e+00     1.54e-01    
+h_layer_23             1x1x2560               True     False    6.91e-02   7.51e+00     4.63e-01    
+h_layer_31             1x1x2560               True     False    1.59e-01   6.28e+01     1.99e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   2.63e-02     1.26e-03    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   6.66e-02     1.98e-03    
+b11__gdn_conv          1x2x8192               True     False    9.38e-01   3.49e+00     1.79e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.44e-01   9.51e-01     3.60e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.93e-01   6.57e-01     3.34e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   4.67e-03     1.28e-03    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.37e-02     8.23e-04    
+b11__gdn_recur_out     1x2x32x128             True     False    6.58e-01   5.86e-01     1.26e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    9.34e-01   1.24e+00     4.76e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.50e-01   8.85e-01     7.36e-03    
+h_layer_24             1x1x2560               True     False    6.15e-02   1.15e+01     4.85e-01    
+h_layer_25             1x1x2560               True     False    4.36e-02   2.09e+01     5.84e-01    
+h_layer_26             1x1x2560               True     False    7.22e-02   9.76e+01     6.95e-01    
+h_layer_27             1x1x2560               True     False    1.80e-01   2.16e+01     5.35e-01    
+h_layer_28             1x1x2560               True     False    2.28e-01   2.34e+01     6.29e-01    
+h_layer_29             1x1x2560               True     False    3.23e-01   1.75e+01     6.90e-01    
+h_layer_30             1x1x2560               True     False    1.95e-01   2.74e+01     8.41e-01    
+b12__post_input_norm   1x2x2560               True     False    2.38e-01   2.44e+01     1.07e+00    
+b12__q_proj            1x2x8192               True     False    5.89e-01   1.17e+01     1.35e+00    
+b12__k_proj            1x2x1024               True     False    3.85e-01   7.02e+00     8.97e-01    
+b12__v_proj            1x2x1024               True     False    9.00e-01   1.16e+01     1.04e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.64e-01   8.64e+00     1.01e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.98e-01   8.03e+00     1.20e+00    
+b12__o_proj            1x2x2560               True     False    2.85e-01   5.83e+00     3.28e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.11e-01   1.96e+01     1.02e+00    
+b12__mlp_gate          1x2x9216               True     False    7.86e-01   1.25e+01     9.06e-01    
+b12__mlp_up            1x2x9216               True     False    6.01e-01   8.52e+00     8.09e-01    
+b12__mlp_down          1x2x2560               True     False    2.84e-01   3.21e+01     8.29e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.41e-01   1.03e+00     2.07e-02    
+h_layer_8              1x1x2560               True     False    3.71e-02   1.64e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -2.62e-02  1.44e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    3.77e-01   1.10e+01     3.31e-01    
+h_layer_31             1x1x2560               True     False    2.74e-01   2.28e+01     2.32e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.74e-02     1.30e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.17e-02     1.64e-03    
+b11__gdn_conv          1x1x8192               True     False    5.76e-01   1.34e+01     3.76e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.90e-01   8.40e-01     3.88e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   7.91e-01     5.72e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   5.17e-03     1.37e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   8.53e-03     7.45e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.57e-01   5.40e-01     1.62e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.26e-01   1.58e+00     6.81e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.53e-01   7.27e-01     1.06e-02    
+h_layer_24             1x1x2560               True     False    4.26e-01   8.34e+00     3.55e-01    
+h_layer_25             1x1x2560               True     False    4.80e-01   6.62e+00     3.72e-01    
+h_layer_26             1x1x2560               True     False    4.83e-01   6.73e+00     4.05e-01    
+h_layer_27             1x1x2560               True     False    4.47e-01   7.36e+00     5.51e-01    
+h_layer_28             1x1x2560               True     False    5.00e-01   8.09e+00     6.01e-01    
+h_layer_29             1x1x2560               True     False    4.79e-01   1.31e+01     6.88e-01    
+h_layer_30             1x1x2560               True     False    4.21e-01   9.29e+00     8.18e-01    
+b12__post_input_norm   1x1x2560               True     False    3.51e-01   1.81e+01     9.91e-01    
+b12__q_proj            1x1x8192               True     False    5.62e-01   1.17e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.48e-01   8.36e+00     8.57e-01    
+b12__v_proj            1x1x1024               True     False    8.88e-01   1.17e+01     1.12e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.36e-01   8.09e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    3.72e-01   9.26e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.44e-01   8.91e+00     9.32e-01    
+b12__mlp_gate          1x1x9216               True     False    8.53e-01   1.29e+01     7.86e-01    
+b12__mlp_up            1x1x9216               True     False    6.94e-01   7.18e+00     6.91e-01    
+b12__mlp_down          1x1x2560               True     False    4.32e-01   1.17e+01     7.09e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    6.85e-01   1.49e+00     2.32e-02    
+h_layer_8              1x1x2560               True     False    1.50e-02   1.61e+01     1.74e-01    
+h_layer_16             1x1x2560               True     False    -6.40e-02  1.39e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    2.58e-01   1.28e+01     3.69e-01    
+h_layer_31             1x1x2560               True     False    2.04e-01   2.79e+01     2.39e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   8.93e-03     1.27e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.45e-02     1.56e-03    
+b11__gdn_conv          1x1x8192               True     False    7.27e-01   3.69e+00     2.77e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.31e-01   6.99e-01     3.93e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.65e-01   8.17e-01     5.37e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.50e-03     1.39e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   8.07e-03     1.23e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    6.22e-01   4.43e-01     1.45e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.16e-01   1.50e+00     7.96e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.40e-01   1.10e+00     1.05e-02    
+h_layer_24             1x1x2560               True     False    2.73e-01   1.27e+01     4.03e-01    
+h_layer_25             1x1x2560               True     False    3.17e-01   1.27e+01     4.19e-01    
+h_layer_26             1x1x2560               True     False    3.49e-01   6.47e+00     4.57e-01    
+h_layer_27             1x1x2560               True     False    3.45e-01   1.27e+01     5.51e-01    
+h_layer_28             1x1x2560               True     False    3.79e-01   8.89e+00     5.95e-01    
+h_layer_29             1x1x2560               True     False    3.73e-01   1.23e+01     6.95e-01    
+h_layer_30             1x1x2560               True     False    2.68e-01   8.59e+00     8.75e-01    
+b12__post_input_norm   1x1x2560               True     False    2.28e-01   1.89e+01     1.13e+00    
+b12__q_proj            1x1x8192               True     False    4.87e-01   1.45e+01     1.65e+00    
+b12__k_proj            1x1x1024               True     False    3.40e-01   6.16e+00     8.99e-01    
+b12__v_proj            1x1x1024               True     False    8.68e-01   1.32e+01     1.18e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.61e-01   9.48e+00     1.11e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.52e-01   8.28e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.12e-01   9.53e+00     1.07e+00    
+b12__mlp_gate          1x1x9216               True     False    7.80e-01   1.24e+01     9.11e-01    
+b12__mlp_up            1x1x9216               True     False    6.63e-01   6.97e+00     6.63e-01    
+b12__mlp_down          1x1x2560               True     False    1.79e-01   2.68e+01     7.58e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.85e-01   max|Δ|=5.23e-01   DIV   cos=4.06e-01   max|Δ|=9.39e+00   DIV   cos=4.41e-01   max|Δ|=1.09e+01   DIV   cos=4.69e-01   max|Δ|=7.77e+00   DIV   cos=6.15e-02   max|Δ|=1.15e+01   DIV   cos=4.26e-01   max|Δ|=8.34e+00   DIV   cos=2.73e-01   max|Δ|=1.27e+01   DIV  
+  h_layer_25            cos=9.86e-01   max|Δ|=5.11e-01   DIV   cos=4.55e-01   max|Δ|=8.64e+00   DIV   cos=5.00e-01   max|Δ|=9.60e+00   DIV   cos=5.34e-01   max|Δ|=6.17e+00   DIV   cos=4.36e-02   max|Δ|=2.09e+01   DIV   cos=4.80e-01   max|Δ|=6.62e+00   DIV   cos=3.17e-01   max|Δ|=1.27e+01   DIV  
+  h_layer_26            cos=9.85e-01   max|Δ|=7.83e-01   DIV   cos=4.75e-01   max|Δ|=7.16e+00   DIV   cos=4.28e-01   max|Δ|=6.23e+00   DIV   cos=4.64e-01   max|Δ|=6.80e+00   DIV   cos=7.22e-02   max|Δ|=9.76e+01   DIV   cos=4.83e-01   max|Δ|=6.73e+00   DIV   cos=3.49e-01   max|Δ|=6.47e+00   DIV  
+  h_layer_27            cos=9.86e-01   max|Δ|=5.50e-01   DIV   cos=4.14e-01   max|Δ|=8.40e+00   DIV   cos=4.11e-01   max|Δ|=8.55e+00   DIV   cos=4.93e-01   max|Δ|=8.63e+00   DIV   cos=1.80e-01   max|Δ|=2.16e+01   DIV   cos=4.47e-01   max|Δ|=7.36e+00   DIV   cos=3.45e-01   max|Δ|=1.27e+01   DIV  
+  h_layer_28            cos=9.86e-01   max|Δ|=4.96e-01   DIV   cos=4.65e-01   max|Δ|=8.49e+00   DIV   cos=4.70e-01   max|Δ|=7.16e+00   DIV   cos=5.42e-01   max|Δ|=7.08e+00   DIV   cos=2.28e-01   max|Δ|=2.34e+01   DIV   cos=5.00e-01   max|Δ|=8.09e+00   DIV   cos=3.79e-01   max|Δ|=8.89e+00   DIV  
+  h_layer_29            cos=9.86e-01   max|Δ|=6.28e-01   DIV   cos=4.45e-01   max|Δ|=1.31e+01   DIV   cos=4.57e-01   max|Δ|=9.86e+00   DIV   cos=5.37e-01   max|Δ|=7.80e+00   DIV   cos=3.23e-01   max|Δ|=1.75e+01   DIV   cos=4.79e-01   max|Δ|=1.31e+01   DIV   cos=3.73e-01   max|Δ|=1.23e+01   DIV  
+  h_layer_30            cos=9.82e-01   max|Δ|=6.86e-01   DIV   cos=3.82e-01   max|Δ|=9.63e+00   DIV   cos=3.74e-01   max|Δ|=9.07e+00   DIV   cos=4.14e-01   max|Δ|=9.20e+00   DIV   cos=1.95e-01   max|Δ|=2.74e+01   DIV   cos=4.21e-01   max|Δ|=9.29e+00   DIV   cos=2.68e-01   max|Δ|=8.59e+00   DIV  
+  h_layer_31            cos=9.58e-01   max|Δ|=2.52e+01   DIV   cos=2.12e-01   max|Δ|=4.78e+01   DIV   cos=2.34e-01   max|Δ|=2.87e+01   DIV   cos=3.79e-01   max|Δ|=2.98e+01   DIV   cos=1.59e-01   max|Δ|=6.28e+01   DIV   cos=2.74e-01   max|Δ|=2.28e+01   DIV   cos=2.04e-01   max|Δ|=2.79e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=4.26e-01     DIV
+    h_layer_25             median=4.80e-01     DIV
+    h_layer_26             median=4.64e-01     DIV
+    h_layer_27             median=4.14e-01     DIV
+    h_layer_28             median=4.70e-01     DIV
+    h_layer_29             median=4.57e-01     DIV
+    h_layer_30             median=3.82e-01     DIV
+    h_layer_31             median=2.34e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=3.24e-01   max|Δ|=2.02e+01   mean|Δ|=1.04e+00   rel_l2=1.13e+00   DIV cos=3.23e-01   max|Δ|=1.99e+01   mean|Δ|=1.03e+00   rel_l2=1.13e+00   DIV cos=3.46e-01   max|Δ|=1.90e+01   mean|Δ|=1.00e+00   rel_l2=1.12e+00   DIV cos=2.38e-01   max|Δ|=2.44e+01   mean|Δ|=1.07e+00   rel_l2=1.23e+00   DIV cos=3.51e-01   max|Δ|=1.81e+01   mean|Δ|=9.91e-01   rel_l2=1.11e+00   DIV cos=2.28e-01   max|Δ|=1.89e+01   mean|Δ|=1.13e+00   rel_l2=1.21e+00   DIV
+  q_proj              <missing>                                            cos=5.89e-01   max|Δ|=1.03e+01   mean|Δ|=1.54e+00   rel_l2=8.23e-01   DIV cos=6.17e-01   max|Δ|=1.21e+01   mean|Δ|=1.37e+00   rel_l2=8.06e-01   DIV cos=6.01e-01   max|Δ|=1.26e+01   mean|Δ|=1.36e+00   rel_l2=8.28e-01   DIV cos=5.89e-01   max|Δ|=1.17e+01   mean|Δ|=1.35e+00   rel_l2=8.37e-01   DIV cos=5.62e-01   max|Δ|=1.17e+01   mean|Δ|=1.52e+00   rel_l2=8.48e-01   DIV cos=4.87e-01   max|Δ|=1.45e+01   mean|Δ|=1.65e+00   rel_l2=9.04e-01   DIV
+  k_proj              <missing>                                            cos=4.74e-01   max|Δ|=6.51e+00   mean|Δ|=8.05e-01   rel_l2=9.34e-01   DIV cos=4.30e-01   max|Δ|=8.48e+00   mean|Δ|=8.15e-01   rel_l2=9.72e-01   DIV cos=3.61e-01   max|Δ|=6.54e+00   mean|Δ|=8.66e-01   rel_l2=1.04e+00   DIV cos=3.85e-01   max|Δ|=7.02e+00   mean|Δ|=8.97e-01   rel_l2=1.00e+00   DIV cos=3.48e-01   max|Δ|=8.36e+00   mean|Δ|=8.57e-01   rel_l2=1.00e+00   DIV cos=3.40e-01   max|Δ|=6.16e+00   mean|Δ|=8.99e-01   rel_l2=1.01e+00   DIV
+  v_proj              <missing>                                            cos=9.01e-01   max|Δ|=1.11e+01   mean|Δ|=1.07e+00   rel_l2=4.36e-01   DIV cos=8.93e-01   max|Δ|=1.20e+01   mean|Δ|=1.08e+00   rel_l2=4.53e-01   DIV cos=8.87e-01   max|Δ|=1.12e+01   mean|Δ|=1.03e+00   rel_l2=4.64e-01   DIV cos=9.00e-01   max|Δ|=1.16e+01   mean|Δ|=1.04e+00   rel_l2=4.36e-01   DIV cos=8.88e-01   max|Δ|=1.17e+01   mean|Δ|=1.12e+00   rel_l2=4.61e-01   DIV cos=8.68e-01   max|Δ|=1.32e+01   mean|Δ|=1.18e+00   rel_l2=4.98e-01   DIV
+  qk_norm_q           <missing>                                            cos=4.49e-01   max|Δ|=8.16e+00   mean|Δ|=1.00e+00   rel_l2=1.02e+00   DIV cos=4.34e-01   max|Δ|=8.27e+00   mean|Δ|=1.01e+00   rel_l2=1.03e+00   DIV cos=4.14e-01   max|Δ|=9.01e+00   mean|Δ|=1.04e+00   rel_l2=1.06e+00   DIV cos=4.64e-01   max|Δ|=8.64e+00   mean|Δ|=1.01e+00   rel_l2=1.05e+00   DIV cos=4.36e-01   max|Δ|=8.09e+00   mean|Δ|=9.94e-01   rel_l2=1.03e+00   DIV cos=3.61e-01   max|Δ|=9.48e+00   mean|Δ|=1.11e+00   rel_l2=1.13e+00   DIV
+  qk_norm_k           <missing>                                            cos=4.95e-01   max|Δ|=8.37e+00   mean|Δ|=1.07e+00   rel_l2=9.98e-01   DIV cos=4.65e-01   max|Δ|=9.51e+00   mean|Δ|=1.10e+00   rel_l2=1.03e+00   DIV cos=3.96e-01   max|Δ|=8.34e+00   mean|Δ|=1.18e+00   rel_l2=1.09e+00   DIV cos=3.98e-01   max|Δ|=8.03e+00   mean|Δ|=1.20e+00   rel_l2=1.10e+00   DIV cos=3.72e-01   max|Δ|=9.26e+00   mean|Δ|=1.19e+00   rel_l2=1.12e+00   DIV cos=3.52e-01   max|Δ|=8.28e+00   mean|Δ|=1.21e+00   rel_l2=1.14e+00   DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=2.85e-01   max|Δ|=5.83e+00   mean|Δ|=3.28e-01   rel_l2=1.40e+00   DIV <missing>                                            <missing>                                           
+  post_attn_norm      <missing>                                            cos=3.87e-01   max|Δ|=1.02e+01   mean|Δ|=9.83e-01   rel_l2=1.11e+00   DIV cos=4.07e-01   max|Δ|=1.08e+01   mean|Δ|=9.77e-01   rel_l2=1.11e+00   DIV cos=4.66e-01   max|Δ|=1.01e+01   mean|Δ|=9.13e-01   rel_l2=1.05e+00   DIV cos=3.11e-01   max|Δ|=1.96e+01   mean|Δ|=1.02e+00   rel_l2=1.21e+00   DIV cos=4.44e-01   max|Δ|=8.91e+00   mean|Δ|=9.32e-01   rel_l2=1.06e+00   DIV cos=3.12e-01   max|Δ|=9.53e+00   mean|Δ|=1.07e+00   rel_l2=1.18e+00   DIV
+  mlp_gate            <missing>                                            cos=8.10e-01   max|Δ|=1.19e+01   mean|Δ|=9.42e-01   rel_l2=8.25e-01   DIV cos=8.70e-01   max|Δ|=1.24e+01   mean|Δ|=7.52e-01   rel_l2=6.49e-01   DIV cos=8.66e-01   max|Δ|=1.27e+01   mean|Δ|=7.54e-01   rel_l2=6.58e-01   DIV cos=7.86e-01   max|Δ|=1.25e+01   mean|Δ|=9.06e-01   rel_l2=7.66e-01   DIV cos=8.53e-01   max|Δ|=1.29e+01   mean|Δ|=7.86e-01   rel_l2=7.11e-01   DIV cos=7.80e-01   max|Δ|=1.24e+01   mean|Δ|=9.11e-01   rel_l2=8.04e-01   DIV
+  mlp_up              <missing>                                            cos=6.44e-01   max|Δ|=6.88e+00   mean|Δ|=7.13e-01   rel_l2=1.06e+00   DIV cos=7.19e-01   max|Δ|=7.29e+00   mean|Δ|=6.64e-01   rel_l2=9.15e-01   DIV cos=7.39e-01   max|Δ|=7.33e+00   mean|Δ|=6.11e-01   rel_l2=8.83e-01   DIV cos=6.01e-01   max|Δ|=8.52e+00   mean|Δ|=8.09e-01   rel_l2=1.17e+00   DIV cos=6.94e-01   max|Δ|=7.18e+00   mean|Δ|=6.91e-01   rel_l2=1.10e+00   DIV cos=6.63e-01   max|Δ|=6.97e+00   mean|Δ|=6.63e-01   rel_l2=9.21e-01   DIV
+  mlp_down            <missing>                                            cos=4.11e-01   max|Δ|=5.60e+00   mean|Δ|=7.64e-01   rel_l2=1.16e+00   DIV cos=4.43e-01   max|Δ|=9.13e+00   mean|Δ|=7.57e-01   rel_l2=9.97e-01   DIV cos=4.51e-01   max|Δ|=2.94e+01   mean|Δ|=6.55e-01   rel_l2=9.42e-01   DIV cos=2.84e-01   max|Δ|=3.21e+01   mean|Δ|=8.29e-01   rel_l2=1.05e+00   DIV cos=4.32e-01   max|Δ|=1.17e+01   mean|Δ|=7.09e-01   rel_l2=1.15e+00   DIV cos=1.79e-01   max|Δ|=2.68e+01   mean|Δ|=7.58e-01   rel_l2=1.34e+00   DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=3.23e-01     DIV
+    q_proj               median=5.89e-01     DIV
+    k_proj               median=3.73e-01     DIV
+    v_proj               median=8.91e-01     DIV
+    qk_norm_q            median=4.35e-01     DIV
+    qk_norm_k            median=3.97e-01     DIV
+    o_proj               median=2.85e-01     DIV
+    post_attn_norm       median=3.97e-01     DIV
+    mlp_gate             median=8.32e-01     DIV
+    mlp_up               median=6.78e-01     DIV
+    mlp_down             median=4.22e-01     DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.426032)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/profiling-artifacts/post422_20260423_seed1.bench.json
+++ b/profiling-artifacts/post422_20260423_seed1.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA A100 80GB PCIe",
+    "total_vram_mb": 81920,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 15.09623595,
+    "model_vram_mb": 17683
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 508,
+      "output_tokens": 128,
+      "total_time_secs": 2.442199267,
+      "tokens_per_sec": 52.4117756194544,
+      "peak_vram_mb": 18021
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 508,
+      "output_tokens": 512,
+      "total_time_secs": 9.769954813,
+      "tokens_per_sec": 52.40556479531795,
+      "peak_vram_mb": 18021
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 508,
+      "output_tokens": 1024,
+      "total_time_secs": 19.543141329,
+      "tokens_per_sec": 52.39689887932652,
+      "peak_vram_mb": 18021
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 508,
+      "output_tokens": 2048,
+      "total_time_secs": 39.084481271,
+      "tokens_per_sec": 52.39931382995174,
+      "peak_vram_mb": 18021
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 508,
+    "prefill_time_ms": 377.243418,
+    "prefill_tokens_per_sec": 1346.6106385453224,
+    "time_to_first_token_ms": 377.243418,
+    "mean_inter_token_ms": 32.44682068503937,
+    "p50_inter_token_ms": 44.007887000000004,
+    "p99_inter_token_ms": 52.528655,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 30.819660567270358,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.2828282828282828,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post422_20260423_seed1_compare_bf16.txt
+++ b/profiling-artifacts/post422_20260423_seed1_compare_bf16.txt
@@ -1,0 +1,2008 @@
+# seed 1 compare vs bf16 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.51e-03     7.72e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.05e-01     2.09e-02    
+h_layer_16             1x1x2560               True     False    9.47e-01   7.19e-01     5.06e-02    
+h_layer_23             1x1x2560               True     False    9.73e-01   7.93e-01     9.31e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.08e+01     1.15e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.91e-03     8.07e-08    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   1.56e-02     2.02e-06    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   5.57e-02     8.54e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   3.91e-03     9.91e-05    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   3.91e-03     9.32e-04    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.55e-02     7.64e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   3.91e-03     4.48e-06    
+b11__gdn_gated_norm    1x508x4096             True     True     1.00e+00   2.34e-02     4.87e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.56e-02     6.26e-05    
+h_layer_24             1x1x2560               True     False    9.76e-01   9.45e-01     9.79e-02    
+h_layer_25             1x1x2560               True     False    9.77e-01   9.34e-01     1.00e-01    
+h_layer_26             1x1x2560               True     False    9.81e-01   9.41e-01     1.03e-01    
+h_layer_27             1x1x2560               True     False    9.79e-01   1.38e+00     1.20e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   1.12e+00     1.35e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   1.62e+00     1.48e-01    
+h_layer_30             1x1x2560               True     False    9.80e-01   1.03e+00     1.70e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.48e-01   8.98e-01     1.87e-02    
+h_layer_8              1x1x2560               True     False    7.32e-02   1.45e+01     1.78e-01    
+h_layer_16             1x1x2560               True     False    1.42e-02   1.24e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    4.38e-01   1.20e+01     3.06e-01    
+h_layer_31             1x1x2560               True     False    3.49e-01   2.61e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.45e-06    
+b11__gdn_conv          1x1x8192               True     False    4.71e-01   1.85e+01     4.05e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.32e-01   8.60e-01     4.08e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.00e-01   8.08e-01     5.51e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     7.78e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.83e-03     7.56e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.64e-01   4.82e-01     1.33e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.67e-01   1.43e+00     6.41e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.60e-01   6.41e-01     9.64e-03    
+h_layer_24             1x1x2560               True     False    4.85e-01   1.12e+01     3.23e-01    
+h_layer_25             1x1x2560               True     False    5.29e-01   1.03e+01     3.36e-01    
+h_layer_26             1x1x2560               True     False    5.58e-01   7.39e+00     3.84e-01    
+h_layer_27             1x1x2560               True     False    5.04e-01   1.12e+01     4.88e-01    
+h_layer_28             1x1x2560               True     False    5.63e-01   9.75e+00     5.35e-01    
+h_layer_29             1x1x2560               True     False    5.46e-01   1.42e+01     6.10e-01    
+h_layer_30             1x1x2560               True     False    4.95e-01   9.53e+00     7.31e-01    
+b12__post_input_norm   1x1x2560               True     False    4.31e-01   1.96e+01     9.28e-01    
+b12__q_proj            1x1x8192               True     False    5.74e-01   1.02e+01     1.51e+00    
+b12__k_proj            1x1x1024               True     False    4.86e-01   5.91e+00     8.39e-01    
+b12__v_proj            1x1x1024               True     False    9.06e-01   9.09e+00     1.00e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.51e-01   7.45e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    4.90e-01   8.03e+00     1.05e+00    
+b12__post_attn_norm    1x1x2560               True     False    5.18e-01   1.03e+01     8.70e-01    
+b12__mlp_gate          1x1x9216               True     False    8.42e-01   1.08e+01     7.08e-01    
+b12__mlp_up            1x1x9216               True     False    7.20e-01   6.63e+00     5.82e-01    
+b12__mlp_down          1x1x2560               True     False    5.05e-01   1.12e+01     5.86e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.64e-01   7.11e-01     2.09e-02    
+h_layer_8              1x1x2560               True     False    4.68e-02   1.66e+01     1.81e-01    
+h_layer_16             1x1x2560               True     False    -1.07e-02  1.51e+01     1.96e-01    
+h_layer_23             1x1x2560               True     False    3.44e-01   7.25e+00     3.49e-01    
+h_layer_31             1x1x2560               True     False    2.54e-01   3.98e+01     2.19e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.91e-03     4.39e-07    
+b11__gdn_conv          1x1x8192               True     False    9.03e-01   3.16e+00     2.74e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.85e-01   8.69e-01     3.31e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.47e-01   9.62e-01     4.90e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.25e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.66e-03     5.97e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.70e-01   6.04e-01     1.40e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.00e-01   1.26e+00     6.27e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.42e-01   6.41e-01     9.76e-03    
+h_layer_24             1x1x2560               True     False    4.18e-01   7.32e+00     3.66e-01    
+h_layer_25             1x1x2560               True     False    4.26e-01   8.51e+00     4.30e-01    
+h_layer_26             1x1x2560               True     False    5.42e-01   6.18e+01     5.35e-01    
+h_layer_27             1x1x2560               True     False    3.93e-01   1.21e+01     5.24e-01    
+h_layer_28             1x1x2560               True     False    4.59e-01   1.35e+01     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.47e-01   1.81e+01     6.30e-01    
+h_layer_30             1x1x2560               True     False    4.18e-01   9.53e+00     7.51e-01    
+b12__post_input_norm   1x1x2560               True     False    3.23e-01   2.15e+01     9.72e-01    
+b12__q_proj            1x1x8192               True     False    5.90e-01   1.28e+01     1.42e+00    
+b12__k_proj            1x1x1024               True     False    2.80e-01   8.14e+00     9.94e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   1.08e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.78e-01   8.67e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    2.95e-01   1.05e+01     1.25e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.26e-01   1.15e+01     9.11e-01    
+b12__mlp_gate          1x1x9216               True     False    8.44e-01   1.30e+01     7.90e-01    
+b12__mlp_up            1x1x9216               True     False    6.51e-01   8.26e+00     6.77e-01    
+b12__mlp_down          1x1x2560               True     False    4.44e-01   1.58e+01     7.41e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.93e-01   8.75e-01     2.14e-02    
+h_layer_8              1x1x2560               True     False    2.79e-02   1.52e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -4.78e-02  1.36e+01     1.99e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.09e+01     3.29e-01    
+h_layer_31             1x1x2560               True     False    2.31e-01   3.73e+01     2.28e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   3.91e-03     1.53e-06    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   1.56e-02     3.86e-05    
+b11__gdn_conv          1x1x8192               True     False    6.59e-01   1.32e+01     3.80e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.86e-01   8.10e-01     3.70e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.70e-01   8.38e-01     5.85e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.11e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.82e-03     6.51e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.60e-01   5.33e-01     1.56e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.90e-01   1.18e+00     5.57e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.50e-01   7.42e-01     9.60e-03    
+h_layer_24             1x1x2560               True     False    4.15e-01   8.81e+00     3.47e-01    
+h_layer_25             1x1x2560               True     False    4.83e-01   7.12e+00     3.59e-01    
+h_layer_26             1x1x2560               True     False    5.12e-01   7.08e+00     3.98e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   7.38e+00     5.22e-01    
+h_layer_28             1x1x2560               True     False    4.83e-01   7.38e+00     5.92e-01    
+h_layer_29             1x1x2560               True     False    4.58e-01   1.20e+01     6.62e-01    
+h_layer_30             1x1x2560               True     False    3.88e-01   9.55e+00     8.22e-01    
+b12__post_input_norm   1x1x2560               True     False    3.15e-01   1.97e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    5.77e-01   1.08e+01     1.47e+00    
+b12__k_proj            1x1x1024               True     False    3.36e-01   7.71e+00     8.97e-01    
+b12__v_proj            1x1x1024               True     False    8.98e-01   1.01e+01     1.05e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.16e-01   8.52e+00     1.03e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.62e-01   9.44e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.09e-01   9.94e+00     9.69e-01    
+b12__mlp_gate          1x1x9216               True     False    8.42e-01   1.28e+01     8.10e-01    
+b12__mlp_up            1x1x9216               True     False    6.39e-01   7.70e+00     7.29e-01    
+b12__mlp_down          1x1x2560               True     False    4.04e-01   1.21e+01     7.72e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.28e-01   1.23e+00     2.11e-02    
+h_layer_8              1x1x2560               True     False    -5.38e-03  1.47e+01     1.74e-01    
+h_layer_16             1x1x2560               True     False    -7.04e-02  1.33e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.57e-01   1.20e+01     3.17e-01    
+h_layer_31             1x1x2560               True     False    3.65e-01   2.72e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.91e-03     4.75e-07    
+b11__gdn_conv          1x1x8192               True     False    6.82e-01   4.88e+00     3.21e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.12e-01   8.63e-01     4.17e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.50e-01   8.85e-01     5.58e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.34e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   4.37e-03     6.94e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.83e-01   5.60e-01     1.60e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.60e-01   1.30e+00     7.48e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   5.94e-01     1.17e-02    
+h_layer_24             1x1x2560               True     False    4.24e-01   9.88e+00     3.42e-01    
+h_layer_25             1x1x2560               True     False    4.86e-01   7.50e+00     3.56e-01    
+h_layer_26             1x1x2560               True     False    4.19e-01   6.61e+00     3.86e-01    
+h_layer_27             1x1x2560               True     False    4.63e-01   1.11e+01     4.96e-01    
+h_layer_28             1x1x2560               True     False    5.22e-01   7.50e+00     5.44e-01    
+h_layer_29             1x1x2560               True     False    5.20e-01   1.16e+01     6.24e-01    
+h_layer_30             1x1x2560               True     False    4.24e-01   9.38e+00     7.79e-01    
+b12__post_input_norm   1x1x2560               True     False    3.46e-01   1.98e+01     9.88e-01    
+b12__q_proj            1x1x8192               True     False    6.24e-01   1.20e+01     1.32e+00    
+b12__k_proj            1x1x1024               True     False    3.09e-01   6.19e+00     9.35e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   9.22e+00     1.02e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.05e-01   8.95e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.26e-01   8.20e+00     1.28e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.66e-01   1.06e+01     9.04e-01    
+b12__mlp_gate          1x1x9216               True     False    8.76e-01   1.23e+01     6.74e-01    
+b12__mlp_up            1x1x9216               True     False    7.23e-01   7.07e+00     5.87e-01    
+b12__mlp_down          1x1x2560               True     False    5.47e-01   1.96e+01     6.01e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.32e-01   4.77e-01     1.73e-02    
+h_layer_8              1x1x2560               True     False    1.47e-02   1.62e+01     1.74e-01    
+h_layer_16             1x1x2560               True     False    -3.29e-02  1.48e+01     1.87e-01    
+h_layer_23             1x1x2560               True     False    3.81e-01   6.31e+00     3.35e-01    
+h_layer_31             1x1x2560               True     False    3.30e-01   2.87e+01     2.15e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   6.25e-02     5.08e-06    
+b11__gdn_conv          1x1x8192               True     False    9.02e-01   2.96e+00     2.56e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.40e-01   8.85e-01     3.30e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.93e-01   9.54e-01     5.16e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.25e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.46e-02     1.47e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    5.01e-01   4.46e-01     1.35e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.14e-01   1.21e+00     5.45e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.56e-01   6.25e-01     7.64e-03    
+h_layer_24             1x1x2560               True     False    4.34e-01   6.17e+00     3.51e-01    
+h_layer_25             1x1x2560               True     False    4.67e-01   6.59e+00     3.90e-01    
+h_layer_26             1x1x2560               True     False    5.36e-01   4.28e+01     4.71e-01    
+h_layer_27             1x1x2560               True     False    4.20e-01   9.56e+00     5.08e-01    
+h_layer_28             1x1x2560               True     False    4.75e-01   1.01e+01     5.59e-01    
+h_layer_29             1x1x2560               True     False    4.61e-01   1.48e+01     6.34e-01    
+h_layer_30             1x1x2560               True     False    4.27e-01   8.59e+00     7.66e-01    
+b12__post_input_norm   1x1x2560               True     False    3.42e-01   1.90e+01     9.73e-01    
+b12__q_proj            1x1x8192               True     False    5.85e-01   1.26e+01     1.43e+00    
+b12__k_proj            1x1x1024               True     False    3.20e-01   7.07e+00     9.34e-01    
+b12__v_proj            1x1x1024               True     False    9.02e-01   9.28e+00     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.89e-01   9.61e+00     1.05e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.33e-01   9.06e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.47e-01   1.02e+01     9.12e-01    
+b12__mlp_gate          1x1x9216               True     False    8.54e-01   1.27e+01     7.87e-01    
+b12__mlp_up            1x1x9216               True     False    6.95e-01   7.95e+00     6.41e-01    
+b12__mlp_down          1x1x2560               True     False    4.45e-01   2.12e+01     7.04e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.01e-01   9.69e-01     2.41e-02    
+h_layer_8              1x1x2560               True     False    5.29e-02   1.55e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -2.61e-02  1.35e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.70e-01   7.22e+00     3.19e-01    
+h_layer_31             1x1x2560               True     False    2.81e-01   2.70e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.04e-06    
+b11__gdn_conv          1x1x8192               True     False    6.87e-01   1.10e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.67e-01   8.28e-01     3.61e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.54e-01   8.28e-01     5.94e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.00e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.58e-03     1.02e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    3.60e-01   5.70e-01     1.50e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.26e-01   1.54e+00     6.60e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.38e-01   9.38e-01     1.02e-02    
+h_layer_24             1x1x2560               True     False    4.19e-01   6.30e+00     3.40e-01    
+h_layer_25             1x1x2560               True     False    4.86e-01   6.54e+00     3.53e-01    
+h_layer_26             1x1x2560               True     False    4.90e-01   7.35e+00     3.93e-01    
+h_layer_27             1x1x2560               True     False    4.22e-01   7.19e+00     5.16e-01    
+h_layer_28             1x1x2560               True     False    4.96e-01   7.14e+00     5.68e-01    
+h_layer_29             1x1x2560               True     False    4.81e-01   9.12e+00     6.37e-01    
+h_layer_30             1x1x2560               True     False    4.00e-01   9.90e+00     8.01e-01    
+b12__post_input_norm   1x1x2560               True     False    3.27e-01   2.05e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    5.44e-01   1.10e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.74e-01   8.53e+00     8.97e-01    
+b12__v_proj            1x1x1024               True     False    8.96e-01   9.78e+00     1.06e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.16e-01   8.91e+00     1.02e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.95e-01   9.22e+00     1.16e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.23e-01   1.03e+01     9.51e-01    
+b12__mlp_gate          1x1x9216               True     False    8.35e-01   1.36e+01     8.86e-01    
+b12__mlp_up            1x1x9216               True     False    6.58e-01   8.61e+00     7.45e-01    
+b12__mlp_down          1x1x2560               True     False    4.43e-01   1.54e+01     7.34e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.04e-01   1.28e+00     2.00e-02    
+h_layer_8              1x1x2560               True     False    1.51e-04   1.53e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -5.40e-02  1.37e+01     1.94e-01    
+h_layer_23             1x1x2560               True     False    2.98e-01   1.22e+01     3.37e-01    
+h_layer_31             1x1x2560               True     False    2.89e-01   3.38e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.59e-06    
+b11__gdn_conv          1x1x8192               True     False    6.68e-01   6.15e+00     3.06e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.72e-01   8.42e-01     4.12e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.57e-01   9.14e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     8.24e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.26e-03     9.49e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.63e-01   4.45e-01     1.52e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.69e-01   1.17e+00     7.56e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   7.81e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    3.70e-01   1.00e+01     3.56e-01    
+h_layer_25             1x1x2560               True     False    4.51e-01   7.81e+00     3.66e-01    
+h_layer_26             1x1x2560               True     False    4.30e-01   6.94e+00     3.95e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   1.46e+01     5.14e-01    
+h_layer_28             1x1x2560               True     False    5.22e-01   8.88e+00     5.32e-01    
+h_layer_29             1x1x2560               True     False    5.19e-01   1.31e+01     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.08e-01   9.42e+00     7.53e-01    
+b12__post_input_norm   1x1x2560               True     False    3.40e-01   1.93e+01     9.90e-01    
+b12__q_proj            1x1x8192               True     False    5.97e-01   1.22e+01     1.39e+00    
+b12__k_proj            1x1x1024               True     False    3.09e-01   6.85e+00     9.61e-01    
+b12__v_proj            1x1x1024               True     False    8.89e-01   1.16e+01     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.94e-01   9.73e+00     1.06e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.26e-01   7.38e+00     1.26e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.42e-01   1.05e+01     9.29e-01    
+b12__mlp_gate          1x1x9216               True     False    8.36e-01   1.28e+01     7.91e-01    
+b12__mlp_up            1x1x9216               True     False    6.93e-01   7.82e+00     6.31e-01    
+b12__mlp_down          1x1x2560               True     False    2.54e-01   3.08e+01     6.34e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.99e-01   2.71e-01     1.43e-02    
+h_layer_8              1x1x2560               True     False    3.34e-01   2.19e+00     1.15e-01    
+h_layer_16             1x1x2560               True     False    2.13e-01   3.45e+00     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.55e-01   9.53e+00     3.63e-01    
+h_layer_31             1x1x2560               True     False    4.29e-01   3.69e+01     1.78e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   1.56e-02     1.45e-06    
+b11__gdn_conv          1x2x8192               True     False    9.51e-01   4.06e+00     1.85e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.50e-01   9.00e-01     3.27e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.96e-01   9.22e-01     3.13e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   3.91e-03     8.09e-04    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.25e-02     8.20e-04    
+b11__gdn_recur_out     1x2x32x128             True     False    6.70e-01   5.61e-01     1.39e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    8.68e-01   1.95e+00     6.01e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.19e-01   1.06e+00     7.77e-03    
+h_layer_24             1x1x2560               True     False    4.66e-01   1.00e+01     3.89e-01    
+h_layer_25             1x1x2560               True     False    4.94e-01   1.03e+01     4.17e-01    
+h_layer_26             1x1x2560               True     False    5.28e-01   4.00e+01     4.71e-01    
+h_layer_27             1x1x2560               True     False    4.94e-01   1.09e+01     5.54e-01    
+h_layer_28             1x1x2560               True     False    5.33e-01   1.10e+01     5.91e-01    
+h_layer_29             1x1x2560               True     False    5.43e-01   1.10e+01     6.40e-01    
+h_layer_30             1x1x2560               True     False    4.80e-01   1.12e+01     7.57e-01    
+b12__post_input_norm   1x2x2560               True     False    2.52e-01   1.64e+01     1.06e+00    
+b12__q_proj            1x2x8192               True     False    6.30e-01   1.08e+01     1.21e+00    
+b12__k_proj            1x2x1024               True     False    3.53e-01   7.52e+00     9.55e-01    
+b12__v_proj            1x2x1024               True     False    8.89e-01   9.02e+00     1.06e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.25e-01   1.09e+01     1.03e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.59e-01   1.00e+01     1.20e+00    
+b12__o_proj            1x2x2560               True     False    3.37e-01   8.23e+00     3.01e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.53e-01   1.19e+01     1.00e+00    
+b12__mlp_gate          1x2x9216               True     False    8.20e-01   1.28e+01     8.57e-01    
+b12__mlp_up            1x2x9216               True     False    6.79e-01   9.78e+00     6.95e-01    
+b12__mlp_down          1x2x2560               True     False    4.50e-01   2.74e+01     6.80e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.74e-01   6.09e-01     1.91e-02    
+h_layer_8              1x1x2560               True     False    2.31e-02   1.69e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -3.50e-02  1.53e+01     1.97e-01    
+h_layer_23             1x1x2560               True     False    2.15e-01   7.03e+00     3.84e-01    
+h_layer_31             1x1x2560               True     False    2.08e-01   3.12e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     8.11e-07    
+b11__gdn_conv          1x1x8192               True     False    7.23e-01   1.45e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.36e-01   8.54e-01     3.52e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   8.22e-01     5.38e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     6.71e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.36e-02     8.05e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.78e-01   6.18e-01     1.57e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.90e-01   1.34e+00     5.74e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   6.41e-01     8.90e-03    
+h_layer_24             1x1x2560               True     False    2.46e-01   7.03e+00     3.96e-01    
+h_layer_25             1x1x2560               True     False    2.25e-01   8.15e+00     4.46e-01    
+h_layer_26             1x1x2560               True     False    1.87e-01   6.65e+01     5.38e-01    
+h_layer_27             1x1x2560               True     False    2.41e-01   6.00e+00     5.24e-01    
+h_layer_28             1x1x2560               True     False    3.15e-01   6.69e+00     6.01e-01    
+h_layer_29             1x1x2560               True     False    3.13e-01   7.39e+00     6.70e-01    
+h_layer_30             1x1x2560               True     False    2.49e-01   1.26e+01     8.28e-01    
+b12__post_input_norm   1x1x2560               True     False    1.98e-01   2.08e+01     1.11e+00    
+b12__q_proj            1x1x8192               True     False    5.00e-01   1.20e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    3.36e-01   6.80e+00     9.76e-01    
+b12__v_proj            1x1x1024               True     False    8.75e-01   9.41e+00     1.18e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.29e-01   1.07e+01     1.14e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.70e-01   6.78e+00     1.24e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.02e-01   1.10e+01     1.05e+00    
+b12__mlp_gate          1x1x9216               True     False    8.08e-01   1.35e+01     9.45e-01    
+b12__mlp_up            1x1x9216               True     False    6.30e-01   7.88e+00     7.81e-01    
+b12__mlp_down          1x1x2560               True     False    3.36e-01   1.93e+01     7.60e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.43e-01   9.14e-01     1.92e-02    
+h_layer_8              1x1x2560               True     False    2.83e-02   1.62e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -1.41e-02  1.41e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.15e+01     3.34e-01    
+h_layer_31             1x1x2560               True     False    3.35e-01   2.82e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.91e-03     4.79e-07    
+b11__gdn_conv          1x1x8192               True     False    6.46e-01   1.42e+01     3.64e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.05e-01   8.68e-01     3.85e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.41e-01   8.79e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.84e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   3.83e-03     5.99e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.56e-01   4.78e-01     1.58e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.96e-01   1.12e+00     5.95e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.58e-01   6.41e-01     9.42e-03    
+h_layer_24             1x1x2560               True     False    4.12e-01   9.94e+00     3.57e-01    
+h_layer_25             1x1x2560               True     False    4.66e-01   8.44e+00     3.69e-01    
+h_layer_26             1x1x2560               True     False    3.85e-01   6.62e+00     4.06e-01    
+h_layer_27             1x1x2560               True     False    4.71e-01   1.41e+01     5.17e-01    
+h_layer_28             1x1x2560               True     False    4.98e-01   8.62e+00     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.83e-01   1.22e+01     6.59e-01    
+h_layer_30             1x1x2560               True     False    3.98e-01   9.36e+00     7.97e-01    
+b12__post_input_norm   1x1x2560               True     False    3.31e-01   2.03e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    6.12e-01   1.08e+01     1.40e+00    
+b12__k_proj            1x1x1024               True     False    3.50e-01   5.55e+00     8.95e-01    
+b12__v_proj            1x1x1024               True     False    8.91e-01   1.19e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.70e-01   8.97e+00     1.08e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.64e-01   6.77e+00     1.22e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.48e-01   1.05e+01     9.30e-01    
+b12__mlp_gate          1x1x9216               True     False    8.67e-01   1.20e+01     7.54e-01    
+b12__mlp_up            1x1x9216               True     False    7.18e-01   7.21e+00     6.18e-01    
+b12__mlp_down          1x1x2560               True     False    4.51e-01   2.40e+01     5.93e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=3.51e-03   ok    cos=8.48e-01   max|Δ|=8.98e-01   DIV   cos=7.64e-01   max|Δ|=7.11e-01   DIV   cos=7.93e-01   max|Δ|=8.75e-01   DIV   cos=8.28e-01   max|Δ|=1.23e+00   DIV   cos=8.32e-01   max|Δ|=4.77e-01   DIV   cos=7.01e-01   max|Δ|=9.69e-01   DIV   cos=8.04e-01   max|Δ|=1.28e+00   DIV   cos=8.99e-01   max|Δ|=2.71e-01   DIV   cos=7.74e-01   max|Δ|=6.09e-01   DIV   cos=8.43e-01   max|Δ|=9.14e-01   DIV  
+  h_layer_8             cos=9.76e-01   max|Δ|=1.05e-01   DIV   cos=7.32e-02   max|Δ|=1.45e+01   DIV   cos=4.68e-02   max|Δ|=1.66e+01   DIV   cos=2.79e-02   max|Δ|=1.52e+01   DIV   cos=-5.38e-03  max|Δ|=1.47e+01   DIV   cos=1.47e-02   max|Δ|=1.62e+01   DIV   cos=5.29e-02   max|Δ|=1.55e+01   DIV   cos=1.51e-04   max|Δ|=1.53e+01   DIV   cos=3.34e-01   max|Δ|=2.19e+00   DIV   cos=2.31e-02   max|Δ|=1.69e+01   DIV   cos=2.83e-02   max|Δ|=1.62e+01   DIV  
+  h_layer_16            cos=9.47e-01   max|Δ|=7.19e-01   DIV   cos=1.42e-02   max|Δ|=1.24e+01   DIV   cos=-1.07e-02  max|Δ|=1.51e+01   DIV   cos=-4.78e-02  max|Δ|=1.36e+01   DIV   cos=-7.04e-02  max|Δ|=1.33e+01   DIV   cos=-3.29e-02  max|Δ|=1.48e+01   DIV   cos=-2.61e-02  max|Δ|=1.35e+01   DIV   cos=-5.40e-02  max|Δ|=1.37e+01   DIV   cos=2.13e-01   max|Δ|=3.45e+00   DIV   cos=-3.50e-02  max|Δ|=1.53e+01   DIV   cos=-1.41e-02  max|Δ|=1.41e+01   DIV  
+  h_layer_23            cos=9.73e-01   max|Δ|=7.93e-01   DIV   cos=4.38e-01   max|Δ|=1.20e+01   DIV   cos=3.44e-01   max|Δ|=7.25e+00   DIV   cos=3.56e-01   max|Δ|=1.09e+01   DIV   cos=3.57e-01   max|Δ|=1.20e+01   DIV   cos=3.81e-01   max|Δ|=6.31e+00   DIV   cos=3.70e-01   max|Δ|=7.22e+00   DIV   cos=2.98e-01   max|Δ|=1.22e+01   DIV   cos=4.55e-01   max|Δ|=9.53e+00   DIV   cos=2.15e-01   max|Δ|=7.03e+00   DIV   cos=3.56e-01   max|Δ|=1.15e+01   DIV  
+  h_layer_31            cos=9.57e-01   max|Δ|=2.08e+01   DIV   cos=3.49e-01   max|Δ|=2.61e+01   DIV   cos=2.54e-01   max|Δ|=3.98e+01   DIV   cos=2.31e-01   max|Δ|=3.73e+01   DIV   cos=3.65e-01   max|Δ|=2.72e+01   DIV   cos=3.30e-01   max|Δ|=2.87e+01   DIV   cos=2.81e-01   max|Δ|=2.70e+01   DIV   cos=2.89e-01   max|Δ|=3.38e+01   DIV   cos=4.29e-01   max|Δ|=3.69e+01   DIV   cos=2.08e-01   max|Δ|=3.12e+01   DIV   cos=3.35e-01   max|Δ|=2.82e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_0' (pos=0_s1)
+Phase B10 verdict: DIVERGENCE AT LAYER 0
+  -> Input-path bug: embedding lookup, rotary_inv_freq build, first
+     block's Q/K/V proj or GDN sub-op, OR prompt-token construction
+     mismatch between kiln and reference. Verify `prompt_tokens` meta
+     matches exactly, then narrow to layer 0's sub-ops.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.51e-03     7.72e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.05e-01     2.09e-02    
+h_layer_16             1x1x2560               True     False    9.47e-01   7.19e-01     5.06e-02    
+h_layer_23             1x1x2560               True     False    9.73e-01   7.93e-01     9.31e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.08e+01     1.15e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.91e-03     8.07e-08    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   1.56e-02     2.02e-06    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   5.57e-02     8.54e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   3.91e-03     9.91e-05    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   3.91e-03     9.32e-04    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.55e-02     7.64e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   3.91e-03     4.48e-06    
+b11__gdn_gated_norm    1x508x4096             True     True     1.00e+00   2.34e-02     4.87e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.56e-02     6.26e-05    
+h_layer_24             1x1x2560               True     False    9.76e-01   9.45e-01     9.79e-02    
+h_layer_25             1x1x2560               True     False    9.77e-01   9.34e-01     1.00e-01    
+h_layer_26             1x1x2560               True     False    9.81e-01   9.41e-01     1.03e-01    
+h_layer_27             1x1x2560               True     False    9.79e-01   1.38e+00     1.20e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   1.12e+00     1.35e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   1.62e+00     1.48e-01    
+h_layer_30             1x1x2560               True     False    9.80e-01   1.03e+00     1.70e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.48e-01   8.98e-01     1.87e-02    
+h_layer_8              1x1x2560               True     False    7.32e-02   1.45e+01     1.78e-01    
+h_layer_16             1x1x2560               True     False    1.42e-02   1.24e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    4.38e-01   1.20e+01     3.06e-01    
+h_layer_31             1x1x2560               True     False    3.49e-01   2.61e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.45e-06    
+b11__gdn_conv          1x1x8192               True     False    4.71e-01   1.85e+01     4.05e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.32e-01   8.60e-01     4.08e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.00e-01   8.08e-01     5.51e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     7.78e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.83e-03     7.56e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.64e-01   4.82e-01     1.33e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.67e-01   1.43e+00     6.41e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.60e-01   6.41e-01     9.64e-03    
+h_layer_24             1x1x2560               True     False    4.85e-01   1.12e+01     3.23e-01    
+h_layer_25             1x1x2560               True     False    5.29e-01   1.03e+01     3.36e-01    
+h_layer_26             1x1x2560               True     False    5.58e-01   7.39e+00     3.84e-01    
+h_layer_27             1x1x2560               True     False    5.04e-01   1.12e+01     4.88e-01    
+h_layer_28             1x1x2560               True     False    5.63e-01   9.75e+00     5.35e-01    
+h_layer_29             1x1x2560               True     False    5.46e-01   1.42e+01     6.10e-01    
+h_layer_30             1x1x2560               True     False    4.95e-01   9.53e+00     7.31e-01    
+b12__post_input_norm   1x1x2560               True     False    4.31e-01   1.96e+01     9.28e-01    
+b12__q_proj            1x1x8192               True     False    5.74e-01   1.02e+01     1.51e+00    
+b12__k_proj            1x1x1024               True     False    4.86e-01   5.91e+00     8.39e-01    
+b12__v_proj            1x1x1024               True     False    9.06e-01   9.09e+00     1.00e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.51e-01   7.45e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    4.90e-01   8.03e+00     1.05e+00    
+b12__post_attn_norm    1x1x2560               True     False    5.18e-01   1.03e+01     8.70e-01    
+b12__mlp_gate          1x1x9216               True     False    8.42e-01   1.08e+01     7.08e-01    
+b12__mlp_up            1x1x9216               True     False    7.20e-01   6.63e+00     5.82e-01    
+b12__mlp_down          1x1x2560               True     False    5.05e-01   1.12e+01     5.86e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.64e-01   7.11e-01     2.09e-02    
+h_layer_8              1x1x2560               True     False    4.68e-02   1.66e+01     1.81e-01    
+h_layer_16             1x1x2560               True     False    -1.07e-02  1.51e+01     1.96e-01    
+h_layer_23             1x1x2560               True     False    3.44e-01   7.25e+00     3.49e-01    
+h_layer_31             1x1x2560               True     False    2.54e-01   3.98e+01     2.19e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.91e-03     4.39e-07    
+b11__gdn_conv          1x1x8192               True     False    9.03e-01   3.16e+00     2.74e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.85e-01   8.69e-01     3.31e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.47e-01   9.62e-01     4.90e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.25e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.66e-03     5.97e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.70e-01   6.04e-01     1.40e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.00e-01   1.26e+00     6.27e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.42e-01   6.41e-01     9.76e-03    
+h_layer_24             1x1x2560               True     False    4.18e-01   7.32e+00     3.66e-01    
+h_layer_25             1x1x2560               True     False    4.26e-01   8.51e+00     4.30e-01    
+h_layer_26             1x1x2560               True     False    5.42e-01   6.18e+01     5.35e-01    
+h_layer_27             1x1x2560               True     False    3.93e-01   1.21e+01     5.24e-01    
+h_layer_28             1x1x2560               True     False    4.59e-01   1.35e+01     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.47e-01   1.81e+01     6.30e-01    
+h_layer_30             1x1x2560               True     False    4.18e-01   9.53e+00     7.51e-01    
+b12__post_input_norm   1x1x2560               True     False    3.23e-01   2.15e+01     9.72e-01    
+b12__q_proj            1x1x8192               True     False    5.90e-01   1.28e+01     1.42e+00    
+b12__k_proj            1x1x1024               True     False    2.80e-01   8.14e+00     9.94e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   1.08e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.78e-01   8.67e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    2.95e-01   1.05e+01     1.25e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.26e-01   1.15e+01     9.11e-01    
+b12__mlp_gate          1x1x9216               True     False    8.44e-01   1.30e+01     7.90e-01    
+b12__mlp_up            1x1x9216               True     False    6.51e-01   8.26e+00     6.77e-01    
+b12__mlp_down          1x1x2560               True     False    4.44e-01   1.58e+01     7.41e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.93e-01   8.75e-01     2.14e-02    
+h_layer_8              1x1x2560               True     False    2.79e-02   1.52e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -4.78e-02  1.36e+01     1.99e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.09e+01     3.29e-01    
+h_layer_31             1x1x2560               True     False    2.31e-01   3.73e+01     2.28e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   3.91e-03     1.53e-06    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   1.56e-02     3.86e-05    
+b11__gdn_conv          1x1x8192               True     False    6.59e-01   1.32e+01     3.80e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.86e-01   8.10e-01     3.70e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.70e-01   8.38e-01     5.85e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.11e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.82e-03     6.51e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.60e-01   5.33e-01     1.56e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.90e-01   1.18e+00     5.57e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.50e-01   7.42e-01     9.60e-03    
+h_layer_24             1x1x2560               True     False    4.15e-01   8.81e+00     3.47e-01    
+h_layer_25             1x1x2560               True     False    4.83e-01   7.12e+00     3.59e-01    
+h_layer_26             1x1x2560               True     False    5.12e-01   7.08e+00     3.98e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   7.38e+00     5.22e-01    
+h_layer_28             1x1x2560               True     False    4.83e-01   7.38e+00     5.92e-01    
+h_layer_29             1x1x2560               True     False    4.58e-01   1.20e+01     6.62e-01    
+h_layer_30             1x1x2560               True     False    3.88e-01   9.55e+00     8.22e-01    
+b12__post_input_norm   1x1x2560               True     False    3.15e-01   1.97e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    5.77e-01   1.08e+01     1.47e+00    
+b12__k_proj            1x1x1024               True     False    3.36e-01   7.71e+00     8.97e-01    
+b12__v_proj            1x1x1024               True     False    8.98e-01   1.01e+01     1.05e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.16e-01   8.52e+00     1.03e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.62e-01   9.44e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.09e-01   9.94e+00     9.69e-01    
+b12__mlp_gate          1x1x9216               True     False    8.42e-01   1.28e+01     8.10e-01    
+b12__mlp_up            1x1x9216               True     False    6.39e-01   7.70e+00     7.29e-01    
+b12__mlp_down          1x1x2560               True     False    4.04e-01   1.21e+01     7.72e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.28e-01   1.23e+00     2.11e-02    
+h_layer_8              1x1x2560               True     False    -5.38e-03  1.47e+01     1.74e-01    
+h_layer_16             1x1x2560               True     False    -7.04e-02  1.33e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.57e-01   1.20e+01     3.17e-01    
+h_layer_31             1x1x2560               True     False    3.65e-01   2.72e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.91e-03     4.75e-07    
+b11__gdn_conv          1x1x8192               True     False    6.82e-01   4.88e+00     3.21e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.12e-01   8.63e-01     4.17e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.50e-01   8.85e-01     5.58e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.34e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   4.37e-03     6.94e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.83e-01   5.60e-01     1.60e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.60e-01   1.30e+00     7.48e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   5.94e-01     1.17e-02    
+h_layer_24             1x1x2560               True     False    4.24e-01   9.88e+00     3.42e-01    
+h_layer_25             1x1x2560               True     False    4.86e-01   7.50e+00     3.56e-01    
+h_layer_26             1x1x2560               True     False    4.19e-01   6.61e+00     3.86e-01    
+h_layer_27             1x1x2560               True     False    4.63e-01   1.11e+01     4.96e-01    
+h_layer_28             1x1x2560               True     False    5.22e-01   7.50e+00     5.44e-01    
+h_layer_29             1x1x2560               True     False    5.20e-01   1.16e+01     6.24e-01    
+h_layer_30             1x1x2560               True     False    4.24e-01   9.38e+00     7.79e-01    
+b12__post_input_norm   1x1x2560               True     False    3.46e-01   1.98e+01     9.88e-01    
+b12__q_proj            1x1x8192               True     False    6.24e-01   1.20e+01     1.32e+00    
+b12__k_proj            1x1x1024               True     False    3.09e-01   6.19e+00     9.35e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   9.22e+00     1.02e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.05e-01   8.95e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.26e-01   8.20e+00     1.28e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.66e-01   1.06e+01     9.04e-01    
+b12__mlp_gate          1x1x9216               True     False    8.76e-01   1.23e+01     6.74e-01    
+b12__mlp_up            1x1x9216               True     False    7.23e-01   7.07e+00     5.87e-01    
+b12__mlp_down          1x1x2560               True     False    5.47e-01   1.96e+01     6.01e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.32e-01   4.77e-01     1.73e-02    
+h_layer_8              1x1x2560               True     False    1.47e-02   1.62e+01     1.74e-01    
+h_layer_16             1x1x2560               True     False    -3.29e-02  1.48e+01     1.87e-01    
+h_layer_23             1x1x2560               True     False    3.81e-01   6.31e+00     3.35e-01    
+h_layer_31             1x1x2560               True     False    3.30e-01   2.87e+01     2.15e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   6.25e-02     5.08e-06    
+b11__gdn_conv          1x1x8192               True     False    9.02e-01   2.96e+00     2.56e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.40e-01   8.85e-01     3.30e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.93e-01   9.54e-01     5.16e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.25e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.46e-02     1.47e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    5.01e-01   4.46e-01     1.35e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.14e-01   1.21e+00     5.45e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.56e-01   6.25e-01     7.64e-03    
+h_layer_24             1x1x2560               True     False    4.34e-01   6.17e+00     3.51e-01    
+h_layer_25             1x1x2560               True     False    4.67e-01   6.59e+00     3.90e-01    
+h_layer_26             1x1x2560               True     False    5.36e-01   4.28e+01     4.71e-01    
+h_layer_27             1x1x2560               True     False    4.20e-01   9.56e+00     5.08e-01    
+h_layer_28             1x1x2560               True     False    4.75e-01   1.01e+01     5.59e-01    
+h_layer_29             1x1x2560               True     False    4.61e-01   1.48e+01     6.34e-01    
+h_layer_30             1x1x2560               True     False    4.27e-01   8.59e+00     7.66e-01    
+b12__post_input_norm   1x1x2560               True     False    3.42e-01   1.90e+01     9.73e-01    
+b12__q_proj            1x1x8192               True     False    5.85e-01   1.26e+01     1.43e+00    
+b12__k_proj            1x1x1024               True     False    3.20e-01   7.07e+00     9.34e-01    
+b12__v_proj            1x1x1024               True     False    9.02e-01   9.28e+00     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.89e-01   9.61e+00     1.05e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.33e-01   9.06e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.47e-01   1.02e+01     9.12e-01    
+b12__mlp_gate          1x1x9216               True     False    8.54e-01   1.27e+01     7.87e-01    
+b12__mlp_up            1x1x9216               True     False    6.95e-01   7.95e+00     6.41e-01    
+b12__mlp_down          1x1x2560               True     False    4.45e-01   2.12e+01     7.04e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.01e-01   9.69e-01     2.41e-02    
+h_layer_8              1x1x2560               True     False    5.29e-02   1.55e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -2.61e-02  1.35e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.70e-01   7.22e+00     3.19e-01    
+h_layer_31             1x1x2560               True     False    2.81e-01   2.70e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.04e-06    
+b11__gdn_conv          1x1x8192               True     False    6.87e-01   1.10e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.67e-01   8.28e-01     3.61e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.54e-01   8.28e-01     5.94e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.00e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.58e-03     1.02e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    3.60e-01   5.70e-01     1.50e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.26e-01   1.54e+00     6.60e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.38e-01   9.38e-01     1.02e-02    
+h_layer_24             1x1x2560               True     False    4.19e-01   6.30e+00     3.40e-01    
+h_layer_25             1x1x2560               True     False    4.86e-01   6.54e+00     3.53e-01    
+h_layer_26             1x1x2560               True     False    4.90e-01   7.35e+00     3.93e-01    
+h_layer_27             1x1x2560               True     False    4.22e-01   7.19e+00     5.16e-01    
+h_layer_28             1x1x2560               True     False    4.96e-01   7.14e+00     5.68e-01    
+h_layer_29             1x1x2560               True     False    4.81e-01   9.12e+00     6.37e-01    
+h_layer_30             1x1x2560               True     False    4.00e-01   9.90e+00     8.01e-01    
+b12__post_input_norm   1x1x2560               True     False    3.27e-01   2.05e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    5.44e-01   1.10e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.74e-01   8.53e+00     8.97e-01    
+b12__v_proj            1x1x1024               True     False    8.96e-01   9.78e+00     1.06e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.16e-01   8.91e+00     1.02e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.95e-01   9.22e+00     1.16e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.23e-01   1.03e+01     9.51e-01    
+b12__mlp_gate          1x1x9216               True     False    8.35e-01   1.36e+01     8.86e-01    
+b12__mlp_up            1x1x9216               True     False    6.58e-01   8.61e+00     7.45e-01    
+b12__mlp_down          1x1x2560               True     False    4.43e-01   1.54e+01     7.34e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.04e-01   1.28e+00     2.00e-02    
+h_layer_8              1x1x2560               True     False    1.51e-04   1.53e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -5.40e-02  1.37e+01     1.94e-01    
+h_layer_23             1x1x2560               True     False    2.98e-01   1.22e+01     3.37e-01    
+h_layer_31             1x1x2560               True     False    2.89e-01   3.38e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.59e-06    
+b11__gdn_conv          1x1x8192               True     False    6.68e-01   6.15e+00     3.06e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.72e-01   8.42e-01     4.12e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.57e-01   9.14e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     8.24e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.26e-03     9.49e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.63e-01   4.45e-01     1.52e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.69e-01   1.17e+00     7.56e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   7.81e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    3.70e-01   1.00e+01     3.56e-01    
+h_layer_25             1x1x2560               True     False    4.51e-01   7.81e+00     3.66e-01    
+h_layer_26             1x1x2560               True     False    4.30e-01   6.94e+00     3.95e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   1.46e+01     5.14e-01    
+h_layer_28             1x1x2560               True     False    5.22e-01   8.88e+00     5.32e-01    
+h_layer_29             1x1x2560               True     False    5.19e-01   1.31e+01     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.08e-01   9.42e+00     7.53e-01    
+b12__post_input_norm   1x1x2560               True     False    3.40e-01   1.93e+01     9.90e-01    
+b12__q_proj            1x1x8192               True     False    5.97e-01   1.22e+01     1.39e+00    
+b12__k_proj            1x1x1024               True     False    3.09e-01   6.85e+00     9.61e-01    
+b12__v_proj            1x1x1024               True     False    8.89e-01   1.16e+01     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.94e-01   9.73e+00     1.06e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.26e-01   7.38e+00     1.26e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.42e-01   1.05e+01     9.29e-01    
+b12__mlp_gate          1x1x9216               True     False    8.36e-01   1.28e+01     7.91e-01    
+b12__mlp_up            1x1x9216               True     False    6.93e-01   7.82e+00     6.31e-01    
+b12__mlp_down          1x1x2560               True     False    2.54e-01   3.08e+01     6.34e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.99e-01   2.71e-01     1.43e-02    
+h_layer_8              1x1x2560               True     False    3.34e-01   2.19e+00     1.15e-01    
+h_layer_16             1x1x2560               True     False    2.13e-01   3.45e+00     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.55e-01   9.53e+00     3.63e-01    
+h_layer_31             1x1x2560               True     False    4.29e-01   3.69e+01     1.78e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   1.56e-02     1.45e-06    
+b11__gdn_conv          1x2x8192               True     False    9.51e-01   4.06e+00     1.85e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.50e-01   9.00e-01     3.27e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.96e-01   9.22e-01     3.13e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   3.91e-03     8.09e-04    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.25e-02     8.20e-04    
+b11__gdn_recur_out     1x2x32x128             True     False    6.70e-01   5.61e-01     1.39e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    8.68e-01   1.95e+00     6.01e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.19e-01   1.06e+00     7.77e-03    
+h_layer_24             1x1x2560               True     False    4.66e-01   1.00e+01     3.89e-01    
+h_layer_25             1x1x2560               True     False    4.94e-01   1.03e+01     4.17e-01    
+h_layer_26             1x1x2560               True     False    5.28e-01   4.00e+01     4.71e-01    
+h_layer_27             1x1x2560               True     False    4.94e-01   1.09e+01     5.54e-01    
+h_layer_28             1x1x2560               True     False    5.33e-01   1.10e+01     5.91e-01    
+h_layer_29             1x1x2560               True     False    5.43e-01   1.10e+01     6.40e-01    
+h_layer_30             1x1x2560               True     False    4.80e-01   1.12e+01     7.57e-01    
+b12__post_input_norm   1x2x2560               True     False    2.52e-01   1.64e+01     1.06e+00    
+b12__q_proj            1x2x8192               True     False    6.30e-01   1.08e+01     1.21e+00    
+b12__k_proj            1x2x1024               True     False    3.53e-01   7.52e+00     9.55e-01    
+b12__v_proj            1x2x1024               True     False    8.89e-01   9.02e+00     1.06e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.25e-01   1.09e+01     1.03e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.59e-01   1.00e+01     1.20e+00    
+b12__o_proj            1x2x2560               True     False    3.37e-01   8.23e+00     3.01e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.53e-01   1.19e+01     1.00e+00    
+b12__mlp_gate          1x2x9216               True     False    8.20e-01   1.28e+01     8.57e-01    
+b12__mlp_up            1x2x9216               True     False    6.79e-01   9.78e+00     6.95e-01    
+b12__mlp_down          1x2x2560               True     False    4.50e-01   2.74e+01     6.80e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.74e-01   6.09e-01     1.91e-02    
+h_layer_8              1x1x2560               True     False    2.31e-02   1.69e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -3.50e-02  1.53e+01     1.97e-01    
+h_layer_23             1x1x2560               True     False    2.15e-01   7.03e+00     3.84e-01    
+h_layer_31             1x1x2560               True     False    2.08e-01   3.12e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     8.11e-07    
+b11__gdn_conv          1x1x8192               True     False    7.23e-01   1.45e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.36e-01   8.54e-01     3.52e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   8.22e-01     5.38e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     6.71e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.36e-02     8.05e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.78e-01   6.18e-01     1.57e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.90e-01   1.34e+00     5.74e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   6.41e-01     8.90e-03    
+h_layer_24             1x1x2560               True     False    2.46e-01   7.03e+00     3.96e-01    
+h_layer_25             1x1x2560               True     False    2.25e-01   8.15e+00     4.46e-01    
+h_layer_26             1x1x2560               True     False    1.87e-01   6.65e+01     5.38e-01    
+h_layer_27             1x1x2560               True     False    2.41e-01   6.00e+00     5.24e-01    
+h_layer_28             1x1x2560               True     False    3.15e-01   6.69e+00     6.01e-01    
+h_layer_29             1x1x2560               True     False    3.13e-01   7.39e+00     6.70e-01    
+h_layer_30             1x1x2560               True     False    2.49e-01   1.26e+01     8.28e-01    
+b12__post_input_norm   1x1x2560               True     False    1.98e-01   2.08e+01     1.11e+00    
+b12__q_proj            1x1x8192               True     False    5.00e-01   1.20e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    3.36e-01   6.80e+00     9.76e-01    
+b12__v_proj            1x1x1024               True     False    8.75e-01   9.41e+00     1.18e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.29e-01   1.07e+01     1.14e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.70e-01   6.78e+00     1.24e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.02e-01   1.10e+01     1.05e+00    
+b12__mlp_gate          1x1x9216               True     False    8.08e-01   1.35e+01     9.45e-01    
+b12__mlp_up            1x1x9216               True     False    6.30e-01   7.88e+00     7.81e-01    
+b12__mlp_down          1x1x2560               True     False    3.36e-01   1.93e+01     7.60e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.43e-01   9.14e-01     1.92e-02    
+h_layer_8              1x1x2560               True     False    2.83e-02   1.62e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -1.41e-02  1.41e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.15e+01     3.34e-01    
+h_layer_31             1x1x2560               True     False    3.35e-01   2.82e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.91e-03     4.79e-07    
+b11__gdn_conv          1x1x8192               True     False    6.46e-01   1.42e+01     3.64e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.05e-01   8.68e-01     3.85e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.41e-01   8.79e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.84e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   3.83e-03     5.99e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.56e-01   4.78e-01     1.58e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.96e-01   1.12e+00     5.95e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.58e-01   6.41e-01     9.42e-03    
+h_layer_24             1x1x2560               True     False    4.12e-01   9.94e+00     3.57e-01    
+h_layer_25             1x1x2560               True     False    4.66e-01   8.44e+00     3.69e-01    
+h_layer_26             1x1x2560               True     False    3.85e-01   6.62e+00     4.06e-01    
+h_layer_27             1x1x2560               True     False    4.71e-01   1.41e+01     5.17e-01    
+h_layer_28             1x1x2560               True     False    4.98e-01   8.62e+00     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.83e-01   1.22e+01     6.59e-01    
+h_layer_30             1x1x2560               True     False    3.98e-01   9.36e+00     7.97e-01    
+b12__post_input_norm   1x1x2560               True     False    3.31e-01   2.03e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    6.12e-01   1.08e+01     1.40e+00    
+b12__k_proj            1x1x1024               True     False    3.50e-01   5.55e+00     8.95e-01    
+b12__v_proj            1x1x1024               True     False    8.91e-01   1.19e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.70e-01   8.97e+00     1.08e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.64e-01   6.77e+00     1.22e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.48e-01   1.05e+01     9.30e-01    
+b12__mlp_gate          1x1x9216               True     False    8.67e-01   1.20e+01     7.54e-01    
+b12__mlp_up            1x1x9216               True     False    7.18e-01   7.21e+00     6.18e-01    
+b12__mlp_down          1x1x2560               True     False    4.51e-01   2.40e+01     5.93e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok 
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=8.07e-08   rel_l2=1.51e-05   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=1.53e-06   rel_l2=6.62e-05   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok 
+  gdn_in_proj               cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=2.02e-06   rel_l2=6.76e-05   ok  cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=1.45e-06   rel_l2=8.85e-05   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=4.39e-07   rel_l2=1.91e-05   ok  cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=3.86e-05   rel_l2=3.18e-04   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=4.75e-07   rel_l2=3.73e-05   ok  cos=1.00e+00   max|Δ|=6.25e-02   mean|Δ|=5.08e-06   rel_l2=3.51e-04   ok  cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=1.04e-06   rel_l2=6.09e-05   ok  cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=1.59e-06   rel_l2=9.92e-05   ok  cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=1.45e-06   rel_l2=7.10e-05   ok  cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=8.11e-07   rel_l2=4.30e-05   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=4.79e-07   rel_l2=2.97e-05   ok 
+  gdn_conv                  cos=1.00e+00   max|Δ|=5.57e-02   mean|Δ|=8.54e-05   rel_l2=2.29e-03   ok  cos=4.71e-01   max|Δ|=1.85e+01   mean|Δ|=4.05e-02   rel_l2=4.90e+00   DIV cos=9.03e-01   max|Δ|=3.16e+00   mean|Δ|=2.74e-02   rel_l2=9.01e-01   DIV cos=6.59e-01   max|Δ|=1.32e+01   mean|Δ|=3.80e-02   rel_l2=2.87e+00   DIV cos=6.82e-01   max|Δ|=4.88e+00   mean|Δ|=3.21e-02   rel_l2=2.98e+00   DIV cos=9.02e-01   max|Δ|=2.96e+00   mean|Δ|=2.56e-02   rel_l2=8.75e-01   DIV cos=6.87e-01   max|Δ|=1.10e+01   mean|Δ|=3.53e-02   rel_l2=2.50e+00   DIV cos=6.68e-01   max|Δ|=6.15e+00   mean|Δ|=3.06e-02   rel_l2=2.81e+00   DIV cos=9.51e-01   max|Δ|=4.06e+00   mean|Δ|=1.85e-02   rel_l2=3.62e-01   ok  cos=7.23e-01   max|Δ|=1.45e+01   mean|Δ|=3.53e-02   rel_l2=2.10e+00   DIV cos=6.46e-01   max|Δ|=1.42e+01   mean|Δ|=3.64e-02   rel_l2=3.22e+00   DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.79e-01   mean|Δ|=4.00e-02   rel_l2=9.12e-01   ok  cos=6.32e-01   max|Δ|=8.60e-01   mean|Δ|=4.08e-02   rel_l2=9.47e-01   DIV cos=7.85e-01   max|Δ|=8.69e-01   mean|Δ|=3.31e-02   rel_l2=9.32e-01   DIV cos=7.86e-01   max|Δ|=8.10e-01   mean|Δ|=3.70e-02   rel_l2=9.32e-01   DIV cos=6.12e-01   max|Δ|=8.63e-01   mean|Δ|=4.17e-02   rel_l2=9.49e-01   DIV cos=8.40e-01   max|Δ|=8.85e-01   mean|Δ|=3.30e-02   rel_l2=9.27e-01   DIV cos=7.67e-01   max|Δ|=8.28e-01   mean|Δ|=3.61e-02   rel_l2=9.34e-01   DIV cos=6.72e-01   max|Δ|=8.42e-01   mean|Δ|=4.12e-02   rel_l2=9.43e-01   DIV cos=8.50e-01   max|Δ|=9.00e-01   mean|Δ|=3.27e-02   rel_l2=9.26e-01   DIV cos=8.36e-01   max|Δ|=8.54e-01   mean|Δ|=3.52e-02   rel_l2=9.27e-01   DIV cos=7.05e-01   max|Δ|=8.68e-01   mean|Δ|=3.85e-02   rel_l2=9.40e-01   DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.91e-05   rel_l2=3.19e-03   ok  cos=3.00e-01   max|Δ|=8.08e-01   mean|Δ|=5.51e-02   rel_l2=1.18e+00   DIV cos=4.47e-01   max|Δ|=9.62e-01   mean|Δ|=4.90e-02   rel_l2=1.05e+00   DIV cos=2.70e-01   max|Δ|=8.38e-01   mean|Δ|=5.85e-02   rel_l2=1.21e+00   DIV cos=3.50e-01   max|Δ|=8.85e-01   mean|Δ|=5.58e-02   rel_l2=1.14e+00   DIV cos=4.93e-01   max|Δ|=9.54e-01   mean|Δ|=5.16e-02   rel_l2=1.01e+00   DIV cos=2.54e-01   max|Δ|=8.28e-01   mean|Δ|=5.94e-02   rel_l2=1.22e+00   DIV cos=3.57e-01   max|Δ|=9.14e-01   mean|Δ|=5.59e-02   rel_l2=1.13e+00   DIV cos=6.96e-01   max|Δ|=9.22e-01   mean|Δ|=3.13e-02   rel_l2=7.80e-01   DIV cos=2.97e-01   max|Δ|=8.22e-01   mean|Δ|=5.38e-02   rel_l2=1.19e+00   DIV cos=3.41e-01   max|Δ|=8.79e-01   mean|Δ|=5.59e-02   rel_l2=1.15e+00   DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.32e-04   rel_l2=3.03e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=7.78e-04   rel_l2=2.48e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=1.25e-03   rel_l2=3.10e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=1.11e-03   rel_l2=3.46e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=1.34e-03   rel_l2=3.68e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=1.25e-03   rel_l2=3.47e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.00e-04   rel_l2=2.99e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=8.24e-04   rel_l2=2.82e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=8.09e-04   rel_l2=2.67e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=6.71e-04   rel_l2=2.72e-03   ok  cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.84e-04   rel_l2=2.96e-03   ok 
+  gdn_gate_g                cos=1.00e+00   max|Δ|=1.55e-02   mean|Δ|=7.64e-04   rel_l2=1.69e-03   ok  cos=1.00e+00   max|Δ|=6.83e-03   mean|Δ|=7.56e-04   rel_l2=1.71e-03   ok  cos=1.00e+00   max|Δ|=5.66e-03   mean|Δ|=5.97e-04   rel_l2=1.03e-03   ok  cos=1.00e+00   max|Δ|=5.82e-03   mean|Δ|=6.51e-04   rel_l2=1.40e-03   ok  cos=1.00e+00   max|Δ|=4.37e-03   mean|Δ|=6.94e-04   rel_l2=1.48e-03   ok  cos=1.00e+00   max|Δ|=1.46e-02   mean|Δ|=1.47e-03   rel_l2=2.41e-03   ok  cos=1.00e+00   max|Δ|=7.58e-03   mean|Δ|=1.02e-03   rel_l2=1.90e-03   ok  cos=1.00e+00   max|Δ|=7.26e-03   mean|Δ|=9.49e-04   rel_l2=1.91e-03   ok  cos=1.00e+00   max|Δ|=1.25e-02   mean|Δ|=8.20e-04   rel_l2=1.57e-03   ok  cos=1.00e+00   max|Δ|=1.36e-02   mean|Δ|=8.05e-04   rel_l2=2.19e-03   ok  cos=1.00e+00   max|Δ|=3.83e-03   mean|Δ|=5.99e-04   rel_l2=1.37e-03   ok 
+  gdn_recur_out             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=4.48e-06   rel_l2=4.53e-03   ok  cos=4.64e-01   max|Δ|=4.82e-01   mean|Δ|=1.33e-03   rel_l2=8.53e+00   DIV cos=5.70e-01   max|Δ|=6.04e-01   mean|Δ|=1.40e-03   rel_l2=7.27e+00   DIV cos=3.60e-01   max|Δ|=5.33e-01   mean|Δ|=1.56e-03   rel_l2=6.68e+00   DIV cos=4.83e-01   max|Δ|=5.60e-01   mean|Δ|=1.60e-03   rel_l2=1.20e+01   DIV cos=5.01e-01   max|Δ|=4.46e-01   mean|Δ|=1.35e-03   rel_l2=6.61e+00   DIV cos=3.60e-01   max|Δ|=5.70e-01   mean|Δ|=1.50e-03   rel_l2=7.36e+00   DIV cos=4.63e-01   max|Δ|=4.45e-01   mean|Δ|=1.52e-03   rel_l2=1.08e+01   DIV cos=6.70e-01   max|Δ|=5.61e-01   mean|Δ|=1.39e-03   rel_l2=1.11e+01   DIV cos=4.78e-01   max|Δ|=6.18e-01   mean|Δ|=1.57e-03   rel_l2=8.22e+00   DIV cos=3.56e-01   max|Δ|=4.78e-01   mean|Δ|=1.58e-03   rel_l2=5.99e+00   DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=2.34e-02   mean|Δ|=4.87e-05   rel_l2=5.07e-03   ok  cos=8.67e-01   max|Δ|=1.43e+00   mean|Δ|=6.41e-03   rel_l2=7.02e-01   DIV cos=9.00e-01   max|Δ|=1.26e+00   mean|Δ|=6.27e-03   rel_l2=6.45e-01   DIV cos=8.90e-01   max|Δ|=1.18e+00   mean|Δ|=5.57e-03   rel_l2=6.80e-01   DIV cos=8.60e-01   max|Δ|=1.30e+00   mean|Δ|=7.48e-03   rel_l2=7.11e-01   DIV cos=9.14e-01   max|Δ|=1.21e+00   mean|Δ|=5.45e-03   rel_l2=6.47e-01   DIV cos=8.26e-01   max|Δ|=1.54e+00   mean|Δ|=6.60e-03   rel_l2=9.99e-01   DIV cos=8.69e-01   max|Δ|=1.17e+00   mean|Δ|=7.56e-03   rel_l2=8.07e-01   DIV cos=8.68e-01   max|Δ|=1.95e+00   mean|Δ|=6.01e-03   rel_l2=7.72e-01   DIV cos=8.90e-01   max|Δ|=1.34e+00   mean|Δ|=5.74e-03   rel_l2=7.59e-01   DIV cos=8.96e-01   max|Δ|=1.12e+00   mean|Δ|=5.95e-03   rel_l2=6.56e-01   DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=6.26e-05   rel_l2=3.36e-03   ok  cos=9.60e-01   max|Δ|=6.41e-01   mean|Δ|=9.64e-03   rel_l2=4.40e-01   ok  cos=9.42e-01   max|Δ|=6.41e-01   mean|Δ|=9.76e-03   rel_l2=5.83e-01   DIV cos=9.50e-01   max|Δ|=7.42e-01   mean|Δ|=9.60e-03   rel_l2=5.40e-01   ok  cos=9.46e-01   max|Δ|=5.94e-01   mean|Δ|=1.17e-02   rel_l2=4.26e-01   DIV cos=9.56e-01   max|Δ|=6.25e-01   mean|Δ|=7.64e-03   rel_l2=5.06e-01   ok  cos=9.38e-01   max|Δ|=9.38e-01   mean|Δ|=1.02e-02   rel_l2=7.70e-01   DIV cos=9.47e-01   max|Δ|=7.81e-01   mean|Δ|=1.07e-02   rel_l2=5.02e-01   DIV cos=9.19e-01   max|Δ|=1.06e+00   mean|Δ|=7.77e-03   rel_l2=6.69e-01   DIV cos=9.47e-01   max|Δ|=6.41e-01   mean|Δ|=8.90e-03   rel_l2=5.73e-01   DIV cos=9.58e-01   max|Δ|=6.41e-01   mean|Δ|=9.42e-03   rel_l2=4.45e-01   ok 
+
+  first sub-op with MEDIAN cos_sim < 0.95: 'gdn_conv' (median cos_sim = 0.686549)
+Phase B11b verdict: B12 TARGET = 'gdn_conv'.
+    Most-likely cause: causal_conv1d: kernel packing, stride/pad, SiLU activation, or bias
+  -> Queue B12 task to investigate this sub-op in isolation.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.51e-03     7.72e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.05e-01     2.09e-02    
+h_layer_16             1x1x2560               True     False    9.47e-01   7.19e-01     5.06e-02    
+h_layer_23             1x1x2560               True     False    9.73e-01   7.93e-01     9.31e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.08e+01     1.15e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.91e-03     8.07e-08    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   1.56e-02     2.02e-06    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   5.57e-02     8.54e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   3.91e-03     9.91e-05    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   3.91e-03     9.32e-04    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.55e-02     7.64e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   3.91e-03     4.48e-06    
+b11__gdn_gated_norm    1x508x4096             True     True     1.00e+00   2.34e-02     4.87e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.56e-02     6.26e-05    
+h_layer_24             1x1x2560               True     False    9.76e-01   9.45e-01     9.79e-02    
+h_layer_25             1x1x2560               True     False    9.77e-01   9.34e-01     1.00e-01    
+h_layer_26             1x1x2560               True     False    9.81e-01   9.41e-01     1.03e-01    
+h_layer_27             1x1x2560               True     False    9.79e-01   1.38e+00     1.20e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   1.12e+00     1.35e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   1.62e+00     1.48e-01    
+h_layer_30             1x1x2560               True     False    9.80e-01   1.03e+00     1.70e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.48e-01   8.98e-01     1.87e-02    
+h_layer_8              1x1x2560               True     False    7.32e-02   1.45e+01     1.78e-01    
+h_layer_16             1x1x2560               True     False    1.42e-02   1.24e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    4.38e-01   1.20e+01     3.06e-01    
+h_layer_31             1x1x2560               True     False    3.49e-01   2.61e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.45e-06    
+b11__gdn_conv          1x1x8192               True     False    4.71e-01   1.85e+01     4.05e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.32e-01   8.60e-01     4.08e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.00e-01   8.08e-01     5.51e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     7.78e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.83e-03     7.56e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.64e-01   4.82e-01     1.33e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.67e-01   1.43e+00     6.41e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.60e-01   6.41e-01     9.64e-03    
+h_layer_24             1x1x2560               True     False    4.85e-01   1.12e+01     3.23e-01    
+h_layer_25             1x1x2560               True     False    5.29e-01   1.03e+01     3.36e-01    
+h_layer_26             1x1x2560               True     False    5.58e-01   7.39e+00     3.84e-01    
+h_layer_27             1x1x2560               True     False    5.04e-01   1.12e+01     4.88e-01    
+h_layer_28             1x1x2560               True     False    5.63e-01   9.75e+00     5.35e-01    
+h_layer_29             1x1x2560               True     False    5.46e-01   1.42e+01     6.10e-01    
+h_layer_30             1x1x2560               True     False    4.95e-01   9.53e+00     7.31e-01    
+b12__post_input_norm   1x1x2560               True     False    4.31e-01   1.96e+01     9.28e-01    
+b12__q_proj            1x1x8192               True     False    5.74e-01   1.02e+01     1.51e+00    
+b12__k_proj            1x1x1024               True     False    4.86e-01   5.91e+00     8.39e-01    
+b12__v_proj            1x1x1024               True     False    9.06e-01   9.09e+00     1.00e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.51e-01   7.45e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    4.90e-01   8.03e+00     1.05e+00    
+b12__post_attn_norm    1x1x2560               True     False    5.18e-01   1.03e+01     8.70e-01    
+b12__mlp_gate          1x1x9216               True     False    8.42e-01   1.08e+01     7.08e-01    
+b12__mlp_up            1x1x9216               True     False    7.20e-01   6.63e+00     5.82e-01    
+b12__mlp_down          1x1x2560               True     False    5.05e-01   1.12e+01     5.86e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.64e-01   7.11e-01     2.09e-02    
+h_layer_8              1x1x2560               True     False    4.68e-02   1.66e+01     1.81e-01    
+h_layer_16             1x1x2560               True     False    -1.07e-02  1.51e+01     1.96e-01    
+h_layer_23             1x1x2560               True     False    3.44e-01   7.25e+00     3.49e-01    
+h_layer_31             1x1x2560               True     False    2.54e-01   3.98e+01     2.19e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.91e-03     4.39e-07    
+b11__gdn_conv          1x1x8192               True     False    9.03e-01   3.16e+00     2.74e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.85e-01   8.69e-01     3.31e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.47e-01   9.62e-01     4.90e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.25e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.66e-03     5.97e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.70e-01   6.04e-01     1.40e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.00e-01   1.26e+00     6.27e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.42e-01   6.41e-01     9.76e-03    
+h_layer_24             1x1x2560               True     False    4.18e-01   7.32e+00     3.66e-01    
+h_layer_25             1x1x2560               True     False    4.26e-01   8.51e+00     4.30e-01    
+h_layer_26             1x1x2560               True     False    5.42e-01   6.18e+01     5.35e-01    
+h_layer_27             1x1x2560               True     False    3.93e-01   1.21e+01     5.24e-01    
+h_layer_28             1x1x2560               True     False    4.59e-01   1.35e+01     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.47e-01   1.81e+01     6.30e-01    
+h_layer_30             1x1x2560               True     False    4.18e-01   9.53e+00     7.51e-01    
+b12__post_input_norm   1x1x2560               True     False    3.23e-01   2.15e+01     9.72e-01    
+b12__q_proj            1x1x8192               True     False    5.90e-01   1.28e+01     1.42e+00    
+b12__k_proj            1x1x1024               True     False    2.80e-01   8.14e+00     9.94e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   1.08e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.78e-01   8.67e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    2.95e-01   1.05e+01     1.25e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.26e-01   1.15e+01     9.11e-01    
+b12__mlp_gate          1x1x9216               True     False    8.44e-01   1.30e+01     7.90e-01    
+b12__mlp_up            1x1x9216               True     False    6.51e-01   8.26e+00     6.77e-01    
+b12__mlp_down          1x1x2560               True     False    4.44e-01   1.58e+01     7.41e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.93e-01   8.75e-01     2.14e-02    
+h_layer_8              1x1x2560               True     False    2.79e-02   1.52e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -4.78e-02  1.36e+01     1.99e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.09e+01     3.29e-01    
+h_layer_31             1x1x2560               True     False    2.31e-01   3.73e+01     2.28e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   3.91e-03     1.53e-06    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   1.56e-02     3.86e-05    
+b11__gdn_conv          1x1x8192               True     False    6.59e-01   1.32e+01     3.80e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.86e-01   8.10e-01     3.70e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.70e-01   8.38e-01     5.85e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.11e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   5.82e-03     6.51e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.60e-01   5.33e-01     1.56e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.90e-01   1.18e+00     5.57e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.50e-01   7.42e-01     9.60e-03    
+h_layer_24             1x1x2560               True     False    4.15e-01   8.81e+00     3.47e-01    
+h_layer_25             1x1x2560               True     False    4.83e-01   7.12e+00     3.59e-01    
+h_layer_26             1x1x2560               True     False    5.12e-01   7.08e+00     3.98e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   7.38e+00     5.22e-01    
+h_layer_28             1x1x2560               True     False    4.83e-01   7.38e+00     5.92e-01    
+h_layer_29             1x1x2560               True     False    4.58e-01   1.20e+01     6.62e-01    
+h_layer_30             1x1x2560               True     False    3.88e-01   9.55e+00     8.22e-01    
+b12__post_input_norm   1x1x2560               True     False    3.15e-01   1.97e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    5.77e-01   1.08e+01     1.47e+00    
+b12__k_proj            1x1x1024               True     False    3.36e-01   7.71e+00     8.97e-01    
+b12__v_proj            1x1x1024               True     False    8.98e-01   1.01e+01     1.05e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.16e-01   8.52e+00     1.03e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.62e-01   9.44e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.09e-01   9.94e+00     9.69e-01    
+b12__mlp_gate          1x1x9216               True     False    8.42e-01   1.28e+01     8.10e-01    
+b12__mlp_up            1x1x9216               True     False    6.39e-01   7.70e+00     7.29e-01    
+b12__mlp_down          1x1x2560               True     False    4.04e-01   1.21e+01     7.72e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.28e-01   1.23e+00     2.11e-02    
+h_layer_8              1x1x2560               True     False    -5.38e-03  1.47e+01     1.74e-01    
+h_layer_16             1x1x2560               True     False    -7.04e-02  1.33e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.57e-01   1.20e+01     3.17e-01    
+h_layer_31             1x1x2560               True     False    3.65e-01   2.72e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.91e-03     4.75e-07    
+b11__gdn_conv          1x1x8192               True     False    6.82e-01   4.88e+00     3.21e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.12e-01   8.63e-01     4.17e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.50e-01   8.85e-01     5.58e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.34e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   4.37e-03     6.94e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.83e-01   5.60e-01     1.60e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.60e-01   1.30e+00     7.48e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   5.94e-01     1.17e-02    
+h_layer_24             1x1x2560               True     False    4.24e-01   9.88e+00     3.42e-01    
+h_layer_25             1x1x2560               True     False    4.86e-01   7.50e+00     3.56e-01    
+h_layer_26             1x1x2560               True     False    4.19e-01   6.61e+00     3.86e-01    
+h_layer_27             1x1x2560               True     False    4.63e-01   1.11e+01     4.96e-01    
+h_layer_28             1x1x2560               True     False    5.22e-01   7.50e+00     5.44e-01    
+h_layer_29             1x1x2560               True     False    5.20e-01   1.16e+01     6.24e-01    
+h_layer_30             1x1x2560               True     False    4.24e-01   9.38e+00     7.79e-01    
+b12__post_input_norm   1x1x2560               True     False    3.46e-01   1.98e+01     9.88e-01    
+b12__q_proj            1x1x8192               True     False    6.24e-01   1.20e+01     1.32e+00    
+b12__k_proj            1x1x1024               True     False    3.09e-01   6.19e+00     9.35e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   9.22e+00     1.02e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.05e-01   8.95e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.26e-01   8.20e+00     1.28e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.66e-01   1.06e+01     9.04e-01    
+b12__mlp_gate          1x1x9216               True     False    8.76e-01   1.23e+01     6.74e-01    
+b12__mlp_up            1x1x9216               True     False    7.23e-01   7.07e+00     5.87e-01    
+b12__mlp_down          1x1x2560               True     False    5.47e-01   1.96e+01     6.01e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.32e-01   4.77e-01     1.73e-02    
+h_layer_8              1x1x2560               True     False    1.47e-02   1.62e+01     1.74e-01    
+h_layer_16             1x1x2560               True     False    -3.29e-02  1.48e+01     1.87e-01    
+h_layer_23             1x1x2560               True     False    3.81e-01   6.31e+00     3.35e-01    
+h_layer_31             1x1x2560               True     False    3.30e-01   2.87e+01     2.15e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   6.25e-02     5.08e-06    
+b11__gdn_conv          1x1x8192               True     False    9.02e-01   2.96e+00     2.56e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.40e-01   8.85e-01     3.30e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.93e-01   9.54e-01     5.16e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     1.25e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.46e-02     1.47e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    5.01e-01   4.46e-01     1.35e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.14e-01   1.21e+00     5.45e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.56e-01   6.25e-01     7.64e-03    
+h_layer_24             1x1x2560               True     False    4.34e-01   6.17e+00     3.51e-01    
+h_layer_25             1x1x2560               True     False    4.67e-01   6.59e+00     3.90e-01    
+h_layer_26             1x1x2560               True     False    5.36e-01   4.28e+01     4.71e-01    
+h_layer_27             1x1x2560               True     False    4.20e-01   9.56e+00     5.08e-01    
+h_layer_28             1x1x2560               True     False    4.75e-01   1.01e+01     5.59e-01    
+h_layer_29             1x1x2560               True     False    4.61e-01   1.48e+01     6.34e-01    
+h_layer_30             1x1x2560               True     False    4.27e-01   8.59e+00     7.66e-01    
+b12__post_input_norm   1x1x2560               True     False    3.42e-01   1.90e+01     9.73e-01    
+b12__q_proj            1x1x8192               True     False    5.85e-01   1.26e+01     1.43e+00    
+b12__k_proj            1x1x1024               True     False    3.20e-01   7.07e+00     9.34e-01    
+b12__v_proj            1x1x1024               True     False    9.02e-01   9.28e+00     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.89e-01   9.61e+00     1.05e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.33e-01   9.06e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.47e-01   1.02e+01     9.12e-01    
+b12__mlp_gate          1x1x9216               True     False    8.54e-01   1.27e+01     7.87e-01    
+b12__mlp_up            1x1x9216               True     False    6.95e-01   7.95e+00     6.41e-01    
+b12__mlp_down          1x1x2560               True     False    4.45e-01   2.12e+01     7.04e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.01e-01   9.69e-01     2.41e-02    
+h_layer_8              1x1x2560               True     False    5.29e-02   1.55e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -2.61e-02  1.35e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.70e-01   7.22e+00     3.19e-01    
+h_layer_31             1x1x2560               True     False    2.81e-01   2.70e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.04e-06    
+b11__gdn_conv          1x1x8192               True     False    6.87e-01   1.10e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.67e-01   8.28e-01     3.61e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.54e-01   8.28e-01     5.94e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.00e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.58e-03     1.02e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    3.60e-01   5.70e-01     1.50e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.26e-01   1.54e+00     6.60e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.38e-01   9.38e-01     1.02e-02    
+h_layer_24             1x1x2560               True     False    4.19e-01   6.30e+00     3.40e-01    
+h_layer_25             1x1x2560               True     False    4.86e-01   6.54e+00     3.53e-01    
+h_layer_26             1x1x2560               True     False    4.90e-01   7.35e+00     3.93e-01    
+h_layer_27             1x1x2560               True     False    4.22e-01   7.19e+00     5.16e-01    
+h_layer_28             1x1x2560               True     False    4.96e-01   7.14e+00     5.68e-01    
+h_layer_29             1x1x2560               True     False    4.81e-01   9.12e+00     6.37e-01    
+h_layer_30             1x1x2560               True     False    4.00e-01   9.90e+00     8.01e-01    
+b12__post_input_norm   1x1x2560               True     False    3.27e-01   2.05e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    5.44e-01   1.10e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.74e-01   8.53e+00     8.97e-01    
+b12__v_proj            1x1x1024               True     False    8.96e-01   9.78e+00     1.06e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.16e-01   8.91e+00     1.02e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.95e-01   9.22e+00     1.16e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.23e-01   1.03e+01     9.51e-01    
+b12__mlp_gate          1x1x9216               True     False    8.35e-01   1.36e+01     8.86e-01    
+b12__mlp_up            1x1x9216               True     False    6.58e-01   8.61e+00     7.45e-01    
+b12__mlp_down          1x1x2560               True     False    4.43e-01   1.54e+01     7.34e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.04e-01   1.28e+00     2.00e-02    
+h_layer_8              1x1x2560               True     False    1.51e-04   1.53e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -5.40e-02  1.37e+01     1.94e-01    
+h_layer_23             1x1x2560               True     False    2.98e-01   1.22e+01     3.37e-01    
+h_layer_31             1x1x2560               True     False    2.89e-01   3.38e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     1.59e-06    
+b11__gdn_conv          1x1x8192               True     False    6.68e-01   6.15e+00     3.06e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.72e-01   8.42e-01     4.12e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.57e-01   9.14e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     8.24e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.26e-03     9.49e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.63e-01   4.45e-01     1.52e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.69e-01   1.17e+00     7.56e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   7.81e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    3.70e-01   1.00e+01     3.56e-01    
+h_layer_25             1x1x2560               True     False    4.51e-01   7.81e+00     3.66e-01    
+h_layer_26             1x1x2560               True     False    4.30e-01   6.94e+00     3.95e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   1.46e+01     5.14e-01    
+h_layer_28             1x1x2560               True     False    5.22e-01   8.88e+00     5.32e-01    
+h_layer_29             1x1x2560               True     False    5.19e-01   1.31e+01     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.08e-01   9.42e+00     7.53e-01    
+b12__post_input_norm   1x1x2560               True     False    3.40e-01   1.93e+01     9.90e-01    
+b12__q_proj            1x1x8192               True     False    5.97e-01   1.22e+01     1.39e+00    
+b12__k_proj            1x1x1024               True     False    3.09e-01   6.85e+00     9.61e-01    
+b12__v_proj            1x1x1024               True     False    8.89e-01   1.16e+01     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.94e-01   9.73e+00     1.06e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.26e-01   7.38e+00     1.26e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.42e-01   1.05e+01     9.29e-01    
+b12__mlp_gate          1x1x9216               True     False    8.36e-01   1.28e+01     7.91e-01    
+b12__mlp_up            1x1x9216               True     False    6.93e-01   7.82e+00     6.31e-01    
+b12__mlp_down          1x1x2560               True     False    2.54e-01   3.08e+01     6.34e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.99e-01   2.71e-01     1.43e-02    
+h_layer_8              1x1x2560               True     False    3.34e-01   2.19e+00     1.15e-01    
+h_layer_16             1x1x2560               True     False    2.13e-01   3.45e+00     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.55e-01   9.53e+00     3.63e-01    
+h_layer_31             1x1x2560               True     False    4.29e-01   3.69e+01     1.78e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   1.56e-02     1.45e-06    
+b11__gdn_conv          1x2x8192               True     False    9.51e-01   4.06e+00     1.85e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.50e-01   9.00e-01     3.27e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.96e-01   9.22e-01     3.13e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   3.91e-03     8.09e-04    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.25e-02     8.20e-04    
+b11__gdn_recur_out     1x2x32x128             True     False    6.70e-01   5.61e-01     1.39e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    8.68e-01   1.95e+00     6.01e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.19e-01   1.06e+00     7.77e-03    
+h_layer_24             1x1x2560               True     False    4.66e-01   1.00e+01     3.89e-01    
+h_layer_25             1x1x2560               True     False    4.94e-01   1.03e+01     4.17e-01    
+h_layer_26             1x1x2560               True     False    5.28e-01   4.00e+01     4.71e-01    
+h_layer_27             1x1x2560               True     False    4.94e-01   1.09e+01     5.54e-01    
+h_layer_28             1x1x2560               True     False    5.33e-01   1.10e+01     5.91e-01    
+h_layer_29             1x1x2560               True     False    5.43e-01   1.10e+01     6.40e-01    
+h_layer_30             1x1x2560               True     False    4.80e-01   1.12e+01     7.57e-01    
+b12__post_input_norm   1x2x2560               True     False    2.52e-01   1.64e+01     1.06e+00    
+b12__q_proj            1x2x8192               True     False    6.30e-01   1.08e+01     1.21e+00    
+b12__k_proj            1x2x1024               True     False    3.53e-01   7.52e+00     9.55e-01    
+b12__v_proj            1x2x1024               True     False    8.89e-01   9.02e+00     1.06e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.25e-01   1.09e+01     1.03e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.59e-01   1.00e+01     1.20e+00    
+b12__o_proj            1x2x2560               True     False    3.37e-01   8.23e+00     3.01e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.53e-01   1.19e+01     1.00e+00    
+b12__mlp_gate          1x2x9216               True     False    8.20e-01   1.28e+01     8.57e-01    
+b12__mlp_up            1x2x9216               True     False    6.79e-01   9.78e+00     6.95e-01    
+b12__mlp_down          1x2x2560               True     False    4.50e-01   2.74e+01     6.80e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.74e-01   6.09e-01     1.91e-02    
+h_layer_8              1x1x2560               True     False    2.31e-02   1.69e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -3.50e-02  1.53e+01     1.97e-01    
+h_layer_23             1x1x2560               True     False    2.15e-01   7.03e+00     3.84e-01    
+h_layer_31             1x1x2560               True     False    2.08e-01   3.12e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   7.81e-03     8.11e-07    
+b11__gdn_conv          1x1x8192               True     False    7.23e-01   1.45e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.36e-01   8.54e-01     3.52e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   8.22e-01     5.38e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     6.71e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.36e-02     8.05e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.78e-01   6.18e-01     1.57e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.90e-01   1.34e+00     5.74e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   6.41e-01     8.90e-03    
+h_layer_24             1x1x2560               True     False    2.46e-01   7.03e+00     3.96e-01    
+h_layer_25             1x1x2560               True     False    2.25e-01   8.15e+00     4.46e-01    
+h_layer_26             1x1x2560               True     False    1.87e-01   6.65e+01     5.38e-01    
+h_layer_27             1x1x2560               True     False    2.41e-01   6.00e+00     5.24e-01    
+h_layer_28             1x1x2560               True     False    3.15e-01   6.69e+00     6.01e-01    
+h_layer_29             1x1x2560               True     False    3.13e-01   7.39e+00     6.70e-01    
+h_layer_30             1x1x2560               True     False    2.49e-01   1.26e+01     8.28e-01    
+b12__post_input_norm   1x1x2560               True     False    1.98e-01   2.08e+01     1.11e+00    
+b12__q_proj            1x1x8192               True     False    5.00e-01   1.20e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    3.36e-01   6.80e+00     9.76e-01    
+b12__v_proj            1x1x1024               True     False    8.75e-01   9.41e+00     1.18e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.29e-01   1.07e+01     1.14e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.70e-01   6.78e+00     1.24e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.02e-01   1.10e+01     1.05e+00    
+b12__mlp_gate          1x1x9216               True     False    8.08e-01   1.35e+01     9.45e-01    
+b12__mlp_up            1x1x9216               True     False    6.30e-01   7.88e+00     7.81e-01    
+b12__mlp_down          1x1x2560               True     False    3.36e-01   1.93e+01     7.60e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_bf16/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.43e-01   9.14e-01     1.92e-02    
+h_layer_8              1x1x2560               True     False    2.83e-02   1.62e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -1.41e-02  1.41e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.15e+01     3.34e-01    
+h_layer_31             1x1x2560               True     False    3.35e-01   2.82e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.91e-03     4.79e-07    
+b11__gdn_conv          1x1x8192               True     False    6.46e-01   1.42e+01     3.64e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.05e-01   8.68e-01     3.85e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.41e-01   8.79e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.91e-03     9.84e-04    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   3.83e-03     5.99e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.56e-01   4.78e-01     1.58e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.96e-01   1.12e+00     5.95e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.58e-01   6.41e-01     9.42e-03    
+h_layer_24             1x1x2560               True     False    4.12e-01   9.94e+00     3.57e-01    
+h_layer_25             1x1x2560               True     False    4.66e-01   8.44e+00     3.69e-01    
+h_layer_26             1x1x2560               True     False    3.85e-01   6.62e+00     4.06e-01    
+h_layer_27             1x1x2560               True     False    4.71e-01   1.41e+01     5.17e-01    
+h_layer_28             1x1x2560               True     False    4.98e-01   8.62e+00     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.83e-01   1.22e+01     6.59e-01    
+h_layer_30             1x1x2560               True     False    3.98e-01   9.36e+00     7.97e-01    
+b12__post_input_norm   1x1x2560               True     False    3.31e-01   2.03e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    6.12e-01   1.08e+01     1.40e+00    
+b12__k_proj            1x1x1024               True     False    3.50e-01   5.55e+00     8.95e-01    
+b12__v_proj            1x1x1024               True     False    8.91e-01   1.19e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.70e-01   8.97e+00     1.08e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.64e-01   6.77e+00     1.22e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.48e-01   1.05e+01     9.30e-01    
+b12__mlp_gate          1x1x9216               True     False    8.67e-01   1.20e+01     7.54e-01    
+b12__mlp_up            1x1x9216               True     False    7.18e-01   7.21e+00     6.18e-01    
+b12__mlp_down          1x1x2560               True     False    4.51e-01   2.40e+01     5.93e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.76e-01   max|Δ|=9.45e-01   DIV   cos=4.85e-01   max|Δ|=1.12e+01   DIV   cos=4.18e-01   max|Δ|=7.32e+00   DIV   cos=4.15e-01   max|Δ|=8.81e+00   DIV   cos=4.24e-01   max|Δ|=9.88e+00   DIV   cos=4.34e-01   max|Δ|=6.17e+00   DIV   cos=4.19e-01   max|Δ|=6.30e+00   DIV   cos=3.70e-01   max|Δ|=1.00e+01   DIV   cos=4.66e-01   max|Δ|=1.00e+01   DIV   cos=2.46e-01   max|Δ|=7.03e+00   DIV   cos=4.12e-01   max|Δ|=9.94e+00   DIV  
+  h_layer_25            cos=9.77e-01   max|Δ|=9.34e-01   DIV   cos=5.29e-01   max|Δ|=1.03e+01   DIV   cos=4.26e-01   max|Δ|=8.51e+00   DIV   cos=4.83e-01   max|Δ|=7.12e+00   DIV   cos=4.86e-01   max|Δ|=7.50e+00   DIV   cos=4.67e-01   max|Δ|=6.59e+00   DIV   cos=4.86e-01   max|Δ|=6.54e+00   DIV   cos=4.51e-01   max|Δ|=7.81e+00   DIV   cos=4.94e-01   max|Δ|=1.03e+01   DIV   cos=2.25e-01   max|Δ|=8.15e+00   DIV   cos=4.66e-01   max|Δ|=8.44e+00   DIV  
+  h_layer_26            cos=9.81e-01   max|Δ|=9.41e-01   DIV   cos=5.58e-01   max|Δ|=7.39e+00   DIV   cos=5.42e-01   max|Δ|=6.18e+01   DIV   cos=5.12e-01   max|Δ|=7.08e+00   DIV   cos=4.19e-01   max|Δ|=6.61e+00   DIV   cos=5.36e-01   max|Δ|=4.28e+01   DIV   cos=4.90e-01   max|Δ|=7.35e+00   DIV   cos=4.30e-01   max|Δ|=6.94e+00   DIV   cos=5.28e-01   max|Δ|=4.00e+01   DIV   cos=1.87e-01   max|Δ|=6.65e+01   DIV   cos=3.85e-01   max|Δ|=6.62e+00   DIV  
+  h_layer_27            cos=9.79e-01   max|Δ|=1.38e+00   DIV   cos=5.04e-01   max|Δ|=1.12e+01   DIV   cos=3.93e-01   max|Δ|=1.21e+01   DIV   cos=4.48e-01   max|Δ|=7.38e+00   DIV   cos=4.63e-01   max|Δ|=1.11e+01   DIV   cos=4.20e-01   max|Δ|=9.56e+00   DIV   cos=4.22e-01   max|Δ|=7.19e+00   DIV   cos=4.48e-01   max|Δ|=1.46e+01   DIV   cos=4.94e-01   max|Δ|=1.09e+01   DIV   cos=2.41e-01   max|Δ|=6.00e+00   DIV   cos=4.71e-01   max|Δ|=1.41e+01   DIV  
+  h_layer_28            cos=9.82e-01   max|Δ|=1.12e+00   DIV   cos=5.63e-01   max|Δ|=9.75e+00   DIV   cos=4.59e-01   max|Δ|=1.35e+01   DIV   cos=4.83e-01   max|Δ|=7.38e+00   DIV   cos=5.22e-01   max|Δ|=7.50e+00   DIV   cos=4.75e-01   max|Δ|=1.01e+01   DIV   cos=4.96e-01   max|Δ|=7.14e+00   DIV   cos=5.22e-01   max|Δ|=8.88e+00   DIV   cos=5.33e-01   max|Δ|=1.10e+01   DIV   cos=3.15e-01   max|Δ|=6.69e+00   DIV   cos=4.98e-01   max|Δ|=8.62e+00   DIV  
+  h_layer_29            cos=9.81e-01   max|Δ|=1.62e+00   DIV   cos=5.46e-01   max|Δ|=1.42e+01   DIV   cos=4.47e-01   max|Δ|=1.81e+01   DIV   cos=4.58e-01   max|Δ|=1.20e+01   DIV   cos=5.20e-01   max|Δ|=1.16e+01   DIV   cos=4.61e-01   max|Δ|=1.48e+01   DIV   cos=4.81e-01   max|Δ|=9.12e+00   DIV   cos=5.19e-01   max|Δ|=1.31e+01   DIV   cos=5.43e-01   max|Δ|=1.10e+01   DIV   cos=3.13e-01   max|Δ|=7.39e+00   DIV   cos=4.83e-01   max|Δ|=1.22e+01   DIV  
+  h_layer_30            cos=9.80e-01   max|Δ|=1.03e+00   DIV   cos=4.95e-01   max|Δ|=9.53e+00   DIV   cos=4.18e-01   max|Δ|=9.53e+00   DIV   cos=3.88e-01   max|Δ|=9.55e+00   DIV   cos=4.24e-01   max|Δ|=9.38e+00   DIV   cos=4.27e-01   max|Δ|=8.59e+00   DIV   cos=4.00e-01   max|Δ|=9.90e+00   DIV   cos=4.08e-01   max|Δ|=9.42e+00   DIV   cos=4.80e-01   max|Δ|=1.12e+01   DIV   cos=2.49e-01   max|Δ|=1.26e+01   DIV   cos=3.98e-01   max|Δ|=9.36e+00   DIV  
+  h_layer_31            cos=9.57e-01   max|Δ|=2.08e+01   DIV   cos=3.49e-01   max|Δ|=2.61e+01   DIV   cos=2.54e-01   max|Δ|=3.98e+01   DIV   cos=2.31e-01   max|Δ|=3.73e+01   DIV   cos=3.65e-01   max|Δ|=2.72e+01   DIV   cos=3.30e-01   max|Δ|=2.87e+01   DIV   cos=2.81e-01   max|Δ|=2.70e+01   DIV   cos=2.89e-01   max|Δ|=3.38e+01   DIV   cos=4.29e-01   max|Δ|=3.69e+01   DIV   cos=2.08e-01   max|Δ|=3.12e+01   DIV   cos=3.35e-01   max|Δ|=2.82e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=4.19e-01     DIV
+    h_layer_25             median=4.83e-01     DIV
+    h_layer_26             median=5.12e-01     DIV
+    h_layer_27             median=4.48e-01     DIV
+    h_layer_28             median=4.98e-01     DIV
+    h_layer_29             median=4.83e-01     DIV
+    h_layer_30             median=4.18e-01     DIV
+    h_layer_31             median=3.30e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=4.31e-01   max|Δ|=1.96e+01   mean|Δ|=9.28e-01   rel_l2=1.04e+00   DIV cos=3.23e-01   max|Δ|=2.15e+01   mean|Δ|=9.72e-01   rel_l2=1.12e+00   DIV cos=3.15e-01   max|Δ|=1.97e+01   mean|Δ|=1.02e+00   rel_l2=1.14e+00   DIV cos=3.46e-01   max|Δ|=1.98e+01   mean|Δ|=9.88e-01   rel_l2=1.11e+00   DIV cos=3.42e-01   max|Δ|=1.90e+01   mean|Δ|=9.73e-01   rel_l2=1.12e+00   DIV cos=3.27e-01   max|Δ|=2.05e+01   mean|Δ|=1.00e+00   rel_l2=1.12e+00   DIV cos=3.40e-01   max|Δ|=1.93e+01   mean|Δ|=9.90e-01   rel_l2=1.12e+00   DIV cos=2.52e-01   max|Δ|=1.64e+01   mean|Δ|=1.06e+00   rel_l2=1.21e+00   DIV cos=1.98e-01   max|Δ|=2.08e+01   mean|Δ|=1.11e+00   rel_l2=1.24e+00   DIV cos=3.31e-01   max|Δ|=2.03e+01   mean|Δ|=1.02e+00   rel_l2=1.12e+00   DIV
+  q_proj              <missing>                                            cos=5.74e-01   max|Δ|=1.02e+01   mean|Δ|=1.51e+00   rel_l2=8.34e-01   DIV cos=5.90e-01   max|Δ|=1.28e+01   mean|Δ|=1.42e+00   rel_l2=8.31e-01   DIV cos=5.77e-01   max|Δ|=1.08e+01   mean|Δ|=1.47e+00   rel_l2=8.40e-01   DIV cos=6.24e-01   max|Δ|=1.20e+01   mean|Δ|=1.32e+00   rel_l2=8.04e-01   DIV cos=5.85e-01   max|Δ|=1.26e+01   mean|Δ|=1.43e+00   rel_l2=8.32e-01   DIV cos=5.44e-01   max|Δ|=1.10e+01   mean|Δ|=1.52e+00   rel_l2=8.72e-01   DIV cos=5.97e-01   max|Δ|=1.22e+01   mean|Δ|=1.39e+00   rel_l2=8.29e-01   DIV cos=6.30e-01   max|Δ|=1.08e+01   mean|Δ|=1.21e+00   rel_l2=8.12e-01   DIV cos=5.00e-01   max|Δ|=1.20e+01   mean|Δ|=1.54e+00   rel_l2=9.11e-01   DIV cos=6.12e-01   max|Δ|=1.08e+01   mean|Δ|=1.40e+00   rel_l2=8.06e-01   DIV
+  k_proj              <missing>                                            cos=4.86e-01   max|Δ|=5.91e+00   mean|Δ|=8.39e-01   rel_l2=9.64e-01   DIV cos=2.80e-01   max|Δ|=8.14e+00   mean|Δ|=9.94e-01   rel_l2=1.05e+00   DIV cos=3.36e-01   max|Δ|=7.71e+00   mean|Δ|=8.97e-01   rel_l2=1.05e+00   DIV cos=3.09e-01   max|Δ|=6.19e+00   mean|Δ|=9.35e-01   rel_l2=1.07e+00   DIV cos=3.20e-01   max|Δ|=7.07e+00   mean|Δ|=9.34e-01   rel_l2=1.04e+00   DIV cos=3.74e-01   max|Δ|=8.53e+00   mean|Δ|=8.97e-01   rel_l2=1.00e+00   DIV cos=3.09e-01   max|Δ|=6.85e+00   mean|Δ|=9.61e-01   rel_l2=1.09e+00   DIV cos=3.53e-01   max|Δ|=7.52e+00   mean|Δ|=9.55e-01   rel_l2=1.01e+00   DIV cos=3.36e-01   max|Δ|=6.80e+00   mean|Δ|=9.76e-01   rel_l2=1.03e+00   DIV cos=3.50e-01   max|Δ|=5.55e+00   mean|Δ|=8.95e-01   rel_l2=1.02e+00   DIV
+  v_proj              <missing>                                            cos=9.06e-01   max|Δ|=9.09e+00   mean|Δ|=1.00e+00   rel_l2=4.23e-01   DIV cos=8.95e-01   max|Δ|=1.08e+01   mean|Δ|=1.07e+00   rel_l2=4.46e-01   DIV cos=8.98e-01   max|Δ|=1.01e+01   mean|Δ|=1.05e+00   rel_l2=4.41e-01   DIV cos=8.95e-01   max|Δ|=9.22e+00   mean|Δ|=1.02e+00   rel_l2=4.49e-01   DIV cos=9.02e-01   max|Δ|=9.28e+00   mean|Δ|=1.04e+00   rel_l2=4.31e-01   DIV cos=8.96e-01   max|Δ|=9.78e+00   mean|Δ|=1.06e+00   rel_l2=4.46e-01   DIV cos=8.89e-01   max|Δ|=1.16e+01   mean|Δ|=1.04e+00   rel_l2=4.62e-01   DIV cos=8.89e-01   max|Δ|=9.02e+00   mean|Δ|=1.06e+00   rel_l2=4.59e-01   DIV cos=8.75e-01   max|Δ|=9.41e+00   mean|Δ|=1.18e+00   rel_l2=4.88e-01   DIV cos=8.91e-01   max|Δ|=1.19e+01   mean|Δ|=1.03e+00   rel_l2=4.54e-01   DIV
+  qk_norm_q           <missing>                                            cos=4.51e-01   max|Δ|=7.45e+00   mean|Δ|=9.94e-01   rel_l2=1.03e+00   DIV cos=3.78e-01   max|Δ|=8.67e+00   mean|Δ|=1.04e+00   rel_l2=1.07e+00   DIV cos=4.16e-01   max|Δ|=8.52e+00   mean|Δ|=1.03e+00   rel_l2=1.06e+00   DIV cos=4.05e-01   max|Δ|=8.95e+00   mean|Δ|=1.04e+00   rel_l2=1.06e+00   DIV cos=3.89e-01   max|Δ|=9.61e+00   mean|Δ|=1.05e+00   rel_l2=1.07e+00   DIV cos=4.16e-01   max|Δ|=8.91e+00   mean|Δ|=1.02e+00   rel_l2=1.06e+00   DIV cos=3.94e-01   max|Δ|=9.73e+00   mean|Δ|=1.06e+00   rel_l2=1.08e+00   DIV cos=4.25e-01   max|Δ|=1.09e+01   mean|Δ|=1.03e+00   rel_l2=1.07e+00   DIV cos=3.29e-01   max|Δ|=1.07e+01   mean|Δ|=1.14e+00   rel_l2=1.15e+00   DIV cos=3.70e-01   max|Δ|=8.97e+00   mean|Δ|=1.08e+00   rel_l2=1.11e+00   DIV
+  qk_norm_k           <missing>                                            cos=4.90e-01   max|Δ|=8.03e+00   mean|Δ|=1.05e+00   rel_l2=1.00e+00   DIV cos=2.95e-01   max|Δ|=1.05e+01   mean|Δ|=1.25e+00   rel_l2=1.19e+00   DIV cos=3.62e-01   max|Δ|=9.44e+00   mean|Δ|=1.19e+00   rel_l2=1.13e+00   DIV cos=3.26e-01   max|Δ|=8.20e+00   mean|Δ|=1.28e+00   rel_l2=1.16e+00   DIV cos=3.33e-01   max|Δ|=9.06e+00   mean|Δ|=1.21e+00   rel_l2=1.15e+00   DIV cos=3.95e-01   max|Δ|=9.22e+00   mean|Δ|=1.16e+00   rel_l2=1.09e+00   DIV cos=3.26e-01   max|Δ|=7.38e+00   mean|Δ|=1.26e+00   rel_l2=1.16e+00   DIV cos=3.59e-01   max|Δ|=1.00e+01   mean|Δ|=1.20e+00   rel_l2=1.13e+00   DIV cos=3.70e-01   max|Δ|=6.78e+00   mean|Δ|=1.24e+00   rel_l2=1.12e+00   DIV cos=3.64e-01   max|Δ|=6.77e+00   mean|Δ|=1.22e+00   rel_l2=1.12e+00   DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=3.37e-01   max|Δ|=8.23e+00   mean|Δ|=3.01e-01   rel_l2=1.40e+00   DIV <missing>                                            <missing>                                           
+  post_attn_norm      <missing>                                            cos=5.18e-01   max|Δ|=1.03e+01   mean|Δ|=8.70e-01   rel_l2=9.76e-01   DIV cos=4.26e-01   max|Δ|=1.15e+01   mean|Δ|=9.11e-01   rel_l2=1.07e+00   DIV cos=4.09e-01   max|Δ|=9.94e+00   mean|Δ|=9.69e-01   rel_l2=1.10e+00   DIV cos=4.66e-01   max|Δ|=1.06e+01   mean|Δ|=9.04e-01   rel_l2=1.03e+00   DIV cos=4.47e-01   max|Δ|=1.02e+01   mean|Δ|=9.12e-01   rel_l2=1.06e+00   DIV cos=4.23e-01   max|Δ|=1.03e+01   mean|Δ|=9.51e-01   rel_l2=1.09e+00   DIV cos=4.42e-01   max|Δ|=1.05e+01   mean|Δ|=9.29e-01   rel_l2=1.06e+00   DIV cos=3.53e-01   max|Δ|=1.19e+01   mean|Δ|=1.00e+00   rel_l2=1.16e+00   DIV cos=3.02e-01   max|Δ|=1.10e+01   mean|Δ|=1.05e+00   rel_l2=1.21e+00   DIV cos=4.48e-01   max|Δ|=1.05e+01   mean|Δ|=9.30e-01   rel_l2=1.06e+00   DIV
+  mlp_gate            <missing>                                            cos=8.42e-01   max|Δ|=1.08e+01   mean|Δ|=7.08e-01   rel_l2=6.43e-01   DIV cos=8.44e-01   max|Δ|=1.30e+01   mean|Δ|=7.90e-01   rel_l2=7.45e-01   DIV cos=8.42e-01   max|Δ|=1.28e+01   mean|Δ|=8.10e-01   rel_l2=7.12e-01   DIV cos=8.76e-01   max|Δ|=1.23e+01   mean|Δ|=6.74e-01   rel_l2=5.83e-01   DIV cos=8.54e-01   max|Δ|=1.27e+01   mean|Δ|=7.87e-01   rel_l2=7.25e-01   DIV cos=8.35e-01   max|Δ|=1.36e+01   mean|Δ|=8.86e-01   rel_l2=7.77e-01   DIV cos=8.36e-01   max|Δ|=1.28e+01   mean|Δ|=7.91e-01   rel_l2=6.87e-01   DIV cos=8.20e-01   max|Δ|=1.28e+01   mean|Δ|=8.57e-01   rel_l2=7.22e-01   DIV cos=8.08e-01   max|Δ|=1.35e+01   mean|Δ|=9.45e-01   rel_l2=8.87e-01   DIV cos=8.67e-01   max|Δ|=1.20e+01   mean|Δ|=7.54e-01   rel_l2=6.62e-01   DIV
+  mlp_up              <missing>                                            cos=7.20e-01   max|Δ|=6.63e+00   mean|Δ|=5.82e-01   rel_l2=8.56e-01   DIV cos=6.51e-01   max|Δ|=8.26e+00   mean|Δ|=6.77e-01   rel_l2=9.87e-01   DIV cos=6.39e-01   max|Δ|=7.70e+00   mean|Δ|=7.29e-01   rel_l2=1.09e+00   DIV cos=7.23e-01   max|Δ|=7.07e+00   mean|Δ|=5.87e-01   rel_l2=8.45e-01   DIV cos=6.95e-01   max|Δ|=7.95e+00   mean|Δ|=6.41e-01   rel_l2=9.41e-01   DIV cos=6.58e-01   max|Δ|=8.61e+00   mean|Δ|=7.45e-01   rel_l2=1.12e+00   DIV cos=6.93e-01   max|Δ|=7.82e+00   mean|Δ|=6.31e-01   rel_l2=9.26e-01   DIV cos=6.79e-01   max|Δ|=9.78e+00   mean|Δ|=6.95e-01   rel_l2=9.36e-01   DIV cos=6.30e-01   max|Δ|=7.88e+00   mean|Δ|=7.81e-01   rel_l2=1.13e+00   DIV cos=7.18e-01   max|Δ|=7.21e+00   mean|Δ|=6.18e-01   rel_l2=9.25e-01   DIV
+  mlp_down            <missing>                                            cos=5.05e-01   max|Δ|=1.12e+01   mean|Δ|=5.86e-01   rel_l2=9.90e-01   DIV cos=4.44e-01   max|Δ|=1.58e+01   mean|Δ|=7.41e-01   rel_l2=9.49e-01   DIV cos=4.04e-01   max|Δ|=1.21e+01   mean|Δ|=7.72e-01   rel_l2=1.05e+00   DIV cos=5.47e-01   max|Δ|=1.96e+01   mean|Δ|=6.01e-01   rel_l2=8.80e-01   DIV cos=4.45e-01   max|Δ|=2.12e+01   mean|Δ|=7.04e-01   rel_l2=9.89e-01   DIV cos=4.43e-01   max|Δ|=1.54e+01   mean|Δ|=7.34e-01   rel_l2=1.02e+00   DIV cos=2.54e-01   max|Δ|=3.08e+01   mean|Δ|=6.34e-01   rel_l2=1.13e+00   DIV cos=4.50e-01   max|Δ|=2.74e+01   mean|Δ|=6.80e-01   rel_l2=9.32e-01   DIV cos=3.36e-01   max|Δ|=1.93e+01   mean|Δ|=7.60e-01   rel_l2=1.02e+00   DIV cos=4.51e-01   max|Δ|=2.40e+01   mean|Δ|=5.93e-01   rel_l2=9.76e-01   DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=3.29e-01     DIV
+    q_proj               median=5.88e-01     DIV
+    k_proj               median=3.36e-01     DIV
+    v_proj               median=8.95e-01     DIV
+    qk_norm_q            median=4.00e-01     DIV
+    qk_norm_k            median=3.61e-01     DIV
+    o_proj               median=3.37e-01     DIV
+    post_attn_norm       median=4.34e-01     DIV
+    mlp_gate             median=8.42e-01     DIV
+    mlp_up               median=6.86e-01     DIV
+    mlp_down             median=4.44e-01     DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.419222)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/profiling-artifacts/post422_20260423_seed1_compare_fp32.txt
+++ b/profiling-artifacts/post422_20260423_seed1_compare_fp32.txt
@@ -1,0 +1,2008 @@
+# seed 1 compare vs fp32 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.26e-02     7.67e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.05e-01     2.08e-02    
+h_layer_16             1x1x2560               True     False    9.50e-01   6.31e-01     4.94e-02    
+h_layer_23             1x1x2560               True     False    9.74e-01   7.58e-01     9.19e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.05e+01     1.15e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.02e-02     1.28e-03    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   6.66e-02     1.82e-03    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   6.19e-02     7.34e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   4.47e-03     1.30e-04    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   5.17e-03     1.19e-03    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.85e-02     8.10e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   6.09e-03     3.95e-06    
+b11__gdn_gated_norm    1x508x4096             True     False    1.00e+00   1.93e-02     4.82e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.19e-02     5.76e-05    
+h_layer_24             1x1x2560               True     False    9.76e-01   8.89e-01     9.65e-02    
+h_layer_25             1x1x2560               True     False    9.78e-01   8.73e-01     9.86e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   8.77e-01     1.01e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   1.21e+00     1.18e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   1.05e+00     1.33e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   1.43e+00     1.45e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   1.01e+00     1.67e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.49e-01   8.96e-01     1.86e-02    
+h_layer_8              1x1x2560               True     False    7.30e-02   1.46e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    1.34e-02   1.23e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    4.37e-01   1.20e+01     3.06e-01    
+h_layer_31             1x1x2560               True     False    3.50e-01   2.62e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.19e-02     1.31e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.07e-02     1.62e-03    
+b11__gdn_conv          1x1x8192               True     False    4.71e-01   1.85e+01     4.05e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.32e-01   8.62e-01     4.08e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.00e-01   8.08e-01     5.50e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.38e-03     1.12e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.44e-03     8.35e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.65e-01   4.82e-01     1.33e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.68e-01   1.42e+00     6.40e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.60e-01   6.38e-01     9.62e-03    
+h_layer_24             1x1x2560               True     False    4.86e-01   1.12e+01     3.24e-01    
+h_layer_25             1x1x2560               True     False    5.30e-01   1.03e+01     3.36e-01    
+h_layer_26             1x1x2560               True     False    5.60e-01   7.34e+00     3.83e-01    
+h_layer_27             1x1x2560               True     False    5.06e-01   1.11e+01     4.88e-01    
+h_layer_28             1x1x2560               True     False    5.65e-01   9.62e+00     5.35e-01    
+h_layer_29             1x1x2560               True     False    5.49e-01   1.40e+01     6.10e-01    
+h_layer_30             1x1x2560               True     False    4.96e-01   9.54e+00     7.31e-01    
+b12__post_input_norm   1x1x2560               True     False    4.32e-01   1.96e+01     9.28e-01    
+b12__q_proj            1x1x8192               True     False    5.75e-01   1.01e+01     1.51e+00    
+b12__k_proj            1x1x1024               True     False    4.85e-01   5.92e+00     8.40e-01    
+b12__v_proj            1x1x1024               True     False    9.06e-01   9.05e+00     1.00e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.51e-01   7.48e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    4.89e-01   8.03e+00     1.05e+00    
+b12__post_attn_norm    1x1x2560               True     False    5.19e-01   1.03e+01     8.69e-01    
+b12__mlp_gate          1x1x9216               True     False    8.43e-01   1.08e+01     7.06e-01    
+b12__mlp_up            1x1x9216               True     False    7.22e-01   6.63e+00     5.80e-01    
+b12__mlp_down          1x1x2560               True     False    5.07e-01   1.15e+01     5.86e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.62e-01   7.19e-01     2.09e-02    
+h_layer_8              1x1x2560               True     False    4.62e-02   1.66e+01     1.81e-01    
+h_layer_16             1x1x2560               True     False    -1.06e-02  1.51e+01     1.96e-01    
+h_layer_23             1x1x2560               True     False    3.43e-01   7.26e+00     3.49e-01    
+h_layer_31             1x1x2560               True     False    2.54e-01   3.97e+01     2.19e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.51e-02     1.28e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   5.97e-02     2.18e-03    
+b11__gdn_conv          1x1x8192               True     False    9.03e-01   3.15e+00     2.74e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.85e-01   8.69e-01     3.31e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.47e-01   9.62e-01     4.90e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.74e-03     1.36e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   9.31e-03     7.14e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.69e-01   6.04e-01     1.40e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.01e-01   1.25e+00     6.28e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.42e-01   6.42e-01     9.76e-03    
+h_layer_24             1x1x2560               True     False    4.17e-01   7.26e+00     3.66e-01    
+h_layer_25             1x1x2560               True     False    4.24e-01   8.48e+00     4.32e-01    
+h_layer_26             1x1x2560               True     False    5.42e-01   6.25e+01     5.38e-01    
+h_layer_27             1x1x2560               True     False    4.00e-01   1.17e+01     5.24e-01    
+h_layer_28             1x1x2560               True     False    4.62e-01   1.33e+01     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.50e-01   1.79e+01     6.30e-01    
+h_layer_30             1x1x2560               True     False    4.19e-01   9.57e+00     7.50e-01    
+b12__post_input_norm   1x1x2560               True     False    3.23e-01   2.16e+01     9.71e-01    
+b12__q_proj            1x1x8192               True     False    5.91e-01   1.28e+01     1.42e+00    
+b12__k_proj            1x1x1024               True     False    2.80e-01   8.12e+00     9.96e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   1.08e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.78e-01   8.73e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    2.94e-01   1.05e+01     1.26e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.27e-01   1.15e+01     9.10e-01    
+b12__mlp_gate          1x1x9216               True     False    8.44e-01   1.30e+01     7.91e-01    
+b12__mlp_up            1x1x9216               True     False    6.51e-01   8.22e+00     6.77e-01    
+b12__mlp_down          1x1x2560               True     False    4.44e-01   1.59e+01     7.40e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.92e-01   8.77e-01     2.15e-02    
+h_layer_8              1x1x2560               True     False    2.75e-02   1.54e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -4.70e-02  1.37e+01     1.99e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.09e+01     3.28e-01    
+h_layer_31             1x1x2560               True     False    2.29e-01   3.75e+01     2.28e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.55e-02     1.31e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.87e-02     1.84e-03    
+b11__gdn_conv          1x1x8192               True     False    6.59e-01   1.32e+01     3.80e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.86e-01   8.09e-01     3.70e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.70e-01   8.39e-01     5.86e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.35e-03     1.19e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   4.89e-03     5.91e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.59e-01   5.33e-01     1.56e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.89e-01   1.20e+00     5.58e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.50e-01   7.49e-01     9.61e-03    
+h_layer_24             1x1x2560               True     False    4.15e-01   8.78e+00     3.47e-01    
+h_layer_25             1x1x2560               True     False    4.82e-01   7.15e+00     3.59e-01    
+h_layer_26             1x1x2560               True     False    5.13e-01   7.10e+00     3.98e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   7.41e+00     5.22e-01    
+h_layer_28             1x1x2560               True     False    4.83e-01   7.39e+00     5.92e-01    
+h_layer_29             1x1x2560               True     False    4.58e-01   1.20e+01     6.62e-01    
+h_layer_30             1x1x2560               True     False    3.88e-01   9.53e+00     8.22e-01    
+b12__post_input_norm   1x1x2560               True     False    3.15e-01   1.98e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    5.77e-01   1.09e+01     1.47e+00    
+b12__k_proj            1x1x1024               True     False    3.36e-01   7.71e+00     8.98e-01    
+b12__v_proj            1x1x1024               True     False    8.98e-01   1.02e+01     1.06e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.16e-01   8.54e+00     1.03e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.62e-01   9.43e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.08e-01   9.99e+00     9.69e-01    
+b12__mlp_gate          1x1x9216               True     False    8.42e-01   1.28e+01     8.12e-01    
+b12__mlp_up            1x1x9216               True     False    6.39e-01   7.67e+00     7.29e-01    
+b12__mlp_down          1x1x2560               True     False    4.02e-01   1.21e+01     7.72e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.27e-01   1.23e+00     2.11e-02    
+h_layer_8              1x1x2560               True     False    -5.15e-03  1.49e+01     1.75e-01    
+h_layer_16             1x1x2560               True     False    -6.95e-02  1.33e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.53e-01   1.21e+01     3.18e-01    
+h_layer_31             1x1x2560               True     False    3.62e-01   2.74e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   7.88e-03     1.26e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.28e-02     1.52e-03    
+b11__gdn_conv          1x1x8192               True     False    6.82e-01   4.87e+00     3.21e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.12e-01   8.61e-01     4.17e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.50e-01   8.86e-01     5.58e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.08e-03     1.48e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   3.13e-03     5.50e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.82e-01   5.60e-01     1.60e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.60e-01   1.30e+00     7.48e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   6.00e-01     1.17e-02    
+h_layer_24             1x1x2560               True     False    4.22e-01   9.96e+00     3.42e-01    
+h_layer_25             1x1x2560               True     False    4.83e-01   7.68e+00     3.57e-01    
+h_layer_26             1x1x2560               True     False    4.17e-01   6.56e+00     3.86e-01    
+h_layer_27             1x1x2560               True     False    4.60e-01   1.12e+01     4.96e-01    
+h_layer_28             1x1x2560               True     False    5.19e-01   7.74e+00     5.45e-01    
+h_layer_29             1x1x2560               True     False    5.17e-01   1.18e+01     6.25e-01    
+h_layer_30             1x1x2560               True     False    4.22e-01   9.36e+00     7.80e-01    
+b12__post_input_norm   1x1x2560               True     False    3.44e-01   1.98e+01     9.91e-01    
+b12__q_proj            1x1x8192               True     False    6.23e-01   1.21e+01     1.32e+00    
+b12__k_proj            1x1x1024               True     False    3.09e-01   6.20e+00     9.35e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   9.34e+00     1.02e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.05e-01   8.97e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.26e-01   8.21e+00     1.28e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.64e-01   1.07e+01     9.06e-01    
+b12__mlp_gate          1x1x9216               True     False    8.74e-01   1.24e+01     6.79e-01    
+b12__mlp_up            1x1x9216               True     False    7.19e-01   7.12e+00     5.90e-01    
+b12__mlp_down          1x1x2560               True     False    5.41e-01   1.95e+01     6.07e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.32e-01   4.70e-01     1.74e-02    
+h_layer_8              1x1x2560               True     False    1.55e-02   1.61e+01     1.73e-01    
+h_layer_16             1x1x2560               True     False    -3.19e-02  1.46e+01     1.87e-01    
+h_layer_23             1x1x2560               True     False    3.83e-01   6.10e+00     3.36e-01    
+h_layer_31             1x1x2560               True     False    3.29e-01   2.87e+01     2.16e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.55e-02     1.27e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.68e-02     2.00e-03    
+b11__gdn_conv          1x1x8192               True     False    9.02e-01   2.98e+00     2.56e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.40e-01   8.83e-01     3.30e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.93e-01   9.54e-01     5.16e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.00e-03     1.17e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.85e-02     1.53e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    5.01e-01   4.46e-01     1.35e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.13e-01   1.21e+00     5.45e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.56e-01   6.25e-01     7.66e-03    
+h_layer_24             1x1x2560               True     False    4.36e-01   6.11e+00     3.51e-01    
+h_layer_25             1x1x2560               True     False    4.66e-01   6.79e+00     3.92e-01    
+h_layer_26             1x1x2560               True     False    5.36e-01   4.34e+01     4.73e-01    
+h_layer_27             1x1x2560               True     False    4.16e-01   9.83e+00     5.08e-01    
+h_layer_28             1x1x2560               True     False    4.72e-01   1.04e+01     5.59e-01    
+h_layer_29             1x1x2560               True     False    4.58e-01   1.50e+01     6.34e-01    
+h_layer_30             1x1x2560               True     False    4.25e-01   8.44e+00     7.65e-01    
+b12__post_input_norm   1x1x2560               True     False    3.41e-01   1.88e+01     9.75e-01    
+b12__q_proj            1x1x8192               True     False    5.85e-01   1.27e+01     1.43e+00    
+b12__k_proj            1x1x1024               True     False    3.19e-01   7.09e+00     9.34e-01    
+b12__v_proj            1x1x1024               True     False    9.02e-01   9.32e+00     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.88e-01   9.59e+00     1.05e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.33e-01   9.09e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.45e-01   1.01e+01     9.14e-01    
+b12__mlp_gate          1x1x9216               True     False    8.53e-01   1.27e+01     7.90e-01    
+b12__mlp_up            1x1x9216               True     False    6.95e-01   8.01e+00     6.41e-01    
+b12__mlp_down          1x1x2560               True     False    4.43e-01   2.09e+01     7.04e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.00e-01   9.74e-01     2.41e-02    
+h_layer_8              1x1x2560               True     False    5.20e-02   1.57e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -2.57e-02  1.37e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.67e-01   7.34e+00     3.19e-01    
+h_layer_31             1x1x2560               True     False    2.81e-01   2.70e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.33e-02     1.31e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.44e-02     1.72e-03    
+b11__gdn_conv          1x1x8192               True     False    6.86e-01   1.10e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.67e-01   8.29e-01     3.61e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.55e-01   8.25e-01     5.94e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.32e-03     1.27e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.83e-03     1.10e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    3.59e-01   5.70e-01     1.50e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.27e-01   1.54e+00     6.60e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.38e-01   9.38e-01     1.02e-02    
+h_layer_24             1x1x2560               True     False    4.16e-01   6.27e+00     3.39e-01    
+h_layer_25             1x1x2560               True     False    4.83e-01   6.51e+00     3.52e-01    
+h_layer_26             1x1x2560               True     False    4.88e-01   7.34e+00     3.93e-01    
+h_layer_27             1x1x2560               True     False    4.21e-01   7.16e+00     5.16e-01    
+h_layer_28             1x1x2560               True     False    4.95e-01   7.11e+00     5.68e-01    
+h_layer_29             1x1x2560               True     False    4.79e-01   9.37e+00     6.37e-01    
+h_layer_30             1x1x2560               True     False    3.99e-01   9.92e+00     8.00e-01    
+b12__post_input_norm   1x1x2560               True     False    3.26e-01   2.06e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    5.43e-01   1.11e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.73e-01   8.55e+00     8.98e-01    
+b12__v_proj            1x1x1024               True     False    8.96e-01   9.82e+00     1.06e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.14e-01   8.96e+00     1.02e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.95e-01   9.24e+00     1.16e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.22e-01   1.04e+01     9.52e-01    
+b12__mlp_gate          1x1x9216               True     False    8.35e-01   1.36e+01     8.88e-01    
+b12__mlp_up            1x1x9216               True     False    6.58e-01   8.60e+00     7.45e-01    
+b12__mlp_down          1x1x2560               True     False    4.42e-01   1.51e+01     7.35e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.03e-01   1.29e+00     2.00e-02    
+h_layer_8              1x1x2560               True     False    -1.03e-03  1.54e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -5.48e-02  1.37e+01     1.94e-01    
+h_layer_23             1x1x2560               True     False    3.00e-01   1.22e+01     3.36e-01    
+h_layer_31             1x1x2560               True     False    2.90e-01   3.39e+01     2.20e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.14e-02     1.32e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   2.95e-02     1.69e-03    
+b11__gdn_conv          1x1x8192               True     False    6.68e-01   6.15e+00     3.06e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.72e-01   8.42e-01     4.12e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.57e-01   9.13e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.55e-03     1.05e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   8.93e-03     9.07e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.62e-01   4.45e-01     1.52e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.70e-01   1.16e+00     7.56e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   7.80e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    3.73e-01   9.97e+00     3.55e-01    
+h_layer_25             1x1x2560               True     False    4.53e-01   7.72e+00     3.65e-01    
+h_layer_26             1x1x2560               True     False    4.32e-01   6.99e+00     3.95e-01    
+h_layer_27             1x1x2560               True     False    4.51e-01   1.44e+01     5.13e-01    
+h_layer_28             1x1x2560               True     False    5.25e-01   8.69e+00     5.31e-01    
+h_layer_29             1x1x2560               True     False    5.21e-01   1.29e+01     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.10e-01   9.51e+00     7.52e-01    
+b12__post_input_norm   1x1x2560               True     False    3.41e-01   1.92e+01     9.88e-01    
+b12__q_proj            1x1x8192               True     False    5.98e-01   1.21e+01     1.39e+00    
+b12__k_proj            1x1x1024               True     False    3.10e-01   6.85e+00     9.60e-01    
+b12__v_proj            1x1x1024               True     False    8.89e-01   1.15e+01     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.95e-01   9.73e+00     1.06e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.27e-01   7.39e+00     1.26e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.44e-01   1.04e+01     9.27e-01    
+b12__mlp_gate          1x1x9216               True     False    8.36e-01   1.28e+01     7.92e-01    
+b12__mlp_up            1x1x9216               True     False    6.93e-01   7.80e+00     6.31e-01    
+b12__mlp_down          1x1x2560               True     False    2.55e-01   3.11e+01     6.35e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    9.01e-01   2.71e-01     1.42e-02    
+h_layer_8              1x1x2560               True     False    3.33e-01   2.18e+00     1.15e-01    
+h_layer_16             1x1x2560               True     False    2.12e-01   3.46e+00     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.53e-01   9.54e+00     3.63e-01    
+h_layer_31             1x1x2560               True     False    4.31e-01   3.70e+01     1.78e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   3.00e-02     1.24e-03    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   6.48e-02     2.08e-03    
+b11__gdn_conv          1x2x8192               True     False    9.51e-01   4.06e+00     1.85e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.50e-01   8.99e-01     3.27e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.96e-01   9.22e-01     3.13e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   3.66e-03     1.15e-03    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.73e-02     1.02e-03    
+b11__gdn_recur_out     1x2x32x128             True     False    6.70e-01   5.61e-01     1.39e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    8.69e-01   1.95e+00     6.01e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.20e-01   1.05e+00     7.77e-03    
+h_layer_24             1x1x2560               True     False    4.65e-01   1.00e+01     3.89e-01    
+h_layer_25             1x1x2560               True     False    4.93e-01   1.04e+01     4.17e-01    
+h_layer_26             1x1x2560               True     False    5.27e-01   4.04e+01     4.72e-01    
+h_layer_27             1x1x2560               True     False    4.96e-01   1.10e+01     5.54e-01    
+h_layer_28             1x1x2560               True     False    5.34e-01   1.11e+01     5.91e-01    
+h_layer_29             1x1x2560               True     False    5.44e-01   1.11e+01     6.40e-01    
+h_layer_30             1x1x2560               True     False    4.81e-01   1.12e+01     7.56e-01    
+b12__post_input_norm   1x2x2560               True     False    2.52e-01   1.63e+01     1.06e+00    
+b12__q_proj            1x2x8192               True     False    6.32e-01   1.07e+01     1.20e+00    
+b12__k_proj            1x2x1024               True     False    3.54e-01   7.51e+00     9.53e-01    
+b12__v_proj            1x2x1024               True     False    8.89e-01   8.99e+00     1.06e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.26e-01   1.09e+01     1.03e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.60e-01   1.00e+01     1.20e+00    
+b12__o_proj            1x2x2560               True     False    3.38e-01   8.22e+00     3.00e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.53e-01   1.19e+01     1.00e+00    
+b12__mlp_gate          1x2x9216               True     False    8.20e-01   1.27e+01     8.58e-01    
+b12__mlp_up            1x2x9216               True     False    6.79e-01   9.77e+00     6.95e-01    
+b12__mlp_down          1x2x2560               True     False    4.52e-01   2.74e+01     6.78e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.71e-01   6.16e-01     1.92e-02    
+h_layer_8              1x1x2560               True     False    2.29e-02   1.68e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -3.52e-02  1.51e+01     1.97e-01    
+h_layer_23             1x1x2560               True     False    2.32e-01   6.83e+00     3.80e-01    
+h_layer_31             1x1x2560               True     False    2.09e-01   3.27e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.50e-02     1.29e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.60e-02     2.01e-03    
+b11__gdn_conv          1x1x8192               True     False    7.23e-01   1.45e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.36e-01   8.52e-01     3.52e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   8.22e-01     5.38e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.52e-03     1.17e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.20e-02     7.96e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.80e-01   6.18e-01     1.57e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.89e-01   1.35e+00     5.75e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   6.43e-01     8.91e-03    
+h_layer_24             1x1x2560               True     False    2.58e-01   6.84e+00     3.94e-01    
+h_layer_25             1x1x2560               True     False    2.40e-01   8.30e+00     4.36e-01    
+h_layer_26             1x1x2560               True     False    1.90e-01   6.21e+01     5.21e-01    
+h_layer_27             1x1x2560               True     False    2.47e-01   6.09e+00     5.24e-01    
+h_layer_28             1x1x2560               True     False    3.20e-01   6.79e+00     6.02e-01    
+h_layer_29             1x1x2560               True     False    3.19e-01   7.49e+00     6.70e-01    
+h_layer_30             1x1x2560               True     False    2.52e-01   1.31e+01     8.30e-01    
+b12__post_input_norm   1x1x2560               True     False    2.01e-01   2.05e+01     1.11e+00    
+b12__q_proj            1x1x8192               True     False    5.03e-01   1.20e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    3.41e-01   6.78e+00     9.69e-01    
+b12__v_proj            1x1x1024               True     False    8.76e-01   9.40e+00     1.17e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.34e-01   1.05e+01     1.13e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.76e-01   6.74e+00     1.23e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.05e-01   1.09e+01     1.04e+00    
+b12__mlp_gate          1x1x9216               True     False    8.09e-01   1.34e+01     9.38e-01    
+b12__mlp_up            1x1x9216               True     False    6.28e-01   7.85e+00     7.82e-01    
+b12__mlp_down          1x1x2560               True     False    3.38e-01   2.02e+01     7.64e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.44e-01   9.11e-01     1.92e-02    
+h_layer_8              1x1x2560               True     False    2.87e-02   1.62e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -1.37e-02  1.41e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.15e+01     3.34e-01    
+h_layer_31             1x1x2560               True     False    3.35e-01   2.82e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   7.79e-03     1.26e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.25e-02     1.66e-03    
+b11__gdn_conv          1x1x8192               True     False    6.45e-01   1.42e+01     3.64e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.05e-01   8.69e-01     3.85e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.41e-01   8.79e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.39e-03     1.16e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   4.39e-03     6.80e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.54e-01   4.78e-01     1.58e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.95e-01   1.14e+00     5.95e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.58e-01   6.39e-01     9.42e-03    
+h_layer_24             1x1x2560               True     False    4.13e-01   9.90e+00     3.56e-01    
+h_layer_25             1x1x2560               True     False    4.66e-01   8.39e+00     3.69e-01    
+h_layer_26             1x1x2560               True     False    3.85e-01   6.60e+00     4.06e-01    
+h_layer_27             1x1x2560               True     False    4.71e-01   1.41e+01     5.17e-01    
+h_layer_28             1x1x2560               True     False    4.97e-01   8.73e+00     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.82e-01   1.24e+01     6.59e-01    
+h_layer_30             1x1x2560               True     False    3.99e-01   9.40e+00     7.97e-01    
+b12__post_input_norm   1x1x2560               True     False    3.32e-01   2.01e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    6.11e-01   1.08e+01     1.40e+00    
+b12__k_proj            1x1x1024               True     False    3.49e-01   5.55e+00     8.95e-01    
+b12__v_proj            1x1x1024               True     False    8.91e-01   1.19e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.70e-01   8.95e+00     1.08e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.63e-01   6.82e+00     1.22e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.49e-01   1.04e+01     9.30e-01    
+b12__mlp_gate          1x1x9216               True     False    8.66e-01   1.20e+01     7.57e-01    
+b12__mlp_up            1x1x9216               True     False    7.18e-01   7.20e+00     6.18e-01    
+b12__mlp_down          1x1x2560               True     False    4.50e-01   2.41e+01     5.92e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=1.26e-02   ok    cos=8.49e-01   max|Δ|=8.96e-01   DIV   cos=7.62e-01   max|Δ|=7.19e-01   DIV   cos=7.92e-01   max|Δ|=8.77e-01   DIV   cos=8.27e-01   max|Δ|=1.23e+00   DIV   cos=8.32e-01   max|Δ|=4.70e-01   DIV   cos=7.00e-01   max|Δ|=9.74e-01   DIV   cos=8.03e-01   max|Δ|=1.29e+00   DIV   cos=9.01e-01   max|Δ|=2.71e-01   DIV   cos=7.71e-01   max|Δ|=6.16e-01   DIV   cos=8.44e-01   max|Δ|=9.11e-01   DIV  
+  h_layer_8             cos=9.76e-01   max|Δ|=1.05e-01   DIV   cos=7.30e-02   max|Δ|=1.46e+01   DIV   cos=4.62e-02   max|Δ|=1.66e+01   DIV   cos=2.75e-02   max|Δ|=1.54e+01   DIV   cos=-5.15e-03  max|Δ|=1.49e+01   DIV   cos=1.55e-02   max|Δ|=1.61e+01   DIV   cos=5.20e-02   max|Δ|=1.57e+01   DIV   cos=-1.03e-03  max|Δ|=1.54e+01   DIV   cos=3.33e-01   max|Δ|=2.18e+00   DIV   cos=2.29e-02   max|Δ|=1.68e+01   DIV   cos=2.87e-02   max|Δ|=1.62e+01   DIV  
+  h_layer_16            cos=9.50e-01   max|Δ|=6.31e-01   DIV   cos=1.34e-02   max|Δ|=1.23e+01   DIV   cos=-1.06e-02  max|Δ|=1.51e+01   DIV   cos=-4.70e-02  max|Δ|=1.37e+01   DIV   cos=-6.95e-02  max|Δ|=1.33e+01   DIV   cos=-3.19e-02  max|Δ|=1.46e+01   DIV   cos=-2.57e-02  max|Δ|=1.37e+01   DIV   cos=-5.48e-02  max|Δ|=1.37e+01   DIV   cos=2.12e-01   max|Δ|=3.46e+00   DIV   cos=-3.52e-02  max|Δ|=1.51e+01   DIV   cos=-1.37e-02  max|Δ|=1.41e+01   DIV  
+  h_layer_23            cos=9.74e-01   max|Δ|=7.58e-01   DIV   cos=4.37e-01   max|Δ|=1.20e+01   DIV   cos=3.43e-01   max|Δ|=7.26e+00   DIV   cos=3.56e-01   max|Δ|=1.09e+01   DIV   cos=3.53e-01   max|Δ|=1.21e+01   DIV   cos=3.83e-01   max|Δ|=6.10e+00   DIV   cos=3.67e-01   max|Δ|=7.34e+00   DIV   cos=3.00e-01   max|Δ|=1.22e+01   DIV   cos=4.53e-01   max|Δ|=9.54e+00   DIV   cos=2.32e-01   max|Δ|=6.83e+00   DIV   cos=3.56e-01   max|Δ|=1.15e+01   DIV  
+  h_layer_31            cos=9.57e-01   max|Δ|=2.05e+01   DIV   cos=3.50e-01   max|Δ|=2.62e+01   DIV   cos=2.54e-01   max|Δ|=3.97e+01   DIV   cos=2.29e-01   max|Δ|=3.75e+01   DIV   cos=3.62e-01   max|Δ|=2.74e+01   DIV   cos=3.29e-01   max|Δ|=2.87e+01   DIV   cos=2.81e-01   max|Δ|=2.70e+01   DIV   cos=2.90e-01   max|Δ|=3.39e+01   DIV   cos=4.31e-01   max|Δ|=3.70e+01   DIV   cos=2.09e-01   max|Δ|=3.27e+01   DIV   cos=3.35e-01   max|Δ|=2.82e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_0' (pos=0_s1)
+Phase B10 verdict: DIVERGENCE AT LAYER 0
+  -> Input-path bug: embedding lookup, rotary_inv_freq build, first
+     block's Q/K/V proj or GDN sub-op, OR prompt-token construction
+     mismatch between kiln and reference. Verify `prompt_tokens` meta
+     matches exactly, then narrow to layer 0's sub-ops.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.26e-02     7.67e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.05e-01     2.08e-02    
+h_layer_16             1x1x2560               True     False    9.50e-01   6.31e-01     4.94e-02    
+h_layer_23             1x1x2560               True     False    9.74e-01   7.58e-01     9.19e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.05e+01     1.15e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.02e-02     1.28e-03    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   6.66e-02     1.82e-03    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   6.19e-02     7.34e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   4.47e-03     1.30e-04    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   5.17e-03     1.19e-03    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.85e-02     8.10e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   6.09e-03     3.95e-06    
+b11__gdn_gated_norm    1x508x4096             True     False    1.00e+00   1.93e-02     4.82e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.19e-02     5.76e-05    
+h_layer_24             1x1x2560               True     False    9.76e-01   8.89e-01     9.65e-02    
+h_layer_25             1x1x2560               True     False    9.78e-01   8.73e-01     9.86e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   8.77e-01     1.01e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   1.21e+00     1.18e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   1.05e+00     1.33e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   1.43e+00     1.45e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   1.01e+00     1.67e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.49e-01   8.96e-01     1.86e-02    
+h_layer_8              1x1x2560               True     False    7.30e-02   1.46e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    1.34e-02   1.23e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    4.37e-01   1.20e+01     3.06e-01    
+h_layer_31             1x1x2560               True     False    3.50e-01   2.62e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.19e-02     1.31e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.07e-02     1.62e-03    
+b11__gdn_conv          1x1x8192               True     False    4.71e-01   1.85e+01     4.05e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.32e-01   8.62e-01     4.08e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.00e-01   8.08e-01     5.50e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.38e-03     1.12e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.44e-03     8.35e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.65e-01   4.82e-01     1.33e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.68e-01   1.42e+00     6.40e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.60e-01   6.38e-01     9.62e-03    
+h_layer_24             1x1x2560               True     False    4.86e-01   1.12e+01     3.24e-01    
+h_layer_25             1x1x2560               True     False    5.30e-01   1.03e+01     3.36e-01    
+h_layer_26             1x1x2560               True     False    5.60e-01   7.34e+00     3.83e-01    
+h_layer_27             1x1x2560               True     False    5.06e-01   1.11e+01     4.88e-01    
+h_layer_28             1x1x2560               True     False    5.65e-01   9.62e+00     5.35e-01    
+h_layer_29             1x1x2560               True     False    5.49e-01   1.40e+01     6.10e-01    
+h_layer_30             1x1x2560               True     False    4.96e-01   9.54e+00     7.31e-01    
+b12__post_input_norm   1x1x2560               True     False    4.32e-01   1.96e+01     9.28e-01    
+b12__q_proj            1x1x8192               True     False    5.75e-01   1.01e+01     1.51e+00    
+b12__k_proj            1x1x1024               True     False    4.85e-01   5.92e+00     8.40e-01    
+b12__v_proj            1x1x1024               True     False    9.06e-01   9.05e+00     1.00e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.51e-01   7.48e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    4.89e-01   8.03e+00     1.05e+00    
+b12__post_attn_norm    1x1x2560               True     False    5.19e-01   1.03e+01     8.69e-01    
+b12__mlp_gate          1x1x9216               True     False    8.43e-01   1.08e+01     7.06e-01    
+b12__mlp_up            1x1x9216               True     False    7.22e-01   6.63e+00     5.80e-01    
+b12__mlp_down          1x1x2560               True     False    5.07e-01   1.15e+01     5.86e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.62e-01   7.19e-01     2.09e-02    
+h_layer_8              1x1x2560               True     False    4.62e-02   1.66e+01     1.81e-01    
+h_layer_16             1x1x2560               True     False    -1.06e-02  1.51e+01     1.96e-01    
+h_layer_23             1x1x2560               True     False    3.43e-01   7.26e+00     3.49e-01    
+h_layer_31             1x1x2560               True     False    2.54e-01   3.97e+01     2.19e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.51e-02     1.28e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   5.97e-02     2.18e-03    
+b11__gdn_conv          1x1x8192               True     False    9.03e-01   3.15e+00     2.74e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.85e-01   8.69e-01     3.31e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.47e-01   9.62e-01     4.90e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.74e-03     1.36e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   9.31e-03     7.14e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.69e-01   6.04e-01     1.40e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.01e-01   1.25e+00     6.28e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.42e-01   6.42e-01     9.76e-03    
+h_layer_24             1x1x2560               True     False    4.17e-01   7.26e+00     3.66e-01    
+h_layer_25             1x1x2560               True     False    4.24e-01   8.48e+00     4.32e-01    
+h_layer_26             1x1x2560               True     False    5.42e-01   6.25e+01     5.38e-01    
+h_layer_27             1x1x2560               True     False    4.00e-01   1.17e+01     5.24e-01    
+h_layer_28             1x1x2560               True     False    4.62e-01   1.33e+01     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.50e-01   1.79e+01     6.30e-01    
+h_layer_30             1x1x2560               True     False    4.19e-01   9.57e+00     7.50e-01    
+b12__post_input_norm   1x1x2560               True     False    3.23e-01   2.16e+01     9.71e-01    
+b12__q_proj            1x1x8192               True     False    5.91e-01   1.28e+01     1.42e+00    
+b12__k_proj            1x1x1024               True     False    2.80e-01   8.12e+00     9.96e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   1.08e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.78e-01   8.73e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    2.94e-01   1.05e+01     1.26e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.27e-01   1.15e+01     9.10e-01    
+b12__mlp_gate          1x1x9216               True     False    8.44e-01   1.30e+01     7.91e-01    
+b12__mlp_up            1x1x9216               True     False    6.51e-01   8.22e+00     6.77e-01    
+b12__mlp_down          1x1x2560               True     False    4.44e-01   1.59e+01     7.40e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.92e-01   8.77e-01     2.15e-02    
+h_layer_8              1x1x2560               True     False    2.75e-02   1.54e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -4.70e-02  1.37e+01     1.99e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.09e+01     3.28e-01    
+h_layer_31             1x1x2560               True     False    2.29e-01   3.75e+01     2.28e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.55e-02     1.31e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.87e-02     1.84e-03    
+b11__gdn_conv          1x1x8192               True     False    6.59e-01   1.32e+01     3.80e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.86e-01   8.09e-01     3.70e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.70e-01   8.39e-01     5.86e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.35e-03     1.19e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   4.89e-03     5.91e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.59e-01   5.33e-01     1.56e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.89e-01   1.20e+00     5.58e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.50e-01   7.49e-01     9.61e-03    
+h_layer_24             1x1x2560               True     False    4.15e-01   8.78e+00     3.47e-01    
+h_layer_25             1x1x2560               True     False    4.82e-01   7.15e+00     3.59e-01    
+h_layer_26             1x1x2560               True     False    5.13e-01   7.10e+00     3.98e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   7.41e+00     5.22e-01    
+h_layer_28             1x1x2560               True     False    4.83e-01   7.39e+00     5.92e-01    
+h_layer_29             1x1x2560               True     False    4.58e-01   1.20e+01     6.62e-01    
+h_layer_30             1x1x2560               True     False    3.88e-01   9.53e+00     8.22e-01    
+b12__post_input_norm   1x1x2560               True     False    3.15e-01   1.98e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    5.77e-01   1.09e+01     1.47e+00    
+b12__k_proj            1x1x1024               True     False    3.36e-01   7.71e+00     8.98e-01    
+b12__v_proj            1x1x1024               True     False    8.98e-01   1.02e+01     1.06e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.16e-01   8.54e+00     1.03e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.62e-01   9.43e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.08e-01   9.99e+00     9.69e-01    
+b12__mlp_gate          1x1x9216               True     False    8.42e-01   1.28e+01     8.12e-01    
+b12__mlp_up            1x1x9216               True     False    6.39e-01   7.67e+00     7.29e-01    
+b12__mlp_down          1x1x2560               True     False    4.02e-01   1.21e+01     7.72e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.27e-01   1.23e+00     2.11e-02    
+h_layer_8              1x1x2560               True     False    -5.15e-03  1.49e+01     1.75e-01    
+h_layer_16             1x1x2560               True     False    -6.95e-02  1.33e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.53e-01   1.21e+01     3.18e-01    
+h_layer_31             1x1x2560               True     False    3.62e-01   2.74e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   7.88e-03     1.26e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.28e-02     1.52e-03    
+b11__gdn_conv          1x1x8192               True     False    6.82e-01   4.87e+00     3.21e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.12e-01   8.61e-01     4.17e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.50e-01   8.86e-01     5.58e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.08e-03     1.48e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   3.13e-03     5.50e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.82e-01   5.60e-01     1.60e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.60e-01   1.30e+00     7.48e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   6.00e-01     1.17e-02    
+h_layer_24             1x1x2560               True     False    4.22e-01   9.96e+00     3.42e-01    
+h_layer_25             1x1x2560               True     False    4.83e-01   7.68e+00     3.57e-01    
+h_layer_26             1x1x2560               True     False    4.17e-01   6.56e+00     3.86e-01    
+h_layer_27             1x1x2560               True     False    4.60e-01   1.12e+01     4.96e-01    
+h_layer_28             1x1x2560               True     False    5.19e-01   7.74e+00     5.45e-01    
+h_layer_29             1x1x2560               True     False    5.17e-01   1.18e+01     6.25e-01    
+h_layer_30             1x1x2560               True     False    4.22e-01   9.36e+00     7.80e-01    
+b12__post_input_norm   1x1x2560               True     False    3.44e-01   1.98e+01     9.91e-01    
+b12__q_proj            1x1x8192               True     False    6.23e-01   1.21e+01     1.32e+00    
+b12__k_proj            1x1x1024               True     False    3.09e-01   6.20e+00     9.35e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   9.34e+00     1.02e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.05e-01   8.97e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.26e-01   8.21e+00     1.28e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.64e-01   1.07e+01     9.06e-01    
+b12__mlp_gate          1x1x9216               True     False    8.74e-01   1.24e+01     6.79e-01    
+b12__mlp_up            1x1x9216               True     False    7.19e-01   7.12e+00     5.90e-01    
+b12__mlp_down          1x1x2560               True     False    5.41e-01   1.95e+01     6.07e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.32e-01   4.70e-01     1.74e-02    
+h_layer_8              1x1x2560               True     False    1.55e-02   1.61e+01     1.73e-01    
+h_layer_16             1x1x2560               True     False    -3.19e-02  1.46e+01     1.87e-01    
+h_layer_23             1x1x2560               True     False    3.83e-01   6.10e+00     3.36e-01    
+h_layer_31             1x1x2560               True     False    3.29e-01   2.87e+01     2.16e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.55e-02     1.27e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.68e-02     2.00e-03    
+b11__gdn_conv          1x1x8192               True     False    9.02e-01   2.98e+00     2.56e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.40e-01   8.83e-01     3.30e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.93e-01   9.54e-01     5.16e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.00e-03     1.17e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.85e-02     1.53e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    5.01e-01   4.46e-01     1.35e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.13e-01   1.21e+00     5.45e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.56e-01   6.25e-01     7.66e-03    
+h_layer_24             1x1x2560               True     False    4.36e-01   6.11e+00     3.51e-01    
+h_layer_25             1x1x2560               True     False    4.66e-01   6.79e+00     3.92e-01    
+h_layer_26             1x1x2560               True     False    5.36e-01   4.34e+01     4.73e-01    
+h_layer_27             1x1x2560               True     False    4.16e-01   9.83e+00     5.08e-01    
+h_layer_28             1x1x2560               True     False    4.72e-01   1.04e+01     5.59e-01    
+h_layer_29             1x1x2560               True     False    4.58e-01   1.50e+01     6.34e-01    
+h_layer_30             1x1x2560               True     False    4.25e-01   8.44e+00     7.65e-01    
+b12__post_input_norm   1x1x2560               True     False    3.41e-01   1.88e+01     9.75e-01    
+b12__q_proj            1x1x8192               True     False    5.85e-01   1.27e+01     1.43e+00    
+b12__k_proj            1x1x1024               True     False    3.19e-01   7.09e+00     9.34e-01    
+b12__v_proj            1x1x1024               True     False    9.02e-01   9.32e+00     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.88e-01   9.59e+00     1.05e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.33e-01   9.09e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.45e-01   1.01e+01     9.14e-01    
+b12__mlp_gate          1x1x9216               True     False    8.53e-01   1.27e+01     7.90e-01    
+b12__mlp_up            1x1x9216               True     False    6.95e-01   8.01e+00     6.41e-01    
+b12__mlp_down          1x1x2560               True     False    4.43e-01   2.09e+01     7.04e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.00e-01   9.74e-01     2.41e-02    
+h_layer_8              1x1x2560               True     False    5.20e-02   1.57e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -2.57e-02  1.37e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.67e-01   7.34e+00     3.19e-01    
+h_layer_31             1x1x2560               True     False    2.81e-01   2.70e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.33e-02     1.31e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.44e-02     1.72e-03    
+b11__gdn_conv          1x1x8192               True     False    6.86e-01   1.10e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.67e-01   8.29e-01     3.61e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.55e-01   8.25e-01     5.94e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.32e-03     1.27e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.83e-03     1.10e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    3.59e-01   5.70e-01     1.50e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.27e-01   1.54e+00     6.60e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.38e-01   9.38e-01     1.02e-02    
+h_layer_24             1x1x2560               True     False    4.16e-01   6.27e+00     3.39e-01    
+h_layer_25             1x1x2560               True     False    4.83e-01   6.51e+00     3.52e-01    
+h_layer_26             1x1x2560               True     False    4.88e-01   7.34e+00     3.93e-01    
+h_layer_27             1x1x2560               True     False    4.21e-01   7.16e+00     5.16e-01    
+h_layer_28             1x1x2560               True     False    4.95e-01   7.11e+00     5.68e-01    
+h_layer_29             1x1x2560               True     False    4.79e-01   9.37e+00     6.37e-01    
+h_layer_30             1x1x2560               True     False    3.99e-01   9.92e+00     8.00e-01    
+b12__post_input_norm   1x1x2560               True     False    3.26e-01   2.06e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    5.43e-01   1.11e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.73e-01   8.55e+00     8.98e-01    
+b12__v_proj            1x1x1024               True     False    8.96e-01   9.82e+00     1.06e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.14e-01   8.96e+00     1.02e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.95e-01   9.24e+00     1.16e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.22e-01   1.04e+01     9.52e-01    
+b12__mlp_gate          1x1x9216               True     False    8.35e-01   1.36e+01     8.88e-01    
+b12__mlp_up            1x1x9216               True     False    6.58e-01   8.60e+00     7.45e-01    
+b12__mlp_down          1x1x2560               True     False    4.42e-01   1.51e+01     7.35e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.03e-01   1.29e+00     2.00e-02    
+h_layer_8              1x1x2560               True     False    -1.03e-03  1.54e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -5.48e-02  1.37e+01     1.94e-01    
+h_layer_23             1x1x2560               True     False    3.00e-01   1.22e+01     3.36e-01    
+h_layer_31             1x1x2560               True     False    2.90e-01   3.39e+01     2.20e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.14e-02     1.32e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   2.95e-02     1.69e-03    
+b11__gdn_conv          1x1x8192               True     False    6.68e-01   6.15e+00     3.06e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.72e-01   8.42e-01     4.12e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.57e-01   9.13e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.55e-03     1.05e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   8.93e-03     9.07e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.62e-01   4.45e-01     1.52e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.70e-01   1.16e+00     7.56e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   7.80e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    3.73e-01   9.97e+00     3.55e-01    
+h_layer_25             1x1x2560               True     False    4.53e-01   7.72e+00     3.65e-01    
+h_layer_26             1x1x2560               True     False    4.32e-01   6.99e+00     3.95e-01    
+h_layer_27             1x1x2560               True     False    4.51e-01   1.44e+01     5.13e-01    
+h_layer_28             1x1x2560               True     False    5.25e-01   8.69e+00     5.31e-01    
+h_layer_29             1x1x2560               True     False    5.21e-01   1.29e+01     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.10e-01   9.51e+00     7.52e-01    
+b12__post_input_norm   1x1x2560               True     False    3.41e-01   1.92e+01     9.88e-01    
+b12__q_proj            1x1x8192               True     False    5.98e-01   1.21e+01     1.39e+00    
+b12__k_proj            1x1x1024               True     False    3.10e-01   6.85e+00     9.60e-01    
+b12__v_proj            1x1x1024               True     False    8.89e-01   1.15e+01     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.95e-01   9.73e+00     1.06e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.27e-01   7.39e+00     1.26e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.44e-01   1.04e+01     9.27e-01    
+b12__mlp_gate          1x1x9216               True     False    8.36e-01   1.28e+01     7.92e-01    
+b12__mlp_up            1x1x9216               True     False    6.93e-01   7.80e+00     6.31e-01    
+b12__mlp_down          1x1x2560               True     False    2.55e-01   3.11e+01     6.35e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    9.01e-01   2.71e-01     1.42e-02    
+h_layer_8              1x1x2560               True     False    3.33e-01   2.18e+00     1.15e-01    
+h_layer_16             1x1x2560               True     False    2.12e-01   3.46e+00     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.53e-01   9.54e+00     3.63e-01    
+h_layer_31             1x1x2560               True     False    4.31e-01   3.70e+01     1.78e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   3.00e-02     1.24e-03    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   6.48e-02     2.08e-03    
+b11__gdn_conv          1x2x8192               True     False    9.51e-01   4.06e+00     1.85e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.50e-01   8.99e-01     3.27e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.96e-01   9.22e-01     3.13e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   3.66e-03     1.15e-03    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.73e-02     1.02e-03    
+b11__gdn_recur_out     1x2x32x128             True     False    6.70e-01   5.61e-01     1.39e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    8.69e-01   1.95e+00     6.01e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.20e-01   1.05e+00     7.77e-03    
+h_layer_24             1x1x2560               True     False    4.65e-01   1.00e+01     3.89e-01    
+h_layer_25             1x1x2560               True     False    4.93e-01   1.04e+01     4.17e-01    
+h_layer_26             1x1x2560               True     False    5.27e-01   4.04e+01     4.72e-01    
+h_layer_27             1x1x2560               True     False    4.96e-01   1.10e+01     5.54e-01    
+h_layer_28             1x1x2560               True     False    5.34e-01   1.11e+01     5.91e-01    
+h_layer_29             1x1x2560               True     False    5.44e-01   1.11e+01     6.40e-01    
+h_layer_30             1x1x2560               True     False    4.81e-01   1.12e+01     7.56e-01    
+b12__post_input_norm   1x2x2560               True     False    2.52e-01   1.63e+01     1.06e+00    
+b12__q_proj            1x2x8192               True     False    6.32e-01   1.07e+01     1.20e+00    
+b12__k_proj            1x2x1024               True     False    3.54e-01   7.51e+00     9.53e-01    
+b12__v_proj            1x2x1024               True     False    8.89e-01   8.99e+00     1.06e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.26e-01   1.09e+01     1.03e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.60e-01   1.00e+01     1.20e+00    
+b12__o_proj            1x2x2560               True     False    3.38e-01   8.22e+00     3.00e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.53e-01   1.19e+01     1.00e+00    
+b12__mlp_gate          1x2x9216               True     False    8.20e-01   1.27e+01     8.58e-01    
+b12__mlp_up            1x2x9216               True     False    6.79e-01   9.77e+00     6.95e-01    
+b12__mlp_down          1x2x2560               True     False    4.52e-01   2.74e+01     6.78e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.71e-01   6.16e-01     1.92e-02    
+h_layer_8              1x1x2560               True     False    2.29e-02   1.68e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -3.52e-02  1.51e+01     1.97e-01    
+h_layer_23             1x1x2560               True     False    2.32e-01   6.83e+00     3.80e-01    
+h_layer_31             1x1x2560               True     False    2.09e-01   3.27e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.50e-02     1.29e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.60e-02     2.01e-03    
+b11__gdn_conv          1x1x8192               True     False    7.23e-01   1.45e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.36e-01   8.52e-01     3.52e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   8.22e-01     5.38e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.52e-03     1.17e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.20e-02     7.96e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.80e-01   6.18e-01     1.57e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.89e-01   1.35e+00     5.75e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   6.43e-01     8.91e-03    
+h_layer_24             1x1x2560               True     False    2.58e-01   6.84e+00     3.94e-01    
+h_layer_25             1x1x2560               True     False    2.40e-01   8.30e+00     4.36e-01    
+h_layer_26             1x1x2560               True     False    1.90e-01   6.21e+01     5.21e-01    
+h_layer_27             1x1x2560               True     False    2.47e-01   6.09e+00     5.24e-01    
+h_layer_28             1x1x2560               True     False    3.20e-01   6.79e+00     6.02e-01    
+h_layer_29             1x1x2560               True     False    3.19e-01   7.49e+00     6.70e-01    
+h_layer_30             1x1x2560               True     False    2.52e-01   1.31e+01     8.30e-01    
+b12__post_input_norm   1x1x2560               True     False    2.01e-01   2.05e+01     1.11e+00    
+b12__q_proj            1x1x8192               True     False    5.03e-01   1.20e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    3.41e-01   6.78e+00     9.69e-01    
+b12__v_proj            1x1x1024               True     False    8.76e-01   9.40e+00     1.17e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.34e-01   1.05e+01     1.13e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.76e-01   6.74e+00     1.23e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.05e-01   1.09e+01     1.04e+00    
+b12__mlp_gate          1x1x9216               True     False    8.09e-01   1.34e+01     9.38e-01    
+b12__mlp_up            1x1x9216               True     False    6.28e-01   7.85e+00     7.82e-01    
+b12__mlp_down          1x1x2560               True     False    3.38e-01   2.02e+01     7.64e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.44e-01   9.11e-01     1.92e-02    
+h_layer_8              1x1x2560               True     False    2.87e-02   1.62e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -1.37e-02  1.41e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.15e+01     3.34e-01    
+h_layer_31             1x1x2560               True     False    3.35e-01   2.82e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   7.79e-03     1.26e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.25e-02     1.66e-03    
+b11__gdn_conv          1x1x8192               True     False    6.45e-01   1.42e+01     3.64e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.05e-01   8.69e-01     3.85e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.41e-01   8.79e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.39e-03     1.16e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   4.39e-03     6.80e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.54e-01   4.78e-01     1.58e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.95e-01   1.14e+00     5.95e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.58e-01   6.39e-01     9.42e-03    
+h_layer_24             1x1x2560               True     False    4.13e-01   9.90e+00     3.56e-01    
+h_layer_25             1x1x2560               True     False    4.66e-01   8.39e+00     3.69e-01    
+h_layer_26             1x1x2560               True     False    3.85e-01   6.60e+00     4.06e-01    
+h_layer_27             1x1x2560               True     False    4.71e-01   1.41e+01     5.17e-01    
+h_layer_28             1x1x2560               True     False    4.97e-01   8.73e+00     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.82e-01   1.24e+01     6.59e-01    
+h_layer_30             1x1x2560               True     False    3.99e-01   9.40e+00     7.97e-01    
+b12__post_input_norm   1x1x2560               True     False    3.32e-01   2.01e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    6.11e-01   1.08e+01     1.40e+00    
+b12__k_proj            1x1x1024               True     False    3.49e-01   5.55e+00     8.95e-01    
+b12__v_proj            1x1x1024               True     False    8.91e-01   1.19e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.70e-01   8.95e+00     1.08e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.63e-01   6.82e+00     1.22e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.49e-01   1.04e+01     9.30e-01    
+b12__mlp_gate          1x1x9216               True     False    8.66e-01   1.20e+01     7.57e-01    
+b12__mlp_up            1x1x9216               True     False    7.18e-01   7.20e+00     6.18e-01    
+b12__mlp_down          1x1x2560               True     False    4.50e-01   2.41e+01     5.92e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok 
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.02e-02   mean|Δ|=1.28e-03   rel_l2=1.65e-03   ok  cos=1.00e+00   max|Δ|=1.19e-02   mean|Δ|=1.31e-03   rel_l2=1.70e-03   ok  cos=1.00e+00   max|Δ|=1.51e-02   mean|Δ|=1.28e-03   rel_l2=1.66e-03   ok  cos=1.00e+00   max|Δ|=1.55e-02   mean|Δ|=1.31e-03   rel_l2=1.69e-03   ok  cos=1.00e+00   max|Δ|=7.88e-03   mean|Δ|=1.26e-03   rel_l2=1.64e-03   ok  cos=1.00e+00   max|Δ|=1.55e-02   mean|Δ|=1.27e-03   rel_l2=1.63e-03   ok  cos=1.00e+00   max|Δ|=1.33e-02   mean|Δ|=1.31e-03   rel_l2=1.67e-03   ok  cos=1.00e+00   max|Δ|=1.14e-02   mean|Δ|=1.32e-03   rel_l2=1.73e-03   ok  cos=1.00e+00   max|Δ|=3.00e-02   mean|Δ|=1.24e-03   rel_l2=1.64e-03   ok  cos=1.00e+00   max|Δ|=1.50e-02   mean|Δ|=1.29e-03   rel_l2=1.61e-03   ok  cos=1.00e+00   max|Δ|=7.79e-03   mean|Δ|=1.26e-03   rel_l2=1.62e-03   ok 
+  gdn_in_proj               cos=1.00e+00   max|Δ|=6.66e-02   mean|Δ|=1.82e-03   rel_l2=1.94e-03   ok  cos=1.00e+00   max|Δ|=3.07e-02   mean|Δ|=1.62e-03   rel_l2=2.03e-03   ok  cos=1.00e+00   max|Δ|=5.97e-02   mean|Δ|=2.18e-03   rel_l2=1.86e-03   ok  cos=1.00e+00   max|Δ|=3.87e-02   mean|Δ|=1.84e-03   rel_l2=2.13e-03   ok  cos=1.00e+00   max|Δ|=3.28e-02   mean|Δ|=1.52e-03   rel_l2=2.07e-03   ok  cos=1.00e+00   max|Δ|=3.68e-02   mean|Δ|=2.00e-03   rel_l2=1.93e-03   ok  cos=1.00e+00   max|Δ|=3.44e-02   mean|Δ|=1.72e-03   rel_l2=1.99e-03   ok  cos=1.00e+00   max|Δ|=2.95e-02   mean|Δ|=1.69e-03   rel_l2=2.32e-03   ok  cos=1.00e+00   max|Δ|=6.48e-02   mean|Δ|=2.08e-03   rel_l2=1.89e-03   ok  cos=1.00e+00   max|Δ|=3.60e-02   mean|Δ|=2.01e-03   rel_l2=1.86e-03   ok  cos=1.00e+00   max|Δ|=3.25e-02   mean|Δ|=1.66e-03   rel_l2=1.98e-03   ok 
+  gdn_conv                  cos=1.00e+00   max|Δ|=6.19e-02   mean|Δ|=7.34e-05   rel_l2=1.58e-03   ok  cos=4.71e-01   max|Δ|=1.85e+01   mean|Δ|=4.05e-02   rel_l2=4.89e+00   DIV cos=9.03e-01   max|Δ|=3.15e+00   mean|Δ|=2.74e-02   rel_l2=9.00e-01   DIV cos=6.59e-01   max|Δ|=1.32e+01   mean|Δ|=3.80e-02   rel_l2=2.87e+00   DIV cos=6.82e-01   max|Δ|=4.87e+00   mean|Δ|=3.21e-02   rel_l2=2.98e+00   DIV cos=9.02e-01   max|Δ|=2.98e+00   mean|Δ|=2.56e-02   rel_l2=8.77e-01   DIV cos=6.86e-01   max|Δ|=1.10e+01   mean|Δ|=3.53e-02   rel_l2=2.50e+00   DIV cos=6.68e-01   max|Δ|=6.15e+00   mean|Δ|=3.06e-02   rel_l2=2.80e+00   DIV cos=9.51e-01   max|Δ|=4.06e+00   mean|Δ|=1.85e-02   rel_l2=3.62e-01   ok  cos=7.23e-01   max|Δ|=1.45e+01   mean|Δ|=3.53e-02   rel_l2=2.10e+00   DIV cos=6.45e-01   max|Δ|=1.42e+01   mean|Δ|=3.64e-02   rel_l2=3.22e+00   DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.79e-01   mean|Δ|=4.00e-02   rel_l2=9.12e-01   ok  cos=6.32e-01   max|Δ|=8.62e-01   mean|Δ|=4.08e-02   rel_l2=9.47e-01   DIV cos=7.85e-01   max|Δ|=8.69e-01   mean|Δ|=3.31e-02   rel_l2=9.32e-01   DIV cos=7.86e-01   max|Δ|=8.09e-01   mean|Δ|=3.70e-02   rel_l2=9.32e-01   DIV cos=6.12e-01   max|Δ|=8.61e-01   mean|Δ|=4.17e-02   rel_l2=9.48e-01   DIV cos=8.40e-01   max|Δ|=8.83e-01   mean|Δ|=3.30e-02   rel_l2=9.27e-01   DIV cos=7.67e-01   max|Δ|=8.29e-01   mean|Δ|=3.61e-02   rel_l2=9.34e-01   DIV cos=6.72e-01   max|Δ|=8.42e-01   mean|Δ|=4.12e-02   rel_l2=9.43e-01   DIV cos=8.50e-01   max|Δ|=8.99e-01   mean|Δ|=3.27e-02   rel_l2=9.26e-01   DIV cos=8.36e-01   max|Δ|=8.52e-01   mean|Δ|=3.52e-02   rel_l2=9.27e-01   DIV cos=7.05e-01   max|Δ|=8.69e-01   mean|Δ|=3.85e-02   rel_l2=9.40e-01   DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=4.47e-03   mean|Δ|=1.30e-04   rel_l2=2.67e-03   ok  cos=3.00e-01   max|Δ|=8.08e-01   mean|Δ|=5.50e-02   rel_l2=1.18e+00   DIV cos=4.47e-01   max|Δ|=9.62e-01   mean|Δ|=4.90e-02   rel_l2=1.05e+00   DIV cos=2.70e-01   max|Δ|=8.39e-01   mean|Δ|=5.86e-02   rel_l2=1.21e+00   DIV cos=3.50e-01   max|Δ|=8.86e-01   mean|Δ|=5.58e-02   rel_l2=1.14e+00   DIV cos=4.93e-01   max|Δ|=9.54e-01   mean|Δ|=5.16e-02   rel_l2=1.01e+00   DIV cos=2.55e-01   max|Δ|=8.25e-01   mean|Δ|=5.94e-02   rel_l2=1.22e+00   DIV cos=3.57e-01   max|Δ|=9.13e-01   mean|Δ|=5.59e-02   rel_l2=1.13e+00   DIV cos=6.96e-01   max|Δ|=9.22e-01   mean|Δ|=3.13e-02   rel_l2=7.80e-01   DIV cos=2.97e-01   max|Δ|=8.22e-01   mean|Δ|=5.38e-02   rel_l2=1.19e+00   DIV cos=3.41e-01   max|Δ|=8.79e-01   mean|Δ|=5.59e-02   rel_l2=1.15e+00   DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=5.17e-03   mean|Δ|=1.19e-03   rel_l2=2.69e-03   ok  cos=1.00e+00   max|Δ|=4.38e-03   mean|Δ|=1.12e-03   rel_l2=2.49e-03   ok  cos=1.00e+00   max|Δ|=4.74e-03   mean|Δ|=1.36e-03   rel_l2=2.71e-03   ok  cos=1.00e+00   max|Δ|=4.35e-03   mean|Δ|=1.19e-03   rel_l2=2.78e-03   ok  cos=1.00e+00   max|Δ|=4.08e-03   mean|Δ|=1.48e-03   rel_l2=3.22e-03   ok  cos=1.00e+00   max|Δ|=3.00e-03   mean|Δ|=1.17e-03   rel_l2=2.46e-03   ok  cos=1.00e+00   max|Δ|=4.32e-03   mean|Δ|=1.27e-03   rel_l2=3.08e-03   ok  cos=1.00e+00   max|Δ|=3.55e-03   mean|Δ|=1.05e-03   rel_l2=2.40e-03   ok  cos=1.00e+00   max|Δ|=3.66e-03   mean|Δ|=1.15e-03   rel_l2=2.38e-03   ok  cos=1.00e+00   max|Δ|=3.52e-03   mean|Δ|=1.17e-03   rel_l2=2.75e-03   ok  cos=1.00e+00   max|Δ|=3.39e-03   mean|Δ|=1.16e-03   rel_l2=2.47e-03   ok 
+  gdn_gate_g                cos=1.00e+00   max|Δ|=1.85e-02   mean|Δ|=8.10e-04   rel_l2=1.79e-03   ok  cos=1.00e+00   max|Δ|=7.44e-03   mean|Δ|=8.35e-04   rel_l2=1.91e-03   ok  cos=1.00e+00   max|Δ|=9.31e-03   mean|Δ|=7.14e-04   rel_l2=1.35e-03   ok  cos=1.00e+00   max|Δ|=4.89e-03   mean|Δ|=5.91e-04   rel_l2=1.30e-03   ok  cos=1.00e+00   max|Δ|=3.13e-03   mean|Δ|=5.50e-04   rel_l2=1.20e-03   ok  cos=1.00e+00   max|Δ|=1.85e-02   mean|Δ|=1.53e-03   rel_l2=2.77e-03   ok  cos=1.00e+00   max|Δ|=6.83e-03   mean|Δ|=1.10e-03   rel_l2=2.01e-03   ok  cos=1.00e+00   max|Δ|=8.93e-03   mean|Δ|=9.07e-04   rel_l2=1.92e-03   ok  cos=1.00e+00   max|Δ|=1.73e-02   mean|Δ|=1.02e-03   rel_l2=1.97e-03   ok  cos=1.00e+00   max|Δ|=1.20e-02   mean|Δ|=7.96e-04   rel_l2=2.00e-03   ok  cos=1.00e+00   max|Δ|=4.39e-03   mean|Δ|=6.80e-04   rel_l2=1.51e-03   ok 
+  gdn_recur_out             cos=1.00e+00   max|Δ|=6.09e-03   mean|Δ|=3.95e-06   rel_l2=3.43e-03   ok  cos=4.65e-01   max|Δ|=4.82e-01   mean|Δ|=1.33e-03   rel_l2=8.52e+00   DIV cos=5.69e-01   max|Δ|=6.04e-01   mean|Δ|=1.40e-03   rel_l2=7.21e+00   DIV cos=3.59e-01   max|Δ|=5.33e-01   mean|Δ|=1.56e-03   rel_l2=6.67e+00   DIV cos=4.82e-01   max|Δ|=5.60e-01   mean|Δ|=1.60e-03   rel_l2=1.20e+01   DIV cos=5.01e-01   max|Δ|=4.46e-01   mean|Δ|=1.35e-03   rel_l2=6.63e+00   DIV cos=3.59e-01   max|Δ|=5.70e-01   mean|Δ|=1.50e-03   rel_l2=7.34e+00   DIV cos=4.62e-01   max|Δ|=4.45e-01   mean|Δ|=1.52e-03   rel_l2=1.07e+01   DIV cos=6.70e-01   max|Δ|=5.61e-01   mean|Δ|=1.39e-03   rel_l2=1.11e+01   DIV cos=4.80e-01   max|Δ|=6.18e-01   mean|Δ|=1.57e-03   rel_l2=8.27e+00   DIV cos=3.54e-01   max|Δ|=4.78e-01   mean|Δ|=1.58e-03   rel_l2=5.99e+00   DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=1.93e-02   mean|Δ|=4.82e-05   rel_l2=4.15e-03   ok  cos=8.68e-01   max|Δ|=1.42e+00   mean|Δ|=6.40e-03   rel_l2=6.98e-01   DIV cos=9.01e-01   max|Δ|=1.25e+00   mean|Δ|=6.28e-03   rel_l2=6.45e-01   DIV cos=8.89e-01   max|Δ|=1.20e+00   mean|Δ|=5.58e-03   rel_l2=6.85e-01   DIV cos=8.60e-01   max|Δ|=1.30e+00   mean|Δ|=7.48e-03   rel_l2=7.10e-01   DIV cos=9.13e-01   max|Δ|=1.21e+00   mean|Δ|=5.45e-03   rel_l2=6.52e-01   DIV cos=8.27e-01   max|Δ|=1.54e+00   mean|Δ|=6.60e-03   rel_l2=9.98e-01   DIV cos=8.70e-01   max|Δ|=1.16e+00   mean|Δ|=7.56e-03   rel_l2=8.02e-01   DIV cos=8.69e-01   max|Δ|=1.95e+00   mean|Δ|=6.01e-03   rel_l2=7.68e-01   DIV cos=8.89e-01   max|Δ|=1.35e+00   mean|Δ|=5.75e-03   rel_l2=7.63e-01   DIV cos=8.95e-01   max|Δ|=1.14e+00   mean|Δ|=5.95e-03   rel_l2=6.59e-01   DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.19e-02   mean|Δ|=5.76e-05   rel_l2=2.42e-03   ok  cos=9.60e-01   max|Δ|=6.38e-01   mean|Δ|=9.62e-03   rel_l2=4.38e-01   ok  cos=9.42e-01   max|Δ|=6.42e-01   mean|Δ|=9.76e-03   rel_l2=5.84e-01   DIV cos=9.50e-01   max|Δ|=7.49e-01   mean|Δ|=9.61e-03   rel_l2=5.44e-01   ok  cos=9.46e-01   max|Δ|=6.00e-01   mean|Δ|=1.17e-02   rel_l2=4.28e-01   DIV cos=9.56e-01   max|Δ|=6.25e-01   mean|Δ|=7.66e-03   rel_l2=5.06e-01   ok  cos=9.38e-01   max|Δ|=9.38e-01   mean|Δ|=1.02e-02   rel_l2=7.71e-01   DIV cos=9.47e-01   max|Δ|=7.80e-01   mean|Δ|=1.07e-02   rel_l2=5.02e-01   DIV cos=9.20e-01   max|Δ|=1.05e+00   mean|Δ|=7.77e-03   rel_l2=6.64e-01   DIV cos=9.47e-01   max|Δ|=6.43e-01   mean|Δ|=8.91e-03   rel_l2=5.75e-01   DIV cos=9.58e-01   max|Δ|=6.39e-01   mean|Δ|=9.42e-03   rel_l2=4.44e-01   ok 
+
+  first sub-op with MEDIAN cos_sim < 0.95: 'gdn_conv' (median cos_sim = 0.686430)
+Phase B11b verdict: B12 TARGET = 'gdn_conv'.
+    Most-likely cause: causal_conv1d: kernel packing, stride/pad, SiLU activation, or bias
+  -> Queue B12 task to investigate this sub-op in isolation.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.26e-02     7.67e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.05e-01     2.08e-02    
+h_layer_16             1x1x2560               True     False    9.50e-01   6.31e-01     4.94e-02    
+h_layer_23             1x1x2560               True     False    9.74e-01   7.58e-01     9.19e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.05e+01     1.15e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.02e-02     1.28e-03    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   6.66e-02     1.82e-03    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   6.19e-02     7.34e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   4.47e-03     1.30e-04    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   5.17e-03     1.19e-03    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.85e-02     8.10e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   6.09e-03     3.95e-06    
+b11__gdn_gated_norm    1x508x4096             True     False    1.00e+00   1.93e-02     4.82e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.19e-02     5.76e-05    
+h_layer_24             1x1x2560               True     False    9.76e-01   8.89e-01     9.65e-02    
+h_layer_25             1x1x2560               True     False    9.78e-01   8.73e-01     9.86e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   8.77e-01     1.01e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   1.21e+00     1.18e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   1.05e+00     1.33e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   1.43e+00     1.45e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   1.01e+00     1.67e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.49e-01   8.96e-01     1.86e-02    
+h_layer_8              1x1x2560               True     False    7.30e-02   1.46e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    1.34e-02   1.23e+01     1.90e-01    
+h_layer_23             1x1x2560               True     False    4.37e-01   1.20e+01     3.06e-01    
+h_layer_31             1x1x2560               True     False    3.50e-01   2.62e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.19e-02     1.31e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.07e-02     1.62e-03    
+b11__gdn_conv          1x1x8192               True     False    4.71e-01   1.85e+01     4.05e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.32e-01   8.62e-01     4.08e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.00e-01   8.08e-01     5.50e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.38e-03     1.12e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   7.44e-03     8.35e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.65e-01   4.82e-01     1.33e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.68e-01   1.42e+00     6.40e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.60e-01   6.38e-01     9.62e-03    
+h_layer_24             1x1x2560               True     False    4.86e-01   1.12e+01     3.24e-01    
+h_layer_25             1x1x2560               True     False    5.30e-01   1.03e+01     3.36e-01    
+h_layer_26             1x1x2560               True     False    5.60e-01   7.34e+00     3.83e-01    
+h_layer_27             1x1x2560               True     False    5.06e-01   1.11e+01     4.88e-01    
+h_layer_28             1x1x2560               True     False    5.65e-01   9.62e+00     5.35e-01    
+h_layer_29             1x1x2560               True     False    5.49e-01   1.40e+01     6.10e-01    
+h_layer_30             1x1x2560               True     False    4.96e-01   9.54e+00     7.31e-01    
+b12__post_input_norm   1x1x2560               True     False    4.32e-01   1.96e+01     9.28e-01    
+b12__q_proj            1x1x8192               True     False    5.75e-01   1.01e+01     1.51e+00    
+b12__k_proj            1x1x1024               True     False    4.85e-01   5.92e+00     8.40e-01    
+b12__v_proj            1x1x1024               True     False    9.06e-01   9.05e+00     1.00e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.51e-01   7.48e+00     9.94e-01    
+b12__qk_norm_k         1x1x4x256              True     False    4.89e-01   8.03e+00     1.05e+00    
+b12__post_attn_norm    1x1x2560               True     False    5.19e-01   1.03e+01     8.69e-01    
+b12__mlp_gate          1x1x9216               True     False    8.43e-01   1.08e+01     7.06e-01    
+b12__mlp_up            1x1x9216               True     False    7.22e-01   6.63e+00     5.80e-01    
+b12__mlp_down          1x1x2560               True     False    5.07e-01   1.15e+01     5.86e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.62e-01   7.19e-01     2.09e-02    
+h_layer_8              1x1x2560               True     False    4.62e-02   1.66e+01     1.81e-01    
+h_layer_16             1x1x2560               True     False    -1.06e-02  1.51e+01     1.96e-01    
+h_layer_23             1x1x2560               True     False    3.43e-01   7.26e+00     3.49e-01    
+h_layer_31             1x1x2560               True     False    2.54e-01   3.97e+01     2.19e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.51e-02     1.28e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   5.97e-02     2.18e-03    
+b11__gdn_conv          1x1x8192               True     False    9.03e-01   3.15e+00     2.74e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.85e-01   8.69e-01     3.31e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.47e-01   9.62e-01     4.90e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.74e-03     1.36e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   9.31e-03     7.14e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    5.69e-01   6.04e-01     1.40e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.01e-01   1.25e+00     6.28e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.42e-01   6.42e-01     9.76e-03    
+h_layer_24             1x1x2560               True     False    4.17e-01   7.26e+00     3.66e-01    
+h_layer_25             1x1x2560               True     False    4.24e-01   8.48e+00     4.32e-01    
+h_layer_26             1x1x2560               True     False    5.42e-01   6.25e+01     5.38e-01    
+h_layer_27             1x1x2560               True     False    4.00e-01   1.17e+01     5.24e-01    
+h_layer_28             1x1x2560               True     False    4.62e-01   1.33e+01     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.50e-01   1.79e+01     6.30e-01    
+h_layer_30             1x1x2560               True     False    4.19e-01   9.57e+00     7.50e-01    
+b12__post_input_norm   1x1x2560               True     False    3.23e-01   2.16e+01     9.71e-01    
+b12__q_proj            1x1x8192               True     False    5.91e-01   1.28e+01     1.42e+00    
+b12__k_proj            1x1x1024               True     False    2.80e-01   8.12e+00     9.96e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   1.08e+01     1.07e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.78e-01   8.73e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    2.94e-01   1.05e+01     1.26e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.27e-01   1.15e+01     9.10e-01    
+b12__mlp_gate          1x1x9216               True     False    8.44e-01   1.30e+01     7.91e-01    
+b12__mlp_up            1x1x9216               True     False    6.51e-01   8.22e+00     6.77e-01    
+b12__mlp_down          1x1x2560               True     False    4.44e-01   1.59e+01     7.40e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.92e-01   8.77e-01     2.15e-02    
+h_layer_8              1x1x2560               True     False    2.75e-02   1.54e+01     1.85e-01    
+h_layer_16             1x1x2560               True     False    -4.70e-02  1.37e+01     1.99e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.09e+01     3.28e-01    
+h_layer_31             1x1x2560               True     False    2.29e-01   3.75e+01     2.28e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.55e-02     1.31e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.87e-02     1.84e-03    
+b11__gdn_conv          1x1x8192               True     False    6.59e-01   1.32e+01     3.80e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.86e-01   8.09e-01     3.70e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.70e-01   8.39e-01     5.86e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.35e-03     1.19e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   4.89e-03     5.91e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.59e-01   5.33e-01     1.56e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.89e-01   1.20e+00     5.58e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.50e-01   7.49e-01     9.61e-03    
+h_layer_24             1x1x2560               True     False    4.15e-01   8.78e+00     3.47e-01    
+h_layer_25             1x1x2560               True     False    4.82e-01   7.15e+00     3.59e-01    
+h_layer_26             1x1x2560               True     False    5.13e-01   7.10e+00     3.98e-01    
+h_layer_27             1x1x2560               True     False    4.48e-01   7.41e+00     5.22e-01    
+h_layer_28             1x1x2560               True     False    4.83e-01   7.39e+00     5.92e-01    
+h_layer_29             1x1x2560               True     False    4.58e-01   1.20e+01     6.62e-01    
+h_layer_30             1x1x2560               True     False    3.88e-01   9.53e+00     8.22e-01    
+b12__post_input_norm   1x1x2560               True     False    3.15e-01   1.98e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    5.77e-01   1.09e+01     1.47e+00    
+b12__k_proj            1x1x1024               True     False    3.36e-01   7.71e+00     8.98e-01    
+b12__v_proj            1x1x1024               True     False    8.98e-01   1.02e+01     1.06e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.16e-01   8.54e+00     1.03e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.62e-01   9.43e+00     1.19e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.08e-01   9.99e+00     9.69e-01    
+b12__mlp_gate          1x1x9216               True     False    8.42e-01   1.28e+01     8.12e-01    
+b12__mlp_up            1x1x9216               True     False    6.39e-01   7.67e+00     7.29e-01    
+b12__mlp_down          1x1x2560               True     False    4.02e-01   1.21e+01     7.72e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.27e-01   1.23e+00     2.11e-02    
+h_layer_8              1x1x2560               True     False    -5.15e-03  1.49e+01     1.75e-01    
+h_layer_16             1x1x2560               True     False    -6.95e-02  1.33e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.53e-01   1.21e+01     3.18e-01    
+h_layer_31             1x1x2560               True     False    3.62e-01   2.74e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   7.88e-03     1.26e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.28e-02     1.52e-03    
+b11__gdn_conv          1x1x8192               True     False    6.82e-01   4.87e+00     3.21e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.12e-01   8.61e-01     4.17e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.50e-01   8.86e-01     5.58e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.08e-03     1.48e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   3.13e-03     5.50e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.82e-01   5.60e-01     1.60e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.60e-01   1.30e+00     7.48e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.46e-01   6.00e-01     1.17e-02    
+h_layer_24             1x1x2560               True     False    4.22e-01   9.96e+00     3.42e-01    
+h_layer_25             1x1x2560               True     False    4.83e-01   7.68e+00     3.57e-01    
+h_layer_26             1x1x2560               True     False    4.17e-01   6.56e+00     3.86e-01    
+h_layer_27             1x1x2560               True     False    4.60e-01   1.12e+01     4.96e-01    
+h_layer_28             1x1x2560               True     False    5.19e-01   7.74e+00     5.45e-01    
+h_layer_29             1x1x2560               True     False    5.17e-01   1.18e+01     6.25e-01    
+h_layer_30             1x1x2560               True     False    4.22e-01   9.36e+00     7.80e-01    
+b12__post_input_norm   1x1x2560               True     False    3.44e-01   1.98e+01     9.91e-01    
+b12__q_proj            1x1x8192               True     False    6.23e-01   1.21e+01     1.32e+00    
+b12__k_proj            1x1x1024               True     False    3.09e-01   6.20e+00     9.35e-01    
+b12__v_proj            1x1x1024               True     False    8.95e-01   9.34e+00     1.02e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.05e-01   8.97e+00     1.04e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.26e-01   8.21e+00     1.28e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.64e-01   1.07e+01     9.06e-01    
+b12__mlp_gate          1x1x9216               True     False    8.74e-01   1.24e+01     6.79e-01    
+b12__mlp_up            1x1x9216               True     False    7.19e-01   7.12e+00     5.90e-01    
+b12__mlp_down          1x1x2560               True     False    5.41e-01   1.95e+01     6.07e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.32e-01   4.70e-01     1.74e-02    
+h_layer_8              1x1x2560               True     False    1.55e-02   1.61e+01     1.73e-01    
+h_layer_16             1x1x2560               True     False    -3.19e-02  1.46e+01     1.87e-01    
+h_layer_23             1x1x2560               True     False    3.83e-01   6.10e+00     3.36e-01    
+h_layer_31             1x1x2560               True     False    3.29e-01   2.87e+01     2.16e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.55e-02     1.27e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.68e-02     2.00e-03    
+b11__gdn_conv          1x1x8192               True     False    9.02e-01   2.98e+00     2.56e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.40e-01   8.83e-01     3.30e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    4.93e-01   9.54e-01     5.16e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.00e-03     1.17e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.85e-02     1.53e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    5.01e-01   4.46e-01     1.35e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    9.13e-01   1.21e+00     5.45e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.56e-01   6.25e-01     7.66e-03    
+h_layer_24             1x1x2560               True     False    4.36e-01   6.11e+00     3.51e-01    
+h_layer_25             1x1x2560               True     False    4.66e-01   6.79e+00     3.92e-01    
+h_layer_26             1x1x2560               True     False    5.36e-01   4.34e+01     4.73e-01    
+h_layer_27             1x1x2560               True     False    4.16e-01   9.83e+00     5.08e-01    
+h_layer_28             1x1x2560               True     False    4.72e-01   1.04e+01     5.59e-01    
+h_layer_29             1x1x2560               True     False    4.58e-01   1.50e+01     6.34e-01    
+h_layer_30             1x1x2560               True     False    4.25e-01   8.44e+00     7.65e-01    
+b12__post_input_norm   1x1x2560               True     False    3.41e-01   1.88e+01     9.75e-01    
+b12__q_proj            1x1x8192               True     False    5.85e-01   1.27e+01     1.43e+00    
+b12__k_proj            1x1x1024               True     False    3.19e-01   7.09e+00     9.34e-01    
+b12__v_proj            1x1x1024               True     False    9.02e-01   9.32e+00     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.88e-01   9.59e+00     1.05e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.33e-01   9.09e+00     1.21e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.45e-01   1.01e+01     9.14e-01    
+b12__mlp_gate          1x1x9216               True     False    8.53e-01   1.27e+01     7.90e-01    
+b12__mlp_up            1x1x9216               True     False    6.95e-01   8.01e+00     6.41e-01    
+b12__mlp_down          1x1x2560               True     False    4.43e-01   2.09e+01     7.04e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.00e-01   9.74e-01     2.41e-02    
+h_layer_8              1x1x2560               True     False    5.20e-02   1.57e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -2.57e-02  1.37e+01     1.84e-01    
+h_layer_23             1x1x2560               True     False    3.67e-01   7.34e+00     3.19e-01    
+h_layer_31             1x1x2560               True     False    2.81e-01   2.70e+01     2.23e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.33e-02     1.31e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.44e-02     1.72e-03    
+b11__gdn_conv          1x1x8192               True     False    6.86e-01   1.10e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.67e-01   8.29e-01     3.61e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.55e-01   8.25e-01     5.94e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   4.32e-03     1.27e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   6.83e-03     1.10e-03    
+b11__gdn_recur_out     1x1x32x128             True     False    3.59e-01   5.70e-01     1.50e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.27e-01   1.54e+00     6.60e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.38e-01   9.38e-01     1.02e-02    
+h_layer_24             1x1x2560               True     False    4.16e-01   6.27e+00     3.39e-01    
+h_layer_25             1x1x2560               True     False    4.83e-01   6.51e+00     3.52e-01    
+h_layer_26             1x1x2560               True     False    4.88e-01   7.34e+00     3.93e-01    
+h_layer_27             1x1x2560               True     False    4.21e-01   7.16e+00     5.16e-01    
+h_layer_28             1x1x2560               True     False    4.95e-01   7.11e+00     5.68e-01    
+h_layer_29             1x1x2560               True     False    4.79e-01   9.37e+00     6.37e-01    
+h_layer_30             1x1x2560               True     False    3.99e-01   9.92e+00     8.00e-01    
+b12__post_input_norm   1x1x2560               True     False    3.26e-01   2.06e+01     1.00e+00    
+b12__q_proj            1x1x8192               True     False    5.43e-01   1.11e+01     1.52e+00    
+b12__k_proj            1x1x1024               True     False    3.73e-01   8.55e+00     8.98e-01    
+b12__v_proj            1x1x1024               True     False    8.96e-01   9.82e+00     1.06e+00    
+b12__qk_norm_q         1x1x16x256             True     False    4.14e-01   8.96e+00     1.02e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.95e-01   9.24e+00     1.16e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.22e-01   1.04e+01     9.52e-01    
+b12__mlp_gate          1x1x9216               True     False    8.35e-01   1.36e+01     8.88e-01    
+b12__mlp_up            1x1x9216               True     False    6.58e-01   8.60e+00     7.45e-01    
+b12__mlp_down          1x1x2560               True     False    4.42e-01   1.51e+01     7.35e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.03e-01   1.29e+00     2.00e-02    
+h_layer_8              1x1x2560               True     False    -1.03e-03  1.54e+01     1.84e-01    
+h_layer_16             1x1x2560               True     False    -5.48e-02  1.37e+01     1.94e-01    
+h_layer_23             1x1x2560               True     False    3.00e-01   1.22e+01     3.36e-01    
+h_layer_31             1x1x2560               True     False    2.90e-01   3.39e+01     2.20e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.14e-02     1.32e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   2.95e-02     1.69e-03    
+b11__gdn_conv          1x1x8192               True     False    6.68e-01   6.15e+00     3.06e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    6.72e-01   8.42e-01     4.12e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.57e-01   9.13e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.55e-03     1.05e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   8.93e-03     9.07e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.62e-01   4.45e-01     1.52e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.70e-01   1.16e+00     7.56e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   7.80e-01     1.07e-02    
+h_layer_24             1x1x2560               True     False    3.73e-01   9.97e+00     3.55e-01    
+h_layer_25             1x1x2560               True     False    4.53e-01   7.72e+00     3.65e-01    
+h_layer_26             1x1x2560               True     False    4.32e-01   6.99e+00     3.95e-01    
+h_layer_27             1x1x2560               True     False    4.51e-01   1.44e+01     5.13e-01    
+h_layer_28             1x1x2560               True     False    5.25e-01   8.69e+00     5.31e-01    
+h_layer_29             1x1x2560               True     False    5.21e-01   1.29e+01     6.11e-01    
+h_layer_30             1x1x2560               True     False    4.10e-01   9.51e+00     7.52e-01    
+b12__post_input_norm   1x1x2560               True     False    3.41e-01   1.92e+01     9.88e-01    
+b12__q_proj            1x1x8192               True     False    5.98e-01   1.21e+01     1.39e+00    
+b12__k_proj            1x1x1024               True     False    3.10e-01   6.85e+00     9.60e-01    
+b12__v_proj            1x1x1024               True     False    8.89e-01   1.15e+01     1.04e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.95e-01   9.73e+00     1.06e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.27e-01   7.39e+00     1.26e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.44e-01   1.04e+01     9.27e-01    
+b12__mlp_gate          1x1x9216               True     False    8.36e-01   1.28e+01     7.92e-01    
+b12__mlp_up            1x1x9216               True     False    6.93e-01   7.80e+00     6.31e-01    
+b12__mlp_down          1x1x2560               True     False    2.55e-01   3.11e+01     6.35e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    9.01e-01   2.71e-01     1.42e-02    
+h_layer_8              1x1x2560               True     False    3.33e-01   2.18e+00     1.15e-01    
+h_layer_16             1x1x2560               True     False    2.12e-01   3.46e+00     1.89e-01    
+h_layer_23             1x1x2560               True     False    4.53e-01   9.54e+00     3.63e-01    
+h_layer_31             1x1x2560               True     False    4.31e-01   3.70e+01     1.78e+00    
+b11__tok_embed         1x2x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x2x2560               True     True     1.00e+00   3.00e-02     1.24e-03    
+b11__gdn_in_proj       1x2x12352              True     True     1.00e+00   6.48e-02     2.08e-03    
+b11__gdn_conv          1x2x8192               True     False    9.51e-01   4.06e+00     1.85e-02    
+b11__gdn_qk_norm_q     1x2x32x128             True     False    8.50e-01   8.99e-01     3.27e-02    
+b11__gdn_qk_norm_k     1x2x32x128             True     False    6.96e-01   9.22e-01     3.13e-02    
+b11__gdn_gate_beta     1x2x32                 True     True     1.00e+00   3.66e-03     1.15e-03    
+b11__gdn_gate_g        1x2x32                 True     True     1.00e+00   1.73e-02     1.02e-03    
+b11__gdn_recur_out     1x2x32x128             True     False    6.70e-01   5.61e-01     1.39e-03    
+b11__gdn_gated_norm    1x2x4096               True     False    8.69e-01   1.95e+00     6.01e-03    
+b11__gdn_out_proj      1x2x2560               True     False    9.20e-01   1.05e+00     7.77e-03    
+h_layer_24             1x1x2560               True     False    4.65e-01   1.00e+01     3.89e-01    
+h_layer_25             1x1x2560               True     False    4.93e-01   1.04e+01     4.17e-01    
+h_layer_26             1x1x2560               True     False    5.27e-01   4.04e+01     4.72e-01    
+h_layer_27             1x1x2560               True     False    4.96e-01   1.10e+01     5.54e-01    
+h_layer_28             1x1x2560               True     False    5.34e-01   1.11e+01     5.91e-01    
+h_layer_29             1x1x2560               True     False    5.44e-01   1.11e+01     6.40e-01    
+h_layer_30             1x1x2560               True     False    4.81e-01   1.12e+01     7.56e-01    
+b12__post_input_norm   1x2x2560               True     False    2.52e-01   1.63e+01     1.06e+00    
+b12__q_proj            1x2x8192               True     False    6.32e-01   1.07e+01     1.20e+00    
+b12__k_proj            1x2x1024               True     False    3.54e-01   7.51e+00     9.53e-01    
+b12__v_proj            1x2x1024               True     False    8.89e-01   8.99e+00     1.06e+00    
+b12__qk_norm_q         1x2x16x256             True     False    4.26e-01   1.09e+01     1.03e+00    
+b12__qk_norm_k         1x2x4x256              True     False    3.60e-01   1.00e+01     1.20e+00    
+b12__o_proj            1x2x2560               True     False    3.38e-01   8.22e+00     3.00e-01    
+b12__post_attn_norm    1x2x2560               True     False    3.53e-01   1.19e+01     1.00e+00    
+b12__mlp_gate          1x2x9216               True     False    8.20e-01   1.27e+01     8.58e-01    
+b12__mlp_up            1x2x9216               True     False    6.79e-01   9.77e+00     6.95e-01    
+b12__mlp_down          1x2x2560               True     False    4.52e-01   2.74e+01     6.78e-01    
+prompt_tokens          2                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    7.71e-01   6.16e-01     1.92e-02    
+h_layer_8              1x1x2560               True     False    2.29e-02   1.68e+01     1.77e-01    
+h_layer_16             1x1x2560               True     False    -3.52e-02  1.51e+01     1.97e-01    
+h_layer_23             1x1x2560               True     False    2.32e-01   6.83e+00     3.80e-01    
+h_layer_31             1x1x2560               True     False    2.09e-01   3.27e+01     2.21e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   1.50e-02     1.29e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.60e-02     2.01e-03    
+b11__gdn_conv          1x1x8192               True     False    7.23e-01   1.45e+01     3.53e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    8.36e-01   8.52e-01     3.52e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    2.97e-01   8.22e-01     5.38e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.52e-03     1.17e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   1.20e-02     7.96e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    4.80e-01   6.18e-01     1.57e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.89e-01   1.35e+00     5.75e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.47e-01   6.43e-01     8.91e-03    
+h_layer_24             1x1x2560               True     False    2.58e-01   6.84e+00     3.94e-01    
+h_layer_25             1x1x2560               True     False    2.40e-01   8.30e+00     4.36e-01    
+h_layer_26             1x1x2560               True     False    1.90e-01   6.21e+01     5.21e-01    
+h_layer_27             1x1x2560               True     False    2.47e-01   6.09e+00     5.24e-01    
+h_layer_28             1x1x2560               True     False    3.20e-01   6.79e+00     6.02e-01    
+h_layer_29             1x1x2560               True     False    3.19e-01   7.49e+00     6.70e-01    
+h_layer_30             1x1x2560               True     False    2.52e-01   1.31e+01     8.30e-01    
+b12__post_input_norm   1x1x2560               True     False    2.01e-01   2.05e+01     1.11e+00    
+b12__q_proj            1x1x8192               True     False    5.03e-01   1.20e+01     1.54e+00    
+b12__k_proj            1x1x1024               True     False    3.41e-01   6.78e+00     9.69e-01    
+b12__v_proj            1x1x1024               True     False    8.76e-01   9.40e+00     1.17e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.34e-01   1.05e+01     1.13e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.76e-01   6.74e+00     1.23e+00    
+b12__post_attn_norm    1x1x2560               True     False    3.05e-01   1.09e+01     1.04e+00    
+b12__mlp_gate          1x1x9216               True     False    8.09e-01   1.34e+01     9.38e-01    
+b12__mlp_up            1x1x9216               True     False    6.28e-01   7.85e+00     7.82e-01    
+b12__mlp_down          1x1x2560               True     False    3.38e-01   2.02e+01     7.64e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post422_20260423_seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post422_20260423_refs_fp32/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     False    8.44e-01   9.11e-01     1.92e-02    
+h_layer_8              1x1x2560               True     False    2.87e-02   1.62e+01     1.79e-01    
+h_layer_16             1x1x2560               True     False    -1.37e-02  1.41e+01     1.89e-01    
+h_layer_23             1x1x2560               True     False    3.56e-01   1.15e+01     3.34e-01    
+h_layer_31             1x1x2560               True     False    3.35e-01   2.82e+01     2.14e+00    
+b11__tok_embed         1x1x2560               True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x1x2560               True     True     1.00e+00   7.79e-03     1.26e-03    
+b11__gdn_in_proj       1x1x12352              True     True     1.00e+00   3.25e-02     1.66e-03    
+b11__gdn_conv          1x1x8192               True     False    6.45e-01   1.42e+01     3.64e-02    
+b11__gdn_qk_norm_q     1x1x32x128             True     False    7.05e-01   8.69e-01     3.85e-02    
+b11__gdn_qk_norm_k     1x1x32x128             True     False    3.41e-01   8.79e-01     5.59e-02    
+b11__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.39e-03     1.16e-03    
+b11__gdn_gate_g        1x1x32                 True     True     1.00e+00   4.39e-03     6.80e-04    
+b11__gdn_recur_out     1x1x32x128             True     False    3.54e-01   4.78e-01     1.58e-03    
+b11__gdn_gated_norm    1x1x4096               True     False    8.95e-01   1.14e+00     5.95e-03    
+b11__gdn_out_proj      1x1x2560               True     False    9.58e-01   6.39e-01     9.42e-03    
+h_layer_24             1x1x2560               True     False    4.13e-01   9.90e+00     3.56e-01    
+h_layer_25             1x1x2560               True     False    4.66e-01   8.39e+00     3.69e-01    
+h_layer_26             1x1x2560               True     False    3.85e-01   6.60e+00     4.06e-01    
+h_layer_27             1x1x2560               True     False    4.71e-01   1.41e+01     5.17e-01    
+h_layer_28             1x1x2560               True     False    4.97e-01   8.73e+00     5.72e-01    
+h_layer_29             1x1x2560               True     False    4.82e-01   1.24e+01     6.59e-01    
+h_layer_30             1x1x2560               True     False    3.99e-01   9.40e+00     7.97e-01    
+b12__post_input_norm   1x1x2560               True     False    3.32e-01   2.01e+01     1.02e+00    
+b12__q_proj            1x1x8192               True     False    6.11e-01   1.08e+01     1.40e+00    
+b12__k_proj            1x1x1024               True     False    3.49e-01   5.55e+00     8.95e-01    
+b12__v_proj            1x1x1024               True     False    8.91e-01   1.19e+01     1.03e+00    
+b12__qk_norm_q         1x1x16x256             True     False    3.70e-01   8.95e+00     1.08e+00    
+b12__qk_norm_k         1x1x4x256              True     False    3.63e-01   6.82e+00     1.22e+00    
+b12__post_attn_norm    1x1x2560               True     False    4.49e-01   1.04e+01     9.30e-01    
+b12__mlp_gate          1x1x9216               True     False    8.66e-01   1.20e+01     7.57e-01    
+b12__mlp_up            1x1x9216               True     False    7.18e-01   7.20e+00     6.18e-01    
+b12__mlp_down          1x1x2560               True     False    4.50e-01   2.41e+01     5.92e-01    
+prompt_tokens          1                      True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.76e-01   max|Δ|=8.89e-01   DIV   cos=4.86e-01   max|Δ|=1.12e+01   DIV   cos=4.17e-01   max|Δ|=7.26e+00   DIV   cos=4.15e-01   max|Δ|=8.78e+00   DIV   cos=4.22e-01   max|Δ|=9.96e+00   DIV   cos=4.36e-01   max|Δ|=6.11e+00   DIV   cos=4.16e-01   max|Δ|=6.27e+00   DIV   cos=3.73e-01   max|Δ|=9.97e+00   DIV   cos=4.65e-01   max|Δ|=1.00e+01   DIV   cos=2.58e-01   max|Δ|=6.84e+00   DIV   cos=4.13e-01   max|Δ|=9.90e+00   DIV  
+  h_layer_25            cos=9.78e-01   max|Δ|=8.73e-01   DIV   cos=5.30e-01   max|Δ|=1.03e+01   DIV   cos=4.24e-01   max|Δ|=8.48e+00   DIV   cos=4.82e-01   max|Δ|=7.15e+00   DIV   cos=4.83e-01   max|Δ|=7.68e+00   DIV   cos=4.66e-01   max|Δ|=6.79e+00   DIV   cos=4.83e-01   max|Δ|=6.51e+00   DIV   cos=4.53e-01   max|Δ|=7.72e+00   DIV   cos=4.93e-01   max|Δ|=1.04e+01   DIV   cos=2.40e-01   max|Δ|=8.30e+00   DIV   cos=4.66e-01   max|Δ|=8.39e+00   DIV  
+  h_layer_26            cos=9.82e-01   max|Δ|=8.77e-01   DIV   cos=5.60e-01   max|Δ|=7.34e+00   DIV   cos=5.42e-01   max|Δ|=6.25e+01   DIV   cos=5.13e-01   max|Δ|=7.10e+00   DIV   cos=4.17e-01   max|Δ|=6.56e+00   DIV   cos=5.36e-01   max|Δ|=4.34e+01   DIV   cos=4.88e-01   max|Δ|=7.34e+00   DIV   cos=4.32e-01   max|Δ|=6.99e+00   DIV   cos=5.27e-01   max|Δ|=4.04e+01   DIV   cos=1.90e-01   max|Δ|=6.21e+01   DIV   cos=3.85e-01   max|Δ|=6.60e+00   DIV  
+  h_layer_27            cos=9.80e-01   max|Δ|=1.21e+00   DIV   cos=5.06e-01   max|Δ|=1.11e+01   DIV   cos=4.00e-01   max|Δ|=1.17e+01   DIV   cos=4.48e-01   max|Δ|=7.41e+00   DIV   cos=4.60e-01   max|Δ|=1.12e+01   DIV   cos=4.16e-01   max|Δ|=9.83e+00   DIV   cos=4.21e-01   max|Δ|=7.16e+00   DIV   cos=4.51e-01   max|Δ|=1.44e+01   DIV   cos=4.96e-01   max|Δ|=1.10e+01   DIV   cos=2.47e-01   max|Δ|=6.09e+00   DIV   cos=4.71e-01   max|Δ|=1.41e+01   DIV  
+  h_layer_28            cos=9.83e-01   max|Δ|=1.05e+00   DIV   cos=5.65e-01   max|Δ|=9.62e+00   DIV   cos=4.62e-01   max|Δ|=1.33e+01   DIV   cos=4.83e-01   max|Δ|=7.39e+00   DIV   cos=5.19e-01   max|Δ|=7.74e+00   DIV   cos=4.72e-01   max|Δ|=1.04e+01   DIV   cos=4.95e-01   max|Δ|=7.11e+00   DIV   cos=5.25e-01   max|Δ|=8.69e+00   DIV   cos=5.34e-01   max|Δ|=1.11e+01   DIV   cos=3.20e-01   max|Δ|=6.79e+00   DIV   cos=4.97e-01   max|Δ|=8.73e+00   DIV  
+  h_layer_29            cos=9.82e-01   max|Δ|=1.43e+00   DIV   cos=5.49e-01   max|Δ|=1.40e+01   DIV   cos=4.50e-01   max|Δ|=1.79e+01   DIV   cos=4.58e-01   max|Δ|=1.20e+01   DIV   cos=5.17e-01   max|Δ|=1.18e+01   DIV   cos=4.58e-01   max|Δ|=1.50e+01   DIV   cos=4.79e-01   max|Δ|=9.37e+00   DIV   cos=5.21e-01   max|Δ|=1.29e+01   DIV   cos=5.44e-01   max|Δ|=1.11e+01   DIV   cos=3.19e-01   max|Δ|=7.49e+00   DIV   cos=4.82e-01   max|Δ|=1.24e+01   DIV  
+  h_layer_30            cos=9.81e-01   max|Δ|=1.01e+00   DIV   cos=4.96e-01   max|Δ|=9.54e+00   DIV   cos=4.19e-01   max|Δ|=9.57e+00   DIV   cos=3.88e-01   max|Δ|=9.53e+00   DIV   cos=4.22e-01   max|Δ|=9.36e+00   DIV   cos=4.25e-01   max|Δ|=8.44e+00   DIV   cos=3.99e-01   max|Δ|=9.92e+00   DIV   cos=4.10e-01   max|Δ|=9.51e+00   DIV   cos=4.81e-01   max|Δ|=1.12e+01   DIV   cos=2.52e-01   max|Δ|=1.31e+01   DIV   cos=3.99e-01   max|Δ|=9.40e+00   DIV  
+  h_layer_31            cos=9.57e-01   max|Δ|=2.05e+01   DIV   cos=3.50e-01   max|Δ|=2.62e+01   DIV   cos=2.54e-01   max|Δ|=3.97e+01   DIV   cos=2.29e-01   max|Δ|=3.75e+01   DIV   cos=3.62e-01   max|Δ|=2.74e+01   DIV   cos=3.29e-01   max|Δ|=2.87e+01   DIV   cos=2.81e-01   max|Δ|=2.70e+01   DIV   cos=2.90e-01   max|Δ|=3.39e+01   DIV   cos=4.31e-01   max|Δ|=3.70e+01   DIV   cos=2.09e-01   max|Δ|=3.27e+01   DIV   cos=3.35e-01   max|Δ|=2.82e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=4.17e-01     DIV
+    h_layer_25             median=4.82e-01     DIV
+    h_layer_26             median=5.13e-01     DIV
+    h_layer_27             median=4.51e-01     DIV
+    h_layer_28             median=4.97e-01     DIV
+    h_layer_29             median=4.82e-01     DIV
+    h_layer_30             median=4.19e-01     DIV
+    h_layer_31             median=3.29e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=4.32e-01   max|Δ|=1.96e+01   mean|Δ|=9.28e-01   rel_l2=1.04e+00   DIV cos=3.23e-01   max|Δ|=2.16e+01   mean|Δ|=9.71e-01   rel_l2=1.12e+00   DIV cos=3.15e-01   max|Δ|=1.98e+01   mean|Δ|=1.02e+00   rel_l2=1.14e+00   DIV cos=3.44e-01   max|Δ|=1.98e+01   mean|Δ|=9.91e-01   rel_l2=1.11e+00   DIV cos=3.41e-01   max|Δ|=1.88e+01   mean|Δ|=9.75e-01   rel_l2=1.12e+00   DIV cos=3.26e-01   max|Δ|=2.06e+01   mean|Δ|=1.00e+00   rel_l2=1.12e+00   DIV cos=3.41e-01   max|Δ|=1.92e+01   mean|Δ|=9.88e-01   rel_l2=1.12e+00   DIV cos=2.52e-01   max|Δ|=1.63e+01   mean|Δ|=1.06e+00   rel_l2=1.21e+00   DIV cos=2.01e-01   max|Δ|=2.05e+01   mean|Δ|=1.11e+00   rel_l2=1.24e+00   DIV cos=3.32e-01   max|Δ|=2.01e+01   mean|Δ|=1.02e+00   rel_l2=1.12e+00   DIV
+  q_proj              <missing>                                            cos=5.75e-01   max|Δ|=1.01e+01   mean|Δ|=1.51e+00   rel_l2=8.34e-01   DIV cos=5.91e-01   max|Δ|=1.28e+01   mean|Δ|=1.42e+00   rel_l2=8.31e-01   DIV cos=5.77e-01   max|Δ|=1.09e+01   mean|Δ|=1.47e+00   rel_l2=8.40e-01   DIV cos=6.23e-01   max|Δ|=1.21e+01   mean|Δ|=1.32e+00   rel_l2=8.06e-01   DIV cos=5.85e-01   max|Δ|=1.27e+01   mean|Δ|=1.43e+00   rel_l2=8.33e-01   DIV cos=5.43e-01   max|Δ|=1.11e+01   mean|Δ|=1.52e+00   rel_l2=8.73e-01   DIV cos=5.98e-01   max|Δ|=1.21e+01   mean|Δ|=1.39e+00   rel_l2=8.28e-01   DIV cos=6.32e-01   max|Δ|=1.07e+01   mean|Δ|=1.20e+00   rel_l2=8.09e-01   DIV cos=5.03e-01   max|Δ|=1.20e+01   mean|Δ|=1.54e+00   rel_l2=9.08e-01   DIV cos=6.11e-01   max|Δ|=1.08e+01   mean|Δ|=1.40e+00   rel_l2=8.06e-01   DIV
+  k_proj              <missing>                                            cos=4.85e-01   max|Δ|=5.92e+00   mean|Δ|=8.40e-01   rel_l2=9.65e-01   DIV cos=2.80e-01   max|Δ|=8.12e+00   mean|Δ|=9.96e-01   rel_l2=1.06e+00   DIV cos=3.36e-01   max|Δ|=7.71e+00   mean|Δ|=8.98e-01   rel_l2=1.05e+00   DIV cos=3.09e-01   max|Δ|=6.20e+00   mean|Δ|=9.35e-01   rel_l2=1.07e+00   DIV cos=3.19e-01   max|Δ|=7.09e+00   mean|Δ|=9.34e-01   rel_l2=1.04e+00   DIV cos=3.73e-01   max|Δ|=8.55e+00   mean|Δ|=8.98e-01   rel_l2=1.00e+00   DIV cos=3.10e-01   max|Δ|=6.85e+00   mean|Δ|=9.60e-01   rel_l2=1.09e+00   DIV cos=3.54e-01   max|Δ|=7.51e+00   mean|Δ|=9.53e-01   rel_l2=1.01e+00   DIV cos=3.41e-01   max|Δ|=6.78e+00   mean|Δ|=9.69e-01   rel_l2=1.03e+00   DIV cos=3.49e-01   max|Δ|=5.55e+00   mean|Δ|=8.95e-01   rel_l2=1.02e+00   DIV
+  v_proj              <missing>                                            cos=9.06e-01   max|Δ|=9.05e+00   mean|Δ|=1.00e+00   rel_l2=4.23e-01   DIV cos=8.95e-01   max|Δ|=1.08e+01   mean|Δ|=1.07e+00   rel_l2=4.46e-01   DIV cos=8.98e-01   max|Δ|=1.02e+01   mean|Δ|=1.06e+00   rel_l2=4.41e-01   DIV cos=8.95e-01   max|Δ|=9.34e+00   mean|Δ|=1.02e+00   rel_l2=4.50e-01   DIV cos=9.02e-01   max|Δ|=9.32e+00   mean|Δ|=1.04e+00   rel_l2=4.32e-01   DIV cos=8.96e-01   max|Δ|=9.82e+00   mean|Δ|=1.06e+00   rel_l2=4.47e-01   DIV cos=8.89e-01   max|Δ|=1.15e+01   mean|Δ|=1.04e+00   rel_l2=4.61e-01   DIV cos=8.89e-01   max|Δ|=8.99e+00   mean|Δ|=1.06e+00   rel_l2=4.59e-01   DIV cos=8.76e-01   max|Δ|=9.40e+00   mean|Δ|=1.17e+00   rel_l2=4.86e-01   DIV cos=8.91e-01   max|Δ|=1.19e+01   mean|Δ|=1.03e+00   rel_l2=4.54e-01   DIV
+  qk_norm_q           <missing>                                            cos=4.51e-01   max|Δ|=7.48e+00   mean|Δ|=9.94e-01   rel_l2=1.03e+00   DIV cos=3.78e-01   max|Δ|=8.73e+00   mean|Δ|=1.04e+00   rel_l2=1.07e+00   DIV cos=4.16e-01   max|Δ|=8.54e+00   mean|Δ|=1.03e+00   rel_l2=1.06e+00   DIV cos=4.05e-01   max|Δ|=8.97e+00   mean|Δ|=1.04e+00   rel_l2=1.06e+00   DIV cos=3.88e-01   max|Δ|=9.59e+00   mean|Δ|=1.05e+00   rel_l2=1.07e+00   DIV cos=4.14e-01   max|Δ|=8.96e+00   mean|Δ|=1.02e+00   rel_l2=1.06e+00   DIV cos=3.95e-01   max|Δ|=9.73e+00   mean|Δ|=1.06e+00   rel_l2=1.08e+00   DIV cos=4.26e-01   max|Δ|=1.09e+01   mean|Δ|=1.03e+00   rel_l2=1.07e+00   DIV cos=3.34e-01   max|Δ|=1.05e+01   mean|Δ|=1.13e+00   rel_l2=1.14e+00   DIV cos=3.70e-01   max|Δ|=8.95e+00   mean|Δ|=1.08e+00   rel_l2=1.11e+00   DIV
+  qk_norm_k           <missing>                                            cos=4.89e-01   max|Δ|=8.03e+00   mean|Δ|=1.05e+00   rel_l2=1.00e+00   DIV cos=2.94e-01   max|Δ|=1.05e+01   mean|Δ|=1.26e+00   rel_l2=1.19e+00   DIV cos=3.62e-01   max|Δ|=9.43e+00   mean|Δ|=1.19e+00   rel_l2=1.13e+00   DIV cos=3.26e-01   max|Δ|=8.21e+00   mean|Δ|=1.28e+00   rel_l2=1.16e+00   DIV cos=3.33e-01   max|Δ|=9.09e+00   mean|Δ|=1.21e+00   rel_l2=1.15e+00   DIV cos=3.95e-01   max|Δ|=9.24e+00   mean|Δ|=1.16e+00   rel_l2=1.10e+00   DIV cos=3.27e-01   max|Δ|=7.39e+00   mean|Δ|=1.26e+00   rel_l2=1.16e+00   DIV cos=3.60e-01   max|Δ|=1.00e+01   mean|Δ|=1.20e+00   rel_l2=1.13e+00   DIV cos=3.76e-01   max|Δ|=6.74e+00   mean|Δ|=1.23e+00   rel_l2=1.11e+00   DIV cos=3.63e-01   max|Δ|=6.82e+00   mean|Δ|=1.22e+00   rel_l2=1.12e+00   DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=3.38e-01   max|Δ|=8.22e+00   mean|Δ|=3.00e-01   rel_l2=1.40e+00   DIV <missing>                                            <missing>                                           
+  post_attn_norm      <missing>                                            cos=5.19e-01   max|Δ|=1.03e+01   mean|Δ|=8.69e-01   rel_l2=9.75e-01   DIV cos=4.27e-01   max|Δ|=1.15e+01   mean|Δ|=9.10e-01   rel_l2=1.07e+00   DIV cos=4.08e-01   max|Δ|=9.99e+00   mean|Δ|=9.69e-01   rel_l2=1.10e+00   DIV cos=4.64e-01   max|Δ|=1.07e+01   mean|Δ|=9.06e-01   rel_l2=1.04e+00   DIV cos=4.45e-01   max|Δ|=1.01e+01   mean|Δ|=9.14e-01   rel_l2=1.06e+00   DIV cos=4.22e-01   max|Δ|=1.04e+01   mean|Δ|=9.52e-01   rel_l2=1.09e+00   DIV cos=4.44e-01   max|Δ|=1.04e+01   mean|Δ|=9.27e-01   rel_l2=1.06e+00   DIV cos=3.53e-01   max|Δ|=1.19e+01   mean|Δ|=1.00e+00   rel_l2=1.16e+00   DIV cos=3.05e-01   max|Δ|=1.09e+01   mean|Δ|=1.04e+00   rel_l2=1.21e+00   DIV cos=4.49e-01   max|Δ|=1.04e+01   mean|Δ|=9.30e-01   rel_l2=1.06e+00   DIV
+  mlp_gate            <missing>                                            cos=8.43e-01   max|Δ|=1.08e+01   mean|Δ|=7.06e-01   rel_l2=6.41e-01   DIV cos=8.44e-01   max|Δ|=1.30e+01   mean|Δ|=7.91e-01   rel_l2=7.48e-01   DIV cos=8.42e-01   max|Δ|=1.28e+01   mean|Δ|=8.12e-01   rel_l2=7.14e-01   DIV cos=8.74e-01   max|Δ|=1.24e+01   mean|Δ|=6.79e-01   rel_l2=5.88e-01   DIV cos=8.53e-01   max|Δ|=1.27e+01   mean|Δ|=7.90e-01   rel_l2=7.29e-01   DIV cos=8.35e-01   max|Δ|=1.36e+01   mean|Δ|=8.88e-01   rel_l2=7.80e-01   DIV cos=8.36e-01   max|Δ|=1.28e+01   mean|Δ|=7.92e-01   rel_l2=6.88e-01   DIV cos=8.20e-01   max|Δ|=1.27e+01   mean|Δ|=8.58e-01   rel_l2=7.24e-01   DIV cos=8.09e-01   max|Δ|=1.34e+01   mean|Δ|=9.38e-01   rel_l2=8.72e-01   DIV cos=8.66e-01   max|Δ|=1.20e+01   mean|Δ|=7.57e-01   rel_l2=6.65e-01   DIV
+  mlp_up              <missing>                                            cos=7.22e-01   max|Δ|=6.63e+00   mean|Δ|=5.80e-01   rel_l2=8.53e-01   DIV cos=6.51e-01   max|Δ|=8.22e+00   mean|Δ|=6.77e-01   rel_l2=9.89e-01   DIV cos=6.39e-01   max|Δ|=7.67e+00   mean|Δ|=7.29e-01   rel_l2=1.09e+00   DIV cos=7.19e-01   max|Δ|=7.12e+00   mean|Δ|=5.90e-01   rel_l2=8.48e-01   DIV cos=6.95e-01   max|Δ|=8.01e+00   mean|Δ|=6.41e-01   rel_l2=9.39e-01   DIV cos=6.58e-01   max|Δ|=8.60e+00   mean|Δ|=7.45e-01   rel_l2=1.12e+00   DIV cos=6.93e-01   max|Δ|=7.80e+00   mean|Δ|=6.31e-01   rel_l2=9.25e-01   DIV cos=6.79e-01   max|Δ|=9.77e+00   mean|Δ|=6.95e-01   rel_l2=9.37e-01   DIV cos=6.28e-01   max|Δ|=7.85e+00   mean|Δ|=7.82e-01   rel_l2=1.12e+00   DIV cos=7.18e-01   max|Δ|=7.20e+00   mean|Δ|=6.18e-01   rel_l2=9.26e-01   DIV
+  mlp_down            <missing>                                            cos=5.07e-01   max|Δ|=1.15e+01   mean|Δ|=5.86e-01   rel_l2=9.86e-01   DIV cos=4.44e-01   max|Δ|=1.59e+01   mean|Δ|=7.40e-01   rel_l2=9.49e-01   DIV cos=4.02e-01   max|Δ|=1.21e+01   mean|Δ|=7.72e-01   rel_l2=1.06e+00   DIV cos=5.41e-01   max|Δ|=1.95e+01   mean|Δ|=6.07e-01   rel_l2=8.84e-01   DIV cos=4.43e-01   max|Δ|=2.09e+01   mean|Δ|=7.04e-01   rel_l2=9.93e-01   DIV cos=4.42e-01   max|Δ|=1.51e+01   mean|Δ|=7.35e-01   rel_l2=1.03e+00   DIV cos=2.55e-01   max|Δ|=3.11e+01   mean|Δ|=6.35e-01   rel_l2=1.12e+00   DIV cos=4.52e-01   max|Δ|=2.74e+01   mean|Δ|=6.78e-01   rel_l2=9.31e-01   DIV cos=3.38e-01   max|Δ|=2.02e+01   mean|Δ|=7.64e-01   rel_l2=1.01e+00   DIV cos=4.50e-01   max|Δ|=2.41e+01   mean|Δ|=5.92e-01   rel_l2=9.78e-01   DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=3.29e-01     DIV
+    q_proj               median=5.88e-01     DIV
+    k_proj               median=3.39e-01     DIV
+    v_proj               median=8.95e-01     DIV
+    qk_norm_q            median=4.00e-01     DIV
+    qk_norm_k            median=3.61e-01     DIV
+    o_proj               median=3.38e-01     DIV
+    post_attn_norm       median=4.35e-01     DIV
+    mlp_gate             median=8.42e-01     DIV
+    mlp_up               median=6.86e-01     DIV
+    mlp_down             median=4.43e-01     DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.416640)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']


### PR DESCRIPTION
## Summary
- rerun the standard native-MTP workload on fresh `main` after PR #422 and confirm the seed split still holds on current `main`
- generate fresh B10/B11/B12 comparator artifacts for seeds 0 and 1 against bf16 and fp32 HF references using the existing dump/reference path
- document the honest blocker verdict: the existing comparator contract only has one fully-contexted row per seed, so it cannot localize a seed1-only upstream divergence beyond `0_s0`

## Preflight
- fresh `origin/main` under test: `c66cf41` (PR #422)
- recent PR history contains no newer open or merged PR that already lands a post-#422 upstream base-stack bisect artifact for the standard native-MTP workload
- fresh standard-workload rerun still reproduces the split on current `main`:
  - seed 0: `494` prompt tokens, `49.98 tok/s`, `α=0.7162`
  - seed 1: `508` prompt tokens, `30.82 tok/s`, `α=0.2828`
- current `PROFILING.md` still points the next narrow task upstream of `h_main`, not at another decode-kernel retry

## Verdict
The task is still live, but the existing B10/B11/B12 replay contract is structurally insufficient for the requested localization.

- only `mtp_pos=0 / step=0` (`0_s0`) carries the full prompt into the dump (`494` tokens on seed 0, `508` on seed 1)
- every later `mtp_pos=0` dump carries `prompt_tokens` length `1`, and `mtp_pos=2` carries `2` then `1`
- `scripts/mtp_h_main_reference_dump.py` forwards exactly that embedded `prompt_tokens` tensor, so every later row is an HF replay on an under-conditioned sequence and cannot serve as a source-of-truth seed-specific bisect

On the only valid fully-contexted row, seed 0 and seed 1 do not separate cleanly:
- `h_layer_0`: `1.00` vs `1.00`
- `h_layer_24`: `0.985` vs `0.976`
- `h_layer_31`: `0.958` vs `0.957`
- B11 `gdn_conv`: `1.00` vs `1.00`

The mechanically-generated full reports point to the same nominal surfaces for both seeds (`B10 -> layer 0`, `B11 -> gdn_conv`, `B12 -> h_layer_24`), which makes them unsuitable as a seed1-only localization verdict.

## Hardware
- pool A6000 resume failed (`not enough free GPUs on the host machine`)
- direct A6000 launch hit `SUPPLY_CONSTRAINT`
- direct A40 launch returned a RunPod internal error
- used `A100 PCIe` per the documented fallback order

## Validation
- `python3 -m py_compile scripts/mtp_compare.py scripts/mtp_h_main_reference_dump.py scripts/c15_h_main_drift_audit.py`
- fresh RunPod rerun of the standard native-MTP workload for seeds `0` and `1` on `c66cf41`
- fresh kiln hidden-state dumps with `KILN_MTP_DUMP_HIDDEN_STATES=1`, `KILN_MTP_DUMP_B11_TAPS=1`, and `KILN_MTP_DUMP_B12_GQA_TAPS=1`
- fresh bf16 and fp32 HF reference dumps from `scripts/mtp_h_main_reference_dump.py`
- fresh B10/B11/B12 comparator runs for both seeds
