### PR TITLE
phase6: bisect first post-#422 seed1 upstream h_main divergence

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -252,6 +252,74 @@ tap on the standard workload, using the existing hidden-state dump path and a
 layer/sub-op comparator. Seed 1's failure is already visible before the
 accept/reject seam.
 
+## Phase C38 post-#422 seed1-only upstream `h_main` bisect (2026-04-23)
+
+**Scope:** rerun the standard native-MTP workload on fresh `main`, then use
+the existing B10/B12 hidden-state dump + HF reference + comparator path to
+name the first seed1-only divergence upstream of `h_main`.
+
+**Preflight outcome:** proceed. Fresh `main` was `c66cf41` (PR #422 itself),
+recent PR history contained no newer open or merged post-#422 upstream-base
+bisect artifact, the standard workload still reproduced the seed split, and
+the latest recommendation in this file still pointed upstream of `h_main`
+rather than at another decode-kernel retry.
+
+| Seed | prompt tokens | decode tok/s | α |
+| --- | ---: | ---: | ---: |
+| 0 | 494 | 41.9 | 0.7397 |
+| 1 | 508 | 22.5 | 0.3093 |
+
+**Hardware:** direct RunPod fallback on `NVIDIA RTX A6000` with
+`ghcr.io/ericflo/kiln-runpod:latest`. Pool resume failed on the first try, but
+direct launch succeeded on A6000, so no fallback GPU was needed.
+
+### Result
+
+The fresh artifact does **not** localize a seed1-only first divergence with
+the current B10/B12 path.
+
+- **B10:** both seeds first diverge at the same boundary: last clean tap
+  `h_layer_8`, first divergent tap `h_layer_16`. That means the existing
+  per-layer boundary scan does **not** distinguish the trapped seed from the
+  escaping seed by first-divergent layer.
+- **B12:** both seeds again name `h_layer_31` as the first divergent GQA-tail
+  layer. Seed 1 is worse (`median cos_sim 0.9710` vs `0.9795` for seed 0),
+  but the first divergent layer is still the same.
+- **Sub-op blocker:** the kiln-side dumps contained **zero** `b12__*` tensors
+  and no `h_pre_final_norm` tensor even with
+  `KILN_MTP_DUMP_B12_GQA_TAPS=1`. The HF reference wrote 11 `b12__*` tensors
+  plus `h_pre_final_norm`, but still could not emit `rope_q`, `rope_k`, or
+  `attn_out` because those taps remain hook-unreachable in the current Python
+  reference path. So the current B12 route is structurally unable to produce a
+  trustworthy first-sub-op verdict on fresh `main`.
+
+### Execution notes
+
+- The task brief's `step-{step}.safetensors` path template did not work for
+  this direct B10/B12 run because `{step}` is only substituted when the splice
+  capture path is armed. The effective capture path here was the fixed file
+  `.../step-0.safetensors`.
+- The baked RunPod image had `torch` and `huggingface-hub`, but not
+  `transformers`; installing it on-pod was required for
+  `scripts/mtp_h_main_reference_dump.py`.
+- The raw comparator footer still prints `Overall verdict: divergence(s) at:
+  ['h_main']` because the B10/B12 mode walks the legacy primary taps first and
+  the reference dump intentionally omits them. The B10/B12 summary tables are
+  the authoritative verdicts for this phase.
+
+### Recommendation
+
+Do **not** guess a kernel fix from this artifact. The honest next task is to
+repair or re-verify the current B12 tap plumbing first: kiln must actually
+emit the `b12__*` tensors it advertises, and the HF reference still needs the
+remaining `rope_q` / `rope_k` / `attn_out` taps. Only after that should the
+project retry a narrower seed1-only upstream bisect. As captured here, the
+existing source-of-truth path stops at:
+
+- shared first boundary divergence at `h_layer_16`, and
+- shared first GQA-tail divergence at `h_layer_31`, with seed 1 only worse in
+  magnitude, not different in first-divergent layer.
+
 ## Phase 6 post-#412 preflight — tiled recurrent-state retry is obsolete (2026-04-23)
 
 **Scope:** re-check the queued "prototype vLLM-style block-tiled

--- a/docs/phase-c38/c38-seed1-upstream-bisect.md
+++ b/docs/phase-c38/c38-seed1-upstream-bisect.md
@@ -1,0 +1,202 @@
+# Phase C38 — post-#422 seed1-only upstream `h_main` bisect
+
+**Date:** 2026-04-23  
+**Fresh main:** `c66cf41e02c53add403db3031249a6818d8efe5c` (PR #422)  
+**Hardware:** RunPod `NVIDIA RTX A6000` via `ghcr.io/ericflo/kiln-runpod:latest`
+
+## Preflight
+
+1. **No newer PR already lands this artifact:** satisfied. Fresh `gh pr list`
+   on `ericflo/kiln` still showed PR #422 as the newest relevant merged item;
+   there was no newer open or merged PR landing a post-#422 upstream-base
+   hidden-state bisect for the standard native-MTP workload.
+2. **Fresh current `main` still reproduces the seed split:** satisfied.
+3. **`PROFILING.md` still points upstream of `h_main`:** satisfied. Phase C37
+   explicitly recommended bisecting the first seed1-only divergence upstream
+   of the `h_main` tap rather than retrying another decode-kernel change.
+
+## Validation
+
+- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
+- Fresh RunPod rerun of the standard workload for seeds 0 and 1
+- Fresh kiln hidden-state dumps with `KILN_MTP_DUMP_HIDDEN_STATES=1` and
+  `KILN_MTP_DUMP_B12_GQA_TAPS=1`
+- Fresh HF reference dumps with `scripts/mtp_h_main_reference_dump.py --b12-taps`
+- Fresh comparator runs with `scripts/mtp_compare.py --b10` and `--b12`
+- Re-ran the comparator commands on-pod and confirmed the committed
+  `.txt` artifacts are the generated outputs for this run
+
+## Commands run
+
+Local preflight:
+
+```bash
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+gh pr list --repo ericflo/kiln --state all --limit 30
+```
+
+RunPod setup:
+
+```bash
+export RUNPOD_API_KEY=$(ce secret-get --name RUNPOD_API_KEY)
+RP=/data/.clouderic-internal/repos/apps/trajectory-trainer/scripts/runpod_api.py
+
+python3 $RP wait 3slsfd81ftanhz
+B2_KEY_ID=$(ce secret-get --name B2_APPLICATION_KEY_ID)
+B2_KEY=$(ce secret-get --name B2_APPLICATION_KEY)
+python3 $RP ssh 3slsfd81ftanhz \
+  "export B2_APPLICATION_KEY_ID='$B2_KEY_ID' B2_APPLICATION_KEY='$B2_KEY'; kiln-setup --clone"
+python3 $RP bg 3slsfd81ftanhz /tmp/build.log \
+  'source /root/.kiln-build-env && cd /workspace/kiln && export KILN_CUDA_ARCHS=86 && cargo build --release --features cuda --bin kiln-bench'
+python3 $RP wait-file 3slsfd81ftanhz /workspace/kiln/target/release/kiln-bench --timeout 3600
+```
+
+The baked image did not include `transformers`, so the existing HF reference
+script required this one-time dependency install:
+
+```bash
+python3 $RP ssh 3slsfd81ftanhz 'python3 -m pip install transformers'
+```
+
+Per-seed standard workload + dump + compare:
+
+```bash
+for seed in 0 1; do
+  rm -rf profiling-artifacts/post422_20260423_seed${seed}_captures
+  mkdir -p profiling-artifacts/post422_20260423_seed${seed}_captures
+
+  KILN_SPEC_METHOD=mtp \
+  KILN_BENCH_FORCE_MTP=1 \
+  KILN_MTP_DUMP_HIDDEN_STATES=1 \
+  KILN_MTP_DUMP_B12_GQA_TAPS=1 \
+  KILN_MTP_DUMP_PATH=/workspace/kiln/profiling-artifacts/post422_20260423_seed${seed}_captures/step-0.safetensors \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+    --seed ${seed} \
+    > profiling-artifacts/post422_20260423_seed${seed}.bench.json \
+    2> profiling-artifacts/post422_20260423_seed${seed}.bench.stderr
+
+  python3 scripts/mtp_h_main_reference_dump.py \
+    --checkpoint /workspace/qwen3.5-4b \
+    --kiln-dump profiling-artifacts/post422_20260423_seed${seed}_captures/step-0.safetensors \
+    --out profiling-artifacts/post422_20260423_seed${seed}_ref.safetensors \
+    --b12-taps
+
+  python3 scripts/mtp_compare.py --b10 \
+    --pair seed${seed}:profiling-artifacts/post422_20260423_seed${seed}_captures/step-0.safetensors,profiling-artifacts/post422_20260423_seed${seed}_ref.safetensors \
+    > profiling-artifacts/post422_20260423_seed${seed}_b10_compare.txt || test $? -eq 1
+
+  python3 scripts/mtp_compare.py --b12 \
+    --pair seed${seed}:profiling-artifacts/post422_20260423_seed${seed}_captures/step-0.safetensors,profiling-artifacts/post422_20260423_seed${seed}_ref.safetensors \
+    > profiling-artifacts/post422_20260423_seed${seed}_b12_compare.txt || test $? -eq 1
+done
+```
+
+## Fresh seed split
+
+| Seed | prompt tokens | decode tok/s | α |
+| --- | ---: | ---: | ---: |
+| 0 | 494 | 41.93 | 0.7397 |
+| 1 | 508 | 22.52 | 0.3093 |
+
+This still reproduces the post-#420 / post-#422 split on fresh current
+`main`: seed 0 escapes near the paper floor and seed 1 stays trapped.
+
+## Comparator outputs
+
+- [`profiling-artifacts/post422_20260423_seed0_b10_compare.txt`](../../profiling-artifacts/post422_20260423_seed0_b10_compare.txt)
+- [`profiling-artifacts/post422_20260423_seed1_b10_compare.txt`](../../profiling-artifacts/post422_20260423_seed1_b10_compare.txt)
+- [`profiling-artifacts/post422_20260423_seed0_b12_compare.txt`](../../profiling-artifacts/post422_20260423_seed0_b12_compare.txt)
+- [`profiling-artifacts/post422_20260423_seed1_b12_compare.txt`](../../profiling-artifacts/post422_20260423_seed1_b12_compare.txt)
+
+## B10 result
+
+The first divergent boundary is the same for both seeds:
+
+| Seed | last matching tap | first divergent tap | comment |
+| --- | --- | --- | --- |
+| 0 | `h_layer_8` | `h_layer_16` | seed 0 is still the escaping case end to end |
+| 1 | `h_layer_8` | `h_layer_16` | seed 1 is the failing case |
+
+So the existing B10 boundary scan does **not** isolate a seed1-only first
+divergence. It only says both seeds already differ from the HF reference by
+`h_layer_16`, while seed 1 later diverges more severely.
+
+## B12 result
+
+The first divergent GQA-tail layer is also the same for both seeds:
+
+| Seed | first layer with median `cos_sim < 0.995` | median cos at `h_layer_31` |
+| --- | --- | ---: |
+| 0 | `h_layer_31` | 0.979465 |
+| 1 | `h_layer_31` | 0.971042 |
+
+That is directionally useful, but still not a seed1-only earliest boundary.
+Seed 1 is worse in magnitude, not different in the first layer that trips the
+comparator's bar.
+
+## Structural blocker in the current B12 path
+
+The current B12 route still cannot produce a trustworthy first-sub-op verdict.
+
+Kiln-side key inspection after the run showed:
+
+- seed 0 kiln dump: `0` `b12__*` tensors, no `h_pre_final_norm`
+- seed 1 kiln dump: `0` `b12__*` tensors, no `h_pre_final_norm`
+
+HF-reference key inspection showed:
+
+- seed 0 reference dump: `11` `b12__*` tensors plus `h_pre_final_norm`
+- seed 1 reference dump: `11` `b12__*` tensors plus `h_pre_final_norm`
+
+The reference script also logged that `rope_q`, `rope_k`, and `attn_out`
+remain hook-unreachable in the current Python path, so even the reference side
+is incomplete for the full 14-tap B12 contract.
+
+That combination means the B12 summary's "re-run with the b12__ sub-op tap env
+flags set" is not actionable on this exact revision: the env flags were set,
+but the kiln dump still emitted no `b12__*` tensors.
+
+## Comparator-footnote caveat
+
+The raw comparator footer still prints:
+
+```text
+Overall verdict: divergence(s) at: ['h_main']
+```
+
+That line is not the phase verdict here. In B10/B12 mode, `mtp_compare.py`
+still walks the legacy primary taps first, and the reference dump intentionally
+does not include those MTP-head tensors. The authoritative phase verdicts are
+the B10/B12 summary tables, not that footer.
+
+## Verdict
+
+**The existing B10/B12 comparator path is structurally insufficient to
+localize a seed1-only earliest upstream divergence on fresh `main`.**
+
+What this artifact does establish:
+
+1. The fresh seed split still holds on `c66cf41`.
+2. Both seeds first diverge from the HF reference by `h_layer_16`.
+3. Both seeds first cross the B12 GQA-tail bar at `h_layer_31`.
+4. Seed 1 is worse than seed 0 in drift magnitude, but not different in the
+   first divergent boundary that the current B10/B12 route can see.
+5. The current kiln-side B12 dump path did not emit the promised `b12__*`
+   tensors, and the HF reference still misses 3 of the 14 expected sub-op taps.
+
+## Recommendation
+
+Do not broaden this into a fix task. The next narrow task should first repair
+or verify the current B12 plumbing:
+
+- kiln-side `KILN_MTP_DUMP_B12_GQA_TAPS=1` must actually write `b12__*`
+  tensors and `h_pre_final_norm`;
+- the HF reference needs `rope_q`, `rope_k`, and `attn_out` taps so the
+  B12 contract is complete.
+
+Only after that should the project retry the "first seed1-only upstream
+divergence" localization. As of this phase, the honest source-of-truth verdict
+is that the current comparator stack stops at shared layer-level boundaries and
+cannot yet name a seed1-only first divergent sub-op.

--- a/profiling-artifacts/post422_20260423_seed0_b10_compare.txt
+++ b/profiling-artifacts/post422_20260423_seed0_b10_compare.txt
@@ -1,0 +1,59 @@
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== seed0 ===
+  kiln dump : profiling-artifacts/post422_20260423_seed0_captures/step-0.safetensors
+  ref  dump : profiling-artifacts/post422_20260423_seed0_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   9.77e-04     6.67e-05    
+h_layer_8              1x1x2560               True     True     1.00e+00   5.86e-03     1.05e-03    
+h_layer_16             1x1x2560               True     False    1.00e+00   3.12e-02     4.29e-03    
+h_layer_23             1x1x2560               True     False    1.00e+00   7.81e-02     1.19e-02    
+h_layer_31             1x1x2560               True     False    9.79e-01   2.48e+01     1.31e+00    
+h_layer_24             1x1x2560               True     False    1.00e+00   1.25e-01     1.30e-02    
+h_layer_25             1x1x2560               True     False    1.00e+00   1.25e-01     1.39e-02    
+h_layer_26             1x1x2560               True     False    1.00e+00   1.25e-01     1.50e-02    
+h_layer_27             1x1x2560               True     False    1.00e+00   9.38e-02     1.63e-02    
+h_layer_28             1x1x2560               True     False    9.99e-01   1.15e-01     2.85e-02    
+h_layer_29             1x1x2560               True     False    9.99e-01   1.48e-01     3.32e-02    
+h_layer_30             1x1x2560               True     False    9.99e-01   1.95e-01     4.21e-02    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=seed0                       
+  ------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=9.77e-04   ok   
+  h_layer_8             cos=1.00e+00   max|Δ|=5.86e-03   ok   
+  h_layer_16            cos=1.00e+00   max|Δ|=3.12e-02   DIV  
+  h_layer_23            cos=1.00e+00   max|Δ|=7.81e-02   DIV  
+  h_layer_31            cos=9.79e-01   max|Δ|=2.48e+01   DIV  
+  h_pre_final_norm      <missing>                       
+
+  first diverging tap: 'h_layer_16' (pos=seed0)
+  last matching tap before divergence: 'h_layer_8'
+Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK
+  -> The first bad transformer block lies between h_layer_8
+     and h_layer_16. Narrow by capturing intermediate layers
+     (e.g. layers 4 and 12) and re-running B10 on the new dump.
+
+Overall verdict: divergence(s) at: ['h_main']

--- a/profiling-artifacts/post422_20260423_seed0_b12_compare.txt
+++ b/profiling-artifacts/post422_20260423_seed0_b12_compare.txt
@@ -1,0 +1,70 @@
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== seed0 ===
+  kiln dump : profiling-artifacts/post422_20260423_seed0_captures/step-0.safetensors
+  ref  dump : profiling-artifacts/post422_20260423_seed0_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   9.77e-04     6.67e-05    
+h_layer_8              1x1x2560               True     True     1.00e+00   5.86e-03     1.05e-03    
+h_layer_16             1x1x2560               True     False    1.00e+00   3.12e-02     4.29e-03    
+h_layer_23             1x1x2560               True     False    1.00e+00   7.81e-02     1.19e-02    
+h_layer_31             1x1x2560               True     False    9.79e-01   2.48e+01     1.31e+00    
+h_layer_24             1x1x2560               True     False    1.00e+00   1.25e-01     1.30e-02    
+h_layer_25             1x1x2560               True     False    1.00e+00   1.25e-01     1.39e-02    
+h_layer_26             1x1x2560               True     False    1.00e+00   1.25e-01     1.50e-02    
+h_layer_27             1x1x2560               True     False    1.00e+00   9.38e-02     1.63e-02    
+h_layer_28             1x1x2560               True     False    9.99e-01   1.15e-01     2.85e-02    
+h_layer_29             1x1x2560               True     False    9.99e-01   1.48e-01     3.32e-02    
+h_layer_30             1x1x2560               True     False    9.99e-01   1.95e-01     4.21e-02    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=seed0                       
+  ------------------------------------------------------
+  h_layer_24            cos=1.00e+00   max|Δ|=1.25e-01   ok   
+  h_layer_25            cos=1.00e+00   max|Δ|=1.25e-01   ok   
+  h_layer_26            cos=1.00e+00   max|Δ|=1.25e-01   ok   
+  h_layer_27            cos=1.00e+00   max|Δ|=9.38e-02   ok   
+  h_layer_28            cos=9.99e-01   max|Δ|=1.15e-01   ok   
+  h_layer_29            cos=9.99e-01   max|Δ|=1.48e-01   ok   
+  h_layer_30            cos=9.99e-01   max|Δ|=1.95e-01   ok   
+  h_layer_31            cos=9.79e-01   max|Δ|=2.48e+01   DIV  
+  h_pre_final_norm      <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=1.00e+00     ok
+    h_layer_25             median=1.00e+00     ok
+    h_layer_26             median=1.00e+00     ok
+    h_layer_27             median=1.00e+00     ok
+    h_layer_28             median=9.99e-01     ok
+    h_layer_29             median=9.99e-01     ok
+    h_layer_30             median=9.99e-01     ok
+    h_layer_31             median=9.79e-01     DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_31' (median = 0.979465)
+Phase B12 verdict: LAYER 31 IS THE FIRST DIVERGENT LAYER, but no b12__
+  sub-op taps were captured, so no localized target is available.
+  -> Re-run both dumps with the b12__ sub-op tap env flags set.
+
+Overall verdict: divergence(s) at: ['h_main']

--- a/profiling-artifacts/post422_20260423_seed1_b10_compare.txt
+++ b/profiling-artifacts/post422_20260423_seed1_b10_compare.txt
@@ -1,0 +1,59 @@
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== seed1 ===
+  kiln dump : profiling-artifacts/post422_20260423_seed1_captures/step-0.safetensors
+  ref  dump : profiling-artifacts/post422_20260423_seed1_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.56e-02     1.02e-04    
+h_layer_8              1x1x2560               True     True     1.00e+00   3.12e-02     1.73e-03    
+h_layer_16             1x1x2560               True     False    1.00e+00   2.51e-02     4.30e-03    
+h_layer_23             1x1x2560               True     False    9.99e-01   3.12e-01     1.33e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   2.11e+01     1.05e+00    
+h_layer_24             1x1x2560               True     False    9.99e-01   2.50e-01     1.42e-02    
+h_layer_25             1x1x2560               True     False    9.99e-01   2.50e-01     1.49e-02    
+h_layer_26             1x1x2560               True     False    1.00e+00   1.25e-01     1.54e-02    
+h_layer_27             1x1x2560               True     False    1.00e+00   2.50e-01     1.64e-02    
+h_layer_28             1x1x2560               True     False    1.00e+00   1.25e-01     2.27e-02    
+h_layer_29             1x1x2560               True     False    9.99e-01   2.50e-01     2.53e-02    
+h_layer_30             1x1x2560               True     False    9.99e-01   2.50e-01     2.94e-02    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=seed1                       
+  ------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=1.56e-02   ok   
+  h_layer_8             cos=1.00e+00   max|Δ|=3.12e-02   ok   
+  h_layer_16            cos=1.00e+00   max|Δ|=2.51e-02   DIV  
+  h_layer_23            cos=9.99e-01   max|Δ|=3.12e-01   DIV  
+  h_layer_31            cos=9.71e-01   max|Δ|=2.11e+01   DIV  
+  h_pre_final_norm      <missing>                       
+
+  first diverging tap: 'h_layer_16' (pos=seed1)
+  last matching tap before divergence: 'h_layer_8'
+Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK
+  -> The first bad transformer block lies between h_layer_8
+     and h_layer_16. Narrow by capturing intermediate layers
+     (e.g. layers 4 and 12) and re-running B10 on the new dump.
+
+Overall verdict: divergence(s) at: ['h_main']

--- a/profiling-artifacts/post422_20260423_seed1_b12_compare.txt
+++ b/profiling-artifacts/post422_20260423_seed1_b12_compare.txt
@@ -1,0 +1,70 @@
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== seed1 ===
+  kiln dump : profiling-artifacts/post422_20260423_seed1_captures/step-0.safetensors
+  ref  dump : profiling-artifacts/post422_20260423_seed1_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.56e-02     1.02e-04    
+h_layer_8              1x1x2560               True     True     1.00e+00   3.12e-02     1.73e-03    
+h_layer_16             1x1x2560               True     False    1.00e+00   2.51e-02     4.30e-03    
+h_layer_23             1x1x2560               True     False    9.99e-01   3.12e-01     1.33e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   2.11e+01     1.05e+00    
+h_layer_24             1x1x2560               True     False    9.99e-01   2.50e-01     1.42e-02    
+h_layer_25             1x1x2560               True     False    9.99e-01   2.50e-01     1.49e-02    
+h_layer_26             1x1x2560               True     False    1.00e+00   1.25e-01     1.54e-02    
+h_layer_27             1x1x2560               True     False    1.00e+00   2.50e-01     1.64e-02    
+h_layer_28             1x1x2560               True     False    1.00e+00   1.25e-01     2.27e-02    
+h_layer_29             1x1x2560               True     False    9.99e-01   2.50e-01     2.53e-02    
+h_layer_30             1x1x2560               True     False    9.99e-01   2.50e-01     2.94e-02    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=seed1                       
+  ------------------------------------------------------
+  h_layer_24            cos=9.99e-01   max|Δ|=2.50e-01   ok   
+  h_layer_25            cos=9.99e-01   max|Δ|=2.50e-01   ok   
+  h_layer_26            cos=1.00e+00   max|Δ|=1.25e-01   ok   
+  h_layer_27            cos=1.00e+00   max|Δ|=2.50e-01   ok   
+  h_layer_28            cos=1.00e+00   max|Δ|=1.25e-01   ok   
+  h_layer_29            cos=9.99e-01   max|Δ|=2.50e-01   ok   
+  h_layer_30            cos=9.99e-01   max|Δ|=2.50e-01   ok   
+  h_layer_31            cos=9.71e-01   max|Δ|=2.11e+01   DIV  
+  h_pre_final_norm      <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=9.99e-01     ok
+    h_layer_25             median=9.99e-01     ok
+    h_layer_26             median=1.00e+00     ok
+    h_layer_27             median=1.00e+00     ok
+    h_layer_28             median=1.00e+00     ok
+    h_layer_29             median=9.99e-01     ok
+    h_layer_30             median=9.99e-01     ok
+    h_layer_31             median=9.71e-01     DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_31' (median = 0.971042)
+Phase B12 verdict: LAYER 31 IS THE FIRST DIVERGENT LAYER, but no b12__
+  sub-op taps were captured, so no localized target is available.
+  -> Re-run both dumps with the b12__ sub-op tap env flags set.
+
+Overall verdict: divergence(s) at: ['h_main']


### PR DESCRIPTION
## Summary
- rerun the standard native-MTP workload on fresh `main` and confirm the post-#422 seed split still reproduces on the standard workload
- commit fresh B10/B12 comparator artifacts for seeds 0 and 1 plus a Phase C38 write-up in `PROFILING.md` and `docs/phase-c38/c38-seed1-upstream-bisect.md`
- document the actual blocker on current `main`: the existing B10/B12 path still does not localize a seed1-only first divergent sub-op

## Fresh current-main rerun
- fresh `main` on pod: `c66cf41e02c53add403db3031249a6818d8efe5c` (PR #422)
- seed 0: `494` prompt tokens, `41.93 tok/s`, `α=0.7397`
- seed 1: `508` prompt tokens, `22.52 tok/s`, `α=0.3093`
- hardware: direct RunPod `NVIDIA RTX A6000` on `ghcr.io/ericflo/kiln-runpod:latest`

## Verdict
- **B10 does not isolate a seed1-only first divergence**: both seeds first diverge at the same boundary (`h_layer_16`, last clean tap `h_layer_8`)
- **B12 does not isolate a seed1-only first divergent GQA layer either**: both seeds first cross the B12 bar at `h_layer_31` (seed 1 is worse in magnitude, not different in first-divergent layer)
- **the current B12 path is structurally insufficient on fresh main**:
  - kiln-side dumps emitted `0` `b12__*` tensors and no `h_pre_final_norm` even with `KILN_MTP_DUMP_B12_GQA_TAPS=1`
  - HF reference emitted `11` `b12__*` tensors plus `h_pre_final_norm`, but still missed `rope_q`, `rope_k`, and `attn_out`

So this task closes with a source-of-truth blocker artifact, not a fix: the current B10/B12 comparator stack stops at shared layer-level boundaries and still cannot name a seed1-only first divergent sub-op on `main`.

## Validation
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- fresh RunPod rerun for seeds 0 and 1 on the standard workload
- fresh HF reference dumps with `scripts/mtp_h_main_reference_dump.py --b12-taps`
- fresh `scripts/mtp_compare.py --b10` and `--b12` outputs for both seeds
- reran the comparator commands on-pod and `cmp`-verified they match the committed `.txt` outputs byte-for-byte
