### PR TITLE
phase6: emit full replay context for native mtp dumps

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -328,6 +328,63 @@ by serializing the full chained prompt history into every splice dump or by
 teaching the HF reference side to reconstruct the chained history C15-style
 before re-running the existing comparators.
 
+## Phase C39 full replay context for post-#423 seed bisect (2026-04-23)
+
+**Scope:** land the missing replay-contract fix from C38/PR #423, rerun the
+standard native-MTP seed-0 / seed-1 workload on fresh `main`, and verify
+whether fully conditioned B10/B11/B12 replays expose a seed-1-only first
+upstream boundary or sub-op.
+
+**Contract result:** fixed. The dump now serializes the full replay sequence
+whose final hidden row produced each captured `h_main`, and the fresh rerun
+shows monotonically growing lengths instead of collapsing to the local verifier
+slice:
+
+- seed 0: `494 -> 495 -> 496 -> 497`, then `502 -> 503 -> 504` at `mtp_pos=2`
+- seed 1: `508 -> 509 -> 510 -> 511 -> 512 -> 513 -> 514 -> 515`, then
+  `520 -> 521 -> 522` at `mtp_pos=2`
+
+Source-of-truth artifact: `docs/phase-c39/replay_lengths.json`
+
+**Fresh workload check (A6000, kiln image):**
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 445.2 | 36.88 | 0.7067 |
+| 1 | 508 | 453.1 | 24.03 | 0.2929 |
+
+The seed split still reproduces after the replay fix.
+
+### Verdict
+
+**No seed-1-only first upstream boundary was found.** With the replay bug
+removed, both seeds land on the same comparator verdicts in both bf16 and
+fp32:
+
+- B10: first diverging boundary tap = `h_layer_8` at `0_s0`
+- B11b: all layer-0 GDN sub-ops remain clean (`cos_sim >= 0.95`)
+- B12: late-stack drift first appears at `h_layer_24`, not layer 31
+
+Artifacts:
+
+- `docs/phase-c39/seed0_compare_bf16.txt`
+- `docs/phase-c39/seed0_compare_fp32.txt`
+- `docs/phase-c39/seed1_compare_bf16.txt`
+- `docs/phase-c39/seed1_compare_fp32.txt`
+
+### Recommendation
+
+Do **not** queue another "seed-1-only upstream replay" task from this state.
+C39 turns C38's blocker into a concrete negative result: the seed split does
+not separate at a distinct first B10/B11/B12 boundary on the current build.
+The next narrow task should either:
+
+1. bisect the **shared** early-GDN drift between `h_layer_0` and `h_layer_8`,
+   or
+2. treat the seed-specific behaviour as downstream of this shared `h_main`
+   boundary and move back into acceptance / verification dynamics instead of
+   another replay-contract rerun.
+
 ## Phase 6 post-#412 preflight — tiled recurrent-state retry is obsolete (2026-04-23)
 
 **Scope:** re-check the queued "prototype vLLM-style block-tiled

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1685,6 +1685,7 @@ impl ModelRunner {
 
         let mut base_pos = prompt_tokens.len();
         let mut mtp_pos = 0usize;
+        let mut h_prev_replay_tokens = prompt_tokens.to_vec();
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut draft_accepted_count: usize = 0;
         let mut total_draft_attempts: usize = 0;
@@ -1743,6 +1744,7 @@ impl ModelRunner {
                 &*self.backend,
                 last_token,
                 &h_prev,
+                &h_prev_replay_tokens,
                 &self.weights,
                 &self.config,
                 &mut base_cache,
@@ -1761,9 +1763,17 @@ impl ModelRunner {
             if result.draft_accepted {
                 draft_accepted_count += 1;
             }
+            let mut next_h_prev_replay_tokens = h_prev_replay_tokens.clone();
+            next_h_prev_replay_tokens.push(last_token);
+            if result.draft_accepted {
+                if let Some(&draft_token) = result.accepted_tokens.first() {
+                    next_h_prev_replay_tokens.push(draft_token);
+                }
+            }
             base_pos += result.base_advance;
             mtp_pos += result.mtp_advance;
             h_prev = result.new_h_prev;
+            h_prev_replay_tokens = next_h_prev_replay_tokens;
 
             if result.accepted_tokens.is_empty() {
                 if result.hit_eos {
@@ -2120,6 +2130,7 @@ impl ModelRunner {
 
         let mut base_pos = prompt_tokens.len();
         let mut mtp_pos = 0usize;
+        let mut h_prev_replay_tokens = prompt_tokens.to_vec();
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut finish_reason = FinishReason::MaxTokens;
         let mut rng = match params.seed {
@@ -2164,6 +2175,7 @@ impl ModelRunner {
                 &*self.backend,
                 last_token,
                 &h_prev,
+                &h_prev_replay_tokens,
                 &self.weights,
                 &self.config,
                 &mut base_cache,
@@ -2179,9 +2191,17 @@ impl ModelRunner {
             )
             .context("mtp speculative decode step failed")?;
 
+            let mut next_h_prev_replay_tokens = h_prev_replay_tokens.clone();
+            next_h_prev_replay_tokens.push(last_token);
+            if result.draft_accepted {
+                if let Some(&draft_token) = result.accepted_tokens.first() {
+                    next_h_prev_replay_tokens.push(draft_token);
+                }
+            }
             base_pos += result.base_advance;
             mtp_pos += result.mtp_advance;
             h_prev = result.new_h_prev;
+            h_prev_replay_tokens = next_h_prev_replay_tokens;
 
             if result.accepted_tokens.is_empty() {
                 if result.hit_eos {

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -69,8 +69,17 @@ thread_local! {
     /// serialized alongside the taps (see [`write_mtp_dump`]). The HF
     /// reference (`scripts/mtp_h_main_reference_dump.py`) prefers these
     /// tokens over its canonical greeting, guaranteeing both sides replay
-    /// the exact same prompt during the per-tap bisect.
+    /// the exact same fully-conditioned sequence during the per-tap bisect.
     static H_MAIN_PROMPT_TOKENS: RefCell<Option<Vec<u32>>> =
+        const { RefCell::new(None) };
+
+    /// Optional one-shot override for the replay sequence serialized with the
+    /// next armed h_main capture. When unset, `stash_h_main_prompt_tokens`
+    /// records the local forward-call slice. Native-MTP replay uses this to
+    /// serialize the full conditioned sequence whose final hidden row produced
+    /// the captured `h_main`, rather than only the current `[last_token]` or
+    /// `[last_token, draft_token]` slice.
+    static H_MAIN_PROMPT_TOKENS_OVERRIDE: RefCell<Option<Vec<u32>>> =
         const { RefCell::new(None) };
 
     /// Phase B11b: thread-local sink for layer-0 GDN sub-op taps. Kept
@@ -523,7 +532,16 @@ pub fn stash_h_main_prompt_tokens(tokens: &[u32]) {
     if !is_h_main_capture_armed() {
         return;
     }
-    H_MAIN_PROMPT_TOKENS.with(|c| *c.borrow_mut() = Some(tokens.to_vec()));
+    let replay_tokens = H_MAIN_PROMPT_TOKENS_OVERRIDE
+        .with(|c| c.borrow_mut().take())
+        .unwrap_or_else(|| tokens.to_vec());
+    H_MAIN_PROMPT_TOKENS.with(|c| *c.borrow_mut() = Some(replay_tokens));
+}
+
+/// Override the replay sequence serialized for the next armed h_main
+/// capture. Consumed once by [`stash_h_main_prompt_tokens`].
+pub fn set_h_main_prompt_tokens_override(tokens: &[u32]) {
+    H_MAIN_PROMPT_TOKENS_OVERRIDE.with(|c| *c.borrow_mut() = Some(tokens.to_vec()));
 }
 
 /// Phase B11: drain the stashed prompt tokens. Returns an empty vector when
@@ -1299,15 +1317,16 @@ fn tensor_to_f32_host(t: &Tensor) -> Result<(Vec<usize>, Vec<f32>)> {
 /// trio. These are written under their captured names alongside the
 /// static taps; an empty slice makes this behave identically to Phase B6.
 ///
-/// Phase B11: `prompt_tokens` carries the base-model input token ids from
-/// the forward pass that produced the h_main value (see
-/// [`stash_h_main_prompt_tokens`] / [`drain_h_main_prompt_tokens`]). When
-/// non-empty, it is serialized as a flat I32 tensor named `prompt_tokens`
-/// plus a 1-element I32 scalar `meta__prompt_tokens_len`. The HF reference
+/// Phase B11/C39: `prompt_tokens` carries the fully-conditioned replay
+/// sequence whose final hidden row produced the captured `h_main` value (see
+/// [`stash_h_main_prompt_tokens`] / [`set_h_main_prompt_tokens_override`] /
+/// [`drain_h_main_prompt_tokens`]). When non-empty, it is serialized as a
+/// flat I32 tensor named `prompt_tokens` plus 1-element I32 scalars
+/// `meta__prompt_tokens_len` and `meta__replay_tokens_len`. The HF reference
 /// (`scripts/mtp_h_main_reference_dump.py`) prefers these tokens over its
-/// canonical greeting so both sides replay the exact same prompt during
-/// the per-tap bisect. Pass `&[]` (or legacy callers using `&extra_subops`
-/// before this param) to skip the prompt-tokens emission.
+/// canonical greeting so both sides replay the exact same conditioned
+/// sequence during the per-tap bisect. Pass `&[]` (or legacy callers using
+/// `&extra_subops` before this param) to skip the replay-tokens emission.
 ///
 /// Phase B11b: `b11_taps` carries the layer-0 GDN sub-op taps captured via
 /// [`arm_b11_layer0_capture`] / [`capture_b11_layer0_tap`] /
@@ -1369,9 +1388,10 @@ pub fn write_mtp_dump(
 
     // Materialize every tensor to a host byte buffer first so the
     // TensorViews we build below can borrow from a stable backing store.
-    // Capacity: static taps + subops + 4 meta + optional (prompt_tokens, len)
+    // Capacity: static taps + subops + 4 meta + optional
+    // (prompt_tokens, prompt_len, replay_len)
     // + b11 taps + b12 taps + c6 taps + c7 taps + c14 taps.
-    let prompt_reserve = if prompt_tokens.is_empty() { 0 } else { 2 };
+    let prompt_reserve = if prompt_tokens.is_empty() { 0 } else { 3 };
     let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> = Vec::with_capacity(
         taps.len()
             + extra_subops.len()
@@ -1436,12 +1456,19 @@ pub fn write_mtp_dump(
         swf.to_le_bytes().to_vec(),
     ));
 
-    // Phase B11: serialize the base-model prompt tokens so the HF reference
-    // can replay the exact same input instead of its canonical fallback.
+    // Phase B11/C39: serialize the fully-conditioned replay sequence so the
+    // HF reference can replay the exact same input instead of its canonical
+    // fallback or an under-conditioned local token slice.
     if !prompt_tokens.is_empty() {
         let len_i32 = prompt_tokens.len() as i32;
         backings.push((
             "meta__prompt_tokens_len".into(),
+            vec![1],
+            Dtype::I32,
+            len_i32.to_le_bytes().to_vec(),
+        ));
+        backings.push((
+            "meta__replay_tokens_len".into(),
             vec![1],
             Dtype::I32,
             len_i32.to_le_bytes().to_vec(),
@@ -1904,6 +1931,26 @@ mod tests {
     }
 
     #[test]
+    fn stash_h_main_prompt_tokens_prefers_full_replay_override() {
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_HIDDEN_STATES", "1");
+        }
+        arm_h_main_capture();
+        set_h_main_prompt_tokens_override(&[10, 20, 30, 40, 50]);
+        stash_h_main_prompt_tokens(&[30, 40]);
+        assert_eq!(drain_h_main_prompt_tokens(), vec![10, 20, 30, 40, 50]);
+
+        // The override is one-shot; a second stash falls back to the local slice.
+        stash_h_main_prompt_tokens(&[60, 70]);
+        assert_eq!(drain_h_main_prompt_tokens(), vec![60, 70]);
+
+        let _ = drain_h_main_capture();
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_HIDDEN_STATES");
+        }
+    }
+
+    #[test]
     fn write_mtp_dump_emits_prompt_tokens_when_provided() {
         use safetensors::SafeTensors;
 
@@ -1933,6 +1980,7 @@ mod tests {
         let names: Vec<&str> = st.names().into_iter().map(|s| s.as_str()).collect();
         assert!(names.contains(&"prompt_tokens"));
         assert!(names.contains(&"meta__prompt_tokens_len"));
+        assert!(names.contains(&"meta__replay_tokens_len"));
 
         let pt = st.tensor("prompt_tokens").unwrap();
         assert_eq!(pt.dtype(), safetensors::Dtype::I32);
@@ -1947,6 +1995,12 @@ mod tests {
         assert_eq!(len_meta.dtype(), safetensors::Dtype::I32);
         let len_val = i32::from_le_bytes(len_meta.data()[0..4].try_into().unwrap());
         assert_eq!(len_val, prompt.len() as i32);
+
+        let replay_len_meta = st.tensor("meta__replay_tokens_len").unwrap();
+        assert_eq!(replay_len_meta.dtype(), safetensors::Dtype::I32);
+        let replay_len_val =
+            i32::from_le_bytes(replay_len_meta.data()[0..4].try_into().unwrap());
+        assert_eq!(replay_len_val, prompt.len() as i32);
 
         let _ = std::fs::remove_file(&tmp);
     }
@@ -2000,6 +2054,7 @@ mod tests {
         // should be serialized.
         assert!(!names.contains(&"prompt_tokens"));
         assert!(!names.contains(&"meta__prompt_tokens_len"));
+        assert!(!names.contains(&"meta__replay_tokens_len"));
         // With b11_taps = &[], no b11__* tensors should appear.
         assert!(!names.iter().any(|n| n.starts_with("b11__")));
         // With b12_taps = &[], no b12__* tensors should appear.

--- a/crates/kiln-model/src/speculative.rs
+++ b/crates/kiln-model/src/speculative.rs
@@ -753,6 +753,7 @@ pub fn speculative_mtp_decode_step(
     backend: &dyn BackendRuntime,
     last_token: TokenId,
     h_prev: &Tensor,
+    h_prev_replay_tokens: &[TokenId],
     weights: &GpuWeights,
     config: &ModelConfig,
     base_cache: &mut PagedKvCache,
@@ -806,6 +807,10 @@ pub fn speculative_mtp_decode_step(
         .snapshot_for_decode_rollback()
         .context("snapshot linear attention state before MTP verify")?;
     let verify_input = [last_token, draft_token];
+    let mut verify_replay_tokens = Vec::with_capacity(h_prev_replay_tokens.len() + verify_input.len());
+    verify_replay_tokens.extend_from_slice(h_prev_replay_tokens);
+    verify_replay_tokens.extend_from_slice(&verify_input);
+    crate::mtp_debug::set_h_main_prompt_tokens_override(&verify_replay_tokens);
     let (verify_logits, hidden_after_draft) = model_forward_paged_with_last_hidden(
         backend,
         &verify_input,
@@ -923,6 +928,10 @@ pub fn speculative_mtp_decode_step(
             .restore_from_decode_rollback(&linear_state_snapshot)
             .context("restore linear attention state after MTP rejection")?;
         let verify_input0 = [last_token];
+        let mut replay_tokens = Vec::with_capacity(h_prev_replay_tokens.len() + 1);
+        replay_tokens.extend_from_slice(h_prev_replay_tokens);
+        replay_tokens.push(last_token);
+        crate::mtp_debug::set_h_main_prompt_tokens_override(&replay_tokens);
         let (_verify_logits0, hidden_after_last) = model_forward_paged_with_last_hidden(
             backend,
             &verify_input0,

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -1649,6 +1649,7 @@ fn bench_latency_paged_mtp(
     let mut num_tokens = 1usize; // counting the first token from prefill
     let mut base_pos = actual_prompt_tokens;
     let mut mtp_pos = 0usize;
+    let mut h_prev_replay_tokens = prompt_token_ids.clone();
     let mut draft_accepted_count = 0usize;
     let mut total_draft_attempts = 0usize;
     let params = SamplingParams {
@@ -1678,6 +1679,7 @@ fn bench_latency_paged_mtp(
             &*backend,
             last_token,
             &h_prev,
+            &h_prev_replay_tokens,
             weights,
             config,
             &mut base_cache,
@@ -1703,6 +1705,14 @@ fn bench_latency_paged_mtp(
             draft_accepted_count += 1;
         }
 
+        let mut next_h_prev_replay_tokens = h_prev_replay_tokens.clone();
+        next_h_prev_replay_tokens.push(last_token);
+        if step.draft_accepted {
+            if let Some(&draft_token) = step.accepted_tokens.first() {
+                next_h_prev_replay_tokens.push(draft_token);
+            }
+        }
+
         let per_token_ms = (step_time.as_secs_f64() * 1000.0) / step.accepted_tokens.len() as f64;
         for &_tok in &step.accepted_tokens {
             inter_token_ms.push(per_token_ms);
@@ -1716,6 +1726,7 @@ fn bench_latency_paged_mtp(
         base_pos += step.base_advance;
         mtp_pos += step.mtp_advance;
         h_prev = step.new_h_prev;
+        h_prev_replay_tokens = next_h_prev_replay_tokens;
 
         if step.hit_eos {
             break;

--- a/docs/phase-c39/c39-post423-full-replay-context.md
+++ b/docs/phase-c39/c39-post423-full-replay-context.md
@@ -1,0 +1,111 @@
+# Phase C39 — full replay context for post-#423 seed bisect
+
+**Date:** 2026-04-23  
+**Branch under test:** `ce/phase-c39-full-replay-context` (`906666e` before artifacts)  
+**Hardware:** RunPod `NVIDIA RTX A6000` using `ghcr.io/ericflo/kiln-runpod:latest`
+
+## Goal
+
+Fix the post-#423 replay contract so every B10/B11/B12 dump carries the full
+conditioned token sequence needed for an honest HF replay, then rerun the
+standard native-MTP seed-0 / seed-1 investigation on fresh `main`.
+
+## Validation
+
+Local:
+
+```bash
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+```
+
+Pod:
+
+```bash
+source /root/.kiln-build-env
+export KILN_CUDA_ARCHS=86
+cargo build --release --features cuda --bin kiln-bench
+cargo test -p kiln-model mtp_debug --lib -- --test-threads=1
+python3 -m pip install --upgrade numpy transformers sentencepiece safetensors
+hf download Qwen/Qwen3.5-4B --local-dir /workspace/qwen3.5-4b
+```
+
+Fresh workload rerun and compare generation:
+
+```bash
+KILN_W4A16=1 \
+KILN_CUDA_GRAPHS=true \
+KILN_SPEC_METHOD=mtp \
+KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_SPLICE=1 \
+KILN_MTP_DUMP_SPLICE_POS=0,2 \
+KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 \
+KILN_MTP_DUMP_B11_TAPS=1 \
+KILN_MTP_DUMP_B12_GQA_TAPS=1 \
+KILN_MTP_DUMP_PATH=/workspace/c39-work/seed${seed}_captures/mtp_pos-{pos}/step-{step}.safetensors \
+./target/release/kiln-bench \
+  --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+  --seed ${seed}
+
+python3 scripts/mtp_h_main_reference_dump.py --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump <dump> --out <ref> --device cuda --b11-taps --b12-taps
+python3 scripts/mtp_h_main_reference_dump.py --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump <dump> --out <ref-fp32> --device cuda --b11-taps --b12-taps --fp32
+
+python3 scripts/mtp_compare.py --b10 ...
+python3 scripts/mtp_compare.py --b11 ...
+python3 scripts/mtp_compare.py --b12 ...
+```
+
+## Fresh workload check
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 445.2 | 36.88 | 0.7067 |
+| 1 | 508 | 453.1 | 24.03 | 0.2929 |
+
+The seed split still reproduces on the fixed replay contract.
+
+## Replay-contract result
+
+The dump fix worked. Every captured row now carries the full conditioned
+sequence length instead of collapsing to the local verifier slice:
+
+- seed 0: `494 -> 495 -> 496 -> 497`, then `502 -> 503 -> 504` at `mtp_pos=2`
+- seed 1: `508 -> 509 -> 510 -> 511 -> 512 -> 513 -> 514 -> 515`, then
+  `520 -> 521 -> 522` at `mtp_pos=2`
+
+Source of truth: [replay_lengths.json](./replay_lengths.json)
+
+## Verdict
+
+**The replay bug from PR #423 is fixed, but it does not uncover a seed-1-only
+first upstream boundary or sub-op.**
+
+With fully conditioned HF replays, both seeds land on the same comparator
+verdicts in both bf16 and fp32:
+
+- B10: first diverging boundary tap is `h_layer_8` at `0_s0`
+- B11b: all layer-0 GDN sub-ops stay within `cos_sim >= 0.95`
+- B12: late-stack drift first appears at `h_layer_24`, not layer 31
+
+Artifacts:
+
+- [seed0_compare_bf16.txt](./seed0_compare_bf16.txt)
+- [seed0_compare_fp32.txt](./seed0_compare_fp32.txt)
+- [seed1_compare_bf16.txt](./seed1_compare_bf16.txt)
+- [seed1_compare_fp32.txt](./seed1_compare_fp32.txt)
+- [seed0.bench.json](./seed0.bench.json)
+- [seed1.bench.json](./seed1.bench.json)
+
+## Recommendation
+
+Do not frame the next task as "find the first seed-1-only upstream `h_main`
+boundary" anymore; C39 refutes that route on the current build. The next
+narrow task should either:
+
+1. bisect the shared early-GDN drift between `h_layer_0` and `h_layer_8`, or
+2. treat the seed split as downstream of this shared `h_main` boundary and
+   move the seed-specific audit back into accept/reject dynamics rather than
+   another replay-contract pass.

--- a/docs/phase-c39/replay_lengths.json
+++ b/docs/phase-c39/replay_lengths.json
@@ -1,0 +1,78 @@
+{
+  "seed0": [
+    {
+      "path": "mtp_pos-0/step-0.safetensors",
+      "replay_tokens_len": 494
+    },
+    {
+      "path": "mtp_pos-0/step-1.safetensors",
+      "replay_tokens_len": 495
+    },
+    {
+      "path": "mtp_pos-0/step-2.safetensors",
+      "replay_tokens_len": 496
+    },
+    {
+      "path": "mtp_pos-0/step-3.safetensors",
+      "replay_tokens_len": 497
+    },
+    {
+      "path": "mtp_pos-2/step-0.safetensors",
+      "replay_tokens_len": 502
+    },
+    {
+      "path": "mtp_pos-2/step-1.safetensors",
+      "replay_tokens_len": 503
+    },
+    {
+      "path": "mtp_pos-2/step-2.safetensors",
+      "replay_tokens_len": 504
+    }
+  ],
+  "seed1": [
+    {
+      "path": "mtp_pos-0/step-0.safetensors",
+      "replay_tokens_len": 508
+    },
+    {
+      "path": "mtp_pos-0/step-1.safetensors",
+      "replay_tokens_len": 509
+    },
+    {
+      "path": "mtp_pos-0/step-2.safetensors",
+      "replay_tokens_len": 510
+    },
+    {
+      "path": "mtp_pos-0/step-3.safetensors",
+      "replay_tokens_len": 511
+    },
+    {
+      "path": "mtp_pos-0/step-4.safetensors",
+      "replay_tokens_len": 512
+    },
+    {
+      "path": "mtp_pos-0/step-5.safetensors",
+      "replay_tokens_len": 513
+    },
+    {
+      "path": "mtp_pos-0/step-6.safetensors",
+      "replay_tokens_len": 514
+    },
+    {
+      "path": "mtp_pos-0/step-7.safetensors",
+      "replay_tokens_len": 515
+    },
+    {
+      "path": "mtp_pos-2/step-0.safetensors",
+      "replay_tokens_len": 520
+    },
+    {
+      "path": "mtp_pos-2/step-1.safetensors",
+      "replay_tokens_len": 521
+    },
+    {
+      "path": "mtp_pos-2/step-2.safetensors",
+      "replay_tokens_len": 522
+    }
+  ]
+}

--- a/docs/phase-c39/seed0.bench.json
+++ b/docs/phase-c39/seed0.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 18.885584796,
+    "model_vram_mb": 17527
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 494,
+      "output_tokens": 128,
+      "total_time_secs": 2.986810681,
+      "tokens_per_sec": 42.85507642457771,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 494,
+      "output_tokens": 512,
+      "total_time_secs": 11.708715931,
+      "tokens_per_sec": 43.728108446497416,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 494,
+      "output_tokens": 1024,
+      "total_time_secs": 23.650799104,
+      "tokens_per_sec": 43.29663431231858,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 494,
+      "output_tokens": 2048,
+      "total_time_secs": 46.735294883,
+      "tokens_per_sec": 43.82127052214153,
+      "peak_vram_mb": 17832
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 445.229688,
+    "prefill_tokens_per_sec": 1109.5396675344793,
+    "time_to_first_token_ms": 445.229688,
+    "mean_inter_token_ms": 27.112282031496065,
+    "p50_inter_token_ms": 18.407569499999997,
+    "p99_inter_token_ms": 62.046114,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 36.88365290823952,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7066666666666667,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/docs/phase-c39/seed0_compare_bf16.txt
+++ b/docs/phase-c39/seed0_compare_bf16.txt
@@ -1,0 +1,1310 @@
+# seed 0 compare vs bf16 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.56e-02     7.56e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   1.04e-01     1.92e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   3.12e-01     4.20e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   5.62e-01     7.33e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.51e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.91e-03     2.32e-08    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   1.56e-02     5.89e-07    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.23e-02     8.21e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.83e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   3.91e-03     9.98e-05    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   3.91e-03     8.86e-04    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.55e-02     7.69e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   7.81e-03     4.22e-06    
+b11__gdn_gated_norm    1x494x4096             True     True     1.00e+00   2.34e-02     5.05e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.56e-02     6.47e-05    
+h_layer_24             1x1x2560               True     False    9.84e-01   5.00e-01     7.64e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   5.39e-01     7.79e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   5.55e-01     8.31e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   5.62e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   5.61e-01     1.20e-01    
+h_layer_29             1x1x2560               True     False    9.85e-01   5.94e-01     1.33e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.56e-01     1.60e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   1.56e-01     1.66e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   1.56e-01     3.45e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.25e+00     6.05e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.95e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.06e+00     6.33e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.50e-01     6.48e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.12e-01     6.89e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.33e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   5.27e-01     1.11e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.33e-01     1.25e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   8.12e-01     1.46e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.69e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.88e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   1.84e-01     3.13e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   5.00e-01     5.35e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.61e+01     1.43e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   4.22e-01     5.43e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.53e-01     5.70e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   9.38e-01     6.04e-02    
+h_layer_27             1x1x2560               True     False    9.90e-01   6.25e-01     8.91e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   6.25e-01     1.03e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.56e-01     1.14e-01    
+h_layer_30             1x1x2560               True     False    9.87e-01   1.38e+00     1.36e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.90e-01   1.88e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   4.06e-01     3.28e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   5.00e-01     6.24e-02    
+h_layer_31             1x1x2560               True     False    9.26e-01   1.62e+01     1.22e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   5.00e-01     6.34e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   6.25e-01     6.63e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   4.38e-01     6.85e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   7.50e-01     9.48e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.00e+00     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   8.75e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   6.17e-01     1.40e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.91e-03     6.12e-04    
+h_layer_8              1x1x2560               True     False    8.23e-01   3.30e-01     5.04e-02    
+h_layer_16             1x1x2560               True     False    6.36e-01   9.69e-01     1.27e-01    
+h_layer_23             1x1x2560               True     False    2.31e-01   7.58e+00     4.11e-01    
+h_layer_31             1x1x2560               True     False    6.57e-01   2.73e+01     1.84e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.31e-01   6.41e+00     4.26e-01    
+h_layer_25             1x1x2560               True     False    2.35e-01   6.34e+00     4.25e-01    
+h_layer_26             1x1x2560               True     False    1.70e-01   1.10e+01     4.44e-01    
+h_layer_27             1x1x2560               True     False    2.48e-01   1.04e+01     5.26e-01    
+h_layer_28             1x1x2560               True     False    3.76e-01   1.21e+01     5.76e-01    
+h_layer_29             1x1x2560               True     False    4.52e-01   9.31e+00     6.40e-01    
+h_layer_30             1x1x2560               True     False    5.00e-01   1.16e+01     6.97e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.77e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   2.81e-01     1.80e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   4.06e-01     4.35e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.69e-01     7.59e-02    
+h_layer_31             1x1x2560               True     False    9.37e-01   1.86e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   4.59e-01     7.97e-02    
+h_layer_25             1x1x2560               True     False    9.82e-01   5.12e-01     8.86e-02    
+h_layer_26             1x1x2560               True     False    9.76e-01   5.41e-01     1.01e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.71e-01     1.28e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.25e+00     1.47e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   7.50e-01     1.64e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   8.28e-01     1.95e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.57e-03     1.89e-03    
+h_layer_8              1x1x2560               True     False    9.84e-01   3.44e-01     1.80e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   4.06e-01     4.35e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   4.61e-01     7.46e-02    
+h_layer_31             1x1x2560               True     False    9.16e-01   2.08e+01     1.20e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   5.04e-01     7.73e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   4.92e-01     7.90e-02    
+h_layer_26             1x1x2560               True     False    9.80e-01   5.53e-01     8.34e-02    
+h_layer_27             1x1x2560               True     False    9.77e-01   5.92e-01     1.35e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   5.73e-01     1.24e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   7.03e-01     1.42e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   8.44e-01     1.70e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=7.69e-03   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=1.00e+00   max|Δ|=3.91e-03   ok    cos=9.99e-01   max|Δ|=9.77e-03   ok    cos=9.99e-01   max|Δ|=7.57e-03   ok   
+  h_layer_8             cos=9.80e-01   max|Δ|=1.04e-01   DIV   cos=9.87e-01   max|Δ|=1.56e-01   DIV   cos=9.88e-01   max|Δ|=1.88e-01   DIV   cos=9.90e-01   max|Δ|=1.88e-01   DIV   cos=8.23e-01   max|Δ|=3.30e-01   DIV   cos=9.87e-01   max|Δ|=2.81e-01   DIV   cos=9.84e-01   max|Δ|=3.44e-01   DIV  
+  h_layer_16            cos=9.66e-01   max|Δ|=3.12e-01   DIV   cos=9.79e-01   max|Δ|=1.56e-01   DIV   cos=9.85e-01   max|Δ|=1.84e-01   DIV   cos=9.83e-01   max|Δ|=4.06e-01   DIV   cos=6.36e-01   max|Δ|=9.69e-01   DIV   cos=9.72e-01   max|Δ|=4.06e-01   DIV   cos=9.72e-01   max|Δ|=4.06e-01   DIV  
+  h_layer_23            cos=9.82e-01   max|Δ|=5.62e-01   DIV   cos=9.88e-01   max|Δ|=1.25e+00   DIV   cos=9.92e-01   max|Δ|=5.00e-01   DIV   cos=9.89e-01   max|Δ|=5.00e-01   DIV   cos=2.31e-01   max|Δ|=7.58e+00   DIV   cos=9.82e-01   max|Δ|=4.69e-01   DIV   cos=9.83e-01   max|Δ|=4.61e-01   DIV  
+  h_layer_31            cos=9.57e-01   max|Δ|=2.51e+01   DIV   cos=9.66e-01   max|Δ|=1.95e+01   DIV   cos=9.71e-01   max|Δ|=1.61e+01   DIV   cos=9.26e-01   max|Δ|=1.62e+01   DIV   cos=6.57e-01   max|Δ|=2.73e+01   DIV   cos=9.37e-01   max|Δ|=1.86e+01   DIV   cos=9.16e-01   max|Δ|=2.08e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_8' (pos=0_s0)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK
+  -> The first bad transformer block lies between h_layer_0
+     and h_layer_8. Narrow by capturing intermediate layers
+     (e.g. layers 4 and 12) and re-running B10 on the new dump.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.56e-02     7.56e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   1.04e-01     1.92e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   3.12e-01     4.20e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   5.62e-01     7.33e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.51e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.91e-03     2.32e-08    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   1.56e-02     5.89e-07    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.23e-02     8.21e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.83e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   3.91e-03     9.98e-05    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   3.91e-03     8.86e-04    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.55e-02     7.69e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   7.81e-03     4.22e-06    
+b11__gdn_gated_norm    1x494x4096             True     True     1.00e+00   2.34e-02     5.05e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.56e-02     6.47e-05    
+h_layer_24             1x1x2560               True     False    9.84e-01   5.00e-01     7.64e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   5.39e-01     7.79e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   5.55e-01     8.31e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   5.62e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   5.61e-01     1.20e-01    
+h_layer_29             1x1x2560               True     False    9.85e-01   5.94e-01     1.33e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.56e-01     1.60e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   1.56e-01     1.66e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   1.56e-01     3.45e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.25e+00     6.05e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.95e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.06e+00     6.33e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.50e-01     6.48e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.12e-01     6.89e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.33e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   5.27e-01     1.11e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.33e-01     1.25e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   8.12e-01     1.46e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.69e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.88e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   1.84e-01     3.13e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   5.00e-01     5.35e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.61e+01     1.43e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   4.22e-01     5.43e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.53e-01     5.70e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   9.38e-01     6.04e-02    
+h_layer_27             1x1x2560               True     False    9.90e-01   6.25e-01     8.91e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   6.25e-01     1.03e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.56e-01     1.14e-01    
+h_layer_30             1x1x2560               True     False    9.87e-01   1.38e+00     1.36e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.90e-01   1.88e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   4.06e-01     3.28e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   5.00e-01     6.24e-02    
+h_layer_31             1x1x2560               True     False    9.26e-01   1.62e+01     1.22e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   5.00e-01     6.34e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   6.25e-01     6.63e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   4.38e-01     6.85e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   7.50e-01     9.48e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.00e+00     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   8.75e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   6.17e-01     1.40e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.91e-03     6.12e-04    
+h_layer_8              1x1x2560               True     False    8.23e-01   3.30e-01     5.04e-02    
+h_layer_16             1x1x2560               True     False    6.36e-01   9.69e-01     1.27e-01    
+h_layer_23             1x1x2560               True     False    2.31e-01   7.58e+00     4.11e-01    
+h_layer_31             1x1x2560               True     False    6.57e-01   2.73e+01     1.84e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.31e-01   6.41e+00     4.26e-01    
+h_layer_25             1x1x2560               True     False    2.35e-01   6.34e+00     4.25e-01    
+h_layer_26             1x1x2560               True     False    1.70e-01   1.10e+01     4.44e-01    
+h_layer_27             1x1x2560               True     False    2.48e-01   1.04e+01     5.26e-01    
+h_layer_28             1x1x2560               True     False    3.76e-01   1.21e+01     5.76e-01    
+h_layer_29             1x1x2560               True     False    4.52e-01   9.31e+00     6.40e-01    
+h_layer_30             1x1x2560               True     False    5.00e-01   1.16e+01     6.97e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.77e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   2.81e-01     1.80e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   4.06e-01     4.35e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.69e-01     7.59e-02    
+h_layer_31             1x1x2560               True     False    9.37e-01   1.86e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   4.59e-01     7.97e-02    
+h_layer_25             1x1x2560               True     False    9.82e-01   5.12e-01     8.86e-02    
+h_layer_26             1x1x2560               True     False    9.76e-01   5.41e-01     1.01e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.71e-01     1.28e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.25e+00     1.47e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   7.50e-01     1.64e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   8.28e-01     1.95e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.57e-03     1.89e-03    
+h_layer_8              1x1x2560               True     False    9.84e-01   3.44e-01     1.80e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   4.06e-01     4.35e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   4.61e-01     7.46e-02    
+h_layer_31             1x1x2560               True     False    9.16e-01   2.08e+01     1.20e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   5.04e-01     7.73e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   4.92e-01     7.90e-02    
+h_layer_26             1x1x2560               True     False    9.80e-01   5.53e-01     8.34e-02    
+h_layer_27             1x1x2560               True     False    9.77e-01   5.92e-01     1.35e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   5.73e-01     1.24e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   7.03e-01     1.42e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   8.44e-01     1.70e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=2.32e-08   rel_l2=7.56e-06   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_in_proj               cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=5.89e-07   rel_l2=3.73e-05   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_conv                  cos=1.00e+00   max|Δ|=6.23e-02   mean|Δ|=8.21e-05   rel_l2=2.27e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.83e-01   mean|Δ|=4.04e-02   rel_l2=9.12e-01   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.98e-05   rel_l2=3.20e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=8.86e-04   rel_l2=2.98e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_g                cos=1.00e+00   max|Δ|=1.55e-02   mean|Δ|=7.69e-04   rel_l2=1.65e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_recur_out             cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=4.22e-06   rel_l2=4.44e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=2.34e-02   mean|Δ|=5.05e-05   rel_l2=5.04e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=6.47e-05   rel_l2=2.88e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+Phase B11b verdict: ALL layer-0 GDN sub-ops match within cos_sim >= 0.95.
+  -> Divergence is NOT localized inside layer 0's GDN block at this bar.
+  -> Re-check B10 atol/rtol and consider extending taps to layers 1-7
+     (GDN stack) before committing to a B12 target.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.56e-02     7.56e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   1.04e-01     1.92e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   3.12e-01     4.20e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   5.62e-01     7.33e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.51e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.91e-03     2.32e-08    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   1.56e-02     5.89e-07    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.23e-02     8.21e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.83e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   3.91e-03     9.98e-05    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   3.91e-03     8.86e-04    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.55e-02     7.69e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   7.81e-03     4.22e-06    
+b11__gdn_gated_norm    1x494x4096             True     True     1.00e+00   2.34e-02     5.05e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.56e-02     6.47e-05    
+h_layer_24             1x1x2560               True     False    9.84e-01   5.00e-01     7.64e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   5.39e-01     7.79e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   5.55e-01     8.31e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   5.62e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   5.61e-01     1.20e-01    
+h_layer_29             1x1x2560               True     False    9.85e-01   5.94e-01     1.33e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.56e-01     1.60e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   1.56e-01     1.66e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   1.56e-01     3.45e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.25e+00     6.05e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.95e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.06e+00     6.33e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.50e-01     6.48e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.12e-01     6.89e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.33e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   5.27e-01     1.11e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.33e-01     1.25e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   8.12e-01     1.46e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.69e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.88e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   1.84e-01     3.13e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   5.00e-01     5.35e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.61e+01     1.43e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   4.22e-01     5.43e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.53e-01     5.70e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   9.38e-01     6.04e-02    
+h_layer_27             1x1x2560               True     False    9.90e-01   6.25e-01     8.91e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   6.25e-01     1.03e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.56e-01     1.14e-01    
+h_layer_30             1x1x2560               True     False    9.87e-01   1.38e+00     1.36e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.90e-01   1.88e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   4.06e-01     3.28e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   5.00e-01     6.24e-02    
+h_layer_31             1x1x2560               True     False    9.26e-01   1.62e+01     1.22e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   5.00e-01     6.34e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   6.25e-01     6.63e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   4.38e-01     6.85e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   7.50e-01     9.48e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.00e+00     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   8.75e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   6.17e-01     1.40e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.91e-03     6.12e-04    
+h_layer_8              1x1x2560               True     False    8.23e-01   3.30e-01     5.04e-02    
+h_layer_16             1x1x2560               True     False    6.36e-01   9.69e-01     1.27e-01    
+h_layer_23             1x1x2560               True     False    2.31e-01   7.58e+00     4.11e-01    
+h_layer_31             1x1x2560               True     False    6.57e-01   2.73e+01     1.84e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.31e-01   6.41e+00     4.26e-01    
+h_layer_25             1x1x2560               True     False    2.35e-01   6.34e+00     4.25e-01    
+h_layer_26             1x1x2560               True     False    1.70e-01   1.10e+01     4.44e-01    
+h_layer_27             1x1x2560               True     False    2.48e-01   1.04e+01     5.26e-01    
+h_layer_28             1x1x2560               True     False    3.76e-01   1.21e+01     5.76e-01    
+h_layer_29             1x1x2560               True     False    4.52e-01   9.31e+00     6.40e-01    
+h_layer_30             1x1x2560               True     False    5.00e-01   1.16e+01     6.97e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.77e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   2.81e-01     1.80e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   4.06e-01     4.35e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.69e-01     7.59e-02    
+h_layer_31             1x1x2560               True     False    9.37e-01   1.86e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   4.59e-01     7.97e-02    
+h_layer_25             1x1x2560               True     False    9.82e-01   5.12e-01     8.86e-02    
+h_layer_26             1x1x2560               True     False    9.76e-01   5.41e-01     1.01e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.71e-01     1.28e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.25e+00     1.47e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   7.50e-01     1.64e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   8.28e-01     1.95e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.57e-03     1.89e-03    
+h_layer_8              1x1x2560               True     False    9.84e-01   3.44e-01     1.80e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   4.06e-01     4.35e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   4.61e-01     7.46e-02    
+h_layer_31             1x1x2560               True     False    9.16e-01   2.08e+01     1.20e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   5.04e-01     7.73e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   4.92e-01     7.90e-02    
+h_layer_26             1x1x2560               True     False    9.80e-01   5.53e-01     8.34e-02    
+h_layer_27             1x1x2560               True     False    9.77e-01   5.92e-01     1.35e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   5.73e-01     1.24e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   7.03e-01     1.42e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   8.44e-01     1.70e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.84e-01   max|Δ|=5.00e-01   DIV   cos=9.89e-01   max|Δ|=1.06e+00   DIV   cos=9.92e-01   max|Δ|=4.22e-01   DIV   cos=9.90e-01   max|Δ|=5.00e-01   DIV   cos=2.31e-01   max|Δ|=6.41e+00   DIV   cos=9.83e-01   max|Δ|=4.59e-01   DIV   cos=9.85e-01   max|Δ|=5.04e-01   DIV  
+  h_layer_25            cos=9.85e-01   max|Δ|=5.39e-01   DIV   cos=9.90e-01   max|Δ|=7.50e-01   DIV   cos=9.92e-01   max|Δ|=4.53e-01   DIV   cos=9.90e-01   max|Δ|=6.25e-01   DIV   cos=2.35e-01   max|Δ|=6.34e+00   DIV   cos=9.82e-01   max|Δ|=5.12e-01   DIV   cos=9.86e-01   max|Δ|=4.92e-01   DIV  
+  h_layer_26            cos=9.85e-01   max|Δ|=5.55e-01   DIV   cos=9.88e-01   max|Δ|=5.12e-01   DIV   cos=9.90e-01   max|Δ|=9.38e-01   DIV   cos=9.88e-01   max|Δ|=4.38e-01   DIV   cos=1.70e-01   max|Δ|=1.10e+01   DIV   cos=9.76e-01   max|Δ|=5.41e-01   DIV   cos=9.80e-01   max|Δ|=5.53e-01   DIV  
+  h_layer_27            cos=9.86e-01   max|Δ|=5.62e-01   DIV   cos=9.89e-01   max|Δ|=5.33e-01   DIV   cos=9.90e-01   max|Δ|=6.25e-01   DIV   cos=9.88e-01   max|Δ|=7.50e-01   DIV   cos=2.48e-01   max|Δ|=1.04e+01   DIV   cos=9.81e-01   max|Δ|=6.71e-01   DIV   cos=9.77e-01   max|Δ|=5.92e-01   DIV  
+  h_layer_28            cos=9.86e-01   max|Δ|=5.61e-01   DIV   cos=9.89e-01   max|Δ|=5.27e-01   DIV   cos=9.90e-01   max|Δ|=6.25e-01   DIV   cos=9.88e-01   max|Δ|=1.00e+00   DIV   cos=3.76e-01   max|Δ|=1.21e+01   DIV   cos=9.81e-01   max|Δ|=1.25e+00   DIV   cos=9.83e-01   max|Δ|=5.73e-01   DIV  
+  h_layer_29            cos=9.85e-01   max|Δ|=5.94e-01   DIV   cos=9.88e-01   max|Δ|=5.33e-01   DIV   cos=9.90e-01   max|Δ|=6.56e-01   DIV   cos=9.88e-01   max|Δ|=8.75e-01   DIV   cos=4.52e-01   max|Δ|=9.31e+00   DIV   cos=9.82e-01   max|Δ|=7.50e-01   DIV   cos=9.83e-01   max|Δ|=7.03e-01   DIV  
+  h_layer_30            cos=9.82e-01   max|Δ|=6.56e-01   DIV   cos=9.84e-01   max|Δ|=8.12e-01   DIV   cos=9.87e-01   max|Δ|=1.38e+00   DIV   cos=9.84e-01   max|Δ|=6.17e-01   DIV   cos=5.00e-01   max|Δ|=1.16e+01   DIV   cos=9.76e-01   max|Δ|=8.28e-01   DIV   cos=9.77e-01   max|Δ|=8.44e-01   DIV  
+  h_layer_31            cos=9.57e-01   max|Δ|=2.51e+01   DIV   cos=9.66e-01   max|Δ|=1.95e+01   DIV   cos=9.71e-01   max|Δ|=1.61e+01   DIV   cos=9.26e-01   max|Δ|=1.62e+01   DIV   cos=6.57e-01   max|Δ|=2.73e+01   DIV   cos=9.37e-01   max|Δ|=1.86e+01   DIV   cos=9.16e-01   max|Δ|=2.08e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=9.85e-01     DIV
+    h_layer_25             median=9.86e-01     DIV
+    h_layer_26             median=9.85e-01     DIV
+    h_layer_27             median=9.86e-01     DIV
+    h_layer_28             median=9.86e-01     DIV
+    h_layer_29             median=9.85e-01     DIV
+    h_layer_30             median=9.82e-01     DIV
+    h_layer_31             median=9.37e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  q_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  k_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  v_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_q           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_k           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV <missing>                                            <missing>                                           
+  post_attn_norm      <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_gate            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_up              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_down            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=nan          DIV
+    q_proj               median=nan          DIV
+    k_proj               median=nan          DIV
+    v_proj               median=nan          DIV
+    qk_norm_q            median=nan          DIV
+    qk_norm_k            median=nan          DIV
+    o_proj               median=nan          DIV
+    post_attn_norm       median=nan          DIV
+    mlp_gate             median=nan          DIV
+    mlp_up               median=nan          DIV
+    mlp_down             median=nan          DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.984684)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/docs/phase-c39/seed0_compare_fp32.txt
+++ b/docs/phase-c39/seed0_compare_fp32.txt
@@ -1,0 +1,1310 @@
+# seed 0 compare vs fp32 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   2.06e-02     7.53e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   1.01e-01     1.91e-02    
+h_layer_16             1x1x2560               True     False    9.67e-01   2.79e-01     4.18e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   5.42e-01     7.33e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.52e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.00e-02     1.28e-03    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   6.66e-02     1.77e-03    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.20e-02     7.08e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.84e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   5.43e-03     1.33e-04    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   5.42e-03     1.20e-03    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   2.23e-02     8.42e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   6.05e-03     3.71e-06    
+b11__gdn_gated_norm    1x494x4096             True     False    1.00e+00   1.94e-02     5.09e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.20e-02     6.01e-05    
+h_layer_24             1x1x2560               True     False    9.84e-01   5.10e-01     7.65e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   5.42e-01     7.78e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   5.57e-01     8.34e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   5.66e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.85e-01   5.63e-01     1.20e-01    
+h_layer_29             1x1x2560               True     False    9.85e-01   6.28e-01     1.34e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   6.68e-01     1.61e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.82e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.87e-01     1.66e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   1.59e-01     3.43e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.21e+00     6.06e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.93e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.07e+00     6.36e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.16e-01     6.51e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.25e-01     6.93e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.50e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   5.43e-01     1.12e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.54e-01     1.26e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   8.43e-01     1.47e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.63e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   2.18e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   1.85e-01     3.13e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   4.01e-01     5.32e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.61e+01     1.44e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   4.11e-01     5.42e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.24e-01     5.65e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   1.03e+00     6.01e-02    
+h_layer_27             1x1x2560               True     False    9.90e-01   6.12e-01     8.96e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   6.14e-01     1.03e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.69e-01     1.15e-01    
+h_layer_30             1x1x2560               True     False    9.86e-01   1.37e+00     1.36e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.41e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.90e-01   2.12e-01     1.60e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   3.75e-01     3.22e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   4.87e-01     6.20e-02    
+h_layer_31             1x1x2560               True     False    9.25e-01   1.64e+01     1.23e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   5.69e-01     6.33e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.74e-01     6.59e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   4.04e-01     6.82e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   1.04e+00     9.49e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.28e+00     1.07e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   1.02e+00     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   6.38e-01     1.39e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.68e-03     6.11e-04    
+h_layer_8              1x1x2560               True     False    8.07e-01   3.57e-01     5.27e-02    
+h_layer_16             1x1x2560               True     False    5.06e-01   1.48e+00     1.44e-01    
+h_layer_23             1x1x2560               True     False    1.71e-01   4.35e+00     4.30e-01    
+h_layer_31             1x1x2560               True     False    6.54e-01   2.94e+01     1.83e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    1.73e-01   4.50e+00     4.46e-01    
+h_layer_25             1x1x2560               True     False    1.81e-01   3.89e+00     4.48e-01    
+h_layer_26             1x1x2560               True     False    1.39e-01   7.55e+00     4.66e-01    
+h_layer_27             1x1x2560               True     False    1.97e-01   4.11e+00     5.41e-01    
+h_layer_28             1x1x2560               True     False    3.24e-01   7.98e+00     6.02e-01    
+h_layer_29             1x1x2560               True     False    4.08e-01   4.32e+00     6.60e-01    
+h_layer_30             1x1x2560               True     False    4.80e-01   9.65e+00     7.24e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.45e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   2.32e-01     1.80e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   3.62e-01     4.27e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.72e-01     7.61e-02    
+h_layer_31             1x1x2560               True     False    9.35e-01   1.87e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   4.46e-01     7.95e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   5.22e-01     8.89e-02    
+h_layer_26             1x1x2560               True     False    9.76e-01   6.09e-01     1.00e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   5.90e-01     1.29e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   1.17e+00     1.51e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   7.08e-01     1.68e-01    
+h_layer_30             1x1x2560               True     False    9.74e-01   8.87e-01     2.02e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.65e-03     1.91e-03    
+h_layer_8              1x1x2560               True     False    9.84e-01   3.14e-01     1.81e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   3.87e-01     4.40e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   4.64e-01     7.42e-02    
+h_layer_31             1x1x2560               True     False    9.14e-01   2.14e+01     1.21e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   5.15e-01     7.69e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   5.01e-01     7.88e-02    
+h_layer_26             1x1x2560               True     False    9.80e-01   6.49e-01     8.28e-02    
+h_layer_27             1x1x2560               True     False    9.80e-01   5.59e-01     1.26e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   5.80e-01     1.23e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.57e-01     1.42e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   8.40e-01     1.71e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=2.06e-02   ok    cos=9.99e-01   max|Δ|=1.82e-02   ok    cos=9.99e-01   max|Δ|=7.63e-03   ok    cos=9.99e-01   max|Δ|=2.41e-02   ok    cos=1.00e+00   max|Δ|=3.68e-03   ok    cos=9.99e-01   max|Δ|=9.45e-03   ok    cos=9.99e-01   max|Δ|=7.65e-03   ok   
+  h_layer_8             cos=9.80e-01   max|Δ|=1.01e-01   DIV   cos=9.88e-01   max|Δ|=1.87e-01   DIV   cos=9.88e-01   max|Δ|=2.18e-01   DIV   cos=9.90e-01   max|Δ|=2.12e-01   DIV   cos=8.07e-01   max|Δ|=3.57e-01   DIV   cos=9.87e-01   max|Δ|=2.32e-01   DIV   cos=9.84e-01   max|Δ|=3.14e-01   DIV  
+  h_layer_16            cos=9.67e-01   max|Δ|=2.79e-01   DIV   cos=9.79e-01   max|Δ|=1.59e-01   DIV   cos=9.85e-01   max|Δ|=1.85e-01   DIV   cos=9.84e-01   max|Δ|=3.75e-01   DIV   cos=5.06e-01   max|Δ|=1.48e+00   DIV   cos=9.73e-01   max|Δ|=3.62e-01   DIV   cos=9.72e-01   max|Δ|=3.87e-01   DIV  
+  h_layer_23            cos=9.82e-01   max|Δ|=5.42e-01   DIV   cos=9.88e-01   max|Δ|=1.21e+00   DIV   cos=9.92e-01   max|Δ|=4.01e-01   DIV   cos=9.89e-01   max|Δ|=4.87e-01   DIV   cos=1.71e-01   max|Δ|=4.35e+00   DIV   cos=9.82e-01   max|Δ|=4.72e-01   DIV   cos=9.83e-01   max|Δ|=4.64e-01   DIV  
+  h_layer_31            cos=9.57e-01   max|Δ|=2.52e+01   DIV   cos=9.66e-01   max|Δ|=1.93e+01   DIV   cos=9.71e-01   max|Δ|=1.61e+01   DIV   cos=9.25e-01   max|Δ|=1.64e+01   DIV   cos=6.54e-01   max|Δ|=2.94e+01   DIV   cos=9.35e-01   max|Δ|=1.87e+01   DIV   cos=9.14e-01   max|Δ|=2.14e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_8' (pos=0_s0)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK
+  -> The first bad transformer block lies between h_layer_0
+     and h_layer_8. Narrow by capturing intermediate layers
+     (e.g. layers 4 and 12) and re-running B10 on the new dump.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   2.06e-02     7.53e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   1.01e-01     1.91e-02    
+h_layer_16             1x1x2560               True     False    9.67e-01   2.79e-01     4.18e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   5.42e-01     7.33e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.52e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.00e-02     1.28e-03    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   6.66e-02     1.77e-03    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.20e-02     7.08e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.84e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   5.43e-03     1.33e-04    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   5.42e-03     1.20e-03    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   2.23e-02     8.42e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   6.05e-03     3.71e-06    
+b11__gdn_gated_norm    1x494x4096             True     False    1.00e+00   1.94e-02     5.09e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.20e-02     6.01e-05    
+h_layer_24             1x1x2560               True     False    9.84e-01   5.10e-01     7.65e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   5.42e-01     7.78e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   5.57e-01     8.34e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   5.66e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.85e-01   5.63e-01     1.20e-01    
+h_layer_29             1x1x2560               True     False    9.85e-01   6.28e-01     1.34e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   6.68e-01     1.61e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.82e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.87e-01     1.66e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   1.59e-01     3.43e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.21e+00     6.06e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.93e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.07e+00     6.36e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.16e-01     6.51e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.25e-01     6.93e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.50e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   5.43e-01     1.12e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.54e-01     1.26e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   8.43e-01     1.47e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.63e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   2.18e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   1.85e-01     3.13e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   4.01e-01     5.32e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.61e+01     1.44e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   4.11e-01     5.42e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.24e-01     5.65e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   1.03e+00     6.01e-02    
+h_layer_27             1x1x2560               True     False    9.90e-01   6.12e-01     8.96e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   6.14e-01     1.03e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.69e-01     1.15e-01    
+h_layer_30             1x1x2560               True     False    9.86e-01   1.37e+00     1.36e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.41e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.90e-01   2.12e-01     1.60e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   3.75e-01     3.22e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   4.87e-01     6.20e-02    
+h_layer_31             1x1x2560               True     False    9.25e-01   1.64e+01     1.23e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   5.69e-01     6.33e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.74e-01     6.59e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   4.04e-01     6.82e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   1.04e+00     9.49e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.28e+00     1.07e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   1.02e+00     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   6.38e-01     1.39e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.68e-03     6.11e-04    
+h_layer_8              1x1x2560               True     False    8.07e-01   3.57e-01     5.27e-02    
+h_layer_16             1x1x2560               True     False    5.06e-01   1.48e+00     1.44e-01    
+h_layer_23             1x1x2560               True     False    1.71e-01   4.35e+00     4.30e-01    
+h_layer_31             1x1x2560               True     False    6.54e-01   2.94e+01     1.83e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    1.73e-01   4.50e+00     4.46e-01    
+h_layer_25             1x1x2560               True     False    1.81e-01   3.89e+00     4.48e-01    
+h_layer_26             1x1x2560               True     False    1.39e-01   7.55e+00     4.66e-01    
+h_layer_27             1x1x2560               True     False    1.97e-01   4.11e+00     5.41e-01    
+h_layer_28             1x1x2560               True     False    3.24e-01   7.98e+00     6.02e-01    
+h_layer_29             1x1x2560               True     False    4.08e-01   4.32e+00     6.60e-01    
+h_layer_30             1x1x2560               True     False    4.80e-01   9.65e+00     7.24e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.45e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   2.32e-01     1.80e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   3.62e-01     4.27e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.72e-01     7.61e-02    
+h_layer_31             1x1x2560               True     False    9.35e-01   1.87e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   4.46e-01     7.95e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   5.22e-01     8.89e-02    
+h_layer_26             1x1x2560               True     False    9.76e-01   6.09e-01     1.00e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   5.90e-01     1.29e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   1.17e+00     1.51e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   7.08e-01     1.68e-01    
+h_layer_30             1x1x2560               True     False    9.74e-01   8.87e-01     2.02e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.65e-03     1.91e-03    
+h_layer_8              1x1x2560               True     False    9.84e-01   3.14e-01     1.81e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   3.87e-01     4.40e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   4.64e-01     7.42e-02    
+h_layer_31             1x1x2560               True     False    9.14e-01   2.14e+01     1.21e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   5.15e-01     7.69e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   5.01e-01     7.88e-02    
+h_layer_26             1x1x2560               True     False    9.80e-01   6.49e-01     8.28e-02    
+h_layer_27             1x1x2560               True     False    9.80e-01   5.59e-01     1.26e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   5.80e-01     1.23e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.57e-01     1.42e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   8.40e-01     1.71e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.00e-02   mean|Δ|=1.28e-03   rel_l2=1.65e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_in_proj               cos=1.00e+00   max|Δ|=6.66e-02   mean|Δ|=1.77e-03   rel_l2=1.95e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_conv                  cos=1.00e+00   max|Δ|=6.20e-02   mean|Δ|=7.08e-05   rel_l2=1.58e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.84e-01   mean|Δ|=4.04e-02   rel_l2=9.12e-01   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=5.43e-03   mean|Δ|=1.33e-04   rel_l2=2.69e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=5.42e-03   mean|Δ|=1.20e-03   rel_l2=2.76e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_g                cos=1.00e+00   max|Δ|=2.23e-02   mean|Δ|=8.42e-04   rel_l2=1.80e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_recur_out             cos=1.00e+00   max|Δ|=6.05e-03   mean|Δ|=3.71e-06   rel_l2=3.35e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=1.94e-02   mean|Δ|=5.09e-05   rel_l2=4.18e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.20e-02   mean|Δ|=6.01e-05   rel_l2=2.42e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+Phase B11b verdict: ALL layer-0 GDN sub-ops match within cos_sim >= 0.95.
+  -> Divergence is NOT localized inside layer 0's GDN block at this bar.
+  -> Re-check B10 atol/rtol and consider extending taps to layers 1-7
+     (GDN stack) before committing to a B12 target.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   2.06e-02     7.53e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   1.01e-01     1.91e-02    
+h_layer_16             1x1x2560               True     False    9.67e-01   2.79e-01     4.18e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   5.42e-01     7.33e-02    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.52e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.00e-02     1.28e-03    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   6.66e-02     1.77e-03    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.20e-02     7.08e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.84e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   5.43e-03     1.33e-04    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   5.42e-03     1.20e-03    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   2.23e-02     8.42e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   6.05e-03     3.71e-06    
+b11__gdn_gated_norm    1x494x4096             True     False    1.00e+00   1.94e-02     5.09e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.20e-02     6.01e-05    
+h_layer_24             1x1x2560               True     False    9.84e-01   5.10e-01     7.65e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   5.42e-01     7.78e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   5.57e-01     8.34e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   5.66e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.85e-01   5.63e-01     1.20e-01    
+h_layer_29             1x1x2560               True     False    9.85e-01   6.28e-01     1.34e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   6.68e-01     1.61e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.82e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.87e-01     1.66e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   1.59e-01     3.43e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.21e+00     6.06e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.93e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.07e+00     6.36e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.16e-01     6.51e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.25e-01     6.93e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.50e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   5.43e-01     1.12e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.54e-01     1.26e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   8.43e-01     1.47e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.63e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   2.18e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   1.85e-01     3.13e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   4.01e-01     5.32e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.61e+01     1.44e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   4.11e-01     5.42e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.24e-01     5.65e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   1.03e+00     6.01e-02    
+h_layer_27             1x1x2560               True     False    9.90e-01   6.12e-01     8.96e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   6.14e-01     1.03e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.69e-01     1.15e-01    
+h_layer_30             1x1x2560               True     False    9.86e-01   1.37e+00     1.36e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.41e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.90e-01   2.12e-01     1.60e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   3.75e-01     3.22e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   4.87e-01     6.20e-02    
+h_layer_31             1x1x2560               True     False    9.25e-01   1.64e+01     1.23e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   5.69e-01     6.33e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.74e-01     6.59e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   4.04e-01     6.82e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   1.04e+00     9.49e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.28e+00     1.07e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   1.02e+00     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   6.38e-01     1.39e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.68e-03     6.11e-04    
+h_layer_8              1x1x2560               True     False    8.07e-01   3.57e-01     5.27e-02    
+h_layer_16             1x1x2560               True     False    5.06e-01   1.48e+00     1.44e-01    
+h_layer_23             1x1x2560               True     False    1.71e-01   4.35e+00     4.30e-01    
+h_layer_31             1x1x2560               True     False    6.54e-01   2.94e+01     1.83e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    1.73e-01   4.50e+00     4.46e-01    
+h_layer_25             1x1x2560               True     False    1.81e-01   3.89e+00     4.48e-01    
+h_layer_26             1x1x2560               True     False    1.39e-01   7.55e+00     4.66e-01    
+h_layer_27             1x1x2560               True     False    1.97e-01   4.11e+00     5.41e-01    
+h_layer_28             1x1x2560               True     False    3.24e-01   7.98e+00     6.02e-01    
+h_layer_29             1x1x2560               True     False    4.08e-01   4.32e+00     6.60e-01    
+h_layer_30             1x1x2560               True     False    4.80e-01   9.65e+00     7.24e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.45e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   2.32e-01     1.80e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   3.62e-01     4.27e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.72e-01     7.61e-02    
+h_layer_31             1x1x2560               True     False    9.35e-01   1.87e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   4.46e-01     7.95e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   5.22e-01     8.89e-02    
+h_layer_26             1x1x2560               True     False    9.76e-01   6.09e-01     1.00e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   5.90e-01     1.29e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   1.17e+00     1.51e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   7.08e-01     1.68e-01    
+h_layer_30             1x1x2560               True     False    9.74e-01   8.87e-01     2.02e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.65e-03     1.91e-03    
+h_layer_8              1x1x2560               True     False    9.84e-01   3.14e-01     1.81e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   3.87e-01     4.40e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   4.64e-01     7.42e-02    
+h_layer_31             1x1x2560               True     False    9.14e-01   2.14e+01     1.21e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   5.15e-01     7.69e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   5.01e-01     7.88e-02    
+h_layer_26             1x1x2560               True     False    9.80e-01   6.49e-01     8.28e-02    
+h_layer_27             1x1x2560               True     False    9.80e-01   5.59e-01     1.26e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   5.80e-01     1.23e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.57e-01     1.42e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   8.40e-01     1.71e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.84e-01   max|Δ|=5.10e-01   DIV   cos=9.89e-01   max|Δ|=1.07e+00   DIV   cos=9.92e-01   max|Δ|=4.11e-01   DIV   cos=9.90e-01   max|Δ|=5.69e-01   DIV   cos=1.73e-01   max|Δ|=4.50e+00   DIV   cos=9.83e-01   max|Δ|=4.46e-01   DIV   cos=9.85e-01   max|Δ|=5.15e-01   DIV  
+  h_layer_25            cos=9.85e-01   max|Δ|=5.42e-01   DIV   cos=9.90e-01   max|Δ|=8.16e-01   DIV   cos=9.92e-01   max|Δ|=4.24e-01   DIV   cos=9.90e-01   max|Δ|=7.74e-01   DIV   cos=1.81e-01   max|Δ|=3.89e+00   DIV   cos=9.81e-01   max|Δ|=5.22e-01   DIV   cos=9.86e-01   max|Δ|=5.01e-01   DIV  
+  h_layer_26            cos=9.85e-01   max|Δ|=5.57e-01   DIV   cos=9.88e-01   max|Δ|=5.25e-01   DIV   cos=9.90e-01   max|Δ|=1.03e+00   DIV   cos=9.88e-01   max|Δ|=4.04e-01   DIV   cos=1.39e-01   max|Δ|=7.55e+00   DIV   cos=9.76e-01   max|Δ|=6.09e-01   DIV   cos=9.80e-01   max|Δ|=6.49e-01   DIV  
+  h_layer_27            cos=9.86e-01   max|Δ|=5.66e-01   DIV   cos=9.89e-01   max|Δ|=5.50e-01   DIV   cos=9.90e-01   max|Δ|=6.12e-01   DIV   cos=9.88e-01   max|Δ|=1.04e+00   DIV   cos=1.97e-01   max|Δ|=4.11e+00   DIV   cos=9.80e-01   max|Δ|=5.90e-01   DIV   cos=9.80e-01   max|Δ|=5.59e-01   DIV  
+  h_layer_28            cos=9.85e-01   max|Δ|=5.63e-01   DIV   cos=9.88e-01   max|Δ|=5.43e-01   DIV   cos=9.90e-01   max|Δ|=6.14e-01   DIV   cos=9.88e-01   max|Δ|=1.28e+00   DIV   cos=3.24e-01   max|Δ|=7.98e+00   DIV   cos=9.80e-01   max|Δ|=1.17e+00   DIV   cos=9.83e-01   max|Δ|=5.80e-01   DIV  
+  h_layer_29            cos=9.85e-01   max|Δ|=6.28e-01   DIV   cos=9.88e-01   max|Δ|=5.54e-01   DIV   cos=9.90e-01   max|Δ|=6.69e-01   DIV   cos=9.88e-01   max|Δ|=1.02e+00   DIV   cos=4.08e-01   max|Δ|=4.32e+00   DIV   cos=9.81e-01   max|Δ|=7.08e-01   DIV   cos=9.83e-01   max|Δ|=6.57e-01   DIV  
+  h_layer_30            cos=9.81e-01   max|Δ|=6.68e-01   DIV   cos=9.84e-01   max|Δ|=8.43e-01   DIV   cos=9.86e-01   max|Δ|=1.37e+00   DIV   cos=9.84e-01   max|Δ|=6.38e-01   DIV   cos=4.80e-01   max|Δ|=9.65e+00   DIV   cos=9.74e-01   max|Δ|=8.87e-01   DIV   cos=9.77e-01   max|Δ|=8.40e-01   DIV  
+  h_layer_31            cos=9.57e-01   max|Δ|=2.52e+01   DIV   cos=9.66e-01   max|Δ|=1.93e+01   DIV   cos=9.71e-01   max|Δ|=1.61e+01   DIV   cos=9.25e-01   max|Δ|=1.64e+01   DIV   cos=6.54e-01   max|Δ|=2.94e+01   DIV   cos=9.35e-01   max|Δ|=1.87e+01   DIV   cos=9.14e-01   max|Δ|=2.14e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=9.85e-01     DIV
+    h_layer_25             median=9.86e-01     DIV
+    h_layer_26             median=9.85e-01     DIV
+    h_layer_27             median=9.86e-01     DIV
+    h_layer_28             median=9.85e-01     DIV
+    h_layer_29             median=9.85e-01     DIV
+    h_layer_30             median=9.81e-01     DIV
+    h_layer_31             median=9.35e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  q_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  k_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  v_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_q           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_k           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV <missing>                                            <missing>                                           
+  post_attn_norm      <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_gate            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_up              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_down            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=nan          DIV
+    q_proj               median=nan          DIV
+    k_proj               median=nan          DIV
+    v_proj               median=nan          DIV
+    qk_norm_q            median=nan          DIV
+    qk_norm_k            median=nan          DIV
+    o_proj               median=nan          DIV
+    post_attn_norm       median=nan          DIV
+    mlp_gate             median=nan          DIV
+    mlp_up               median=nan          DIV
+    mlp_down             median=nan          DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.984731)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/docs/phase-c39/seed1.bench.json
+++ b/docs/phase-c39/seed1.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 18.921443521,
+    "model_vram_mb": 17527
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 508,
+      "output_tokens": 128,
+      "total_time_secs": 2.933101358,
+      "tokens_per_sec": 43.63981478201613,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 508,
+      "output_tokens": 512,
+      "total_time_secs": 11.934874274,
+      "tokens_per_sec": 42.89948836037483,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 508,
+      "output_tokens": 1024,
+      "total_time_secs": 23.544038076,
+      "tokens_per_sec": 43.49296398071286,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 508,
+      "output_tokens": 2048,
+      "total_time_secs": 46.88566354,
+      "tokens_per_sec": 43.68072978753453,
+      "peak_vram_mb": 17832
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 508,
+    "prefill_time_ms": 453.145643,
+    "prefill_tokens_per_sec": 1121.0523765314015,
+    "time_to_first_token_ms": 453.145643,
+    "mean_inter_token_ms": 41.60932053149608,
+    "p50_inter_token_ms": 55.89333,
+    "p99_inter_token_ms": 67.416214,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 24.03307689783236,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.29292929292929293,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/docs/phase-c39/seed1_compare_bf16.txt
+++ b/docs/phase-c39/seed1_compare_bf16.txt
@@ -1,0 +1,2006 @@
+# seed 1 compare vs bf16 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.45e-03     7.81e-04    
+h_layer_8              1x1x2560               True     False    9.77e-01   1.04e-01     2.04e-02    
+h_layer_16             1x1x2560               True     False    9.48e-01   7.19e-01     5.10e-02    
+h_layer_23             1x1x2560               True     False    9.72e-01   9.92e-01     9.52e-02    
+h_layer_31             1x1x2560               True     False    9.56e-01   2.10e+01     1.17e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.91e-03     8.07e-08    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   1.56e-02     2.02e-06    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   5.57e-02     8.54e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   3.91e-03     9.91e-05    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   3.91e-03     9.36e-04    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.55e-02     7.31e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   7.81e-03     4.48e-06    
+b11__gdn_gated_norm    1x508x4096             True     True     1.00e+00   2.34e-02     4.88e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.56e-02     6.29e-05    
+h_layer_24             1x1x2560               True     False    9.74e-01   1.14e+00     9.88e-02    
+h_layer_25             1x1x2560               True     False    9.76e-01   1.15e+00     1.02e-01    
+h_layer_26             1x1x2560               True     False    9.80e-01   1.16e+00     1.05e-01    
+h_layer_27             1x1x2560               True     False    9.78e-01   1.75e+00     1.22e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.37e+00     1.38e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   1.62e+00     1.52e-01    
+h_layer_30             1x1x2560               True     False    9.79e-01   1.14e+00     1.76e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.64e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   4.06e-01     1.85e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   2.81e-01     3.92e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   5.62e-01     6.99e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.61e+01     1.29e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.91e-01     7.12e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.70e-01     7.31e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   6.25e-01     7.72e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   8.75e-01     1.07e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   7.19e-01     1.15e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.91e-01     1.31e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   8.46e-01     1.53e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.54e-01   1.58e-01     3.00e-02    
+h_layer_16             1x1x2560               True     False    8.35e-01   1.41e+00     9.49e-02    
+h_layer_23             1x1x2560               True     False    2.70e-01   1.62e+01     4.09e-01    
+h_layer_31             1x1x2560               True     False    6.69e-01   2.05e+01     1.63e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.71e-01   1.80e+01     4.22e-01    
+h_layer_25             1x1x2560               True     False    2.61e-01   1.97e+01     4.34e-01    
+h_layer_26             1x1x2560               True     False    2.20e-01   1.81e+01     4.61e-01    
+h_layer_27             1x1x2560               True     False    4.08e-01   2.17e+01     5.28e-01    
+h_layer_28             1x1x2560               True     False    4.69e-01   2.42e+01     5.82e-01    
+h_layer_29             1x1x2560               True     False    5.43e-01   2.34e+01     6.22e-01    
+h_layer_30             1x1x2560               True     False    5.31e-01   2.29e+01     6.91e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.78e-01   1.10e-01     2.09e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   6.88e-01     3.94e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   1.25e+00     7.15e-02    
+h_layer_31             1x1x2560               True     False    9.53e-01   1.82e+01     1.40e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   1.50e+00     8.26e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   1.50e+00     8.84e-02    
+h_layer_26             1x1x2560               True     False    9.69e-01   1.75e+00     1.14e-01    
+h_layer_27             1x1x2560               True     False    9.77e-01   2.00e+00     1.32e-01    
+h_layer_28             1x1x2560               True     False    9.79e-01   8.75e-01     1.45e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   9.04e-01     1.59e-01    
+h_layer_30             1x1x2560               True     False    9.78e-01   8.48e-01     1.77e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.79e-03     1.77e-03    
+h_layer_8              1x1x2560               True     False    9.82e-01   3.12e-01     1.98e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   3.12e-01     3.43e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   8.75e-01     6.53e-02    
+h_layer_31             1x1x2560               True     False    9.08e-01   1.61e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   1.25e+00     6.92e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   1.25e+00     7.18e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   4.48e-01     7.61e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   1.12e+00     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   1.00e+00     1.14e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.46e-01     1.27e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   1.12e+00     1.53e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.70e-03     9.19e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   4.06e-01     2.13e-02    
+h_layer_16             1x1x2560               True     False    9.74e-01   6.25e-01     3.96e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   3.37e-01     6.91e-02    
+h_layer_31             1x1x2560               True     False    9.11e-01   1.68e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.00e-01     7.02e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   6.25e-01     7.22e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   3.87e-01     7.55e-02    
+h_layer_27             1x1x2560               True     False    9.78e-01   6.43e-01     1.33e-01    
+h_layer_28             1x1x2560               True     False    9.79e-01   8.75e-01     1.46e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   7.91e-01     1.61e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   9.49e-01     1.84e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.47e-03    
+h_layer_8              1x1x2560               True     False    9.13e-01   2.20e-01     3.50e-02    
+h_layer_16             1x1x2560               True     False    7.21e-01   1.06e+00     1.15e-01    
+h_layer_23             1x1x2560               True     False    8.11e-01   1.95e+00     2.21e-01    
+h_layer_31             1x1x2560               True     False    9.12e-01   1.74e+01     1.41e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.07e-01   3.38e+00     2.33e-01    
+h_layer_25             1x1x2560               True     False    8.26e-01   4.25e+00     2.32e-01    
+h_layer_26             1x1x2560               True     False    8.44e-01   2.29e+00     2.39e-01    
+h_layer_27             1x1x2560               True     False    8.93e-01   3.81e+00     2.66e-01    
+h_layer_28             1x1x2560               True     False    9.08e-01   4.25e+00     2.88e-01    
+h_layer_29             1x1x2560               True     False    9.16e-01   4.38e+00     3.09e-01    
+h_layer_30             1x1x2560               True     False    9.12e-01   4.25e+00     3.37e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.73e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   4.06e-01     1.89e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.41e-01     3.32e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   4.20e-01     6.57e-02    
+h_layer_31             1x1x2560               True     False    8.91e-01   1.50e+01     1.20e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   4.35e-01     6.78e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   6.25e-01     7.16e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   9.38e-01     8.11e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   6.74e-01     1.05e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   6.84e-01     1.09e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   7.23e-01     1.21e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   1.12e+00     1.46e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.11e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   1.56e-01     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.47e-01   3.16e-01     5.44e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.12e-01     7.70e-02    
+h_layer_31             1x1x2560               True     False    9.16e-01   1.38e+01     1.33e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   4.10e-01     7.91e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   5.00e-01     8.03e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   6.88e-01     8.53e-02    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.07e-01     1.30e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   8.75e-01     1.39e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   8.75e-01     1.54e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   1.25e+00     1.80e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.04e-01   2.34e-01     3.94e-02    
+h_layer_16             1x1x2560               True     False    6.81e-01   1.31e+00     1.29e-01    
+h_layer_23             1x1x2560               True     False    5.64e-01   6.19e+00     3.55e-01    
+h_layer_31             1x1x2560               True     False    7.39e-01   2.78e+01     1.59e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    5.89e-01   7.06e+00     3.57e-01    
+h_layer_25             1x1x2560               True     False    5.93e-01   9.19e+00     3.57e-01    
+h_layer_26             1x1x2560               True     False    5.38e-01   1.15e+01     3.72e-01    
+h_layer_27             1x1x2560               True     False    6.76e-01   1.21e+01     4.31e-01    
+h_layer_28             1x1x2560               True     False    7.22e-01   1.22e+01     4.71e-01    
+h_layer_29             1x1x2560               True     False    7.42e-01   1.30e+01     5.06e-01    
+h_layer_30             1x1x2560               True     False    7.23e-01   1.31e+01     5.52e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.67e-03    
+h_layer_8              1x1x2560               True     False    9.82e-01   1.05e-01     1.85e-02    
+h_layer_16             1x1x2560               True     False    9.75e-01   4.69e-01     4.01e-02    
+h_layer_23             1x1x2560               True     False    9.81e-01   7.50e-01     8.11e-02    
+h_layer_31             1x1x2560               True     False    9.04e-01   1.20e+01     1.25e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.82e-01   7.50e-01     8.50e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   7.50e-01     9.14e-02    
+h_layer_26             1x1x2560               True     False    9.67e-01   5.66e-01     1.08e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   1.38e+00     1.29e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   6.41e-01     1.40e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   6.45e-01     1.50e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   8.36e-01     1.77e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          522                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=3.45e-03   ok    cos=9.99e-01   max|Δ|=9.64e-03   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=8.79e-03   ok    cos=1.00e+00   max|Δ|=4.70e-03   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=7.81e-03   ok    cos=9.99e-01   max|Δ|=7.81e-03   ok    cos=9.99e-01   max|Δ|=7.81e-03   ok    cos=9.99e-01   max|Δ|=7.81e-03   ok   
+  h_layer_8             cos=9.77e-01   max|Δ|=1.04e-01   DIV   cos=9.87e-01   max|Δ|=4.06e-01   DIV   cos=9.54e-01   max|Δ|=1.58e-01   DIV   cos=9.78e-01   max|Δ|=1.10e-01   DIV   cos=9.82e-01   max|Δ|=3.12e-01   DIV   cos=9.80e-01   max|Δ|=4.06e-01   DIV   cos=9.13e-01   max|Δ|=2.20e-01   DIV   cos=9.85e-01   max|Δ|=4.06e-01   DIV   cos=9.86e-01   max|Δ|=1.56e-01   DIV   cos=9.04e-01   max|Δ|=2.34e-01   DIV   cos=9.82e-01   max|Δ|=1.05e-01   DIV  
+  h_layer_16            cos=9.48e-01   max|Δ|=7.19e-01   DIV   cos=9.72e-01   max|Δ|=2.81e-01   DIV   cos=8.35e-01   max|Δ|=1.41e+00   DIV   cos=9.79e-01   max|Δ|=6.88e-01   DIV   cos=9.83e-01   max|Δ|=3.12e-01   DIV   cos=9.74e-01   max|Δ|=6.25e-01   DIV   cos=7.21e-01   max|Δ|=1.06e+00   DIV   cos=9.84e-01   max|Δ|=1.41e-01   DIV   cos=9.47e-01   max|Δ|=3.16e-01   DIV   cos=6.81e-01   max|Δ|=1.31e+00   DIV   cos=9.75e-01   max|Δ|=4.69e-01   DIV  
+  h_layer_23            cos=9.72e-01   max|Δ|=9.92e-01   DIV   cos=9.87e-01   max|Δ|=5.62e-01   DIV   cos=2.70e-01   max|Δ|=1.62e+01   DIV   cos=9.84e-01   max|Δ|=1.25e+00   DIV   cos=9.87e-01   max|Δ|=8.75e-01   DIV   cos=9.86e-01   max|Δ|=3.37e-01   DIV   cos=8.11e-01   max|Δ|=1.95e+00   DIV   cos=9.87e-01   max|Δ|=4.20e-01   DIV   cos=9.82e-01   max|Δ|=4.12e-01   DIV   cos=5.64e-01   max|Δ|=6.19e+00   DIV   cos=9.81e-01   max|Δ|=7.50e-01   DIV  
+  h_layer_31            cos=9.56e-01   max|Δ|=2.10e+01   DIV   cos=9.30e-01   max|Δ|=1.61e+01   DIV   cos=6.69e-01   max|Δ|=2.05e+01   DIV   cos=9.53e-01   max|Δ|=1.82e+01   DIV   cos=9.08e-01   max|Δ|=1.61e+01   DIV   cos=9.11e-01   max|Δ|=1.68e+01   DIV   cos=9.12e-01   max|Δ|=1.74e+01   DIV   cos=8.91e-01   max|Δ|=1.50e+01   DIV   cos=9.16e-01   max|Δ|=1.38e+01   DIV   cos=7.39e-01   max|Δ|=2.78e+01   DIV   cos=9.04e-01   max|Δ|=1.20e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_8' (pos=0_s0)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK
+  -> The first bad transformer block lies between h_layer_0
+     and h_layer_8. Narrow by capturing intermediate layers
+     (e.g. layers 4 and 12) and re-running B10 on the new dump.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.45e-03     7.81e-04    
+h_layer_8              1x1x2560               True     False    9.77e-01   1.04e-01     2.04e-02    
+h_layer_16             1x1x2560               True     False    9.48e-01   7.19e-01     5.10e-02    
+h_layer_23             1x1x2560               True     False    9.72e-01   9.92e-01     9.52e-02    
+h_layer_31             1x1x2560               True     False    9.56e-01   2.10e+01     1.17e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.91e-03     8.07e-08    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   1.56e-02     2.02e-06    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   5.57e-02     8.54e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   3.91e-03     9.91e-05    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   3.91e-03     9.36e-04    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.55e-02     7.31e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   7.81e-03     4.48e-06    
+b11__gdn_gated_norm    1x508x4096             True     True     1.00e+00   2.34e-02     4.88e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.56e-02     6.29e-05    
+h_layer_24             1x1x2560               True     False    9.74e-01   1.14e+00     9.88e-02    
+h_layer_25             1x1x2560               True     False    9.76e-01   1.15e+00     1.02e-01    
+h_layer_26             1x1x2560               True     False    9.80e-01   1.16e+00     1.05e-01    
+h_layer_27             1x1x2560               True     False    9.78e-01   1.75e+00     1.22e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.37e+00     1.38e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   1.62e+00     1.52e-01    
+h_layer_30             1x1x2560               True     False    9.79e-01   1.14e+00     1.76e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.64e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   4.06e-01     1.85e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   2.81e-01     3.92e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   5.62e-01     6.99e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.61e+01     1.29e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.91e-01     7.12e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.70e-01     7.31e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   6.25e-01     7.72e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   8.75e-01     1.07e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   7.19e-01     1.15e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.91e-01     1.31e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   8.46e-01     1.53e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.54e-01   1.58e-01     3.00e-02    
+h_layer_16             1x1x2560               True     False    8.35e-01   1.41e+00     9.49e-02    
+h_layer_23             1x1x2560               True     False    2.70e-01   1.62e+01     4.09e-01    
+h_layer_31             1x1x2560               True     False    6.69e-01   2.05e+01     1.63e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.71e-01   1.80e+01     4.22e-01    
+h_layer_25             1x1x2560               True     False    2.61e-01   1.97e+01     4.34e-01    
+h_layer_26             1x1x2560               True     False    2.20e-01   1.81e+01     4.61e-01    
+h_layer_27             1x1x2560               True     False    4.08e-01   2.17e+01     5.28e-01    
+h_layer_28             1x1x2560               True     False    4.69e-01   2.42e+01     5.82e-01    
+h_layer_29             1x1x2560               True     False    5.43e-01   2.34e+01     6.22e-01    
+h_layer_30             1x1x2560               True     False    5.31e-01   2.29e+01     6.91e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.78e-01   1.10e-01     2.09e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   6.88e-01     3.94e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   1.25e+00     7.15e-02    
+h_layer_31             1x1x2560               True     False    9.53e-01   1.82e+01     1.40e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   1.50e+00     8.26e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   1.50e+00     8.84e-02    
+h_layer_26             1x1x2560               True     False    9.69e-01   1.75e+00     1.14e-01    
+h_layer_27             1x1x2560               True     False    9.77e-01   2.00e+00     1.32e-01    
+h_layer_28             1x1x2560               True     False    9.79e-01   8.75e-01     1.45e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   9.04e-01     1.59e-01    
+h_layer_30             1x1x2560               True     False    9.78e-01   8.48e-01     1.77e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.79e-03     1.77e-03    
+h_layer_8              1x1x2560               True     False    9.82e-01   3.12e-01     1.98e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   3.12e-01     3.43e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   8.75e-01     6.53e-02    
+h_layer_31             1x1x2560               True     False    9.08e-01   1.61e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   1.25e+00     6.92e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   1.25e+00     7.18e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   4.48e-01     7.61e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   1.12e+00     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   1.00e+00     1.14e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.46e-01     1.27e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   1.12e+00     1.53e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.70e-03     9.19e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   4.06e-01     2.13e-02    
+h_layer_16             1x1x2560               True     False    9.74e-01   6.25e-01     3.96e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   3.37e-01     6.91e-02    
+h_layer_31             1x1x2560               True     False    9.11e-01   1.68e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.00e-01     7.02e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   6.25e-01     7.22e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   3.87e-01     7.55e-02    
+h_layer_27             1x1x2560               True     False    9.78e-01   6.43e-01     1.33e-01    
+h_layer_28             1x1x2560               True     False    9.79e-01   8.75e-01     1.46e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   7.91e-01     1.61e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   9.49e-01     1.84e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.47e-03    
+h_layer_8              1x1x2560               True     False    9.13e-01   2.20e-01     3.50e-02    
+h_layer_16             1x1x2560               True     False    7.21e-01   1.06e+00     1.15e-01    
+h_layer_23             1x1x2560               True     False    8.11e-01   1.95e+00     2.21e-01    
+h_layer_31             1x1x2560               True     False    9.12e-01   1.74e+01     1.41e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.07e-01   3.38e+00     2.33e-01    
+h_layer_25             1x1x2560               True     False    8.26e-01   4.25e+00     2.32e-01    
+h_layer_26             1x1x2560               True     False    8.44e-01   2.29e+00     2.39e-01    
+h_layer_27             1x1x2560               True     False    8.93e-01   3.81e+00     2.66e-01    
+h_layer_28             1x1x2560               True     False    9.08e-01   4.25e+00     2.88e-01    
+h_layer_29             1x1x2560               True     False    9.16e-01   4.38e+00     3.09e-01    
+h_layer_30             1x1x2560               True     False    9.12e-01   4.25e+00     3.37e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.73e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   4.06e-01     1.89e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.41e-01     3.32e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   4.20e-01     6.57e-02    
+h_layer_31             1x1x2560               True     False    8.91e-01   1.50e+01     1.20e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   4.35e-01     6.78e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   6.25e-01     7.16e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   9.38e-01     8.11e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   6.74e-01     1.05e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   6.84e-01     1.09e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   7.23e-01     1.21e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   1.12e+00     1.46e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.11e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   1.56e-01     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.47e-01   3.16e-01     5.44e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.12e-01     7.70e-02    
+h_layer_31             1x1x2560               True     False    9.16e-01   1.38e+01     1.33e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   4.10e-01     7.91e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   5.00e-01     8.03e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   6.88e-01     8.53e-02    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.07e-01     1.30e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   8.75e-01     1.39e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   8.75e-01     1.54e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   1.25e+00     1.80e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.04e-01   2.34e-01     3.94e-02    
+h_layer_16             1x1x2560               True     False    6.81e-01   1.31e+00     1.29e-01    
+h_layer_23             1x1x2560               True     False    5.64e-01   6.19e+00     3.55e-01    
+h_layer_31             1x1x2560               True     False    7.39e-01   2.78e+01     1.59e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    5.89e-01   7.06e+00     3.57e-01    
+h_layer_25             1x1x2560               True     False    5.93e-01   9.19e+00     3.57e-01    
+h_layer_26             1x1x2560               True     False    5.38e-01   1.15e+01     3.72e-01    
+h_layer_27             1x1x2560               True     False    6.76e-01   1.21e+01     4.31e-01    
+h_layer_28             1x1x2560               True     False    7.22e-01   1.22e+01     4.71e-01    
+h_layer_29             1x1x2560               True     False    7.42e-01   1.30e+01     5.06e-01    
+h_layer_30             1x1x2560               True     False    7.23e-01   1.31e+01     5.52e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.67e-03    
+h_layer_8              1x1x2560               True     False    9.82e-01   1.05e-01     1.85e-02    
+h_layer_16             1x1x2560               True     False    9.75e-01   4.69e-01     4.01e-02    
+h_layer_23             1x1x2560               True     False    9.81e-01   7.50e-01     8.11e-02    
+h_layer_31             1x1x2560               True     False    9.04e-01   1.20e+01     1.25e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.82e-01   7.50e-01     8.50e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   7.50e-01     9.14e-02    
+h_layer_26             1x1x2560               True     False    9.67e-01   5.66e-01     1.08e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   1.38e+00     1.29e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   6.41e-01     1.40e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   6.45e-01     1.50e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   8.36e-01     1.77e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          522                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=8.07e-08   rel_l2=1.51e-05   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_in_proj               cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=2.02e-06   rel_l2=6.76e-05   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_conv                  cos=1.00e+00   max|Δ|=5.57e-02   mean|Δ|=8.54e-05   rel_l2=2.29e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.79e-01   mean|Δ|=4.00e-02   rel_l2=9.12e-01   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.91e-05   rel_l2=3.19e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.36e-04   rel_l2=3.04e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_g                cos=1.00e+00   max|Δ|=1.55e-02   mean|Δ|=7.31e-04   rel_l2=1.62e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_recur_out             cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=4.48e-06   rel_l2=4.57e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=2.34e-02   mean|Δ|=4.88e-05   rel_l2=5.07e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=6.29e-05   rel_l2=3.37e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+Phase B11b verdict: ALL layer-0 GDN sub-ops match within cos_sim >= 0.95.
+  -> Divergence is NOT localized inside layer 0's GDN block at this bar.
+  -> Re-check B10 atol/rtol and consider extending taps to layers 1-7
+     (GDN stack) before committing to a B12 target.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.45e-03     7.81e-04    
+h_layer_8              1x1x2560               True     False    9.77e-01   1.04e-01     2.04e-02    
+h_layer_16             1x1x2560               True     False    9.48e-01   7.19e-01     5.10e-02    
+h_layer_23             1x1x2560               True     False    9.72e-01   9.92e-01     9.52e-02    
+h_layer_31             1x1x2560               True     False    9.56e-01   2.10e+01     1.17e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.91e-03     8.07e-08    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   1.56e-02     2.02e-06    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   5.57e-02     8.54e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   3.91e-03     9.91e-05    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   3.91e-03     9.36e-04    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.55e-02     7.31e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   7.81e-03     4.48e-06    
+b11__gdn_gated_norm    1x508x4096             True     True     1.00e+00   2.34e-02     4.88e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.56e-02     6.29e-05    
+h_layer_24             1x1x2560               True     False    9.74e-01   1.14e+00     9.88e-02    
+h_layer_25             1x1x2560               True     False    9.76e-01   1.15e+00     1.02e-01    
+h_layer_26             1x1x2560               True     False    9.80e-01   1.16e+00     1.05e-01    
+h_layer_27             1x1x2560               True     False    9.78e-01   1.75e+00     1.22e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.37e+00     1.38e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   1.62e+00     1.52e-01    
+h_layer_30             1x1x2560               True     False    9.79e-01   1.14e+00     1.76e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.64e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   4.06e-01     1.85e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   2.81e-01     3.92e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   5.62e-01     6.99e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.61e+01     1.29e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.91e-01     7.12e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.70e-01     7.31e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   6.25e-01     7.72e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   8.75e-01     1.07e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   7.19e-01     1.15e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.91e-01     1.31e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   8.46e-01     1.53e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.54e-01   1.58e-01     3.00e-02    
+h_layer_16             1x1x2560               True     False    8.35e-01   1.41e+00     9.49e-02    
+h_layer_23             1x1x2560               True     False    2.70e-01   1.62e+01     4.09e-01    
+h_layer_31             1x1x2560               True     False    6.69e-01   2.05e+01     1.63e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.71e-01   1.80e+01     4.22e-01    
+h_layer_25             1x1x2560               True     False    2.61e-01   1.97e+01     4.34e-01    
+h_layer_26             1x1x2560               True     False    2.20e-01   1.81e+01     4.61e-01    
+h_layer_27             1x1x2560               True     False    4.08e-01   2.17e+01     5.28e-01    
+h_layer_28             1x1x2560               True     False    4.69e-01   2.42e+01     5.82e-01    
+h_layer_29             1x1x2560               True     False    5.43e-01   2.34e+01     6.22e-01    
+h_layer_30             1x1x2560               True     False    5.31e-01   2.29e+01     6.91e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.78e-01   1.10e-01     2.09e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   6.88e-01     3.94e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   1.25e+00     7.15e-02    
+h_layer_31             1x1x2560               True     False    9.53e-01   1.82e+01     1.40e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   1.50e+00     8.26e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   1.50e+00     8.84e-02    
+h_layer_26             1x1x2560               True     False    9.69e-01   1.75e+00     1.14e-01    
+h_layer_27             1x1x2560               True     False    9.77e-01   2.00e+00     1.32e-01    
+h_layer_28             1x1x2560               True     False    9.79e-01   8.75e-01     1.45e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   9.04e-01     1.59e-01    
+h_layer_30             1x1x2560               True     False    9.78e-01   8.48e-01     1.77e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.79e-03     1.77e-03    
+h_layer_8              1x1x2560               True     False    9.82e-01   3.12e-01     1.98e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   3.12e-01     3.43e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   8.75e-01     6.53e-02    
+h_layer_31             1x1x2560               True     False    9.08e-01   1.61e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   1.25e+00     6.92e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   1.25e+00     7.18e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   4.48e-01     7.61e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   1.12e+00     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   1.00e+00     1.14e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.46e-01     1.27e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   1.12e+00     1.53e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.70e-03     9.19e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   4.06e-01     2.13e-02    
+h_layer_16             1x1x2560               True     False    9.74e-01   6.25e-01     3.96e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   3.37e-01     6.91e-02    
+h_layer_31             1x1x2560               True     False    9.11e-01   1.68e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.00e-01     7.02e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   6.25e-01     7.22e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   3.87e-01     7.55e-02    
+h_layer_27             1x1x2560               True     False    9.78e-01   6.43e-01     1.33e-01    
+h_layer_28             1x1x2560               True     False    9.79e-01   8.75e-01     1.46e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   7.91e-01     1.61e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   9.49e-01     1.84e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.47e-03    
+h_layer_8              1x1x2560               True     False    9.13e-01   2.20e-01     3.50e-02    
+h_layer_16             1x1x2560               True     False    7.21e-01   1.06e+00     1.15e-01    
+h_layer_23             1x1x2560               True     False    8.11e-01   1.95e+00     2.21e-01    
+h_layer_31             1x1x2560               True     False    9.12e-01   1.74e+01     1.41e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.07e-01   3.38e+00     2.33e-01    
+h_layer_25             1x1x2560               True     False    8.26e-01   4.25e+00     2.32e-01    
+h_layer_26             1x1x2560               True     False    8.44e-01   2.29e+00     2.39e-01    
+h_layer_27             1x1x2560               True     False    8.93e-01   3.81e+00     2.66e-01    
+h_layer_28             1x1x2560               True     False    9.08e-01   4.25e+00     2.88e-01    
+h_layer_29             1x1x2560               True     False    9.16e-01   4.38e+00     3.09e-01    
+h_layer_30             1x1x2560               True     False    9.12e-01   4.25e+00     3.37e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.73e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   4.06e-01     1.89e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.41e-01     3.32e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   4.20e-01     6.57e-02    
+h_layer_31             1x1x2560               True     False    8.91e-01   1.50e+01     1.20e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   4.35e-01     6.78e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   6.25e-01     7.16e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   9.38e-01     8.11e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   6.74e-01     1.05e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   6.84e-01     1.09e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   7.23e-01     1.21e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   1.12e+00     1.46e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.11e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   1.56e-01     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.47e-01   3.16e-01     5.44e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.12e-01     7.70e-02    
+h_layer_31             1x1x2560               True     False    9.16e-01   1.38e+01     1.33e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   4.10e-01     7.91e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   5.00e-01     8.03e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   6.88e-01     8.53e-02    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.07e-01     1.30e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   8.75e-01     1.39e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   8.75e-01     1.54e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   1.25e+00     1.80e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.04e-01   2.34e-01     3.94e-02    
+h_layer_16             1x1x2560               True     False    6.81e-01   1.31e+00     1.29e-01    
+h_layer_23             1x1x2560               True     False    5.64e-01   6.19e+00     3.55e-01    
+h_layer_31             1x1x2560               True     False    7.39e-01   2.78e+01     1.59e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    5.89e-01   7.06e+00     3.57e-01    
+h_layer_25             1x1x2560               True     False    5.93e-01   9.19e+00     3.57e-01    
+h_layer_26             1x1x2560               True     False    5.38e-01   1.15e+01     3.72e-01    
+h_layer_27             1x1x2560               True     False    6.76e-01   1.21e+01     4.31e-01    
+h_layer_28             1x1x2560               True     False    7.22e-01   1.22e+01     4.71e-01    
+h_layer_29             1x1x2560               True     False    7.42e-01   1.30e+01     5.06e-01    
+h_layer_30             1x1x2560               True     False    7.23e-01   1.31e+01     5.52e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_bf16/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.67e-03    
+h_layer_8              1x1x2560               True     False    9.82e-01   1.05e-01     1.85e-02    
+h_layer_16             1x1x2560               True     False    9.75e-01   4.69e-01     4.01e-02    
+h_layer_23             1x1x2560               True     False    9.81e-01   7.50e-01     8.11e-02    
+h_layer_31             1x1x2560               True     False    9.04e-01   1.20e+01     1.25e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.82e-01   7.50e-01     8.50e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   7.50e-01     9.14e-02    
+h_layer_26             1x1x2560               True     False    9.67e-01   5.66e-01     1.08e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   1.38e+00     1.29e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   6.41e-01     1.40e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   6.45e-01     1.50e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   8.36e-01     1.77e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          522                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.74e-01   max|Δ|=1.14e+00   DIV   cos=9.87e-01   max|Δ|=5.91e-01   DIV   cos=2.71e-01   max|Δ|=1.80e+01   DIV   cos=9.81e-01   max|Δ|=1.50e+00   DIV   cos=9.87e-01   max|Δ|=1.25e+00   DIV   cos=9.87e-01   max|Δ|=5.00e-01   DIV   cos=8.07e-01   max|Δ|=3.38e+00   DIV   cos=9.87e-01   max|Δ|=4.35e-01   DIV   cos=9.83e-01   max|Δ|=4.10e-01   DIV   cos=5.89e-01   max|Δ|=7.06e+00   DIV   cos=9.82e-01   max|Δ|=7.50e-01   DIV  
+  h_layer_25            cos=9.76e-01   max|Δ|=1.15e+00   DIV   cos=9.88e-01   max|Δ|=5.70e-01   DIV   cos=2.61e-01   max|Δ|=1.97e+01   DIV   cos=9.81e-01   max|Δ|=1.50e+00   DIV   cos=9.87e-01   max|Δ|=1.25e+00   DIV   cos=9.88e-01   max|Δ|=6.25e-01   DIV   cos=8.26e-01   max|Δ|=4.25e+00   DIV   cos=9.87e-01   max|Δ|=6.25e-01   DIV   cos=9.85e-01   max|Δ|=5.00e-01   DIV   cos=5.93e-01   max|Δ|=9.19e+00   DIV   cos=9.81e-01   max|Δ|=7.50e-01   DIV  
+  h_layer_26            cos=9.80e-01   max|Δ|=1.16e+00   DIV   cos=9.86e-01   max|Δ|=6.25e-01   DIV   cos=2.20e-01   max|Δ|=1.81e+01   DIV   cos=9.69e-01   max|Δ|=1.75e+00   DIV   cos=9.85e-01   max|Δ|=4.48e-01   DIV   cos=9.86e-01   max|Δ|=3.87e-01   DIV   cos=8.44e-01   max|Δ|=2.29e+00   DIV   cos=9.82e-01   max|Δ|=9.38e-01   DIV   cos=9.82e-01   max|Δ|=6.88e-01   DIV   cos=5.38e-01   max|Δ|=1.15e+01   DIV   cos=9.67e-01   max|Δ|=5.66e-01   DIV  
+  h_layer_27            cos=9.78e-01   max|Δ|=1.75e+00   DIV   cos=9.86e-01   max|Δ|=8.75e-01   DIV   cos=4.08e-01   max|Δ|=2.17e+01   DIV   cos=9.77e-01   max|Δ|=2.00e+00   DIV   cos=9.87e-01   max|Δ|=1.12e+00   DIV   cos=9.78e-01   max|Δ|=6.43e-01   DIV   cos=8.93e-01   max|Δ|=3.81e+00   DIV   cos=9.88e-01   max|Δ|=6.74e-01   DIV   cos=9.81e-01   max|Δ|=6.07e-01   DIV   cos=6.76e-01   max|Δ|=1.21e+01   DIV   cos=9.81e-01   max|Δ|=1.38e+00   DIV  
+  h_layer_28            cos=9.81e-01   max|Δ|=1.37e+00   DIV   cos=9.87e-01   max|Δ|=7.19e-01   DIV   cos=4.69e-01   max|Δ|=2.42e+01   DIV   cos=9.79e-01   max|Δ|=8.75e-01   DIV   cos=9.86e-01   max|Δ|=1.00e+00   DIV   cos=9.79e-01   max|Δ|=8.75e-01   DIV   cos=9.08e-01   max|Δ|=4.25e+00   DIV   cos=9.87e-01   max|Δ|=6.84e-01   DIV   cos=9.81e-01   max|Δ|=8.75e-01   DIV   cos=7.22e-01   max|Δ|=1.22e+01   DIV   cos=9.80e-01   max|Δ|=6.41e-01   DIV  
+  h_layer_29            cos=9.80e-01   max|Δ|=1.62e+00   DIV   cos=9.87e-01   max|Δ|=6.91e-01   DIV   cos=5.43e-01   max|Δ|=2.34e+01   DIV   cos=9.80e-01   max|Δ|=9.04e-01   DIV   cos=9.87e-01   max|Δ|=6.46e-01   DIV   cos=9.80e-01   max|Δ|=7.91e-01   DIV   cos=9.16e-01   max|Δ|=4.38e+00   DIV   cos=9.88e-01   max|Δ|=7.23e-01   DIV   cos=9.80e-01   max|Δ|=8.75e-01   DIV   cos=7.42e-01   max|Δ|=1.30e+01   DIV   cos=9.82e-01   max|Δ|=6.45e-01   DIV  
+  h_layer_30            cos=9.79e-01   max|Δ|=1.14e+00   DIV   cos=9.82e-01   max|Δ|=8.46e-01   DIV   cos=5.31e-01   max|Δ|=2.29e+01   DIV   cos=9.78e-01   max|Δ|=8.48e-01   DIV   cos=9.82e-01   max|Δ|=1.12e+00   DIV   cos=9.75e-01   max|Δ|=9.49e-01   DIV   cos=9.12e-01   max|Δ|=4.25e+00   DIV   cos=9.82e-01   max|Δ|=1.12e+00   DIV   cos=9.75e-01   max|Δ|=1.25e+00   DIV   cos=7.23e-01   max|Δ|=1.31e+01   DIV   cos=9.75e-01   max|Δ|=8.36e-01   DIV  
+  h_layer_31            cos=9.56e-01   max|Δ|=2.10e+01   DIV   cos=9.30e-01   max|Δ|=1.61e+01   DIV   cos=6.69e-01   max|Δ|=2.05e+01   DIV   cos=9.53e-01   max|Δ|=1.82e+01   DIV   cos=9.08e-01   max|Δ|=1.61e+01   DIV   cos=9.11e-01   max|Δ|=1.68e+01   DIV   cos=9.12e-01   max|Δ|=1.74e+01   DIV   cos=8.91e-01   max|Δ|=1.50e+01   DIV   cos=9.16e-01   max|Δ|=1.38e+01   DIV   cos=7.39e-01   max|Δ|=2.78e+01   DIV   cos=9.04e-01   max|Δ|=1.20e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=9.82e-01     DIV
+    h_layer_25             median=9.81e-01     DIV
+    h_layer_26             median=9.80e-01     DIV
+    h_layer_27             median=9.78e-01     DIV
+    h_layer_28             median=9.80e-01     DIV
+    h_layer_29             median=9.80e-01     DIV
+    h_layer_30             median=9.75e-01     DIV
+    h_layer_31             median=9.11e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  q_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  k_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  v_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_q           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_k           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV <missing>                                            <missing>                                           
+  post_attn_norm      <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_gate            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_up              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_down            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=nan          DIV
+    q_proj               median=nan          DIV
+    k_proj               median=nan          DIV
+    v_proj               median=nan          DIV
+    qk_norm_q            median=nan          DIV
+    qk_norm_k            median=nan          DIV
+    o_proj               median=nan          DIV
+    post_attn_norm       median=nan          DIV
+    mlp_gate             median=nan          DIV
+    mlp_up               median=nan          DIV
+    mlp_down             median=nan          DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.981826)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/docs/phase-c39/seed1_compare_fp32.txt
+++ b/docs/phase-c39/seed1_compare_fp32.txt
@@ -1,0 +1,2006 @@
+# seed 1 compare vs fp32 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.26e-02     7.76e-04    
+h_layer_8              1x1x2560               True     False    9.77e-01   1.05e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.46e-01   7.25e-01     5.18e-02    
+h_layer_23             1x1x2560               True     False    9.70e-01   9.84e-01     9.69e-02    
+h_layer_31             1x1x2560               True     False    9.56e-01   2.06e+01     1.17e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.02e-02     1.28e-03    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   6.66e-02     1.82e-03    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   6.19e-02     7.34e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   4.47e-03     1.30e-04    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   5.17e-03     1.21e-03    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.73e-02     8.17e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   6.09e-03     3.94e-06    
+b11__gdn_gated_norm    1x508x4096             True     False    1.00e+00   1.94e-02     4.84e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.24e-02     5.79e-05    
+h_layer_24             1x1x2560               True     False    9.73e-01   1.15e+00     1.01e-01    
+h_layer_25             1x1x2560               True     False    9.75e-01   1.16e+00     1.03e-01    
+h_layer_26             1x1x2560               True     False    9.80e-01   1.17e+00     1.06e-01    
+h_layer_27             1x1x2560               True     False    9.77e-01   1.84e+00     1.24e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.38e+00     1.40e-01    
+h_layer_29             1x1x2560               True     False    9.79e-01   1.68e+00     1.53e-01    
+h_layer_30             1x1x2560               True     False    9.79e-01   1.18e+00     1.77e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   4.15e-01     1.85e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   2.13e-01     3.90e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   6.45e-01     6.95e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.60e+01     1.29e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.88e-01   5.91e-01     7.09e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.72e-01     7.24e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   7.34e-01     7.67e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   1.03e+00     1.05e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   7.18e-01     1.13e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.79e-01     1.29e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   8.43e-01     1.51e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.73e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.54e-01   1.54e-01     2.98e-02    
+h_layer_16             1x1x2560               True     False    8.33e-01   1.45e+00     9.50e-02    
+h_layer_23             1x1x2560               True     False    2.69e-01   1.61e+01     4.09e-01    
+h_layer_31             1x1x2560               True     False    6.68e-01   2.03e+01     1.64e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.70e-01   1.79e+01     4.22e-01    
+h_layer_25             1x1x2560               True     False    2.59e-01   1.97e+01     4.34e-01    
+h_layer_26             1x1x2560               True     False    2.19e-01   1.81e+01     4.61e-01    
+h_layer_27             1x1x2560               True     False    4.07e-01   2.17e+01     5.28e-01    
+h_layer_28             1x1x2560               True     False    4.69e-01   2.40e+01     5.82e-01    
+h_layer_29             1x1x2560               True     False    5.42e-01   2.32e+01     6.22e-01    
+h_layer_30             1x1x2560               True     False    5.32e-01   2.27e+01     6.90e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.01e-02     1.33e-03    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.07e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   6.83e-01     3.93e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   1.33e+00     7.17e-02    
+h_layer_31             1x1x2560               True     False    9.53e-01   1.84e+01     1.40e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   1.53e+00     8.29e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   1.49e+00     8.88e-02    
+h_layer_26             1x1x2560               True     False    9.69e-01   1.72e+00     1.15e-01    
+h_layer_27             1x1x2560               True     False    9.77e-01   1.97e+00     1.32e-01    
+h_layer_28             1x1x2560               True     False    9.79e-01   8.44e-01     1.45e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   9.09e-01     1.59e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   8.60e-01     1.77e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.66e-03     1.78e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.20e-01     2.02e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   3.13e-01     3.44e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   8.26e-01     6.47e-02    
+h_layer_31             1x1x2560               True     False    9.08e-01   1.61e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   1.08e+00     6.84e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   1.17e+00     7.09e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   4.48e-01     7.52e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   9.71e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   8.60e-01     1.14e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.55e-01     1.27e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   1.23e+00     1.54e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.93e-03     9.23e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   4.51e-01     2.13e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   6.96e-01     4.06e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   3.33e-01     6.84e-02    
+h_layer_31             1x1x2560               True     False    9.12e-01   1.70e+01     1.27e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.49e-01     6.95e-02    
+h_layer_25             1x1x2560               True     False    9.89e-01   7.20e-01     7.14e-02    
+h_layer_26             1x1x2560               True     False    9.87e-01   3.85e-01     7.48e-02    
+h_layer_27             1x1x2560               True     False    9.79e-01   6.51e-01     1.31e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   8.41e-01     1.44e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   7.87e-01     1.58e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   8.85e-01     1.82e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.70e-02     1.48e-03    
+h_layer_8              1x1x2560               True     False    9.03e-01   2.43e-01     3.72e-02    
+h_layer_16             1x1x2560               True     False    7.38e-01   6.67e-01     1.13e-01    
+h_layer_23             1x1x2560               True     False    8.02e-01   1.92e+00     2.26e-01    
+h_layer_31             1x1x2560               True     False    9.17e-01   1.75e+01     1.39e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.07e-01   2.95e+00     2.32e-01    
+h_layer_25             1x1x2560               True     False    8.29e-01   3.92e+00     2.32e-01    
+h_layer_26             1x1x2560               True     False    8.47e-01   2.17e+00     2.37e-01    
+h_layer_27             1x1x2560               True     False    8.90e-01   4.75e+00     2.64e-01    
+h_layer_28             1x1x2560               True     False    9.08e-01   4.52e+00     2.87e-01    
+h_layer_29             1x1x2560               True     False    9.16e-01   4.87e+00     3.08e-01    
+h_layer_30             1x1x2560               True     False    9.15e-01   4.23e+00     3.33e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.14e-03     1.74e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   3.78e-01     1.91e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.41e-01     3.32e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   4.17e-01     6.60e-02    
+h_layer_31             1x1x2560               True     False    8.92e-01   1.48e+01     1.19e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   4.23e-01     6.80e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   5.56e-01     7.16e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   1.08e+00     8.25e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   6.71e-01     1.07e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   6.77e-01     1.07e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   7.11e-01     1.20e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   8.58e-01     1.45e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   5.81e-03     1.10e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   1.34e-01     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.51e-01   3.08e-01     5.22e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   4.30e-01     7.54e-02    
+h_layer_31             1x1x2560               True     False    9.17e-01   1.40e+01     1.33e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   4.37e-01     7.75e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.22e-01     7.87e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   7.44e-01     8.40e-02    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.01e-01     1.27e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   9.17e-01     1.37e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   9.96e-01     1.51e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   1.35e+00     1.77e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.07e-01   2.44e-01     3.86e-02    
+h_layer_16             1x1x2560               True     False    6.76e-01   1.06e+00     1.29e-01    
+h_layer_23             1x1x2560               True     False    5.55e-01   6.08e+00     3.66e-01    
+h_layer_31             1x1x2560               True     False    7.33e-01   2.77e+01     1.60e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    5.80e-01   7.17e+00     3.68e-01    
+h_layer_25             1x1x2560               True     False    5.85e-01   9.50e+00     3.68e-01    
+h_layer_26             1x1x2560               True     False    5.32e-01   1.18e+01     3.83e-01    
+h_layer_27             1x1x2560               True     False    6.71e-01   1.20e+01     4.41e-01    
+h_layer_28             1x1x2560               True     False    7.14e-01   1.22e+01     4.84e-01    
+h_layer_29             1x1x2560               True     False    7.34e-01   1.32e+01     5.20e-01    
+h_layer_30             1x1x2560               True     False    7.15e-01   1.33e+01     5.64e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.14e-03     1.67e-03    
+h_layer_8              1x1x2560               True     False    9.80e-01   1.01e-01     1.88e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   4.58e-01     4.24e-02    
+h_layer_23             1x1x2560               True     False    9.81e-01   7.67e-01     8.15e-02    
+h_layer_31             1x1x2560               True     False    9.04e-01   1.18e+01     1.25e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   7.92e-01     8.55e-02    
+h_layer_25             1x1x2560               True     False    9.80e-01   7.82e-01     9.23e-02    
+h_layer_26             1x1x2560               True     False    9.65e-01   5.73e-01     1.11e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   1.25e+00     1.30e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   7.69e-01     1.39e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   6.52e-01     1.51e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   8.76e-01     1.76e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          522                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=1.26e-02   ok    cos=9.99e-01   max|Δ|=9.83e-03   ok    cos=9.99e-01   max|Δ|=1.73e-02   ok    cos=9.99e-01   max|Δ|=1.01e-02   ok    cos=9.99e-01   max|Δ|=8.66e-03   ok    cos=1.00e+00   max|Δ|=4.93e-03   ok    cos=9.99e-01   max|Δ|=2.70e-02   ok    cos=9.99e-01   max|Δ|=8.14e-03   ok    cos=9.99e-01   max|Δ|=5.81e-03   ok    cos=9.99e-01   max|Δ|=9.83e-03   ok    cos=9.99e-01   max|Δ|=8.14e-03   ok   
+  h_layer_8             cos=9.77e-01   max|Δ|=1.05e-01   DIV   cos=9.87e-01   max|Δ|=4.15e-01   DIV   cos=9.54e-01   max|Δ|=1.54e-01   DIV   cos=9.79e-01   max|Δ|=1.07e-01   DIV   cos=9.81e-01   max|Δ|=3.20e-01   DIV   cos=9.80e-01   max|Δ|=4.51e-01   DIV   cos=9.03e-01   max|Δ|=2.43e-01   DIV   cos=9.85e-01   max|Δ|=3.78e-01   DIV   cos=9.86e-01   max|Δ|=1.34e-01   DIV   cos=9.07e-01   max|Δ|=2.44e-01   DIV   cos=9.80e-01   max|Δ|=1.01e-01   DIV  
+  h_layer_16            cos=9.46e-01   max|Δ|=7.25e-01   DIV   cos=9.73e-01   max|Δ|=2.13e-01   DIV   cos=8.33e-01   max|Δ|=1.45e+00   DIV   cos=9.79e-01   max|Δ|=6.83e-01   DIV   cos=9.83e-01   max|Δ|=3.13e-01   DIV   cos=9.72e-01   max|Δ|=6.96e-01   DIV   cos=7.38e-01   max|Δ|=6.67e-01   DIV   cos=9.84e-01   max|Δ|=1.41e-01   DIV   cos=9.51e-01   max|Δ|=3.08e-01   DIV   cos=6.76e-01   max|Δ|=1.06e+00   DIV   cos=9.72e-01   max|Δ|=4.58e-01   DIV  
+  h_layer_23            cos=9.70e-01   max|Δ|=9.84e-01   DIV   cos=9.87e-01   max|Δ|=6.45e-01   DIV   cos=2.69e-01   max|Δ|=1.61e+01   DIV   cos=9.84e-01   max|Δ|=1.33e+00   DIV   cos=9.87e-01   max|Δ|=8.26e-01   DIV   cos=9.86e-01   max|Δ|=3.33e-01   DIV   cos=8.02e-01   max|Δ|=1.92e+00   DIV   cos=9.87e-01   max|Δ|=4.17e-01   DIV   cos=9.83e-01   max|Δ|=4.30e-01   DIV   cos=5.55e-01   max|Δ|=6.08e+00   DIV   cos=9.81e-01   max|Δ|=7.67e-01   DIV  
+  h_layer_31            cos=9.56e-01   max|Δ|=2.06e+01   DIV   cos=9.30e-01   max|Δ|=1.60e+01   DIV   cos=6.68e-01   max|Δ|=2.03e+01   DIV   cos=9.53e-01   max|Δ|=1.84e+01   DIV   cos=9.08e-01   max|Δ|=1.61e+01   DIV   cos=9.12e-01   max|Δ|=1.70e+01   DIV   cos=9.17e-01   max|Δ|=1.75e+01   DIV   cos=8.92e-01   max|Δ|=1.48e+01   DIV   cos=9.17e-01   max|Δ|=1.40e+01   DIV   cos=7.33e-01   max|Δ|=2.77e+01   DIV   cos=9.04e-01   max|Δ|=1.18e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_8' (pos=0_s0)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK
+  -> The first bad transformer block lies between h_layer_0
+     and h_layer_8. Narrow by capturing intermediate layers
+     (e.g. layers 4 and 12) and re-running B10 on the new dump.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.26e-02     7.76e-04    
+h_layer_8              1x1x2560               True     False    9.77e-01   1.05e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.46e-01   7.25e-01     5.18e-02    
+h_layer_23             1x1x2560               True     False    9.70e-01   9.84e-01     9.69e-02    
+h_layer_31             1x1x2560               True     False    9.56e-01   2.06e+01     1.17e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.02e-02     1.28e-03    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   6.66e-02     1.82e-03    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   6.19e-02     7.34e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   4.47e-03     1.30e-04    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   5.17e-03     1.21e-03    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.73e-02     8.17e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   6.09e-03     3.94e-06    
+b11__gdn_gated_norm    1x508x4096             True     False    1.00e+00   1.94e-02     4.84e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.24e-02     5.79e-05    
+h_layer_24             1x1x2560               True     False    9.73e-01   1.15e+00     1.01e-01    
+h_layer_25             1x1x2560               True     False    9.75e-01   1.16e+00     1.03e-01    
+h_layer_26             1x1x2560               True     False    9.80e-01   1.17e+00     1.06e-01    
+h_layer_27             1x1x2560               True     False    9.77e-01   1.84e+00     1.24e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.38e+00     1.40e-01    
+h_layer_29             1x1x2560               True     False    9.79e-01   1.68e+00     1.53e-01    
+h_layer_30             1x1x2560               True     False    9.79e-01   1.18e+00     1.77e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   4.15e-01     1.85e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   2.13e-01     3.90e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   6.45e-01     6.95e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.60e+01     1.29e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.88e-01   5.91e-01     7.09e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.72e-01     7.24e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   7.34e-01     7.67e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   1.03e+00     1.05e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   7.18e-01     1.13e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.79e-01     1.29e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   8.43e-01     1.51e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.73e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.54e-01   1.54e-01     2.98e-02    
+h_layer_16             1x1x2560               True     False    8.33e-01   1.45e+00     9.50e-02    
+h_layer_23             1x1x2560               True     False    2.69e-01   1.61e+01     4.09e-01    
+h_layer_31             1x1x2560               True     False    6.68e-01   2.03e+01     1.64e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.70e-01   1.79e+01     4.22e-01    
+h_layer_25             1x1x2560               True     False    2.59e-01   1.97e+01     4.34e-01    
+h_layer_26             1x1x2560               True     False    2.19e-01   1.81e+01     4.61e-01    
+h_layer_27             1x1x2560               True     False    4.07e-01   2.17e+01     5.28e-01    
+h_layer_28             1x1x2560               True     False    4.69e-01   2.40e+01     5.82e-01    
+h_layer_29             1x1x2560               True     False    5.42e-01   2.32e+01     6.22e-01    
+h_layer_30             1x1x2560               True     False    5.32e-01   2.27e+01     6.90e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.01e-02     1.33e-03    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.07e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   6.83e-01     3.93e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   1.33e+00     7.17e-02    
+h_layer_31             1x1x2560               True     False    9.53e-01   1.84e+01     1.40e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   1.53e+00     8.29e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   1.49e+00     8.88e-02    
+h_layer_26             1x1x2560               True     False    9.69e-01   1.72e+00     1.15e-01    
+h_layer_27             1x1x2560               True     False    9.77e-01   1.97e+00     1.32e-01    
+h_layer_28             1x1x2560               True     False    9.79e-01   8.44e-01     1.45e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   9.09e-01     1.59e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   8.60e-01     1.77e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.66e-03     1.78e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.20e-01     2.02e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   3.13e-01     3.44e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   8.26e-01     6.47e-02    
+h_layer_31             1x1x2560               True     False    9.08e-01   1.61e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   1.08e+00     6.84e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   1.17e+00     7.09e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   4.48e-01     7.52e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   9.71e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   8.60e-01     1.14e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.55e-01     1.27e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   1.23e+00     1.54e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.93e-03     9.23e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   4.51e-01     2.13e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   6.96e-01     4.06e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   3.33e-01     6.84e-02    
+h_layer_31             1x1x2560               True     False    9.12e-01   1.70e+01     1.27e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.49e-01     6.95e-02    
+h_layer_25             1x1x2560               True     False    9.89e-01   7.20e-01     7.14e-02    
+h_layer_26             1x1x2560               True     False    9.87e-01   3.85e-01     7.48e-02    
+h_layer_27             1x1x2560               True     False    9.79e-01   6.51e-01     1.31e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   8.41e-01     1.44e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   7.87e-01     1.58e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   8.85e-01     1.82e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.70e-02     1.48e-03    
+h_layer_8              1x1x2560               True     False    9.03e-01   2.43e-01     3.72e-02    
+h_layer_16             1x1x2560               True     False    7.38e-01   6.67e-01     1.13e-01    
+h_layer_23             1x1x2560               True     False    8.02e-01   1.92e+00     2.26e-01    
+h_layer_31             1x1x2560               True     False    9.17e-01   1.75e+01     1.39e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.07e-01   2.95e+00     2.32e-01    
+h_layer_25             1x1x2560               True     False    8.29e-01   3.92e+00     2.32e-01    
+h_layer_26             1x1x2560               True     False    8.47e-01   2.17e+00     2.37e-01    
+h_layer_27             1x1x2560               True     False    8.90e-01   4.75e+00     2.64e-01    
+h_layer_28             1x1x2560               True     False    9.08e-01   4.52e+00     2.87e-01    
+h_layer_29             1x1x2560               True     False    9.16e-01   4.87e+00     3.08e-01    
+h_layer_30             1x1x2560               True     False    9.15e-01   4.23e+00     3.33e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.14e-03     1.74e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   3.78e-01     1.91e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.41e-01     3.32e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   4.17e-01     6.60e-02    
+h_layer_31             1x1x2560               True     False    8.92e-01   1.48e+01     1.19e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   4.23e-01     6.80e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   5.56e-01     7.16e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   1.08e+00     8.25e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   6.71e-01     1.07e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   6.77e-01     1.07e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   7.11e-01     1.20e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   8.58e-01     1.45e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   5.81e-03     1.10e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   1.34e-01     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.51e-01   3.08e-01     5.22e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   4.30e-01     7.54e-02    
+h_layer_31             1x1x2560               True     False    9.17e-01   1.40e+01     1.33e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   4.37e-01     7.75e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.22e-01     7.87e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   7.44e-01     8.40e-02    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.01e-01     1.27e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   9.17e-01     1.37e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   9.96e-01     1.51e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   1.35e+00     1.77e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.07e-01   2.44e-01     3.86e-02    
+h_layer_16             1x1x2560               True     False    6.76e-01   1.06e+00     1.29e-01    
+h_layer_23             1x1x2560               True     False    5.55e-01   6.08e+00     3.66e-01    
+h_layer_31             1x1x2560               True     False    7.33e-01   2.77e+01     1.60e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    5.80e-01   7.17e+00     3.68e-01    
+h_layer_25             1x1x2560               True     False    5.85e-01   9.50e+00     3.68e-01    
+h_layer_26             1x1x2560               True     False    5.32e-01   1.18e+01     3.83e-01    
+h_layer_27             1x1x2560               True     False    6.71e-01   1.20e+01     4.41e-01    
+h_layer_28             1x1x2560               True     False    7.14e-01   1.22e+01     4.84e-01    
+h_layer_29             1x1x2560               True     False    7.34e-01   1.32e+01     5.20e-01    
+h_layer_30             1x1x2560               True     False    7.15e-01   1.33e+01     5.64e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.14e-03     1.67e-03    
+h_layer_8              1x1x2560               True     False    9.80e-01   1.01e-01     1.88e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   4.58e-01     4.24e-02    
+h_layer_23             1x1x2560               True     False    9.81e-01   7.67e-01     8.15e-02    
+h_layer_31             1x1x2560               True     False    9.04e-01   1.18e+01     1.25e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   7.92e-01     8.55e-02    
+h_layer_25             1x1x2560               True     False    9.80e-01   7.82e-01     9.23e-02    
+h_layer_26             1x1x2560               True     False    9.65e-01   5.73e-01     1.11e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   1.25e+00     1.30e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   7.69e-01     1.39e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   6.52e-01     1.51e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   8.76e-01     1.76e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          522                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.02e-02   mean|Δ|=1.28e-03   rel_l2=1.65e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_in_proj               cos=1.00e+00   max|Δ|=6.66e-02   mean|Δ|=1.82e-03   rel_l2=1.94e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_conv                  cos=1.00e+00   max|Δ|=6.19e-02   mean|Δ|=7.34e-05   rel_l2=1.58e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.79e-01   mean|Δ|=4.00e-02   rel_l2=9.12e-01   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=4.47e-03   mean|Δ|=1.30e-04   rel_l2=2.67e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=5.17e-03   mean|Δ|=1.21e-03   rel_l2=2.74e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_g                cos=1.00e+00   max|Δ|=1.73e-02   mean|Δ|=8.17e-04   rel_l2=1.78e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_recur_out             cos=1.00e+00   max|Δ|=6.09e-03   mean|Δ|=3.94e-06   rel_l2=3.45e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=1.94e-02   mean|Δ|=4.84e-05   rel_l2=4.15e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.24e-02   mean|Δ|=5.79e-05   rel_l2=2.44e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+Phase B11b verdict: ALL layer-0 GDN sub-ops match within cos_sim >= 0.95.
+  -> Divergence is NOT localized inside layer 0's GDN block at this bar.
+  -> Re-check B10 atol/rtol and consider extending taps to layers 1-7
+     (GDN stack) before committing to a B12 target.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.26e-02     7.76e-04    
+h_layer_8              1x1x2560               True     False    9.77e-01   1.05e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.46e-01   7.25e-01     5.18e-02    
+h_layer_23             1x1x2560               True     False    9.70e-01   9.84e-01     9.69e-02    
+h_layer_31             1x1x2560               True     False    9.56e-01   2.06e+01     1.17e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.02e-02     1.28e-03    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   6.66e-02     1.82e-03    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   6.19e-02     7.34e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   4.47e-03     1.30e-04    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   5.17e-03     1.21e-03    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.73e-02     8.17e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   6.09e-03     3.94e-06    
+b11__gdn_gated_norm    1x508x4096             True     False    1.00e+00   1.94e-02     4.84e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.24e-02     5.79e-05    
+h_layer_24             1x1x2560               True     False    9.73e-01   1.15e+00     1.01e-01    
+h_layer_25             1x1x2560               True     False    9.75e-01   1.16e+00     1.03e-01    
+h_layer_26             1x1x2560               True     False    9.80e-01   1.17e+00     1.06e-01    
+h_layer_27             1x1x2560               True     False    9.77e-01   1.84e+00     1.24e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.38e+00     1.40e-01    
+h_layer_29             1x1x2560               True     False    9.79e-01   1.68e+00     1.53e-01    
+h_layer_30             1x1x2560               True     False    9.79e-01   1.18e+00     1.77e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   4.15e-01     1.85e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   2.13e-01     3.90e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   6.45e-01     6.95e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.60e+01     1.29e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.88e-01   5.91e-01     7.09e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.72e-01     7.24e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   7.34e-01     7.67e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   1.03e+00     1.05e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   7.18e-01     1.13e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.79e-01     1.29e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   8.43e-01     1.51e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.73e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.54e-01   1.54e-01     2.98e-02    
+h_layer_16             1x1x2560               True     False    8.33e-01   1.45e+00     9.50e-02    
+h_layer_23             1x1x2560               True     False    2.69e-01   1.61e+01     4.09e-01    
+h_layer_31             1x1x2560               True     False    6.68e-01   2.03e+01     1.64e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.70e-01   1.79e+01     4.22e-01    
+h_layer_25             1x1x2560               True     False    2.59e-01   1.97e+01     4.34e-01    
+h_layer_26             1x1x2560               True     False    2.19e-01   1.81e+01     4.61e-01    
+h_layer_27             1x1x2560               True     False    4.07e-01   2.17e+01     5.28e-01    
+h_layer_28             1x1x2560               True     False    4.69e-01   2.40e+01     5.82e-01    
+h_layer_29             1x1x2560               True     False    5.42e-01   2.32e+01     6.22e-01    
+h_layer_30             1x1x2560               True     False    5.32e-01   2.27e+01     6.90e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.01e-02     1.33e-03    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.07e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   6.83e-01     3.93e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   1.33e+00     7.17e-02    
+h_layer_31             1x1x2560               True     False    9.53e-01   1.84e+01     1.40e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   1.53e+00     8.29e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   1.49e+00     8.88e-02    
+h_layer_26             1x1x2560               True     False    9.69e-01   1.72e+00     1.15e-01    
+h_layer_27             1x1x2560               True     False    9.77e-01   1.97e+00     1.32e-01    
+h_layer_28             1x1x2560               True     False    9.79e-01   8.44e-01     1.45e-01    
+h_layer_29             1x1x2560               True     False    9.80e-01   9.09e-01     1.59e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   8.60e-01     1.77e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.66e-03     1.78e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.20e-01     2.02e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   3.13e-01     3.44e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   8.26e-01     6.47e-02    
+h_layer_31             1x1x2560               True     False    9.08e-01   1.61e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   1.08e+00     6.84e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   1.17e+00     7.09e-02    
+h_layer_26             1x1x2560               True     False    9.85e-01   4.48e-01     7.52e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   9.71e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   8.60e-01     1.14e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.55e-01     1.27e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   1.23e+00     1.54e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.93e-03     9.23e-04    
+h_layer_8              1x1x2560               True     False    9.80e-01   4.51e-01     2.13e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   6.96e-01     4.06e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   3.33e-01     6.84e-02    
+h_layer_31             1x1x2560               True     False    9.12e-01   1.70e+01     1.27e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.49e-01     6.95e-02    
+h_layer_25             1x1x2560               True     False    9.89e-01   7.20e-01     7.14e-02    
+h_layer_26             1x1x2560               True     False    9.87e-01   3.85e-01     7.48e-02    
+h_layer_27             1x1x2560               True     False    9.79e-01   6.51e-01     1.31e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   8.41e-01     1.44e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   7.87e-01     1.58e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   8.85e-01     1.82e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.70e-02     1.48e-03    
+h_layer_8              1x1x2560               True     False    9.03e-01   2.43e-01     3.72e-02    
+h_layer_16             1x1x2560               True     False    7.38e-01   6.67e-01     1.13e-01    
+h_layer_23             1x1x2560               True     False    8.02e-01   1.92e+00     2.26e-01    
+h_layer_31             1x1x2560               True     False    9.17e-01   1.75e+01     1.39e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.07e-01   2.95e+00     2.32e-01    
+h_layer_25             1x1x2560               True     False    8.29e-01   3.92e+00     2.32e-01    
+h_layer_26             1x1x2560               True     False    8.47e-01   2.17e+00     2.37e-01    
+h_layer_27             1x1x2560               True     False    8.90e-01   4.75e+00     2.64e-01    
+h_layer_28             1x1x2560               True     False    9.08e-01   4.52e+00     2.87e-01    
+h_layer_29             1x1x2560               True     False    9.16e-01   4.87e+00     3.08e-01    
+h_layer_30             1x1x2560               True     False    9.15e-01   4.23e+00     3.33e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.14e-03     1.74e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   3.78e-01     1.91e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.41e-01     3.32e-02    
+h_layer_23             1x1x2560               True     False    9.87e-01   4.17e-01     6.60e-02    
+h_layer_31             1x1x2560               True     False    8.92e-01   1.48e+01     1.19e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   4.23e-01     6.80e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   5.56e-01     7.16e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   1.08e+00     8.25e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   6.71e-01     1.07e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   6.77e-01     1.07e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   7.11e-01     1.20e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   8.58e-01     1.45e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   5.81e-03     1.10e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   1.34e-01     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.51e-01   3.08e-01     5.22e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   4.30e-01     7.54e-02    
+h_layer_31             1x1x2560               True     False    9.17e-01   1.40e+01     1.33e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   4.37e-01     7.75e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.22e-01     7.87e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   7.44e-01     8.40e-02    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.01e-01     1.27e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   9.17e-01     1.37e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   9.96e-01     1.51e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   1.35e+00     1.77e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.07e-01   2.44e-01     3.86e-02    
+h_layer_16             1x1x2560               True     False    6.76e-01   1.06e+00     1.29e-01    
+h_layer_23             1x1x2560               True     False    5.55e-01   6.08e+00     3.66e-01    
+h_layer_31             1x1x2560               True     False    7.33e-01   2.77e+01     1.60e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    5.80e-01   7.17e+00     3.68e-01    
+h_layer_25             1x1x2560               True     False    5.85e-01   9.50e+00     3.68e-01    
+h_layer_26             1x1x2560               True     False    5.32e-01   1.18e+01     3.83e-01    
+h_layer_27             1x1x2560               True     False    6.71e-01   1.20e+01     4.41e-01    
+h_layer_28             1x1x2560               True     False    7.14e-01   1.22e+01     4.84e-01    
+h_layer_29             1x1x2560               True     False    7.34e-01   1.32e+01     5.20e-01    
+h_layer_30             1x1x2560               True     False    7.15e-01   1.33e+01     5.64e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/c39-work/seed1_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/c39-work/refs_fp32/seed1/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.14e-03     1.67e-03    
+h_layer_8              1x1x2560               True     False    9.80e-01   1.01e-01     1.88e-02    
+h_layer_16             1x1x2560               True     False    9.72e-01   4.58e-01     4.24e-02    
+h_layer_23             1x1x2560               True     False    9.81e-01   7.67e-01     8.15e-02    
+h_layer_31             1x1x2560               True     False    9.04e-01   1.18e+01     1.25e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   7.92e-01     8.55e-02    
+h_layer_25             1x1x2560               True     False    9.80e-01   7.82e-01     9.23e-02    
+h_layer_26             1x1x2560               True     False    9.65e-01   5.73e-01     1.11e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   1.25e+00     1.30e-01    
+h_layer_28             1x1x2560               True     False    9.80e-01   7.69e-01     1.39e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   6.52e-01     1.51e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   8.76e-01     1.76e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          522                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.73e-01   max|Δ|=1.15e+00   DIV   cos=9.88e-01   max|Δ|=5.91e-01   DIV   cos=2.70e-01   max|Δ|=1.79e+01   DIV   cos=9.81e-01   max|Δ|=1.53e+00   DIV   cos=9.87e-01   max|Δ|=1.08e+00   DIV   cos=9.87e-01   max|Δ|=5.49e-01   DIV   cos=8.07e-01   max|Δ|=2.95e+00   DIV   cos=9.87e-01   max|Δ|=4.23e-01   DIV   cos=9.84e-01   max|Δ|=4.37e-01   DIV   cos=5.80e-01   max|Δ|=7.17e+00   DIV   cos=9.81e-01   max|Δ|=7.92e-01   DIV  
+  h_layer_25            cos=9.75e-01   max|Δ|=1.16e+00   DIV   cos=9.88e-01   max|Δ|=5.72e-01   DIV   cos=2.59e-01   max|Δ|=1.97e+01   DIV   cos=9.81e-01   max|Δ|=1.49e+00   DIV   cos=9.87e-01   max|Δ|=1.17e+00   DIV   cos=9.89e-01   max|Δ|=7.20e-01   DIV   cos=8.29e-01   max|Δ|=3.92e+00   DIV   cos=9.87e-01   max|Δ|=5.56e-01   DIV   cos=9.85e-01   max|Δ|=4.22e-01   DIV   cos=5.85e-01   max|Δ|=9.50e+00   DIV   cos=9.80e-01   max|Δ|=7.82e-01   DIV  
+  h_layer_26            cos=9.80e-01   max|Δ|=1.17e+00   DIV   cos=9.86e-01   max|Δ|=7.34e-01   DIV   cos=2.19e-01   max|Δ|=1.81e+01   DIV   cos=9.69e-01   max|Δ|=1.72e+00   DIV   cos=9.85e-01   max|Δ|=4.48e-01   DIV   cos=9.87e-01   max|Δ|=3.85e-01   DIV   cos=8.47e-01   max|Δ|=2.17e+00   DIV   cos=9.82e-01   max|Δ|=1.08e+00   DIV   cos=9.82e-01   max|Δ|=7.44e-01   DIV   cos=5.32e-01   max|Δ|=1.18e+01   DIV   cos=9.65e-01   max|Δ|=5.73e-01   DIV  
+  h_layer_27            cos=9.77e-01   max|Δ|=1.84e+00   DIV   cos=9.86e-01   max|Δ|=1.03e+00   DIV   cos=4.07e-01   max|Δ|=2.17e+01   DIV   cos=9.77e-01   max|Δ|=1.97e+00   DIV   cos=9.87e-01   max|Δ|=9.71e-01   DIV   cos=9.79e-01   max|Δ|=6.51e-01   DIV   cos=8.90e-01   max|Δ|=4.75e+00   DIV   cos=9.87e-01   max|Δ|=6.71e-01   DIV   cos=9.81e-01   max|Δ|=6.01e-01   DIV   cos=6.71e-01   max|Δ|=1.20e+01   DIV   cos=9.80e-01   max|Δ|=1.25e+00   DIV  
+  h_layer_28            cos=9.81e-01   max|Δ|=1.38e+00   DIV   cos=9.87e-01   max|Δ|=7.18e-01   DIV   cos=4.69e-01   max|Δ|=2.40e+01   DIV   cos=9.79e-01   max|Δ|=8.44e-01   DIV   cos=9.86e-01   max|Δ|=8.60e-01   DIV   cos=9.80e-01   max|Δ|=8.41e-01   DIV   cos=9.08e-01   max|Δ|=4.52e+00   DIV   cos=9.87e-01   max|Δ|=6.77e-01   DIV   cos=9.82e-01   max|Δ|=9.17e-01   DIV   cos=7.14e-01   max|Δ|=1.22e+01   DIV   cos=9.80e-01   max|Δ|=7.69e-01   DIV  
+  h_layer_29            cos=9.79e-01   max|Δ|=1.68e+00   DIV   cos=9.87e-01   max|Δ|=6.79e-01   DIV   cos=5.42e-01   max|Δ|=2.32e+01   DIV   cos=9.80e-01   max|Δ|=9.09e-01   DIV   cos=9.87e-01   max|Δ|=6.55e-01   DIV   cos=9.81e-01   max|Δ|=7.87e-01   DIV   cos=9.16e-01   max|Δ|=4.87e+00   DIV   cos=9.88e-01   max|Δ|=7.11e-01   DIV   cos=9.81e-01   max|Δ|=9.96e-01   DIV   cos=7.34e-01   max|Δ|=1.32e+01   DIV   cos=9.82e-01   max|Δ|=6.52e-01   DIV  
+  h_layer_30            cos=9.79e-01   max|Δ|=1.18e+00   DIV   cos=9.82e-01   max|Δ|=8.43e-01   DIV   cos=5.32e-01   max|Δ|=2.27e+01   DIV   cos=9.77e-01   max|Δ|=8.60e-01   DIV   cos=9.81e-01   max|Δ|=1.23e+00   DIV   cos=9.76e-01   max|Δ|=8.85e-01   DIV   cos=9.15e-01   max|Δ|=4.23e+00   DIV   cos=9.82e-01   max|Δ|=8.58e-01   DIV   cos=9.76e-01   max|Δ|=1.35e+00   DIV   cos=7.15e-01   max|Δ|=1.33e+01   DIV   cos=9.75e-01   max|Δ|=8.76e-01   DIV  
+  h_layer_31            cos=9.56e-01   max|Δ|=2.06e+01   DIV   cos=9.30e-01   max|Δ|=1.60e+01   DIV   cos=6.68e-01   max|Δ|=2.03e+01   DIV   cos=9.53e-01   max|Δ|=1.84e+01   DIV   cos=9.08e-01   max|Δ|=1.61e+01   DIV   cos=9.12e-01   max|Δ|=1.70e+01   DIV   cos=9.17e-01   max|Δ|=1.75e+01   DIV   cos=8.92e-01   max|Δ|=1.48e+01   DIV   cos=9.17e-01   max|Δ|=1.40e+01   DIV   cos=7.33e-01   max|Δ|=2.77e+01   DIV   cos=9.04e-01   max|Δ|=1.18e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=9.81e-01     DIV
+    h_layer_25             median=9.81e-01     DIV
+    h_layer_26             median=9.80e-01     DIV
+    h_layer_27             median=9.79e-01     DIV
+    h_layer_28             median=9.80e-01     DIV
+    h_layer_29             median=9.81e-01     DIV
+    h_layer_30             median=9.76e-01     DIV
+    h_layer_31             median=9.12e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  q_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  k_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  v_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_q           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_k           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV <missing>                                            <missing>                                           
+  post_attn_norm      <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_gate            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_up              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_down            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=nan          DIV
+    q_proj               median=nan          DIV
+    k_proj               median=nan          DIV
+    v_proj               median=nan          DIV
+    qk_norm_q            median=nan          DIV
+    qk_norm_k            median=nan          DIV
+    o_proj               median=nan          DIV
+    post_attn_norm       median=nan          DIV
+    mlp_gate             median=nan          DIV
+    mlp_up               median=nan          DIV
+    mlp_down             median=nan          DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.981425)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -83,8 +83,10 @@ tap-for-tap.
 Prompt provenance
 -----------------
 
-* If the kiln dump contains a `meta__prompt_tokens_len` scalar and a
-  `prompt_tokens` I32 tensor, we use those directly.
+* If the kiln dump contains a `prompt_tokens` I32 tensor, we treat it as the
+  full replay sequence whose final hidden row produced `h_main`. Newer C39
+  dumps also carry `meta__replay_tokens_len`; older dumps only carry
+  `meta__prompt_tokens_len`.
 * Otherwise we fall back to a canonical 512-token greeting prompt with
   torch seed=42, matching what the kiln bench harness emits by default.
 
@@ -182,7 +184,7 @@ B12_LAYER31_GQA_TAP_NAMES: Tuple[str, ...] = (
 def load_kiln_dump(path: str) -> Dict[str, object]:
     """Load a kiln-side MTP dump. Int tensors with a `meta__` prefix are
     returned as plain Python ints; other tensors as float32 (or int64 for
-    `prompt_tokens`) on CPU."""
+    `prompt_tokens`, which carries the full replay sequence) on CPU."""
     out: Dict[str, object] = {}
     with safe_open(path, framework="pt", device="cpu") as f:
         for name in f.keys():
@@ -1020,8 +1022,9 @@ def main() -> int:
         file=sys.stderr,
     )
 
-    # Resolve the prompt tokens. Prefer kiln-provided `prompt_tokens`, fall
-    # back to the canonical 512-token greeting.
+    # Resolve the replay sequence. Prefer kiln-provided `prompt_tokens`
+    # (full conditioned sequence in C39+ dumps), fall back to the canonical
+    # 512-token greeting for legacy dumps that lack embedded tokens.
     prompt_tokens: Optional[torch.Tensor] = None
     if "prompt_tokens" in kiln:
         raw = kiln["prompt_tokens"]  # type: ignore[assignment]
@@ -1031,8 +1034,15 @@ def main() -> int:
             prompt_tokens = raw.view(1, -1).to(torch.int64).contiguous()
         else:
             prompt_tokens = raw.to(torch.int64).contiguous()
+        expected_len = kiln.get("meta__replay_tokens_len", kiln.get("meta__prompt_tokens_len"))
+        if isinstance(expected_len, int):
+            actual_len = int(prompt_tokens.shape[-1])
+            assert actual_len == expected_len, (
+                f"embedded replay length mismatch: tensor has {actual_len} ids, "
+                f"meta says {expected_len}"
+            )
         print(
-            f"[mtp_h_main_ref] prompt_tokens from kiln dump: shape={tuple(prompt_tokens.shape)}",
+            f"[mtp_h_main_ref] replay tokens from kiln dump: shape={tuple(prompt_tokens.shape)}",
             file=sys.stderr,
         )
     else:
@@ -1079,6 +1089,9 @@ def main() -> int:
     out_dict["meta__draft_token_id"] = torch.tensor([draft_token_id], dtype=torch.int32)
     out_dict["meta__mtp_pos"] = torch.tensor([mtp_pos], dtype=torch.int32)
     out_dict["meta__prompt_tokens_len"] = torch.tensor(
+        [int(prompt_tokens.shape[-1])], dtype=torch.int32
+    )
+    out_dict["meta__replay_tokens_len"] = torch.tensor(
         [int(prompt_tokens.shape[-1])], dtype=torch.int32
     )
     boundary_layers = list(B10_BOUNDARY_LAYERS)


### PR DESCRIPTION
## Summary
- fix the native-MTP dump contract so each captured `h_main` row carries the full replay sequence instead of the local verifier slice
- rerun the standard seed-0 / seed-1 native-MTP workload on fresh `main` and regenerate bf16/fp32 B10/B11/B12 comparator artifacts
- record the C39 result: the replay bug is fixed, but seed 0 and seed 1 still do not split at a distinct first upstream boundary

## Validation
### Local
```bash
python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
```

### Pod setup / build
```bash
source /root/.kiln-build-env
export KILN_CUDA_ARCHS=86
cargo build --release --features cuda --bin kiln-bench
cargo test -p kiln-model mtp_debug --lib -- --test-threads=1
python3 -m pip install --upgrade numpy transformers sentencepiece safetensors
hf download Qwen/Qwen3.5-4B --local-dir /workspace/qwen3.5-4b
```

### Fresh seed rerun
```bash
for seed in 0 1; do
  root=/workspace/c39-work/seed${seed}_captures
  mkdir -p "$root"/mtp_pos-0 "$root"/mtp_pos-2
  KILN_W4A16=1 \
  KILN_CUDA_GRAPHS=true \
  KILN_SPEC_METHOD=mtp \
  KILN_BENCH_FORCE_MTP=1 \
  KILN_MTP_DUMP_SPLICE=1 \
  KILN_MTP_DUMP_SPLICE_POS=0,2 \
  KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
  KILN_MTP_DUMP_HIDDEN_STATES=1 \
  KILN_MTP_DUMP_B11_TAPS=1 \
  KILN_MTP_DUMP_B12_GQA_TAPS=1 \
  KILN_MTP_DUMP_PATH=$root/mtp_pos-{pos}/step-{step}.safetensors \
  ./target/release/kiln-bench \
    --model-path /workspace/qwen3.5-4b \
    --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
    --seed ${seed} \
    > docs/phase-c39/seed${seed}.bench.json
 done
```

### HF replay + compare
```bash
python3 scripts/mtp_h_main_reference_dump.py --checkpoint /workspace/qwen3.5-4b \
  --kiln-dump <dump> --out <ref> --device cuda --b11-taps --b12-taps
python3 scripts/mtp_h_main_reference_dump.py --checkpoint /workspace/qwen3.5-4b \
  --kiln-dump <dump> --out <ref-fp32> --device cuda --b11-taps --b12-taps --fp32
python3 scripts/mtp_compare.py --b10 ...
python3 scripts/mtp_compare.py --b11 ...
python3 scripts/mtp_compare.py --b12 ...
```

## Final verdict
- replay-context fix is confirmed: seed 0 replay lengths grow `494 -> 495 -> 496 -> 497 -> 502 -> 503 -> 504`; seed 1 grows `508 -> 509 -> 510 -> 511 -> 512 -> 513 -> 514 -> 515 -> 520 -> 521 -> 522`
- fresh workload still reproduces the split on A6000: seed 0 `α=0.7067`, seed 1 `α=0.2929`
- with fully conditioned bf16 and fp32 HF replays, both seeds land on the same upstream comparator verdicts:
  - B10: first diverging boundary tap = `h_layer_8` at `0_s0`
  - B11b: all layer-0 GDN sub-ops remain clean
  - B12: late-stack drift first appears at `h_layer_24`
- conclusion: C39 fixes the blocker from #423, but it does **not** reveal a seed-1-only first upstream boundary or sub-op
