### PR TITLE
phase6: refresh post-423 replay bisect artifact

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -428,6 +428,64 @@ full-attention decode backend.
 **Validation:** no pod launched; no CUDA files changed; no build or benchmark
 commands run because this is a docs-only redirect on current-main evidence.
 
+## Phase C39 post-#423 replay-context fix + fresh seed bisect (2026-04-23)
+
+**Scope:** extend the B10/B11/B12 dump contract so every splice row carries
+the fully conditioned replay sequence, rerun the standard native-MTP seed-0 /
+seed-1 workload on fresh `main` after PR #423, and re-run the matched HF
+reference / comparator path on the updated artifacts.
+
+**Preflight outcome:** proceed. Fresh `origin/main` was `61badb6`
+(PR #423), and current `main` did **not** already serialize enough token
+context for later splice rows. An initial rerun on the unchanged bench path
+still logged `replay_tokens_len=1` / `2` after step 0, proving the missing
+context was still present outside the kiln-model generation loop.
+
+**Code path fixed:** the replay-prefix plumbing now covers both the
+kiln-model native-MTP generation loops and the `kiln-bench` native-MTP bench
+loop. Fresh rerun logs on a supported A40 show the intended full-sequence
+contract:
+
+- seed 0: `step-1 replay_tokens_len=495`, `step-2=496`, `mtp_pos=2 step-0=502`
+- seed 1: `step-1 replay_tokens_len=509`, `step-7=515`, `mtp_pos=2 step-0=520`
+
+Those rows previously carried only the current 1-token / 2-token slice.
+
+**Fresh workload check (standard native-MTP path):**
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 8734.0 | 36.13 | 0.7162 |
+| 1 | 508 | 452.6 | 22.92 | 0.2828 |
+
+So the seed split still reproduces on fresh `main`; C39 only changes the
+replay contract, not the underlying acceptance behavior.
+
+**Source-of-truth artifacts:** the refreshed comparator outputs are:
+
+- `profiling-artifacts/post423_20260423_seed0_compare_bf16.txt`
+- `profiling-artifacts/post423_20260423_seed0_compare_fp32.txt`
+- `profiling-artifacts/post423_20260423_seed1_compare_bf16.txt`
+- `profiling-artifacts/post423_20260423_seed1_compare_fp32.txt`
+
+Across both bf16 and fp32 HF references, the seed-0 and seed-1 verdicts are
+the same:
+
+- B10: first diverging tap is `h_layer_8` (`h_layer_0` still matches), verdict
+  `DIVERGENCE IN EARLY GDN STACK`
+- B11: `ALL layer-0 GDN sub-ops match within cos_sim >= 0.95`
+- B12: first below-bar late-stack layer is `h_layer_24`, verdict
+  `DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31)`
+
+**Verdict:** the replay-contract blocker from C38 is fixed, but the refreshed
+post-#423 artifact still does **not** expose a seed1-only first boundary or
+sub-op. With fully conditioned HF replays, both the control and failing seeds
+land the same first boundary verdict (`h_layer_8`) and the same later-stack
+drift verdict (`h_layer_24`). The honest next recommendation is **not** a
+seed1-only fix from this artifact; it is a narrower bisect inside the early
+GDN span between `h_layer_0` and `h_layer_8`, because that is now the first
+shared bad boundary on both seeds.
+
 ## Phase 6 post-#392 current-main re-profile — 2026-04-23
 
 **Scope:** refresh the Phase 6 performance source of truth on fresh `main`

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -4882,7 +4882,7 @@ pub fn model_forward_paged_with_last_hidden(
     // the MTP dump can serialize them, letting the HF reference replay the
     // same prompt instead of its canonical fallback greeting. No-op when
     // h_main capture is disarmed.
-    crate::mtp_debug::stash_h_main_prompt_tokens(token_ids);
+    crate::mtp_debug::stash_h_main_replay_context(token_ids);
     // Phase B11b: arm the layer-0 GDN sub-op capture window in the same
     // place as h_main so both capture modes drain together inside the MTP
     // dump block. No-op unless `KILN_MTP_DUMP_B11_TAPS=1`, so production
@@ -4931,7 +4931,7 @@ pub fn model_forward_paged_last_token_with_last_hidden(
     positions_gpu: Option<&Tensor>,
 ) -> Result<(Tensor, Tensor)> {
     crate::mtp_debug::arm_h_main_capture();
-    crate::mtp_debug::stash_h_main_prompt_tokens(token_ids);
+    crate::mtp_debug::stash_h_main_replay_context(token_ids);
     crate::mtp_debug::arm_b11_layer0_capture();
     let (logits, hidden) = model_forward_paged_inner(
         backend,
@@ -5313,6 +5313,7 @@ pub fn mtp_forward_step(
             // paths / when h_main capture was never armed, which matches
             // the pre-B11 dump format (no `prompt_tokens` tensor emitted).
             let prompt_tokens = crate::mtp_debug::drain_h_main_prompt_tokens();
+            let replay_tokens = crate::mtp_debug::drain_h_main_replay_tokens();
             // Phase B11b: drain any layer-0 GDN sub-op taps stashed during
             // the base-model forward. Empty when `KILN_MTP_DUMP_B11_TAPS`
             // is unset, which keeps the dump format bit-identical to B11.
@@ -5348,6 +5349,7 @@ pub fn mtp_forward_step(
                 &taps,
                 &extra_subops,
                 &prompt_tokens,
+                &replay_tokens,
                 &b11_taps,
                 &b12_taps,
                 &c6_taps,
@@ -5362,6 +5364,7 @@ pub fn mtp_forward_step(
                     splice_step = ?splice_step,
                     subops = extra_subops.len(),
                     prompt_tokens_len = prompt_tokens.len(),
+                    replay_tokens_len = replay_tokens.len(),
                     b11_taps = b11_taps.len(),
                     b12_taps = b12_taps.len(),
                     c6_taps = c6_taps.len(),
@@ -5809,7 +5812,7 @@ pub fn model_forward_paged_streaming_last_token_with_last_hidden_with(
         let is_last_tile = end == total;
         let mode = if is_last_tile {
             crate::mtp_debug::arm_h_main_capture();
-            crate::mtp_debug::stash_h_main_prompt_tokens(token_ids);
+            crate::mtp_debug::stash_h_main_replay_context(token_ids);
             crate::mtp_debug::arm_b11_layer0_capture();
             LmHeadMode::LastRowWithLastHidden
         } else {

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1739,6 +1739,11 @@ impl ModelRunner {
             }
 
             total_draft_attempts += 1;
+            let mut replay_prefix =
+                Vec::with_capacity(prompt_tokens.len() + generated_tokens.len());
+            replay_prefix.extend_from_slice(prompt_tokens);
+            replay_prefix.extend_from_slice(&generated_tokens);
+            crate::mtp_debug::set_h_main_replay_prefix_tokens(&replay_prefix);
             let result = speculative_mtp_decode_step(
                 &*self.backend,
                 last_token,
@@ -1755,8 +1760,9 @@ impl ModelRunner {
                 params,
                 &self.eos_token_ids,
                 &mut rng,
-            )
-            .context("mtp speculative decode step failed")?;
+            );
+            crate::mtp_debug::clear_h_main_replay_prefix_tokens();
+            let result = result.context("mtp speculative decode step failed")?;
 
             if result.draft_accepted {
                 draft_accepted_count += 1;
@@ -2160,6 +2166,11 @@ impl ModelRunner {
                 break;
             }
 
+            let mut replay_prefix =
+                Vec::with_capacity(prompt_tokens.len() + generated_tokens.len());
+            replay_prefix.extend_from_slice(&prompt_tokens);
+            replay_prefix.extend_from_slice(&generated_tokens);
+            crate::mtp_debug::set_h_main_replay_prefix_tokens(&replay_prefix);
             let result = speculative_mtp_decode_step(
                 &*self.backend,
                 last_token,
@@ -2176,8 +2187,9 @@ impl ModelRunner {
                 params,
                 &self.eos_token_ids,
                 &mut rng,
-            )
-            .context("mtp speculative decode step failed")?;
+            );
+            crate::mtp_debug::clear_h_main_replay_prefix_tokens();
+            let result = result.context("mtp speculative decode step failed")?;
 
             base_pos += result.base_advance;
             mtp_pos += result.mtp_advance;

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -64,13 +64,47 @@ thread_local! {
     /// Phase B11: thread-local slot for the base-model input token ids that
     /// fed the forward pass which produced the currently-armed h_main
     /// capture. Populated in `model_forward_paged_with_last_hidden` right
-    /// after [`arm_h_main_capture`] via [`stash_h_main_prompt_tokens`], and
+    /// after [`arm_h_main_capture`] via [`stash_h_main_replay_context`], and
     /// drained in `mtp_forward_step`'s dump block so the tokens can be
     /// serialized alongside the taps (see [`write_mtp_dump`]). The HF
     /// reference (`scripts/mtp_h_main_reference_dump.py`) prefers these
     /// tokens over its canonical greeting, guaranteeing both sides replay
     /// the exact same prompt during the per-tap bisect.
     static H_MAIN_PROMPT_TOKENS: RefCell<Option<Vec<u32>>> =
+        const { RefCell::new(None) };
+
+    /// Phase C39: thread-local slot for the FULL base-model token sequence
+    /// that produced the currently-armed h_main capture. Unlike
+    /// [`H_MAIN_PROMPT_TOKENS`], which preserves the raw per-call slice
+    /// (`[last_token]` or `[last_token, draft_token]` during native-MTP
+    /// verify/replay), this stores the fully-conditioned sequence visible to
+    /// the base-model forward at that step: `prompt ++ accepted_prefix ++
+    /// current_call_suffix`.
+    ///
+    /// The native-MTP loop in `generate.rs` seeds a per-step replay prefix
+    /// before entering `speculative_mtp_decode_step`; the forward dump path
+    /// combines that prefix with the current call tokens and serializes the
+    /// resulting `replay_tokens` tensor. HF-side B10/B11/B12 reference replays
+    /// prefer this full sequence so later step dumps are no longer
+    /// under-conditioned to the current 1-token slice.
+    static H_MAIN_REPLAY_TOKENS: RefCell<Option<Vec<u32>>> =
+        const { RefCell::new(None) };
+
+    /// Phase C39: optional per-step replay prefix injected by the native-MTP
+    /// decode loop. When set, the next [`stash_h_main_replay_context`] call
+    /// combines this prefix with the current base-model call token slice to
+    /// form [`H_MAIN_REPLAY_TOKENS`].
+    ///
+    /// Expected shape in native-MTP:
+    ///   * before verify `[last_token, draft_token]` call:
+    ///       `prompt ++ accepted_tokens_so_far ++ [last_token]`
+    ///   * before reject replay `[last_token]` call:
+    ///       same prefix as above
+    ///
+    /// Combination rule: if the current call's first token already equals the
+    /// prefix tail, we append only `token_ids[1..]` to avoid duplicating the
+    /// just-committed `last_token`.
+    static H_MAIN_REPLAY_PREFIX_TOKENS: RefCell<Option<Vec<u32>>> =
         const { RefCell::new(None) };
 
     /// Phase B11b: thread-local sink for layer-0 GDN sub-op taps. Kept
@@ -519,11 +553,13 @@ pub fn capture_h_main_tap(name: &str, t: &Tensor) -> Result<()> {
 /// Phase B11: stash the base-model prompt tokens for the currently-armed
 /// h_main capture. No-op when the capture window is closed (matches the
 /// semantics of [`arm_h_main_capture`] — callers can invoke unconditionally).
-pub fn stash_h_main_prompt_tokens(tokens: &[u32]) {
+pub fn stash_h_main_replay_context(tokens: &[u32]) {
     if !is_h_main_capture_armed() {
         return;
     }
     H_MAIN_PROMPT_TOKENS.with(|c| *c.borrow_mut() = Some(tokens.to_vec()));
+    let replay_tokens = build_h_main_replay_tokens(tokens);
+    H_MAIN_REPLAY_TOKENS.with(|c| *c.borrow_mut() = Some(replay_tokens));
 }
 
 /// Phase B11: drain the stashed prompt tokens. Returns an empty vector when
@@ -532,6 +568,39 @@ pub fn stash_h_main_prompt_tokens(tokens: &[u32]) {
 /// to skip serializing a `prompt_tokens` tensor.
 pub fn drain_h_main_prompt_tokens() -> Vec<u32> {
     H_MAIN_PROMPT_TOKENS.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+/// Phase C39: set the native-MTP replay prefix used to reconstruct the fully
+/// conditioned sequence for the next h_main capture on this thread.
+pub fn set_h_main_replay_prefix_tokens(tokens: &[u32]) {
+    H_MAIN_REPLAY_PREFIX_TOKENS.with(|c| *c.borrow_mut() = Some(tokens.to_vec()));
+}
+
+/// Phase C39: clear the native-MTP replay prefix after the step finishes so a
+/// later unrelated base-model forward does not inherit stale context.
+pub fn clear_h_main_replay_prefix_tokens() {
+    H_MAIN_REPLAY_PREFIX_TOKENS.with(|c| *c.borrow_mut() = None);
+}
+
+/// Phase C39: drain the fully conditioned replay sequence corresponding to the
+/// most recent h_main capture. Empty when nothing was stashed.
+pub fn drain_h_main_replay_tokens() -> Vec<u32> {
+    H_MAIN_REPLAY_TOKENS.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+fn build_h_main_replay_tokens(tokens: &[u32]) -> Vec<u32> {
+    let mut replay = H_MAIN_REPLAY_PREFIX_TOKENS.with(|c| c.borrow().clone().unwrap_or_default());
+    if replay.is_empty() {
+        return tokens.to_vec();
+    }
+    if let Some((&first, rest)) = tokens.split_first() {
+        if replay.last().copied() == Some(first) {
+            replay.extend_from_slice(rest);
+        } else {
+            replay.extend_from_slice(tokens);
+        }
+    }
+    replay
 }
 
 // -----------------------------------------------------------------------------
@@ -1299,15 +1368,18 @@ fn tensor_to_f32_host(t: &Tensor) -> Result<(Vec<usize>, Vec<f32>)> {
 /// trio. These are written under their captured names alongside the
 /// static taps; an empty slice makes this behave identically to Phase B6.
 ///
-/// Phase B11: `prompt_tokens` carries the base-model input token ids from
-/// the forward pass that produced the h_main value (see
-/// [`stash_h_main_prompt_tokens`] / [`drain_h_main_prompt_tokens`]). When
+/// Phase B11: `prompt_tokens` carries the raw base-model input token ids from
+/// the current forward call that produced the h_main value (see
+/// [`stash_h_main_replay_context`] / [`drain_h_main_prompt_tokens`]). When
 /// non-empty, it is serialized as a flat I32 tensor named `prompt_tokens`
-/// plus a 1-element I32 scalar `meta__prompt_tokens_len`. The HF reference
-/// (`scripts/mtp_h_main_reference_dump.py`) prefers these tokens over its
-/// canonical greeting so both sides replay the exact same prompt during
-/// the per-tap bisect. Pass `&[]` (or legacy callers using `&extra_subops`
-/// before this param) to skip the prompt-tokens emission.
+/// plus a 1-element I32 scalar `meta__prompt_tokens_len`. This legacy field
+/// is kept for older chained-sequence tooling such as the C15 audit.
+///
+/// Phase C39: `replay_tokens` carries the FULLY conditioned token sequence
+/// visible to the base-model forward at that step. The HF-side B10/B11/B12
+/// replay should prefer `replay_tokens` when present and fall back to the
+/// legacy `prompt_tokens` field otherwise. Serialized as flat I32
+/// `replay_tokens` plus `meta__replay_tokens_len`.
 ///
 /// Phase B11b: `b11_taps` carries the layer-0 GDN sub-op taps captured via
 /// [`arm_b11_layer0_capture`] / [`capture_b11_layer0_tap`] /
@@ -1359,6 +1431,7 @@ pub fn write_mtp_dump(
     taps: &[(&str, &Tensor)],
     extra_subops: &[(String, Vec<usize>, Vec<f32>)],
     prompt_tokens: &[u32],
+    replay_tokens: &[u32],
     b11_taps: &[(String, Vec<usize>, Vec<f32>)],
     b12_taps: &[(String, Vec<usize>, Vec<f32>)],
     c6_taps: &[(String, Vec<usize>, Vec<f32>)],
@@ -1369,14 +1442,16 @@ pub fn write_mtp_dump(
 
     // Materialize every tensor to a host byte buffer first so the
     // TensorViews we build below can borrow from a stable backing store.
-    // Capacity: static taps + subops + 4 meta + optional (prompt_tokens, len)
-    // + b11 taps + b12 taps + c6 taps + c7 taps + c14 taps.
+    // Capacity: static taps + subops + 4 meta + optional prompt/replay token
+    // tensors + b11 taps + b12 taps + c6 taps + c7 taps + c14 taps.
     let prompt_reserve = if prompt_tokens.is_empty() { 0 } else { 2 };
+    let replay_reserve = if replay_tokens.is_empty() { 0 } else { 2 };
     let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> = Vec::with_capacity(
         taps.len()
             + extra_subops.len()
             + 4
             + prompt_reserve
+            + replay_reserve
             + b11_taps.len()
             + b12_taps.len()
             + c6_taps.len()
@@ -1456,6 +1531,27 @@ pub fn write_mtp_dump(
             vec![prompt_tokens.len()],
             Dtype::I32,
             pt_bytes,
+        ));
+    }
+
+    if !replay_tokens.is_empty() {
+        let len_i32 = replay_tokens.len() as i32;
+        backings.push((
+            "meta__replay_tokens_len".into(),
+            vec![1],
+            Dtype::I32,
+            len_i32.to_le_bytes().to_vec(),
+        ));
+        let mut rt_bytes = Vec::with_capacity(replay_tokens.len() * 4);
+        for &tok in replay_tokens {
+            let as_i32 = tok as i32;
+            rt_bytes.extend_from_slice(&as_i32.to_le_bytes());
+        }
+        backings.push((
+            "replay_tokens".into(),
+            vec![replay_tokens.len()],
+            Dtype::I32,
+            rt_bytes,
         ));
     }
 
@@ -1545,6 +1641,12 @@ pub fn format_top_k(top: &[(u32, f32)]) -> String {
 mod tests {
     use super::*;
     use candle_core::Device;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn test_env_lock() -> MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
 
     #[test]
     fn top_k_picks_largest_in_descending_order() {
@@ -1571,6 +1673,7 @@ mod tests {
 
     #[test]
     fn should_log_is_false_when_env_unset() {
+        let _guard = test_env_lock();
         // SAFETY: tests are #[cfg(test)] and run with cargo's default serial
         // dispatch within a process. We only mutate KILN_MTP_DEBUG here, so a
         // single set/unset is fine for this check.
@@ -1583,6 +1686,7 @@ mod tests {
 
     #[test]
     fn dump_slot_fires_once_per_position() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         let tmp = std::env::temp_dir().join("kiln_mtp_dump_slot_once.safetensors");
         let tmp_s = tmp.to_string_lossy().into_owned();
@@ -1603,6 +1707,7 @@ mod tests {
 
     #[test]
     fn dump_slot_supports_multi_position_targets() {
+        let _guard = test_env_lock();
         let tmp = std::env::temp_dir().join("kiln_mtp_dump_multi_pos.safetensors");
         let tmp_s = tmp.to_string_lossy().into_owned();
         unsafe {
@@ -1630,6 +1735,7 @@ mod tests {
 
     #[test]
     fn dump_path_for_pos_substitutes_placeholder() {
+        let _guard = test_env_lock();
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_PATH", "/tmp/dump_pos{pos}.safetensors");
         }
@@ -1659,6 +1765,7 @@ mod tests {
 
     #[test]
     fn splice_disabled_by_default_and_consumes_no_slot() {
+        let _guard = test_env_lock();
         // SAFETY: single-test scoped env mutation; callers downstream remove
         // vars on success.
         unsafe {
@@ -1676,6 +1783,7 @@ mod tests {
 
     #[test]
     fn splice_defaults_to_positions_0_and_2_with_8_steps() {
+        let _guard = test_env_lock();
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_SPLICE", "1");
             std::env::set_var(
@@ -1716,6 +1824,7 @@ mod tests {
 
     #[test]
     fn splice_respects_custom_positions_and_max_steps() {
+        let _guard = test_env_lock();
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_SPLICE", "1");
             std::env::set_var("KILN_MTP_DUMP_PATH", "/tmp/c13_custom.safetensors");
@@ -1747,6 +1856,7 @@ mod tests {
 
     #[test]
     fn splice_requires_dump_path_to_fire() {
+        let _guard = test_env_lock();
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_SPLICE", "1");
             std::env::remove_var("KILN_MTP_DUMP_PATH");
@@ -1764,6 +1874,7 @@ mod tests {
 
     #[test]
     fn dump_path_for_pos_and_step_substitutes_both_placeholders() {
+        let _guard = test_env_lock();
         unsafe {
             std::env::set_var(
                 "KILN_MTP_DUMP_PATH",
@@ -1831,6 +1942,7 @@ mod tests {
 
     #[test]
     fn h_main_capture_records_then_drains() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_HIDDEN_STATES", "1");
@@ -1865,6 +1977,7 @@ mod tests {
 
     #[test]
     fn h_main_arm_is_noop_when_env_unset() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::remove_var("KILN_MTP_DUMP_HIDDEN_STATES");
@@ -1877,25 +1990,30 @@ mod tests {
     }
 
     #[test]
-    fn stash_h_main_prompt_tokens_requires_armed_capture() {
+    fn stash_h_main_replay_context_requires_armed_capture() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::remove_var("KILN_MTP_DUMP_HIDDEN_STATES");
         }
         // Disarmed: stash is a silent no-op.
-        stash_h_main_prompt_tokens(&[1, 2, 3]);
+        stash_h_main_replay_context(&[1, 2, 3]);
         assert!(drain_h_main_prompt_tokens().is_empty());
+        assert!(drain_h_main_replay_tokens().is_empty());
 
         // Armed: stash round-trips through drain.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_HIDDEN_STATES", "1");
         }
         arm_h_main_capture();
-        stash_h_main_prompt_tokens(&[10, 20, 30, 40]);
+        stash_h_main_replay_context(&[10, 20, 30, 40]);
         let drained = drain_h_main_prompt_tokens();
         assert_eq!(drained, vec![10, 20, 30, 40]);
+        let replay = drain_h_main_replay_tokens();
+        assert_eq!(replay, vec![10, 20, 30, 40]);
         // Second drain returns empty (moved out).
         assert!(drain_h_main_prompt_tokens().is_empty());
+        assert!(drain_h_main_replay_tokens().is_empty());
         // Clean up capture state.
         let _ = drain_h_main_capture();
         unsafe {
@@ -1920,6 +2038,7 @@ mod tests {
             &[("h_main", &a)],
             &[],
             &prompt,
+            &prompt,
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             /* c6_taps = */ &[],
@@ -1933,6 +2052,8 @@ mod tests {
         let names: Vec<&str> = st.names().into_iter().map(|s| s.as_str()).collect();
         assert!(names.contains(&"prompt_tokens"));
         assert!(names.contains(&"meta__prompt_tokens_len"));
+        assert!(names.contains(&"replay_tokens"));
+        assert!(names.contains(&"meta__replay_tokens_len"));
 
         let pt = st.tensor("prompt_tokens").unwrap();
         assert_eq!(pt.dtype(), safetensors::Dtype::I32);
@@ -1948,7 +2069,32 @@ mod tests {
         let len_val = i32::from_le_bytes(len_meta.data()[0..4].try_into().unwrap());
         assert_eq!(len_val, prompt.len() as i32);
 
+        let replay = st.tensor("replay_tokens").unwrap();
+        assert_eq!(replay.dtype(), safetensors::Dtype::I32);
+        assert_eq!(replay.shape(), &[prompt.len()]);
+        let replay_len_meta = st.tensor("meta__replay_tokens_len").unwrap();
+        let replay_len_val = i32::from_le_bytes(replay_len_meta.data()[0..4].try_into().unwrap());
+        assert_eq!(replay_len_val, prompt.len() as i32);
+
         let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn replay_prefix_combines_with_current_call_without_duplicating_last_token() {
+        let _guard = test_env_lock();
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_HIDDEN_STATES", "1");
+        }
+        arm_h_main_capture();
+        set_h_main_replay_prefix_tokens(&[10, 20, 30]);
+        stash_h_main_replay_context(&[30, 40]);
+        assert_eq!(drain_h_main_prompt_tokens(), vec![30, 40]);
+        assert_eq!(drain_h_main_replay_tokens(), vec![10, 20, 30, 40]);
+        clear_h_main_replay_prefix_tokens();
+        let _ = drain_h_main_capture();
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_HIDDEN_STATES");
+        }
     }
 
     #[test]
@@ -1979,6 +2125,7 @@ mod tests {
             &[("h_main", &a), ("mtp_logits", &b)],
             &[("post_q_proj".to_string(), vec![2], vec![0.1_f32, 0.2])],
             /* prompt_tokens = */ &[],
+            /* replay_tokens = */ &[],
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             /* c6_taps = */ &[],
@@ -2000,6 +2147,8 @@ mod tests {
         // should be serialized.
         assert!(!names.contains(&"prompt_tokens"));
         assert!(!names.contains(&"meta__prompt_tokens_len"));
+        assert!(!names.contains(&"replay_tokens"));
+        assert!(!names.contains(&"meta__replay_tokens_len"));
         // With b11_taps = &[], no b11__* tensors should appear.
         assert!(!names.iter().any(|n| n.starts_with("b11__")));
         // With b12_taps = &[], no b12__* tensors should appear.
@@ -2035,6 +2184,7 @@ mod tests {
 
     #[test]
     fn b11_layer0_capture_records_then_drains() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_B11_TAPS", "1");
@@ -2075,6 +2225,7 @@ mod tests {
 
     #[test]
     fn b11_layer0_arm_is_noop_when_env_unset() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::remove_var("KILN_MTP_DUMP_B11_TAPS");
@@ -2115,6 +2266,7 @@ mod tests {
             &[("h_main", &h)],
             &[],
             /* prompt_tokens = */ &[],
+            /* replay_tokens = */ &[],
             &b11,
             /* b12_taps = */ &[],
             /* c6_taps = */ &[],
@@ -2167,6 +2319,7 @@ mod tests {
 
     #[test]
     fn b12_gqa_capture_records_then_drains() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_B12_GQA_TAPS", "1");
@@ -2207,6 +2360,7 @@ mod tests {
 
     #[test]
     fn b12_gqa_arm_is_noop_when_env_unset() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::remove_var("KILN_MTP_DUMP_B12_GQA_TAPS");
@@ -2247,6 +2401,7 @@ mod tests {
             &[("h_main", &h)],
             &[],
             /* prompt_tokens = */ &[],
+            /* replay_tokens = */ &[],
             /* b11_taps = */ &[],
             &b12,
             /* c6_taps = */ &[],
@@ -2282,6 +2437,7 @@ mod tests {
 
     #[test]
     fn b12_layer_scope_disarmed_returns_false_regardless_of_scope() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::remove_var("KILN_MTP_DUMP_B12_GQA_TAPS");
@@ -2296,6 +2452,7 @@ mod tests {
 
     #[test]
     fn b12_layer_scope_armed_without_scope_returns_false() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_B12_GQA_TAPS", "1");
@@ -2314,6 +2471,7 @@ mod tests {
 
     #[test]
     fn b12_layer_scope_armed_non_31_layer_returns_false() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_B12_GQA_TAPS", "1");
@@ -2335,6 +2493,7 @@ mod tests {
 
     #[test]
     fn b12_layer_scope_armed_layer_31_returns_true() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_B12_GQA_TAPS", "1");
@@ -2351,6 +2510,7 @@ mod tests {
 
     #[test]
     fn b12_layer_scope_exit_clears_slot() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_B12_GQA_TAPS", "1");
@@ -2383,6 +2543,7 @@ mod tests {
 
     #[test]
     fn c6_pre_rope_capture_records_then_drains() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_PRE_ROPE", "1");
@@ -2420,6 +2581,7 @@ mod tests {
 
     #[test]
     fn c6_pre_rope_arm_is_noop_when_env_unset() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::remove_var("KILN_MTP_DUMP_PRE_ROPE");
@@ -2459,6 +2621,7 @@ mod tests {
             &[("h_main", &h)],
             &[],
             /* prompt_tokens = */ &[],
+            /* replay_tokens = */ &[],
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             &c6,
@@ -2511,6 +2674,7 @@ mod tests {
 
     #[test]
     fn c7_sdpa_capture_records_then_drains() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_C7_SDPA", "1");
@@ -2548,6 +2712,7 @@ mod tests {
 
     #[test]
     fn c7_sdpa_arm_is_noop_when_env_unset() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::remove_var("KILN_MTP_DUMP_C7_SDPA");
@@ -2587,6 +2752,7 @@ mod tests {
             &[("h_main", &h)],
             &[],
             /* prompt_tokens = */ &[],
+            /* replay_tokens = */ &[],
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             /* c6_taps = */ &[],
@@ -2640,6 +2806,7 @@ mod tests {
 
     #[test]
     fn c14_post_block_capture_records_then_drains() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::set_var("KILN_MTP_DUMP_C14_POST_BLOCK", "1");
@@ -2677,6 +2844,7 @@ mod tests {
 
     #[test]
     fn c14_post_block_arm_is_noop_when_env_unset() {
+        let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
         unsafe {
             std::env::remove_var("KILN_MTP_DUMP_C14_POST_BLOCK");
@@ -2691,6 +2859,7 @@ mod tests {
 
     #[test]
     fn c14_post_block_splice_flag_enables_capture() {
+        let _guard = test_env_lock();
         // OR-composition contract: setting the C13 splice meta-flag alone is
         // sufficient to enable C14 capture, without needing a separate
         // explicit per-phase opt-in. This is what lets a single
@@ -2740,6 +2909,7 @@ mod tests {
             &[("h_main", &h)],
             &[],
             /* prompt_tokens = */ &[],
+            /* replay_tokens = */ &[],
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             /* c6_taps = */ &[],

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -13,6 +13,7 @@ use serde::Serialize;
 use kiln_core::block::BlockTable;
 use kiln_core::config::ModelConfig;
 use kiln_core::sampling::SamplingParams;
+use kiln_core::token::TokenId;
 use kiln_core::tokenizer::{ChatMessage, KilnTokenizer};
 use kiln_core::vram::detect_vram;
 use kiln_model::backend as runtime_backend;

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -1649,6 +1649,7 @@ fn bench_latency_paged_mtp(
     let mut num_tokens = 1usize; // counting the first token from prefill
     let mut base_pos = actual_prompt_tokens;
     let mut mtp_pos = 0usize;
+    let mut generated_tokens: Vec<TokenId> = Vec::new();
     let mut draft_accepted_count = 0usize;
     let mut total_draft_attempts = 0usize;
     let params = SamplingParams {
@@ -1673,6 +1674,11 @@ fn bench_latency_paged_mtp(
             break;
         }
 
+        generated_tokens.push(last_token);
+        let mut replay_prefix = Vec::with_capacity(prompt_token_ids.len() + generated_tokens.len());
+        replay_prefix.extend_from_slice(&prompt_token_ids);
+        replay_prefix.extend_from_slice(&generated_tokens);
+        kiln_model::mtp_debug::set_h_main_replay_prefix_tokens(&replay_prefix);
         let step_start = Instant::now();
         let step = speculative_mtp_decode_step(
             &*backend,
@@ -1690,8 +1696,9 @@ fn bench_latency_paged_mtp(
             &params,
             &eos_token_ids,
             &mut rng,
-        )
-        .context("speculative_mtp_decode_step failed")?;
+        );
+        kiln_model::mtp_debug::clear_h_main_replay_prefix_tokens();
+        let step = step.context("speculative_mtp_decode_step failed")?;
         let step_time = step_start.elapsed();
 
         if step.accepted_tokens.is_empty() {
@@ -1710,6 +1717,10 @@ fn bench_latency_paged_mtp(
             if num_tokens >= max_output_tokens {
                 break;
             }
+        }
+
+        for &tok in &step.accepted_tokens[..step.accepted_tokens.len().saturating_sub(1)] {
+            generated_tokens.push(tok);
         }
 
         last_token = *step.accepted_tokens.last().unwrap();

--- a/docs/phase-c39/c39-post423-seed-bisect.md
+++ b/docs/phase-c39/c39-post423-seed-bisect.md
@@ -1,0 +1,171 @@
+# Phase C39 — post-#423 replay-context fix + fresh seed bisect
+
+**Date:** 2026-04-23  
+**Current main:** `61badb6` (PR #423 on `main`)  
+**Hardware:** RunPod `NVIDIA A40` via `ghcr.io/ericflo/kiln-runpod:latest`
+
+## Preflight
+
+1. **Fresh-main baseline:** satisfied. Work started from fresh `origin/main`
+   at `61badb6`, the merge commit for PR #423.
+2. **No existing post-#423 artifact already closes this gap:** satisfied.
+   Fresh `main` still lacked a full per-step replay contract for later
+   B10/B11/B12 rows.
+3. **Only fix the missing replay contract if it is still missing:** satisfied.
+   An initial rerun on the unchanged bench path still emitted later
+   `replay_tokens_len=1` / `2`, proving the under-conditioned replay problem
+   was still present outside the kiln-model generation loop.
+
+## Code change
+
+The dump contract now carries `replay_tokens` plus
+`meta__replay_tokens_len`, and the native-MTP bench loop seeds the per-step
+replay prefix before each `speculative_mtp_decode_step`.
+
+That change matters because the kiln dump still records the immediate
+`prompt_tokens` slice (`1` token at most later in the run), but the HF
+reference path now has the **fully conditioned sequence** needed to replay
+the exact absolute position seen at each dumped step.
+
+## Validation commands run
+
+```bash
+cd /workspace/kiln
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py scripts/c15_h_main_drift_audit.py
+source /root/.kiln-build-env
+cargo test -p kiln-model mtp_debug --features cuda --lib -- --nocapture
+```
+
+```bash
+for seed in 0 1; do
+  root=/workspace/kiln/profiling-artifacts/post423_20260423_seed${seed}_captures
+  rm -rf "$root"
+  mkdir -p "$root"/mtp_pos-0 "$root"/mtp_pos-2
+
+  KILN_W4A16=1 \
+  KILN_CUDA_GRAPHS=true \
+  KILN_SPEC_METHOD=mtp \
+  KILN_BENCH_FORCE_MTP=1 \
+  KILN_MTP_DUMP_SPLICE=1 \
+  KILN_MTP_DUMP_SPLICE_POS=0,2 \
+  KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+  KILN_MTP_DUMP_HIDDEN_STATES=1 \
+  KILN_MTP_DUMP_B11_TAPS=1 \
+  KILN_MTP_DUMP_B12_GQA_TAPS=1 \
+  KILN_MTP_DUMP_PATH=$root/mtp_pos-{pos}/step-{step}.safetensors \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+    --seed ${seed} \
+    > /workspace/kiln/profiling-artifacts/post423_20260423_seed${seed}.bench.json \
+    2> /workspace/kiln/profiling-artifacts/post423_20260423_seed${seed}.bench.stderr
+done
+```
+
+```bash
+for seed in 0 1; do
+  root=/workspace/kiln/profiling-artifacts/post423_20260423_seed${seed}_captures
+  while IFS= read -r dump; do
+    rel=${dump#${root}/}
+    out_bf16=/workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed${seed}/${rel}
+    out_fp32=/workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed${seed}/${rel}
+    mkdir -p "$(dirname "$out_bf16")" "$(dirname "$out_fp32")"
+
+    python3 scripts/mtp_h_main_reference_dump.py \
+      --checkpoint /workspace/qwen3.5-4b \
+      --kiln-dump "$dump" \
+      --out "$out_bf16" \
+      --device cuda \
+      --b11-taps \
+      --b12-taps
+
+    python3 scripts/mtp_h_main_reference_dump.py \
+      --checkpoint /workspace/qwen3.5-4b \
+      --kiln-dump "$dump" \
+      --out "$out_fp32" \
+      --device cuda \
+      --b11-taps \
+      --b12-taps \
+      --fp32
+  done < <(find "$root" -type f -name '*.safetensors' | sort)
+done
+```
+
+Comparator pass:
+
+```bash
+python3 scripts/mtp_compare.py --b10 ...
+python3 scripts/mtp_compare.py --b11 ...
+python3 scripts/mtp_compare.py --b12 ...
+```
+
+## Fresh workload check
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 8734.0 | 36.13 | 0.7162 |
+| 1 | 508 | 452.6 | 22.92 | 0.2828 |
+
+The seed split still reproduces on fresh `main`.
+
+## Replay-contract proof
+
+The updated dump path now emits full replay lengths on later rows instead of
+the previous 1-token / 2-token under-conditioned slices:
+
+- seed 0: `step-1 replay_tokens_len=495`, `step-2=496`, `mtp_pos=2 step-0=502`
+- seed 1: `step-1 replay_tokens_len=509`, `step-7=515`, `mtp_pos=2 step-0=520`
+
+The evidence is in:
+
+- [`profiling-artifacts/post423_20260423_seed0.bench.stderr`](../../profiling-artifacts/post423_20260423_seed0.bench.stderr)
+- [`profiling-artifacts/post423_20260423_seed1.bench.stderr`](../../profiling-artifacts/post423_20260423_seed1.bench.stderr)
+
+## Refreshed compare outputs
+
+- [`profiling-artifacts/post423_20260423_seed0_compare_bf16.txt`](../../profiling-artifacts/post423_20260423_seed0_compare_bf16.txt)
+- [`profiling-artifacts/post423_20260423_seed0_compare_fp32.txt`](../../profiling-artifacts/post423_20260423_seed0_compare_fp32.txt)
+- [`profiling-artifacts/post423_20260423_seed1_compare_bf16.txt`](../../profiling-artifacts/post423_20260423_seed1_compare_bf16.txt)
+- [`profiling-artifacts/post423_20260423_seed1_compare_fp32.txt`](../../profiling-artifacts/post423_20260423_seed1_compare_fp32.txt)
+
+Across both bf16 and fp32 HF references, the refreshed B10/B11/B12 verdicts
+are the same for seed 0 and seed 1:
+
+| Surface | Seed 0 | Seed 1 |
+| --- | --- | --- |
+| B10 first diverging tap | `h_layer_8` | `h_layer_8` |
+| B10 verdict | `DIVERGENCE IN EARLY GDN STACK` | `DIVERGENCE IN EARLY GDN STACK` |
+| B11 verdict | `ALL layer-0 GDN sub-ops match within cos_sim >= 0.95` | same |
+| B12 first below-bar layer | `h_layer_24` | `h_layer_24` |
+| B12 verdict | `DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31)` | same |
+
+Representative fp32 medians:
+
+- seed 0 B12 first below-bar layer: `h_layer_24` median cos `0.985383`
+- seed 1 B12 first below-bar layer: `h_layer_24` median cos `0.984894`
+
+## Verdict
+
+**C39 fixes the replay-contract blocker from C38, but it does not expose a
+seed1-only first boundary or sub-op.**
+
+With fully conditioned HF replays, both the control seed and the failing seed
+land the same first shared bad boundary:
+
+1. `h_layer_0` still matches.
+2. The first bad B10 boundary is `h_layer_8`.
+3. B11 does not isolate a bad layer-0 GDN sub-op.
+4. The later-stack B12 drift still first appears at `h_layer_24` for both
+   seeds.
+
+That is an honest negative result for the original seed-specific bisect
+question: the refreshed post-#423 artifact does **not** justify a seed1-only
+fix target.
+
+## Next recommendation
+
+Do **not** claim a seed1-only localization from this artifact.
+
+The next narrow task should bisect inside the shared early-GDN span between
+`h_layer_0` and `h_layer_8` on the updated replay contract, because that is
+now the first trustworthy bad boundary on both seeds.

--- a/profiling-artifacts/post423_20260423_seed0.bench.json
+++ b/profiling-artifacts/post423_20260423_seed0.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA A40",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 21.5974463,
+    "model_vram_mb": 17528
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 494,
+      "output_tokens": 128,
+      "total_time_secs": 3.270578936,
+      "tokens_per_sec": 39.136801925516956,
+      "peak_vram_mb": 17833
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 494,
+      "output_tokens": 512,
+      "total_time_secs": 12.102439557,
+      "tokens_per_sec": 42.305520105147835,
+      "peak_vram_mb": 17833
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 494,
+      "output_tokens": 1024,
+      "total_time_secs": 23.09851119,
+      "tokens_per_sec": 44.33186154626791,
+      "peak_vram_mb": 17833
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 494,
+      "output_tokens": 2048,
+      "total_time_secs": 46.562997328,
+      "tokens_per_sec": 43.98342283623705,
+      "peak_vram_mb": 17833
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 8734.000553,
+    "prefill_tokens_per_sec": 56.560564314404395,
+    "time_to_first_token_ms": 8734.000553,
+    "mean_inter_token_ms": 27.67479859055118,
+    "p50_inter_token_ms": 19.9579825,
+    "p99_inter_token_ms": 67.799211,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 36.133957641210195,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7162162162162162,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post423_20260423_seed0.bench.stderr
+++ b/profiling-artifacts/post423_20260423_seed0.bench.stderr
@@ -1,0 +1,105 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA A40 (46068 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T07:48:43.521993Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T07:48:43.523142Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T07:48:43.523355Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T07:48:43.523368Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T07:48:43.523453Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T07:49:05.117520Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m18173 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 18173 ms (parallel)
+Model loaded in 21.60s (backend: cuda, VRAM: 17528 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=47] (494 prompt tokens)...
+    Prefill (MTP): 8734.0ms (57 tok/s)
+[2m2026-04-23T07:49:14.395964Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m28
+[2m2026-04-23T07:49:14.539449Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m5339 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m494 [3mreplay_tokens_len[0m[2m=[0m494 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m0 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:49:14.605723Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m31192 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m495 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:49:14.667993Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m33416 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m496 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:49:14.727399Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m321 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m497 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:49:14.863402Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m7071 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m502 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m14 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:49:14.927753Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-1.safetensors [3mdraft_token_id[0m[2m=[0m10641 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m503 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:49:14.991323Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-2.safetensors [3mdraft_token_id[0m[2m=[0m11 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m504 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 27.7ms (36.1 tok/s), α = 0.716 (53/74)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T07:49:18.420506Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 3270.5ms (39.1 tok/s)
+  => 39.1 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 3563.7ms (35.9 tok/s)
+    Run 2/4: 128 tokens in 2826.4ms (45.3 tok/s)
+    Run 3/4: 128 tokens in 2844.6ms (45.0 tok/s)
+    Run 4/4: 128 tokens in 2867.6ms (44.6 tok/s)
+  => 42.3 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2852.6ms (44.9 tok/s)
+    Run 2/8: 128 tokens in 2916.6ms (43.9 tok/s)
+    Run 3/8: 128 tokens in 3020.0ms (42.4 tok/s)
+    Run 4/8: 128 tokens in 2898.7ms (44.2 tok/s)
+    Run 5/8: 128 tokens in 2834.8ms (45.2 tok/s)
+    Run 6/8: 128 tokens in 2822.9ms (45.3 tok/s)
+    Run 7/8: 128 tokens in 2838.8ms (45.1 tok/s)
+    Run 8/8: 128 tokens in 2913.9ms (43.9 tok/s)
+  => 44.3 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2835.2ms (45.1 tok/s)
+    Run 2/16: 128 tokens in 2863.3ms (44.7 tok/s)
+    Run 3/16: 128 tokens in 3685.8ms (34.7 tok/s)
+    Run 4/16: 128 tokens in 2959.7ms (43.2 tok/s)
+    Run 5/16: 128 tokens in 2869.9ms (44.6 tok/s)
+    Run 6/16: 128 tokens in 2828.4ms (45.3 tok/s)
+    Run 7/16: 128 tokens in 2849.0ms (44.9 tok/s)
+    Run 8/16: 128 tokens in 2816.2ms (45.5 tok/s)
+    Run 9/16: 128 tokens in 2822.0ms (45.4 tok/s)
+    Run 10/16: 128 tokens in 2839.7ms (45.1 tok/s)
+    Run 11/16: 128 tokens in 2875.0ms (44.5 tok/s)
+    Run 12/16: 128 tokens in 2894.7ms (44.2 tok/s)
+    Run 13/16: 128 tokens in 2867.4ms (44.6 tok/s)
+    Run 14/16: 128 tokens in 2848.7ms (44.9 tok/s)
+    Run 15/16: 128 tokens in 2859.8ms (44.8 tok/s)
+    Run 16/16: 128 tokens in 2847.7ms (44.9 tok/s)
+  => 44.0 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA A40 (46068 MB VRAM, source: nvidia-smi)
+Model load time: 21.60s (VRAM: 17528 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               494        128         39.1      17833
+4               494        512         42.3      17833
+8               494       1024         44.3      17833
+16              494       2048         44.0      17833
+
+--- Latency (single request) ---
+Prompt tokens:         494
+Prefill time:          8734.0 ms (57 tok/s)
+Time to first token:   8734.0 ms
+Mean inter-token:      27.7 ms (36.1 tok/s)
+P50 inter-token:       20.0 ms
+P99 inter-token:       67.8 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.716
+

--- a/profiling-artifacts/post423_20260423_seed0_compare_bf16.txt
+++ b/profiling-artifacts/post423_20260423_seed0_compare_bf16.txt
@@ -1,0 +1,1331 @@
+# seed 0 compare vs bf16 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.56e-02     7.56e-04    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.04e-01     1.95e-02    
+h_layer_16             1x1x2560               True     False    9.65e-01   3.75e-01     4.22e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   5.00e-01     6.94e-02    
+h_layer_31             1x1x2560               True     False    9.60e-01   2.52e+01     1.33e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.91e-03     2.32e-08    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   1.56e-02     5.89e-07    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.23e-02     8.21e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.83e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   3.91e-03     9.98e-05    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   3.91e-03     8.86e-04    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.55e-02     7.69e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   7.81e-03     4.22e-06    
+b11__gdn_gated_norm    1x494x4096             True     True     1.00e+00   2.34e-02     5.05e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.56e-02     6.47e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   4.30e-01     7.24e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   4.84e-01     7.49e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   5.23e-01     8.01e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.00e-01     9.85e-02    
+h_layer_28             1x1x2560               True     False    9.86e-01   5.02e-01     1.17e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.09e-01     1.30e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.84e-01     1.59e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   1.56e-01     1.67e-02    
+h_layer_16             1x1x2560               True     False    9.78e-01   1.88e-01     3.49e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.25e+00     5.99e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.96e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.06e+00     6.27e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.50e-01     6.43e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.55e-01     6.89e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.66e-01     9.61e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   5.57e-01     1.10e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.31e-01     1.25e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   7.50e-01     1.45e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.69e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.56e-01     1.60e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.80e-01     3.15e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   5.00e-01     5.36e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.62e+01     1.45e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   4.06e-01     5.51e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.53e-01     5.70e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   1.00e+00     6.04e-02    
+h_layer_27             1x1x2560               True     False    9.91e-01   7.50e-01     8.65e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   6.25e-01     1.01e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.09e-01     1.14e-01    
+h_layer_30             1x1x2560               True     False    9.87e-01   1.00e+00     1.34e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.89e-01   2.19e-01     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.82e-01   4.06e-01     3.43e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   5.00e-01     6.14e-02    
+h_layer_31             1x1x2560               True     False    9.27e-01   1.62e+01     1.23e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   6.25e-01     6.32e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.50e-01     6.63e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   3.91e-01     6.84e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.02e-01     9.34e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.00e+00     1.04e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   7.50e-01     1.17e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   6.56e-01     1.38e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.91e-03     6.12e-04    
+h_layer_8              1x1x2560               True     False    8.51e-01   2.95e-01     4.60e-02    
+h_layer_16             1x1x2560               True     False    6.55e-01   8.79e-01     1.24e-01    
+h_layer_23             1x1x2560               True     False    2.44e-01   6.75e+00     4.11e-01    
+h_layer_31             1x1x2560               True     False    6.72e-01   2.58e+01     1.82e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.41e-01   5.67e+00     4.26e-01    
+h_layer_25             1x1x2560               True     False    2.41e-01   5.64e+00     4.28e-01    
+h_layer_26             1x1x2560               True     False    1.63e-01   1.10e+01     4.49e-01    
+h_layer_27             1x1x2560               True     False    2.36e-01   1.03e+01     5.39e-01    
+h_layer_28             1x1x2560               True     False    3.64e-01   1.23e+01     5.88e-01    
+h_layer_29             1x1x2560               True     False    4.42e-01   9.25e+00     6.57e-01    
+h_layer_30             1x1x2560               True     False    5.02e-01   1.10e+01     7.05e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.77e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   3.44e-01     1.88e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   5.00e-01     4.80e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.57e-01     7.63e-02    
+h_layer_31             1x1x2560               True     False    9.38e-01   1.82e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.82e-01   4.82e-01     8.11e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   4.65e-01     8.95e-02    
+h_layer_26             1x1x2560               True     False    9.76e-01   5.68e-01     1.02e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   7.10e-01     1.27e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   1.12e+00     1.44e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   7.70e-01     1.61e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   8.20e-01     1.93e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.57e-03     1.89e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   4.38e-01     1.97e-02    
+h_layer_16             1x1x2560               True     False    9.64e-01   3.44e-01     4.96e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.28e-01     7.37e-02    
+h_layer_31             1x1x2560               True     False    9.19e-01   2.08e+01     1.21e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   4.67e-01     7.75e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.59e-01     7.95e-02    
+h_layer_26             1x1x2560               True     False    9.80e-01   5.14e-01     8.42e-02    
+h_layer_27             1x1x2560               True     False    9.77e-01   6.09e-01     1.35e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   6.19e-01     1.25e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.72e-01     1.44e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   7.62e-01     1.71e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=7.69e-03   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=1.00e+00   max|Δ|=3.91e-03   ok    cos=9.99e-01   max|Δ|=9.77e-03   ok    cos=9.99e-01   max|Δ|=7.57e-03   ok   
+  h_layer_8             cos=9.79e-01   max|Δ|=1.04e-01   DIV   cos=9.87e-01   max|Δ|=1.56e-01   DIV   cos=9.88e-01   max|Δ|=1.56e-01   DIV   cos=9.89e-01   max|Δ|=2.19e-01   DIV   cos=8.51e-01   max|Δ|=2.95e-01   DIV   cos=9.86e-01   max|Δ|=3.44e-01   DIV   cos=9.81e-01   max|Δ|=4.38e-01   DIV  
+  h_layer_16            cos=9.65e-01   max|Δ|=3.75e-01   DIV   cos=9.78e-01   max|Δ|=1.88e-01   DIV   cos=9.84e-01   max|Δ|=1.80e-01   DIV   cos=9.82e-01   max|Δ|=4.06e-01   DIV   cos=6.55e-01   max|Δ|=8.79e-01   DIV   cos=9.66e-01   max|Δ|=5.00e-01   DIV   cos=9.64e-01   max|Δ|=3.44e-01   DIV  
+  h_layer_23            cos=9.84e-01   max|Δ|=5.00e-01   DIV   cos=9.88e-01   max|Δ|=1.25e+00   DIV   cos=9.92e-01   max|Δ|=5.00e-01   DIV   cos=9.89e-01   max|Δ|=5.00e-01   DIV   cos=2.44e-01   max|Δ|=6.75e+00   DIV   cos=9.82e-01   max|Δ|=4.57e-01   DIV   cos=9.84e-01   max|Δ|=4.28e-01   DIV  
+  h_layer_31            cos=9.60e-01   max|Δ|=2.52e+01   DIV   cos=9.66e-01   max|Δ|=1.96e+01   DIV   cos=9.71e-01   max|Δ|=1.62e+01   DIV   cos=9.27e-01   max|Δ|=1.62e+01   DIV   cos=6.72e-01   max|Δ|=2.58e+01   DIV   cos=9.38e-01   max|Δ|=1.82e+01   DIV   cos=9.19e-01   max|Δ|=2.08e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_8' (pos=0_s0)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK
+  -> The first bad transformer block lies between h_layer_0
+     and h_layer_8. Narrow by capturing intermediate layers
+     (e.g. layers 4 and 12) and re-running B10 on the new dump.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.56e-02     7.56e-04    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.04e-01     1.95e-02    
+h_layer_16             1x1x2560               True     False    9.65e-01   3.75e-01     4.22e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   5.00e-01     6.94e-02    
+h_layer_31             1x1x2560               True     False    9.60e-01   2.52e+01     1.33e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.91e-03     2.32e-08    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   1.56e-02     5.89e-07    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.23e-02     8.21e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.83e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   3.91e-03     9.98e-05    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   3.91e-03     8.86e-04    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.55e-02     7.69e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   7.81e-03     4.22e-06    
+b11__gdn_gated_norm    1x494x4096             True     True     1.00e+00   2.34e-02     5.05e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.56e-02     6.47e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   4.30e-01     7.24e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   4.84e-01     7.49e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   5.23e-01     8.01e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.00e-01     9.85e-02    
+h_layer_28             1x1x2560               True     False    9.86e-01   5.02e-01     1.17e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.09e-01     1.30e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.84e-01     1.59e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   1.56e-01     1.67e-02    
+h_layer_16             1x1x2560               True     False    9.78e-01   1.88e-01     3.49e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.25e+00     5.99e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.96e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.06e+00     6.27e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.50e-01     6.43e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.55e-01     6.89e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.66e-01     9.61e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   5.57e-01     1.10e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.31e-01     1.25e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   7.50e-01     1.45e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.69e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.56e-01     1.60e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.80e-01     3.15e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   5.00e-01     5.36e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.62e+01     1.45e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   4.06e-01     5.51e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.53e-01     5.70e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   1.00e+00     6.04e-02    
+h_layer_27             1x1x2560               True     False    9.91e-01   7.50e-01     8.65e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   6.25e-01     1.01e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.09e-01     1.14e-01    
+h_layer_30             1x1x2560               True     False    9.87e-01   1.00e+00     1.34e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.89e-01   2.19e-01     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.82e-01   4.06e-01     3.43e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   5.00e-01     6.14e-02    
+h_layer_31             1x1x2560               True     False    9.27e-01   1.62e+01     1.23e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   6.25e-01     6.32e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.50e-01     6.63e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   3.91e-01     6.84e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.02e-01     9.34e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.00e+00     1.04e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   7.50e-01     1.17e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   6.56e-01     1.38e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.91e-03     6.12e-04    
+h_layer_8              1x1x2560               True     False    8.51e-01   2.95e-01     4.60e-02    
+h_layer_16             1x1x2560               True     False    6.55e-01   8.79e-01     1.24e-01    
+h_layer_23             1x1x2560               True     False    2.44e-01   6.75e+00     4.11e-01    
+h_layer_31             1x1x2560               True     False    6.72e-01   2.58e+01     1.82e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.41e-01   5.67e+00     4.26e-01    
+h_layer_25             1x1x2560               True     False    2.41e-01   5.64e+00     4.28e-01    
+h_layer_26             1x1x2560               True     False    1.63e-01   1.10e+01     4.49e-01    
+h_layer_27             1x1x2560               True     False    2.36e-01   1.03e+01     5.39e-01    
+h_layer_28             1x1x2560               True     False    3.64e-01   1.23e+01     5.88e-01    
+h_layer_29             1x1x2560               True     False    4.42e-01   9.25e+00     6.57e-01    
+h_layer_30             1x1x2560               True     False    5.02e-01   1.10e+01     7.05e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.77e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   3.44e-01     1.88e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   5.00e-01     4.80e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.57e-01     7.63e-02    
+h_layer_31             1x1x2560               True     False    9.38e-01   1.82e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.82e-01   4.82e-01     8.11e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   4.65e-01     8.95e-02    
+h_layer_26             1x1x2560               True     False    9.76e-01   5.68e-01     1.02e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   7.10e-01     1.27e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   1.12e+00     1.44e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   7.70e-01     1.61e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   8.20e-01     1.93e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.57e-03     1.89e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   4.38e-01     1.97e-02    
+h_layer_16             1x1x2560               True     False    9.64e-01   3.44e-01     4.96e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.28e-01     7.37e-02    
+h_layer_31             1x1x2560               True     False    9.19e-01   2.08e+01     1.21e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   4.67e-01     7.75e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.59e-01     7.95e-02    
+h_layer_26             1x1x2560               True     False    9.80e-01   5.14e-01     8.42e-02    
+h_layer_27             1x1x2560               True     False    9.77e-01   6.09e-01     1.35e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   6.19e-01     1.25e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.72e-01     1.44e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   7.62e-01     1.71e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=2.32e-08   rel_l2=7.56e-06   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_in_proj               cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=5.89e-07   rel_l2=3.73e-05   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_conv                  cos=1.00e+00   max|Δ|=6.23e-02   mean|Δ|=8.21e-05   rel_l2=2.27e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.83e-01   mean|Δ|=4.04e-02   rel_l2=9.12e-01   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.98e-05   rel_l2=3.20e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=8.86e-04   rel_l2=2.98e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_g                cos=1.00e+00   max|Δ|=1.55e-02   mean|Δ|=7.69e-04   rel_l2=1.65e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_recur_out             cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=4.22e-06   rel_l2=4.44e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=2.34e-02   mean|Δ|=5.05e-05   rel_l2=5.04e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=6.47e-05   rel_l2=2.88e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+Phase B11b verdict: ALL layer-0 GDN sub-ops match within cos_sim >= 0.95.
+  -> Divergence is NOT localized inside layer 0's GDN block at this bar.
+  -> Re-check B10 atol/rtol and consider extending taps to layers 1-7
+     (GDN stack) before committing to a B12 target.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.56e-02     7.56e-04    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.04e-01     1.95e-02    
+h_layer_16             1x1x2560               True     False    9.65e-01   3.75e-01     4.22e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   5.00e-01     6.94e-02    
+h_layer_31             1x1x2560               True     False    9.60e-01   2.52e+01     1.33e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.91e-03     2.32e-08    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   1.56e-02     5.89e-07    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.23e-02     8.21e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.83e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   3.91e-03     9.98e-05    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   3.91e-03     8.86e-04    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   1.55e-02     7.69e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   7.81e-03     4.22e-06    
+b11__gdn_gated_norm    1x494x4096             True     True     1.00e+00   2.34e-02     5.05e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.56e-02     6.47e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   4.30e-01     7.24e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   4.84e-01     7.49e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   5.23e-01     8.01e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.00e-01     9.85e-02    
+h_layer_28             1x1x2560               True     False    9.86e-01   5.02e-01     1.17e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.09e-01     1.30e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   6.84e-01     1.59e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   1.56e-01     1.67e-02    
+h_layer_16             1x1x2560               True     False    9.78e-01   1.88e-01     3.49e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.25e+00     5.99e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.96e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.06e+00     6.27e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.50e-01     6.43e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.55e-01     6.89e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.66e-01     9.61e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   5.57e-01     1.10e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.31e-01     1.25e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   7.50e-01     1.45e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.69e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.56e-01     1.60e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.80e-01     3.15e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   5.00e-01     5.36e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.62e+01     1.45e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   4.06e-01     5.51e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.53e-01     5.70e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   1.00e+00     6.04e-02    
+h_layer_27             1x1x2560               True     False    9.91e-01   7.50e-01     8.65e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   6.25e-01     1.01e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.09e-01     1.14e-01    
+h_layer_30             1x1x2560               True     False    9.87e-01   1.00e+00     1.34e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.89e-01   2.19e-01     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.82e-01   4.06e-01     3.43e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   5.00e-01     6.14e-02    
+h_layer_31             1x1x2560               True     False    9.27e-01   1.62e+01     1.23e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   6.25e-01     6.32e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   7.50e-01     6.63e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   3.91e-01     6.84e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.02e-01     9.34e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.00e+00     1.04e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   7.50e-01     1.17e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   6.56e-01     1.38e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.91e-03     6.12e-04    
+h_layer_8              1x1x2560               True     False    8.51e-01   2.95e-01     4.60e-02    
+h_layer_16             1x1x2560               True     False    6.55e-01   8.79e-01     1.24e-01    
+h_layer_23             1x1x2560               True     False    2.44e-01   6.75e+00     4.11e-01    
+h_layer_31             1x1x2560               True     False    6.72e-01   2.58e+01     1.82e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    2.41e-01   5.67e+00     4.26e-01    
+h_layer_25             1x1x2560               True     False    2.41e-01   5.64e+00     4.28e-01    
+h_layer_26             1x1x2560               True     False    1.63e-01   1.10e+01     4.49e-01    
+h_layer_27             1x1x2560               True     False    2.36e-01   1.03e+01     5.39e-01    
+h_layer_28             1x1x2560               True     False    3.64e-01   1.23e+01     5.88e-01    
+h_layer_29             1x1x2560               True     False    4.42e-01   9.25e+00     6.57e-01    
+h_layer_30             1x1x2560               True     False    5.02e-01   1.10e+01     7.05e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.77e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   3.44e-01     1.88e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   5.00e-01     4.80e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.57e-01     7.63e-02    
+h_layer_31             1x1x2560               True     False    9.38e-01   1.82e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.82e-01   4.82e-01     8.11e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   4.65e-01     8.95e-02    
+h_layer_26             1x1x2560               True     False    9.76e-01   5.68e-01     1.02e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   7.10e-01     1.27e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   1.12e+00     1.44e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   7.70e-01     1.61e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   8.20e-01     1.93e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.57e-03     1.89e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   4.38e-01     1.97e-02    
+h_layer_16             1x1x2560               True     False    9.64e-01   3.44e-01     4.96e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.28e-01     7.37e-02    
+h_layer_31             1x1x2560               True     False    9.19e-01   2.08e+01     1.21e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   4.67e-01     7.75e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.59e-01     7.95e-02    
+h_layer_26             1x1x2560               True     False    9.80e-01   5.14e-01     8.42e-02    
+h_layer_27             1x1x2560               True     False    9.77e-01   6.09e-01     1.35e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   6.19e-01     1.25e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.72e-01     1.44e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   7.62e-01     1.71e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.85e-01   max|Δ|=4.30e-01   DIV   cos=9.89e-01   max|Δ|=1.06e+00   DIV   cos=9.92e-01   max|Δ|=4.06e-01   DIV   cos=9.90e-01   max|Δ|=6.25e-01   DIV   cos=2.41e-01   max|Δ|=5.67e+00   DIV   cos=9.82e-01   max|Δ|=4.82e-01   DIV   cos=9.84e-01   max|Δ|=4.67e-01   DIV  
+  h_layer_25            cos=9.86e-01   max|Δ|=4.84e-01   DIV   cos=9.90e-01   max|Δ|=7.50e-01   DIV   cos=9.92e-01   max|Δ|=4.53e-01   DIV   cos=9.90e-01   max|Δ|=7.50e-01   DIV   cos=2.41e-01   max|Δ|=5.64e+00   DIV   cos=9.81e-01   max|Δ|=4.65e-01   DIV   cos=9.85e-01   max|Δ|=4.59e-01   DIV  
+  h_layer_26            cos=9.86e-01   max|Δ|=5.23e-01   DIV   cos=9.88e-01   max|Δ|=5.55e-01   DIV   cos=9.90e-01   max|Δ|=1.00e+00   DIV   cos=9.88e-01   max|Δ|=3.91e-01   DIV   cos=1.63e-01   max|Δ|=1.10e+01   DIV   cos=9.76e-01   max|Δ|=5.68e-01   DIV   cos=9.80e-01   max|Δ|=5.14e-01   DIV  
+  h_layer_27            cos=9.87e-01   max|Δ|=5.00e-01   DIV   cos=9.89e-01   max|Δ|=5.66e-01   DIV   cos=9.91e-01   max|Δ|=7.50e-01   DIV   cos=9.89e-01   max|Δ|=5.02e-01   DIV   cos=2.36e-01   max|Δ|=1.03e+01   DIV   cos=9.81e-01   max|Δ|=7.10e-01   DIV   cos=9.77e-01   max|Δ|=6.09e-01   DIV  
+  h_layer_28            cos=9.86e-01   max|Δ|=5.02e-01   DIV   cos=9.89e-01   max|Δ|=5.57e-01   DIV   cos=9.90e-01   max|Δ|=6.25e-01   DIV   cos=9.88e-01   max|Δ|=1.00e+00   DIV   cos=3.64e-01   max|Δ|=1.23e+01   DIV   cos=9.82e-01   max|Δ|=1.12e+00   DIV   cos=9.82e-01   max|Δ|=6.19e-01   DIV  
+  h_layer_29            cos=9.86e-01   max|Δ|=6.09e-01   DIV   cos=9.88e-01   max|Δ|=5.31e-01   DIV   cos=9.90e-01   max|Δ|=6.09e-01   DIV   cos=9.89e-01   max|Δ|=7.50e-01   DIV   cos=4.42e-01   max|Δ|=9.25e+00   DIV   cos=9.83e-01   max|Δ|=7.70e-01   DIV   cos=9.83e-01   max|Δ|=6.72e-01   DIV  
+  h_layer_30            cos=9.82e-01   max|Δ|=6.84e-01   DIV   cos=9.85e-01   max|Δ|=7.50e-01   DIV   cos=9.87e-01   max|Δ|=1.00e+00   DIV   cos=9.85e-01   max|Δ|=6.56e-01   DIV   cos=5.02e-01   max|Δ|=1.10e+01   DIV   cos=9.76e-01   max|Δ|=8.20e-01   DIV   cos=9.77e-01   max|Δ|=7.62e-01   DIV  
+  h_layer_31            cos=9.60e-01   max|Δ|=2.52e+01   DIV   cos=9.66e-01   max|Δ|=1.96e+01   DIV   cos=9.71e-01   max|Δ|=1.62e+01   DIV   cos=9.27e-01   max|Δ|=1.62e+01   DIV   cos=6.72e-01   max|Δ|=2.58e+01   DIV   cos=9.38e-01   max|Δ|=1.82e+01   DIV   cos=9.19e-01   max|Δ|=2.08e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=9.85e-01     DIV
+    h_layer_25             median=9.86e-01     DIV
+    h_layer_26             median=9.86e-01     DIV
+    h_layer_27             median=9.87e-01     DIV
+    h_layer_28             median=9.86e-01     DIV
+    h_layer_29             median=9.86e-01     DIV
+    h_layer_30             median=9.82e-01     DIV
+    h_layer_31             median=9.38e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  q_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  k_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  v_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_q           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_k           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV <missing>                                            <missing>                                           
+  post_attn_norm      <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_gate            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_up              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_down            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=nan          DIV
+    q_proj               median=nan          DIV
+    k_proj               median=nan          DIV
+    v_proj               median=nan          DIV
+    qk_norm_q            median=nan          DIV
+    qk_norm_k            median=nan          DIV
+    o_proj               median=nan          DIV
+    post_attn_norm       median=nan          DIV
+    mlp_gate             median=nan          DIV
+    mlp_up               median=nan          DIV
+    mlp_down             median=nan          DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.985426)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/profiling-artifacts/post423_20260423_seed0_compare_fp32.txt
+++ b/profiling-artifacts/post423_20260423_seed0_compare_fp32.txt
@@ -1,0 +1,1331 @@
+# seed 0 compare vs fp32 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   2.06e-02     7.53e-04    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.01e-01     1.95e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   3.42e-01     4.20e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.80e-01     6.92e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.52e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.00e-02     1.28e-03    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   6.66e-02     1.77e-03    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.20e-02     7.08e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.84e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   5.43e-03     1.33e-04    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   5.42e-03     1.20e-03    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   2.23e-02     8.42e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   6.05e-03     3.71e-06    
+b11__gdn_gated_norm    1x494x4096             True     False    1.00e+00   1.94e-02     5.09e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.20e-02     6.01e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   4.40e-01     7.26e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   4.88e-01     7.50e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   5.52e-01     8.03e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.04e-01     9.87e-02    
+h_layer_28             1x1x2560               True     False    9.86e-01   4.98e-01     1.17e-01    
+h_layer_29             1x1x2560               True     False    9.85e-01   6.44e-01     1.32e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   7.06e-01     1.62e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.82e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   1.87e-01     1.66e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   1.79e-01     3.47e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.21e+00     6.02e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.95e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.07e+00     6.32e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.16e-01     6.49e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.68e-01     6.96e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.83e-01     9.63e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   5.72e-01     1.12e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.43e-01     1.27e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   7.80e-01     1.48e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.63e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.86e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.81e-01     3.15e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   4.01e-01     5.35e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.62e+01     1.45e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   3.92e-01     5.53e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.24e-01     5.70e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   1.09e+00     6.05e-02    
+h_layer_27             1x1x2560               True     False    9.91e-01   7.37e-01     8.70e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   5.52e-01     1.01e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.22e-01     1.14e-01    
+h_layer_30             1x1x2560               True     False    9.87e-01   9.91e-01     1.35e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.41e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.89e-01   2.43e-01     1.64e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   3.75e-01     3.35e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   4.87e-01     6.14e-02    
+h_layer_31             1x1x2560               True     False    9.26e-01   1.64e+01     1.24e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   6.94e-01     6.34e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.99e-01     6.65e-02    
+h_layer_26             1x1x2560               True     False    9.87e-01   3.58e-01     6.87e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   7.94e-01     9.42e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.28e+00     1.05e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   8.95e-01     1.17e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   6.61e-01     1.38e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.68e-03     6.11e-04    
+h_layer_8              1x1x2560               True     False    8.35e-01   3.22e-01     4.84e-02    
+h_layer_16             1x1x2560               True     False    5.13e-01   1.46e+00     1.43e-01    
+h_layer_23             1x1x2560               True     False    1.81e-01   4.54e+00     4.28e-01    
+h_layer_31             1x1x2560               True     False    6.66e-01   2.79e+01     1.81e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    1.80e-01   4.72e+00     4.46e-01    
+h_layer_25             1x1x2560               True     False    1.88e-01   4.11e+00     4.49e-01    
+h_layer_26             1x1x2560               True     False    1.39e-01   7.46e+00     4.70e-01    
+h_layer_27             1x1x2560               True     False    1.95e-01   4.02e+00     5.54e-01    
+h_layer_28             1x1x2560               True     False    3.22e-01   8.23e+00     6.11e-01    
+h_layer_29             1x1x2560               True     False    4.03e-01   4.26e+00     6.74e-01    
+h_layer_30             1x1x2560               True     False    4.84e-01   9.11e+00     7.29e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.45e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   2.95e-01     1.89e-02    
+h_layer_16             1x1x2560               True     False    9.67e-01   4.56e-01     4.72e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.49e-01     7.64e-02    
+h_layer_31             1x1x2560               True     False    9.36e-01   1.83e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.82e-01   4.66e-01     8.06e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   5.07e-01     9.01e-02    
+h_layer_26             1x1x2560               True     False    9.75e-01   5.84e-01     1.01e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.06e-01     1.27e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.05e+00     1.48e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   7.11e-01     1.65e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   9.11e-01     1.98e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.65e-03     1.91e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   4.08e-01     1.97e-02    
+h_layer_16             1x1x2560               True     False    9.64e-01   3.25e-01     5.00e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.31e-01     7.33e-02    
+h_layer_31             1x1x2560               True     False    9.18e-01   2.13e+01     1.22e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   4.78e-01     7.70e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.68e-01     7.93e-02    
+h_layer_26             1x1x2560               True     False    9.79e-01   8.99e-01     8.37e-02    
+h_layer_27             1x1x2560               True     False    9.79e-01   5.72e-01     1.26e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   6.23e-01     1.24e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.26e-01     1.43e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   7.69e-01     1.73e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=2.06e-02   ok    cos=9.99e-01   max|Δ|=1.82e-02   ok    cos=9.99e-01   max|Δ|=7.63e-03   ok    cos=9.99e-01   max|Δ|=2.41e-02   ok    cos=1.00e+00   max|Δ|=3.68e-03   ok    cos=9.99e-01   max|Δ|=9.45e-03   ok    cos=9.99e-01   max|Δ|=7.65e-03   ok   
+  h_layer_8             cos=9.79e-01   max|Δ|=1.01e-01   DIV   cos=9.87e-01   max|Δ|=1.87e-01   DIV   cos=9.88e-01   max|Δ|=1.86e-01   DIV   cos=9.89e-01   max|Δ|=2.43e-01   DIV   cos=8.35e-01   max|Δ|=3.22e-01   DIV   cos=9.86e-01   max|Δ|=2.95e-01   DIV   cos=9.81e-01   max|Δ|=4.08e-01   DIV  
+  h_layer_16            cos=9.66e-01   max|Δ|=3.42e-01   DIV   cos=9.79e-01   max|Δ|=1.79e-01   DIV   cos=9.84e-01   max|Δ|=1.81e-01   DIV   cos=9.83e-01   max|Δ|=3.75e-01   DIV   cos=5.13e-01   max|Δ|=1.46e+00   DIV   cos=9.67e-01   max|Δ|=4.56e-01   DIV   cos=9.64e-01   max|Δ|=3.25e-01   DIV  
+  h_layer_23            cos=9.84e-01   max|Δ|=4.80e-01   DIV   cos=9.88e-01   max|Δ|=1.21e+00   DIV   cos=9.92e-01   max|Δ|=4.01e-01   DIV   cos=9.89e-01   max|Δ|=4.87e-01   DIV   cos=1.81e-01   max|Δ|=4.54e+00   DIV   cos=9.82e-01   max|Δ|=4.49e-01   DIV   cos=9.84e-01   max|Δ|=4.31e-01   DIV  
+  h_layer_31            cos=9.59e-01   max|Δ|=2.52e+01   DIV   cos=9.66e-01   max|Δ|=1.95e+01   DIV   cos=9.71e-01   max|Δ|=1.62e+01   DIV   cos=9.26e-01   max|Δ|=1.64e+01   DIV   cos=6.66e-01   max|Δ|=2.79e+01   DIV   cos=9.36e-01   max|Δ|=1.83e+01   DIV   cos=9.18e-01   max|Δ|=2.13e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_8' (pos=0_s0)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK
+  -> The first bad transformer block lies between h_layer_0
+     and h_layer_8. Narrow by capturing intermediate layers
+     (e.g. layers 4 and 12) and re-running B10 on the new dump.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   2.06e-02     7.53e-04    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.01e-01     1.95e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   3.42e-01     4.20e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.80e-01     6.92e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.52e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.00e-02     1.28e-03    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   6.66e-02     1.77e-03    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.20e-02     7.08e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.84e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   5.43e-03     1.33e-04    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   5.42e-03     1.20e-03    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   2.23e-02     8.42e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   6.05e-03     3.71e-06    
+b11__gdn_gated_norm    1x494x4096             True     False    1.00e+00   1.94e-02     5.09e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.20e-02     6.01e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   4.40e-01     7.26e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   4.88e-01     7.50e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   5.52e-01     8.03e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.04e-01     9.87e-02    
+h_layer_28             1x1x2560               True     False    9.86e-01   4.98e-01     1.17e-01    
+h_layer_29             1x1x2560               True     False    9.85e-01   6.44e-01     1.32e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   7.06e-01     1.62e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.82e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   1.87e-01     1.66e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   1.79e-01     3.47e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.21e+00     6.02e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.95e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.07e+00     6.32e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.16e-01     6.49e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.68e-01     6.96e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.83e-01     9.63e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   5.72e-01     1.12e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.43e-01     1.27e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   7.80e-01     1.48e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.63e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.86e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.81e-01     3.15e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   4.01e-01     5.35e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.62e+01     1.45e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   3.92e-01     5.53e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.24e-01     5.70e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   1.09e+00     6.05e-02    
+h_layer_27             1x1x2560               True     False    9.91e-01   7.37e-01     8.70e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   5.52e-01     1.01e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.22e-01     1.14e-01    
+h_layer_30             1x1x2560               True     False    9.87e-01   9.91e-01     1.35e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.41e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.89e-01   2.43e-01     1.64e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   3.75e-01     3.35e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   4.87e-01     6.14e-02    
+h_layer_31             1x1x2560               True     False    9.26e-01   1.64e+01     1.24e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   6.94e-01     6.34e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.99e-01     6.65e-02    
+h_layer_26             1x1x2560               True     False    9.87e-01   3.58e-01     6.87e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   7.94e-01     9.42e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.28e+00     1.05e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   8.95e-01     1.17e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   6.61e-01     1.38e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.68e-03     6.11e-04    
+h_layer_8              1x1x2560               True     False    8.35e-01   3.22e-01     4.84e-02    
+h_layer_16             1x1x2560               True     False    5.13e-01   1.46e+00     1.43e-01    
+h_layer_23             1x1x2560               True     False    1.81e-01   4.54e+00     4.28e-01    
+h_layer_31             1x1x2560               True     False    6.66e-01   2.79e+01     1.81e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    1.80e-01   4.72e+00     4.46e-01    
+h_layer_25             1x1x2560               True     False    1.88e-01   4.11e+00     4.49e-01    
+h_layer_26             1x1x2560               True     False    1.39e-01   7.46e+00     4.70e-01    
+h_layer_27             1x1x2560               True     False    1.95e-01   4.02e+00     5.54e-01    
+h_layer_28             1x1x2560               True     False    3.22e-01   8.23e+00     6.11e-01    
+h_layer_29             1x1x2560               True     False    4.03e-01   4.26e+00     6.74e-01    
+h_layer_30             1x1x2560               True     False    4.84e-01   9.11e+00     7.29e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.45e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   2.95e-01     1.89e-02    
+h_layer_16             1x1x2560               True     False    9.67e-01   4.56e-01     4.72e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.49e-01     7.64e-02    
+h_layer_31             1x1x2560               True     False    9.36e-01   1.83e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.82e-01   4.66e-01     8.06e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   5.07e-01     9.01e-02    
+h_layer_26             1x1x2560               True     False    9.75e-01   5.84e-01     1.01e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.06e-01     1.27e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.05e+00     1.48e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   7.11e-01     1.65e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   9.11e-01     1.98e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.65e-03     1.91e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   4.08e-01     1.97e-02    
+h_layer_16             1x1x2560               True     False    9.64e-01   3.25e-01     5.00e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.31e-01     7.33e-02    
+h_layer_31             1x1x2560               True     False    9.18e-01   2.13e+01     1.22e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   4.78e-01     7.70e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.68e-01     7.93e-02    
+h_layer_26             1x1x2560               True     False    9.79e-01   8.99e-01     8.37e-02    
+h_layer_27             1x1x2560               True     False    9.79e-01   5.72e-01     1.26e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   6.23e-01     1.24e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.26e-01     1.43e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   7.69e-01     1.73e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.00e-02   mean|Δ|=1.28e-03   rel_l2=1.65e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_in_proj               cos=1.00e+00   max|Δ|=6.66e-02   mean|Δ|=1.77e-03   rel_l2=1.95e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_conv                  cos=1.00e+00   max|Δ|=6.20e-02   mean|Δ|=7.08e-05   rel_l2=1.58e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.84e-01   mean|Δ|=4.04e-02   rel_l2=9.12e-01   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=5.43e-03   mean|Δ|=1.33e-04   rel_l2=2.69e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=5.42e-03   mean|Δ|=1.20e-03   rel_l2=2.76e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_g                cos=1.00e+00   max|Δ|=2.23e-02   mean|Δ|=8.42e-04   rel_l2=1.80e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_recur_out             cos=1.00e+00   max|Δ|=6.05e-03   mean|Δ|=3.71e-06   rel_l2=3.35e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=1.94e-02   mean|Δ|=5.09e-05   rel_l2=4.18e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.20e-02   mean|Δ|=6.01e-05   rel_l2=2.42e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+Phase B11b verdict: ALL layer-0 GDN sub-ops match within cos_sim >= 0.95.
+  -> Divergence is NOT localized inside layer 0's GDN block at this bar.
+  -> Re-check B10 atol/rtol and consider extending taps to layers 1-7
+     (GDN stack) before committing to a B12 target.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   2.06e-02     7.53e-04    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.01e-01     1.95e-02    
+h_layer_16             1x1x2560               True     False    9.66e-01   3.42e-01     4.20e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.80e-01     6.92e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.52e+01     1.34e+00    
+b11__tok_embed         1x494x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x494x2560             True     True     1.00e+00   3.00e-02     1.28e-03    
+b11__gdn_in_proj       1x494x12352            True     True     1.00e+00   6.66e-02     1.77e-03    
+b11__gdn_conv          1x494x8192             True     True     1.00e+00   6.20e-02     7.08e-05    
+b11__gdn_qk_norm_q     1x494x32x128           True     False    1.00e+00   8.84e-01     4.04e-02    
+b11__gdn_qk_norm_k     1x494x32x128           True     True     1.00e+00   5.43e-03     1.33e-04    
+b11__gdn_gate_beta     1x494x32               True     True     1.00e+00   5.42e-03     1.20e-03    
+b11__gdn_gate_g        1x494x32               True     True     1.00e+00   2.23e-02     8.42e-04    
+b11__gdn_recur_out     1x494x32x128           True     True     1.00e+00   6.05e-03     3.71e-06    
+b11__gdn_gated_norm    1x494x4096             True     False    1.00e+00   1.94e-02     5.09e-05    
+b11__gdn_out_proj      1x494x2560             True     True     1.00e+00   1.20e-02     6.01e-05    
+h_layer_24             1x1x2560               True     False    9.85e-01   4.40e-01     7.26e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   4.88e-01     7.50e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   5.52e-01     8.03e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.04e-01     9.87e-02    
+h_layer_28             1x1x2560               True     False    9.86e-01   4.98e-01     1.17e-01    
+h_layer_29             1x1x2560               True     False    9.85e-01   6.44e-01     1.32e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   7.06e-01     1.62e-01    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.82e-02     1.59e-03    
+h_layer_8              1x1x2560               True     False    9.87e-01   1.87e-01     1.66e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   1.79e-01     3.47e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.21e+00     6.02e-02    
+h_layer_31             1x1x2560               True     False    9.66e-01   1.95e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.07e+00     6.32e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.16e-01     6.49e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   5.68e-01     6.96e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.83e-01     9.63e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   5.72e-01     1.12e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   5.43e-01     1.27e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   7.80e-01     1.48e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.63e-03     1.68e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.86e-01     1.59e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   1.81e-01     3.15e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   4.01e-01     5.35e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.62e+01     1.45e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.92e-01   3.92e-01     5.53e-02    
+h_layer_25             1x1x2560               True     False    9.92e-01   4.24e-01     5.70e-02    
+h_layer_26             1x1x2560               True     False    9.90e-01   1.09e+00     6.05e-02    
+h_layer_27             1x1x2560               True     False    9.91e-01   7.37e-01     8.70e-02    
+h_layer_28             1x1x2560               True     False    9.90e-01   5.52e-01     1.01e-01    
+h_layer_29             1x1x2560               True     False    9.90e-01   6.22e-01     1.14e-01    
+h_layer_30             1x1x2560               True     False    9.87e-01   9.91e-01     1.35e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.41e-02     1.76e-03    
+h_layer_8              1x1x2560               True     False    9.89e-01   2.43e-01     1.64e-02    
+h_layer_16             1x1x2560               True     False    9.83e-01   3.75e-01     3.35e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   4.87e-01     6.14e-02    
+h_layer_31             1x1x2560               True     False    9.26e-01   1.64e+01     1.24e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   6.94e-01     6.34e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.99e-01     6.65e-02    
+h_layer_26             1x1x2560               True     False    9.87e-01   3.58e-01     6.87e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   7.94e-01     9.42e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   1.28e+00     1.05e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   8.95e-01     1.17e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   6.61e-01     1.38e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.68e-03     6.11e-04    
+h_layer_8              1x1x2560               True     False    8.35e-01   3.22e-01     4.84e-02    
+h_layer_16             1x1x2560               True     False    5.13e-01   1.46e+00     1.43e-01    
+h_layer_23             1x1x2560               True     False    1.81e-01   4.54e+00     4.28e-01    
+h_layer_31             1x1x2560               True     False    6.66e-01   2.79e+01     1.81e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    1.80e-01   4.72e+00     4.46e-01    
+h_layer_25             1x1x2560               True     False    1.88e-01   4.11e+00     4.49e-01    
+h_layer_26             1x1x2560               True     False    1.39e-01   7.46e+00     4.70e-01    
+h_layer_27             1x1x2560               True     False    1.95e-01   4.02e+00     5.54e-01    
+h_layer_28             1x1x2560               True     False    3.22e-01   8.23e+00     6.11e-01    
+h_layer_29             1x1x2560               True     False    4.03e-01   4.26e+00     6.74e-01    
+h_layer_30             1x1x2560               True     False    4.84e-01   9.11e+00     7.29e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=10641 ref=10641 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.45e-03     1.80e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   2.95e-01     1.89e-02    
+h_layer_16             1x1x2560               True     False    9.67e-01   4.56e-01     4.72e-02    
+h_layer_23             1x1x2560               True     False    9.82e-01   4.49e-01     7.64e-02    
+h_layer_31             1x1x2560               True     False    9.36e-01   1.83e+01     1.33e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.82e-01   4.66e-01     8.06e-02    
+h_layer_25             1x1x2560               True     False    9.81e-01   5.07e-01     9.01e-02    
+h_layer_26             1x1x2560               True     False    9.75e-01   5.84e-01     1.01e-01    
+h_layer_27             1x1x2560               True     False    9.81e-01   6.06e-01     1.27e-01    
+h_layer_28             1x1x2560               True     False    9.81e-01   1.05e+00     1.48e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   7.11e-01     1.65e-01    
+h_layer_30             1x1x2560               True     False    9.75e-01   9.11e-01     1.98e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          503                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed0_captures/mtp_pos-2/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed0/mtp_pos-2/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.65e-03     1.91e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   4.08e-01     1.97e-02    
+h_layer_16             1x1x2560               True     False    9.64e-01   3.25e-01     5.00e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.31e-01     7.33e-02    
+h_layer_31             1x1x2560               True     False    9.18e-01   2.13e+01     1.22e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   4.78e-01     7.70e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.68e-01     7.93e-02    
+h_layer_26             1x1x2560               True     False    9.79e-01   8.99e-01     8.37e-02    
+h_layer_27             1x1x2560               True     False    9.79e-01   5.72e-01     1.26e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   6.23e-01     1.24e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.26e-01     1.43e-01    
+h_layer_30             1x1x2560               True     False    9.76e-01   7.69e-01     1.73e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          504                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=2_s0                         pos=2_s1                         pos=2_s2                        
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.85e-01   max|Δ|=4.40e-01   DIV   cos=9.89e-01   max|Δ|=1.07e+00   DIV   cos=9.92e-01   max|Δ|=3.92e-01   DIV   cos=9.89e-01   max|Δ|=6.94e-01   DIV   cos=1.80e-01   max|Δ|=4.72e+00   DIV   cos=9.82e-01   max|Δ|=4.66e-01   DIV   cos=9.84e-01   max|Δ|=4.78e-01   DIV  
+  h_layer_25            cos=9.86e-01   max|Δ|=4.88e-01   DIV   cos=9.90e-01   max|Δ|=8.16e-01   DIV   cos=9.92e-01   max|Δ|=4.24e-01   DIV   cos=9.90e-01   max|Δ|=8.99e-01   DIV   cos=1.88e-01   max|Δ|=4.11e+00   DIV   cos=9.81e-01   max|Δ|=5.07e-01   DIV   cos=9.85e-01   max|Δ|=4.68e-01   DIV  
+  h_layer_26            cos=9.86e-01   max|Δ|=5.52e-01   DIV   cos=9.88e-01   max|Δ|=5.68e-01   DIV   cos=9.90e-01   max|Δ|=1.09e+00   DIV   cos=9.87e-01   max|Δ|=3.58e-01   DIV   cos=1.39e-01   max|Δ|=7.46e+00   DIV   cos=9.75e-01   max|Δ|=5.84e-01   DIV   cos=9.79e-01   max|Δ|=8.99e-01   DIV  
+  h_layer_27            cos=9.87e-01   max|Δ|=5.04e-01   DIV   cos=9.89e-01   max|Δ|=5.83e-01   DIV   cos=9.91e-01   max|Δ|=7.37e-01   DIV   cos=9.88e-01   max|Δ|=7.94e-01   DIV   cos=1.95e-01   max|Δ|=4.02e+00   DIV   cos=9.81e-01   max|Δ|=6.06e-01   DIV   cos=9.79e-01   max|Δ|=5.72e-01   DIV  
+  h_layer_28            cos=9.86e-01   max|Δ|=4.98e-01   DIV   cos=9.88e-01   max|Δ|=5.72e-01   DIV   cos=9.90e-01   max|Δ|=5.52e-01   DIV   cos=9.88e-01   max|Δ|=1.28e+00   DIV   cos=3.22e-01   max|Δ|=8.23e+00   DIV   cos=9.81e-01   max|Δ|=1.05e+00   DIV   cos=9.82e-01   max|Δ|=6.23e-01   DIV  
+  h_layer_29            cos=9.85e-01   max|Δ|=6.44e-01   DIV   cos=9.88e-01   max|Δ|=5.43e-01   DIV   cos=9.90e-01   max|Δ|=6.22e-01   DIV   cos=9.88e-01   max|Δ|=8.95e-01   DIV   cos=4.03e-01   max|Δ|=4.26e+00   DIV   cos=9.82e-01   max|Δ|=7.11e-01   DIV   cos=9.83e-01   max|Δ|=6.26e-01   DIV  
+  h_layer_30            cos=9.81e-01   max|Δ|=7.06e-01   DIV   cos=9.84e-01   max|Δ|=7.80e-01   DIV   cos=9.87e-01   max|Δ|=9.91e-01   DIV   cos=9.85e-01   max|Δ|=6.61e-01   DIV   cos=4.84e-01   max|Δ|=9.11e+00   DIV   cos=9.75e-01   max|Δ|=9.11e-01   DIV   cos=9.76e-01   max|Δ|=7.69e-01   DIV  
+  h_layer_31            cos=9.59e-01   max|Δ|=2.52e+01   DIV   cos=9.66e-01   max|Δ|=1.95e+01   DIV   cos=9.71e-01   max|Δ|=1.62e+01   DIV   cos=9.26e-01   max|Δ|=1.64e+01   DIV   cos=6.66e-01   max|Δ|=2.79e+01   DIV   cos=9.36e-01   max|Δ|=1.83e+01   DIV   cos=9.18e-01   max|Δ|=2.13e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=9.85e-01     DIV
+    h_layer_25             median=9.86e-01     DIV
+    h_layer_26             median=9.86e-01     DIV
+    h_layer_27             median=9.87e-01     DIV
+    h_layer_28             median=9.86e-01     DIV
+    h_layer_29             median=9.85e-01     DIV
+    h_layer_30             median=9.81e-01     DIV
+    h_layer_31             median=9.36e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=2_s0                                             pos=2_s1                                             pos=2_s2                                            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  q_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  k_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  v_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_q           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_k           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV <missing>                                            <missing>                                           
+  post_attn_norm      <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_gate            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_up              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_down            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=nan          DIV
+    q_proj               median=nan          DIV
+    k_proj               median=nan          DIV
+    v_proj               median=nan          DIV
+    qk_norm_q            median=nan          DIV
+    qk_norm_k            median=nan          DIV
+    o_proj               median=nan          DIV
+    post_attn_norm       median=nan          DIV
+    mlp_gate             median=nan          DIV
+    mlp_up               median=nan          DIV
+    mlp_down             median=nan          DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.985383)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/profiling-artifacts/post423_20260423_seed1.bench.json
+++ b/profiling-artifacts/post423_20260423_seed1.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA A40",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 19.072079725,
+    "model_vram_mb": 17528
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 508,
+      "output_tokens": 128,
+      "total_time_secs": 2.881893562,
+      "tokens_per_sec": 44.41524200885806,
+      "peak_vram_mb": 17833
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 508,
+      "output_tokens": 512,
+      "total_time_secs": 13.612118135,
+      "tokens_per_sec": 37.61354367646325,
+      "peak_vram_mb": 17833
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 508,
+      "output_tokens": 1024,
+      "total_time_secs": 23.2910107,
+      "tokens_per_sec": 43.96546003046574,
+      "peak_vram_mb": 17833
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 508,
+      "output_tokens": 2048,
+      "total_time_secs": 45.571401481,
+      "tokens_per_sec": 44.94046558681915,
+      "peak_vram_mb": 17833
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 508,
+    "prefill_time_ms": 452.569774,
+    "prefill_tokens_per_sec": 1122.4788511837294,
+    "time_to_first_token_ms": 452.569774,
+    "mean_inter_token_ms": 43.62563130708661,
+    "p50_inter_token_ms": 55.001553,
+    "p99_inter_token_ms": 69.18988,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 22.92230438938218,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.2828282828282828,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post423_20260423_seed1.bench.stderr
+++ b/profiling-artifacts/post423_20260423_seed1.bench.stderr
@@ -1,0 +1,108 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA A40 (46068 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T07:50:45.770973Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T07:50:45.772219Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T07:50:45.772447Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T07:50:45.772461Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T07:50:45.772556Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T07:51:04.841113Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m17425 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 17425 ms (parallel)
+Model loaded in 19.07s (backend: cuda, VRAM: 17528 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (508 prompt tokens)...
+    Prefill (MTP): 452.6ms (1122 tok/s)
+[2m2026-04-23T07:51:05.912645Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m29
+[2m2026-04-23T07:51:06.079457Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m25015 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m508 [3mreplay_tokens_len[0m[2m=[0m508 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m0 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:51:06.152030Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m314 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m509 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:51:06.219609Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m1330 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m510 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:51:06.287240Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m47205 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m511 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:51:06.354807Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-4.safetensors [3mdraft_token_id[0m[2m=[0m369 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(4) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m512 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:51:06.422120Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-5.safetensors [3mdraft_token_id[0m[2m=[0m799 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(5) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m513 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:51:06.488984Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-6.safetensors [3mdraft_token_id[0m[2m=[0m30797 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(6) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m514 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:51:06.556020Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-7.safetensors [3mdraft_token_id[0m[2m=[0m314 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(7) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m515 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:51:06.702616Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m421 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m520 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m14 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T07:51:06.769356Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-1.safetensors [3mdraft_token_id[0m[2m=[0m3202 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m521 [3mb11_taps[0m[2m=[0m11 [3mb12_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 43.6ms (22.9 tok/s), α = 0.283 (28/99)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T07:51:11.876403Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 2881.8ms (44.4 tok/s)
+  => 44.4 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 2845.4ms (45.0 tok/s)
+    Run 2/4: 128 tokens in 3211.8ms (39.9 tok/s)
+    Run 3/4: 128 tokens in 3659.0ms (35.0 tok/s)
+    Run 4/4: 128 tokens in 3895.6ms (32.9 tok/s)
+  => 37.6 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2839.0ms (45.1 tok/s)
+    Run 2/8: 128 tokens in 2851.3ms (44.9 tok/s)
+    Run 3/8: 128 tokens in 2846.3ms (45.0 tok/s)
+    Run 4/8: 128 tokens in 3191.4ms (40.1 tok/s)
+    Run 5/8: 128 tokens in 2892.3ms (44.3 tok/s)
+    Run 6/8: 128 tokens in 2863.7ms (44.7 tok/s)
+    Run 7/8: 128 tokens in 2842.4ms (45.0 tok/s)
+    Run 8/8: 128 tokens in 2964.3ms (43.2 tok/s)
+  => 44.0 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2860.2ms (44.8 tok/s)
+    Run 2/16: 128 tokens in 2840.0ms (45.1 tok/s)
+    Run 3/16: 128 tokens in 2812.6ms (45.5 tok/s)
+    Run 4/16: 128 tokens in 2814.7ms (45.5 tok/s)
+    Run 5/16: 128 tokens in 2821.3ms (45.4 tok/s)
+    Run 6/16: 128 tokens in 2830.0ms (45.2 tok/s)
+    Run 7/16: 128 tokens in 2833.4ms (45.2 tok/s)
+    Run 8/16: 128 tokens in 2817.4ms (45.4 tok/s)
+    Run 9/16: 128 tokens in 2828.3ms (45.3 tok/s)
+    Run 10/16: 128 tokens in 2819.9ms (45.4 tok/s)
+    Run 11/16: 128 tokens in 2819.3ms (45.4 tok/s)
+    Run 12/16: 128 tokens in 2822.1ms (45.4 tok/s)
+    Run 13/16: 128 tokens in 2832.6ms (45.2 tok/s)
+    Run 14/16: 128 tokens in 3035.3ms (42.2 tok/s)
+    Run 15/16: 128 tokens in 2947.6ms (43.4 tok/s)
+    Run 16/16: 128 tokens in 2836.1ms (45.1 tok/s)
+  => 44.9 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA A40 (46068 MB VRAM, source: nvidia-smi)
+Model load time: 19.07s (VRAM: 17528 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               508        128         44.4      17833
+4               508        512         37.6      17833
+8               508       1024         44.0      17833
+16              508       2048         44.9      17833
+
+--- Latency (single request) ---
+Prompt tokens:         508
+Prefill time:          452.6 ms (1122 tok/s)
+Time to first token:   452.6 ms
+Mean inter-token:      43.6 ms (22.9 tok/s)
+P50 inter-token:       55.0 ms
+P99 inter-token:       69.2 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.283
+

--- a/profiling-artifacts/post423_20260423_seed1_compare_bf16.txt
+++ b/profiling-artifacts/post423_20260423_seed1_compare_bf16.txt
@@ -1,0 +1,1862 @@
+# seed 1 compare vs bf16 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.39e-03     7.74e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.03e-01     2.08e-02    
+h_layer_16             1x1x2560               True     False    9.49e-01   5.62e-01     5.04e-02    
+h_layer_23             1x1x2560               True     False    9.74e-01   7.89e-01     9.27e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.09e+01     1.16e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.91e-03     8.07e-08    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   1.56e-02     2.02e-06    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   5.57e-02     8.54e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   3.91e-03     9.91e-05    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   3.91e-03     9.36e-04    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.55e-02     7.31e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   7.81e-03     4.48e-06    
+b11__gdn_gated_norm    1x508x4096             True     True     1.00e+00   2.34e-02     4.88e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.56e-02     6.29e-05    
+h_layer_24             1x1x2560               True     False    9.76e-01   9.26e-01     9.66e-02    
+h_layer_25             1x1x2560               True     False    9.78e-01   9.18e-01     9.88e-02    
+h_layer_26             1x1x2560               True     False    9.81e-01   9.30e-01     1.02e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   1.38e+00     1.18e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   1.13e+00     1.33e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   1.38e+00     1.45e-01    
+h_layer_30             1x1x2560               True     False    9.80e-01   9.06e-01     1.69e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.64e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   3.44e-01     1.83e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   2.50e-01     3.87e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   6.25e-01     7.04e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.62e+01     1.30e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.33e-01     7.23e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.22e-01     7.35e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   4.82e-01     7.79e-02    
+h_layer_27             1x1x2560               True     False    9.85e-01   1.12e+00     1.09e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   6.88e-01     1.18e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.60e-01     1.34e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   7.99e-01     1.56e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.58e-01   1.39e-01     2.88e-02    
+h_layer_16             1x1x2560               True     False    8.36e-01   5.94e-01     9.52e-02    
+h_layer_23             1x1x2560               True     False    9.78e-01   5.77e-01     8.66e-02    
+h_layer_31             1x1x2560               True     False    9.25e-01   1.91e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   5.55e-01     8.62e-02    
+h_layer_25             1x1x2560               True     False    9.83e-01   5.80e-01     8.48e-02    
+h_layer_26             1x1x2560               True     False    9.79e-01   6.00e-01     8.70e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.70e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.56e-01     1.12e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   6.88e-01     1.24e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   1.12e+00     1.43e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.78e-01   1.04e-01     2.12e-02    
+h_layer_16             1x1x2560               True     False    9.76e-01   3.75e-01     4.14e-02    
+h_layer_23             1x1x2560               True     False    9.90e-01   6.25e-01     5.92e-02    
+h_layer_31             1x1x2560               True     False    9.60e-01   1.88e+01     1.37e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   8.75e-01     6.18e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.75e-01     6.39e-02    
+h_layer_26             1x1x2560               True     False    9.89e-01   3.71e-01     6.72e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.23e-01     9.45e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   6.02e-01     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.72e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.86e-01   6.72e-01     1.40e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.79e-03     1.77e-03    
+h_layer_8              1x1x2560               True     False    9.82e-01   3.12e-01     1.96e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   3.12e-01     3.29e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   7.50e-01     6.04e-02    
+h_layer_31             1x1x2560               True     False    9.17e-01   1.61e+01     1.27e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.12e+00     6.32e-02    
+h_layer_25             1x1x2560               True     False    9.89e-01   1.12e+00     6.50e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   4.02e-01     6.91e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   6.25e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   7.50e-01     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   5.78e-01     1.19e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   1.00e+00     1.42e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.70e-03     9.19e-04    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.12e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.76e-01   5.62e-01     3.74e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.38e-01     7.34e-02    
+h_layer_31             1x1x2560               True     False    9.13e-01   1.64e+01     1.29e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   3.96e-01     7.56e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   3.96e-01     7.74e-02    
+h_layer_26             1x1x2560               True     False    9.84e-01   4.30e-01     8.10e-02    
+h_layer_27             1x1x2560               True     False    9.73e-01   7.33e-01     1.47e-01    
+h_layer_28             1x1x2560               True     False    9.75e-01   8.75e-01     1.57e-01    
+h_layer_29             1x1x2560               True     False    9.77e-01   8.44e-01     1.72e-01    
+h_layer_30             1x1x2560               True     False    9.72e-01   1.12e+00     1.93e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.47e-03    
+h_layer_8              1x1x2560               True     False    9.11e-01   2.25e-01     3.56e-02    
+h_layer_16             1x1x2560               True     False    7.68e-01   2.00e+00     1.03e-01    
+h_layer_23             1x1x2560               True     False    8.38e-01   2.81e+00     2.02e-01    
+h_layer_31             1x1x2560               True     False    9.14e-01   1.82e+01     1.41e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.30e-01   4.38e+00     2.15e-01    
+h_layer_25             1x1x2560               True     False    8.45e-01   5.00e+00     2.17e-01    
+h_layer_26             1x1x2560               True     False    8.65e-01   1.98e+00     2.22e-01    
+h_layer_27             1x1x2560               True     False    9.06e-01   3.81e+00     2.46e-01    
+h_layer_28             1x1x2560               True     False    9.18e-01   4.62e+00     2.67e-01    
+h_layer_29             1x1x2560               True     False    9.26e-01   4.38e+00     2.87e-01    
+h_layer_30             1x1x2560               True     False    9.20e-01   5.12e+00     3.13e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.73e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   4.38e-01     1.87e-02    
+h_layer_16             1x1x2560               True     False    9.86e-01   1.49e-01     3.12e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   4.30e-01     6.34e-02    
+h_layer_31             1x1x2560               True     False    9.02e-01   1.46e+01     1.19e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   5.00e-01     6.46e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   6.25e-01     6.86e-02    
+h_layer_26             1x1x2560               True     False    9.83e-01   1.25e+00     7.85e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   6.62e-01     1.11e-01    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.82e-01     1.07e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.95e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   1.00e+00     1.45e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.11e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   9.38e-02     1.63e-02    
+h_layer_16             1x1x2560               True     False    9.52e-01   2.86e-01     5.19e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   3.73e-01     7.59e-02    
+h_layer_31             1x1x2560               True     False    9.22e-01   1.36e+01     1.31e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   3.66e-01     7.84e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.10e-01     8.00e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   6.88e-01     8.37e-02    
+h_layer_27             1x1x2560               True     False    9.82e-01   5.57e-01     1.25e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   6.25e-01     1.33e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   6.72e-01     1.49e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   1.38e+00     1.72e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.03e-01   2.34e-01     3.92e-02    
+h_layer_16             1x1x2560               True     False    6.60e-01   1.81e+00     1.31e-01    
+h_layer_23             1x1x2560               True     False    4.32e-01   8.16e+00     3.94e-01    
+h_layer_31             1x1x2560               True     False    6.27e-01   2.83e+01     1.71e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    4.58e-01   8.75e+00     3.98e-01    
+h_layer_25             1x1x2560               True     False    4.69e-01   1.06e+01     3.99e-01    
+h_layer_26             1x1x2560               True     False    3.85e-01   1.27e+01     4.27e-01    
+h_layer_27             1x1x2560               True     False    5.15e-01   1.22e+01     5.32e-01    
+h_layer_28             1x1x2560               True     False    5.94e-01   1.31e+01     5.74e-01    
+h_layer_29             1x1x2560               True     False    6.25e-01   1.40e+01     6.14e-01    
+h_layer_30             1x1x2560               True     False    5.79e-01   1.59e+01     6.89e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                        
+  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=3.39e-03   ok    cos=9.99e-01   max|Δ|=9.64e-03   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=8.79e-03   ok    cos=1.00e+00   max|Δ|=4.70e-03   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=7.81e-03   ok    cos=9.99e-01   max|Δ|=7.81e-03   ok    cos=9.99e-01   max|Δ|=7.81e-03   ok   
+  h_layer_8             cos=9.76e-01   max|Δ|=1.03e-01   DIV   cos=9.88e-01   max|Δ|=3.44e-01   DIV   cos=9.58e-01   max|Δ|=1.39e-01   DIV   cos=9.78e-01   max|Δ|=1.04e-01   DIV   cos=9.82e-01   max|Δ|=3.12e-01   DIV   cos=9.81e-01   max|Δ|=3.12e-01   DIV   cos=9.11e-01   max|Δ|=2.25e-01   DIV   cos=9.85e-01   max|Δ|=4.38e-01   DIV   cos=9.86e-01   max|Δ|=9.38e-02   DIV   cos=9.03e-01   max|Δ|=2.34e-01   DIV  
+  h_layer_16            cos=9.49e-01   max|Δ|=5.62e-01   DIV   cos=9.73e-01   max|Δ|=2.50e-01   DIV   cos=8.36e-01   max|Δ|=5.94e-01   DIV   cos=9.76e-01   max|Δ|=3.75e-01   DIV   cos=9.85e-01   max|Δ|=3.12e-01   DIV   cos=9.76e-01   max|Δ|=5.62e-01   DIV   cos=7.68e-01   max|Δ|=2.00e+00   DIV   cos=9.86e-01   max|Δ|=1.49e-01   DIV   cos=9.52e-01   max|Δ|=2.86e-01   DIV   cos=6.60e-01   max|Δ|=1.81e+00   DIV  
+  h_layer_23            cos=9.74e-01   max|Δ|=7.89e-01   DIV   cos=9.86e-01   max|Δ|=6.25e-01   DIV   cos=9.78e-01   max|Δ|=5.77e-01   DIV   cos=9.90e-01   max|Δ|=6.25e-01   DIV   cos=9.89e-01   max|Δ|=7.50e-01   DIV   cos=9.84e-01   max|Δ|=4.38e-01   DIV   cos=8.38e-01   max|Δ|=2.81e+00   DIV   cos=9.88e-01   max|Δ|=4.30e-01   DIV   cos=9.83e-01   max|Δ|=3.73e-01   DIV   cos=4.32e-01   max|Δ|=8.16e+00   DIV  
+  h_layer_31            cos=9.59e-01   max|Δ|=2.09e+01   DIV   cos=9.30e-01   max|Δ|=1.62e+01   DIV   cos=9.25e-01   max|Δ|=1.91e+01   DIV   cos=9.60e-01   max|Δ|=1.88e+01   DIV   cos=9.17e-01   max|Δ|=1.61e+01   DIV   cos=9.13e-01   max|Δ|=1.64e+01   DIV   cos=9.14e-01   max|Δ|=1.82e+01   DIV   cos=9.02e-01   max|Δ|=1.46e+01   DIV   cos=9.22e-01   max|Δ|=1.36e+01   DIV   cos=6.27e-01   max|Δ|=2.83e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_8' (pos=0_s0)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK
+  -> The first bad transformer block lies between h_layer_0
+     and h_layer_8. Narrow by capturing intermediate layers
+     (e.g. layers 4 and 12) and re-running B10 on the new dump.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.39e-03     7.74e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.03e-01     2.08e-02    
+h_layer_16             1x1x2560               True     False    9.49e-01   5.62e-01     5.04e-02    
+h_layer_23             1x1x2560               True     False    9.74e-01   7.89e-01     9.27e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.09e+01     1.16e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.91e-03     8.07e-08    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   1.56e-02     2.02e-06    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   5.57e-02     8.54e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   3.91e-03     9.91e-05    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   3.91e-03     9.36e-04    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.55e-02     7.31e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   7.81e-03     4.48e-06    
+b11__gdn_gated_norm    1x508x4096             True     True     1.00e+00   2.34e-02     4.88e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.56e-02     6.29e-05    
+h_layer_24             1x1x2560               True     False    9.76e-01   9.26e-01     9.66e-02    
+h_layer_25             1x1x2560               True     False    9.78e-01   9.18e-01     9.88e-02    
+h_layer_26             1x1x2560               True     False    9.81e-01   9.30e-01     1.02e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   1.38e+00     1.18e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   1.13e+00     1.33e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   1.38e+00     1.45e-01    
+h_layer_30             1x1x2560               True     False    9.80e-01   9.06e-01     1.69e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.64e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   3.44e-01     1.83e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   2.50e-01     3.87e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   6.25e-01     7.04e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.62e+01     1.30e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.33e-01     7.23e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.22e-01     7.35e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   4.82e-01     7.79e-02    
+h_layer_27             1x1x2560               True     False    9.85e-01   1.12e+00     1.09e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   6.88e-01     1.18e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.60e-01     1.34e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   7.99e-01     1.56e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.58e-01   1.39e-01     2.88e-02    
+h_layer_16             1x1x2560               True     False    8.36e-01   5.94e-01     9.52e-02    
+h_layer_23             1x1x2560               True     False    9.78e-01   5.77e-01     8.66e-02    
+h_layer_31             1x1x2560               True     False    9.25e-01   1.91e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   5.55e-01     8.62e-02    
+h_layer_25             1x1x2560               True     False    9.83e-01   5.80e-01     8.48e-02    
+h_layer_26             1x1x2560               True     False    9.79e-01   6.00e-01     8.70e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.70e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.56e-01     1.12e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   6.88e-01     1.24e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   1.12e+00     1.43e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.78e-01   1.04e-01     2.12e-02    
+h_layer_16             1x1x2560               True     False    9.76e-01   3.75e-01     4.14e-02    
+h_layer_23             1x1x2560               True     False    9.90e-01   6.25e-01     5.92e-02    
+h_layer_31             1x1x2560               True     False    9.60e-01   1.88e+01     1.37e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   8.75e-01     6.18e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.75e-01     6.39e-02    
+h_layer_26             1x1x2560               True     False    9.89e-01   3.71e-01     6.72e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.23e-01     9.45e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   6.02e-01     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.72e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.86e-01   6.72e-01     1.40e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.79e-03     1.77e-03    
+h_layer_8              1x1x2560               True     False    9.82e-01   3.12e-01     1.96e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   3.12e-01     3.29e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   7.50e-01     6.04e-02    
+h_layer_31             1x1x2560               True     False    9.17e-01   1.61e+01     1.27e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.12e+00     6.32e-02    
+h_layer_25             1x1x2560               True     False    9.89e-01   1.12e+00     6.50e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   4.02e-01     6.91e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   6.25e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   7.50e-01     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   5.78e-01     1.19e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   1.00e+00     1.42e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.70e-03     9.19e-04    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.12e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.76e-01   5.62e-01     3.74e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.38e-01     7.34e-02    
+h_layer_31             1x1x2560               True     False    9.13e-01   1.64e+01     1.29e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   3.96e-01     7.56e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   3.96e-01     7.74e-02    
+h_layer_26             1x1x2560               True     False    9.84e-01   4.30e-01     8.10e-02    
+h_layer_27             1x1x2560               True     False    9.73e-01   7.33e-01     1.47e-01    
+h_layer_28             1x1x2560               True     False    9.75e-01   8.75e-01     1.57e-01    
+h_layer_29             1x1x2560               True     False    9.77e-01   8.44e-01     1.72e-01    
+h_layer_30             1x1x2560               True     False    9.72e-01   1.12e+00     1.93e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.47e-03    
+h_layer_8              1x1x2560               True     False    9.11e-01   2.25e-01     3.56e-02    
+h_layer_16             1x1x2560               True     False    7.68e-01   2.00e+00     1.03e-01    
+h_layer_23             1x1x2560               True     False    8.38e-01   2.81e+00     2.02e-01    
+h_layer_31             1x1x2560               True     False    9.14e-01   1.82e+01     1.41e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.30e-01   4.38e+00     2.15e-01    
+h_layer_25             1x1x2560               True     False    8.45e-01   5.00e+00     2.17e-01    
+h_layer_26             1x1x2560               True     False    8.65e-01   1.98e+00     2.22e-01    
+h_layer_27             1x1x2560               True     False    9.06e-01   3.81e+00     2.46e-01    
+h_layer_28             1x1x2560               True     False    9.18e-01   4.62e+00     2.67e-01    
+h_layer_29             1x1x2560               True     False    9.26e-01   4.38e+00     2.87e-01    
+h_layer_30             1x1x2560               True     False    9.20e-01   5.12e+00     3.13e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.73e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   4.38e-01     1.87e-02    
+h_layer_16             1x1x2560               True     False    9.86e-01   1.49e-01     3.12e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   4.30e-01     6.34e-02    
+h_layer_31             1x1x2560               True     False    9.02e-01   1.46e+01     1.19e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   5.00e-01     6.46e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   6.25e-01     6.86e-02    
+h_layer_26             1x1x2560               True     False    9.83e-01   1.25e+00     7.85e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   6.62e-01     1.11e-01    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.82e-01     1.07e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.95e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   1.00e+00     1.45e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.11e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   9.38e-02     1.63e-02    
+h_layer_16             1x1x2560               True     False    9.52e-01   2.86e-01     5.19e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   3.73e-01     7.59e-02    
+h_layer_31             1x1x2560               True     False    9.22e-01   1.36e+01     1.31e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   3.66e-01     7.84e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.10e-01     8.00e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   6.88e-01     8.37e-02    
+h_layer_27             1x1x2560               True     False    9.82e-01   5.57e-01     1.25e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   6.25e-01     1.33e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   6.72e-01     1.49e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   1.38e+00     1.72e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.03e-01   2.34e-01     3.92e-02    
+h_layer_16             1x1x2560               True     False    6.60e-01   1.81e+00     1.31e-01    
+h_layer_23             1x1x2560               True     False    4.32e-01   8.16e+00     3.94e-01    
+h_layer_31             1x1x2560               True     False    6.27e-01   2.83e+01     1.71e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    4.58e-01   8.75e+00     3.98e-01    
+h_layer_25             1x1x2560               True     False    4.69e-01   1.06e+01     3.99e-01    
+h_layer_26             1x1x2560               True     False    3.85e-01   1.27e+01     4.27e-01    
+h_layer_27             1x1x2560               True     False    5.15e-01   1.22e+01     5.32e-01    
+h_layer_28             1x1x2560               True     False    5.94e-01   1.31e+01     5.74e-01    
+h_layer_29             1x1x2560               True     False    6.25e-01   1.40e+01     6.14e-01    
+h_layer_30             1x1x2560               True     False    5.79e-01   1.59e+01     6.89e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                            
+  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=8.07e-08   rel_l2=1.51e-05   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_in_proj               cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=2.02e-06   rel_l2=6.76e-05   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_conv                  cos=1.00e+00   max|Δ|=5.57e-02   mean|Δ|=8.54e-05   rel_l2=2.29e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.79e-01   mean|Δ|=4.00e-02   rel_l2=9.12e-01   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.91e-05   rel_l2=3.19e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=3.91e-03   mean|Δ|=9.36e-04   rel_l2=3.04e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_g                cos=1.00e+00   max|Δ|=1.55e-02   mean|Δ|=7.31e-04   rel_l2=1.62e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_recur_out             cos=1.00e+00   max|Δ|=7.81e-03   mean|Δ|=4.48e-06   rel_l2=4.57e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=2.34e-02   mean|Δ|=4.88e-05   rel_l2=5.07e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.56e-02   mean|Δ|=6.29e-05   rel_l2=3.37e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+Phase B11b verdict: ALL layer-0 GDN sub-ops match within cos_sim >= 0.95.
+  -> Divergence is NOT localized inside layer 0's GDN block at this bar.
+  -> Re-check B10 atol/rtol and consider extending taps to layers 1-7
+     (GDN stack) before committing to a B12 target.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.39e-03     7.74e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.03e-01     2.08e-02    
+h_layer_16             1x1x2560               True     False    9.49e-01   5.62e-01     5.04e-02    
+h_layer_23             1x1x2560               True     False    9.74e-01   7.89e-01     9.27e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.09e+01     1.16e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.91e-03     8.07e-08    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   1.56e-02     2.02e-06    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   5.57e-02     8.54e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   3.91e-03     9.91e-05    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   3.91e-03     9.36e-04    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.55e-02     7.31e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   7.81e-03     4.48e-06    
+b11__gdn_gated_norm    1x508x4096             True     True     1.00e+00   2.34e-02     4.88e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.56e-02     6.29e-05    
+h_layer_24             1x1x2560               True     False    9.76e-01   9.26e-01     9.66e-02    
+h_layer_25             1x1x2560               True     False    9.78e-01   9.18e-01     9.88e-02    
+h_layer_26             1x1x2560               True     False    9.81e-01   9.30e-01     1.02e-01    
+h_layer_27             1x1x2560               True     False    9.80e-01   1.38e+00     1.18e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   1.13e+00     1.33e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   1.38e+00     1.45e-01    
+h_layer_30             1x1x2560               True     False    9.80e-01   9.06e-01     1.69e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.64e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   3.44e-01     1.83e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   2.50e-01     3.87e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   6.25e-01     7.04e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.62e+01     1.30e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.33e-01     7.23e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.22e-01     7.35e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   4.82e-01     7.79e-02    
+h_layer_27             1x1x2560               True     False    9.85e-01   1.12e+00     1.09e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   6.88e-01     1.18e-01    
+h_layer_29             1x1x2560               True     False    9.86e-01   6.60e-01     1.34e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   7.99e-01     1.56e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.58e-01   1.39e-01     2.88e-02    
+h_layer_16             1x1x2560               True     False    8.36e-01   5.94e-01     9.52e-02    
+h_layer_23             1x1x2560               True     False    9.78e-01   5.77e-01     8.66e-02    
+h_layer_31             1x1x2560               True     False    9.25e-01   1.91e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   5.55e-01     8.62e-02    
+h_layer_25             1x1x2560               True     False    9.83e-01   5.80e-01     8.48e-02    
+h_layer_26             1x1x2560               True     False    9.79e-01   6.00e-01     8.70e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.70e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.56e-01     1.12e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   6.88e-01     1.24e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   1.12e+00     1.43e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.78e-01   1.04e-01     2.12e-02    
+h_layer_16             1x1x2560               True     False    9.76e-01   3.75e-01     4.14e-02    
+h_layer_23             1x1x2560               True     False    9.90e-01   6.25e-01     5.92e-02    
+h_layer_31             1x1x2560               True     False    9.60e-01   1.88e+01     1.37e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.90e-01   8.75e-01     6.18e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.75e-01     6.39e-02    
+h_layer_26             1x1x2560               True     False    9.89e-01   3.71e-01     6.72e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.23e-01     9.45e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   6.02e-01     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.72e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.86e-01   6.72e-01     1.40e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.79e-03     1.77e-03    
+h_layer_8              1x1x2560               True     False    9.82e-01   3.12e-01     1.96e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   3.12e-01     3.29e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   7.50e-01     6.04e-02    
+h_layer_31             1x1x2560               True     False    9.17e-01   1.61e+01     1.27e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   1.12e+00     6.32e-02    
+h_layer_25             1x1x2560               True     False    9.89e-01   1.12e+00     6.50e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   4.02e-01     6.91e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   6.25e-01     9.69e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   7.50e-01     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   5.78e-01     1.19e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   1.00e+00     1.42e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.70e-03     9.19e-04    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.12e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.76e-01   5.62e-01     3.74e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.38e-01     7.34e-02    
+h_layer_31             1x1x2560               True     False    9.13e-01   1.64e+01     1.29e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   3.96e-01     7.56e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   3.96e-01     7.74e-02    
+h_layer_26             1x1x2560               True     False    9.84e-01   4.30e-01     8.10e-02    
+h_layer_27             1x1x2560               True     False    9.73e-01   7.33e-01     1.47e-01    
+h_layer_28             1x1x2560               True     False    9.75e-01   8.75e-01     1.57e-01    
+h_layer_29             1x1x2560               True     False    9.77e-01   8.44e-01     1.72e-01    
+h_layer_30             1x1x2560               True     False    9.72e-01   1.12e+00     1.93e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.47e-03    
+h_layer_8              1x1x2560               True     False    9.11e-01   2.25e-01     3.56e-02    
+h_layer_16             1x1x2560               True     False    7.68e-01   2.00e+00     1.03e-01    
+h_layer_23             1x1x2560               True     False    8.38e-01   2.81e+00     2.02e-01    
+h_layer_31             1x1x2560               True     False    9.14e-01   1.82e+01     1.41e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.30e-01   4.38e+00     2.15e-01    
+h_layer_25             1x1x2560               True     False    8.45e-01   5.00e+00     2.17e-01    
+h_layer_26             1x1x2560               True     False    8.65e-01   1.98e+00     2.22e-01    
+h_layer_27             1x1x2560               True     False    9.06e-01   3.81e+00     2.46e-01    
+h_layer_28             1x1x2560               True     False    9.18e-01   4.62e+00     2.67e-01    
+h_layer_29             1x1x2560               True     False    9.26e-01   4.38e+00     2.87e-01    
+h_layer_30             1x1x2560               True     False    9.20e-01   5.12e+00     3.13e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.73e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   4.38e-01     1.87e-02    
+h_layer_16             1x1x2560               True     False    9.86e-01   1.49e-01     3.12e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   4.30e-01     6.34e-02    
+h_layer_31             1x1x2560               True     False    9.02e-01   1.46e+01     1.19e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   5.00e-01     6.46e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   6.25e-01     6.86e-02    
+h_layer_26             1x1x2560               True     False    9.83e-01   1.25e+00     7.85e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   6.62e-01     1.11e-01    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.82e-01     1.07e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.95e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   1.00e+00     1.45e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.11e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   9.38e-02     1.63e-02    
+h_layer_16             1x1x2560               True     False    9.52e-01   2.86e-01     5.19e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   3.73e-01     7.59e-02    
+h_layer_31             1x1x2560               True     False    9.22e-01   1.36e+01     1.31e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.83e-01   3.66e-01     7.84e-02    
+h_layer_25             1x1x2560               True     False    9.85e-01   4.10e-01     8.00e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   6.88e-01     8.37e-02    
+h_layer_27             1x1x2560               True     False    9.82e-01   5.57e-01     1.25e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   6.25e-01     1.33e-01    
+h_layer_29             1x1x2560               True     False    9.82e-01   6.72e-01     1.49e-01    
+h_layer_30             1x1x2560               True     False    9.77e-01   1.38e+00     1.72e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_bf16/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.81e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.03e-01   2.34e-01     3.92e-02    
+h_layer_16             1x1x2560               True     False    6.60e-01   1.81e+00     1.31e-01    
+h_layer_23             1x1x2560               True     False    4.32e-01   8.16e+00     3.94e-01    
+h_layer_31             1x1x2560               True     False    6.27e-01   2.83e+01     1.71e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    4.58e-01   8.75e+00     3.98e-01    
+h_layer_25             1x1x2560               True     False    4.69e-01   1.06e+01     3.99e-01    
+h_layer_26             1x1x2560               True     False    3.85e-01   1.27e+01     4.27e-01    
+h_layer_27             1x1x2560               True     False    5.15e-01   1.22e+01     5.32e-01    
+h_layer_28             1x1x2560               True     False    5.94e-01   1.31e+01     5.74e-01    
+h_layer_29             1x1x2560               True     False    6.25e-01   1.40e+01     6.14e-01    
+h_layer_30             1x1x2560               True     False    5.79e-01   1.59e+01     6.89e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                        
+  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.76e-01   max|Δ|=9.26e-01   DIV   cos=9.87e-01   max|Δ|=5.33e-01   DIV   cos=9.81e-01   max|Δ|=5.55e-01   DIV   cos=9.90e-01   max|Δ|=8.75e-01   DIV   cos=9.89e-01   max|Δ|=1.12e+00   DIV   cos=9.85e-01   max|Δ|=3.96e-01   DIV   cos=8.30e-01   max|Δ|=4.38e+00   DIV   cos=9.89e-01   max|Δ|=5.00e-01   DIV   cos=9.83e-01   max|Δ|=3.66e-01   DIV   cos=4.58e-01   max|Δ|=8.75e+00   DIV  
+  h_layer_25            cos=9.78e-01   max|Δ|=9.18e-01   DIV   cos=9.88e-01   max|Δ|=5.22e-01   DIV   cos=9.83e-01   max|Δ|=5.80e-01   DIV   cos=9.90e-01   max|Δ|=8.75e-01   DIV   cos=9.89e-01   max|Δ|=1.12e+00   DIV   cos=9.86e-01   max|Δ|=3.96e-01   DIV   cos=8.45e-01   max|Δ|=5.00e+00   DIV   cos=9.88e-01   max|Δ|=6.25e-01   DIV   cos=9.85e-01   max|Δ|=4.10e-01   DIV   cos=4.69e-01   max|Δ|=1.06e+01   DIV  
+  h_layer_26            cos=9.81e-01   max|Δ|=9.30e-01   DIV   cos=9.86e-01   max|Δ|=4.82e-01   DIV   cos=9.79e-01   max|Δ|=6.00e-01   DIV   cos=9.89e-01   max|Δ|=3.71e-01   DIV   cos=9.88e-01   max|Δ|=4.02e-01   DIV   cos=9.84e-01   max|Δ|=4.30e-01   DIV   cos=8.65e-01   max|Δ|=1.98e+00   DIV   cos=9.83e-01   max|Δ|=1.25e+00   DIV   cos=9.82e-01   max|Δ|=6.88e-01   DIV   cos=3.85e-01   max|Δ|=1.27e+01   DIV  
+  h_layer_27            cos=9.80e-01   max|Δ|=1.38e+00   DIV   cos=9.85e-01   max|Δ|=1.12e+00   DIV   cos=9.87e-01   max|Δ|=5.70e-01   DIV   cos=9.89e-01   max|Δ|=5.23e-01   DIV   cos=9.88e-01   max|Δ|=6.25e-01   DIV   cos=9.73e-01   max|Δ|=7.33e-01   DIV   cos=9.06e-01   max|Δ|=3.81e+00   DIV   cos=9.87e-01   max|Δ|=6.62e-01   DIV   cos=9.82e-01   max|Δ|=5.57e-01   DIV   cos=5.15e-01   max|Δ|=1.22e+01   DIV  
+  h_layer_28            cos=9.83e-01   max|Δ|=1.13e+00   DIV   cos=9.86e-01   max|Δ|=6.88e-01   DIV   cos=9.88e-01   max|Δ|=6.56e-01   DIV   cos=9.89e-01   max|Δ|=6.02e-01   DIV   cos=9.88e-01   max|Δ|=7.50e-01   DIV   cos=9.75e-01   max|Δ|=8.75e-01   DIV   cos=9.18e-01   max|Δ|=4.62e+00   DIV   cos=9.88e-01   max|Δ|=6.82e-01   DIV   cos=9.83e-01   max|Δ|=6.25e-01   DIV   cos=5.94e-01   max|Δ|=1.31e+01   DIV  
+  h_layer_29            cos=9.81e-01   max|Δ|=1.38e+00   DIV   cos=9.86e-01   max|Δ|=6.60e-01   DIV   cos=9.88e-01   max|Δ|=6.88e-01   DIV   cos=9.89e-01   max|Δ|=6.72e-01   DIV   cos=9.89e-01   max|Δ|=5.78e-01   DIV   cos=9.77e-01   max|Δ|=8.44e-01   DIV   cos=9.26e-01   max|Δ|=4.38e+00   DIV   cos=9.89e-01   max|Δ|=6.95e-01   DIV   cos=9.82e-01   max|Δ|=6.72e-01   DIV   cos=6.25e-01   max|Δ|=1.40e+01   DIV  
+  h_layer_30            cos=9.80e-01   max|Δ|=9.06e-01   DIV   cos=9.81e-01   max|Δ|=7.99e-01   DIV   cos=9.84e-01   max|Δ|=1.12e+00   DIV   cos=9.86e-01   max|Δ|=6.72e-01   DIV   cos=9.85e-01   max|Δ|=1.00e+00   DIV   cos=9.72e-01   max|Δ|=1.12e+00   DIV   cos=9.20e-01   max|Δ|=5.12e+00   DIV   cos=9.82e-01   max|Δ|=1.00e+00   DIV   cos=9.77e-01   max|Δ|=1.38e+00   DIV   cos=5.79e-01   max|Δ|=1.59e+01   DIV  
+  h_layer_31            cos=9.59e-01   max|Δ|=2.09e+01   DIV   cos=9.30e-01   max|Δ|=1.62e+01   DIV   cos=9.25e-01   max|Δ|=1.91e+01   DIV   cos=9.60e-01   max|Δ|=1.88e+01   DIV   cos=9.17e-01   max|Δ|=1.61e+01   DIV   cos=9.13e-01   max|Δ|=1.64e+01   DIV   cos=9.14e-01   max|Δ|=1.82e+01   DIV   cos=9.02e-01   max|Δ|=1.46e+01   DIV   cos=9.22e-01   max|Δ|=1.36e+01   DIV   cos=6.27e-01   max|Δ|=2.83e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=9.84e-01     DIV
+    h_layer_25             median=9.86e-01     DIV
+    h_layer_26             median=9.83e-01     DIV
+    h_layer_27             median=9.84e-01     DIV
+    h_layer_28             median=9.84e-01     DIV
+    h_layer_29             median=9.84e-01     DIV
+    h_layer_30             median=9.81e-01     DIV
+    h_layer_31             median=9.19e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                            
+  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  q_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  k_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  v_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_q           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_k           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV <missing>                                           
+  post_attn_norm      <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_gate            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_up              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_down            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=nan          DIV
+    q_proj               median=nan          DIV
+    k_proj               median=nan          DIV
+    v_proj               median=nan          DIV
+    qk_norm_q            median=nan          DIV
+    qk_norm_k            median=nan          DIV
+    o_proj               median=nan          DIV
+    post_attn_norm       median=nan          DIV
+    mlp_gate             median=nan          DIV
+    mlp_up               median=nan          DIV
+    mlp_down             median=nan          DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.984201)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/profiling-artifacts/post423_20260423_seed1_compare_fp32.txt
+++ b/profiling-artifacts/post423_20260423_seed1_compare_fp32.txt
@@ -1,0 +1,1862 @@
+# seed 1 compare vs fp32 HF
+
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.26e-02     7.70e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.03e-01     2.11e-02    
+h_layer_16             1x1x2560               True     False    9.47e-01   5.69e-01     5.13e-02    
+h_layer_23             1x1x2560               True     False    9.72e-01   7.81e-01     9.47e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.06e+01     1.16e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.02e-02     1.28e-03    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   6.66e-02     1.82e-03    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   6.19e-02     7.34e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   4.47e-03     1.30e-04    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   5.17e-03     1.21e-03    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.73e-02     8.17e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   6.09e-03     3.94e-06    
+b11__gdn_gated_norm    1x508x4096             True     False    1.00e+00   1.94e-02     4.84e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.24e-02     5.79e-05    
+h_layer_24             1x1x2560               True     False    9.75e-01   9.32e-01     9.83e-02    
+h_layer_25             1x1x2560               True     False    9.77e-01   9.28e-01     1.00e-01    
+h_layer_26             1x1x2560               True     False    9.81e-01   9.36e-01     1.03e-01    
+h_layer_27             1x1x2560               True     False    9.79e-01   1.46e+00     1.20e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   1.14e+00     1.35e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   1.43e+00     1.47e-01    
+h_layer_30             1x1x2560               True     False    9.80e-01   9.42e-01     1.71e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   3.53e-01     1.84e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   1.82e-01     3.87e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   7.08e-01     7.05e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.62e+01     1.30e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.33e-01     7.23e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.24e-01     7.31e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   5.47e-01     7.78e-02    
+h_layer_27             1x1x2560               True     False    9.85e-01   1.28e+00     1.07e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   6.87e-01     1.16e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.47e-01     1.32e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   7.96e-01     1.54e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.73e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.57e-01   1.35e-01     2.88e-02    
+h_layer_16             1x1x2560               True     False    8.40e-01   5.49e-01     9.38e-02    
+h_layer_23             1x1x2560               True     False    9.78e-01   5.83e-01     8.66e-02    
+h_layer_31             1x1x2560               True     False    9.26e-01   1.89e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   5.76e-01     8.62e-02    
+h_layer_25             1x1x2560               True     False    9.83e-01   6.07e-01     8.47e-02    
+h_layer_26             1x1x2560               True     False    9.79e-01   6.28e-01     8.68e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.90e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.64e-01     1.11e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   6.97e-01     1.23e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   9.79e-01     1.42e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.01e-02     1.33e-03    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.02e-01     2.09e-02    
+h_layer_16             1x1x2560               True     False    9.76e-01   3.70e-01     4.11e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   7.04e-01     5.94e-02    
+h_layer_31             1x1x2560               True     False    9.60e-01   1.89e+01     1.36e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   9.04e-01     6.21e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.68e-01     6.41e-02    
+h_layer_26             1x1x2560               True     False    9.89e-01   3.72e-01     6.73e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.21e-01     9.44e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   5.98e-01     1.05e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.79e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.86e-01   6.86e-01     1.40e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.66e-03     1.78e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.20e-01     2.00e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   3.13e-01     3.29e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   7.01e-01     6.00e-02    
+h_layer_31             1x1x2560               True     False    9.18e-01   1.61e+01     1.27e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   9.59e-01     6.26e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   1.05e+00     6.44e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   3.96e-01     6.87e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   5.67e-01     9.71e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.10e-01     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.00e-01     1.19e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   1.10e+00     1.42e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.93e-03     9.23e-04    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.57e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.75e-01   6.33e-01     3.80e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.13e-01     7.23e-02    
+h_layer_31             1x1x2560               True     False    9.14e-01   1.66e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   3.95e-01     7.46e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   4.70e-01     7.63e-02    
+h_layer_26             1x1x2560               True     False    9.84e-01   4.31e-01     8.00e-02    
+h_layer_27             1x1x2560               True     False    9.74e-01   7.41e-01     1.44e-01    
+h_layer_28             1x1x2560               True     False    9.76e-01   8.93e-01     1.54e-01    
+h_layer_29             1x1x2560               True     False    9.78e-01   8.40e-01     1.68e-01    
+h_layer_30             1x1x2560               True     False    9.73e-01   1.16e+00     1.89e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.70e-02     1.48e-03    
+h_layer_8              1x1x2560               True     False    9.02e-01   2.48e-01     3.76e-02    
+h_layer_16             1x1x2560               True     False    8.02e-01   1.60e+00     9.70e-02    
+h_layer_23             1x1x2560               True     False    8.38e-01   2.61e+00     2.04e-01    
+h_layer_31             1x1x2560               True     False    9.20e-01   1.84e+01     1.39e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.37e-01   3.95e+00     2.12e-01    
+h_layer_25             1x1x2560               True     False    8.52e-01   4.67e+00     2.12e-01    
+h_layer_26             1x1x2560               True     False    8.68e-01   1.86e+00     2.20e-01    
+h_layer_27             1x1x2560               True     False    9.05e-01   4.75e+00     2.45e-01    
+h_layer_28             1x1x2560               True     False    9.19e-01   4.90e+00     2.66e-01    
+h_layer_29             1x1x2560               True     False    9.26e-01   4.87e+00     2.86e-01    
+h_layer_30             1x1x2560               True     False    9.23e-01   5.11e+00     3.11e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.14e-03     1.74e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   4.10e-01     1.88e-02    
+h_layer_16             1x1x2560               True     False    9.86e-01   1.47e-01     3.16e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   4.27e-01     6.43e-02    
+h_layer_31             1x1x2560               True     False    9.02e-01   1.46e+01     1.18e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.88e-01   5.00e-01     6.52e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.56e-01     6.91e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   1.39e+00     8.05e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   6.59e-01     1.15e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   6.75e-01     1.09e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   6.83e-01     1.20e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   7.33e-01     1.46e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   5.81e-03     1.10e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   8.91e-02     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.55e-01   2.78e-01     5.01e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   3.83e-01     7.32e-02    
+h_layer_31             1x1x2560               True     False    9.23e-01   1.37e+01     1.31e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   3.93e-01     7.56e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   3.91e-01     7.72e-02    
+h_layer_26             1x1x2560               True     False    9.83e-01   7.44e-01     8.17e-02    
+h_layer_27             1x1x2560               True     False    9.83e-01   5.41e-01     1.22e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   6.67e-01     1.31e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.21e-01     1.46e-01    
+h_layer_30             1x1x2560               True     False    9.78e-01   1.48e+00     1.68e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.07e-01   2.44e-01     3.85e-02    
+h_layer_16             1x1x2560               True     False    6.49e-01   1.56e+00     1.31e-01    
+h_layer_23             1x1x2560               True     False    4.20e-01   8.04e+00     4.06e-01    
+h_layer_31             1x1x2560               True     False    6.18e-01   2.83e+01     1.72e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    4.46e-01   8.86e+00     4.11e-01    
+h_layer_25             1x1x2560               True     False    4.58e-01   1.09e+01     4.12e-01    
+h_layer_26             1x1x2560               True     False    3.76e-01   1.30e+01     4.39e-01    
+h_layer_27             1x1x2560               True     False    5.07e-01   1.21e+01     5.43e-01    
+h_layer_28             1x1x2560               True     False    5.82e-01   1.30e+01     5.89e-01    
+h_layer_29             1x1x2560               True     False    6.14e-01   1.42e+01     6.30e-01    
+h_layer_30             1x1x2560               True     False    5.68e-01   1.60e+01     7.03e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                        
+  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=1.26e-02   ok    cos=9.99e-01   max|Δ|=9.83e-03   ok    cos=9.99e-01   max|Δ|=1.73e-02   ok    cos=9.99e-01   max|Δ|=1.01e-02   ok    cos=9.99e-01   max|Δ|=8.66e-03   ok    cos=1.00e+00   max|Δ|=4.93e-03   ok    cos=9.99e-01   max|Δ|=2.70e-02   ok    cos=9.99e-01   max|Δ|=8.14e-03   ok    cos=9.99e-01   max|Δ|=5.81e-03   ok    cos=9.99e-01   max|Δ|=9.83e-03   ok   
+  h_layer_8             cos=9.76e-01   max|Δ|=1.03e-01   DIV   cos=9.88e-01   max|Δ|=3.53e-01   DIV   cos=9.57e-01   max|Δ|=1.35e-01   DIV   cos=9.79e-01   max|Δ|=1.02e-01   DIV   cos=9.81e-01   max|Δ|=3.20e-01   DIV   cos=9.81e-01   max|Δ|=3.57e-01   DIV   cos=9.02e-01   max|Δ|=2.48e-01   DIV   cos=9.85e-01   max|Δ|=4.10e-01   DIV   cos=9.86e-01   max|Δ|=8.91e-02   DIV   cos=9.07e-01   max|Δ|=2.44e-01   DIV  
+  h_layer_16            cos=9.47e-01   max|Δ|=5.69e-01   DIV   cos=9.73e-01   max|Δ|=1.82e-01   DIV   cos=8.40e-01   max|Δ|=5.49e-01   DIV   cos=9.76e-01   max|Δ|=3.70e-01   DIV   cos=9.85e-01   max|Δ|=3.13e-01   DIV   cos=9.75e-01   max|Δ|=6.33e-01   DIV   cos=8.02e-01   max|Δ|=1.60e+00   DIV   cos=9.86e-01   max|Δ|=1.47e-01   DIV   cos=9.55e-01   max|Δ|=2.78e-01   DIV   cos=6.49e-01   max|Δ|=1.56e+00   DIV  
+  h_layer_23            cos=9.72e-01   max|Δ|=7.81e-01   DIV   cos=9.86e-01   max|Δ|=7.08e-01   DIV   cos=9.78e-01   max|Δ|=5.83e-01   DIV   cos=9.89e-01   max|Δ|=7.04e-01   DIV   cos=9.89e-01   max|Δ|=7.01e-01   DIV   cos=9.84e-01   max|Δ|=4.13e-01   DIV   cos=8.38e-01   max|Δ|=2.61e+00   DIV   cos=9.88e-01   max|Δ|=4.27e-01   DIV   cos=9.84e-01   max|Δ|=3.83e-01   DIV   cos=4.20e-01   max|Δ|=8.04e+00   DIV  
+  h_layer_31            cos=9.59e-01   max|Δ|=2.06e+01   DIV   cos=9.30e-01   max|Δ|=1.62e+01   DIV   cos=9.26e-01   max|Δ|=1.89e+01   DIV   cos=9.60e-01   max|Δ|=1.89e+01   DIV   cos=9.18e-01   max|Δ|=1.61e+01   DIV   cos=9.14e-01   max|Δ|=1.66e+01   DIV   cos=9.20e-01   max|Δ|=1.84e+01   DIV   cos=9.02e-01   max|Δ|=1.46e+01   DIV   cos=9.23e-01   max|Δ|=1.37e+01   DIV   cos=6.18e-01   max|Δ|=2.83e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  first diverging tap: 'h_layer_8' (pos=0_s0)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK
+  -> The first bad transformer block lies between h_layer_0
+     and h_layer_8. Narrow by capturing intermediate layers
+     (e.g. layers 4 and 12) and re-running B10 on the new dump.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-0 GDN sub-op bisect (B11b), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.26e-02     7.70e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.03e-01     2.11e-02    
+h_layer_16             1x1x2560               True     False    9.47e-01   5.69e-01     5.13e-02    
+h_layer_23             1x1x2560               True     False    9.72e-01   7.81e-01     9.47e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.06e+01     1.16e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.02e-02     1.28e-03    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   6.66e-02     1.82e-03    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   6.19e-02     7.34e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   4.47e-03     1.30e-04    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   5.17e-03     1.21e-03    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.73e-02     8.17e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   6.09e-03     3.94e-06    
+b11__gdn_gated_norm    1x508x4096             True     False    1.00e+00   1.94e-02     4.84e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.24e-02     5.79e-05    
+h_layer_24             1x1x2560               True     False    9.75e-01   9.32e-01     9.83e-02    
+h_layer_25             1x1x2560               True     False    9.77e-01   9.28e-01     1.00e-01    
+h_layer_26             1x1x2560               True     False    9.81e-01   9.36e-01     1.03e-01    
+h_layer_27             1x1x2560               True     False    9.79e-01   1.46e+00     1.20e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   1.14e+00     1.35e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   1.43e+00     1.47e-01    
+h_layer_30             1x1x2560               True     False    9.80e-01   9.42e-01     1.71e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   3.53e-01     1.84e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   1.82e-01     3.87e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   7.08e-01     7.05e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.62e+01     1.30e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.33e-01     7.23e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.24e-01     7.31e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   5.47e-01     7.78e-02    
+h_layer_27             1x1x2560               True     False    9.85e-01   1.28e+00     1.07e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   6.87e-01     1.16e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.47e-01     1.32e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   7.96e-01     1.54e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.73e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.57e-01   1.35e-01     2.88e-02    
+h_layer_16             1x1x2560               True     False    8.40e-01   5.49e-01     9.38e-02    
+h_layer_23             1x1x2560               True     False    9.78e-01   5.83e-01     8.66e-02    
+h_layer_31             1x1x2560               True     False    9.26e-01   1.89e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   5.76e-01     8.62e-02    
+h_layer_25             1x1x2560               True     False    9.83e-01   6.07e-01     8.47e-02    
+h_layer_26             1x1x2560               True     False    9.79e-01   6.28e-01     8.68e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.90e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.64e-01     1.11e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   6.97e-01     1.23e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   9.79e-01     1.42e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.01e-02     1.33e-03    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.02e-01     2.09e-02    
+h_layer_16             1x1x2560               True     False    9.76e-01   3.70e-01     4.11e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   7.04e-01     5.94e-02    
+h_layer_31             1x1x2560               True     False    9.60e-01   1.89e+01     1.36e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   9.04e-01     6.21e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.68e-01     6.41e-02    
+h_layer_26             1x1x2560               True     False    9.89e-01   3.72e-01     6.73e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.21e-01     9.44e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   5.98e-01     1.05e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.79e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.86e-01   6.86e-01     1.40e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.66e-03     1.78e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.20e-01     2.00e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   3.13e-01     3.29e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   7.01e-01     6.00e-02    
+h_layer_31             1x1x2560               True     False    9.18e-01   1.61e+01     1.27e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   9.59e-01     6.26e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   1.05e+00     6.44e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   3.96e-01     6.87e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   5.67e-01     9.71e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.10e-01     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.00e-01     1.19e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   1.10e+00     1.42e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.93e-03     9.23e-04    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.57e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.75e-01   6.33e-01     3.80e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.13e-01     7.23e-02    
+h_layer_31             1x1x2560               True     False    9.14e-01   1.66e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   3.95e-01     7.46e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   4.70e-01     7.63e-02    
+h_layer_26             1x1x2560               True     False    9.84e-01   4.31e-01     8.00e-02    
+h_layer_27             1x1x2560               True     False    9.74e-01   7.41e-01     1.44e-01    
+h_layer_28             1x1x2560               True     False    9.76e-01   8.93e-01     1.54e-01    
+h_layer_29             1x1x2560               True     False    9.78e-01   8.40e-01     1.68e-01    
+h_layer_30             1x1x2560               True     False    9.73e-01   1.16e+00     1.89e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.70e-02     1.48e-03    
+h_layer_8              1x1x2560               True     False    9.02e-01   2.48e-01     3.76e-02    
+h_layer_16             1x1x2560               True     False    8.02e-01   1.60e+00     9.70e-02    
+h_layer_23             1x1x2560               True     False    8.38e-01   2.61e+00     2.04e-01    
+h_layer_31             1x1x2560               True     False    9.20e-01   1.84e+01     1.39e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.37e-01   3.95e+00     2.12e-01    
+h_layer_25             1x1x2560               True     False    8.52e-01   4.67e+00     2.12e-01    
+h_layer_26             1x1x2560               True     False    8.68e-01   1.86e+00     2.20e-01    
+h_layer_27             1x1x2560               True     False    9.05e-01   4.75e+00     2.45e-01    
+h_layer_28             1x1x2560               True     False    9.19e-01   4.90e+00     2.66e-01    
+h_layer_29             1x1x2560               True     False    9.26e-01   4.87e+00     2.86e-01    
+h_layer_30             1x1x2560               True     False    9.23e-01   5.11e+00     3.11e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.14e-03     1.74e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   4.10e-01     1.88e-02    
+h_layer_16             1x1x2560               True     False    9.86e-01   1.47e-01     3.16e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   4.27e-01     6.43e-02    
+h_layer_31             1x1x2560               True     False    9.02e-01   1.46e+01     1.18e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.88e-01   5.00e-01     6.52e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.56e-01     6.91e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   1.39e+00     8.05e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   6.59e-01     1.15e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   6.75e-01     1.09e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   6.83e-01     1.20e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   7.33e-01     1.46e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   5.81e-03     1.10e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   8.91e-02     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.55e-01   2.78e-01     5.01e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   3.83e-01     7.32e-02    
+h_layer_31             1x1x2560               True     False    9.23e-01   1.37e+01     1.31e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   3.93e-01     7.56e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   3.91e-01     7.72e-02    
+h_layer_26             1x1x2560               True     False    9.83e-01   7.44e-01     8.17e-02    
+h_layer_27             1x1x2560               True     False    9.83e-01   5.41e-01     1.22e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   6.67e-01     1.31e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.21e-01     1.46e-01    
+h_layer_30             1x1x2560               True     False    9.78e-01   1.48e+00     1.68e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.07e-01   2.44e-01     3.85e-02    
+h_layer_16             1x1x2560               True     False    6.49e-01   1.56e+00     1.31e-01    
+h_layer_23             1x1x2560               True     False    4.20e-01   8.04e+00     4.06e-01    
+h_layer_31             1x1x2560               True     False    6.18e-01   2.83e+01     1.72e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    4.46e-01   8.86e+00     4.11e-01    
+h_layer_25             1x1x2560               True     False    4.58e-01   1.09e+01     4.12e-01    
+h_layer_26             1x1x2560               True     False    3.76e-01   1.30e+01     4.39e-01    
+h_layer_27             1x1x2560               True     False    5.07e-01   1.21e+01     5.43e-01    
+h_layer_28             1x1x2560               True     False    5.82e-01   1.30e+01     5.89e-01    
+h_layer_29             1x1x2560               True     False    6.14e-01   1.42e+01     6.30e-01    
+h_layer_30             1x1x2560               True     False    5.68e-01   1.60e+01     7.03e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B11b layer-0 GDN sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                       pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                            
+  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  tok_embed                 cos=1.00e+00   max|Δ|=0.00e+00   mean|Δ|=0.00e+00   rel_l2=0.00e+00   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  layer_0_post_input_norm   cos=1.00e+00   max|Δ|=3.02e-02   mean|Δ|=1.28e-03   rel_l2=1.65e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_in_proj               cos=1.00e+00   max|Δ|=6.66e-02   mean|Δ|=1.82e-03   rel_l2=1.94e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_conv                  cos=1.00e+00   max|Δ|=6.19e-02   mean|Δ|=7.34e-05   rel_l2=1.58e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_q             cos=1.00e+00   max|Δ|=8.79e-01   mean|Δ|=4.00e-02   rel_l2=9.12e-01   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_qk_norm_k             cos=1.00e+00   max|Δ|=4.47e-03   mean|Δ|=1.30e-04   rel_l2=2.67e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_beta             cos=1.00e+00   max|Δ|=5.17e-03   mean|Δ|=1.21e-03   rel_l2=2.74e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gate_g                cos=1.00e+00   max|Δ|=1.73e-02   mean|Δ|=8.17e-04   rel_l2=1.78e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_recur_out             cos=1.00e+00   max|Δ|=6.09e-03   mean|Δ|=3.94e-06   rel_l2=3.45e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_gated_norm            cos=1.00e+00   max|Δ|=1.94e-02   mean|Δ|=4.84e-05   rel_l2=4.15e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  gdn_out_proj              cos=1.00e+00   max|Δ|=1.24e-02   mean|Δ|=5.79e-05   rel_l2=2.44e-03   ok  cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+Phase B11b verdict: ALL layer-0 GDN sub-ops match within cos_sim >= 0.95.
+  -> Divergence is NOT localized inside layer 0's GDN block at this bar.
+  -> Re-check B10 atol/rtol and consider extending taps to layers 1-7
+     (GDN stack) before committing to a B12 target.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+
+MTP numerical bisect — mode: layer-31 drift bisect (B12), atol=0.01, rtol=0.1
+
+=== 0_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.26e-02     7.70e-04    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.03e-01     2.11e-02    
+h_layer_16             1x1x2560               True     False    9.47e-01   5.69e-01     5.13e-02    
+h_layer_23             1x1x2560               True     False    9.72e-01   7.81e-01     9.47e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.06e+01     1.16e+00    
+b11__tok_embed         1x508x2560             True     True     1.00e+00   0.00e+00     0.00e+00    
+b11__layer_0_post_input_norm 1x508x2560             True     True     1.00e+00   3.02e-02     1.28e-03    
+b11__gdn_in_proj       1x508x12352            True     True     1.00e+00   6.66e-02     1.82e-03    
+b11__gdn_conv          1x508x8192             True     True     1.00e+00   6.19e-02     7.34e-05    
+b11__gdn_qk_norm_q     1x508x32x128           True     False    1.00e+00   8.79e-01     4.00e-02    
+b11__gdn_qk_norm_k     1x508x32x128           True     True     1.00e+00   4.47e-03     1.30e-04    
+b11__gdn_gate_beta     1x508x32               True     True     1.00e+00   5.17e-03     1.21e-03    
+b11__gdn_gate_g        1x508x32               True     True     1.00e+00   1.73e-02     8.17e-04    
+b11__gdn_recur_out     1x508x32x128           True     True     1.00e+00   6.09e-03     3.94e-06    
+b11__gdn_gated_norm    1x508x4096             True     False    1.00e+00   1.94e-02     4.84e-05    
+b11__gdn_out_proj      1x508x2560             True     True     1.00e+00   1.24e-02     5.79e-05    
+h_layer_24             1x1x2560               True     False    9.75e-01   9.32e-01     9.83e-02    
+h_layer_25             1x1x2560               True     False    9.77e-01   9.28e-01     1.00e-01    
+h_layer_26             1x1x2560               True     False    9.81e-01   9.36e-01     1.03e-01    
+h_layer_27             1x1x2560               True     False    9.79e-01   1.46e+00     1.20e-01    
+h_layer_28             1x1x2560               True     False    9.82e-01   1.14e+00     1.35e-01    
+h_layer_29             1x1x2560               True     False    9.81e-01   1.43e+00     1.47e-01    
+h_layer_30             1x1x2560               True     False    9.80e-01   9.42e-01     1.71e-01    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     2.13e-03    
+h_layer_8              1x1x2560               True     False    9.88e-01   3.53e-01     1.84e-02    
+h_layer_16             1x1x2560               True     False    9.73e-01   1.82e-01     3.87e-02    
+h_layer_23             1x1x2560               True     False    9.86e-01   7.08e-01     7.05e-02    
+h_layer_31             1x1x2560               True     False    9.30e-01   1.62e+01     1.30e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.87e-01   5.33e-01     7.23e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.24e-01     7.31e-02    
+h_layer_26             1x1x2560               True     False    9.86e-01   5.47e-01     7.78e-02    
+h_layer_27             1x1x2560               True     False    9.85e-01   1.28e+00     1.07e-01    
+h_layer_28             1x1x2560               True     False    9.86e-01   6.87e-01     1.16e-01    
+h_layer_29             1x1x2560               True     False    9.87e-01   6.47e-01     1.32e-01    
+h_layer_30             1x1x2560               True     False    9.81e-01   7.96e-01     1.54e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          509                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=1330 ref=1330 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.73e-02     1.38e-03    
+h_layer_8              1x1x2560               True     False    9.57e-01   1.35e-01     2.88e-02    
+h_layer_16             1x1x2560               True     False    8.40e-01   5.49e-01     9.38e-02    
+h_layer_23             1x1x2560               True     False    9.78e-01   5.83e-01     8.66e-02    
+h_layer_31             1x1x2560               True     False    9.26e-01   1.89e+01     1.32e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.81e-01   5.76e-01     8.62e-02    
+h_layer_25             1x1x2560               True     False    9.83e-01   6.07e-01     8.47e-02    
+h_layer_26             1x1x2560               True     False    9.79e-01   6.28e-01     8.68e-02    
+h_layer_27             1x1x2560               True     False    9.87e-01   5.90e-01     1.01e-01    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.64e-01     1.11e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   6.97e-01     1.23e-01    
+h_layer_30             1x1x2560               True     False    9.85e-01   9.79e-01     1.42e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          510                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=47205 ref=47205 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.01e-02     1.33e-03    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.02e-01     2.09e-02    
+h_layer_16             1x1x2560               True     False    9.76e-01   3.70e-01     4.11e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   7.04e-01     5.94e-02    
+h_layer_31             1x1x2560               True     False    9.60e-01   1.89e+01     1.36e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   9.04e-01     6.21e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   8.68e-01     6.41e-02    
+h_layer_26             1x1x2560               True     False    9.89e-01   3.72e-01     6.73e-02    
+h_layer_27             1x1x2560               True     False    9.89e-01   5.21e-01     9.44e-02    
+h_layer_28             1x1x2560               True     False    9.89e-01   5.98e-01     1.05e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.79e-01     1.18e-01    
+h_layer_30             1x1x2560               True     False    9.86e-01   6.86e-01     1.40e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          511                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s4 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-4.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-4.safetensors
+Metadata:
+  meta__draft_token_id: kiln=369 ref=369 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.66e-03     1.78e-03    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.20e-01     2.00e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   3.13e-01     3.29e-02    
+h_layer_23             1x1x2560               True     False    9.89e-01   7.01e-01     6.00e-02    
+h_layer_31             1x1x2560               True     False    9.18e-01   1.61e+01     1.27e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.89e-01   9.59e-01     6.26e-02    
+h_layer_25             1x1x2560               True     False    9.90e-01   1.05e+00     6.44e-02    
+h_layer_26             1x1x2560               True     False    9.88e-01   3.96e-01     6.87e-02    
+h_layer_27             1x1x2560               True     False    9.88e-01   5.67e-01     9.71e-02    
+h_layer_28             1x1x2560               True     False    9.88e-01   6.10e-01     1.06e-01    
+h_layer_29             1x1x2560               True     False    9.89e-01   6.00e-01     1.19e-01    
+h_layer_30             1x1x2560               True     False    9.84e-01   1.10e+00     1.42e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          512                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s5 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-5.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-5.safetensors
+Metadata:
+  meta__draft_token_id: kiln=799 ref=799 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   4.93e-03     9.23e-04    
+h_layer_8              1x1x2560               True     False    9.81e-01   3.57e-01     2.06e-02    
+h_layer_16             1x1x2560               True     False    9.75e-01   6.33e-01     3.80e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   4.13e-01     7.23e-02    
+h_layer_31             1x1x2560               True     False    9.14e-01   1.66e+01     1.28e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.85e-01   3.95e-01     7.46e-02    
+h_layer_25             1x1x2560               True     False    9.87e-01   4.70e-01     7.63e-02    
+h_layer_26             1x1x2560               True     False    9.84e-01   4.31e-01     8.00e-02    
+h_layer_27             1x1x2560               True     False    9.74e-01   7.41e-01     1.44e-01    
+h_layer_28             1x1x2560               True     False    9.76e-01   8.93e-01     1.54e-01    
+h_layer_29             1x1x2560               True     False    9.78e-01   8.40e-01     1.68e-01    
+h_layer_30             1x1x2560               True     False    9.73e-01   1.16e+00     1.89e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          513                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s6 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-6.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-6.safetensors
+Metadata:
+  meta__draft_token_id: kiln=30797 ref=30797 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.70e-02     1.48e-03    
+h_layer_8              1x1x2560               True     False    9.02e-01   2.48e-01     3.76e-02    
+h_layer_16             1x1x2560               True     False    8.02e-01   1.60e+00     9.70e-02    
+h_layer_23             1x1x2560               True     False    8.38e-01   2.61e+00     2.04e-01    
+h_layer_31             1x1x2560               True     False    9.20e-01   1.84e+01     1.39e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    8.37e-01   3.95e+00     2.12e-01    
+h_layer_25             1x1x2560               True     False    8.52e-01   4.67e+00     2.12e-01    
+h_layer_26             1x1x2560               True     False    8.68e-01   1.86e+00     2.20e-01    
+h_layer_27             1x1x2560               True     False    9.05e-01   4.75e+00     2.45e-01    
+h_layer_28             1x1x2560               True     False    9.19e-01   4.90e+00     2.66e-01    
+h_layer_29             1x1x2560               True     False    9.26e-01   4.87e+00     2.86e-01    
+h_layer_30             1x1x2560               True     False    9.23e-01   5.11e+00     3.11e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          514                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 0_s7 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-0/step-7.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-0/step-7.safetensors
+Metadata:
+  meta__draft_token_id: kiln=314 ref=314 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   8.14e-03     1.74e-03    
+h_layer_8              1x1x2560               True     False    9.85e-01   4.10e-01     1.88e-02    
+h_layer_16             1x1x2560               True     False    9.86e-01   1.47e-01     3.16e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   4.27e-01     6.43e-02    
+h_layer_31             1x1x2560               True     False    9.02e-01   1.46e+01     1.18e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.88e-01   5.00e-01     6.52e-02    
+h_layer_25             1x1x2560               True     False    9.88e-01   5.56e-01     6.91e-02    
+h_layer_26             1x1x2560               True     False    9.82e-01   1.39e+00     8.05e-02    
+h_layer_27             1x1x2560               True     False    9.86e-01   6.59e-01     1.15e-01    
+h_layer_28             1x1x2560               True     False    9.87e-01   6.75e-01     1.09e-01    
+h_layer_29             1x1x2560               True     False    9.88e-01   6.83e-01     1.20e-01    
+h_layer_30             1x1x2560               True     False    9.82e-01   7.33e-01     1.46e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          515                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   5.81e-03     1.10e-03    
+h_layer_8              1x1x2560               True     False    9.86e-01   8.91e-02     1.62e-02    
+h_layer_16             1x1x2560               True     False    9.55e-01   2.78e-01     5.01e-02    
+h_layer_23             1x1x2560               True     False    9.84e-01   3.83e-01     7.32e-02    
+h_layer_31             1x1x2560               True     False    9.23e-01   1.37e+01     1.31e+00    
+b11__tok_embed         1x2x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x2x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x2x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x2x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x2x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x2x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x2x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x2x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x2x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    9.84e-01   3.93e-01     7.56e-02    
+h_layer_25             1x1x2560               True     False    9.86e-01   3.91e-01     7.72e-02    
+h_layer_26             1x1x2560               True     False    9.83e-01   7.44e-01     8.17e-02    
+h_layer_27             1x1x2560               True     False    9.83e-01   5.41e-01     1.22e-01    
+h_layer_28             1x1x2560               True     False    9.83e-01   6.67e-01     1.31e-01    
+h_layer_29             1x1x2560               True     False    9.83e-01   6.21e-01     1.46e-01    
+h_layer_30             1x1x2560               True     False    9.78e-01   1.48e+00     1.68e-01    
+b12__post_input_norm   1x2x2560               False    False    nan        nan          nan         
+b12__q_proj            1x2x8192               False    False    nan        nan          nan         
+b12__k_proj            1x2x1024               False    False    nan        nan          nan         
+b12__v_proj            1x2x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x2x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x2x4x256              False    False    nan        nan          nan         
+b12__o_proj            1x2x2560               False    False    nan        nan          nan         
+b12__post_attn_norm    1x2x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x2x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x2x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x2x2560               False    False    nan        nan          nan         
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          520                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== 2_s1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post423_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post423_20260423_refs_fp32/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   9.83e-03     1.34e-03    
+h_layer_8              1x1x2560               True     False    9.07e-01   2.44e-01     3.85e-02    
+h_layer_16             1x1x2560               True     False    6.49e-01   1.56e+00     1.31e-01    
+h_layer_23             1x1x2560               True     False    4.20e-01   8.04e+00     4.06e-01    
+h_layer_31             1x1x2560               True     False    6.18e-01   2.83e+01     1.72e+00    
+b11__tok_embed         1x1x2560               False    False    nan        nan          nan         
+b11__layer_0_post_input_norm 1x1x2560               False    False    nan        nan          nan         
+b11__gdn_in_proj       1x1x12352              False    False    nan        nan          nan         
+b11__gdn_conv          1x1x8192               False    False    nan        nan          nan         
+b11__gdn_qk_norm_q     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_qk_norm_k     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gate_beta     1x1x32                 False    False    nan        nan          nan         
+b11__gdn_gate_g        1x1x32                 False    False    nan        nan          nan         
+b11__gdn_recur_out     1x1x32x128             False    False    nan        nan          nan         
+b11__gdn_gated_norm    1x1x4096               False    False    nan        nan          nan         
+b11__gdn_out_proj      1x1x2560               False    False    nan        nan          nan         
+h_layer_24             1x1x2560               True     False    4.46e-01   8.86e+00     4.11e-01    
+h_layer_25             1x1x2560               True     False    4.58e-01   1.09e+01     4.12e-01    
+h_layer_26             1x1x2560               True     False    3.76e-01   1.30e+01     4.39e-01    
+h_layer_27             1x1x2560               True     False    5.07e-01   1.21e+01     5.43e-01    
+h_layer_28             1x1x2560               True     False    5.82e-01   1.30e+01     5.89e-01    
+h_layer_29             1x1x2560               True     False    6.14e-01   1.42e+01     6.30e-01    
+h_layer_30             1x1x2560               True     False    5.68e-01   1.60e+01     7.03e-01    
+b12__post_input_norm   1x1x2560               False    False    nan        nan          nan         
+b12__q_proj            1x1x8192               False    False    nan        nan          nan         
+b12__k_proj            1x1x1024               False    False    nan        nan          nan         
+b12__v_proj            1x1x1024               False    False    nan        nan          nan         
+b12__qk_norm_q         1x1x16x256             False    False    nan        nan          nan         
+b12__qk_norm_k         1x1x4x256              False    False    nan        nan          nan         
+b12__post_attn_norm    1x1x2560               False    False    nan        nan          nan         
+b12__mlp_gate          1x1x9216               False    False    nan        nan          nan         
+b12__mlp_up            1x1x9216               False    False    nan        nan          nan         
+b12__mlp_down          1x1x2560               False    False    nan        nan          nan         
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          521                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B12 layer-31 drift bisect — per-layer cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=0_s0                         pos=0_s1                         pos=0_s2                         pos=0_s3                         pos=0_s4                         pos=0_s5                         pos=0_s6                         pos=0_s7                         pos=2_s0                         pos=2_s1                        
+  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_24            cos=9.75e-01   max|Δ|=9.32e-01   DIV   cos=9.87e-01   max|Δ|=5.33e-01   DIV   cos=9.81e-01   max|Δ|=5.76e-01   DIV   cos=9.89e-01   max|Δ|=9.04e-01   DIV   cos=9.89e-01   max|Δ|=9.59e-01   DIV   cos=9.85e-01   max|Δ|=3.95e-01   DIV   cos=8.37e-01   max|Δ|=3.95e+00   DIV   cos=9.88e-01   max|Δ|=5.00e-01   DIV   cos=9.84e-01   max|Δ|=3.93e-01   DIV   cos=4.46e-01   max|Δ|=8.86e+00   DIV  
+  h_layer_25            cos=9.77e-01   max|Δ|=9.28e-01   DIV   cos=9.88e-01   max|Δ|=5.24e-01   DIV   cos=9.83e-01   max|Δ|=6.07e-01   DIV   cos=9.90e-01   max|Δ|=8.68e-01   DIV   cos=9.90e-01   max|Δ|=1.05e+00   DIV   cos=9.87e-01   max|Δ|=4.70e-01   DIV   cos=8.52e-01   max|Δ|=4.67e+00   DIV   cos=9.88e-01   max|Δ|=5.56e-01   DIV   cos=9.86e-01   max|Δ|=3.91e-01   DIV   cos=4.58e-01   max|Δ|=1.09e+01   DIV  
+  h_layer_26            cos=9.81e-01   max|Δ|=9.36e-01   DIV   cos=9.86e-01   max|Δ|=5.47e-01   DIV   cos=9.79e-01   max|Δ|=6.28e-01   DIV   cos=9.89e-01   max|Δ|=3.72e-01   DIV   cos=9.88e-01   max|Δ|=3.96e-01   DIV   cos=9.84e-01   max|Δ|=4.31e-01   DIV   cos=8.68e-01   max|Δ|=1.86e+00   DIV   cos=9.82e-01   max|Δ|=1.39e+00   DIV   cos=9.83e-01   max|Δ|=7.44e-01   DIV   cos=3.76e-01   max|Δ|=1.30e+01   DIV  
+  h_layer_27            cos=9.79e-01   max|Δ|=1.46e+00   DIV   cos=9.85e-01   max|Δ|=1.28e+00   DIV   cos=9.87e-01   max|Δ|=5.90e-01   DIV   cos=9.89e-01   max|Δ|=5.21e-01   DIV   cos=9.88e-01   max|Δ|=5.67e-01   DIV   cos=9.74e-01   max|Δ|=7.41e-01   DIV   cos=9.05e-01   max|Δ|=4.75e+00   DIV   cos=9.86e-01   max|Δ|=6.59e-01   DIV   cos=9.83e-01   max|Δ|=5.41e-01   DIV   cos=5.07e-01   max|Δ|=1.21e+01   DIV  
+  h_layer_28            cos=9.82e-01   max|Δ|=1.14e+00   DIV   cos=9.86e-01   max|Δ|=6.87e-01   DIV   cos=9.88e-01   max|Δ|=6.64e-01   DIV   cos=9.89e-01   max|Δ|=5.98e-01   DIV   cos=9.88e-01   max|Δ|=6.10e-01   DIV   cos=9.76e-01   max|Δ|=8.93e-01   DIV   cos=9.19e-01   max|Δ|=4.90e+00   DIV   cos=9.87e-01   max|Δ|=6.75e-01   DIV   cos=9.83e-01   max|Δ|=6.67e-01   DIV   cos=5.82e-01   max|Δ|=1.30e+01   DIV  
+  h_layer_29            cos=9.81e-01   max|Δ|=1.43e+00   DIV   cos=9.87e-01   max|Δ|=6.47e-01   DIV   cos=9.88e-01   max|Δ|=6.97e-01   DIV   cos=9.89e-01   max|Δ|=6.79e-01   DIV   cos=9.89e-01   max|Δ|=6.00e-01   DIV   cos=9.78e-01   max|Δ|=8.40e-01   DIV   cos=9.26e-01   max|Δ|=4.87e+00   DIV   cos=9.88e-01   max|Δ|=6.83e-01   DIV   cos=9.83e-01   max|Δ|=6.21e-01   DIV   cos=6.14e-01   max|Δ|=1.42e+01   DIV  
+  h_layer_30            cos=9.80e-01   max|Δ|=9.42e-01   DIV   cos=9.81e-01   max|Δ|=7.96e-01   DIV   cos=9.85e-01   max|Δ|=9.79e-01   DIV   cos=9.86e-01   max|Δ|=6.86e-01   DIV   cos=9.84e-01   max|Δ|=1.10e+00   DIV   cos=9.73e-01   max|Δ|=1.16e+00   DIV   cos=9.23e-01   max|Δ|=5.11e+00   DIV   cos=9.82e-01   max|Δ|=7.33e-01   DIV   cos=9.78e-01   max|Δ|=1.48e+00   DIV   cos=5.68e-01   max|Δ|=1.60e+01   DIV  
+  h_layer_31            cos=9.59e-01   max|Δ|=2.06e+01   DIV   cos=9.30e-01   max|Δ|=1.62e+01   DIV   cos=9.26e-01   max|Δ|=1.89e+01   DIV   cos=9.60e-01   max|Δ|=1.89e+01   DIV   cos=9.18e-01   max|Δ|=1.61e+01   DIV   cos=9.14e-01   max|Δ|=1.66e+01   DIV   cos=9.20e-01   max|Δ|=1.84e+01   DIV   cos=9.02e-01   max|Δ|=1.46e+01   DIV   cos=9.23e-01   max|Δ|=1.37e+01   DIV   cos=6.18e-01   max|Δ|=2.83e+01   DIV  
+  h_pre_final_norm      <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                        <missing>                       
+
+  per-layer median cos_sim across positions:
+    h_layer_24             median=9.85e-01     DIV
+    h_layer_25             median=9.86e-01     DIV
+    h_layer_26             median=9.83e-01     DIV
+    h_layer_27             median=9.84e-01     DIV
+    h_layer_28             median=9.85e-01     DIV
+    h_layer_29             median=9.85e-01     DIV
+    h_layer_30             median=9.81e-01     DIV
+    h_layer_31             median=9.21e-01     DIV
+
+==============================================================================
+Phase B12 layer-31 GQA sub-op bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                 pos=0_s0                                             pos=0_s1                                             pos=0_s2                                             pos=0_s3                                             pos=0_s4                                             pos=0_s5                                             pos=0_s6                                             pos=0_s7                                             pos=2_s0                                             pos=2_s1                                            
+  ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  post_input_norm     <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  q_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  k_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  v_proj              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_q           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  qk_norm_k           <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  rope_q              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  rope_k              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  attn_out            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                           
+  o_proj              <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV <missing>                                           
+  post_attn_norm      <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_gate            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_up              <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+  mlp_down            <missing>                                            cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV cos=nan        max|Δ|=nan        mean|Δ|=nan        rel_l2=nan        DIV
+
+  per-sub-op median cos_sim across positions:
+    post_input_norm      median=nan          DIV
+    q_proj               median=nan          DIV
+    k_proj               median=nan          DIV
+    v_proj               median=nan          DIV
+    qk_norm_q            median=nan          DIV
+    qk_norm_k            median=nan          DIV
+    o_proj               median=nan          DIV
+    post_attn_norm       median=nan          DIV
+    mlp_gate             median=nan          DIV
+    mlp_up               median=nan          DIV
+    mlp_down             median=nan          DIV
+
+  first layer with MEDIAN cos_sim < 0.995: 'h_layer_24' (median = 0.984894)
+Phase B12 verdict: DRIFT FIRST APPEARS AT 'h_layer_24' (not layer 31).
+  -> The sub-op table for layer 31 localizes only layer-31 drift, so
+     instrument sub-ops inside 'h_layer_24' on the next pass.
+     Compare against fp32 HF to rule out bf16 accumulation before
+     committing more capture budget.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main', 'h_main']

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -83,7 +83,9 @@ tap-for-tap.
 Prompt provenance
 -----------------
 
-* If the kiln dump contains a `meta__prompt_tokens_len` scalar and a
+* If the kiln dump contains a `meta__replay_tokens_len` scalar and a
+  `replay_tokens` I32 tensor, we use those directly.
+* Otherwise if the kiln dump contains a `meta__prompt_tokens_len` scalar and a
   `prompt_tokens` I32 tensor, we use those directly.
 * Otherwise we fall back to a canonical 512-token greeting prompt with
   torch seed=42, matching what the kiln bench harness emits by default.
@@ -187,7 +189,7 @@ def load_kiln_dump(path: str) -> Dict[str, object]:
     with safe_open(path, framework="pt", device="cpu") as f:
         for name in f.keys():
             t = f.get_tensor(name)
-            if name == "prompt_tokens":
+            if name in ("prompt_tokens", "replay_tokens"):
                 # Token IDs — keep integral.
                 out[name] = t.to(torch.int64).contiguous()
             elif name.startswith("meta__"):
@@ -1020,13 +1022,25 @@ def main() -> int:
         file=sys.stderr,
     )
 
-    # Resolve the prompt tokens. Prefer kiln-provided `prompt_tokens`, fall
-    # back to the canonical 512-token greeting.
+    # Resolve the replay tokens. Prefer the fully conditioned `replay_tokens`
+    # contract added in C39; fall back to legacy `prompt_tokens`, then to the
+    # canonical 512-token greeting.
     prompt_tokens: Optional[torch.Tensor] = None
-    if "prompt_tokens" in kiln:
+    if "replay_tokens" in kiln:
+        raw = kiln["replay_tokens"]  # type: ignore[assignment]
+        assert isinstance(raw, torch.Tensor), f"replay_tokens must be a tensor, got {type(raw)}"
+        # Kiln writes it as a flat I32 vector; reshape to [1, N].
+        if raw.ndim == 1:
+            prompt_tokens = raw.view(1, -1).to(torch.int64).contiguous()
+        else:
+            prompt_tokens = raw.to(torch.int64).contiguous()
+        print(
+            f"[mtp_h_main_ref] replay_tokens from kiln dump: shape={tuple(prompt_tokens.shape)}",
+            file=sys.stderr,
+        )
+    elif "prompt_tokens" in kiln:
         raw = kiln["prompt_tokens"]  # type: ignore[assignment]
         assert isinstance(raw, torch.Tensor), f"prompt_tokens must be a tensor, got {type(raw)}"
-        # Kiln writes it as a flat I32 vector; reshape to [1, N].
         if raw.ndim == 1:
             prompt_tokens = raw.view(1, -1).to(torch.int64).contiguous()
         else:
@@ -1081,6 +1095,9 @@ def main() -> int:
     out_dict["meta__prompt_tokens_len"] = torch.tensor(
         [int(prompt_tokens.shape[-1])], dtype=torch.int32
     )
+    out_dict["meta__replay_tokens_len"] = torch.tensor(
+        [int(prompt_tokens.shape[-1])], dtype=torch.int32
+    )
     boundary_layers = list(B10_BOUNDARY_LAYERS)
     if args.b12_taps:
         boundary_layers = sorted(set(boundary_layers) | set(B12_GQA_LAYERS))
@@ -1090,6 +1107,7 @@ def main() -> int:
     # Also write the resolved prompt tokens so later reruns can reproduce
     # bit-exactly even if the kiln dump gets rotated.
     out_dict["prompt_tokens"] = prompt_tokens.view(-1).to(torch.int32).contiguous()
+    out_dict["replay_tokens"] = prompt_tokens.view(-1).to(torch.int32).contiguous()
 
     save_file(out_dict, args.out)
     total_bytes = sum(t.numel() * t.element_size() for t in out_dict.values())


### PR DESCRIPTION
## Summary
- add full replay-token context to the MTP dump path and bench-native MTP loop so later B10/B11/B12 rows replay the full conditioned sequence
- rerun the post-#423 seed0/seed1 native-MTP capture on fresh main and commit the refreshed compare outputs
- record the C39 verdict in PROFILING.md and docs/phase-c39/c39-post423-seed-bisect.md

## Validation
Completed:
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py scripts/c15_h_main_drift_audit.py`
- reran the standard native-MTP workload for seeds `0` and `1` with `KILN_MTP_DUMP_HIDDEN_STATES=1`, `KILN_MTP_DUMP_B11_TAPS=1`, and `KILN_MTP_DUMP_B12_GQA_TAPS=1`
- regenerated matched HF reference dumps in bf16 and fp32 with `scripts/mtp_h_main_reference_dump.py`
- regenerated B10/B11/B12 compare outputs for both seeds against both reference dtypes

Started but not completed before wrap-up:
- `cargo test -p kiln-model mtp_debug --features cuda --lib -- --nocapture` (still in debug-mode flash-attn CUDA compilation on the A40 pod)

## Final verdict
C39 fixes the replay-contract blocker from PR #423/C38: later splice rows now carry full `replay_tokens_len` values (for example seed0 `495/496/502` and seed1 `509..515/520`) instead of only the current-step `1` / `2` token slice. With the fully conditioned HF replays in place, both seed 0 and seed 1 land the same comparator verdicts: B10 first diverging tap `h_layer_8`, B11 no bad layer-0 sub-op, and B12 first late-stack drift at `h_layer_24`. This artifact does not reveal a seed1-only first boundary or sub-op.