### PR TITLE
phase6: densify post-C39 early h_main sweep

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -486,6 +486,100 @@ seed1-only fix from this artifact; it is a narrower bisect inside the early
 GDN span between `h_layer_0` and `h_layer_8`, because that is now the first
 shared bad boundary on both seeds.
 
+## Phase C40 dense early h_main sweep (2026-04-23)
+
+**Scope:** densify the shared upstream `h_main` bisect from C39 by adding an
+opt-in early-layer sweep for `h_layer_1..8`, then rerun the standard
+native-MTP workload on fresh `main` after PR #426.
+
+**Preflight outcome:** proceed. Fresh `origin/main` was `4df936c`
+(PR #426), and no open PR already landed the dense early-layer sweep or a
+committed artifact localizing the first shared drift more narrowly than
+`h_layer_0 -> h_layer_8`.
+
+**Code change:** the h_main dump path now supports
+`KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1`, serializes the actual emitted boundary set
+as `meta__boundary_layers`, mirrors that sequence in
+`scripts/mtp_h_main_reference_dump.py`, and teaches
+`scripts/mtp_compare.py --b10` to derive/report the first divergence from the
+real emitted layer order instead of the historical sparse B10 list.
+
+**Validation commands run (RunPod A6000, kiln image):**
+
+```bash
+cd /workspace/kiln
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+source /root/.kiln-build-env
+cargo test -p kiln-model mtp_debug --lib -- --test-threads=1
+```
+
+**Standard workload rerun:** same C39 shape, but with dense early h_main taps
+enabled:
+
+```bash
+KILN_W4A16=1 \
+KILN_CUDA_GRAPHS=true \
+KILN_SPEC_METHOD=mtp \
+KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_SPLICE=1 \
+KILN_MTP_DUMP_SPLICE_POS=0,2 \
+KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 \
+KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+KILN_MTP_DUMP_PATH=.../mtp_pos-{pos}/step-{step}.safetensors \
+./target/release/kiln-bench \
+  --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+  --seed <0|1>
+```
+
+Matched HF reference dumps were regenerated in bf16 and fp32 with
+`scripts/mtp_h_main_reference_dump.py`, then compared with
+`scripts/mtp_compare.py --b10`.
+
+### Fresh workload check
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 8795.4 | 39.57 | 0.6842 |
+| 1 | 508 | 386.8 | 23.95 | 0.2959 |
+
+The seed split still reproduces on fresh `main`.
+
+### Source-of-truth artifacts
+
+- `profiling-artifacts/post426_c40_20260423_seed0.bench.json`
+- `profiling-artifacts/post426_c40_20260423_seed0.bench.stderr`
+- `profiling-artifacts/post426_c40_20260423_seed1.bench.json`
+- `profiling-artifacts/post426_c40_20260423_seed1.bench.stderr`
+- `profiling-artifacts/post426_c40_20260423_seed0_compare_bf16.txt`
+- `profiling-artifacts/post426_c40_20260423_seed0_compare_fp32.txt`
+- `profiling-artifacts/post426_c40_20260423_seed1_compare_bf16.txt`
+- `profiling-artifacts/post426_c40_20260423_seed1_compare_fp32.txt`
+
+### Verdict
+
+**Both seeds now localize to the exact same first bad layer: transformer block
+1.**
+
+Across both bf16 and fp32 HF references:
+
+- seed 0: first diverging tap = `h_layer_1` (`mtp_pos-0-step-1`)
+- seed 1: first diverging tap = `h_layer_1` (`mtp_pos-2-step-1`)
+- last matching tap before divergence = `h_layer_0` for both seeds
+- comparator verdict = `DIVERGENCE FIRST APPEARS AT LAYER 1` for both seeds
+
+So the shared upstream drift no longer spans `0 -> 8`; it starts immediately
+after layer 1, with layer 0 still numerically clean.
+
+### Recommendation
+
+Do **not** keep bisecting across coarse `h_main` boundaries. The remaining
+narrow span is now **inside transformer block 1** itself: layer-1 input norm,
+GDN projections/conv/qk-norm/gates/recurrent kernel, or the layer-1 residual
+handoff. The next diagnostic task should capture layer-1 sub-op taps rather
+than adding another per-layer sweep.
+
 ## Phase 6 post-#392 current-main re-profile — 2026-04-23
 
 **Scope:** refresh the Phase 6 performance source of truth on fresh `main`

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -4871,8 +4871,10 @@ pub fn model_forward_paged_with_last_hidden(
     // var is unset, so production cost is a single TLS borrow + env lookup.
     // The inner forward pass fills the window with boundary-layer last-row
     // slices plus `h_post_final_norm` (C18 — formerly `h_pre_final_norm`
-    // before kiln started returning post-final-norm `h_prev`); the window
-    // is drained in
+    // before kiln started returning post-final-norm `h_prev`). Phase C40
+    // can opt into a denser early sweep (layers 1..8) via
+    // `KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1`; default B10/B12 behavior is
+    // unchanged when that flag is unset. The window is drained in
     // `mtp_forward_step`'s dump block so the taps appear alongside the
     // standard 8 MTP taps in the same safetensors file. The next call to
     // this function re-arms the window, overwriting any stale buffer from
@@ -5346,6 +5348,7 @@ pub fn mtp_forward_step(
                 mtp_pos,
                 base_pos,
                 swap_fc_norms,
+                &crate::mtp_debug::current_h_main_boundary_layers(),
                 &taps,
                 &extra_subops,
                 &prompt_tokens,

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -472,6 +472,13 @@ pub fn capture_subop(name: &str, t: &Tensor) -> Result<()> {
 /// h_main handoff can be verified independently.
 pub const B10_BOUNDARY_LAYERS: [usize; 5] = [0, 8, 16, 23, 31];
 
+/// Phase C40: optional dense early-stack h_main sweep. When enabled, the
+/// base-model forward records every post-layer hidden state for layers 1..8,
+/// turning the coarse C39 `h_layer_0 -> h_layer_8` span into a precise
+/// earliest-layer bisect without changing the legacy B10/B12 dump shape when
+/// the flag is unset.
+pub const C40_EARLY_H_MAIN_LAYERS: [usize; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+
 /// True when `KILN_MTP_DUMP_HIDDEN_STATES=1` (or `true`) is set. Phase B10
 /// opt-in: when enabled alongside `KILN_MTP_DUMP_PATH`, the base-model
 /// forward records the last-row hidden state at each boundary layer and at
@@ -482,6 +489,34 @@ pub fn is_dump_hidden_states_enabled() -> bool {
     std::env::var("KILN_MTP_DUMP_HIDDEN_STATES")
         .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
         .unwrap_or(false)
+}
+
+/// True when `KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1` (or `true`) is set. Opt-in
+/// Phase C40 mode that extends the default B10 boundary set with layers 1..8.
+pub fn is_dump_early_hmain_sweep_enabled() -> bool {
+    std::env::var("KILN_MTP_DUMP_EARLY_HMAIN_SWEEP")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Ordered layer indices that the current h_main dump should emit.
+///
+/// Default behavior stays identical to historical B10/B12:
+/// - B10 only: [`B10_BOUNDARY_LAYERS`]
+/// - B10 + B12: [`B10_BOUNDARY_LAYERS`] ∪ [`B12_GQA_LAYERS`]
+///
+/// Phase C40 adds `1..=8` only when the explicit early-sweep env flag is on.
+pub fn current_h_main_boundary_layers() -> Vec<usize> {
+    let mut layers = B10_BOUNDARY_LAYERS.to_vec();
+    if is_dump_early_hmain_sweep_enabled() {
+        layers.extend(C40_EARLY_H_MAIN_LAYERS);
+    }
+    if is_dump_b12_gqa_taps_enabled() {
+        layers.extend(B12_GQA_LAYERS);
+    }
+    layers.sort_unstable();
+    layers.dedup();
+    layers
 }
 
 /// True if the Phase B10 base-model hidden-state capture window is currently
@@ -497,13 +532,7 @@ pub fn should_capture_hidden_state_for_layer(layer_idx: usize) -> bool {
     if !armed {
         return false;
     }
-    if B10_BOUNDARY_LAYERS.contains(&layer_idx) {
-        return true;
-    }
-    if is_dump_b12_gqa_taps_enabled() && B12_GQA_LAYERS.contains(&layer_idx) {
-        return true;
-    }
-    false
+    current_h_main_boundary_layers().contains(&layer_idx)
 }
 
 /// True if the Phase B10 hidden-state capture window is currently armed on
@@ -1428,6 +1457,7 @@ pub fn write_mtp_dump(
     mtp_pos: usize,
     base_pos: usize,
     swap_fc_norms: bool,
+    boundary_layers: &[usize],
     taps: &[(&str, &Tensor)],
     extra_subops: &[(String, Vec<usize>, Vec<f32>)],
     prompt_tokens: &[u32],
@@ -1442,14 +1472,17 @@ pub fn write_mtp_dump(
 
     // Materialize every tensor to a host byte buffer first so the
     // TensorViews we build below can borrow from a stable backing store.
-    // Capacity: static taps + subops + 4 meta + optional prompt/replay token
+    // Capacity: static taps + subops + 4 meta + optional boundary-layer meta
+    // + optional prompt/replay token
     // tensors + b11 taps + b12 taps + c6 taps + c7 taps + c14 taps.
+    let boundary_reserve = if boundary_layers.is_empty() { 0 } else { 1 };
     let prompt_reserve = if prompt_tokens.is_empty() { 0 } else { 2 };
     let replay_reserve = if replay_tokens.is_empty() { 0 } else { 2 };
     let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> = Vec::with_capacity(
         taps.len()
             + extra_subops.len()
             + 4
+            + boundary_reserve
             + prompt_reserve
             + replay_reserve
             + b11_taps.len()
@@ -1510,6 +1543,20 @@ pub fn write_mtp_dump(
         Dtype::I32,
         swf.to_le_bytes().to_vec(),
     ));
+
+    if !boundary_layers.is_empty() {
+        let mut bytes = Vec::with_capacity(boundary_layers.len() * 4);
+        for &layer in boundary_layers {
+            let as_i32 = layer as i32;
+            bytes.extend_from_slice(&as_i32.to_le_bytes());
+        }
+        backings.push((
+            "meta__boundary_layers".into(),
+            vec![boundary_layers.len()],
+            Dtype::I32,
+            bytes,
+        ));
+    }
 
     // Phase B11: serialize the base-model prompt tokens so the HF reference
     // can replay the exact same input instead of its canonical fallback.
@@ -2035,6 +2082,7 @@ mod tests {
             /* mtp_pos = */ 0,
             /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[0, 4, 8],
             &[("h_main", &a)],
             &[],
             &prompt,
@@ -2076,6 +2124,16 @@ mod tests {
         let replay_len_val = i32::from_le_bytes(replay_len_meta.data()[0..4].try_into().unwrap());
         assert_eq!(replay_len_val, prompt.len() as i32);
 
+        let boundary = st.tensor("meta__boundary_layers").unwrap();
+        assert_eq!(boundary.dtype(), safetensors::Dtype::I32);
+        assert_eq!(boundary.shape(), &[3]);
+        let layers: Vec<i32> = boundary
+            .data()
+            .chunks_exact(4)
+            .map(|chunk| i32::from_le_bytes(chunk.try_into().unwrap()))
+            .collect();
+        assert_eq!(layers, vec![0, 4, 8]);
+
         let _ = std::fs::remove_file(&tmp);
     }
 
@@ -2109,6 +2167,37 @@ mod tests {
     }
 
     #[test]
+    fn c40_early_hmain_sweep_extends_boundary_layers_only_when_enabled() {
+        let _guard = test_env_lock();
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_EARLY_HMAIN_SWEEP");
+            std::env::remove_var("KILN_MTP_DUMP_B12_GQA_TAPS");
+        }
+        assert_eq!(current_h_main_boundary_layers(), vec![0, 8, 16, 23, 31]);
+
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_EARLY_HMAIN_SWEEP", "1");
+        }
+        assert_eq!(
+            current_h_main_boundary_layers(),
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31]
+        );
+
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_B12_GQA_TAPS", "1");
+        }
+        assert_eq!(
+            current_h_main_boundary_layers(),
+            vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+        );
+
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_EARLY_HMAIN_SWEEP");
+            std::env::remove_var("KILN_MTP_DUMP_B12_GQA_TAPS");
+        }
+    }
+
+    #[test]
     fn write_and_reparse_mtp_dump_round_trips() {
         use safetensors::SafeTensors;
 
@@ -2122,6 +2211,7 @@ mod tests {
             /* mtp_pos = */ 0,
             /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[],
             &[("h_main", &a), ("mtp_logits", &b)],
             &[("post_q_proj".to_string(), vec![2], vec![0.1_f32, 0.2])],
             /* prompt_tokens = */ &[],
@@ -2143,6 +2233,7 @@ mod tests {
         assert!(names.contains(&"meta__mtp_pos"));
         assert!(names.contains(&"meta__base_pos"));
         assert!(names.contains(&"meta__swap_fc_norms"));
+        assert!(!names.contains(&"meta__boundary_layers"));
         // With prompt_tokens = &[], neither the tensor nor its length meta
         // should be serialized.
         assert!(!names.contains(&"prompt_tokens"));
@@ -2263,6 +2354,7 @@ mod tests {
             /* mtp_pos = */ 0,
             /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[],
             &[("h_main", &h)],
             &[],
             /* prompt_tokens = */ &[],
@@ -2398,6 +2490,7 @@ mod tests {
             /* mtp_pos = */ 0,
             /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[],
             &[("h_main", &h)],
             &[],
             /* prompt_tokens = */ &[],
@@ -2618,6 +2711,7 @@ mod tests {
             /* mtp_pos = */ 0,
             /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[],
             &[("h_main", &h)],
             &[],
             /* prompt_tokens = */ &[],
@@ -2749,6 +2843,7 @@ mod tests {
             /* mtp_pos = */ 0,
             /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[],
             &[("h_main", &h)],
             &[],
             /* prompt_tokens = */ &[],
@@ -2906,6 +3001,7 @@ mod tests {
             /* mtp_pos = */ 0,
             /* base_pos = */ 0,
             /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[],
             &[("h_main", &h)],
             &[],
             /* prompt_tokens = */ &[],

--- a/docs/phase-c40/c40-early-hmain-bisect.md
+++ b/docs/phase-c40/c40-early-hmain-bisect.md
@@ -1,0 +1,139 @@
+# Phase C40 — dense early h_main sweep after PR #426
+
+**Date:** 2026-04-23  
+**Current main:** `4df936c` (PR #426 on `main`)  
+**Hardware:** RunPod `NVIDIA RTX A6000` via `ghcr.io/ericflo/kiln-runpod:latest`
+
+## Preflight
+
+1. **Fresh-main baseline:** satisfied. Work started from fresh `origin/main`
+   at `4df936c`, the merge commit for PR #426.
+2. **No committed dense early sweep already present:** satisfied. Fresh main
+   still only localized the shared upstream drift as `h_layer_0 -> h_layer_8`.
+3. **No open PR already covering this exact sweep:** satisfied. No open PR
+   landed a C40-style early-layer artifact.
+
+## Code change
+
+The h_main capture path now supports an opt-in dense early sweep with
+`KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1`. When that flag is set:
+
+- kiln emits `h_layer_1..8` in addition to the historical B10 boundary taps
+- kiln serializes the actual emitted layer order as `meta__boundary_layers`
+- `scripts/mtp_h_main_reference_dump.py` mirrors the same boundary set from
+  the dump metadata
+- `scripts/mtp_compare.py --b10` derives the verdict from the real emitted
+  sequence and can now report the exact earliest layer when the last matching
+  tap and first diverging tap are adjacent
+
+Default B10/B12 behavior is unchanged when the new flag is unset.
+
+## Validation commands run
+
+```bash
+cd /workspace/kiln
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+source /root/.kiln-build-env
+cargo test -p kiln-model mtp_debug --lib -- --test-threads=1
+```
+
+## Standard workload commands run
+
+```bash
+for seed in 0 1; do
+  root=/workspace/kiln/profiling-artifacts/post426_c40_20260423_seed${seed}_captures
+  rm -rf "$root"
+  mkdir -p "$root"/mtp_pos-0 "$root"/mtp_pos-2
+
+  KILN_W4A16=1 \
+  KILN_CUDA_GRAPHS=true \
+  KILN_SPEC_METHOD=mtp \
+  KILN_BENCH_FORCE_MTP=1 \
+  KILN_MTP_DUMP_SPLICE=1 \
+  KILN_MTP_DUMP_SPLICE_POS=0,2 \
+  KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+  KILN_MTP_DUMP_HIDDEN_STATES=1 \
+  KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+  KILN_MTP_DUMP_PATH=$root/mtp_pos-{pos}/step-{step}.safetensors \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+    --seed ${seed} \
+    > /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed${seed}.bench.json \
+    2> /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed${seed}.bench.stderr
+done
+```
+
+Reference regeneration and comparison:
+
+```bash
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump <dump> \
+  --out <bf16-ref> \
+  --device cuda
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump <dump> \
+  --out <fp32-ref> \
+  --device cuda \
+  --fp32
+
+python3 scripts/mtp_compare.py --b10 --pair <label>:<kiln>,<ref>
+```
+
+## Fresh workload check
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 8795.4 | 39.57 | 0.6842 |
+| 1 | 508 | 386.8 | 23.95 | 0.2959 |
+
+The seed split still reproduces on fresh `main`.
+
+## Committed artifacts
+
+- [`profiling-artifacts/post426_c40_20260423_seed0.bench.json`](../../profiling-artifacts/post426_c40_20260423_seed0.bench.json)
+- [`profiling-artifacts/post426_c40_20260423_seed0.bench.stderr`](../../profiling-artifacts/post426_c40_20260423_seed0.bench.stderr)
+- [`profiling-artifacts/post426_c40_20260423_seed1.bench.json`](../../profiling-artifacts/post426_c40_20260423_seed1.bench.json)
+- [`profiling-artifacts/post426_c40_20260423_seed1.bench.stderr`](../../profiling-artifacts/post426_c40_20260423_seed1.bench.stderr)
+- [`profiling-artifacts/post426_c40_20260423_seed0_compare_bf16.txt`](../../profiling-artifacts/post426_c40_20260423_seed0_compare_bf16.txt)
+- [`profiling-artifacts/post426_c40_20260423_seed0_compare_fp32.txt`](../../profiling-artifacts/post426_c40_20260423_seed0_compare_fp32.txt)
+- [`profiling-artifacts/post426_c40_20260423_seed1_compare_bf16.txt`](../../profiling-artifacts/post426_c40_20260423_seed1_compare_bf16.txt)
+- [`profiling-artifacts/post426_c40_20260423_seed1_compare_fp32.txt`](../../profiling-artifacts/post426_c40_20260423_seed1_compare_fp32.txt)
+
+## Verdict
+
+**The dense early sweep localizes the first shared upstream drift to layer 1
+for both seeds.**
+
+Across both bf16 and fp32 HF references:
+
+| Seed | First diverging tap | Position label | Last matching tap | Verdict |
+| --- | --- | --- | --- | --- |
+| 0 | `h_layer_1` | `mtp_pos-0-step-1` | `h_layer_0` | `DIVERGENCE FIRST APPEARS AT LAYER 1` |
+| 1 | `h_layer_1` | `mtp_pos-2-step-1` | `h_layer_0` | same |
+
+Representative bf16 rows from the committed compare outputs:
+
+- seed 0: `h_layer_0` stays `ok` across all captured rows, while `h_layer_1`
+  is already `DIV` by `mtp_pos-0-step-1`
+- seed 1: `h_layer_0` stays `ok` across all captured rows, while `h_layer_1`
+  first drops below tolerance at `mtp_pos-2-step-1`
+
+That means C39's coarse `h_layer_0 -> h_layer_8` span is now closed. The
+shared drift does **not** start at layer 8; it starts immediately after
+transformer block 1.
+
+## Next narrower span
+
+Because both seeds share the same earliest bad layer, the remaining span is no
+longer per-layer. It is **inside transformer block 1**:
+
+- layer-1 input norm output
+- layer-1 GDN in-proj / conv / qk-norm / gates / recurrent kernel
+- layer-1 gated norm / out-proj / residual handoff
+
+The next task should capture layer-1 sub-op taps on the same replay contract
+instead of extending the boundary sweep again.

--- a/profiling-artifacts/post426_c40_20260423_seed0.bench.json
+++ b/profiling-artifacts/post426_c40_20260423_seed0.bench.json
@@ -1,0 +1,62 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.656679494,
+    "model_vram_mb": 17531
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 494,
+      "output_tokens": 128,
+      "total_time_secs": 2.846680296,
+      "tokens_per_sec": 44.96465591160996,
+      "peak_vram_mb": 17580
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 494,
+      "output_tokens": 512,
+      "total_time_secs": 12.012066274,
+      "tokens_per_sec": 42.623807455027034,
+      "peak_vram_mb": 17580
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 494,
+      "output_tokens": 1024,
+      "total_time_secs": 25.587563768,
+      "tokens_per_sec": 40.01944105677705,
+      "peak_vram_mb": 17580
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 494,
+      "output_tokens": 2048,
+      "total_time_secs": 45.680986326,
+      "tokens_per_sec": 44.83265718880397,
+      "peak_vram_mb": 17580
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 8795.428041,
+    "prefill_tokens_per_sec": 56.16554392773299,
+    "time_to_first_token_ms": 8795.428041,
+    "mean_inter_token_ms": 25.270144106299206,
+    "p50_inter_token_ms": 17.6331765,
+    "p99_inter_token_ms": 69.02562800000001,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 39.57239008188819,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6842105263157895,
+    "prompt_subset": "all"
+  },
+  "training": null
+}
+

--- a/profiling-artifacts/post426_c40_20260423_seed0.bench.stderr
+++ b/profiling-artifacts/post426_c40_20260423_seed0.bench.stderr
@@ -1,0 +1,104 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T08:49:10.476607Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T08:49:10.478463Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T08:49:10.478712Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T08:49:10.478722Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T08:49:10.478835Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T08:49:34.131090Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m19609 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 19609 ms (parallel)
+Model loaded in 23.66s (backend: cuda, VRAM: 17531 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=47] (494 prompt tokens)...
+    Prefill (MTP): 8795.4ms (56 tok/s)
+[2m2026-04-23T08:49:43.495024Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m28
+[2m2026-04-23T08:49:43.516231Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m5339 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m494 [3mreplay_tokens_len[0m[2m=[0m494 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T08:49:43.583945Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m31192 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m495 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T08:49:43.650758Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m33416 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m496 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T08:49:43.711119Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m321 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m497 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T08:49:43.843079Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m7071 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m502 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 25.3ms (39.6 tok/s), α = 0.684 (52/76)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T08:49:47.117967Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 2846.6ms (45.0 tok/s)
+  => 45.0 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 2861.0ms (44.7 tok/s)
+    Run 2/4: 128 tokens in 2881.0ms (44.4 tok/s)
+    Run 3/4: 128 tokens in 3081.0ms (41.5 tok/s)
+    Run 4/4: 128 tokens in 3188.8ms (40.1 tok/s)
+  => 42.6 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 3365.5ms (38.0 tok/s)
+    Run 2/8: 128 tokens in 3294.2ms (38.9 tok/s)
+    Run 3/8: 128 tokens in 3492.3ms (36.7 tok/s)
+    Run 4/8: 128 tokens in 3601.1ms (35.5 tok/s)
+    Run 5/8: 128 tokens in 3295.6ms (38.8 tok/s)
+    Run 6/8: 128 tokens in 2850.0ms (44.9 tok/s)
+    Run 7/8: 128 tokens in 2844.9ms (45.0 tok/s)
+    Run 8/8: 128 tokens in 2843.5ms (45.0 tok/s)
+  => 40.0 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2836.3ms (45.1 tok/s)
+    Run 2/16: 128 tokens in 2856.3ms (44.8 tok/s)
+    Run 3/16: 128 tokens in 2852.2ms (44.9 tok/s)
+    Run 4/16: 128 tokens in 2868.0ms (44.6 tok/s)
+    Run 5/16: 128 tokens in 2850.1ms (44.9 tok/s)
+    Run 6/16: 128 tokens in 2849.7ms (44.9 tok/s)
+    Run 7/16: 128 tokens in 2837.8ms (45.1 tok/s)
+    Run 8/16: 128 tokens in 2874.5ms (44.5 tok/s)
+    Run 9/16: 128 tokens in 2879.0ms (44.5 tok/s)
+    Run 10/16: 128 tokens in 2827.3ms (45.3 tok/s)
+    Run 11/16: 128 tokens in 2875.2ms (44.5 tok/s)
+    Run 12/16: 128 tokens in 2857.3ms (44.8 tok/s)
+    Run 13/16: 128 tokens in 2892.4ms (44.3 tok/s)
+    Run 14/16: 128 tokens in 2830.4ms (45.2 tok/s)
+    Run 15/16: 128 tokens in 2827.6ms (45.3 tok/s)
+    Run 16/16: 128 tokens in 2866.4ms (44.7 tok/s)
+  => 44.8 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 23.66s (VRAM: 17531 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               494        128         45.0      17580
+4               494        512         42.6      17580
+8               494       1024         40.0      17580
+16              494       2048         44.8      17580
+
+--- Latency (single request) ---
+Prompt tokens:         494
+Prefill time:          8795.4 ms (56 tok/s)
+Time to first token:   8795.4 ms
+Mean inter-token:      25.3 ms (39.6 tok/s)
+P50 inter-token:       17.6 ms
+P99 inter-token:       69.0 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.684
+
+

--- a/profiling-artifacts/post426_c40_20260423_seed0_compare_bf16.txt
+++ b/profiling-artifacts/post426_c40_20260423_seed0_compare_bf16.txt
@@ -1,0 +1,224 @@
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== mtp_pos-0-step-0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_bf16/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.56e-02     7.56e-04    
+h_layer_1              1x1x2560               True     True     9.99e-01   3.91e-02     1.65e-03    
+h_layer_2              1x1x2560               True     False    9.94e-01   1.95e-02     3.74e-03    
+h_layer_3              1x1x2560               True     False    9.91e-01   3.25e-02     7.50e-03    
+h_layer_4              1x1x2560               True     False    9.88e-01   4.98e-02     1.07e-02    
+h_layer_5              1x1x2560               True     False    9.88e-01   7.81e-02     1.30e-02    
+h_layer_6              1x1x2560               True     False    9.85e-01   1.88e-01     1.55e-02    
+h_layer_7              1x1x2560               True     False    9.78e-01   2.34e-01     1.89e-02    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.03e-01     1.95e-02    
+h_layer_16             1x1x2560               True     False    9.64e-01   4.38e-01     4.37e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   5.00e-01     7.23e-02    
+h_layer_31             1x1x2560               True     False    9.59e-01   2.51e+01     1.34e+00    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-0-step-1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_bf16/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.59e-03    
+h_layer_1              1x1x2560               True     False    9.98e-01   3.12e-02     2.86e-03    
+h_layer_2              1x1x2560               True     False    9.96e-01   3.91e-02     4.42e-03    
+h_layer_3              1x1x2560               True     False    9.94e-01   4.05e-02     8.17e-03    
+h_layer_4              1x1x2560               True     False    9.92e-01   7.81e-02     1.13e-02    
+h_layer_5              1x1x2560               True     False    9.91e-01   5.66e-02     1.37e-02    
+h_layer_6              1x1x2560               True     False    9.90e-01   7.96e-02     1.49e-02    
+h_layer_7              1x1x2560               True     False    9.89e-01   1.56e-01     1.61e-02    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.25e-01     1.65e-02    
+h_layer_16             1x1x2560               True     False    9.78e-01   1.88e-01     3.56e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.06e+00     5.98e-02    
+h_layer_31             1x1x2560               True     False    9.65e-01   1.95e+01     1.32e+00    
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-0-step-2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_bf16/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.69e-03     1.68e-03    
+h_layer_1              1x1x2560               True     False    9.98e-01   2.49e-02     3.14e-03    
+h_layer_2              1x1x2560               True     False    9.96e-01   4.69e-02     4.61e-03    
+h_layer_3              1x1x2560               True     False    9.94e-01   7.81e-02     7.30e-03    
+h_layer_4              1x1x2560               True     False    9.93e-01   7.81e-02     1.00e-02    
+h_layer_5              1x1x2560               True     False    9.92e-01   6.25e-02     1.21e-02    
+h_layer_6              1x1x2560               True     False    9.93e-01   6.45e-02     1.30e-02    
+h_layer_7              1x1x2560               True     False    9.92e-01   7.40e-02     1.44e-02    
+h_layer_8              1x1x2560               True     False    9.88e-01   2.19e-01     1.58e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   1.80e-01     3.10e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   4.22e-01     5.35e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.59e+01     1.44e+00    
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-0-step-3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_bf16/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.56e-02     1.76e-03    
+h_layer_1              1x1x2560               True     False    9.98e-01   2.10e-02     3.07e-03    
+h_layer_2              1x1x2560               True     False    9.97e-01   6.25e-02     4.24e-03    
+h_layer_3              1x1x2560               True     False    9.95e-01   3.66e-02     6.80e-03    
+h_layer_4              1x1x2560               True     False    9.95e-01   4.09e-02     8.35e-03    
+h_layer_5              1x1x2560               True     False    9.93e-01   4.39e-02     1.03e-02    
+h_layer_6              1x1x2560               True     False    9.91e-01   1.88e-01     1.34e-02    
+h_layer_7              1x1x2560               True     False    9.90e-01   8.01e-02     1.56e-02    
+h_layer_8              1x1x2560               True     False    9.89e-01   9.86e-02     1.61e-02    
+h_layer_16             1x1x2560               True     False    9.79e-01   5.31e-01     3.71e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   6.25e-01     6.37e-02    
+h_layer_31             1x1x2560               True     False    9.26e-01   1.62e+01     1.23e+00    
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-2-step-0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_bf16/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.91e-03     6.12e-04    
+h_layer_1              1x1x2560               True     True     9.99e-01   1.12e-02     1.41e-03    
+h_layer_2              1x1x2560               True     False    9.98e-01   1.27e-02     2.48e-03    
+h_layer_3              1x1x2560               True     False    9.96e-01   1.99e-02     4.66e-03    
+h_layer_4              1x1x2560               True     False    9.94e-01   3.21e-02     7.14e-03    
+h_layer_5              1x1x2560               True     False    9.89e-01   6.25e-02     9.32e-03    
+h_layer_6              1x1x2560               True     False    9.67e-01   1.72e-01     2.03e-02    
+h_layer_7              1x1x2560               True     False    9.14e-01   1.72e-01     3.29e-02    
+h_layer_8              1x1x2560               True     False    8.27e-01   3.13e-01     5.02e-02    
+h_layer_16             1x1x2560               True     False    6.42e-01   1.50e+00     1.35e-01    
+h_layer_23             1x1x2560               True     False    4.13e-01   3.18e+00     3.79e-01    
+h_layer_31             1x1x2560               True     False    6.00e-01   2.79e+01     1.92e+00    
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=mtp_pos-0-step-0             pos=mtp_pos-0-step-1             pos=mtp_pos-0-step-2             pos=mtp_pos-0-step-3             pos=mtp_pos-2-step-0            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=7.69e-03   ok    cos=9.99e-01   max|Δ|=1.56e-02   ok    cos=1.00e+00   max|Δ|=3.91e-03   ok   
+  h_layer_1             cos=9.99e-01   max|Δ|=3.91e-02   ok    cos=9.98e-01   max|Δ|=3.12e-02   DIV   cos=9.98e-01   max|Δ|=2.49e-02   DIV   cos=9.98e-01   max|Δ|=2.10e-02   DIV   cos=9.99e-01   max|Δ|=1.12e-02   ok   
+  h_layer_2             cos=9.94e-01   max|Δ|=1.95e-02   DIV   cos=9.96e-01   max|Δ|=3.91e-02   DIV   cos=9.96e-01   max|Δ|=4.69e-02   DIV   cos=9.97e-01   max|Δ|=6.25e-02   DIV   cos=9.98e-01   max|Δ|=1.27e-02   DIV  
+  h_layer_3             cos=9.91e-01   max|Δ|=3.25e-02   DIV   cos=9.94e-01   max|Δ|=4.05e-02   DIV   cos=9.94e-01   max|Δ|=7.81e-02   DIV   cos=9.95e-01   max|Δ|=3.66e-02   DIV   cos=9.96e-01   max|Δ|=1.99e-02   DIV  
+  h_layer_4             cos=9.88e-01   max|Δ|=4.98e-02   DIV   cos=9.92e-01   max|Δ|=7.81e-02   DIV   cos=9.93e-01   max|Δ|=7.81e-02   DIV   cos=9.95e-01   max|Δ|=4.09e-02   DIV   cos=9.94e-01   max|Δ|=3.21e-02   DIV  
+  h_layer_5             cos=9.88e-01   max|Δ|=7.81e-02   DIV   cos=9.91e-01   max|Δ|=5.66e-02   DIV   cos=9.92e-01   max|Δ|=6.25e-02   DIV   cos=9.93e-01   max|Δ|=4.39e-02   DIV   cos=9.89e-01   max|Δ|=6.25e-02   DIV  
+  h_layer_6             cos=9.85e-01   max|Δ|=1.88e-01   DIV   cos=9.90e-01   max|Δ|=7.96e-02   DIV   cos=9.93e-01   max|Δ|=6.45e-02   DIV   cos=9.91e-01   max|Δ|=1.88e-01   DIV   cos=9.67e-01   max|Δ|=1.72e-01   DIV  
+  h_layer_7             cos=9.78e-01   max|Δ|=2.34e-01   DIV   cos=9.89e-01   max|Δ|=1.56e-01   DIV   cos=9.92e-01   max|Δ|=7.40e-02   DIV   cos=9.90e-01   max|Δ|=8.01e-02   DIV   cos=9.14e-01   max|Δ|=1.72e-01   DIV  
+  h_layer_8             cos=9.79e-01   max|Δ|=1.03e-01   DIV   cos=9.88e-01   max|Δ|=1.25e-01   DIV   cos=9.88e-01   max|Δ|=2.19e-01   DIV   cos=9.89e-01   max|Δ|=9.86e-02   DIV   cos=8.27e-01   max|Δ|=3.13e-01   DIV  
+  h_layer_16            cos=9.64e-01   max|Δ|=4.38e-01   DIV   cos=9.78e-01   max|Δ|=1.88e-01   DIV   cos=9.85e-01   max|Δ|=1.80e-01   DIV   cos=9.79e-01   max|Δ|=5.31e-01   DIV   cos=6.42e-01   max|Δ|=1.50e+00   DIV  
+  h_layer_23            cos=9.83e-01   max|Δ|=5.00e-01   DIV   cos=9.88e-01   max|Δ|=1.06e+00   DIV   cos=9.92e-01   max|Δ|=4.22e-01   DIV   cos=9.88e-01   max|Δ|=6.25e-01   DIV   cos=4.13e-01   max|Δ|=3.18e+00   DIV  
+  h_layer_31            cos=9.59e-01   max|Δ|=2.51e+01   DIV   cos=9.65e-01   max|Δ|=1.95e+01   DIV   cos=9.71e-01   max|Δ|=1.59e+01   DIV   cos=9.26e-01   max|Δ|=1.62e+01   DIV   cos=6.00e-01   max|Δ|=2.79e+01   DIV  
+
+  first diverging tap: 'h_layer_1' (pos=mtp_pos-0-step-1)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE FIRST APPEARS AT LAYER 1
+  -> `h_layer_0` still matches, but `h_layer_1` is the first
+     post-layer tap below tolerance. This localizes the earliest shared
+     upstream drift to transformer block 1.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+

--- a/profiling-artifacts/post426_c40_20260423_seed0_compare_fp32.txt
+++ b/profiling-artifacts/post426_c40_20260423_seed0_compare_fp32.txt
@@ -1,0 +1,224 @@
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== mtp_pos-0-step-0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_fp32/seed0/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   2.06e-02     7.53e-04    
+h_layer_1              1x1x2560               True     True     9.99e-01   4.76e-02     1.65e-03    
+h_layer_2              1x1x2560               True     False    9.94e-01   1.89e-02     3.73e-03    
+h_layer_3              1x1x2560               True     False    9.91e-01   3.24e-02     7.51e-03    
+h_layer_4              1x1x2560               True     False    9.88e-01   4.96e-02     1.07e-02    
+h_layer_5              1x1x2560               True     False    9.88e-01   8.11e-02     1.29e-02    
+h_layer_6              1x1x2560               True     False    9.86e-01   2.01e-01     1.54e-02    
+h_layer_7              1x1x2560               True     False    9.79e-01   2.57e-01     1.88e-02    
+h_layer_8              1x1x2560               True     False    9.79e-01   1.00e-01     1.94e-02    
+h_layer_16             1x1x2560               True     False    9.64e-01   4.04e-01     4.35e-02    
+h_layer_23             1x1x2560               True     False    9.83e-01   4.80e-01     7.22e-02    
+h_layer_31             1x1x2560               True     False    9.58e-01   2.52e+01     1.34e+00    
+prompt_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          494                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-0-step-1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_fp32/seed0/mtp_pos-0/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   1.82e-02     1.59e-03    
+h_layer_1              1x1x2560               True     False    9.98e-01   3.65e-02     2.85e-03    
+h_layer_2              1x1x2560               True     False    9.96e-01   3.85e-02     4.42e-03    
+h_layer_3              1x1x2560               True     False    9.94e-01   4.05e-02     8.21e-03    
+h_layer_4              1x1x2560               True     False    9.92e-01   8.37e-02     1.13e-02    
+h_layer_5              1x1x2560               True     False    9.91e-01   5.78e-02     1.36e-02    
+h_layer_6              1x1x2560               True     False    9.90e-01   8.08e-02     1.48e-02    
+h_layer_7              1x1x2560               True     False    9.89e-01   1.74e-01     1.60e-02    
+h_layer_8              1x1x2560               True     False    9.88e-01   1.56e-01     1.64e-02    
+h_layer_16             1x1x2560               True     False    9.78e-01   1.79e-01     3.53e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   1.02e+00     5.98e-02    
+h_layer_31             1x1x2560               True     False    9.65e-01   1.93e+01     1.32e+00    
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          495                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-0-step-2 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-2.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_fp32/seed0/mtp_pos-0/step-2.safetensors
+Metadata:
+  meta__draft_token_id: kiln=33416 ref=33416 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   7.63e-03     1.68e-03    
+h_layer_1              1x1x2560               True     False    9.98e-01   2.54e-02     3.13e-03    
+h_layer_2              1x1x2560               True     False    9.96e-01   3.98e-02     4.61e-03    
+h_layer_3              1x1x2560               True     False    9.94e-01   6.59e-02     7.25e-03    
+h_layer_4              1x1x2560               True     False    9.93e-01   6.48e-02     1.00e-02    
+h_layer_5              1x1x2560               True     False    9.92e-01   5.35e-02     1.20e-02    
+h_layer_6              1x1x2560               True     False    9.93e-01   6.43e-02     1.29e-02    
+h_layer_7              1x1x2560               True     False    9.92e-01   7.10e-02     1.44e-02    
+h_layer_8              1x1x2560               True     False    9.88e-01   2.49e-01     1.58e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   1.81e-01     3.09e-02    
+h_layer_23             1x1x2560               True     False    9.92e-01   4.10e-01     5.33e-02    
+h_layer_31             1x1x2560               True     False    9.71e-01   1.59e+01     1.44e+00    
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          496                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-0-step-3 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-0/step-3.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_fp32/seed0/mtp_pos-0/step-3.safetensors
+Metadata:
+  meta__draft_token_id: kiln=321 ref=321 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   2.41e-02     1.76e-03    
+h_layer_1              1x1x2560               True     False    9.98e-01   2.14e-02     3.07e-03    
+h_layer_2              1x1x2560               True     False    9.97e-01   6.82e-02     4.23e-03    
+h_layer_3              1x1x2560               True     False    9.95e-01   3.61e-02     6.77e-03    
+h_layer_4              1x1x2560               True     False    9.95e-01   4.05e-02     8.33e-03    
+h_layer_5              1x1x2560               True     False    9.93e-01   4.36e-02     1.02e-02    
+h_layer_6              1x1x2560               True     False    9.91e-01   1.69e-01     1.34e-02    
+h_layer_7              1x1x2560               True     False    9.90e-01   8.08e-02     1.56e-02    
+h_layer_8              1x1x2560               True     False    9.90e-01   9.83e-02     1.60e-02    
+h_layer_16             1x1x2560               True     False    9.81e-01   5.00e-01     3.50e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   6.12e-01     6.28e-02    
+h_layer_31             1x1x2560               True     False    9.25e-01   1.65e+01     1.24e+00    
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          497                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-2-step-0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed0_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_fp32/seed0/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=7071 ref=7071 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.68e-03     6.11e-04    
+h_layer_1              1x1x2560               True     True     9.99e-01   1.08e-02     1.42e-03    
+h_layer_2              1x1x2560               True     False    9.98e-01   1.29e-02     2.48e-03    
+h_layer_3              1x1x2560               True     False    9.97e-01   2.22e-02     4.60e-03    
+h_layer_4              1x1x2560               True     False    9.94e-01   3.06e-02     7.06e-03    
+h_layer_5              1x1x2560               True     False    9.89e-01   7.16e-02     9.25e-03    
+h_layer_6              1x1x2560               True     False    9.65e-01   1.62e-01     2.09e-02    
+h_layer_7              1x1x2560               True     False    9.08e-01   2.56e-01     3.41e-02    
+h_layer_8              1x1x2560               True     False    8.11e-01   3.41e-01     5.25e-02    
+h_layer_16             1x1x2560               True     False    5.51e-01   2.78e+00     1.44e-01    
+h_layer_23             1x1x2560               True     False    2.31e-01   7.61e+00     4.15e-01    
+h_layer_31             1x1x2560               True     False    5.83e-01   3.00e+01     1.91e+00    
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          502                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=mtp_pos-0-step-0             pos=mtp_pos-0-step-1             pos=mtp_pos-0-step-2             pos=mtp_pos-0-step-3             pos=mtp_pos-2-step-0            
+  ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=2.06e-02   ok    cos=9.99e-01   max|Δ|=1.82e-02   ok    cos=9.99e-01   max|Δ|=7.63e-03   ok    cos=9.99e-01   max|Δ|=2.41e-02   ok    cos=1.00e+00   max|Δ|=3.68e-03   ok   
+  h_layer_1             cos=9.99e-01   max|Δ|=4.76e-02   ok    cos=9.98e-01   max|Δ|=3.65e-02   DIV   cos=9.98e-01   max|Δ|=2.54e-02   DIV   cos=9.98e-01   max|Δ|=2.14e-02   DIV   cos=9.99e-01   max|Δ|=1.08e-02   ok   
+  h_layer_2             cos=9.94e-01   max|Δ|=1.89e-02   DIV   cos=9.96e-01   max|Δ|=3.85e-02   DIV   cos=9.96e-01   max|Δ|=3.98e-02   DIV   cos=9.97e-01   max|Δ|=6.82e-02   DIV   cos=9.98e-01   max|Δ|=1.29e-02   DIV  
+  h_layer_3             cos=9.91e-01   max|Δ|=3.24e-02   DIV   cos=9.94e-01   max|Δ|=4.05e-02   DIV   cos=9.94e-01   max|Δ|=6.59e-02   DIV   cos=9.95e-01   max|Δ|=3.61e-02   DIV   cos=9.97e-01   max|Δ|=2.22e-02   DIV  
+  h_layer_4             cos=9.88e-01   max|Δ|=4.96e-02   DIV   cos=9.92e-01   max|Δ|=8.37e-02   DIV   cos=9.93e-01   max|Δ|=6.48e-02   DIV   cos=9.95e-01   max|Δ|=4.05e-02   DIV   cos=9.94e-01   max|Δ|=3.06e-02   DIV  
+  h_layer_5             cos=9.88e-01   max|Δ|=8.11e-02   DIV   cos=9.91e-01   max|Δ|=5.78e-02   DIV   cos=9.92e-01   max|Δ|=5.35e-02   DIV   cos=9.93e-01   max|Δ|=4.36e-02   DIV   cos=9.89e-01   max|Δ|=7.16e-02   DIV  
+  h_layer_6             cos=9.86e-01   max|Δ|=2.01e-01   DIV   cos=9.90e-01   max|Δ|=8.08e-02   DIV   cos=9.93e-01   max|Δ|=6.43e-02   DIV   cos=9.91e-01   max|Δ|=1.69e-01   DIV   cos=9.65e-01   max|Δ|=1.62e-01   DIV  
+  h_layer_7             cos=9.79e-01   max|Δ|=2.57e-01   DIV   cos=9.89e-01   max|Δ|=1.74e-01   DIV   cos=9.92e-01   max|Δ|=7.10e-02   DIV   cos=9.90e-01   max|Δ|=8.08e-02   DIV   cos=9.08e-01   max|Δ|=2.56e-01   DIV  
+  h_layer_8             cos=9.79e-01   max|Δ|=1.00e-01   DIV   cos=9.88e-01   max|Δ|=1.56e-01   DIV   cos=9.88e-01   max|Δ|=2.49e-01   DIV   cos=9.90e-01   max|Δ|=9.83e-02   DIV   cos=8.11e-01   max|Δ|=3.41e-01   DIV  
+  h_layer_16            cos=9.64e-01   max|Δ|=4.04e-01   DIV   cos=9.78e-01   max|Δ|=1.79e-01   DIV   cos=9.85e-01   max|Δ|=1.81e-01   DIV   cos=9.81e-01   max|Δ|=5.00e-01   DIV   cos=5.51e-01   max|Δ|=2.78e+00   DIV  
+  h_layer_23            cos=9.83e-01   max|Δ|=4.80e-01   DIV   cos=9.88e-01   max|Δ|=1.02e+00   DIV   cos=9.92e-01   max|Δ|=4.10e-01   DIV   cos=9.88e-01   max|Δ|=6.12e-01   DIV   cos=2.31e-01   max|Δ|=7.61e+00   DIV  
+  h_layer_31            cos=9.58e-01   max|Δ|=2.52e+01   DIV   cos=9.65e-01   max|Δ|=1.93e+01   DIV   cos=9.71e-01   max|Δ|=1.59e+01   DIV   cos=9.25e-01   max|Δ|=1.65e+01   DIV   cos=5.83e-01   max|Δ|=3.00e+01   DIV  
+
+  first diverging tap: 'h_layer_1' (pos=mtp_pos-0-step-1)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE FIRST APPEARS AT LAYER 1
+  -> `h_layer_0` still matches, but `h_layer_1` is the first
+     post-layer tap below tolerance. This localizes the earliest shared
+     upstream drift to transformer block 1.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main', 'h_main', 'h_main']
+

--- a/profiling-artifacts/post426_c40_20260423_seed1.bench.json
+++ b/profiling-artifacts/post426_c40_20260423_seed1.bench.json
@@ -1,0 +1,62 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 19.753499716,
+    "model_vram_mb": 17531
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 508,
+      "output_tokens": 128,
+      "total_time_secs": 2.9184360590000002,
+      "tokens_per_sec": 43.859107210955685,
+      "peak_vram_mb": 17580
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 508,
+      "output_tokens": 512,
+      "total_time_secs": 11.482375188,
+      "tokens_per_sec": 44.59007754206472,
+      "peak_vram_mb": 17580
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 508,
+      "output_tokens": 1024,
+      "total_time_secs": 23.001468006,
+      "tokens_per_sec": 44.51889765178843,
+      "peak_vram_mb": 17580
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 508,
+      "output_tokens": 2048,
+      "total_time_secs": 46.939797167,
+      "tokens_per_sec": 43.630354701229976,
+      "peak_vram_mb": 17580
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 508,
+    "prefill_time_ms": 386.826387,
+    "prefill_tokens_per_sec": 1313.2506392331504,
+    "time_to_first_token_ms": 386.826387,
+    "mean_inter_token_ms": 41.75278885826772,
+    "p50_inter_token_ms": 55.302397000000006,
+    "p99_inter_token_ms": 73.783579,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 23.950495939194827,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.29591836734693877,
+    "prompt_subset": "all"
+  },
+  "training": null
+}
+

--- a/profiling-artifacts/post426_c40_20260423_seed1.bench.stderr
+++ b/profiling-artifacts/post426_c40_20260423_seed1.bench.stderr
@@ -1,0 +1,102 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T08:51:17.389380Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T08:51:17.390931Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T08:51:17.391171Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T08:51:17.391180Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T08:51:17.391285Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T08:51:37.140006Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m17917 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 17917 ms (parallel)
+Model loaded in 19.75s (backend: cuda, VRAM: 17531 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (508 prompt tokens)...
+    Prefill (MTP): 386.8ms (1313 tok/s)
+[2m2026-04-23T08:51:38.138265Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m36
+[2m2026-04-23T08:51:38.157987Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post426_c40_20260423_seed1_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m25015 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m508 [3mreplay_tokens_len[0m[2m=[0m508 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T08:51:38.599576Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post426_c40_20260423_seed1_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m23043 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m517 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T08:51:38.669996Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post426_c40_20260423_seed1_captures/mtp_pos-2/step-1.safetensors [3mdraft_token_id[0m[2m=[0m11 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m518 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 41.8ms (24.0 tok/s), α = 0.296 (29/98)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T08:51:43.881460Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 2918.4ms (43.9 tok/s)
+  => 43.9 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 2893.4ms (44.2 tok/s)
+    Run 2/4: 128 tokens in 2873.4ms (44.5 tok/s)
+    Run 3/4: 128 tokens in 2858.6ms (44.8 tok/s)
+    Run 4/4: 128 tokens in 2856.7ms (44.8 tok/s)
+  => 44.6 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2881.6ms (44.4 tok/s)
+    Run 2/8: 128 tokens in 2853.2ms (44.9 tok/s)
+    Run 3/8: 128 tokens in 2880.6ms (44.4 tok/s)
+    Run 4/8: 128 tokens in 2876.5ms (44.5 tok/s)
+    Run 5/8: 128 tokens in 2864.5ms (44.7 tok/s)
+    Run 6/8: 128 tokens in 2881.7ms (44.4 tok/s)
+    Run 7/8: 128 tokens in 2872.6ms (44.6 tok/s)
+    Run 8/8: 128 tokens in 2890.4ms (44.3 tok/s)
+  => 44.5 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2901.6ms (44.1 tok/s)
+    Run 2/16: 128 tokens in 2888.5ms (44.3 tok/s)
+    Run 3/16: 128 tokens in 2909.5ms (44.0 tok/s)
+    Run 4/16: 128 tokens in 2887.7ms (44.3 tok/s)
+    Run 5/16: 128 tokens in 2861.3ms (44.7 tok/s)
+    Run 6/16: 128 tokens in 2861.1ms (44.7 tok/s)
+    Run 7/16: 128 tokens in 3523.7ms (36.3 tok/s)
+    Run 8/16: 128 tokens in 2884.8ms (44.4 tok/s)
+    Run 9/16: 128 tokens in 2878.8ms (44.5 tok/s)
+    Run 10/16: 128 tokens in 2934.3ms (43.6 tok/s)
+    Run 11/16: 128 tokens in 2886.4ms (44.3 tok/s)
+    Run 12/16: 128 tokens in 2959.8ms (43.2 tok/s)
+    Run 13/16: 128 tokens in 2890.9ms (44.3 tok/s)
+    Run 14/16: 128 tokens in 2876.4ms (44.5 tok/s)
+    Run 15/16: 128 tokens in 2911.4ms (44.0 tok/s)
+    Run 16/16: 128 tokens in 2882.9ms (44.4 tok/s)
+  => 43.6 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 19.75s (VRAM: 17531 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               508        128         43.9      17580
+4               508        512         44.6      17580
+8               508       1024         44.5      17580
+16              508       2048         43.6      17580
+
+--- Latency (single request) ---
+Prompt tokens:         508
+Prefill time:          386.8 ms (1313 tok/s)
+Time to first token:   386.8 ms
+Mean inter-token:      41.8 ms (24.0 tok/s)
+P50 inter-token:       55.3 ms
+P99 inter-token:       73.8 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.296
+
+

--- a/profiling-artifacts/post426_c40_20260423_seed1_compare_bf16.txt
+++ b/profiling-artifacts/post426_c40_20260423_seed1_compare_bf16.txt
@@ -1,0 +1,146 @@
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== mtp_pos-0-step-0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_bf16/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   3.45e-03     7.80e-04    
+h_layer_1              1x1x2560               True     True     9.99e-01   7.81e-03     1.59e-03    
+h_layer_2              1x1x2560               True     False    9.95e-01   3.91e-02     3.37e-03    
+h_layer_3              1x1x2560               True     False    9.91e-01   3.22e-02     7.27e-03    
+h_layer_4              1x1x2560               True     False    9.87e-01   9.38e-02     1.03e-02    
+h_layer_5              1x1x2560               True     False    9.89e-01   1.56e-01     1.21e-02    
+h_layer_6              1x1x2560               True     False    9.85e-01   1.72e-01     1.57e-02    
+h_layer_7              1x1x2560               True     False    9.77e-01   1.25e-01     2.01e-02    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.04e-01     2.08e-02    
+h_layer_16             1x1x2560               True     False    9.45e-01   6.88e-01     5.20e-02    
+h_layer_23             1x1x2560               True     False    9.70e-01   8.24e-01     9.89e-02    
+h_layer_31             1x1x2560               True     False    9.58e-01   2.09e+01     1.16e+00    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-2-step-0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_bf16/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=23043 ref=23043 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.56e-02     1.30e-03    
+h_layer_1              1x1x2560               True     True     9.99e-01   3.12e-02     2.29e-03    
+h_layer_2              1x1x2560               True     False    9.98e-01   1.66e-02     3.42e-03    
+h_layer_3              1x1x2560               True     False    9.97e-01   6.25e-02     5.85e-03    
+h_layer_4              1x1x2560               True     False    9.96e-01   9.38e-02     7.08e-03    
+h_layer_5              1x1x2560               True     False    9.94e-01   4.22e-02     9.05e-03    
+h_layer_6              1x1x2560               True     False    9.90e-01   9.38e-02     1.31e-02    
+h_layer_7              1x1x2560               True     False    9.89e-01   1.56e-01     1.53e-02    
+h_layer_8              1x1x2560               True     False    9.84e-01   9.38e-02     1.77e-02    
+h_layer_16             1x1x2560               True     False    9.41e-01   3.75e-01     5.52e-02    
+h_layer_23             1x1x2560               True     False    9.07e-01   1.75e+00     1.46e-01    
+h_layer_31             1x1x2560               True     False    9.16e-01   1.77e+01     1.54e+00    
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          517                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-2-step-1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_bf16/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   3.12e-02     1.59e-03    
+h_layer_1              1x1x2560               True     False    9.99e-01   1.81e-02     2.97e-03    
+h_layer_2              1x1x2560               True     False    9.96e-01   1.09e-01     4.08e-03    
+h_layer_3              1x1x2560               True     False    9.94e-01   1.41e-01     7.67e-03    
+h_layer_4              1x1x2560               True     False    9.93e-01   2.50e-01     9.19e-03    
+h_layer_5              1x1x2560               True     False    9.93e-01   2.19e-01     1.06e-02    
+h_layer_6              1x1x2560               True     False    9.89e-01   9.38e-02     1.32e-02    
+h_layer_7              1x1x2560               True     False    9.87e-01   8.50e-02     1.63e-02    
+h_layer_8              1x1x2560               True     False    9.85e-01   2.81e-01     1.71e-02    
+h_layer_16             1x1x2560               True     False    9.85e-01   3.44e-01     3.08e-02    
+h_layer_23             1x1x2560               True     False    9.88e-01   3.85e-01     6.57e-02    
+h_layer_31             1x1x2560               True     False    9.25e-01   1.93e+01     1.18e+00    
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          518                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=mtp_pos-0-step-0             pos=mtp_pos-2-step-0             pos=mtp_pos-2-step-1            
+  ------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=3.45e-03   ok    cos=1.00e+00   max|Δ|=1.56e-02   ok    cos=9.99e-01   max|Δ|=3.12e-02   ok   
+  h_layer_1             cos=9.99e-01   max|Δ|=7.81e-03   ok    cos=9.99e-01   max|Δ|=3.12e-02   ok    cos=9.99e-01   max|Δ|=1.81e-02   DIV  
+  h_layer_2             cos=9.95e-01   max|Δ|=3.91e-02   DIV   cos=9.98e-01   max|Δ|=1.66e-02   DIV   cos=9.96e-01   max|Δ|=1.09e-01   DIV  
+  h_layer_3             cos=9.91e-01   max|Δ|=3.22e-02   DIV   cos=9.97e-01   max|Δ|=6.25e-02   DIV   cos=9.94e-01   max|Δ|=1.41e-01   DIV  
+  h_layer_4             cos=9.87e-01   max|Δ|=9.38e-02   DIV   cos=9.96e-01   max|Δ|=9.38e-02   DIV   cos=9.93e-01   max|Δ|=2.50e-01   DIV  
+  h_layer_5             cos=9.89e-01   max|Δ|=1.56e-01   DIV   cos=9.94e-01   max|Δ|=4.22e-02   DIV   cos=9.93e-01   max|Δ|=2.19e-01   DIV  
+  h_layer_6             cos=9.85e-01   max|Δ|=1.72e-01   DIV   cos=9.90e-01   max|Δ|=9.38e-02   DIV   cos=9.89e-01   max|Δ|=9.38e-02   DIV  
+  h_layer_7             cos=9.77e-01   max|Δ|=1.25e-01   DIV   cos=9.89e-01   max|Δ|=1.56e-01   DIV   cos=9.87e-01   max|Δ|=8.50e-02   DIV  
+  h_layer_8             cos=9.76e-01   max|Δ|=1.04e-01   DIV   cos=9.84e-01   max|Δ|=9.38e-02   DIV   cos=9.85e-01   max|Δ|=2.81e-01   DIV  
+  h_layer_16            cos=9.45e-01   max|Δ|=6.88e-01   DIV   cos=9.41e-01   max|Δ|=3.75e-01   DIV   cos=9.85e-01   max|Δ|=3.44e-01   DIV  
+  h_layer_23            cos=9.70e-01   max|Δ|=8.24e-01   DIV   cos=9.07e-01   max|Δ|=1.75e+00   DIV   cos=9.88e-01   max|Δ|=3.85e-01   DIV  
+  h_layer_31            cos=9.58e-01   max|Δ|=2.09e+01   DIV   cos=9.16e-01   max|Δ|=1.77e+01   DIV   cos=9.25e-01   max|Δ|=1.93e+01   DIV  
+
+  first diverging tap: 'h_layer_1' (pos=mtp_pos-2-step-1)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE FIRST APPEARS AT LAYER 1
+  -> `h_layer_0` still matches, but `h_layer_1` is the first
+     post-layer tap below tolerance. This localizes the earliest shared
+     upstream drift to transformer block 1.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main']
+

--- a/profiling-artifacts/post426_c40_20260423_seed1_compare_fp32.txt
+++ b/profiling-artifacts/post426_c40_20260423_seed1_compare_fp32.txt
@@ -1,0 +1,146 @@
+MTP numerical bisect — mode: base-model h_main bisect (B10), atol=0.01, rtol=0.1
+
+=== mtp_pos-0-step-0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed1_captures/mtp_pos-0/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_fp32/seed1/mtp_pos-0/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=25015 ref=25015 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.26e-02     7.76e-04    
+h_layer_1              1x1x2560               True     True     9.99e-01   2.32e-02     1.59e-03    
+h_layer_2              1x1x2560               True     False    9.95e-01   1.68e-02     3.35e-03    
+h_layer_3              1x1x2560               True     False    9.91e-01   3.30e-02     7.34e-03    
+h_layer_4              1x1x2560               True     False    9.87e-01   1.01e-01     1.03e-02    
+h_layer_5              1x1x2560               True     False    9.89e-01   1.44e-01     1.20e-02    
+h_layer_6              1x1x2560               True     False    9.85e-01   1.69e-01     1.57e-02    
+h_layer_7              1x1x2560               True     False    9.77e-01   1.41e-01     2.03e-02    
+h_layer_8              1x1x2560               True     False    9.76e-01   1.04e-01     2.10e-02    
+h_layer_16             1x1x2560               True     False    9.43e-01   6.94e-01     5.29e-02    
+h_layer_23             1x1x2560               True     False    9.68e-01   8.16e-01     1.01e-01    
+h_layer_31             1x1x2560               True     False    9.57e-01   2.06e+01     1.16e+00    
+prompt_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+replay_tokens          508                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-2-step-0 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed1_captures/mtp_pos-2/step-0.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_fp32/seed1/mtp_pos-2/step-0.safetensors
+Metadata:
+  meta__draft_token_id: kiln=23043 ref=23043 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     1.00e+00   1.74e-02     1.29e-03    
+h_layer_1              1x1x2560               True     True     9.99e-01   2.60e-02     2.28e-03    
+h_layer_2              1x1x2560               True     False    9.98e-01   1.62e-02     3.41e-03    
+h_layer_3              1x1x2560               True     False    9.97e-01   6.72e-02     5.84e-03    
+h_layer_4              1x1x2560               True     False    9.96e-01   9.60e-02     7.08e-03    
+h_layer_5              1x1x2560               True     False    9.94e-01   4.11e-02     9.06e-03    
+h_layer_6              1x1x2560               True     False    9.90e-01   9.71e-02     1.31e-02    
+h_layer_7              1x1x2560               True     False    9.89e-01   1.30e-01     1.53e-02    
+h_layer_8              1x1x2560               True     False    9.85e-01   8.64e-02     1.71e-02    
+h_layer_16             1x1x2560               True     False    9.25e-01   2.71e-01     6.18e-02    
+h_layer_23             1x1x2560               True     False    7.25e-01   6.72e+00     2.52e-01    
+h_layer_31             1x1x2560               True     False    8.59e-01   1.86e+01     1.56e+00    
+prompt_tokens          2                      False    False    nan        nan          nan         
+replay_tokens          517                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+=== mtp_pos-2-step-1 ===
+  kiln dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : /workspace/kiln/profiling-artifacts/post426_c40_20260423_refs_fp32/seed1/mtp_pos-2/step-1.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+h_main                 MISSING IN REF DUMP
+tok_embed              MISSING IN REF DUMP
+fc_input               MISSING IN REF DUMP
+fc_output              MISSING IN REF DUMP
+pre_layer              MISSING IN REF DUMP
+post_layer             MISSING IN REF DUMP
+post_final_ln          MISSING IN REF DUMP
+mtp_logits             MISSING IN REF DUMP
+h_layer_0              1x1x2560               True     True     9.99e-01   3.40e-02     1.58e-03    
+h_layer_1              1x1x2560               True     False    9.99e-01   2.92e-02     2.96e-03    
+h_layer_2              1x1x2560               True     False    9.96e-01   1.24e-01     4.07e-03    
+h_layer_3              1x1x2560               True     False    9.94e-01   1.64e-01     7.73e-03    
+h_layer_4              1x1x2560               True     False    9.93e-01   2.72e-01     9.26e-03    
+h_layer_5              1x1x2560               True     False    9.93e-01   2.37e-01     1.07e-02    
+h_layer_6              1x1x2560               True     False    9.89e-01   1.10e-01     1.33e-02    
+h_layer_7              1x1x2560               True     False    9.87e-01   9.54e-02     1.63e-02    
+h_layer_8              1x1x2560               True     False    9.85e-01   2.70e-01     1.71e-02    
+h_layer_16             1x1x2560               True     False    9.84e-01   4.63e-01     3.17e-02    
+h_layer_23             1x1x2560               True     False    9.85e-01   4.03e-01     7.16e-02    
+h_layer_31             1x1x2560               True     False    9.23e-01   1.97e+01     1.18e+00    
+prompt_tokens          1                      False    False    nan        nan          nan         
+replay_tokens          518                    True     True     1.00e+00   0.00e+00     0.00e+00    
+
+  pair verdict: first divergence at tap 'h_main'.
+    Most-likely cause: upstream (base model) — this ref takes h_main FROM kiln, so shouldn't differ
+
+==============================================================================
+Phase B10 per-layer base-model h_main bisect — cos_sim + max|Δ|
+==============================================================================
+  tap                   pos=mtp_pos-0-step-0             pos=mtp_pos-2-step-0             pos=mtp_pos-2-step-1            
+  ------------------------------------------------------------------------------------------------------------------------
+  h_layer_0             cos=1.00e+00   max|Δ|=1.26e-02   ok    cos=1.00e+00   max|Δ|=1.74e-02   ok    cos=9.99e-01   max|Δ|=3.40e-02   ok   
+  h_layer_1             cos=9.99e-01   max|Δ|=2.32e-02   ok    cos=9.99e-01   max|Δ|=2.60e-02   ok    cos=9.99e-01   max|Δ|=2.92e-02   DIV  
+  h_layer_2             cos=9.95e-01   max|Δ|=1.68e-02   DIV   cos=9.98e-01   max|Δ|=1.62e-02   DIV   cos=9.96e-01   max|Δ|=1.24e-01   DIV  
+  h_layer_3             cos=9.91e-01   max|Δ|=3.30e-02   DIV   cos=9.97e-01   max|Δ|=6.72e-02   DIV   cos=9.94e-01   max|Δ|=1.64e-01   DIV  
+  h_layer_4             cos=9.87e-01   max|Δ|=1.01e-01   DIV   cos=9.96e-01   max|Δ|=9.60e-02   DIV   cos=9.93e-01   max|Δ|=2.72e-01   DIV  
+  h_layer_5             cos=9.89e-01   max|Δ|=1.44e-01   DIV   cos=9.94e-01   max|Δ|=4.11e-02   DIV   cos=9.93e-01   max|Δ|=2.37e-01   DIV  
+  h_layer_6             cos=9.85e-01   max|Δ|=1.69e-01   DIV   cos=9.90e-01   max|Δ|=9.71e-02   DIV   cos=9.89e-01   max|Δ|=1.10e-01   DIV  
+  h_layer_7             cos=9.77e-01   max|Δ|=1.41e-01   DIV   cos=9.89e-01   max|Δ|=1.30e-01   DIV   cos=9.87e-01   max|Δ|=9.54e-02   DIV  
+  h_layer_8             cos=9.76e-01   max|Δ|=1.04e-01   DIV   cos=9.85e-01   max|Δ|=8.64e-02   DIV   cos=9.85e-01   max|Δ|=2.70e-01   DIV  
+  h_layer_16            cos=9.43e-01   max|Δ|=6.94e-01   DIV   cos=9.25e-01   max|Δ|=2.71e-01   DIV   cos=9.84e-01   max|Δ|=4.63e-01   DIV  
+  h_layer_23            cos=9.68e-01   max|Δ|=8.16e-01   DIV   cos=7.25e-01   max|Δ|=6.72e+00   DIV   cos=9.85e-01   max|Δ|=4.03e-01   DIV  
+  h_layer_31            cos=9.57e-01   max|Δ|=2.06e+01   DIV   cos=8.59e-01   max|Δ|=1.86e+01   DIV   cos=9.23e-01   max|Δ|=1.97e+01   DIV  
+
+  first diverging tap: 'h_layer_1' (pos=mtp_pos-2-step-1)
+  last matching tap before divergence: 'h_layer_0'
+Phase B10 verdict: DIVERGENCE FIRST APPEARS AT LAYER 1
+  -> `h_layer_0` still matches, but `h_layer_1` is the first
+     post-layer tap below tolerance. This localizes the earliest shared
+     upstream drift to transformer block 1.
+
+Overall verdict: divergence(s) at: ['h_main', 'h_main', 'h_main']
+

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -72,6 +72,7 @@ Exit code:
 """
 
 import argparse
+import re
 import sys
 from typing import Dict, List, Optional, Tuple
 
@@ -431,20 +432,52 @@ def _compare_tap(
     return row
 
 
-def _load(path: str) -> Tuple[Dict[str, np.ndarray], Dict[str, int]]:
+def _load(path: str) -> Tuple[Dict[str, np.ndarray], Dict[str, object]]:
     try:
         tensors = load_file(path)
     except Exception as e:
         print(f"ERROR: failed to load {path}: {e}", file=sys.stderr)
         sys.exit(2)
-    meta: Dict[str, int] = {}
+    meta: Dict[str, object] = {}
     arrays: Dict[str, np.ndarray] = {}
     for key, val in tensors.items():
         if key in META_KEYS or key.startswith("meta__"):
-            meta[key] = int(val.item()) if val.size == 1 else int(val.flatten()[0])
+            if val.size == 1:
+                meta[key] = int(val.item())
+            else:
+                meta[key] = [int(x) for x in val.reshape(-1).tolist()]
         else:
             arrays[key] = val
     return arrays, meta
+
+
+def _extract_h_layer_idx(name: str) -> Optional[int]:
+    m = re.fullmatch(r"h_layer_(\d+)", name)
+    if m is None:
+        return None
+    return int(m.group(1))
+
+
+def _sorted_h_layer_tap_names(names) -> List[str]:
+    layers = sorted(
+        idx
+        for idx in (_extract_h_layer_idx(name) for name in names)
+        if idx is not None
+    )
+    return [f"h_layer_{idx}" for idx in layers]
+
+
+def _meta_boundary_layers(meta: Dict[str, object]) -> List[int]:
+    raw = meta.get("meta__boundary_layers")
+    if isinstance(raw, list):
+        return sorted(int(v) for v in raw)
+    return []
+
+
+def _fmt_meta_value(v: object) -> str:
+    if isinstance(v, list):
+        return "[" + ", ".join(str(int(x)) for x in v) + "]"
+    return str(v)
 
 
 def _ordered_taps(
@@ -462,7 +495,10 @@ def _ordered_taps(
     for name in SUBOP_ORDER:
         if name in common:
             out.append(name)
-    for name in B10_LAYER_TAPS:
+    for name in _sorted_h_layer_tap_names(common):
+        if name in common and name not in out:
+            out.append(name)
+    for name in ("h_pre_final_norm", "h_post_final_norm"):
         if name in common and name not in out:
             out.append(name)
     for name in B11_LAYER0_TAP_NAMES:
@@ -496,7 +532,7 @@ def _compare_pair(
     atol: float,
     rtol: float,
     emit,
-) -> Tuple[bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]:
+) -> Tuple[bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]:
     """Compare a single (kiln, ref) pair. Returns (all_ok, first_divergence,
     rows, kiln_meta, ref_meta). `label` is shown in headers for multi-pair
     runs."""
@@ -513,6 +549,14 @@ def _compare_pair(
         rv = ref_meta.get(k, "<missing>")
         match = "OK" if kv == rv else "MISMATCH"
         emit(f"  {k}: kiln={kv} ref={rv} [{match}]")
+    if "meta__boundary_layers" in kiln_meta or "meta__boundary_layers" in ref_meta:
+        kv = kiln_meta.get("meta__boundary_layers", "<missing>")
+        rv = ref_meta.get("meta__boundary_layers", "<missing>")
+        match = "OK" if kv == rv else "MISMATCH"
+        emit(
+            "  meta__boundary_layers: "
+            f"kiln={_fmt_meta_value(kv)} ref={_fmt_meta_value(rv)} [{match}]"
+        )
     emit("")
 
     header = (
@@ -582,7 +626,7 @@ def _parse_pair_arg(s: str) -> Tuple[str, str, str]:
 
 
 def _emit_b7a_summary(
-    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]],
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     emit,
 ) -> None:
     """Print per-position cos_sim summary for the B7a decision: H1 confirmed
@@ -641,7 +685,7 @@ def _emit_b7a_summary(
 
 
 def _emit_b9_summary(
-    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]],
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
     rtol: float,
     emit,
@@ -764,8 +808,36 @@ def _emit_b9_summary(
         emit("  -> Re-check the full sub-op table above for the first non-zone divergence.")
 
 
+def _b10_layer_taps_for_pair_results(
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
+) -> List[str]:
+    names = set()
+    boundary_layers = set()
+    final_norm_name: Optional[str] = None
+    for _label, _ok, _first_div, rows, kiln_meta, ref_meta in pair_results:
+        boundary_layers.update(_meta_boundary_layers(kiln_meta))
+        boundary_layers.update(_meta_boundary_layers(ref_meta))
+        for row in rows:
+            name = row["name"]
+            if not isinstance(name, str):
+                continue
+            names.add(name)
+            idx = _extract_h_layer_idx(name)
+            if idx is not None:
+                boundary_layers.add(idx)
+            elif name in ("h_pre_final_norm", "h_post_final_norm"):
+                final_norm_name = name
+
+    taps = [f"h_layer_{idx}" for idx in sorted(boundary_layers)]
+    if not taps:
+        taps = [name for name in B10_LAYER_TAPS if name in names]
+    if final_norm_name is not None:
+        taps.append(final_norm_name)
+    return taps
+
+
 def _emit_b10_summary(
-    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]],
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
     rtol: float,
     emit,
@@ -785,9 +857,10 @@ def _emit_b10_summary(
     emit("=" * 78)
 
     labels = [pr[0] for pr in pair_results]
+    b10_layer_taps = _b10_layer_taps_for_pair_results(pair_results)
 
     cell: Dict[str, Dict[str, Tuple[float, float, bool, Tuple[int, ...]]]] = {
-        n: {} for n in B10_LAYER_TAPS
+        n: {} for n in b10_layer_taps
     }
     for label, _ok, _fd, rows, _km, _rm in pair_results:
         for r in rows:
@@ -806,7 +879,7 @@ def _emit_b10_summary(
     emit(header)
     emit("  " + "-" * (len(header) - 2))
     captured_any = False
-    for tap in B10_LAYER_TAPS:
+    for tap in b10_layer_taps:
         cells = []
         for lab in labels:
             entry = cell[tap].get(lab)
@@ -831,7 +904,7 @@ def _emit_b10_summary(
     first_div_tap: Optional[str] = None
     first_div_pos: Optional[str] = None
     last_match_tap: Optional[str] = None
-    for tap in B10_LAYER_TAPS:
+    for tap in b10_layer_taps:
         any_div_here = False
         for lab in labels:
             entry = cell[tap].get(lab)
@@ -858,36 +931,49 @@ def _emit_b10_summary(
     if last_match_tap is not None:
         emit(f"  last matching tap before divergence: '{last_match_tap}'")
 
+    first_div_idx = _extract_h_layer_idx(first_div_tap) if first_div_tap is not None else None
+    last_match_idx = _extract_h_layer_idx(last_match_tap) if last_match_tap is not None else None
+    exact_first_bad_layer = (
+        first_div_idx is not None
+        and last_match_idx is not None
+        and first_div_idx == last_match_idx + 1
+    )
+
     if first_div_tap == "h_layer_0":
         emit("Phase B10 verdict: DIVERGENCE AT LAYER 0")
         emit("  -> Input-path bug: embedding lookup, rotary_inv_freq build, first")
         emit("     block's Q/K/V proj or GDN sub-op, OR prompt-token construction")
         emit("     mismatch between kiln and reference. Verify `prompt_tokens` meta")
         emit("     matches exactly, then narrow to layer 0's sub-ops.")
-    elif first_div_tap in ("h_layer_8", "h_layer_16"):
+    elif exact_first_bad_layer:
+        emit(f"Phase B10 verdict: DIVERGENCE FIRST APPEARS AT LAYER {first_div_idx}")
+        emit(f"  -> `{last_match_tap}` still matches, but `{first_div_tap}` is the first")
+        emit("     post-layer tap below tolerance. This localizes the earliest shared")
+        emit(f"     upstream drift to transformer block {first_div_idx}.")
+    elif first_div_idx is not None and first_div_idx <= 16:
         emit("Phase B10 verdict: DIVERGENCE IN EARLY GDN STACK")
         emit(f"  -> The first bad transformer block lies between {last_match_tap or 'start'}")
         emit(f"     and {first_div_tap}. Narrow by capturing intermediate layers")
-        emit("     (e.g. layers 4 and 12) and re-running B10 on the new dump.")
+        emit("     inside that span and re-running B10 on the new dump.")
     elif first_div_tap == "h_layer_23":
         emit("Phase B10 verdict: DIVERGENCE IN MID-STACK (GDN→GQA transition zone)")
         emit(f"  -> The first bad block lies between {last_match_tap or 'start'} and 23.")
         emit("     Layer 23 is a GQA block (full_attention_interval=4). Narrow by")
         emit("     capturing layers 20, 21, 22 on the next dump.")
-    elif first_div_tap == "h_layer_31":
+    elif first_div_idx is not None:
         emit("Phase B10 verdict: DIVERGENCE IN LATE STACK")
-        emit(f"  -> The first bad block lies between {last_match_tap or 'start'} and 31.")
-        emit("     Narrow by capturing layers 24, 27, 29 on the next dump.")
-    elif first_div_tap == "h_pre_final_norm":
+        emit(f"  -> The first bad block lies between {last_match_tap or 'start'} and {first_div_tap}.")
+        emit("     Narrow by capturing additional layers inside that span.")
+    elif first_div_tap in ("h_pre_final_norm", "h_post_final_norm"):
         emit("Phase B10 verdict: DIVERGENCE AT FINAL-LAYER → h_main HANDOFF")
-        emit("  -> All 32 layers match, but `h_pre_final_norm` (what MTP consumes")
+        emit(f"  -> All 32 layers match, but `{first_div_tap}` (what MTP consumes")
         emit("     as `h_prev`) diverges. The bug is in the last-row extraction")
         emit("     (`narrow(1, seq_len-1, 1)`), the residual add at layer 31, or")
         emit("     how the base-model main path routes hidden into the MTP head.")
 
 
 def _emit_b11_summary(
-    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]],
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
     rtol: float,
     emit,
@@ -1018,7 +1104,7 @@ def _emit_b11_summary(
 
 
 def _emit_b12_summary(
-    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]],
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
     rtol: float,
     emit,
@@ -1234,7 +1320,7 @@ def _emit_b12_summary(
 
 
 def _emit_c6_summary(
-    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]],
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
     rtol: float,
     emit,
@@ -1362,7 +1448,7 @@ def _emit_c6_summary(
 
 
 def _emit_c7_summary(
-    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]],
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
     rtol: float,
     emit,
@@ -1618,7 +1704,7 @@ def main() -> int:
     emit(f"MTP numerical bisect — mode: {mode}, atol={args.atol}, rtol={args.rtol}")
 
     pair_results: List[
-        Tuple[str, bool, str, List[Dict[str, object]], Dict[str, int], Dict[str, int]]
+        Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]
     ] = []
     overall_ok = True
     for label, kpath, rpath in pairs:

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -127,6 +127,13 @@ from safetensors.torch import save_file
 #   - layer 31: GQA (last layer; its output IS `h_pre_final_norm`)
 B10_BOUNDARY_LAYERS: Tuple[int, ...] = (0, 8, 16, 23, 31)
 
+# Phase C40 — optional dense early-stack sweep used to localize the first
+# shared upstream drift inside C39's coarse `h_layer_0 -> h_layer_8` span.
+# The kiln dump now serializes the actual boundary set in
+# `meta__boundary_layers`; this tuple is the fallback when that metadata is
+# absent.
+C40_EARLY_BOUNDARY_LAYERS: Tuple[int, ...] = (1, 2, 3, 4, 5, 6, 7, 8)
+
 
 # Phase B11b — ordered layer-0 GDN sub-op tap names. Must stay in lock-step
 # with `B11_TAP_NAMES` in `crates/kiln-model/src/mtp_debug.rs`. The comparator
@@ -193,10 +200,24 @@ def load_kiln_dump(path: str) -> Dict[str, object]:
                 # Token IDs — keep integral.
                 out[name] = t.to(torch.int64).contiguous()
             elif name.startswith("meta__"):
-                out[name] = int(t.flatten()[0].item())
+                if t.numel() == 1:
+                    out[name] = int(t.flatten()[0].item())
+                else:
+                    out[name] = [int(v) for v in t.view(-1).tolist()]
             else:
                 out[name] = t.to(torch.float32)
     return out
+
+
+def resolve_boundary_layers(kiln_dump: Dict[str, object], capture_b12: bool) -> List[int]:
+    raw = kiln_dump.get("meta__boundary_layers")
+    if isinstance(raw, list) and raw:
+        return sorted({int(v) for v in raw})
+
+    layers = set(B10_BOUNDARY_LAYERS)
+    if capture_b12:
+        layers.update(B12_GQA_LAYERS)
+    return sorted(layers)
 
 
 # -----------------------------------------------------------------------------
@@ -752,6 +773,7 @@ def run_reference_forward(
     checkpoint: str,
     input_ids: torch.Tensor,
     device: torch.device,
+    boundary_layers: Optional[List[int]] = None,
     capture_b11_layer0: bool = False,
     capture_b12: bool = False,
     fp32: bool = False,
@@ -763,6 +785,9 @@ def run_reference_forward(
       shape [1, 1, H].
     - `capture_b11_layer0=True`: 11 full-tensor layer-0 GDN sub-op taps
       under keys in `B11_LAYER0_TAP_NAMES`.
+    - `boundary_layers`: explicit ordered list of `h_layer_<idx>` taps to
+      emit. When omitted, falls back to the legacy B10 set (and the B12 tail
+      extension when `capture_b12=True`).
     - `capture_b12=True`: per-layer `h_layer_{24..30}` taps plus layer-31
       GQA sub-op taps under `b12__<name>` keys.
     - `fp32=True`: load the HF model in float32 (instead of bfloat16) so the
@@ -890,7 +915,9 @@ def run_reference_forward(
     )
 
     taps: Dict[str, torch.Tensor] = {}
-    layers_to_emit: List[int] = list(B10_BOUNDARY_LAYERS)
+    layers_to_emit: List[int] = (
+        sorted(set(boundary_layers)) if boundary_layers is not None else list(B10_BOUNDARY_LAYERS)
+    )
     if capture_b12:
         layers_to_emit = sorted(set(layers_to_emit) | set(B12_GQA_LAYERS))
     for li in layers_to_emit:
@@ -1015,6 +1042,7 @@ def main() -> int:
 
     print(f"[mtp_h_main_ref] loading kiln dump from {args.kiln_dump}", file=sys.stderr)
     kiln = load_kiln_dump(args.kiln_dump)
+    boundary_layers = resolve_boundary_layers(kiln, capture_b12=args.b12_taps)
     draft_token_id = int(kiln.get("meta__draft_token_id", -1))
     mtp_pos = int(kiln.get("meta__mtp_pos", -1))
     print(
@@ -1076,6 +1104,7 @@ def main() -> int:
         args.checkpoint,
         prompt_tokens,
         device,
+        boundary_layers=boundary_layers,
         capture_b11_layer0=args.b11_taps,
         capture_b12=args.b12_taps,
         fp32=args.fp32,
@@ -1098,9 +1127,6 @@ def main() -> int:
     out_dict["meta__replay_tokens_len"] = torch.tensor(
         [int(prompt_tokens.shape[-1])], dtype=torch.int32
     )
-    boundary_layers = list(B10_BOUNDARY_LAYERS)
-    if args.b12_taps:
-        boundary_layers = sorted(set(boundary_layers) | set(B12_GQA_LAYERS))
     out_dict["meta__boundary_layers"] = torch.tensor(
         boundary_layers, dtype=torch.int32
     )


### PR DESCRIPTION
## Summary
- add an opt-in dense early `h_main` sweep for `h_layer_1..8` and serialize the emitted boundary set in `meta__boundary_layers`
- mirror the dynamic boundary set in the HF reference dump and teach the B10 comparator to report the exact earliest layer when adjacent taps split
- commit fresh Phase C40 A6000 artifacts and docs showing the first shared upstream drift now localizes to layer 1 for both seeds

## Validation
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- `source /root/.kiln-build-env && cargo test -p kiln-model mtp_debug --lib -- --test-threads=1`
- RunPod A6000 rerun of the standard native-MTP workload with `KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1`, plus matched HF bf16/fp32 reference replays and `scripts/mtp_compare.py --b10`

## Verdict
- seed 0: first diverging tap `h_layer_1` (`mtp_pos-0-step-1`), last matching tap `h_layer_0`
- seed 1: first diverging tap `h_layer_1` (`mtp_pos-2-step-1`), last matching tap `h_layer_0`
- both bf16 and fp32 references agree, so the remaining span is inside transformer block 1 rather than the old `h_layer_0 -> h_layer_8` range
