### PR TITLE
phase6: bisect transformer block 1 sub-ops after C40

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -580,6 +580,120 @@ GDN projections/conv/qk-norm/gates/recurrent kernel, or the layer-1 residual
 handoff. The next diagnostic task should capture layer-1 sub-op taps rather
 than adding another per-layer sweep.
 
+## Phase C41 post-#427 transformer block 1 sub-op bisect (2026-04-23)
+
+**Scope:** take the post-#427 dense early-layer verdict (`h_layer_0` still ok,
+first shared drift at `h_layer_1`) and narrow it to the earliest shared
+transformer-block-1 sub-op boundary on the same native-MTP replay contract.
+
+**Hardware / image:** RunPod on-demand `NVIDIA A40` (A6000 unavailable; used
+the project fallback order), `ghcr.io/ericflo/kiln-runpod:latest`.
+
+**Code change:** add an opt-in C41 capture path behind
+`KILN_MTP_DUMP_C41_LAYER1_TAPS=1`, serialize the emitted tap ids as
+`meta__c41_tap_ids`, mirror the same tap set in
+`scripts/mtp_h_main_reference_dump.py --c41-taps`, and teach
+`scripts/mtp_compare.py --c41` to report the earliest shared bad layer-1 tap
+from the explicit `c41__*` boundary set. The HF reference path also now slices
+those C41 taps to the final replay token so kiln and HF dump the same shapes.
+
+**Validation commands run (RunPod kiln image):**
+
+```bash
+cd /workspace/kiln
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+source /root/.kiln-build-env
+cargo test -p kiln-model mtp_debug --lib -- --test-threads=1
+```
+
+**Standard workload rerun:** same C40 workload plus the new C41 tap flag:
+
+```bash
+KILN_W4A16=1 \
+KILN_CUDA_GRAPHS=true \
+KILN_SPEC_METHOD=mtp \
+KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_SPLICE=1 \
+KILN_MTP_DUMP_SPLICE_POS=0,2 \
+KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 \
+KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+KILN_MTP_DUMP_C41_LAYER1_TAPS=1 \
+KILN_MTP_DUMP_PATH=.../mtp_pos-{pos}/step-{step}.safetensors \
+./target/release/kiln-bench \
+  --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+  --seed <0|1>
+```
+
+Representative C40 carry-forward positions were re-referenced and compared:
+
+```bash
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-1.safetensors \
+  --out profiling-artifacts/post427_c41_20260423_seed0_ref_bf16.safetensors \
+  --device cuda \
+  --c41-taps
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-1.safetensors \
+  --out profiling-artifacts/post427_c41_20260423_seed1_ref_fp32.safetensors \
+  --device cuda \
+  --fp32 \
+  --c41-taps
+
+python3 scripts/mtp_compare.py --c41 \
+  --pair seed0:profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-1.safetensors,profiling-artifacts/post427_c41_20260423_seed0_ref_bf16.safetensors \
+  --pair seed1:profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-1.safetensors,profiling-artifacts/post427_c41_20260423_seed1_ref_bf16.safetensors
+```
+
+### Fresh workload check
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 8900.8 | 39.0 | 0.740 |
+| 1 | 508 | 479.8 | 42.5 | 0.283 |
+
+The post-#427 seed split still reproduces on fresh main.
+
+### Source-of-truth artifacts
+
+- `profiling-artifacts/post427_c41_20260423_seed0.bench.json`
+- `profiling-artifacts/post427_c41_20260423_seed0.bench.stderr`
+- `profiling-artifacts/post427_c41_20260423_seed1.bench.json`
+- `profiling-artifacts/post427_c41_20260423_seed1.bench.stderr`
+- `profiling-artifacts/post427_c41_20260423_compare_bf16.txt`
+- `profiling-artifacts/post427_c41_20260423_compare_fp32.txt`
+
+### Verdict
+
+**Both seeds and both HF dtypes agree that the earliest bad layer-1 tap is
+`layer_1_post_input_norm`.**
+
+- bf16 compare: earliest shared bad tap = `layer_1_post_input_norm`
+- fp32 compare: earliest shared bad tap = `layer_1_post_input_norm`
+- shared later-good taps still exist (`gdn_gate_beta`, `gdn_recur_out`,
+  `gdn_out_proj`, `layer_1_post_attn_residual`), so this is not a monotonic
+  “everything inside layer 1 is broken” result
+- the first observed bad tensor is already the first explicit C41 boundary
+
+That means the C40 “inside transformer block 1” span is now closed to the
+earliest captured boundary: divergence is already present by the output of
+layer 1 input_layernorm.
+
+### Recommendation
+
+The remaining uncaptured span is now extremely narrow:
+
+- the residual input arriving at transformer block 1
+- the layer-1 `input_layernorm` application itself
+
+Do **not** broaden tracing again. The next task, if needed, should instrument
+the pre-norm residual input and/or audit layer-1 input-layernorm numerics
+directly instead of tracing deeper GDN internals.
+
 ## Phase 6 post-#392 current-main re-profile — 2026-04-23
 
 **Scope:** refresh the Phase 6 performance source of truth on fresh `main`

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -4675,9 +4675,6 @@ pub fn model_forward_segment(
                 let state = linear_state.as_mut().ok_or_else(|| {
                     anyhow::anyhow!("linear attention state required for GDN layers (layer {i})")
                 })?;
-                let capture_b11_taps = crate::mtp_debug::should_capture_b11_tap_for_layer(i);
-                let capture_c41_taps =
-                    crate::mtp_debug::should_capture_c41_layer1_tap_for_layer(i);
                 let normed = {
                     kiln_nvtx::range!(c"kiln/norm/pre_attn");
                     rms_norm(&hidden, &layer.input_layernorm, config.rms_norm_eps)?
@@ -5614,6 +5611,9 @@ fn model_forward_paged_inner(
                 let state = linear_state.as_mut().ok_or_else(|| {
                     anyhow::anyhow!("linear attention state required for GDN layers (layer {i})")
                 })?;
+                let capture_b11_taps = crate::mtp_debug::should_capture_b11_tap_for_layer(i);
+                let capture_c41_taps =
+                    crate::mtp_debug::should_capture_c41_layer1_tap_for_layer(i);
                 let normed = {
                     kiln_nvtx::range!(c"kiln/norm/pre_attn");
                     rms_norm(&hidden, &layer.input_layernorm, config.rms_norm_eps)?

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2600,6 +2600,7 @@ pub fn gated_deltanet_forward(
     recurrent_state: &mut Tensor,
     conv_state: &mut Tensor,
     capture_b11_taps: bool,
+    capture_c41_taps: bool,
 ) -> Result<Tensor> {
     let (batch, seq_len, _hidden) = x.dims3()?;
     let input_dtype = x.dtype();
@@ -2631,6 +2632,10 @@ pub fn gated_deltanet_forward(
     if capture_b11_taps {
         let gdn_in_proj = Tensor::cat(&[&mixed_qkv, &z, &b, &a], candle_core::D::Minus1)?;
         crate::mtp_debug::capture_b11_layer0_tap("gdn_in_proj", &gdn_in_proj)?;
+    }
+    if capture_c41_taps {
+        let gdn_in_proj = Tensor::cat(&[&mixed_qkv, &z, &b, &a], candle_core::D::Minus1)?;
+        crate::mtp_debug::capture_c41_layer1_tap("gdn_in_proj", &gdn_in_proj)?;
     }
 
     // --- Step 2: Causal depthwise conv1d + SiLU on fused QKV ---
@@ -2701,6 +2706,9 @@ pub fn gated_deltanet_forward(
     // `F.silu(...)` (shape [B, T, qkv_dim]).
     if capture_b11_taps {
         crate::mtp_debug::capture_b11_layer0_tap("gdn_conv", &mixed_qkv)?;
+    }
+    if capture_c41_taps {
+        crate::mtp_debug::capture_c41_layer1_tap("gdn_conv", &mixed_qkv)?;
     }
 
     // --- Step 3: Split into Q, K, V and reshape to heads ---
@@ -2831,6 +2839,10 @@ pub fn gated_deltanet_forward(
         crate::mtp_debug::capture_b11_layer0_tap("gdn_qk_norm_q", &q)?;
         crate::mtp_debug::capture_b11_layer0_tap("gdn_qk_norm_k", &k)?;
     }
+    if capture_c41_taps && qk_expanded {
+        crate::mtp_debug::capture_c41_layer1_tap("gdn_qk_norm_q", &q)?;
+        crate::mtp_debug::capture_c41_layer1_tap("gdn_qk_norm_k", &k)?;
+    }
 
     // --- Step 6: Compute gates ---
     //
@@ -2862,6 +2874,10 @@ pub fn gated_deltanet_forward(
     if capture_b11_taps {
         crate::mtp_debug::capture_b11_layer0_tap("gdn_gate_beta", &beta)?;
         crate::mtp_debug::capture_b11_layer0_tap("gdn_gate_g", &g)?;
+    }
+    if capture_c41_taps {
+        crate::mtp_debug::capture_c41_layer1_tap("gdn_gate_beta", &beta)?;
+        crate::mtp_debug::capture_c41_layer1_tap("gdn_gate_g", &g)?;
     }
 
     // --- Step 7: Chunkwise analytical recurrence (Phase 6, approach (b)) ---
@@ -2984,6 +3000,9 @@ pub fn gated_deltanet_forward(
     if capture_b11_taps {
         crate::mtp_debug::capture_b11_layer0_tap("gdn_recur_out", &attn_out)?;
     }
+    if capture_c41_taps {
+        crate::mtp_debug::capture_c41_layer1_tap("gdn_recur_out", &attn_out)?;
+    }
 
     // --- Step 8: Gated RMSNorm — norm(attn_out) * silu(z) ---
     let attn_out = {
@@ -3002,6 +3021,9 @@ pub fn gated_deltanet_forward(
     if capture_b11_taps {
         crate::mtp_debug::capture_b11_layer0_tap("gdn_gated_norm", &attn_out)?;
     }
+    if capture_c41_taps {
+        crate::mtp_debug::capture_c41_layer1_tap("gdn_gated_norm", &attn_out)?;
+    }
 
     // --- Step 9: Output projection ---
     // NOTE: conv1d bias is not loaded by the weight loader. If the model has one,
@@ -3017,6 +3039,9 @@ pub fn gated_deltanet_forward(
     // stream. HF mirror: `self.out_proj(core_attn_out)`.
     if capture_b11_taps {
         crate::mtp_debug::capture_b11_layer0_tap("gdn_out_proj", &out)?;
+    }
+    if capture_c41_taps {
+        crate::mtp_debug::capture_c41_layer1_tap("gdn_out_proj", &out)?;
     }
 
     Ok(out)
@@ -4551,6 +4576,7 @@ pub fn model_forward(
                     &mut state.recurrent_states[linear_attn_idx],
                     &mut state.conv_states[linear_attn_idx],
                     /* capture_b11_taps = */ false,
+                    /* capture_c41_taps = */ false,
                 )
                 .with_context(|| format!("gated deltanet layer {i} (linear attention)"))?;
                 hidden = {
@@ -4661,6 +4687,7 @@ pub fn model_forward_segment(
                     &mut state.recurrent_states[linear_attn_idx],
                     &mut state.conv_states[linear_attn_idx],
                     /* capture_b11_taps = */ false,
+                    /* capture_c41_taps = */ false,
                 )
                 .with_context(|| format!("segment gated deltanet layer {i}"))?;
                 hidden = {
@@ -4896,6 +4923,7 @@ pub fn model_forward_paged_with_last_hidden(
     // giving the comparator both per-layer h_layer_<idx> taps for the GQA
     // tail and per-sub-op taps inside layer 31.
     crate::mtp_debug::arm_b12_gqa_capture();
+    crate::mtp_debug::arm_c41_layer1_capture();
     let (logits, hidden) = model_forward_paged_inner(
         backend,
         token_ids,
@@ -4935,6 +4963,7 @@ pub fn model_forward_paged_last_token_with_last_hidden(
     crate::mtp_debug::arm_h_main_capture();
     crate::mtp_debug::stash_h_main_replay_context(token_ids);
     crate::mtp_debug::arm_b11_layer0_capture();
+    crate::mtp_debug::arm_c41_layer1_capture();
     let (logits, hidden) = model_forward_paged_inner(
         backend,
         token_ids,
@@ -5325,6 +5354,10 @@ pub fn mtp_forward_step(
             // `KILN_MTP_DUMP_B12_GQA_TAPS` is unset, which keeps the dump
             // format bit-identical to the pre-B12 layout.
             let b12_taps = crate::mtp_debug::drain_b12_gqa_capture();
+            // Phase C41: drain any transformer-block-1 taps stashed during
+            // the base-model forward. Empty when
+            // `KILN_MTP_DUMP_C41_LAYER1_TAPS` is unset.
+            let c41_taps = crate::mtp_debug::drain_c41_layer1_capture();
             // Phase C6: drain the 5 pre-RoPE MTP input taps (token_emb,
             // norm_emb, norm_h, concat, fused) captured above. Empty when
             // `KILN_MTP_DUMP_PRE_ROPE` is unset, which keeps the dump format
@@ -5355,6 +5388,7 @@ pub fn mtp_forward_step(
                 &replay_tokens,
                 &b11_taps,
                 &b12_taps,
+                &c41_taps,
                 &c6_taps,
                 &c7_taps,
                 &c14_taps,
@@ -5370,6 +5404,7 @@ pub fn mtp_forward_step(
                     replay_tokens_len = replay_tokens.len(),
                     b11_taps = b11_taps.len(),
                     b12_taps = b12_taps.len(),
+                    c41_taps = c41_taps.len(),
                     c6_taps = c6_taps.len(),
                     c7_taps = c7_taps.len(),
                     c14_taps = c14_taps.len(),
@@ -5584,8 +5619,11 @@ fn model_forward_paged_inner(
                 // layer 0 (the B10 scan localized divergence there) — pre-GDN
                 // input LayerNorm output. Shape [1, T, hidden]. HF mirror:
                 // `hidden_states` after `self.input_layernorm(...)` at layer 0.
-                if crate::mtp_debug::should_capture_b11_tap_for_layer(i) {
+                if capture_b11_taps {
                     crate::mtp_debug::capture_b11_layer0_tap("layer_0_post_input_norm", &normed)?;
+                }
+                if capture_c41_taps {
+                    crate::mtp_debug::capture_c41_layer1_tap("layer_1_post_input_norm", &normed)?;
                 }
                 let attn_out = gated_deltanet_forward(
                     backend,
@@ -5594,14 +5632,20 @@ fn model_forward_paged_inner(
                     config,
                     &mut state.recurrent_states[linear_attn_idx],
                     &mut state.conv_states[linear_attn_idx],
-                    /* capture_b11_taps = */
-                    crate::mtp_debug::should_capture_b11_tap_for_layer(i),
+                    capture_b11_taps,
+                    capture_c41_taps,
                 )
                 .with_context(|| format!("gated deltanet layer {i} (linear attention, paged)"))?;
                 hidden = {
                     kiln_nvtx::range!(c"kiln/residual");
                     (hidden + attn_out)?
                 };
+                if capture_c41_taps {
+                    crate::mtp_debug::capture_c41_layer1_tap(
+                        "layer_1_post_attn_residual",
+                        &hidden,
+                    )?;
+                }
                 let normed_post = {
                     kiln_nvtx::range!(c"kiln/norm/pre_mlp");
                     rms_norm(
@@ -5615,6 +5659,9 @@ fn model_forward_paged_inner(
                     kiln_nvtx::range!(c"kiln/residual");
                     (hidden + ffn_out)?
                 };
+                if capture_c41_taps {
+                    crate::mtp_debug::capture_c41_layer1_tap("layer_1_output", &hidden)?;
+                }
                 linear_attn_idx += 1;
             }
         }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -4675,6 +4675,9 @@ pub fn model_forward_segment(
                 let state = linear_state.as_mut().ok_or_else(|| {
                     anyhow::anyhow!("linear attention state required for GDN layers (layer {i})")
                 })?;
+                let capture_b11_taps = crate::mtp_debug::should_capture_b11_tap_for_layer(i);
+                let capture_c41_taps =
+                    crate::mtp_debug::should_capture_c41_layer1_tap_for_layer(i);
                 let normed = {
                     kiln_nvtx::range!(c"kiln/norm/pre_attn");
                     rms_norm(&hidden, &layer.input_layernorm, config.rms_norm_eps)?

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -130,6 +130,19 @@ thread_local! {
     static B12_GQA_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
         const { RefCell::new(None) };
 
+    /// Phase C41: thread-local sink for transformer block 1 (layer 1) GDN
+    /// sub-op taps. Distinct from the B11 layer-0 sink because C41 is a new
+    /// bisect contract over a different layer and includes explicit residual
+    /// handoff taps (`layer_1_post_attn_residual`, `layer_1_output`) that do
+    /// not belong in the historical B11 namespace.
+    ///
+    /// Driven by [`arm_c41_layer1_capture`] / [`drain_c41_layer1_capture`] /
+    /// [`capture_c41_layer1_tap`], and gated on
+    /// `KILN_MTP_DUMP_C41_LAYER1_TAPS=1` so production decode stays on the
+    /// current fast path when unset.
+    static C41_LAYER1_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
+        const { RefCell::new(None) };
+
     /// Phase B12: thread-local "current absolute layer index" slot. Set by
     /// the main transformer layer loop around each layer's forward call so
     /// that deep inside `gqa_attention_paged` / `transformer_block_paged`
@@ -796,6 +809,87 @@ pub const B12_GQA_TAP_NAMES: &[&str] = &[
     "mlp_up",
     "mlp_down",
 ];
+
+/// True when `KILN_MTP_DUMP_C41_LAYER1_TAPS=1` (or `true`) is set. Opt-in for
+/// the Phase C41 transformer-block-1 bisect: when enabled alongside
+/// `KILN_MTP_DUMP_PATH` *and* `KILN_MTP_DUMP_HIDDEN_STATES=1`, the base-model
+/// forward records the layer-1 GDN and residual-handoff taps listed in
+/// [`C41_LAYER1_TAP_NAMES`] and appends them to the MTP dump safetensors under
+/// names `c41__<name>`.
+pub fn is_dump_c41_layer1_taps_enabled() -> bool {
+    std::env::var("KILN_MTP_DUMP_C41_LAYER1_TAPS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Canonical ordered list of Phase C41 transformer-block-1 tap names. The
+/// comparator (`scripts/mtp_compare.py --c41`) and the HF reference
+/// (`scripts/mtp_h_main_reference_dump.py --c41-taps`) both mirror this exact
+/// order. The list is intentionally minimal and explicit: the earliest bad tap
+/// should identify the first bad boundary *inside* layer 1 without turning C41
+/// into a general-purpose tracing framework.
+pub const C41_LAYER1_TAP_NAMES: &[&str] = &[
+    "layer_1_post_input_norm",
+    "gdn_in_proj",
+    "gdn_conv",
+    "gdn_qk_norm_q",
+    "gdn_qk_norm_k",
+    "gdn_gate_beta",
+    "gdn_gate_g",
+    "gdn_recur_out",
+    "gdn_gated_norm",
+    "gdn_out_proj",
+    "layer_1_post_attn_residual",
+    "layer_1_output",
+];
+
+/// True if the Phase C41 layer-1 capture window is currently armed on this
+/// thread. Call sites use this to gate the host copy so disarmed runs pay zero
+/// cost.
+pub fn is_c41_layer1_capture_armed() -> bool {
+    C41_LAYER1_CAPTURE.with(|c| c.borrow().is_some())
+}
+
+/// True if a C41 transformer-block-1 capture should happen for `layer_idx`.
+/// Exposed as a helper so forward.rs can keep the call sites local to layer 1
+/// without needing another scope-tracking TLS slot.
+pub fn should_capture_c41_layer1_tap_for_layer(layer_idx: usize) -> bool {
+    layer_idx == 1 && is_c41_layer1_capture_armed()
+}
+
+/// Begin a C41 layer-1 capture window. Subsequent
+/// [`capture_c41_layer1_tap`] calls from the same thread record into a fresh
+/// buffer until [`drain_c41_layer1_capture`] is called. Does nothing if
+/// [`is_dump_c41_layer1_taps_enabled`] is false.
+pub fn arm_c41_layer1_capture() {
+    if !is_dump_c41_layer1_taps_enabled() {
+        return;
+    }
+    C41_LAYER1_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
+}
+
+/// Drain the captured C41 layer-1 taps and disarm. Returns whatever was
+/// recorded since the matching [`arm_c41_layer1_capture`] call, in order.
+pub fn drain_c41_layer1_capture() -> Vec<(String, Vec<usize>, Vec<f32>)> {
+    C41_LAYER1_CAPTURE.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+/// Record one named C41 transformer-block-1 tap if a capture window is
+/// currently open on this thread.
+pub fn capture_c41_layer1_tap(name: &str, t: &Tensor) -> Result<()> {
+    let armed = C41_LAYER1_CAPTURE.with(|c| c.borrow().is_some());
+    if !armed {
+        return Ok(());
+    }
+    let (shape, flat) = tensor_to_f32_host(t)
+        .with_context(|| format!("capture_c41_layer1_tap `{name}`: tensor→f32 host copy"))?;
+    C41_LAYER1_CAPTURE.with(|c| {
+        if let Some(buf) = c.borrow_mut().as_mut() {
+            buf.push((name.to_string(), shape, flat));
+        }
+    });
+    Ok(())
+}
 
 /// True if the Phase B12 layer-31 GQA capture window is currently armed on
 /// this thread. Call sites use this to gate the (relatively cheap) host
@@ -1464,6 +1558,7 @@ pub fn write_mtp_dump(
     replay_tokens: &[u32],
     b11_taps: &[(String, Vec<usize>, Vec<f32>)],
     b12_taps: &[(String, Vec<usize>, Vec<f32>)],
+    c41_taps: &[(String, Vec<usize>, Vec<f32>)],
     c6_taps: &[(String, Vec<usize>, Vec<f32>)],
     c7_taps: &[(String, Vec<usize>, Vec<f32>)],
     c14_taps: &[(String, Vec<usize>, Vec<f32>)],
@@ -1473,11 +1568,12 @@ pub fn write_mtp_dump(
     // Materialize every tensor to a host byte buffer first so the
     // TensorViews we build below can borrow from a stable backing store.
     // Capacity: static taps + subops + 4 meta + optional boundary-layer meta
-    // + optional prompt/replay token
-    // tensors + b11 taps + b12 taps + c6 taps + c7 taps + c14 taps.
+    // + optional prompt/replay token tensors + b11 taps + b12 taps + optional
+    // C41 tap-id meta + c41 taps + c6 taps + c7 taps + c14 taps.
     let boundary_reserve = if boundary_layers.is_empty() { 0 } else { 1 };
     let prompt_reserve = if prompt_tokens.is_empty() { 0 } else { 2 };
     let replay_reserve = if replay_tokens.is_empty() { 0 } else { 2 };
+    let c41_meta_reserve = if c41_taps.is_empty() { 0 } else { 1 };
     let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> = Vec::with_capacity(
         taps.len()
             + extra_subops.len()
@@ -1487,6 +1583,8 @@ pub fn write_mtp_dump(
             + replay_reserve
             + b11_taps.len()
             + b12_taps.len()
+            + c41_meta_reserve
+            + c41_taps.len()
             + c6_taps.len()
             + c7_taps.len()
             + c14_taps.len(),
@@ -1623,6 +1721,32 @@ pub fn write_mtp_dump(
             bytes.extend_from_slice(&v.to_le_bytes());
         }
         backings.push((format!("b12__{name}"), shape.clone(), Dtype::F32, bytes));
+    }
+
+    if !c41_taps.is_empty() {
+        let mut bytes = Vec::with_capacity(c41_taps.len() * 4);
+        for (name, _shape, _flat) in c41_taps {
+            let idx = C41_LAYER1_TAP_NAMES
+                .iter()
+                .position(|&tap| tap == name.as_str())
+                .with_context(|| format!("unknown C41 tap `{name}`"))?;
+            let idx_i32 = idx as i32;
+            bytes.extend_from_slice(&idx_i32.to_le_bytes());
+        }
+        backings.push((
+            "meta__c41_tap_ids".into(),
+            vec![c41_taps.len()],
+            Dtype::I32,
+            bytes,
+        ));
+    }
+
+    for (name, shape, flat) in c41_taps {
+        let mut bytes = Vec::with_capacity(flat.len() * 4);
+        for v in flat {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        backings.push((format!("c41__{name}"), shape.clone(), Dtype::F32, bytes));
     }
 
     // Phase C6: serialize the pre-RoPE MTP-input taps under `c6__<name>` so
@@ -2089,6 +2213,7 @@ mod tests {
             &prompt,
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
+            /* c41_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2218,6 +2343,7 @@ mod tests {
             /* replay_tokens = */ &[],
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
+            /* c41_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2361,6 +2487,7 @@ mod tests {
             /* replay_tokens = */ &[],
             &b11,
             /* b12_taps = */ &[],
+            /* c41_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2407,6 +2534,65 @@ mod tests {
         assert_eq!(B12_GQA_TAP_NAMES.len(), 14);
         assert_eq!(B12_GQA_TAP_NAMES[0], "post_input_norm");
         assert_eq!(B12_GQA_TAP_NAMES[13], "mlp_down");
+    }
+
+    #[test]
+    fn c41_layer1_tap_names_enumerate_expected_boundaries() {
+        assert_eq!(C41_LAYER1_TAP_NAMES.len(), 12);
+        assert_eq!(C41_LAYER1_TAP_NAMES[0], "layer_1_post_input_norm");
+        assert_eq!(C41_LAYER1_TAP_NAMES[10], "layer_1_post_attn_residual");
+        assert_eq!(C41_LAYER1_TAP_NAMES[11], "layer_1_output");
+    }
+
+    #[test]
+    fn c41_layer1_capture_records_then_drains() {
+        let _guard = test_env_lock();
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_C41_LAYER1_TAPS", "1");
+        }
+        let a = Tensor::new(&[1.0_f32, 2.0, 3.0][..], &Device::Cpu).unwrap();
+        let b = Tensor::new(&[10.0_f32, 20.0][..], &Device::Cpu).unwrap();
+
+        capture_c41_layer1_tap("layer_1_post_input_norm", &a).unwrap();
+        assert!(drain_c41_layer1_capture().is_empty());
+        assert!(!is_c41_layer1_capture_armed());
+        assert!(!should_capture_c41_layer1_tap_for_layer(1));
+
+        arm_c41_layer1_capture();
+        assert!(is_c41_layer1_capture_armed());
+        assert!(should_capture_c41_layer1_tap_for_layer(1));
+        assert!(!should_capture_c41_layer1_tap_for_layer(0));
+        capture_c41_layer1_tap("layer_1_post_input_norm", &a).unwrap();
+        capture_c41_layer1_tap("layer_1_output", &b).unwrap();
+        let drained = drain_c41_layer1_capture();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].0, "layer_1_post_input_norm");
+        assert_eq!(drained[0].1, vec![3]);
+        assert_eq!(drained[0].2, vec![1.0, 2.0, 3.0]);
+        assert_eq!(drained[1].0, "layer_1_output");
+        assert_eq!(drained[1].1, vec![2]);
+        assert_eq!(drained[1].2, vec![10.0, 20.0]);
+
+        assert!(!is_c41_layer1_capture_armed());
+        capture_c41_layer1_tap("gdn_in_proj", &a).unwrap();
+        assert!(drain_c41_layer1_capture().is_empty());
+
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C41_LAYER1_TAPS");
+        }
+    }
+
+    #[test]
+    fn c41_layer1_arm_is_noop_when_env_unset() {
+        let _guard = test_env_lock();
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C41_LAYER1_TAPS");
+        }
+        arm_c41_layer1_capture();
+        assert!(!is_c41_layer1_capture_armed());
+        let a = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        capture_c41_layer1_tap("layer_1_post_input_norm", &a).unwrap();
+        assert!(drain_c41_layer1_capture().is_empty());
     }
 
     #[test]
@@ -2497,6 +2683,7 @@ mod tests {
             /* replay_tokens = */ &[],
             /* b11_taps = */ &[],
             &b12,
+            /* c41_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2524,6 +2711,67 @@ mod tests {
         let md = st.tensor("b12__mlp_down").unwrap();
         assert_eq!(md.dtype(), safetensors::Dtype::F32);
         assert_eq!(md.shape(), &[3]);
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn write_mtp_dump_emits_c41_taps_and_metadata_when_provided() {
+        use safetensors::SafeTensors;
+
+        let h = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        let tmp = std::env::temp_dir().join("kiln_mtp_dump_with_c41.safetensors");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let c41 = vec![
+            (
+                "layer_1_post_input_norm".to_string(),
+                vec![2],
+                vec![0.61_f32, 0.62],
+            ),
+            (
+                "layer_1_output".to_string(),
+                vec![3],
+                vec![0.71_f32, 0.72, 0.73],
+            ),
+        ];
+        write_mtp_dump(
+            &tmp_s,
+            /* draft_token_id = */ 55,
+            /* mtp_pos = */ 0,
+            /* base_pos = */ 0,
+            /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[],
+            &[("h_main", &h)],
+            &[],
+            /* prompt_tokens = */ &[],
+            /* replay_tokens = */ &[],
+            /* b11_taps = */ &[],
+            /* b12_taps = */ &[],
+            &c41,
+            /* c6_taps = */ &[],
+            /* c7_taps = */ &[],
+            /* c14_taps = */ &[],
+        )
+        .unwrap();
+
+        let raw = std::fs::read(&tmp).unwrap();
+        let st = SafeTensors::deserialize(&raw).unwrap();
+        let names: Vec<&str> = st.names().into_iter().map(|s| s.as_str()).collect();
+        assert!(names.contains(&"c41__layer_1_post_input_norm"));
+        assert!(names.contains(&"c41__layer_1_output"));
+        assert!(names.contains(&"meta__c41_tap_ids"));
+
+        let ids = st.tensor("meta__c41_tap_ids").unwrap();
+        assert_eq!(ids.dtype(), safetensors::Dtype::I32);
+        assert_eq!(ids.shape(), &[2]);
+        let id0 = i32::from_le_bytes(ids.data()[0..4].try_into().unwrap());
+        let id1 = i32::from_le_bytes(ids.data()[4..8].try_into().unwrap());
+        assert_eq!(id0, 0);
+        assert_eq!(id1, 11);
+
+        let out = st.tensor("c41__layer_1_output").unwrap();
+        assert_eq!(out.dtype(), safetensors::Dtype::F32);
+        assert_eq!(out.shape(), &[3]);
 
         let _ = std::fs::remove_file(&tmp);
     }
@@ -2718,6 +2966,7 @@ mod tests {
             /* replay_tokens = */ &[],
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
+            /* c41_taps = */ &[],
             &c6,
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2850,6 +3099,7 @@ mod tests {
             /* replay_tokens = */ &[],
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
+            /* c41_taps = */ &[],
             /* c6_taps = */ &[],
             &c7,
             /* c14_taps = */ &[],
@@ -3008,6 +3258,7 @@ mod tests {
             /* replay_tokens = */ &[],
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
+            /* c41_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             &c14,

--- a/docs/phase-c41/c41-layer1-subop-bisect.md
+++ b/docs/phase-c41/c41-layer1-subop-bisect.md
@@ -1,0 +1,188 @@
+# Phase C41 — transformer block 1 sub-op bisect after PR #427
+
+**Date:** 2026-04-23  
+**Current main preflight base:** `5b79676` (PR #427 on `main`)  
+**Hardware:** RunPod `NVIDIA A40` via `ghcr.io/ericflo/kiln-runpod:latest`
+
+## Preflight
+
+1. **Fresh-main source of truth still valid:** satisfied. Fresh `origin/main`
+   still pointed at PR #427 and
+   [`docs/phase-c40/c40-early-hmain-bisect.md`](../phase-c40/c40-early-hmain-bisect.md)
+   remained the latest committed source of truth for this bisect path.
+2. **Committed C40 verdict still held:** satisfied. C40 still recorded
+   `h_layer_0` as matching and `h_layer_1` as the first shared bad layer for
+   both seeds.
+3. **No committed layer-1 sub-op localization already landed:** satisfied.
+   Fresh main did not already contain committed C41 taps or a localized
+   transformer-block-1 earliest-bad boundary.
+
+## Code change
+
+This task adds a minimal, opt-in C41 bisect path for transformer block 1:
+
+- `crates/kiln-model/src/mtp_debug.rs`
+  adds the dedicated `KILN_MTP_DUMP_C41_LAYER1_TAPS=1` capture switch, the
+  canonical C41 tap list, thread-local capture plumbing, and safetensors
+  metadata serialization via `meta__c41_tap_ids`.
+- `crates/kiln-model/src/forward.rs`
+  arms C41 only on the base-model replay path and captures the explicit
+  transformer-block-1 boundaries:
+  `layer_1_post_input_norm`, GDN in-proj / conv / qk-norm / gates /
+  recurrent output / gated norm / out-proj, `layer_1_post_attn_residual`, and
+  `layer_1_output`.
+- `scripts/mtp_h_main_reference_dump.py`
+  mirrors the same boundary set under `--c41-taps`, resolves tap ordering from
+  kiln metadata, and slices the captured HF tensors to the final replay token
+  so the reference dump matches kiln's `[1, 1, ...]` shape contract.
+- `scripts/mtp_compare.py`
+  adds `--c41` mode and narrows the per-pair / summary report to the explicit
+  `c41__*` tap set so the earliest shared bad layer-1 boundary is reported
+  cleanly.
+
+Default decode remains unchanged when `KILN_MTP_DUMP_C41_LAYER1_TAPS` is
+unset.
+
+## Validation commands run
+
+```bash
+cd /workspace/kiln
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+source /root/.kiln-build-env
+cargo test -p kiln-model mtp_debug --lib -- --test-threads=1
+```
+
+## Standard workload commands run
+
+```bash
+for seed in 0 1; do
+  root=/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed${seed}_captures
+  rm -rf "$root"
+  mkdir -p "$root"/mtp_pos-0 "$root"/mtp_pos-2
+
+  KILN_W4A16=1 \
+  KILN_CUDA_GRAPHS=true \
+  KILN_SPEC_METHOD=mtp \
+  KILN_BENCH_FORCE_MTP=1 \
+  KILN_MTP_DUMP_SPLICE=1 \
+  KILN_MTP_DUMP_SPLICE_POS=0,2 \
+  KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+  KILN_MTP_DUMP_HIDDEN_STATES=1 \
+  KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+  KILN_MTP_DUMP_C41_LAYER1_TAPS=1 \
+  KILN_MTP_DUMP_PATH=$root/mtp_pos-{pos}/step-{step}.safetensors \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+    --seed ${seed} \
+    > /workspace/kiln/profiling-artifacts/post427_c41_20260423_seed${seed}.bench.json \
+    2> /workspace/kiln/profiling-artifacts/post427_c41_20260423_seed${seed}.bench.stderr
+done
+```
+
+Representative C40 divergence points were then re-referenced:
+
+- seed 0 representative dump:
+  `profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-1.safetensors`
+- seed 1 representative dump:
+  `profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-1.safetensors`
+
+Reference regeneration and compare commands:
+
+```bash
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-1.safetensors \
+  --out profiling-artifacts/post427_c41_20260423_seed0_ref_bf16.safetensors \
+  --device cuda \
+  --c41-taps
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-1.safetensors \
+  --out profiling-artifacts/post427_c41_20260423_seed0_ref_fp32.safetensors \
+  --device cuda \
+  --fp32 \
+  --c41-taps
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-1.safetensors \
+  --out profiling-artifacts/post427_c41_20260423_seed1_ref_bf16.safetensors \
+  --device cuda \
+  --c41-taps
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-1.safetensors \
+  --out profiling-artifacts/post427_c41_20260423_seed1_ref_fp32.safetensors \
+  --device cuda \
+  --fp32 \
+  --c41-taps
+
+python3 scripts/mtp_compare.py --c41 \
+  --pair seed0:profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-1.safetensors,profiling-artifacts/post427_c41_20260423_seed0_ref_bf16.safetensors \
+  --pair seed1:profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-1.safetensors,profiling-artifacts/post427_c41_20260423_seed1_ref_bf16.safetensors \
+  --out profiling-artifacts/post427_c41_20260423_compare_bf16.txt
+
+python3 scripts/mtp_compare.py --c41 \
+  --pair seed0:profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-1.safetensors,profiling-artifacts/post427_c41_20260423_seed0_ref_fp32.safetensors \
+  --pair seed1:profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-1.safetensors,profiling-artifacts/post427_c41_20260423_seed1_ref_fp32.safetensors \
+  --out profiling-artifacts/post427_c41_20260423_compare_fp32.txt
+```
+
+## Fresh workload check
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 8900.8 | 39.0 | 0.740 |
+| 1 | 508 | 479.8 | 42.5 | 0.283 |
+
+The post-#427 seed split still reproduces.
+
+## Committed artifacts
+
+- [`profiling-artifacts/post427_c41_20260423_seed0.bench.json`](../../profiling-artifacts/post427_c41_20260423_seed0.bench.json)
+- [`profiling-artifacts/post427_c41_20260423_seed0.bench.stderr`](../../profiling-artifacts/post427_c41_20260423_seed0.bench.stderr)
+- [`profiling-artifacts/post427_c41_20260423_seed1.bench.json`](../../profiling-artifacts/post427_c41_20260423_seed1.bench.json)
+- [`profiling-artifacts/post427_c41_20260423_seed1.bench.stderr`](../../profiling-artifacts/post427_c41_20260423_seed1.bench.stderr)
+- [`profiling-artifacts/post427_c41_20260423_compare_bf16.txt`](../../profiling-artifacts/post427_c41_20260423_compare_bf16.txt)
+- [`profiling-artifacts/post427_c41_20260423_compare_fp32.txt`](../../profiling-artifacts/post427_c41_20260423_compare_fp32.txt)
+
+## Verdict
+
+**The earliest shared bad layer-1 sub-op boundary is
+`layer_1_post_input_norm`.**
+
+Across both bf16 and fp32 reference comparisons:
+
+| Reference dtype | Seed 0 verdict | Seed 1 verdict | Shared earliest bad tap |
+| --- | --- | --- | --- |
+| bf16 | `layer_1_post_input_norm` | `layer_1_post_input_norm` | `layer_1_post_input_norm` |
+| fp32 | `layer_1_post_input_norm` | `layer_1_post_input_norm` | `layer_1_post_input_norm` |
+
+Representative C41 rows:
+
+- seed 0 bf16:
+  `layer_1_post_input_norm` is already `DIV`, `gdn_gate_beta` and
+  `gdn_recur_out` remain `ok`, and `layer_1_post_attn_residual` returns to
+  `ok`
+- seed 1 fp32:
+  `layer_1_post_input_norm` is already `DIV`, `gdn_conv` remains `ok`,
+  `gdn_gate_beta` remains `ok`, and `layer_1_post_attn_residual` remains `ok`
+
+This is enough to close the C40 task premise. The first observed bad tensor is
+not “somewhere inside transformer block 1” anymore; it is already present at
+the output of layer 1 input_layernorm.
+
+## Narrowest remaining span
+
+Because the earliest bad tap is the first explicit C41 boundary, the remaining
+uncaptured span is narrower than the GDN internals:
+
+- the residual input entering transformer block 1
+- the layer-1 `input_layernorm` application itself
+
+If there is a follow-up, it should instrument the pre-norm residual input or
+audit the layer-1 input-layernorm numerics directly. It should **not** widen
+the tracing deeper into later layer-1 sub-ops again.

--- a/profiling-artifacts/post427_c41_20260423_compare_bf16.txt
+++ b/profiling-artifacts/post427_c41_20260423_compare_bf16.txt
@@ -1,0 +1,84 @@
+MTP numerical bisect — mode: transformer block 1 bisect (C41), atol=0.01, rtol=0.1
+
+=== seed0 ===
+  kiln dump : profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : profiling-artifacts/post427_c41_20260423_seed0_ref_bf16.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c41__layer_1_post_input_norm 1x1x2560               True     False    9.98e-01   1.46e-01     3.47e-02    
+c41__gdn_in_proj       1x1x12352              True     False    9.98e-01   1.72e-01     2.33e-02    
+c41__gdn_conv          1x1x8192               True     False    9.99e-01   2.77e-02     3.76e-04    
+c41__gdn_qk_norm_q     1x1x32x128             True     False    9.99e-01   7.94e-01     4.40e-02    
+c41__gdn_qk_norm_k     1x1x32x128             True     False    9.98e-01   3.47e-02     3.46e-03    
+c41__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.12e-02     9.67e-03    
+c41__gdn_gate_g        1x1x32                 True     True     9.99e-01   1.83e-01     2.88e-02    
+c41__gdn_recur_out     1x1x32x128             True     True     1.00e+00   6.71e-04     3.70e-06    
+c41__gdn_gated_norm    1x1x4096               True     False    9.97e-01   1.39e-02     5.04e-04    
+c41__gdn_out_proj      1x1x2560               True     True     9.98e-01   3.91e-03     6.42e-04    
+c41__layer_1_post_attn_residual 1x1x2560               True     True     9.99e-01   1.56e-02     1.70e-03    
+c41__layer_1_output    1x1x2560               True     False    9.98e-01   3.12e-02     2.86e-03    
+
+  pair verdict: first divergence at tap 'c41__layer_1_post_input_norm'.
+    Most-likely cause: <unknown tap>
+
+=== seed1 ===
+  kiln dump : profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : profiling-artifacts/post427_c41_20260423_seed1_ref_bf16.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c41__layer_1_post_input_norm 1x1x2560               True     False    9.98e-01   1.56e-01     3.41e-02    
+c41__gdn_in_proj       1x1x12352              True     False    9.98e-01   2.27e-01     2.31e-02    
+c41__gdn_conv          1x1x8192               True     True     9.99e-01   1.57e-02     4.15e-04    
+c41__gdn_qk_norm_q     1x1x32x128             True     False    9.98e-01   7.72e-01     4.49e-02    
+c41__gdn_qk_norm_k     1x1x32x128             True     False    9.98e-01   2.59e-02     3.75e-03    
+c41__gdn_gate_beta     1x1x32                 True     True     1.00e+00   2.34e-02     7.85e-03    
+c41__gdn_gate_g        1x1x32                 True     False    9.99e-01   6.15e-01     9.00e-02    
+c41__gdn_recur_out     1x1x32x128             True     True     1.00e+00   5.49e-04     4.78e-06    
+c41__gdn_gated_norm    1x1x4096               True     False    9.97e-01   3.08e-02     6.16e-04    
+c41__gdn_out_proj      1x1x2560               True     True     9.98e-01   5.86e-03     7.93e-04    
+c41__layer_1_post_attn_residual 1x1x2560               True     True     9.99e-01   1.56e-02     1.50e-03    
+c41__layer_1_output    1x1x2560               True     False    9.98e-01   1.56e-02     2.94e-03    
+
+  pair verdict: first divergence at tap 'c41__layer_1_post_input_norm'.
+    Most-likely cause: <unknown tap>
+
+==============================================================================
+Phase C41 transformer block 1 bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                         seed0                                                seed1                                               
+  -------------------------------------------------------------------------------------------------------------------------------------
+  layer_1_post_input_norm     cos=9.98e-01   max|Δ|=1.46e-01   mean|Δ|=3.47e-02   rel_l2=5.65e-02   DIV cos=9.98e-01   max|Δ|=1.56e-01   mean|Δ|=3.41e-02   rel_l2=5.77e-02   DIV
+  gdn_in_proj                 cos=9.98e-01   max|Δ|=1.72e-01   mean|Δ|=2.33e-02   rel_l2=5.79e-02   DIV cos=9.98e-01   max|Δ|=2.27e-01   mean|Δ|=2.31e-02   rel_l2=6.53e-02   DIV
+  gdn_conv                    cos=9.99e-01   max|Δ|=2.77e-02   mean|Δ|=3.76e-04   rel_l2=3.81e-02   DIV cos=9.99e-01   max|Δ|=1.57e-02   mean|Δ|=4.15e-04   rel_l2=3.59e-02   ok 
+  gdn_qk_norm_q               cos=9.99e-01   max|Δ|=7.94e-01   mean|Δ|=4.40e-02   rel_l2=9.12e-01   DIV cos=9.98e-01   max|Δ|=7.72e-01   mean|Δ|=4.49e-02   rel_l2=9.12e-01   DIV
+  gdn_qk_norm_k               cos=9.98e-01   max|Δ|=3.47e-02   mean|Δ|=3.46e-03   rel_l2=5.69e-02   DIV cos=9.98e-01   max|Δ|=2.59e-02   mean|Δ|=3.75e-03   rel_l2=6.06e-02   DIV
+  gdn_gate_beta               cos=1.00e+00   max|Δ|=3.12e-02   mean|Δ|=9.67e-03   rel_l2=2.89e-02   ok  cos=1.00e+00   max|Δ|=2.34e-02   mean|Δ|=7.85e-03   rel_l2=1.89e-02   ok 
+  gdn_gate_g                  cos=9.99e-01   max|Δ|=1.83e-01   mean|Δ|=2.88e-02   rel_l2=3.87e-02   ok  cos=9.99e-01   max|Δ|=6.15e-01   mean|Δ|=9.00e-02   rel_l2=1.25e-01   DIV
+  gdn_recur_out               cos=1.00e+00   max|Δ|=6.71e-04   mean|Δ|=3.70e-06   rel_l2=2.89e-02   ok  cos=1.00e+00   max|Δ|=5.49e-04   mean|Δ|=4.78e-06   rel_l2=2.75e-02   ok 
+  gdn_gated_norm              cos=9.97e-01   max|Δ|=1.39e-02   mean|Δ|=5.04e-04   rel_l2=8.11e-02   DIV cos=9.97e-01   max|Δ|=3.08e-02   mean|Δ|=6.16e-04   rel_l2=8.07e-02   DIV
+  gdn_out_proj                cos=9.98e-01   max|Δ|=3.91e-03   mean|Δ|=6.42e-04   rel_l2=5.71e-02   ok  cos=9.98e-01   max|Δ|=5.86e-03   mean|Δ|=7.93e-04   rel_l2=6.06e-02   ok 
+  layer_1_post_attn_residual  cos=9.99e-01   max|Δ|=1.56e-02   mean|Δ|=1.70e-03   rel_l2=3.60e-02   ok  cos=9.99e-01   max|Δ|=1.56e-02   mean|Δ|=1.50e-03   rel_l2=3.59e-02   ok 
+  layer_1_output              cos=9.98e-01   max|Δ|=3.12e-02   mean|Δ|=2.86e-03   rel_l2=6.12e-02   DIV cos=9.98e-01   max|Δ|=1.56e-02   mean|Δ|=2.94e-03   rel_l2=6.82e-02   DIV
+
+  earliest shared bad tap: 'layer_1_post_input_norm'
+Phase C41 verdict: EARLIEST SHARED BAD LAYER-1 TAP = 'layer_1_post_input_norm'.
+    Most-likely cause: layer 1 input_layernorm weight/eps or the layer-1 residual input frame
+  -> Divergence is already present at the first captured layer-1 boundary.
+
+Overall verdict: divergence(s) at: ['c41__layer_1_post_input_norm', 'c41__layer_1_post_input_norm']

--- a/profiling-artifacts/post427_c41_20260423_compare_fp32.txt
+++ b/profiling-artifacts/post427_c41_20260423_compare_fp32.txt
@@ -1,0 +1,84 @@
+MTP numerical bisect — mode: transformer block 1 bisect (C41), atol=0.01, rtol=0.1
+
+=== seed0 ===
+  kiln dump : profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : profiling-artifacts/post427_c41_20260423_seed0_ref_fp32.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c41__layer_1_post_input_norm 1x1x2560               True     False    9.98e-01   1.46e-01     3.46e-02    
+c41__gdn_in_proj       1x1x12352              True     False    9.98e-01   1.66e-01     2.33e-02    
+c41__gdn_conv          1x1x8192               True     False    9.99e-01   2.94e-02     3.75e-04    
+c41__gdn_qk_norm_q     1x1x32x128             True     False    9.99e-01   7.93e-01     4.40e-02    
+c41__gdn_qk_norm_k     1x1x32x128             True     False    9.98e-01   3.33e-02     3.44e-03    
+c41__gdn_gate_beta     1x1x32                 True     True     1.00e+00   3.22e-02     9.47e-03    
+c41__gdn_gate_g        1x1x32                 True     True     9.99e-01   1.96e-01     3.07e-02    
+c41__gdn_recur_out     1x1x32x128             True     True     1.00e+00   6.76e-04     3.67e-06    
+c41__gdn_gated_norm    1x1x4096               True     False    9.97e-01   1.40e-02     5.05e-04    
+c41__gdn_out_proj      1x1x2560               True     True     9.98e-01   5.02e-03     6.50e-04    
+c41__layer_1_post_attn_residual 1x1x2560               True     True     9.99e-01   1.90e-02     1.70e-03    
+c41__layer_1_output    1x1x2560               True     False    9.98e-01   3.65e-02     2.86e-03    
+
+  pair verdict: first divergence at tap 'c41__layer_1_post_input_norm'.
+    Most-likely cause: <unknown tap>
+
+=== seed1 ===
+  kiln dump : profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : profiling-artifacts/post427_c41_20260423_seed1_ref_fp32.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c41__layer_1_post_input_norm 1x1x2560               True     False    9.98e-01   1.50e-01     3.40e-02    
+c41__gdn_in_proj       1x1x12352              True     False    9.98e-01   2.13e-01     2.29e-02    
+c41__gdn_conv          1x1x8192               True     True     9.99e-01   1.48e-02     4.12e-04    
+c41__gdn_qk_norm_q     1x1x32x128             True     False    9.98e-01   7.75e-01     4.49e-02    
+c41__gdn_qk_norm_k     1x1x32x128             True     False    9.98e-01   2.56e-02     3.70e-03    
+c41__gdn_gate_beta     1x1x32                 True     True     1.00e+00   2.25e-02     7.10e-03    
+c41__gdn_gate_g        1x1x32                 True     False    9.99e-01   5.80e-01     8.38e-02    
+c41__gdn_recur_out     1x1x32x128             True     True     1.00e+00   5.14e-04     4.57e-06    
+c41__gdn_gated_norm    1x1x4096               True     False    9.97e-01   3.12e-02     6.07e-04    
+c41__gdn_out_proj      1x1x2560               True     True     9.98e-01   8.41e-03     7.90e-04    
+c41__layer_1_post_attn_residual 1x1x2560               True     True     9.99e-01   9.23e-03     1.48e-03    
+c41__layer_1_output    1x1x2560               True     False    9.98e-01   2.89e-02     2.94e-03    
+
+  pair verdict: first divergence at tap 'c41__layer_1_post_input_norm'.
+    Most-likely cause: <unknown tap>
+
+==============================================================================
+Phase C41 transformer block 1 bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                         seed0                                                seed1                                               
+  -------------------------------------------------------------------------------------------------------------------------------------
+  layer_1_post_input_norm     cos=9.98e-01   max|Δ|=1.46e-01   mean|Δ|=3.46e-02   rel_l2=5.64e-02   DIV cos=9.98e-01   max|Δ|=1.50e-01   mean|Δ|=3.40e-02   rel_l2=5.75e-02   DIV
+  gdn_in_proj                 cos=9.98e-01   max|Δ|=1.66e-01   mean|Δ|=2.33e-02   rel_l2=5.79e-02   DIV cos=9.98e-01   max|Δ|=2.13e-01   mean|Δ|=2.29e-02   rel_l2=6.46e-02   DIV
+  gdn_conv                    cos=9.99e-01   max|Δ|=2.94e-02   mean|Δ|=3.75e-04   rel_l2=3.87e-02   DIV cos=9.99e-01   max|Δ|=1.48e-02   mean|Δ|=4.12e-04   rel_l2=3.60e-02   ok 
+  gdn_qk_norm_q               cos=9.99e-01   max|Δ|=7.93e-01   mean|Δ|=4.40e-02   rel_l2=9.12e-01   DIV cos=9.98e-01   max|Δ|=7.75e-01   mean|Δ|=4.49e-02   rel_l2=9.12e-01   DIV
+  gdn_qk_norm_k               cos=9.98e-01   max|Δ|=3.33e-02   mean|Δ|=3.44e-03   rel_l2=5.66e-02   DIV cos=9.98e-01   max|Δ|=2.56e-02   mean|Δ|=3.70e-03   rel_l2=5.99e-02   DIV
+  gdn_gate_beta               cos=1.00e+00   max|Δ|=3.22e-02   mean|Δ|=9.47e-03   rel_l2=2.83e-02   ok  cos=1.00e+00   max|Δ|=2.25e-02   mean|Δ|=7.10e-03   rel_l2=1.73e-02   ok 
+  gdn_gate_g                  cos=9.99e-01   max|Δ|=1.96e-01   mean|Δ|=3.07e-02   rel_l2=4.13e-02   ok  cos=9.99e-01   max|Δ|=5.80e-01   mean|Δ|=8.38e-02   rel_l2=1.16e-01   DIV
+  gdn_recur_out               cos=1.00e+00   max|Δ|=6.76e-04   mean|Δ|=3.67e-06   rel_l2=2.76e-02   ok  cos=1.00e+00   max|Δ|=5.14e-04   mean|Δ|=4.57e-06   rel_l2=2.47e-02   ok 
+  gdn_gated_norm              cos=9.97e-01   max|Δ|=1.40e-02   mean|Δ|=5.05e-04   rel_l2=8.11e-02   DIV cos=9.97e-01   max|Δ|=3.12e-02   mean|Δ|=6.07e-04   rel_l2=7.97e-02   DIV
+  gdn_out_proj                cos=9.98e-01   max|Δ|=5.02e-03   mean|Δ|=6.50e-04   rel_l2=5.84e-02   ok  cos=9.98e-01   max|Δ|=8.41e-03   mean|Δ|=7.90e-04   rel_l2=6.09e-02   ok 
+  layer_1_post_attn_residual  cos=9.99e-01   max|Δ|=1.90e-02   mean|Δ|=1.70e-03   rel_l2=3.62e-02   ok  cos=9.99e-01   max|Δ|=9.23e-03   mean|Δ|=1.48e-03   rel_l2=3.54e-02   ok 
+  layer_1_output              cos=9.98e-01   max|Δ|=3.65e-02   mean|Δ|=2.86e-03   rel_l2=6.14e-02   DIV cos=9.98e-01   max|Δ|=2.89e-02   mean|Δ|=2.94e-03   rel_l2=6.89e-02   DIV
+
+  earliest shared bad tap: 'layer_1_post_input_norm'
+Phase C41 verdict: EARLIEST SHARED BAD LAYER-1 TAP = 'layer_1_post_input_norm'.
+    Most-likely cause: layer 1 input_layernorm weight/eps or the layer-1 residual input frame
+  -> Divergence is already present at the first captured layer-1 boundary.
+
+Overall verdict: divergence(s) at: ['c41__layer_1_post_input_norm', 'c41__layer_1_post_input_norm']

--- a/profiling-artifacts/post427_c41_20260423_seed0.bench.json
+++ b/profiling-artifacts/post427_c41_20260423_seed0.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA A40",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 23.304661696,
+    "model_vram_mb": 17527
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 494,
+      "output_tokens": 128,
+      "total_time_secs": 3.284207101,
+      "tokens_per_sec": 38.97439962328369,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 494,
+      "output_tokens": 512,
+      "total_time_secs": 13.410780359,
+      "tokens_per_sec": 38.17824066117046,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 494,
+      "output_tokens": 1024,
+      "total_time_secs": 25.336344392,
+      "tokens_per_sec": 40.416248854090014,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 494,
+      "output_tokens": 2048,
+      "total_time_secs": 51.753933499,
+      "tokens_per_sec": 39.57187138325577,
+      "peak_vram_mb": 17831
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 8900.775595000001,
+    "prefill_tokens_per_sec": 55.50078133387655,
+    "time_to_first_token_ms": 8900.775595000001,
+    "mean_inter_token_ms": 31.1130936535433,
+    "p50_inter_token_ms": 22.018741000000002,
+    "p99_inter_token_ms": 75.39080700000001,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 32.1408089833624,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7397260273972602,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post427_c41_20260423_seed0.bench.stderr
+++ b/profiling-artifacts/post427_c41_20260423_seed0.bench.stderr
@@ -1,0 +1,103 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA A40 (46068 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T10:16:22.653282Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T10:16:22.654387Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T10:16:22.654576Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T10:16:22.654583Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T10:16:22.654666Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T10:16:45.956150Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m19192 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 19192 ms (parallel)
+Model loaded in 23.30s (backend: cuda, VRAM: 17527 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=47] (494 prompt tokens)...
+    Prefill (MTP): 8900.8ms (56 tok/s)
+[2m2026-04-23T10:16:55.428742Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m41
+[2m2026-04-23T10:16:55.638207Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m5339 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m494 [3mreplay_tokens_len[0m[2m=[0m494 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:16:55.724171Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m31192 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m495 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:16:55.799652Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m33416 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m496 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:16:55.869815Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m321 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m497 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:16:56.026552Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed0_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m7071 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m502 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 31.1ms (32.1 tok/s), α = 0.740 (54/73)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T10:16:59.882073Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 3284.2ms (39.0 tok/s)
+  => 39.0 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 3064.7ms (41.8 tok/s)
+    Run 2/4: 128 tokens in 3478.3ms (36.8 tok/s)
+    Run 3/4: 128 tokens in 3480.9ms (36.8 tok/s)
+    Run 4/4: 128 tokens in 3386.7ms (37.8 tok/s)
+  => 38.2 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 3474.0ms (36.8 tok/s)
+    Run 2/8: 128 tokens in 3032.2ms (42.2 tok/s)
+    Run 3/8: 128 tokens in 2986.3ms (42.9 tok/s)
+    Run 4/8: 128 tokens in 2988.7ms (42.8 tok/s)
+    Run 5/8: 128 tokens in 3399.1ms (37.7 tok/s)
+    Run 6/8: 128 tokens in 3334.9ms (38.4 tok/s)
+    Run 7/8: 128 tokens in 2968.3ms (43.1 tok/s)
+    Run 8/8: 128 tokens in 3152.6ms (40.6 tok/s)
+  => 40.4 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 3171.1ms (40.4 tok/s)
+    Run 2/16: 128 tokens in 3544.7ms (36.1 tok/s)
+    Run 3/16: 128 tokens in 3271.4ms (39.1 tok/s)
+    Run 4/16: 128 tokens in 3145.9ms (40.7 tok/s)
+    Run 5/16: 128 tokens in 3120.5ms (41.0 tok/s)
+    Run 6/16: 128 tokens in 3342.7ms (38.3 tok/s)
+    Run 7/16: 128 tokens in 3248.1ms (39.4 tok/s)
+    Run 8/16: 128 tokens in 3230.0ms (39.6 tok/s)
+    Run 9/16: 128 tokens in 3065.3ms (41.8 tok/s)
+    Run 10/16: 128 tokens in 3085.3ms (41.5 tok/s)
+    Run 11/16: 128 tokens in 3385.3ms (37.8 tok/s)
+    Run 12/16: 128 tokens in 3038.5ms (42.1 tok/s)
+    Run 13/16: 128 tokens in 3026.0ms (42.3 tok/s)
+    Run 14/16: 128 tokens in 3276.4ms (39.1 tok/s)
+    Run 15/16: 128 tokens in 3615.6ms (35.4 tok/s)
+    Run 16/16: 128 tokens in 3186.5ms (40.2 tok/s)
+  => 39.6 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA A40 (46068 MB VRAM, source: nvidia-smi)
+Model load time: 23.30s (VRAM: 17527 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               494        128         39.0      17831
+4               494        512         38.2      17831
+8               494       1024         40.4      17831
+16              494       2048         39.6      17831
+
+--- Latency (single request) ---
+Prompt tokens:         494
+Prefill time:          8900.8 ms (56 tok/s)
+Time to first token:   8900.8 ms
+Mean inter-token:      31.1 ms (32.1 tok/s)
+P50 inter-token:       22.0 ms
+P99 inter-token:       75.4 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.740
+

--- a/profiling-artifacts/post427_c41_20260423_seed1.bench.json
+++ b/profiling-artifacts/post427_c41_20260423_seed1.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA A40",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 21.783513963,
+    "model_vram_mb": 17527
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 508,
+      "output_tokens": 128,
+      "total_time_secs": 3.010118157,
+      "tokens_per_sec": 42.52324770120311,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 508,
+      "output_tokens": 512,
+      "total_time_secs": 11.94416051,
+      "tokens_per_sec": 42.866135260936815,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 508,
+      "output_tokens": 1024,
+      "total_time_secs": 24.494308761,
+      "tokens_per_sec": 41.805629625703894,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 508,
+      "output_tokens": 2048,
+      "total_time_secs": 47.513584437,
+      "tokens_per_sec": 43.10346239432889,
+      "peak_vram_mb": 17831
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 508,
+    "prefill_time_ms": 479.814162,
+    "prefill_tokens_per_sec": 1058.7432390126075,
+    "time_to_first_token_ms": 479.814162,
+    "mean_inter_token_ms": 43.77273525196851,
+    "p50_inter_token_ms": 56.668748,
+    "p99_inter_token_ms": 74.631038,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 22.84527101730589,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.2828282828282828,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post427_c41_20260423_seed1.bench.stderr
+++ b/profiling-artifacts/post427_c41_20260423_seed1.bench.stderr
@@ -1,0 +1,109 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA A40 (46068 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T10:18:58.209274Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T10:18:58.210161Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T10:18:58.210307Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T10:18:58.210314Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T10:18:58.210383Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T10:19:19.990612Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m19367 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 19367 ms (parallel)
+Model loaded in 21.78s (backend: cuda, VRAM: 17527 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (508 prompt tokens)...
+    Prefill (MTP): 479.8ms (1059 tok/s)
+[2m2026-04-23T10:19:21.113750Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m41
+[2m2026-04-23T10:19:21.303928Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m25015 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m508 [3mreplay_tokens_len[0m[2m=[0m508 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:19:21.375874Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m314 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m509 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:19:21.440220Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m1330 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m510 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:19:21.504289Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m47205 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m511 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:19:21.567030Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-0/step-4.safetensors [3mdraft_token_id[0m[2m=[0m369 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(4) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m512 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:19:21.629914Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-0/step-5.safetensors [3mdraft_token_id[0m[2m=[0m799 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(5) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m513 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:19:21.692794Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-0/step-6.safetensors [3mdraft_token_id[0m[2m=[0m30797 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(6) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m514 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:19:21.755687Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-0/step-7.safetensors [3mdraft_token_id[0m[2m=[0m314 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(7) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m515 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:19:21.891899Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m421 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m520 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:19:21.954442Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-1.safetensors [3mdraft_token_id[0m[2m=[0m3202 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m521 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T10:19:22.021599Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post427_c41_20260423_seed1_captures/mtp_pos-2/step-2.safetensors [3mdraft_token_id[0m[2m=[0m369 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m522 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m12 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 43.8ms (22.8 tok/s), α = 0.283 (28/99)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T10:19:27.137900Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 3010.1ms (42.5 tok/s)
+  => 42.5 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 2986.1ms (42.9 tok/s)
+    Run 2/4: 128 tokens in 2936.4ms (43.6 tok/s)
+    Run 3/4: 128 tokens in 2941.6ms (43.5 tok/s)
+    Run 4/4: 128 tokens in 3079.9ms (41.6 tok/s)
+  => 42.9 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2982.4ms (42.9 tok/s)
+    Run 2/8: 128 tokens in 3320.9ms (38.5 tok/s)
+    Run 3/8: 128 tokens in 3077.6ms (41.6 tok/s)
+    Run 4/8: 128 tokens in 3016.0ms (42.4 tok/s)
+    Run 5/8: 128 tokens in 3089.2ms (41.4 tok/s)
+    Run 6/8: 128 tokens in 3003.8ms (42.6 tok/s)
+    Run 7/8: 128 tokens in 2976.9ms (43.0 tok/s)
+    Run 8/8: 128 tokens in 3027.2ms (42.3 tok/s)
+  => 41.8 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2969.8ms (43.1 tok/s)
+    Run 2/16: 128 tokens in 2996.5ms (42.7 tok/s)
+    Run 3/16: 128 tokens in 2959.6ms (43.2 tok/s)
+    Run 4/16: 128 tokens in 2957.3ms (43.3 tok/s)
+    Run 5/16: 128 tokens in 2968.7ms (43.1 tok/s)
+    Run 6/16: 128 tokens in 2960.2ms (43.2 tok/s)
+    Run 7/16: 128 tokens in 2965.8ms (43.2 tok/s)
+    Run 8/16: 128 tokens in 2981.9ms (42.9 tok/s)
+    Run 9/16: 128 tokens in 3049.7ms (42.0 tok/s)
+    Run 10/16: 128 tokens in 2940.6ms (43.5 tok/s)
+    Run 11/16: 128 tokens in 2932.5ms (43.6 tok/s)
+    Run 12/16: 128 tokens in 3062.4ms (41.8 tok/s)
+    Run 13/16: 128 tokens in 2998.5ms (42.7 tok/s)
+    Run 14/16: 128 tokens in 2969.0ms (43.1 tok/s)
+    Run 15/16: 128 tokens in 2894.3ms (44.2 tok/s)
+    Run 16/16: 128 tokens in 2906.3ms (44.0 tok/s)
+  => 43.1 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA A40 (46068 MB VRAM, source: nvidia-smi)
+Model load time: 21.78s (VRAM: 17527 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               508        128         42.5      17831
+4               508        512         42.9      17831
+8               508       1024         41.8      17831
+16              508       2048         43.1      17831
+
+--- Latency (single request) ---
+Prompt tokens:         508
+Prefill time:          479.8 ms (1059 tok/s)
+Time to first token:   479.8 ms
+Mean inter-token:      43.8 ms (22.8 tok/s)
+P50 inter-token:       56.7 ms
+P99 inter-token:       74.6 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.283
+

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -580,6 +580,7 @@ def _compare_pair(
     atol: float,
     rtol: float,
     emit,
+    focus_keys: Optional[List[str]] = None,
 ) -> Tuple[bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]:
     """Compare a single (kiln, ref) pair. Returns (all_ok, first_divergence,
     rows, kiln_meta, ref_meta). `label` is shown in headers for multi-pair
@@ -618,10 +619,13 @@ def _compare_pair(
     all_ok = True
     rows: List[Dict[str, object]] = []
     canonical_order = _ordered_taps(kiln_arr, ref_arr)
+    if focus_keys is not None:
+        canonical_order = [name for name in canonical_order if name in set(focus_keys)]
 
     # Report missing-on-one-side first so the table itself is uniform width.
-    missing_in_kiln = [n for n in (TAP_ORDER + SUBOP_ORDER) if n in ref_arr and n not in kiln_arr]
-    missing_in_ref = [n for n in (TAP_ORDER + SUBOP_ORDER) if n in kiln_arr and n not in ref_arr]
+    missing_probe = focus_keys if focus_keys is not None else (TAP_ORDER + SUBOP_ORDER)
+    missing_in_kiln = [n for n in missing_probe if n in ref_arr and n not in kiln_arr]
+    missing_in_ref = [n for n in missing_probe if n in kiln_arr and n not in ref_arr]
     for n in missing_in_kiln:
         emit(f"{n:<22} MISSING IN KILN DUMP")
         all_ok = False
@@ -651,8 +655,20 @@ def _compare_pair(
     if all_ok:
         emit("  pair verdict: all taps match within tolerance.")
     else:
-        cause = PRIMARY_HYPOTHESIS.get(first_div) or SUBOP_HYPOTHESIS.get(
-            first_div, "<unknown tap>"
+        base_first_div = first_div
+        for prefix in ("b11__", "b12__", "c41__", "c6__", "c7__"):
+            if base_first_div.startswith(prefix):
+                base_first_div = base_first_div[len(prefix) :]
+                break
+        cause = (
+            PRIMARY_HYPOTHESIS.get(first_div)
+            or SUBOP_HYPOTHESIS.get(base_first_div)
+            or B11_HYPOTHESIS.get(base_first_div)
+            or B12_HYPOTHESIS.get(base_first_div)
+            or C41_HYPOTHESIS.get(base_first_div)
+            or C6_HYPOTHESIS.get(base_first_div)
+            or C7_HYPOTHESIS.get(base_first_div)
+            or "<unknown tap>"
         )
         emit(f"  pair verdict: first divergence at tap '{first_div}'.")
         emit(f"    Most-likely cause: {cause}")
@@ -1875,9 +1891,12 @@ def main() -> int:
         Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]
     ] = []
     overall_ok = True
+    focus_keys = None
+    if args.c41:
+        focus_keys = [f"c41__{name}" for name in C41_LAYER1_TAP_NAMES]
     for label, kpath, rpath in pairs:
         ok, first_div, rows, km, rm = _compare_pair(
-            label, kpath, rpath, args.atol, args.rtol, emit
+            label, kpath, rpath, args.atol, args.rtol, emit, focus_keys=focus_keys
         )
         pair_results.append((label, ok, first_div, rows, km, rm))
         if not ok:

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -65,6 +65,17 @@ Layer-31 GQA sub-op bisect (Phase B12 — per-layer + per-sub-op drift):
     refs and once with fp32 HF refs (--b12-taps --fp32) — to tell whether
     residual drift at layer 31 exceeds bf16 accumulation noise or is benign.
 
+Transformer block 1 sub-op bisect (Phase C41 — earliest shared bad tap):
+    python3 scripts/mtp_compare.py --c41 \\
+        --pair seed0:/tmp/h-kiln-seed0.safetensors,/tmp/h-ref-seed0.safetensors \\
+        --pair seed1:/tmp/h-kiln-seed1.safetensors,/tmp/h-ref-seed1.safetensors
+
+    --c41 defaults atol=1e-2, rtol=1e-1 (bf16-appropriate) and emits a
+    per-seed table for the explicit `c41__<name>` transformer-block-1 tap
+    set. The verdict identifies the earliest tap that BOTH seeds agree is
+    bad under the requested tolerance bar, plus the last tap both seeds
+    still agree is good.
+
 Exit code:
     0 — all taps match within tolerance (all positions, in multi mode)
     1 — at least one tap diverges (normal outcome of a bisect)
@@ -245,6 +256,39 @@ B12_HYPOTHESIS: Dict[str, str] = {
     "mlp_gate": "MLP gate_proj weight/transpose or pre-SiLU bf16 accumulation",
     "mlp_up": "MLP up_proj weight layout or elementwise SiLU(gate)*up path",
     "mlp_down": "MLP down_proj weight layout or bf16 GEMM epilogue cast",
+}
+
+# Phase C41 — transformer block 1 (layer 1) tap set, in forward-graph order.
+# Must stay in lock-step with `C41_LAYER1_TAP_NAMES` in
+# `crates/kiln-model/src/mtp_debug.rs` and `scripts/mtp_h_main_reference_dump.py`.
+C41_LAYER1_TAP_NAMES: Tuple[str, ...] = (
+    "layer_1_post_input_norm",
+    "gdn_in_proj",
+    "gdn_conv",
+    "gdn_qk_norm_q",
+    "gdn_qk_norm_k",
+    "gdn_gate_beta",
+    "gdn_gate_g",
+    "gdn_recur_out",
+    "gdn_gated_norm",
+    "gdn_out_proj",
+    "layer_1_post_attn_residual",
+    "layer_1_output",
+)
+
+C41_HYPOTHESIS: Dict[str, str] = {
+    "layer_1_post_input_norm": "layer 1 input_layernorm weight/eps or the layer-1 residual input frame",
+    "gdn_in_proj": "layer 1 in_proj_qkv / z / a / b weight layout, transpose, or dtype",
+    "gdn_conv": "layer 1 causal_conv1d path: kernel packing, conv-state update, or SiLU epilogue",
+    "gdn_qk_norm_q": "layer 1 Q qk_norm: head expansion, L2 norm, or scale-by-1/sqrt(dk)",
+    "gdn_qk_norm_k": "layer 1 K qk_norm: head expansion or L2 norm",
+    "gdn_gate_beta": "layer 1 beta gate: sigmoid(b) projection split / head layout",
+    "gdn_gate_g": "layer 1 g gate: -exp(A_log) * softplus(a + dt_bias) parameterization",
+    "gdn_recur_out": "layer 1 GDN recurrence kernel / chunkwise delta-rule math",
+    "gdn_gated_norm": "layer 1 GatedRMSNorm(core_attn_out, z) weight/eps or z routing",
+    "gdn_out_proj": "layer 1 out_proj weight layout / transpose / residual dtype",
+    "layer_1_post_attn_residual": "layer 1 residual add after GDN out_proj",
+    "layer_1_output": "layer 1 post-MLP residual handoff into layer 2",
 }
 
 # Phase B12 — the cos_sim bar is tighter than B10/B11 because the expected
@@ -510,6 +554,10 @@ def _ordered_taps(
             out.append(name)
     for name in B12_LAYER31_GQA_TAP_NAMES:
         key = f"b12__{name}"
+        if key in common and key not in out:
+            out.append(key)
+    for name in C41_LAYER1_TAP_NAMES:
+        key = f"c41__{name}"
         if key in common and key not in out:
             out.append(key)
     for name in C6_PRE_ROPE_TAP_NAMES:
@@ -1447,6 +1495,113 @@ def _emit_c6_summary(
         emit("     and/or re-check the abs_pos threading in the MTP block.")
 
 
+def _emit_c41_summary(
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
+    atol: float,
+    rtol: float,
+    emit,
+) -> None:
+    """Phase C41 — transformer block 1 sub-op bisect."""
+    emit("")
+    emit("=" * 78)
+    emit("Phase C41 transformer block 1 bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2")
+    emit("=" * 78)
+
+    labels = [pr[0] for pr in pair_results]
+    cell: Dict[str, Dict[str, Tuple[float, float, float, float, bool]]] = {
+        n: {} for n in C41_LAYER1_TAP_NAMES
+    }
+    for label, _ok, _fd, rows, _km, _rm in pair_results:
+        for r in rows:
+            n = r["name"]
+            if not isinstance(n, str) or not n.startswith("c41__"):
+                continue
+            short = n[len("c41__"):]
+            if short not in cell:
+                continue
+            cell[short][label] = (
+                float(r["cos_sim"]),
+                float(r["max_abs_diff"]),
+                float(r["mean_abs_diff"]),
+                float(r.get("rel_l2", float("nan"))),
+                bool(r["allclose"]),
+            )
+
+    header = "  " + "tap".ljust(28) + " ".join(f"{lab:<52}" for lab in labels)
+    emit(header)
+    emit("  " + "-" * (len(header) - 2))
+    captured_any = False
+    for tap in C41_LAYER1_TAP_NAMES:
+        cells = []
+        for lab in labels:
+            entry = cell[tap].get(lab)
+            if entry is None:
+                cells.append(f"{'<missing>':<52}")
+            else:
+                cs, mxd, mnd, rl2, ok = entry
+                captured_any = True
+                tag = "ok" if ok else "DIV"
+                cells.append(
+                    f"cos={_fmt_sci(cs):<10} max|Δ|={_fmt_sci(mxd):<10} "
+                    f"mean|Δ|={_fmt_sci(mnd):<10} rel_l2={_fmt_sci(rl2):<10} {tag:<3}"
+                )
+        emit(f"  {tap:<28}{' '.join(cells)}")
+
+    emit("")
+    if not captured_any:
+        emit("Phase C41 verdict: no C41 layer-1 taps present in dumps.")
+        emit("  -> Re-run kiln-bench with KILN_MTP_DUMP_C41_LAYER1_TAPS=1 and")
+        emit("     re-run mtp_h_main_reference_dump.py with --c41-taps against")
+        emit("     the same kiln dump.")
+        return
+
+    first_shared_bad: Optional[str] = None
+    last_shared_ok: Optional[str] = None
+    first_per_seed: Dict[str, str] = {}
+    for tap in C41_LAYER1_TAP_NAMES:
+        all_present = True
+        all_ok = True
+        all_bad = True
+        for lab in labels:
+            entry = cell[tap].get(lab)
+            if entry is None:
+                all_present = False
+                all_ok = False
+                all_bad = False
+                continue
+            ok = entry[4]
+            all_ok &= ok
+            all_bad &= not ok
+            if not ok and lab not in first_per_seed:
+                first_per_seed[lab] = tap
+        if all_present and all_ok and first_shared_bad is None:
+            last_shared_ok = tap
+        if all_present and all_bad and first_shared_bad is None:
+            first_shared_bad = tap
+
+    if first_shared_bad is None:
+        emit("Phase C41 verdict: no shared earliest-bad tap across all supplied seeds.")
+        for lab in labels:
+            emit(f"  earliest divergent tap for {lab}: {first_per_seed.get(lab, '<none>')}")
+        emit("  -> Seeds do not yet agree on a single first-bad boundary inside")
+        emit("     transformer block 1. Use the per-seed rows above as the")
+        emit("     narrowest remaining span.")
+        return
+
+    emit(f"  earliest shared bad tap: '{first_shared_bad}'")
+    if last_shared_ok is not None:
+        emit(f"  last shared-good tap: '{last_shared_ok}'")
+    emit(f"Phase C41 verdict: EARLIEST SHARED BAD LAYER-1 TAP = '{first_shared_bad}'.")
+    emit(f"    Most-likely cause: {C41_HYPOTHESIS.get(first_shared_bad, '<unknown tap>')}")
+    if last_shared_ok is not None:
+        emit(
+            "  -> The shared drift is now localized to the boundary between "
+            f"'{last_shared_ok}' and '{first_shared_bad}'."
+        )
+    else:
+        emit("  -> Divergence is already present at the first captured layer-1 boundary.")
+
+
 def _emit_c7_summary(
     pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
@@ -1621,6 +1776,17 @@ def main() -> int:
         ),
     )
     ap.add_argument(
+        "--c41",
+        action="store_true",
+        help=(
+            "Phase C41 mode: emit transformer-block-1 bisect over the explicit "
+            "c41__<name> tap set (layer-1 input norm, GDN internals, "
+            "post-attn residual, final layer output). Defaults atol=1e-2, "
+            "rtol=1e-1 (bf16-appropriate). Verdict names the earliest tap "
+            "that ALL supplied seeds agree is bad."
+        ),
+    )
+    ap.add_argument(
         "--c6",
         action="store_true",
         help=(
@@ -1661,7 +1827,7 @@ def main() -> int:
     # noise; the strict bar stays on to catch real structural drops and the
     # comparator report makes bf16-accumulation drift visible via per-position
     # max|Δ| / rel_l2 columns.
-    bf16_mode = args.b10 or args.b11 or args.b12
+    bf16_mode = args.b10 or args.b11 or args.b12 or args.c41
     if args.atol is None:
         args.atol = 1e-2 if bf16_mode else 1e-3
     if args.rtol is None:
@@ -1689,6 +1855,8 @@ def main() -> int:
     multi = len(pairs) > 1
     if args.c7:
         mode = "SDPA-internal bisect (C7)"
+    elif args.c41:
+        mode = "transformer block 1 bisect (C41)"
     elif args.c6:
         mode = "pre-RoPE MTP input bisect (C6)"
     elif args.b12:
@@ -1717,6 +1885,8 @@ def main() -> int:
 
     if args.c7:
         _emit_c7_summary(pair_results, args.atol, args.rtol, emit)
+    elif args.c41:
+        _emit_c41_summary(pair_results, args.atol, args.rtol, emit)
     elif args.c6:
         _emit_c6_summary(pair_results, args.atol, args.rtol, emit)
     elif args.b12:
@@ -1733,7 +1903,7 @@ def main() -> int:
     # captured" note when the dump didn't include the B9 sub-ops (e.g.
     # legacy dumps from before this PR). Skipped in explicit --b10/--b11/--b12/--c6
     # mode so the per-phase report isn't cluttered by unrelated sub-op tables.
-    if not args.b10 and not args.b11 and not args.b12 and not args.c6 and not args.c7:
+    if not args.b10 and not args.b11 and not args.b12 and not args.c41 and not args.c6 and not args.c7:
         have_b9_taps = any(
             any(r["name"] in B9_H2_ZONE or r["name"] in B9_H3_ZONE for r in pr[3])
             for pr in pair_results

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -4,6 +4,7 @@ Phase B10 — `h_main` base-model reference dump.
 Phase B11b — optional layer-0 GDN sub-op taps (`--b11-taps`).
 Phase B12  — optional per-layer taps for layers 24..31 + GQA sub-op taps at
              layer 31 (`--b12-taps`), plus optional fp32 reference (`--fp32`).
+Phase C41  — optional transformer-block-1 sub-op taps (`--c41-taps`).
 
 This script produces the independent pure-Python reference counterpart to the
 kiln-side main-model forward (the 24×GDN + 8×GQA stack) so that Phase B10 can
@@ -183,6 +184,24 @@ B12_LAYER31_GQA_TAP_NAMES: Tuple[str, ...] = (
 )
 
 
+# Phase C41 — ordered transformer-block-1 tap names. Must stay in lock-step
+# with `C41_LAYER1_TAP_NAMES` in `crates/kiln-model/src/mtp_debug.rs`.
+C41_LAYER1_TAP_NAMES: Tuple[str, ...] = (
+    "layer_1_post_input_norm",
+    "gdn_in_proj",
+    "gdn_conv",
+    "gdn_qk_norm_q",
+    "gdn_qk_norm_k",
+    "gdn_gate_beta",
+    "gdn_gate_g",
+    "gdn_recur_out",
+    "gdn_gated_norm",
+    "gdn_out_proj",
+    "layer_1_post_attn_residual",
+    "layer_1_output",
+)
+
+
 # -----------------------------------------------------------------------------
 # Kiln-dump loader (mirrors mtp_reference_dump.py's loader)
 # -----------------------------------------------------------------------------
@@ -218,6 +237,35 @@ def resolve_boundary_layers(kiln_dump: Dict[str, object], capture_b12: bool) -> 
     if capture_b12:
         layers.update(B12_GQA_LAYERS)
     return sorted(layers)
+
+
+def resolve_c41_tap_names(kiln_dump: Dict[str, object]) -> List[str]:
+    raw = kiln_dump.get("meta__c41_tap_ids")
+    if isinstance(raw, list) and raw:
+        names: List[str] = []
+        for idx in raw:
+            idx_i = int(idx)
+            if 0 <= idx_i < len(C41_LAYER1_TAP_NAMES):
+                names.append(C41_LAYER1_TAP_NAMES[idx_i])
+        if names:
+            return names
+
+    from_keys = sorted(
+        {
+            key[len("c41__") :]
+            for key in kiln_dump.keys()
+            if key.startswith("c41__")
+        },
+        key=lambda name: (
+            C41_LAYER1_TAP_NAMES.index(name)
+            if name in C41_LAYER1_TAP_NAMES
+            else len(C41_LAYER1_TAP_NAMES),
+            name,
+        ),
+    )
+    if from_keys:
+        return from_keys
+    return list(C41_LAYER1_TAP_NAMES)
 
 
 # -----------------------------------------------------------------------------
@@ -764,6 +812,51 @@ def _arm_b12_layer31_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List[ob
     return handles
 
 
+def _arm_c41_layer1_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List[object]:
+    """Attach hooks for the explicit non-GDN boundaries in transformer block 1.
+
+    The internal GDN taps are captured by monkey-patching the layer-1
+    GatedDeltaNet forward; these hooks fill in the surrounding block-level
+    boundaries that are naturally visible outside the GDN helper:
+
+    - `layer_1_post_input_norm`: output of layer 1's input_layernorm
+    - `layer_1_post_attn_residual`: hidden state after `hidden + attn_out`,
+      observed as the input to `post_attention_layernorm`
+    - `layer_1_output`: final transformer-block output after the MLP residual
+    """
+    handles: List[object] = []
+    layer = base.layers[1]
+
+    def _forward_hook(name: str):
+        def _fn(_mod, _inputs, output):
+            tensor = output[0] if isinstance(output, tuple) else output
+            taps_out[name] = tensor.detach().clone()
+
+        return _fn
+
+    def _pre_hook(name: str):
+        def _fn(_mod, inputs):
+            tensor = inputs[0][0] if isinstance(inputs[0], tuple) else inputs[0]
+            taps_out[name] = tensor.detach().clone()
+
+        return _fn
+
+    if hasattr(layer, "input_layernorm"):
+        handles.append(
+            layer.input_layernorm.register_forward_hook(
+                _forward_hook("layer_1_post_input_norm")
+            )
+        )
+    if hasattr(layer, "post_attention_layernorm"):
+        handles.append(
+            layer.post_attention_layernorm.register_forward_pre_hook(
+                _pre_hook("layer_1_post_attn_residual")
+            )
+        )
+    handles.append(layer.register_forward_hook(_forward_hook("layer_1_output")))
+    return handles
+
+
 # -----------------------------------------------------------------------------
 # Reference forward
 # -----------------------------------------------------------------------------
@@ -776,6 +869,8 @@ def run_reference_forward(
     boundary_layers: Optional[List[int]] = None,
     capture_b11_layer0: bool = False,
     capture_b12: bool = False,
+    capture_c41: bool = False,
+    c41_tap_names: Optional[List[str]] = None,
     fp32: bool = False,
 ) -> Dict[str, torch.Tensor]:
     """Run HF Qwen3-Next / Qwen3.5 forward with `output_hidden_states=True`.
@@ -828,9 +923,13 @@ def run_reference_forward(
         file=sys.stderr,
     )
 
-    # Set up B11b instrumentation + embed/norm forward_hooks BEFORE the forward.
+    if capture_b11_layer0 and capture_c41:
+        raise ValueError("capture_b11_layer0 and capture_c41 are mutually exclusive")
+
+    # Set up B11b/C41 instrumentation + forward hooks BEFORE the forward.
     b11_captures: Dict[str, torch.Tensor] = {}
     b12_captures: Dict[str, torch.Tensor] = {}
+    c41_captures: Dict[str, torch.Tensor] = {}
     hook_handles: List[object] = []
     orig_gdn_forward = None
     if capture_b11_layer0:
@@ -863,6 +962,23 @@ def run_reference_forward(
         print(
             f"[mtp_h_main_ref] B11b instrumentation armed: "
             f"monkey-patched {gdn_klass.__name__}.forward + 2 embed/norm hooks",
+            file=sys.stderr,
+        )
+    elif capture_c41:
+        orig_gdn_forward = gdn_klass.forward  # type: ignore[attr-defined]
+        if gdn_layout == "qwen3_5":
+            instrumented = make_qwen3_5_instrumented_gdn_forward(
+                c41_captures, target_layer_idx=1
+            )
+        else:
+            instrumented = make_qwen3_next_instrumented_gdn_forward(
+                c41_captures, target_layer_idx=1
+            )
+        gdn_klass.forward = instrumented  # type: ignore[assignment]
+        hook_handles.extend(_arm_c41_layer1_hooks(base, c41_captures))
+        print(
+            f"[mtp_h_main_ref] C41 instrumentation armed: "
+            f"monkey-patched {gdn_klass.__name__}.forward at layer 1 + 3 block hooks",
             file=sys.stderr,
         )
 
@@ -964,6 +1080,18 @@ def run_reference_forward(
             if name in b12_captures:
                 taps[f"b12__{name}"] = b12_captures[name]
 
+    if capture_c41:
+        wanted = c41_tap_names or list(C41_LAYER1_TAP_NAMES)
+        missing = [n for n in wanted if n not in c41_captures]
+        if missing:
+            print(
+                f"[mtp_h_main_ref] WARNING: C41 instrumentation missed taps: {missing}",
+                file=sys.stderr,
+            )
+        for name in wanted:
+            if name in c41_captures:
+                taps[f"c41__{name}"] = c41_captures[name]
+
     # Free the model and all retained activations before returning.
     del model, out, hs
     if device.type == "cuda":
@@ -1024,6 +1152,18 @@ def main() -> int:
         ),
     )
     ap.add_argument(
+        "--c41-taps",
+        action="store_true",
+        help=(
+            "Also capture the explicit Phase C41 transformer-block-1 tap set "
+            "(input norm output, layer-1 GDN internals, post-attn residual, "
+            "and final layer output). Output tensors are emitted under "
+            "`c41__<name>` keys matching C41_LAYER1_TAP_NAMES in "
+            "crates/kiln-model/src/mtp_debug.rs. The exact tap order is "
+            "resolved from the kiln dump's `meta__c41_tap_ids` when present."
+        ),
+    )
+    ap.add_argument(
         "--fp32",
         action="store_true",
         help=(
@@ -1043,6 +1183,7 @@ def main() -> int:
     print(f"[mtp_h_main_ref] loading kiln dump from {args.kiln_dump}", file=sys.stderr)
     kiln = load_kiln_dump(args.kiln_dump)
     boundary_layers = resolve_boundary_layers(kiln, capture_b12=args.b12_taps)
+    c41_tap_names = resolve_c41_tap_names(kiln) if args.c41_taps else None
     draft_token_id = int(kiln.get("meta__draft_token_id", -1))
     mtp_pos = int(kiln.get("meta__mtp_pos", -1))
     print(
@@ -1107,6 +1248,8 @@ def main() -> int:
         boundary_layers=boundary_layers,
         capture_b11_layer0=args.b11_taps,
         capture_b12=args.b12_taps,
+        capture_c41=args.c41_taps,
+        c41_tap_names=c41_tap_names,
         fp32=args.fp32,
     )
 
@@ -1130,6 +1273,11 @@ def main() -> int:
     out_dict["meta__boundary_layers"] = torch.tensor(
         boundary_layers, dtype=torch.int32
     )
+    if c41_tap_names:
+        out_dict["meta__c41_tap_ids"] = torch.tensor(
+            [C41_LAYER1_TAP_NAMES.index(name) for name in c41_tap_names],
+            dtype=torch.int32,
+        )
     # Also write the resolved prompt tokens so later reruns can reproduce
     # bit-exactly even if the kiln dump gets rotated.
     out_dict["prompt_tokens"] = prompt_tokens.view(-1).to(torch.int32).contiguous()

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -1090,7 +1090,10 @@ def run_reference_forward(
             )
         for name in wanted:
             if name in c41_captures:
-                taps[f"c41__{name}"] = c41_captures[name]
+                tensor = c41_captures[name]
+                if tensor.ndim >= 2:
+                    tensor = tensor[:, -1:, ...].contiguous()
+                taps[f"c41__{name}"] = tensor
 
     # Free the model and all retained activations before returning.
     del model, out, hs


### PR DESCRIPTION
## Summary
- add an opt-in C41 transformer-block-1 tap path for kiln replay dumps and mirror it in the HF reference dump/comparator flow
- rerun the post-#427 native-MTP seed0/seed1 workload with C41 taps enabled and commit the fresh bench + compare artifacts
- document the C41 verdict in `PROFILING.md` and `docs/phase-c41/c41-layer1-subop-bisect.md`

## Validation
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- `source /root/.kiln-build-env && cargo test -p kiln-model mtp_debug --lib -- --test-threads=1`

## Verdict
- fresh main still reproduces the post-#427 seed split
- both bf16 and fp32 C41 compares identify `layer_1_post_input_norm` as the earliest shared bad layer-1 tap
- the remaining uncaptured span is now just the transformer-block-1 residual input frame vs the layer-1 input-layernorm application
