### PR TITLE
phase6: bisect layer1 pre-norm vs input_layernorm after C41

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -6243,3 +6243,140 @@ waits used `runpod_api.py wait-file --timeout`; no `until ssh` or
 - `c12-out/probe-report.md` + `c12-out/probe-report.json` — main-model
   activation-weighted drift audit.
 - `c12-out/bench.log`, `c12-out/probe.log` — runner logs.
+
+## Phase C42 post-#428 layer-1 pre-norm vs input-layernorm bisect (2026-04-23)
+
+**Scope:** resolve the post-C41 remaining span by asking one narrower
+question on fresh `main`: is the first shared bad tensor already present in
+the residual input entering transformer block 1, or is it introduced inside
+layer 1 `input_layernorm` itself?
+
+**Preflight outcome:** proceed. Fresh `origin/main` at `e569d22` (PR #428
+merged) still had
+[`docs/phase-c41/c41-layer1-subop-bisect.md`](docs/phase-c41/c41-layer1-subop-bisect.md)
+as the latest committed source of truth for this path, and that doc still
+recorded `layer_1_post_input_norm` as the earliest shared bad C41 tap for both
+seeds. Fresh main did not already contain committed C42 taps or a doc that
+localized the remaining span any further.
+
+**Hardware / image:** RunPod on-demand fallback `NVIDIA A100-SXM4-80GB`,
+`ghcr.io/ericflo/kiln-runpod:latest`. A6000 and A40 capacity were unavailable
+at the time of the run, so the project-policy fallback order was used.
+
+**Code change:** add a dedicated opt-in C42 capture path behind
+`KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS=1`, serialize the emitted tap ids as
+`meta__c42_tap_ids`, mirror the same four taps in the HF reference dump under
+`--c42-taps`, and add a focused `scripts/mtp_compare.py --c42` mode.
+The explicit tap set is:
+
+- `layer_1_residual_input`
+- `layer_1_input_norm_rms_inv`
+- `layer_1_input_norm_pre_weight`
+- `layer_1_post_input_norm`
+
+No generalized tracing was added; production decode stays on the current fast
+path when the env var is unset.
+
+**Validation commands run:**
+
+```bash
+cd /workspace/kiln
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+source /root/.kiln-build-env
+cargo test -p kiln-model mtp_debug --lib -- --test-threads=1
+```
+
+**Standard workload rerun:** same C41 replay contract plus the new C42 tap
+flag. Build and setup on the fallback A100:
+
+```bash
+cd /workspace/kiln
+source /root/.kiln-build-env
+export KILN_CUDA_ARCHS=80
+cargo build --release --features cuda --bin kiln-bench
+hf download Qwen/Qwen3.5-4B --local-dir /workspace/qwen3.5-4b
+python3 -m pip install transformers safetensors sentencepiece
+```
+
+Then rerun the standard native-MTP workload for seeds `0` and `1`:
+
+```bash
+for seed in 0 1; do
+  root=/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed${seed}_captures
+  rm -rf "$root"
+  mkdir -p "$root"/mtp_pos-0 "$root"/mtp_pos-2
+
+  KILN_W4A16=1 \
+  KILN_CUDA_GRAPHS=true \
+  KILN_SPEC_METHOD=mtp \
+  KILN_BENCH_FORCE_MTP=1 \
+  KILN_MTP_DUMP_SPLICE=1 \
+  KILN_MTP_DUMP_SPLICE_POS=0,2 \
+  KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+  KILN_MTP_DUMP_HIDDEN_STATES=1 \
+  KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+  KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS=1 \
+  KILN_MTP_DUMP_PATH=$root/mtp_pos-{pos}/step-{step}.safetensors \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+    --seed ${seed} \
+    > /workspace/kiln/profiling-artifacts/post428_c42_20260423_seed${seed}.bench.json \
+    2> /workspace/kiln/profiling-artifacts/post428_c42_20260423_seed${seed}.bench.stderr
+done
+```
+
+Representative compare dumps:
+
+- seed 0: `profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors`
+- seed 1: `profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors`
+
+HF references were regenerated in bf16 and fp32 with
+`scripts/mtp_h_main_reference_dump.py --c42-taps`, then compared with:
+
+```bash
+python3 scripts/mtp_compare.py --c42 \
+  --pair seed0:profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors,profiling-artifacts/post428_c42_20260423_seed0_ref_bf16.safetensors \
+  --pair seed1:profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors,profiling-artifacts/post428_c42_20260423_seed1_ref_bf16.safetensors \
+  --out profiling-artifacts/post428_c42_20260423_compare_bf16.txt
+
+python3 scripts/mtp_compare.py --c42 \
+  --pair seed0:profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors,profiling-artifacts/post428_c42_20260423_seed0_ref_fp32.safetensors \
+  --pair seed1:profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors,profiling-artifacts/post428_c42_20260423_seed1_ref_fp32.safetensors \
+  --out profiling-artifacts/post428_c42_20260423_compare_fp32.txt
+```
+
+### Fresh workload check
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 10116.0 | 35.3 | 0.716 |
+| 1 | 508 | 395.3 | 21.2 | 0.293 |
+
+The post-#428 seed split still reproduces.
+
+### Verdict
+
+The first shared bad tensor is **not** already present in the residual input
+entering block 1. Across both bf16 and fp32 comparisons:
+
+- `layer_1_residual_input` remains `ok` for both seeds
+- `layer_1_input_norm_rms_inv` remains `ok` for both seeds
+- `layer_1_input_norm_pre_weight` is the earliest shared `DIV` tap
+- `layer_1_post_input_norm` remains bad, but it is downstream of the first
+  failing C42 boundary
+
+So the shared drift is now localized to the boundary between
+`layer_1_input_norm_rms_inv` and `layer_1_input_norm_pre_weight`. The
+remaining culprit space is inside layer-1 `input_layernorm` numerics,
+specifically the normalization / pre-weight scaling path before the final
+`(1 + weight)` application.
+
+### Evidence
+
+- `profiling-artifacts/post428_c42_20260423_seed0.bench.json`
+- `profiling-artifacts/post428_c42_20260423_seed0.bench.stderr`
+- `profiling-artifacts/post428_c42_20260423_seed1.bench.json`
+- `profiling-artifacts/post428_c42_20260423_seed1.bench.stderr`
+- `profiling-artifacts/post428_c42_20260423_compare_bf16.txt`
+- `profiling-artifacts/post428_c42_20260423_compare_fp32.txt`

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1531,6 +1531,25 @@ pub fn rms_norm_fallback(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor
     Ok(out.to_dtype(x.dtype())?)
 }
 
+/// Phase C42: capture the minimal layer-1 input-layernorm intermediates needed
+/// to distinguish "bad residual input arrives at block 1" from "the residual
+/// input is clean but the RMSNorm math diverges". This intentionally mirrors
+/// the fallback RMSNorm formula instead of widening the general tracing API.
+fn capture_c42_layer1_input_norm_taps(x: &Tensor, weight: &Tensor, eps: f64) -> Result<()> {
+    crate::mtp_debug::capture_c42_layer1_norm_tap("layer_1_residual_input", x)?;
+    let x_f32 = x.to_dtype(DType::F32)?;
+    let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
+    let rms_inv = (variance + eps)?.sqrt()?.recip()?;
+    crate::mtp_debug::capture_c42_layer1_norm_tap("layer_1_input_norm_rms_inv", &rms_inv)?;
+    let pre_weight = x_f32.broadcast_mul(&rms_inv)?;
+    crate::mtp_debug::capture_c42_layer1_norm_tap("layer_1_input_norm_pre_weight", &pre_weight)?;
+    let w_f32 = weight.to_dtype(DType::F32)?;
+    let w_plus_one = (w_f32.ones_like()? + w_f32)?;
+    let post = pre_weight.broadcast_mul(&w_plus_one)?.to_dtype(x.dtype())?;
+    crate::mtp_debug::capture_c42_layer1_norm_tap("layer_1_post_input_norm", &post)?;
+    Ok(())
+}
+
 /// Apply Rotary Position Embeddings (RoPE) to query and key tensors.
 ///
 /// `q`: [batch, seq_len, num_heads, head_dim]
@@ -4924,6 +4943,7 @@ pub fn model_forward_paged_with_last_hidden(
     // tail and per-sub-op taps inside layer 31.
     crate::mtp_debug::arm_b12_gqa_capture();
     crate::mtp_debug::arm_c41_layer1_capture();
+    crate::mtp_debug::arm_c42_layer1_norm_capture();
     let (logits, hidden) = model_forward_paged_inner(
         backend,
         token_ids,
@@ -4964,6 +4984,7 @@ pub fn model_forward_paged_last_token_with_last_hidden(
     crate::mtp_debug::stash_h_main_replay_context(token_ids);
     crate::mtp_debug::arm_b11_layer0_capture();
     crate::mtp_debug::arm_c41_layer1_capture();
+    crate::mtp_debug::arm_c42_layer1_norm_capture();
     let (logits, hidden) = model_forward_paged_inner(
         backend,
         token_ids,
@@ -5358,6 +5379,10 @@ pub fn mtp_forward_step(
             // the base-model forward. Empty when
             // `KILN_MTP_DUMP_C41_LAYER1_TAPS` is unset.
             let c41_taps = crate::mtp_debug::drain_c41_layer1_capture();
+            // Phase C42: drain any layer-1 pre-norm / input-layernorm taps
+            // stashed during the base-model forward. Empty when
+            // `KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS` is unset.
+            let c42_taps = crate::mtp_debug::drain_c42_layer1_norm_capture();
             // Phase C6: drain the 5 pre-RoPE MTP input taps (token_emb,
             // norm_emb, norm_h, concat, fused) captured above. Empty when
             // `KILN_MTP_DUMP_PRE_ROPE` is unset, which keeps the dump format
@@ -5389,6 +5414,7 @@ pub fn mtp_forward_step(
                 &b11_taps,
                 &b12_taps,
                 &c41_taps,
+                &c42_taps,
                 &c6_taps,
                 &c7_taps,
                 &c14_taps,
@@ -5405,6 +5431,7 @@ pub fn mtp_forward_step(
                     b11_taps = b11_taps.len(),
                     b12_taps = b12_taps.len(),
                     c41_taps = c41_taps.len(),
+                    c42_taps = c42_taps.len(),
                     c6_taps = c6_taps.len(),
                     c7_taps = c7_taps.len(),
                     c14_taps = c14_taps.len(),
@@ -5614,6 +5641,15 @@ fn model_forward_paged_inner(
                 let capture_b11_taps = crate::mtp_debug::should_capture_b11_tap_for_layer(i);
                 let capture_c41_taps =
                     crate::mtp_debug::should_capture_c41_layer1_tap_for_layer(i);
+                let capture_c42_taps =
+                    crate::mtp_debug::should_capture_c42_layer1_norm_tap_for_layer(i);
+                if capture_c42_taps {
+                    capture_c42_layer1_input_norm_taps(
+                        &hidden,
+                        &layer.input_layernorm,
+                        config.rms_norm_eps,
+                    )?;
+                }
                 let normed = {
                     kiln_nvtx::range!(c"kiln/norm/pre_attn");
                     rms_norm(&hidden, &layer.input_layernorm, config.rms_norm_eps)?

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -143,6 +143,18 @@ thread_local! {
     static C41_LAYER1_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
         const { RefCell::new(None) };
 
+    /// Phase C42: thread-local sink for the narrowed layer-1 pre-norm /
+    /// input-layernorm bisect. Kept distinct from C41 because this phase only
+    /// wants the residual handoff into block 1 plus the smallest useful
+    /// input-layernorm intermediates under a dedicated `c42__*` namespace.
+    ///
+    /// Driven by [`arm_c42_layer1_norm_capture`] /
+    /// [`drain_c42_layer1_norm_capture`] / [`capture_c42_layer1_norm_tap`],
+    /// and gated on `KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS=1` so production
+    /// decode stays on the current fast path when unset.
+    static C42_LAYER1_NORM_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
+        const { RefCell::new(None) };
+
     /// Phase B12: thread-local "current absolute layer index" slot. Set by
     /// the main transformer layer loop around each layer's forward call so
     /// that deep inside `gqa_attention_paged` / `transformer_block_paged`
@@ -843,6 +855,29 @@ pub const C41_LAYER1_TAP_NAMES: &[&str] = &[
     "layer_1_output",
 ];
 
+/// True when `KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS=1` (or `true`) is set.
+/// Opt-in for the Phase C42 layer-1 pre-norm / input-layernorm bisect: when
+/// enabled alongside `KILN_MTP_DUMP_PATH` and `KILN_MTP_DUMP_HIDDEN_STATES=1`,
+/// the base-model forward records the explicit norm-boundary taps listed in
+/// [`C42_LAYER1_NORM_TAP_NAMES`] and appends them to the MTP dump safetensors
+/// under names `c42__<name>`.
+pub fn is_dump_c42_layer1_norm_taps_enabled() -> bool {
+    std::env::var("KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
+/// Canonical ordered list of Phase C42 layer-1 pre-norm / input-layernorm tap
+/// names. The comparator (`scripts/mtp_compare.py --c42`) and the HF
+/// reference (`scripts/mtp_h_main_reference_dump.py --c42-taps`) both mirror
+/// this exact order.
+pub const C42_LAYER1_NORM_TAP_NAMES: &[&str] = &[
+    "layer_1_residual_input",
+    "layer_1_input_norm_rms_inv",
+    "layer_1_input_norm_pre_weight",
+    "layer_1_post_input_norm",
+];
+
 /// True if the Phase C41 layer-1 capture window is currently armed on this
 /// thread. Call sites use this to gate the host copy so disarmed runs pay zero
 /// cost.
@@ -884,6 +919,48 @@ pub fn capture_c41_layer1_tap(name: &str, t: &Tensor) -> Result<()> {
     let (shape, flat) = tensor_to_f32_host(t)
         .with_context(|| format!("capture_c41_layer1_tap `{name}`: tensor→f32 host copy"))?;
     C41_LAYER1_CAPTURE.with(|c| {
+        if let Some(buf) = c.borrow_mut().as_mut() {
+            buf.push((name.to_string(), shape, flat));
+        }
+    });
+    Ok(())
+}
+
+/// True if the Phase C42 layer-1 norm-boundary capture window is currently
+/// armed on this thread.
+pub fn is_c42_layer1_norm_capture_armed() -> bool {
+    C42_LAYER1_NORM_CAPTURE.with(|c| c.borrow().is_some())
+}
+
+/// True if a C42 layer-1 norm-boundary capture should happen for `layer_idx`.
+pub fn should_capture_c42_layer1_norm_tap_for_layer(layer_idx: usize) -> bool {
+    layer_idx == 1 && is_c42_layer1_norm_capture_armed()
+}
+
+/// Begin a C42 layer-1 norm-boundary capture window.
+pub fn arm_c42_layer1_norm_capture() {
+    if !is_dump_c42_layer1_norm_taps_enabled() {
+        return;
+    }
+    C42_LAYER1_NORM_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
+}
+
+/// Drain the captured C42 layer-1 norm-boundary taps and disarm.
+pub fn drain_c42_layer1_norm_capture() -> Vec<(String, Vec<usize>, Vec<f32>)> {
+    C42_LAYER1_NORM_CAPTURE.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+/// Record one named C42 layer-1 norm-boundary tap if a capture window is
+/// currently open on this thread.
+pub fn capture_c42_layer1_norm_tap(name: &str, t: &Tensor) -> Result<()> {
+    let armed = C42_LAYER1_NORM_CAPTURE.with(|c| c.borrow().is_some());
+    if !armed {
+        return Ok(());
+    }
+    let (shape, flat) = tensor_to_f32_host(t).with_context(|| {
+        format!("capture_c42_layer1_norm_tap `{name}`: tensor→f32 host copy")
+    })?;
+    C42_LAYER1_NORM_CAPTURE.with(|c| {
         if let Some(buf) = c.borrow_mut().as_mut() {
             buf.push((name.to_string(), shape, flat));
         }
@@ -1524,6 +1601,12 @@ fn tensor_to_f32_host(t: &Tensor) -> Result<(Vec<usize>, Vec<f32>)> {
 /// passing `&[]` for both `b11_taps` and `b12_taps` produce the historical
 /// safetensors layout.
 ///
+/// Phase C41 / C42: `c41_taps` and `c42_taps` carry the layer-1 bisect taps
+/// captured via their phase-specific arm/capture/drain helpers. Each slice is
+/// serialized as F32 under `c41__<name>` / `c42__<name>`, with an accompanying
+/// ordered tap-id metadata tensor so the Python side can mirror the exact tap
+/// order from the kiln dump.
+///
 /// Phase C6: `c6_taps` carries the pre-RoPE MTP-input taps captured via
 /// [`arm_pre_rope_capture`] / [`capture_pre_rope_tap`] /
 /// [`drain_pre_rope_capture`]. Each entry is serialized as F32 under the
@@ -1559,6 +1642,7 @@ pub fn write_mtp_dump(
     b11_taps: &[(String, Vec<usize>, Vec<f32>)],
     b12_taps: &[(String, Vec<usize>, Vec<f32>)],
     c41_taps: &[(String, Vec<usize>, Vec<f32>)],
+    c42_taps: &[(String, Vec<usize>, Vec<f32>)],
     c6_taps: &[(String, Vec<usize>, Vec<f32>)],
     c7_taps: &[(String, Vec<usize>, Vec<f32>)],
     c14_taps: &[(String, Vec<usize>, Vec<f32>)],
@@ -1569,11 +1653,12 @@ pub fn write_mtp_dump(
     // TensorViews we build below can borrow from a stable backing store.
     // Capacity: static taps + subops + 4 meta + optional boundary-layer meta
     // + optional prompt/replay token tensors + b11 taps + b12 taps + optional
-    // C41 tap-id meta + c41 taps + c6 taps + c7 taps + c14 taps.
+    // C41/C42 tap-id meta + c41/c42 taps + c6 taps + c7 taps + c14 taps.
     let boundary_reserve = if boundary_layers.is_empty() { 0 } else { 1 };
     let prompt_reserve = if prompt_tokens.is_empty() { 0 } else { 2 };
     let replay_reserve = if replay_tokens.is_empty() { 0 } else { 2 };
     let c41_meta_reserve = if c41_taps.is_empty() { 0 } else { 1 };
+    let c42_meta_reserve = if c42_taps.is_empty() { 0 } else { 1 };
     let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> = Vec::with_capacity(
         taps.len()
             + extra_subops.len()
@@ -1585,6 +1670,8 @@ pub fn write_mtp_dump(
             + b12_taps.len()
             + c41_meta_reserve
             + c41_taps.len()
+            + c42_meta_reserve
+            + c42_taps.len()
             + c6_taps.len()
             + c7_taps.len()
             + c14_taps.len(),
@@ -1747,6 +1834,32 @@ pub fn write_mtp_dump(
             bytes.extend_from_slice(&v.to_le_bytes());
         }
         backings.push((format!("c41__{name}"), shape.clone(), Dtype::F32, bytes));
+    }
+
+    if !c42_taps.is_empty() {
+        let mut bytes = Vec::with_capacity(c42_taps.len() * 4);
+        for (name, _shape, _flat) in c42_taps {
+            let idx = C42_LAYER1_NORM_TAP_NAMES
+                .iter()
+                .position(|&tap| tap == name.as_str())
+                .with_context(|| format!("unknown C42 tap `{name}`"))?;
+            let idx_i32 = idx as i32;
+            bytes.extend_from_slice(&idx_i32.to_le_bytes());
+        }
+        backings.push((
+            "meta__c42_tap_ids".into(),
+            vec![c42_taps.len()],
+            Dtype::I32,
+            bytes,
+        ));
+    }
+
+    for (name, shape, flat) in c42_taps {
+        let mut bytes = Vec::with_capacity(flat.len() * 4);
+        for v in flat {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        backings.push((format!("c42__{name}"), shape.clone(), Dtype::F32, bytes));
     }
 
     // Phase C6: serialize the pre-RoPE MTP-input taps under `c6__<name>` so
@@ -2214,6 +2327,7 @@ mod tests {
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             /* c41_taps = */ &[],
+            /* c42_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2344,6 +2458,7 @@ mod tests {
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             /* c41_taps = */ &[],
+            /* c42_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2488,6 +2603,7 @@ mod tests {
             &b11,
             /* b12_taps = */ &[],
             /* c41_taps = */ &[],
+            /* c42_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2545,6 +2661,13 @@ mod tests {
     }
 
     #[test]
+    fn c42_layer1_norm_tap_names_enumerate_expected_boundaries() {
+        assert_eq!(C42_LAYER1_NORM_TAP_NAMES.len(), 4);
+        assert_eq!(C42_LAYER1_NORM_TAP_NAMES[0], "layer_1_residual_input");
+        assert_eq!(C42_LAYER1_NORM_TAP_NAMES[3], "layer_1_post_input_norm");
+    }
+
+    #[test]
     fn c41_layer1_capture_records_then_drains() {
         let _guard = test_env_lock();
         unsafe {
@@ -2593,6 +2716,57 @@ mod tests {
         let a = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
         capture_c41_layer1_tap("layer_1_post_input_norm", &a).unwrap();
         assert!(drain_c41_layer1_capture().is_empty());
+    }
+
+    #[test]
+    fn c42_layer1_norm_capture_records_then_drains() {
+        let _guard = test_env_lock();
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS", "1");
+        }
+        let a = Tensor::new(&[1.0_f32, 2.0, 3.0][..], &Device::Cpu).unwrap();
+        let b = Tensor::new(&[10.0_f32][..], &Device::Cpu).unwrap();
+
+        capture_c42_layer1_norm_tap("layer_1_residual_input", &a).unwrap();
+        assert!(drain_c42_layer1_norm_capture().is_empty());
+        assert!(!is_c42_layer1_norm_capture_armed());
+        assert!(!should_capture_c42_layer1_norm_tap_for_layer(1));
+
+        arm_c42_layer1_norm_capture();
+        assert!(is_c42_layer1_norm_capture_armed());
+        assert!(should_capture_c42_layer1_norm_tap_for_layer(1));
+        assert!(!should_capture_c42_layer1_norm_tap_for_layer(0));
+        capture_c42_layer1_norm_tap("layer_1_residual_input", &a).unwrap();
+        capture_c42_layer1_norm_tap("layer_1_input_norm_rms_inv", &b).unwrap();
+        let drained = drain_c42_layer1_norm_capture();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].0, "layer_1_residual_input");
+        assert_eq!(drained[0].1, vec![3]);
+        assert_eq!(drained[0].2, vec![1.0, 2.0, 3.0]);
+        assert_eq!(drained[1].0, "layer_1_input_norm_rms_inv");
+        assert_eq!(drained[1].1, vec![1]);
+        assert_eq!(drained[1].2, vec![10.0]);
+
+        assert!(!is_c42_layer1_norm_capture_armed());
+        capture_c42_layer1_norm_tap("layer_1_post_input_norm", &a).unwrap();
+        assert!(drain_c42_layer1_norm_capture().is_empty());
+
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS");
+        }
+    }
+
+    #[test]
+    fn c42_layer1_norm_arm_is_noop_when_env_unset() {
+        let _guard = test_env_lock();
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS");
+        }
+        arm_c42_layer1_norm_capture();
+        assert!(!is_c42_layer1_norm_capture_armed());
+        let a = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        capture_c42_layer1_norm_tap("layer_1_residual_input", &a).unwrap();
+        assert!(drain_c42_layer1_norm_capture().is_empty());
     }
 
     #[test]
@@ -2684,6 +2858,7 @@ mod tests {
             /* b11_taps = */ &[],
             &b12,
             /* c41_taps = */ &[],
+            /* c42_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2748,6 +2923,7 @@ mod tests {
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             &c41,
+            /* c42_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2770,6 +2946,68 @@ mod tests {
         assert_eq!(id1, 11);
 
         let out = st.tensor("c41__layer_1_output").unwrap();
+        assert_eq!(out.dtype(), safetensors::Dtype::F32);
+        assert_eq!(out.shape(), &[3]);
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn write_mtp_dump_emits_c42_taps_and_metadata_when_provided() {
+        use safetensors::SafeTensors;
+
+        let h = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        let tmp = std::env::temp_dir().join("kiln_mtp_dump_with_c42.safetensors");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let c42 = vec![
+            (
+                "layer_1_residual_input".to_string(),
+                vec![2],
+                vec![0.81_f32, 0.82],
+            ),
+            (
+                "layer_1_post_input_norm".to_string(),
+                vec![3],
+                vec![0.91_f32, 0.92, 0.93],
+            ),
+        ];
+        write_mtp_dump(
+            &tmp_s,
+            /* draft_token_id = */ 66,
+            /* mtp_pos = */ 0,
+            /* base_pos = */ 0,
+            /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[],
+            &[("h_main", &h)],
+            &[],
+            /* prompt_tokens = */ &[],
+            /* replay_tokens = */ &[],
+            /* b11_taps = */ &[],
+            /* b12_taps = */ &[],
+            /* c41_taps = */ &[],
+            &c42,
+            /* c6_taps = */ &[],
+            /* c7_taps = */ &[],
+            /* c14_taps = */ &[],
+        )
+        .unwrap();
+
+        let raw = std::fs::read(&tmp).unwrap();
+        let st = SafeTensors::deserialize(&raw).unwrap();
+        let names: Vec<&str> = st.names().into_iter().map(|s| s.as_str()).collect();
+        assert!(names.contains(&"c42__layer_1_residual_input"));
+        assert!(names.contains(&"c42__layer_1_post_input_norm"));
+        assert!(names.contains(&"meta__c42_tap_ids"));
+
+        let ids = st.tensor("meta__c42_tap_ids").unwrap();
+        assert_eq!(ids.dtype(), safetensors::Dtype::I32);
+        assert_eq!(ids.shape(), &[2]);
+        let id0 = i32::from_le_bytes(ids.data()[0..4].try_into().unwrap());
+        let id1 = i32::from_le_bytes(ids.data()[4..8].try_into().unwrap());
+        assert_eq!(id0, 0);
+        assert_eq!(id1, 3);
+
+        let out = st.tensor("c42__layer_1_post_input_norm").unwrap();
         assert_eq!(out.dtype(), safetensors::Dtype::F32);
         assert_eq!(out.shape(), &[3]);
 
@@ -2967,6 +3205,7 @@ mod tests {
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             /* c41_taps = */ &[],
+            /* c42_taps = */ &[],
             &c6,
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3100,6 +3339,7 @@ mod tests {
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             /* c41_taps = */ &[],
+            /* c42_taps = */ &[],
             /* c6_taps = */ &[],
             &c7,
             /* c14_taps = */ &[],
@@ -3259,6 +3499,7 @@ mod tests {
             /* b11_taps = */ &[],
             /* b12_taps = */ &[],
             /* c41_taps = */ &[],
+            /* c42_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             &c14,

--- a/docs/phase-c42/c42-layer1-prenorm-input-layernorm-bisect.md
+++ b/docs/phase-c42/c42-layer1-prenorm-input-layernorm-bisect.md
@@ -1,0 +1,202 @@
+# Phase C42 — layer 1 pre-norm vs input-layernorm bisect after PR #428
+
+**Date:** 2026-04-23  
+**Current main preflight base:** `e569d22` (PR #428 on `main`)  
+**Hardware:** RunPod `NVIDIA A100-SXM4-80GB` via `ghcr.io/ericflo/kiln-runpod:latest`
+
+## Preflight
+
+1. **Fresh-main source of truth still valid:** satisfied. Fresh `origin/main`
+   still pointed at PR #428 and
+   [`docs/phase-c41/c41-layer1-subop-bisect.md`](../phase-c41/c41-layer1-subop-bisect.md)
+   remained the latest committed source of truth for this bisect path.
+2. **Committed C41 verdict still held:** satisfied. C41 still recorded
+   `layer_1_post_input_norm` as the earliest shared bad layer-1 tap for both
+   seeds.
+3. **No committed C42 localization already landed:** satisfied. Fresh main did
+   not already contain committed C42 taps or a doc that localized the
+   remaining span to either the residual input entering block 1 or the
+   layer-1 `input_layernorm` numerics.
+
+## Code change
+
+This task adds a minimal, opt-in C42 bisect path for the layer-1 norm
+boundary only:
+
+- `crates/kiln-model/src/mtp_debug.rs`
+  adds the dedicated `KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS=1` switch, the
+  canonical C42 tap list, a dedicated thread-local sink, and metadata
+  serialization via `meta__c42_tap_ids`.
+- `crates/kiln-model/src/forward.rs`
+  arms C42 only on the base-model replay path and captures the explicit
+  norm-boundary tap set at layer 1:
+  `layer_1_residual_input`, `layer_1_input_norm_rms_inv`,
+  `layer_1_input_norm_pre_weight`, and `layer_1_post_input_norm`.
+- `scripts/mtp_h_main_reference_dump.py`
+  mirrors the same tap set under `--c42-taps`, resolves tap ordering from kiln
+  metadata, and captures the matching HF-side layer-1 input-layernorm
+  intermediates on the same last-token replay contract.
+- `scripts/mtp_compare.py`
+  adds `--c42` mode and narrows reporting to the explicit `c42__*` tap set so
+  the earliest shared bad norm-boundary tensor is reported cleanly.
+
+Default decode remains unchanged when
+`KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS` is unset.
+
+## Validation commands run
+
+```bash
+cd /workspace/kiln
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+source /root/.kiln-build-env
+cargo test -p kiln-model mtp_debug --lib -- --test-threads=1
+```
+
+## Standard workload commands run
+
+Build and checkpoint setup on the RunPod fallback GPU:
+
+```bash
+cd /workspace/kiln
+source /root/.kiln-build-env
+export KILN_CUDA_ARCHS=80
+cargo build --release --features cuda --bin kiln-bench
+hf download Qwen/Qwen3.5-4B --local-dir /workspace/qwen3.5-4b
+python3 -m pip install transformers safetensors sentencepiece
+```
+
+Standard native-MTP rerun with the C42 tap flag enabled:
+
+```bash
+for seed in 0 1; do
+  root=/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed${seed}_captures
+  rm -rf "$root"
+  mkdir -p "$root"/mtp_pos-0 "$root"/mtp_pos-2
+
+  KILN_W4A16=1 \
+  KILN_CUDA_GRAPHS=true \
+  KILN_SPEC_METHOD=mtp \
+  KILN_BENCH_FORCE_MTP=1 \
+  KILN_MTP_DUMP_SPLICE=1 \
+  KILN_MTP_DUMP_SPLICE_POS=0,2 \
+  KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+  KILN_MTP_DUMP_HIDDEN_STATES=1 \
+  KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+  KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS=1 \
+  KILN_MTP_DUMP_PATH=$root/mtp_pos-{pos}/step-{step}.safetensors \
+  ./target/release/kiln-bench \
+    --model-path /workspace/qwen3.5-4b \
+    --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+    --seed ${seed} \
+    > /workspace/kiln/profiling-artifacts/post428_c42_20260423_seed${seed}.bench.json \
+    2> /workspace/kiln/profiling-artifacts/post428_c42_20260423_seed${seed}.bench.stderr
+done
+```
+
+Representative C41 divergence points were then re-referenced:
+
+- seed 0 representative dump:
+  `profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors`
+- seed 1 representative dump:
+  `profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors`
+
+Reference regeneration and compare commands:
+
+```bash
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors \
+  --out profiling-artifacts/post428_c42_20260423_seed0_ref_bf16.safetensors \
+  --device cuda \
+  --c42-taps
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors \
+  --out profiling-artifacts/post428_c42_20260423_seed0_ref_fp32.safetensors \
+  --device cuda \
+  --fp32 \
+  --c42-taps
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors \
+  --out profiling-artifacts/post428_c42_20260423_seed1_ref_bf16.safetensors \
+  --device cuda \
+  --c42-taps
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors \
+  --out profiling-artifacts/post428_c42_20260423_seed1_ref_fp32.safetensors \
+  --device cuda \
+  --fp32 \
+  --c42-taps
+
+python3 scripts/mtp_compare.py --c42 \
+  --pair seed0:profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors,profiling-artifacts/post428_c42_20260423_seed0_ref_bf16.safetensors \
+  --pair seed1:profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors,profiling-artifacts/post428_c42_20260423_seed1_ref_bf16.safetensors \
+  --out profiling-artifacts/post428_c42_20260423_compare_bf16.txt
+
+python3 scripts/mtp_compare.py --c42 \
+  --pair seed0:profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors,profiling-artifacts/post428_c42_20260423_seed0_ref_fp32.safetensors \
+  --pair seed1:profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors,profiling-artifacts/post428_c42_20260423_seed1_ref_fp32.safetensors \
+  --out profiling-artifacts/post428_c42_20260423_compare_fp32.txt
+```
+
+## Fresh workload check
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 10116.0 | 35.3 | 0.716 |
+| 1 | 508 | 395.3 | 21.2 | 0.293 |
+
+The post-#428 seed split still reproduces.
+
+## Committed artifacts
+
+- [`profiling-artifacts/post428_c42_20260423_seed0.bench.json`](../../profiling-artifacts/post428_c42_20260423_seed0.bench.json)
+- [`profiling-artifacts/post428_c42_20260423_seed0.bench.stderr`](../../profiling-artifacts/post428_c42_20260423_seed0.bench.stderr)
+- [`profiling-artifacts/post428_c42_20260423_seed1.bench.json`](../../profiling-artifacts/post428_c42_20260423_seed1.bench.json)
+- [`profiling-artifacts/post428_c42_20260423_seed1.bench.stderr`](../../profiling-artifacts/post428_c42_20260423_seed1.bench.stderr)
+- [`profiling-artifacts/post428_c42_20260423_compare_bf16.txt`](../../profiling-artifacts/post428_c42_20260423_compare_bf16.txt)
+- [`profiling-artifacts/post428_c42_20260423_compare_fp32.txt`](../../profiling-artifacts/post428_c42_20260423_compare_fp32.txt)
+
+## Verdict
+
+**The earliest shared bad layer-1 norm-boundary tap is
+`layer_1_input_norm_pre_weight`.**
+
+Across both bf16 and fp32 reference comparisons:
+
+| Reference dtype | Seed 0 verdict | Seed 1 verdict | Shared earliest bad tap |
+| --- | --- | --- | --- |
+| bf16 | `layer_1_input_norm_pre_weight` | `layer_1_input_norm_pre_weight` | `layer_1_input_norm_pre_weight` |
+| fp32 | `layer_1_input_norm_pre_weight` | `layer_1_input_norm_pre_weight` | `layer_1_input_norm_pre_weight` |
+
+Representative C42 rows:
+
+- seed 0 bf16:
+  `layer_1_residual_input` remains `ok`,
+  `layer_1_input_norm_rms_inv` remains `ok`,
+  and `layer_1_input_norm_pre_weight` is already `DIV`
+- seed 1 fp32:
+  `layer_1_residual_input` remains `ok`,
+  `layer_1_input_norm_rms_inv` remains `ok`,
+  and `layer_1_input_norm_pre_weight` is already `DIV`
+
+This closes the C41 remaining span. The first shared bad tensor is **not**
+already present in the residual entering transformer block 1; it appears
+inside layer 1 `input_layernorm`.
+
+## Narrowest remaining span
+
+C42 localizes the remaining bad span to the norm-local step between:
+
+- `layer_1_input_norm_rms_inv` (last shared-good tap)
+- `layer_1_input_norm_pre_weight` (earliest shared-bad tap)
+
+So the residual input entering block 1 is no longer a viable culprit. The
+remaining work, if any, should stay inside layer-1 input-layernorm numerics:
+the normalization / pre-weight scaling path before the final `(1 + weight)`
+application.

--- a/profiling-artifacts/post428_c42_20260423_compare_bf16.txt
+++ b/profiling-artifacts/post428_c42_20260423_compare_bf16.txt
@@ -1,0 +1,61 @@
+MTP numerical bisect — mode: layer-1 pre-norm / input-layernorm bisect (C42), atol=0.01, rtol=0.1
+
+=== seed0 ===
+  kiln dump : profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : profiling-artifacts/post428_c42_20260423_seed0_ref_bf16.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c42__layer_1_input_norm_pre_weight 1x1x2560               True     False    9.99e-01   1.38e-01     3.19e-02    
+c42__layer_1_input_norm_rms_inv 1x1x1                  True     True     1.00e+00   1.14e-01     1.14e-01    
+c42__layer_1_post_input_norm 1x1x2560               True     False    9.98e-01   1.48e-01     3.46e-02    
+c42__layer_1_residual_input 1x1x2560               True     True     9.99e-01   1.56e-02     1.59e-03    
+
+  pair verdict: first divergence at tap 'c42__layer_1_input_norm_pre_weight'.
+    Most-likely cause: <unknown tap>
+
+=== seed1 ===
+  kiln dump : profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : profiling-artifacts/post428_c42_20260423_seed1_ref_bf16.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c42__layer_1_input_norm_pre_weight 1x1x2560               True     False    9.99e-01   1.43e-01     3.14e-02    
+c42__layer_1_input_norm_rms_inv 1x1x1                  True     True     1.00e+00   1.59e-02     1.59e-02    
+c42__layer_1_post_input_norm 1x1x2560               True     False    9.98e-01   1.56e-01     3.41e-02    
+c42__layer_1_residual_input 1x1x2560               True     True     9.99e-01   6.10e-03     1.34e-03    
+
+  pair verdict: first divergence at tap 'c42__layer_1_input_norm_pre_weight'.
+    Most-likely cause: <unknown tap>
+
+==============================================================================
+Phase C42 layer-1 pre-norm / input-layernorm bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                             seed0                                                seed1                                               
+  -----------------------------------------------------------------------------------------------------------------------------------------
+  layer_1_residual_input          cos=9.99e-01   max|Δ|=1.56e-02   mean|Δ|=1.59e-03   rel_l2=4.03e-02   ok  cos=9.99e-01   max|Δ|=6.10e-03   mean|Δ|=1.34e-03   rel_l2=3.93e-02   ok 
+  layer_1_input_norm_rms_inv      cos=1.00e+00   max|Δ|=1.14e-01   mean|Δ|=1.14e-01   rel_l2=5.69e-03   ok  cos=1.00e+00   max|Δ|=1.59e-02   mean|Δ|=1.59e-02   rel_l2=6.77e-04   ok 
+  layer_1_input_norm_pre_weight   cos=9.99e-01   max|Δ|=1.38e-01   mean|Δ|=3.19e-02   rel_l2=4.00e-02   DIV cos=9.99e-01   max|Δ|=1.43e-01   mean|Δ|=3.14e-02   rel_l2=3.93e-02   DIV
+  layer_1_post_input_norm         cos=9.98e-01   max|Δ|=1.48e-01   mean|Δ|=3.46e-02   rel_l2=5.64e-02   DIV cos=9.98e-01   max|Δ|=1.56e-01   mean|Δ|=3.41e-02   rel_l2=5.77e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight'
+  last shared-good tap: 'layer_1_input_norm_rms_inv'
+Phase C42 verdict: EARLIEST SHARED BAD NORM-BOUNDARY TAP = 'layer_1_input_norm_pre_weight'.
+    Most-likely cause: input_layernorm normalization math diverges before applying (1 + weight)
+  -> The shared drift is now localized to the boundary between 'layer_1_input_norm_rms_inv' and 'layer_1_input_norm_pre_weight'.
+
+Overall verdict: divergence(s) at: ['c42__layer_1_input_norm_pre_weight', 'c42__layer_1_input_norm_pre_weight']

--- a/profiling-artifacts/post428_c42_20260423_compare_fp32.txt
+++ b/profiling-artifacts/post428_c42_20260423_compare_fp32.txt
@@ -1,0 +1,61 @@
+MTP numerical bisect — mode: layer-1 pre-norm / input-layernorm bisect (C42), atol=0.01, rtol=0.1
+
+=== seed0 ===
+  kiln dump : profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : profiling-artifacts/post428_c42_20260423_seed0_ref_fp32.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c42__layer_1_input_norm_pre_weight 1x1x2560               True     False    9.99e-01   1.39e-01     3.18e-02    
+c42__layer_1_input_norm_rms_inv 1x1x1                  True     True     1.00e+00   1.24e-01     1.24e-01    
+c42__layer_1_post_input_norm 1x1x2560               True     False    9.98e-01   1.50e-01     3.45e-02    
+c42__layer_1_residual_input 1x1x2560               True     True     9.99e-01   1.82e-02     1.58e-03    
+
+  pair verdict: first divergence at tap 'c42__layer_1_input_norm_pre_weight'.
+    Most-likely cause: <unknown tap>
+
+=== seed1 ===
+  kiln dump : profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : profiling-artifacts/post428_c42_20260423_seed1_ref_fp32.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c42__layer_1_input_norm_pre_weight 1x1x2560               True     False    9.99e-01   1.39e-01     3.13e-02    
+c42__layer_1_input_norm_rms_inv 1x1x1                  True     True     1.00e+00   9.97e-02     9.97e-02    
+c42__layer_1_post_input_norm 1x1x2560               True     False    9.98e-01   1.50e-01     3.41e-02    
+c42__layer_1_residual_input 1x1x2560               True     True     9.99e-01   9.84e-03     1.34e-03    
+
+  pair verdict: first divergence at tap 'c42__layer_1_input_norm_pre_weight'.
+    Most-likely cause: <unknown tap>
+
+==============================================================================
+Phase C42 layer-1 pre-norm / input-layernorm bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                             seed0                                                seed1                                               
+  -----------------------------------------------------------------------------------------------------------------------------------------
+  layer_1_residual_input          cos=9.99e-01   max|Δ|=1.82e-02   mean|Δ|=1.58e-03   rel_l2=4.03e-02   ok  cos=9.99e-01   max|Δ|=9.84e-03   mean|Δ|=1.34e-03   rel_l2=3.93e-02   ok 
+  layer_1_input_norm_rms_inv      cos=1.00e+00   max|Δ|=1.24e-01   mean|Δ|=1.24e-01   rel_l2=6.20e-03   ok  cos=1.00e+00   max|Δ|=9.97e-02   mean|Δ|=9.97e-02   rel_l2=4.27e-03   ok 
+  layer_1_input_norm_pre_weight   cos=9.99e-01   max|Δ|=1.39e-01   mean|Δ|=3.18e-02   rel_l2=3.99e-02   DIV cos=9.99e-01   max|Δ|=1.39e-01   mean|Δ|=3.13e-02   rel_l2=3.91e-02   DIV
+  layer_1_post_input_norm         cos=9.98e-01   max|Δ|=1.50e-01   mean|Δ|=3.45e-02   rel_l2=5.63e-02   DIV cos=9.98e-01   max|Δ|=1.50e-01   mean|Δ|=3.41e-02   rel_l2=5.76e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight'
+  last shared-good tap: 'layer_1_input_norm_rms_inv'
+Phase C42 verdict: EARLIEST SHARED BAD NORM-BOUNDARY TAP = 'layer_1_input_norm_pre_weight'.
+    Most-likely cause: input_layernorm normalization math diverges before applying (1 + weight)
+  -> The shared drift is now localized to the boundary between 'layer_1_input_norm_rms_inv' and 'layer_1_input_norm_pre_weight'.
+
+Overall verdict: divergence(s) at: ['c42__layer_1_input_norm_pre_weight', 'c42__layer_1_input_norm_pre_weight']

--- a/profiling-artifacts/post428_c42_20260423_seed0.bench.json
+++ b/profiling-artifacts/post428_c42_20260423_seed0.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA A100-SXM4-80GB",
+    "total_vram_mb": 81920,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 20.091099931,
+    "model_vram_mb": 17685
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 494,
+      "output_tokens": 128,
+      "total_time_secs": 3.397491908,
+      "tokens_per_sec": 37.674850585692695,
+      "peak_vram_mb": 17767
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 494,
+      "output_tokens": 512,
+      "total_time_secs": 13.554893669,
+      "tokens_per_sec": 37.77233613945216,
+      "peak_vram_mb": 17767
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 494,
+      "output_tokens": 1024,
+      "total_time_secs": 26.991803955,
+      "tokens_per_sec": 37.937442110471196,
+      "peak_vram_mb": 17767
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 494,
+      "output_tokens": 2048,
+      "total_time_secs": 54.162277937,
+      "tokens_per_sec": 37.81229442347633,
+      "peak_vram_mb": 17767
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 10116.030695,
+    "prefill_tokens_per_sec": 48.83338286470077,
+    "time_to_first_token_ms": 10116.030695,
+    "mean_inter_token_ms": 28.36613504724409,
+    "p50_inter_token_ms": 20.191710500000003,
+    "p99_inter_token_ms": 69.25789999999999,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 35.25330463013342,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7162162162162162,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post428_c42_20260423_seed0.bench.stderr
+++ b/profiling-artifacts/post428_c42_20260423_seed0.bench.stderr
@@ -1,0 +1,103 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA A100-SXM4-80GB (81920 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T11:39:32.924240Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T11:39:32.925285Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T11:39:32.925485Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T11:39:32.925494Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T11:39:32.925562Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T11:39:53.013297Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m16723 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 16723 ms (parallel)
+Model loaded in 20.09s (backend: cuda, VRAM: 17685 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=47] (494 prompt tokens)...
+    Prefill (MTP): 10116.0ms (49 tok/s)
+[2m2026-04-23T11:40:03.685700Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m27
+[2m2026-04-23T11:40:03.724510Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m5339 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m494 [3mreplay_tokens_len[0m[2m=[0m494 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:40:03.795936Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m31192 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m495 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:40:03.863310Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m33416 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m496 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:40:03.930903Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m321 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m497 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:40:04.078726Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed0_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m7071 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m502 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 28.4ms (35.3 tok/s), α = 0.716 (53/74)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T11:40:07.758703Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 3397.4ms (37.7 tok/s)
+  => 37.7 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 3379.7ms (37.9 tok/s)
+    Run 2/4: 128 tokens in 3388.5ms (37.8 tok/s)
+    Run 3/4: 128 tokens in 3394.9ms (37.7 tok/s)
+    Run 4/4: 128 tokens in 3391.6ms (37.7 tok/s)
+  => 37.8 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 3377.2ms (37.9 tok/s)
+    Run 2/8: 128 tokens in 3376.5ms (37.9 tok/s)
+    Run 3/8: 128 tokens in 3376.4ms (37.9 tok/s)
+    Run 4/8: 128 tokens in 3368.8ms (38.0 tok/s)
+    Run 5/8: 128 tokens in 3379.4ms (37.9 tok/s)
+    Run 6/8: 128 tokens in 3374.4ms (37.9 tok/s)
+    Run 7/8: 128 tokens in 3374.9ms (37.9 tok/s)
+    Run 8/8: 128 tokens in 3363.6ms (38.1 tok/s)
+  => 37.9 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 3370.4ms (38.0 tok/s)
+    Run 2/16: 128 tokens in 3375.4ms (37.9 tok/s)
+    Run 3/16: 128 tokens in 3374.3ms (37.9 tok/s)
+    Run 4/16: 128 tokens in 3385.7ms (37.8 tok/s)
+    Run 5/16: 128 tokens in 3396.4ms (37.7 tok/s)
+    Run 6/16: 128 tokens in 3398.2ms (37.7 tok/s)
+    Run 7/16: 128 tokens in 3392.9ms (37.7 tok/s)
+    Run 8/16: 128 tokens in 3384.7ms (37.8 tok/s)
+    Run 9/16: 128 tokens in 3372.1ms (38.0 tok/s)
+    Run 10/16: 128 tokens in 3364.2ms (38.0 tok/s)
+    Run 11/16: 128 tokens in 3360.0ms (38.1 tok/s)
+    Run 12/16: 128 tokens in 3386.6ms (37.8 tok/s)
+    Run 13/16: 128 tokens in 3395.3ms (37.7 tok/s)
+    Run 14/16: 128 tokens in 3399.2ms (37.7 tok/s)
+    Run 15/16: 128 tokens in 3402.4ms (37.6 tok/s)
+    Run 16/16: 128 tokens in 3403.4ms (37.6 tok/s)
+  => 37.8 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA A100-SXM4-80GB (81920 MB VRAM, source: nvidia-smi)
+Model load time: 20.09s (VRAM: 17685 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               494        128         37.7      17767
+4               494        512         37.8      17767
+8               494       1024         37.9      17767
+16              494       2048         37.8      17767
+
+--- Latency (single request) ---
+Prompt tokens:         494
+Prefill time:          10116.0 ms (49 tok/s)
+Time to first token:   10116.0 ms
+Mean inter-token:      28.4 ms (35.3 tok/s)
+P50 inter-token:       20.2 ms
+P99 inter-token:       69.3 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.716
+

--- a/profiling-artifacts/post428_c42_20260423_seed1.bench.json
+++ b/profiling-artifacts/post428_c42_20260423_seed1.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA A100-SXM4-80GB",
+    "total_vram_mb": 81920,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 16.645311854,
+    "model_vram_mb": 17685
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 508,
+      "output_tokens": 128,
+      "total_time_secs": 3.465820614,
+      "tokens_per_sec": 36.93209033466727,
+      "peak_vram_mb": 17767
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 508,
+      "output_tokens": 512,
+      "total_time_secs": 13.921943656,
+      "tokens_per_sec": 36.776474079417866,
+      "peak_vram_mb": 17767
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 508,
+      "output_tokens": 1024,
+      "total_time_secs": 27.887817888,
+      "tokens_per_sec": 36.71854155504302,
+      "peak_vram_mb": 17767
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 508,
+      "output_tokens": 2048,
+      "total_time_secs": 55.36502837,
+      "tokens_per_sec": 36.990859759221685,
+      "peak_vram_mb": 17767
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 508,
+    "prefill_time_ms": 395.338945,
+    "prefill_tokens_per_sec": 1284.9733283929313,
+    "time_to_first_token_ms": 395.338945,
+    "mean_inter_token_ms": 47.16301945275593,
+    "p50_inter_token_ms": 66.163738,
+    "p99_inter_token_ms": 78.725928,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 21.203052976744175,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.29292929292929293,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post428_c42_20260423_seed1.bench.stderr
+++ b/profiling-artifacts/post428_c42_20260423_seed1.bench.stderr
@@ -1,0 +1,109 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA A100-SXM4-80GB (81920 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T11:41:47.823093Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T11:41:47.824156Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T11:41:47.824352Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T11:41:47.824363Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T11:41:47.824432Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T11:42:04.466254Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m15333 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 15333 ms (parallel)
+Model loaded in 16.65s (backend: cuda, VRAM: 17685 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (508 prompt tokens)...
+    Prefill (MTP): 395.3ms (1285 tok/s)
+[2m2026-04-23T11:42:05.427932Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m25
+[2m2026-04-23T11:42:05.461564Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m25015 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m508 [3mreplay_tokens_len[0m[2m=[0m508 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:42:05.532578Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m314 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m509 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:42:05.602522Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m1330 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m510 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:42:05.672171Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m47205 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m511 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:42:05.742288Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-0/step-4.safetensors [3mdraft_token_id[0m[2m=[0m369 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(4) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m512 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:42:05.812420Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-0/step-5.safetensors [3mdraft_token_id[0m[2m=[0m799 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(5) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m513 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:42:05.882205Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-0/step-6.safetensors [3mdraft_token_id[0m[2m=[0m30797 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(6) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m514 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:42:05.952009Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-0/step-7.safetensors [3mdraft_token_id[0m[2m=[0m314 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(7) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m515 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:42:06.103965Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m421 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m520 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:42:06.173367Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-1.safetensors [3mdraft_token_id[0m[2m=[0m3202 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m521 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T11:42:06.242914Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0m/workspace/kiln/profiling-artifacts/post428_c42_20260423_seed1_captures/mtp_pos-2/step-2.safetensors [3mdraft_token_id[0m[2m=[0m369 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m522 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 47.2ms (21.2 tok/s), α = 0.293 (29/99)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T11:42:11.903186Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 3465.8ms (36.9 tok/s)
+  => 36.9 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 3480.2ms (36.8 tok/s)
+    Run 2/4: 128 tokens in 3481.4ms (36.8 tok/s)
+    Run 3/4: 128 tokens in 3477.7ms (36.8 tok/s)
+    Run 4/4: 128 tokens in 3482.4ms (36.8 tok/s)
+  => 36.8 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 3475.5ms (36.8 tok/s)
+    Run 2/8: 128 tokens in 3477.2ms (36.8 tok/s)
+    Run 3/8: 128 tokens in 3475.7ms (36.8 tok/s)
+    Run 4/8: 128 tokens in 3485.6ms (36.7 tok/s)
+    Run 5/8: 128 tokens in 3497.4ms (36.6 tok/s)
+    Run 6/8: 128 tokens in 3496.0ms (36.6 tok/s)
+    Run 7/8: 128 tokens in 3487.4ms (36.7 tok/s)
+    Run 8/8: 128 tokens in 3492.6ms (36.6 tok/s)
+  => 36.7 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 3469.8ms (36.9 tok/s)
+    Run 2/16: 128 tokens in 3476.7ms (36.8 tok/s)
+    Run 3/16: 128 tokens in 3484.7ms (36.7 tok/s)
+    Run 4/16: 128 tokens in 3448.1ms (37.1 tok/s)
+    Run 5/16: 128 tokens in 3455.6ms (37.0 tok/s)
+    Run 6/16: 128 tokens in 3440.1ms (37.2 tok/s)
+    Run 7/16: 128 tokens in 3444.8ms (37.2 tok/s)
+    Run 8/16: 128 tokens in 3462.4ms (37.0 tok/s)
+    Run 9/16: 128 tokens in 3463.2ms (37.0 tok/s)
+    Run 10/16: 128 tokens in 3467.6ms (36.9 tok/s)
+    Run 11/16: 128 tokens in 3470.6ms (36.9 tok/s)
+    Run 12/16: 128 tokens in 3461.2ms (37.0 tok/s)
+    Run 13/16: 128 tokens in 3445.9ms (37.1 tok/s)
+    Run 14/16: 128 tokens in 3425.9ms (37.4 tok/s)
+    Run 15/16: 128 tokens in 3476.3ms (36.8 tok/s)
+    Run 16/16: 128 tokens in 3471.2ms (36.9 tok/s)
+  => 37.0 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA A100-SXM4-80GB (81920 MB VRAM, source: nvidia-smi)
+Model load time: 16.65s (VRAM: 17685 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               508        128         36.9      17767
+4               508        512         36.8      17767
+8               508       1024         36.7      17767
+16              508       2048         37.0      17767
+
+--- Latency (single request) ---
+Prompt tokens:         508
+Prefill time:          395.3 ms (1285 tok/s)
+Time to first token:   395.3 ms
+Mean inter-token:      47.2 ms (21.2 tok/s)
+P50 inter-token:       66.2 ms
+P99 inter-token:       78.7 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.293
+

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -76,6 +76,17 @@ Transformer block 1 sub-op bisect (Phase C41 — earliest shared bad tap):
     bad under the requested tolerance bar, plus the last tap both seeds
     still agree is good.
 
+Layer-1 pre-norm / input-layernorm bisect (Phase C42 — earliest shared bad boundary):
+    python3 scripts/mtp_compare.py --c42 \\
+        --pair seed0:/tmp/h-kiln-seed0.safetensors,/tmp/h-ref-seed0.safetensors \\
+        --pair seed1:/tmp/h-kiln-seed1.safetensors,/tmp/h-ref-seed1.safetensors
+
+    --c42 defaults atol=1e-2, rtol=1e-1 (bf16-appropriate) and emits a
+    per-seed table for the explicit `c42__<name>` layer-1 norm-boundary tap
+    set. The verdict identifies whether the first shared bad tensor is
+    already the residual input entering block 1 or appears inside the
+    `input_layernorm` math itself.
+
 Exit code:
     0 — all taps match within tolerance (all positions, in multi mode)
     1 — at least one tap diverges (normal outcome of a bisect)
@@ -289,6 +300,24 @@ C41_HYPOTHESIS: Dict[str, str] = {
     "gdn_out_proj": "layer 1 out_proj weight layout / transpose / residual dtype",
     "layer_1_post_attn_residual": "layer 1 residual add after GDN out_proj",
     "layer_1_output": "layer 1 post-MLP residual handoff into layer 2",
+}
+
+# Phase C42 — narrowed layer-1 pre-norm / input-layernorm tap set, in
+# forward-graph order. Must stay in lock-step with
+# `C42_LAYER1_NORM_TAP_NAMES` in `crates/kiln-model/src/mtp_debug.rs` and
+# `scripts/mtp_h_main_reference_dump.py`.
+C42_LAYER1_NORM_TAP_NAMES: Tuple[str, ...] = (
+    "layer_1_residual_input",
+    "layer_1_input_norm_rms_inv",
+    "layer_1_input_norm_pre_weight",
+    "layer_1_post_input_norm",
+)
+
+C42_HYPOTHESIS: Dict[str, str] = {
+    "layer_1_residual_input": "upstream drift is already present before layer 1 input_layernorm",
+    "layer_1_input_norm_rms_inv": "input_layernorm RMS reduction / eps path diverges on otherwise matching input",
+    "layer_1_input_norm_pre_weight": "input_layernorm normalization math diverges before applying (1 + weight)",
+    "layer_1_post_input_norm": "input_layernorm weight application diverges after a matching normalized pre-weight tensor",
 }
 
 # Phase B12 — the cos_sim bar is tighter than B10/B11 because the expected
@@ -1618,6 +1647,111 @@ def _emit_c41_summary(
         emit("  -> Divergence is already present at the first captured layer-1 boundary.")
 
 
+def _emit_c42_summary(
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
+    atol: float,
+    rtol: float,
+    emit,
+) -> None:
+    """Phase C42 — layer-1 pre-norm / input-layernorm bisect."""
+    emit("")
+    emit("=" * 78)
+    emit("Phase C42 layer-1 pre-norm / input-layernorm bisect — cos_sim / max|Δ| / mean|Δ| / rel_l2")
+    emit("=" * 78)
+
+    labels = [pr[0] for pr in pair_results]
+    cell: Dict[str, Dict[str, Tuple[float, float, float, float, bool]]] = {
+        n: {} for n in C42_LAYER1_NORM_TAP_NAMES
+    }
+    for label, _ok, _fd, rows, _km, _rm in pair_results:
+        for r in rows:
+            n = r["name"]
+            if not isinstance(n, str) or not n.startswith("c42__"):
+                continue
+            short = n[len("c42__"):]
+            if short not in cell:
+                continue
+            cell[short][label] = (
+                float(r["cos_sim"]),
+                float(r["max_abs_diff"]),
+                float(r["mean_abs_diff"]),
+                float(r.get("rel_l2", float("nan"))),
+                bool(r["allclose"]),
+            )
+
+    header = "  " + "tap".ljust(32) + " ".join(f"{lab:<52}" for lab in labels)
+    emit(header)
+    emit("  " + "-" * (len(header) - 2))
+    captured_any = False
+    for tap in C42_LAYER1_NORM_TAP_NAMES:
+        cells = []
+        for lab in labels:
+            entry = cell[tap].get(lab)
+            if entry is None:
+                cells.append(f"{'<missing>':<52}")
+            else:
+                cs, mxd, mnd, rl2, ok = entry
+                captured_any = True
+                tag = "ok" if ok else "DIV"
+                cells.append(
+                    f"cos={_fmt_sci(cs):<10} max|Δ|={_fmt_sci(mxd):<10} "
+                    f"mean|Δ|={_fmt_sci(mnd):<10} rel_l2={_fmt_sci(rl2):<10} {tag:<3}"
+                )
+        emit(f"  {tap:<32}{' '.join(cells)}")
+
+    emit("")
+    if not captured_any:
+        emit("Phase C42 verdict: no C42 layer-1 norm-boundary taps present in dumps.")
+        emit("  -> Re-run kiln-bench with KILN_MTP_DUMP_C42_LAYER1_NORM_TAPS=1 and")
+        emit("     re-run mtp_h_main_reference_dump.py with --c42-taps against")
+        emit("     the same kiln dump.")
+        return
+
+    first_shared_bad: Optional[str] = None
+    last_shared_ok: Optional[str] = None
+    first_per_seed: Dict[str, str] = {}
+    for tap in C42_LAYER1_NORM_TAP_NAMES:
+        all_present = True
+        all_ok = True
+        all_bad = True
+        for lab in labels:
+            entry = cell[tap].get(lab)
+            if entry is None:
+                all_present = False
+                all_ok = False
+                all_bad = False
+                continue
+            ok = entry[4]
+            all_ok &= ok
+            all_bad &= not ok
+            if not ok and lab not in first_per_seed:
+                first_per_seed[lab] = tap
+        if all_present and all_ok and first_shared_bad is None:
+            last_shared_ok = tap
+        if all_present and all_bad and first_shared_bad is None:
+            first_shared_bad = tap
+
+    if first_shared_bad is None:
+        emit("Phase C42 verdict: no shared earliest-bad tap across all supplied seeds.")
+        for lab in labels:
+            emit(f"  earliest divergent tap for {lab}: {first_per_seed.get(lab, '<none>')}")
+        emit("  -> Seeds do not yet agree on a single first-bad norm boundary.")
+        return
+
+    emit(f"  earliest shared bad tap: '{first_shared_bad}'")
+    if last_shared_ok is not None:
+        emit(f"  last shared-good tap: '{last_shared_ok}'")
+    emit(f"Phase C42 verdict: EARLIEST SHARED BAD NORM-BOUNDARY TAP = '{first_shared_bad}'.")
+    emit(f"    Most-likely cause: {C42_HYPOTHESIS.get(first_shared_bad, '<unknown tap>')}")
+    if first_shared_bad == "layer_1_residual_input":
+        emit("  -> Divergence is already present at the residual input entering block 1.")
+    elif last_shared_ok is not None:
+        emit(
+            "  -> The shared drift is now localized to the boundary between "
+            f"'{last_shared_ok}' and '{first_shared_bad}'."
+        )
+
+
 def _emit_c7_summary(
     pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
@@ -1803,6 +1937,18 @@ def main() -> int:
         ),
     )
     ap.add_argument(
+        "--c42",
+        action="store_true",
+        help=(
+            "Phase C42 mode: emit the narrowed layer-1 pre-norm / "
+            "input-layernorm bisect over the explicit c42__<name> tap set "
+            "(residual input, RMS inverse, normalized pre-weight tensor, "
+            "post-input-norm output). Defaults atol=1e-2, rtol=1e-1 "
+            "(bf16-appropriate). Verdict names the earliest tap that ALL "
+            "supplied seeds agree is bad."
+        ),
+    )
+    ap.add_argument(
         "--c6",
         action="store_true",
         help=(
@@ -1843,7 +1989,7 @@ def main() -> int:
     # noise; the strict bar stays on to catch real structural drops and the
     # comparator report makes bf16-accumulation drift visible via per-position
     # max|Δ| / rel_l2 columns.
-    bf16_mode = args.b10 or args.b11 or args.b12 or args.c41
+    bf16_mode = args.b10 or args.b11 or args.b12 or args.c41 or args.c42
     if args.atol is None:
         args.atol = 1e-2 if bf16_mode else 1e-3
     if args.rtol is None:
@@ -1871,6 +2017,8 @@ def main() -> int:
     multi = len(pairs) > 1
     if args.c7:
         mode = "SDPA-internal bisect (C7)"
+    elif args.c42:
+        mode = "layer-1 pre-norm / input-layernorm bisect (C42)"
     elif args.c41:
         mode = "transformer block 1 bisect (C41)"
     elif args.c6:
@@ -1892,7 +2040,9 @@ def main() -> int:
     ] = []
     overall_ok = True
     focus_keys = None
-    if args.c41:
+    if args.c42:
+        focus_keys = [f"c42__{name}" for name in C42_LAYER1_NORM_TAP_NAMES]
+    elif args.c41:
         focus_keys = [f"c41__{name}" for name in C41_LAYER1_TAP_NAMES]
     for label, kpath, rpath in pairs:
         ok, first_div, rows, km, rm = _compare_pair(
@@ -1904,6 +2054,8 @@ def main() -> int:
 
     if args.c7:
         _emit_c7_summary(pair_results, args.atol, args.rtol, emit)
+    elif args.c42:
+        _emit_c42_summary(pair_results, args.atol, args.rtol, emit)
     elif args.c41:
         _emit_c41_summary(pair_results, args.atol, args.rtol, emit)
     elif args.c6:
@@ -1922,7 +2074,7 @@ def main() -> int:
     # captured" note when the dump didn't include the B9 sub-ops (e.g.
     # legacy dumps from before this PR). Skipped in explicit --b10/--b11/--b12/--c6
     # mode so the per-phase report isn't cluttered by unrelated sub-op tables.
-    if not args.b10 and not args.b11 and not args.b12 and not args.c41 and not args.c6 and not args.c7:
+    if not args.b10 and not args.b11 and not args.b12 and not args.c41 and not args.c42 and not args.c6 and not args.c7:
         have_b9_taps = any(
             any(r["name"] in B9_H2_ZONE or r["name"] in B9_H3_ZONE for r in pr[3])
             for pr in pair_results

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -5,6 +5,7 @@ Phase B11b — optional layer-0 GDN sub-op taps (`--b11-taps`).
 Phase B12  — optional per-layer taps for layers 24..31 + GQA sub-op taps at
              layer 31 (`--b12-taps`), plus optional fp32 reference (`--fp32`).
 Phase C41  — optional transformer-block-1 sub-op taps (`--c41-taps`).
+Phase C42  — optional layer-1 pre-norm / input-layernorm taps (`--c42-taps`).
 
 This script produces the independent pure-Python reference counterpart to the
 kiln-side main-model forward (the 24×GDN + 8×GQA stack) so that Phase B10 can
@@ -202,6 +203,17 @@ C41_LAYER1_TAP_NAMES: Tuple[str, ...] = (
 )
 
 
+# Phase C42 — ordered layer-1 pre-norm / input-layernorm tap names. Must stay
+# in lock-step with `C42_LAYER1_NORM_TAP_NAMES` in
+# `crates/kiln-model/src/mtp_debug.rs`.
+C42_LAYER1_NORM_TAP_NAMES: Tuple[str, ...] = (
+    "layer_1_residual_input",
+    "layer_1_input_norm_rms_inv",
+    "layer_1_input_norm_pre_weight",
+    "layer_1_post_input_norm",
+)
+
+
 # -----------------------------------------------------------------------------
 # Kiln-dump loader (mirrors mtp_reference_dump.py's loader)
 # -----------------------------------------------------------------------------
@@ -266,6 +278,36 @@ def resolve_c41_tap_names(kiln_dump: Dict[str, object]) -> List[str]:
     if from_keys:
         return from_keys
     return list(C41_LAYER1_TAP_NAMES)
+
+
+def resolve_c42_tap_names(kiln_dump: Dict[str, object]) -> List[str]:
+    raw = kiln_dump.get("meta__c42_tap_ids")
+    if isinstance(raw, list) and raw:
+        names: List[str] = []
+        for idx in raw:
+            idx_i = int(idx)
+            if 0 <= idx_i < len(C42_LAYER1_NORM_TAP_NAMES):
+                names.append(C42_LAYER1_NORM_TAP_NAMES[idx_i])
+        if names:
+            return names
+
+    from_keys = sorted(
+        {
+            key[len("c42__") :]
+            for key in kiln_dump.keys()
+            if key.startswith("c42__")
+        },
+        key=lambda name: (
+            C42_LAYER1_NORM_TAP_NAMES.index(name)
+            if name in C42_LAYER1_NORM_TAP_NAMES
+            else len(C42_LAYER1_NORM_TAP_NAMES),
+            name,
+        ),
+    )
+    if from_keys:
+        return from_keys
+
+    return list(C42_LAYER1_NORM_TAP_NAMES)
 
 
 # -----------------------------------------------------------------------------
@@ -857,6 +899,34 @@ def _arm_c41_layer1_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List[obj
     return handles
 
 
+def _arm_c42_layer1_norm_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List[object]:
+    """Attach hooks for the narrowed Phase C42 input-layernorm bisect."""
+    handles: List[object] = []
+    layer = base.layers[1]
+    norm = getattr(layer, "input_layernorm", None)
+    if norm is None:
+        return handles
+
+    eps = float(getattr(norm, "variance_epsilon", getattr(norm, "eps", 1e-6)))
+
+    def _pre_hook(_mod, inputs):
+        tensor = inputs[0][0] if isinstance(inputs[0], tuple) else inputs[0]
+        residual = tensor.detach().clone()
+        taps_out["layer_1_residual_input"] = residual
+        residual_f32 = residual.to(torch.float32)
+        rms_inv = torch.rsqrt(residual_f32.square().mean(dim=-1, keepdim=True) + eps)
+        taps_out["layer_1_input_norm_rms_inv"] = rms_inv
+        taps_out["layer_1_input_norm_pre_weight"] = residual_f32 * rms_inv
+
+    def _forward_hook(_mod, _inputs, output):
+        tensor = output[0] if isinstance(output, tuple) else output
+        taps_out["layer_1_post_input_norm"] = tensor.detach().clone()
+
+    handles.append(norm.register_forward_pre_hook(_pre_hook))
+    handles.append(norm.register_forward_hook(_forward_hook))
+    return handles
+
+
 # -----------------------------------------------------------------------------
 # Reference forward
 # -----------------------------------------------------------------------------
@@ -871,6 +941,8 @@ def run_reference_forward(
     capture_b12: bool = False,
     capture_c41: bool = False,
     c41_tap_names: Optional[List[str]] = None,
+    capture_c42: bool = False,
+    c42_tap_names: Optional[List[str]] = None,
     fp32: bool = False,
 ) -> Dict[str, torch.Tensor]:
     """Run HF Qwen3-Next / Qwen3.5 forward with `output_hidden_states=True`.
@@ -885,6 +957,8 @@ def run_reference_forward(
       extension when `capture_b12=True`).
     - `capture_b12=True`: per-layer `h_layer_{24..30}` taps plus layer-31
       GQA sub-op taps under `b12__<name>` keys.
+    - `capture_c42=True`: layer-1 residual input + explicit input-layernorm
+      intermediates under `c42__<name>` keys.
     - `fp32=True`: load the HF model in float32 (instead of bfloat16) so the
       comparator can distinguish bf16-accumulation noise from real divergence.
     """
@@ -923,13 +997,14 @@ def run_reference_forward(
         file=sys.stderr,
     )
 
-    if capture_b11_layer0 and capture_c41:
-        raise ValueError("capture_b11_layer0 and capture_c41 are mutually exclusive")
+    if sum(bool(v) for v in (capture_b11_layer0, capture_c41, capture_c42)) > 1:
+        raise ValueError("capture_b11_layer0, capture_c41, and capture_c42 are mutually exclusive")
 
     # Set up B11b/C41 instrumentation + forward hooks BEFORE the forward.
     b11_captures: Dict[str, torch.Tensor] = {}
     b12_captures: Dict[str, torch.Tensor] = {}
     c41_captures: Dict[str, torch.Tensor] = {}
+    c42_captures: Dict[str, torch.Tensor] = {}
     hook_handles: List[object] = []
     orig_gdn_forward = None
     if capture_b11_layer0:
@@ -979,6 +1054,13 @@ def run_reference_forward(
         print(
             f"[mtp_h_main_ref] C41 instrumentation armed: "
             f"monkey-patched {gdn_klass.__name__}.forward at layer 1 + 3 block hooks",
+            file=sys.stderr,
+        )
+    elif capture_c42:
+        hook_handles.extend(_arm_c42_layer1_norm_hooks(base, c42_captures))
+        print(
+            "[mtp_h_main_ref] C42 instrumentation armed: layer 1 input_layernorm "
+            "pre/post hooks + explicit norm-local intermediates",
             file=sys.stderr,
         )
 
@@ -1095,6 +1177,21 @@ def run_reference_forward(
                     tensor = tensor[:, -1:, ...].contiguous()
                 taps[f"c41__{name}"] = tensor
 
+    if capture_c42:
+        wanted = c42_tap_names or list(C42_LAYER1_NORM_TAP_NAMES)
+        missing = [n for n in wanted if n not in c42_captures]
+        if missing:
+            print(
+                f"[mtp_h_main_ref] WARNING: C42 instrumentation missed taps: {missing}",
+                file=sys.stderr,
+            )
+        for name in wanted:
+            if name in c42_captures:
+                tensor = c42_captures[name]
+                if tensor.ndim >= 2:
+                    tensor = tensor[:, -1:, ...].contiguous()
+                taps[f"c42__{name}"] = tensor
+
     # Free the model and all retained activations before returning.
     del model, out, hs
     if device.type == "cuda":
@@ -1167,6 +1264,18 @@ def main() -> int:
         ),
     )
     ap.add_argument(
+        "--c42-taps",
+        action="store_true",
+        help=(
+            "Also capture the explicit Phase C42 layer-1 pre-norm / "
+            "input-layernorm tap set (residual input, RMS inverse, pre-weight "
+            "normalized hidden, post-input-norm output). Output tensors are "
+            "emitted under `c42__<name>` keys matching C42_LAYER1_NORM_TAP_NAMES "
+            "in crates/kiln-model/src/mtp_debug.rs. The exact tap order is "
+            "resolved from the kiln dump's `meta__c42_tap_ids` when present."
+        ),
+    )
+    ap.add_argument(
         "--fp32",
         action="store_true",
         help=(
@@ -1187,6 +1296,7 @@ def main() -> int:
     kiln = load_kiln_dump(args.kiln_dump)
     boundary_layers = resolve_boundary_layers(kiln, capture_b12=args.b12_taps)
     c41_tap_names = resolve_c41_tap_names(kiln) if args.c41_taps else None
+    c42_tap_names = resolve_c42_tap_names(kiln) if args.c42_taps else None
     draft_token_id = int(kiln.get("meta__draft_token_id", -1))
     mtp_pos = int(kiln.get("meta__mtp_pos", -1))
     print(
@@ -1253,6 +1363,8 @@ def main() -> int:
         capture_b12=args.b12_taps,
         capture_c41=args.c41_taps,
         c41_tap_names=c41_tap_names,
+        capture_c42=args.c42_taps,
+        c42_tap_names=c42_tap_names,
         fp32=args.fp32,
     )
 
@@ -1279,6 +1391,11 @@ def main() -> int:
     if c41_tap_names:
         out_dict["meta__c41_tap_ids"] = torch.tensor(
             [C41_LAYER1_TAP_NAMES.index(name) for name in c41_tap_names],
+            dtype=torch.int32,
+        )
+    if c42_tap_names:
+        out_dict["meta__c42_tap_ids"] = torch.tensor(
+            [C42_LAYER1_NORM_TAP_NAMES.index(name) for name in c42_tap_names],
             dtype=torch.int32,
         )
     # Also write the resolved prompt tokens so later reruns can reproduce


### PR DESCRIPTION
## Summary
- add an opt-in C42 layer-1 norm-boundary capture path and matching HF reference/comparator support
- rerun the standard native-MTP seed0/seed1 workload and commit the fresh C42 bench + compare artifacts
- document the C42 verdict in `docs/phase-c42` and append the source-of-truth summary to `PROFILING.md`

## Validation
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- `source /root/.kiln-build-env && cargo test -p kiln-model mtp_debug --lib -- --test-threads=1`

## Verdict
- `layer_1_residual_input` is still shared-good for both seeds
- `layer_1_input_norm_rms_inv` is still shared-good for both seeds
- the earliest shared bad tap is `layer_1_input_norm_pre_weight` in both bf16 and fp32 compares
- the remaining span is now localized to layer-1 `input_layernorm` numerics between `rms_inv` and pre-weight scaling
