### PR TITLE
phase6: bisect layer1 row normalization after c44

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -6520,3 +6520,58 @@ Evidence:
 - `profiling-artifacts/post430_c44_20260423_seed1.bench.stderr`
 - `profiling-artifacts/post430_c44_20260423_compare_bf16.txt`
 - `profiling-artifacts/post430_c44_20260423_compare_fp32.txt`
+
+## Phase C45 post-#431 layer-1 row normalization bisect (2026-04-23)
+
+Goal: split the previously-bad C44 row-level scalar-affine site one step
+further so the next replay can distinguish:
+
+- selected residual row values
+- the row-local `rms_inv` scalar
+- the flat row-scalar multiply values
+- the reconstructed row-shaped output before the existing post-input-norm path
+
+Code change:
+
+- add opt-in C45 taps behind `KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1`
+- capture:
+  - `layer_1_residual_input_f32_row_values`
+  - `layer_1_input_norm_rms_inv_scalar`
+  - `layer_1_input_norm_pre_weight_row_scalar_values`
+  - `layer_1_input_norm_pre_weight_row_reconstructed`
+- mirror the C45 tap order in `mtp_h_main_reference_dump.py`
+- add `scripts/mtp_compare.py --c45`
+
+Local validation:
+
+- `cargo test --locked -p kiln-model c45 -- --nocapture`
+- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
+
+Both passed on 2026-04-23.
+
+RunPod validation blocker:
+
+- on-demand launches for `NVIDIA RTX A6000`, `NVIDIA A40`, `NVIDIA A100 80GB PCIe`,
+  `NVIDIA RTX 6000 Ada Generation`, and `NVIDIA L40S` all failed with
+  `SUPPLY_CONSTRAINT`
+- fallback launches on `NVIDIA H200 NVL`, `NVIDIA RTX PRO 4500 Blackwell`, and
+  `NVIDIA H100 PCIe` created pods, but every pod stayed in
+  `desiredStatus=RUNNING` with `runtime: null`, so `runpod_api.py wait` never
+  returned SSH
+
+Verdict:
+
+- no fresh C45 numerical verdict yet
+- the instrumentation and local validation are complete
+- the remaining blocker is RunPod provisioning, not missing code plumbing
+
+Recommendation:
+
+- rerun the committed C45 workload on the next healthy on-demand RunPod pod
+- do not change the tap contract before that rerun; the next missing result is
+  the earliest shared bad C45 tap, not another instrumentation edit
+
+Evidence:
+
+- `profiling-artifacts/post431_c45_20260423_local_validation.txt`
+- `profiling-artifacts/post431_c45_20260423_runpod_blocker.txt`

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1655,6 +1655,65 @@ fn capture_c44_layer1_f32_row_taps(x: &Tensor, eps: f64) -> Result<()> {
     Ok(())
 }
 
+/// Phase C45: split the previously-bad C44 row-level scalar-affine site one
+/// step further so the replay dump can distinguish "selected row values are
+/// already wrong" vs "scalar multiply introduces the drift" vs "flat scalar
+/// multiply stays shared-good and divergence only appears when reconstructing
+/// the row-shaped output".
+fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
+    let x_f32 = x.to_dtype(DType::F32)?;
+    let (batch, seq_len, hidden) = x_f32
+        .dims3()
+        .context("C45 row audit expects layer-1 hidden to be [batch, seq, hidden]")?;
+    anyhow::ensure!(seq_len > 0, "C45 row audit requires non-empty sequence");
+
+    let last_row = x_f32.narrow(1, seq_len - 1, 1)?.contiguous()?;
+    let residual_values = last_row.reshape((batch, hidden))?.contiguous()?;
+    crate::mtp_debug::capture_c45_layer1_row_tap(
+        "layer_1_residual_input_f32_row_values",
+        &residual_values,
+    )?;
+
+    let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
+    let rms_inv = (variance + eps)?.sqrt()?.recip()?;
+    let rms_inv_row = rms_inv.narrow(1, seq_len - 1, 1)?.contiguous()?;
+    crate::mtp_debug::capture_c45_layer1_row_tap(
+        "layer_1_input_norm_rms_inv_scalar",
+        &rms_inv_row,
+    )?;
+
+    let mut row_values = Vec::with_capacity(batch);
+    let mut reconstructed_rows = Vec::with_capacity(batch);
+    for batch_idx in 0..batch {
+        let row = residual_values.narrow(0, batch_idx, 1)?;
+        let scale = rms_inv_row.narrow(0, batch_idx, 1)?;
+        let scale_vals = scale.flatten_all()?.to_vec1::<f32>()?;
+        anyhow::ensure!(
+            scale_vals.len() == 1,
+            "C45 row audit expected one rms_inv scalar per batch row, got {}",
+            scale_vals.len()
+        );
+        let scaled_values = row.affine(scale_vals[0] as f64, 0.0)?.contiguous()?;
+        row_values.push(scaled_values.clone());
+        reconstructed_rows.push(scaled_values.reshape((1, 1, hidden))?);
+    }
+
+    let row_value_refs: Vec<&Tensor> = row_values.iter().collect();
+    let scalar_values = Tensor::cat(&row_value_refs, 0)?;
+    crate::mtp_debug::capture_c45_layer1_row_tap(
+        "layer_1_input_norm_pre_weight_row_scalar_values",
+        &scalar_values,
+    )?;
+
+    let reconstructed_refs: Vec<&Tensor> = reconstructed_rows.iter().collect();
+    let reconstructed = Tensor::cat(&reconstructed_refs, 0)?;
+    crate::mtp_debug::capture_c45_layer1_row_tap(
+        "layer_1_input_norm_pre_weight_row_reconstructed",
+        &reconstructed,
+    )?;
+    Ok(())
+}
+
 /// Apply Rotary Position Embeddings (RoPE) to query and key tensors.
 ///
 /// `q`: [batch, seq_len, num_heads, head_dim]
@@ -5051,6 +5110,7 @@ pub fn model_forward_paged_with_last_hidden(
     crate::mtp_debug::arm_c42_layer1_norm_capture();
     crate::mtp_debug::arm_c43_layer1_preweight_capture();
     crate::mtp_debug::arm_c44_layer1_f32_row_capture();
+    crate::mtp_debug::arm_c45_layer1_row_capture();
     let (logits, hidden) = model_forward_paged_inner(
         backend,
         token_ids,
@@ -5094,6 +5154,7 @@ pub fn model_forward_paged_last_token_with_last_hidden(
     crate::mtp_debug::arm_c42_layer1_norm_capture();
     crate::mtp_debug::arm_c43_layer1_preweight_capture();
     crate::mtp_debug::arm_c44_layer1_f32_row_capture();
+    crate::mtp_debug::arm_c45_layer1_row_capture();
     let (logits, hidden) = model_forward_paged_inner(
         backend,
         token_ids,
@@ -5500,6 +5561,10 @@ pub fn mtp_forward_step(
             // base-model forward. Empty when
             // `KILN_MTP_DUMP_C44_LAYER1_F32_ROW_TAPS` is unset.
             let c44_taps = crate::mtp_debug::drain_c44_layer1_f32_row_capture();
+            // Phase C45: drain the follow-up row-level normalization taps
+            // stashed during the base-model forward. Empty when
+            // `KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS` is unset.
+            let c45_taps = crate::mtp_debug::drain_c45_layer1_row_capture();
             // Phase C6: drain the 5 pre-RoPE MTP input taps (token_emb,
             // norm_emb, norm_h, concat, fused) captured above. Empty when
             // `KILN_MTP_DUMP_PRE_ROPE` is unset, which keeps the dump format
@@ -5534,6 +5599,7 @@ pub fn mtp_forward_step(
                 &c42_taps,
                 &c43_taps,
                 &c44_taps,
+                &c45_taps,
                 &c6_taps,
                 &c7_taps,
                 &c14_taps,
@@ -5553,6 +5619,7 @@ pub fn mtp_forward_step(
                     c42_taps = c42_taps.len(),
                     c43_taps = c43_taps.len(),
                     c44_taps = c44_taps.len(),
+                    c45_taps = c45_taps.len(),
                     c6_taps = c6_taps.len(),
                     c7_taps = c7_taps.len(),
                     c14_taps = c14_taps.len(),
@@ -5768,6 +5835,8 @@ fn model_forward_paged_inner(
                     crate::mtp_debug::should_capture_c43_layer1_preweight_tap_for_layer(i);
                 let capture_c44_taps =
                     crate::mtp_debug::should_capture_c44_layer1_f32_row_tap_for_layer(i);
+                let capture_c45_taps =
+                    crate::mtp_debug::should_capture_c45_layer1_row_tap_for_layer(i);
                 if capture_c42_taps {
                     capture_c42_layer1_input_norm_taps(
                         &hidden,
@@ -5784,6 +5853,9 @@ fn model_forward_paged_inner(
                 }
                 if capture_c44_taps {
                     capture_c44_layer1_f32_row_taps(&hidden, config.rms_norm_eps)?;
+                }
+                if capture_c45_taps {
+                    capture_c45_layer1_row_taps(&hidden, config.rms_norm_eps)?;
                 }
                 let normed = {
                     kiln_nvtx::range!(c"kiln/norm/pre_attn");

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -185,6 +185,20 @@ thread_local! {
     static C44_LAYER1_F32_ROW_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
         const { RefCell::new(None) };
 
+    /// Phase C45: thread-local sink for the follow-up layer-1 row-level
+    /// normalization bisect. This stays separate from C44 because the goal is
+    /// narrower again: split the previously-bad
+    /// `layer_1_input_norm_pre_weight_row_scalar_affine` site into the
+    /// selected row values, the row-scalar multiply values, and the
+    /// reconstructed row-shaped output.
+    ///
+    /// Driven by [`arm_c45_layer1_row_capture`] /
+    /// [`drain_c45_layer1_row_capture`] / [`capture_c45_layer1_row_tap`], and
+    /// gated on `KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1` so production decode
+    /// stays on the current fast path when unset.
+    static C45_LAYER1_ROW_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
+        const { RefCell::new(None) };
+
     /// Phase B12: thread-local "current absolute layer index" slot. Set by
     /// the main transformer layer loop around each layer's forward call so
     /// that deep inside `gqa_attention_paged` / `transformer_block_paged`
@@ -921,6 +935,18 @@ pub fn is_dump_c44_layer1_f32_row_taps_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// True when `KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1` (or `true`) is set.
+/// Opt-in for the Phase C45 layer-1 row-level normalization bisect: when
+/// enabled alongside `KILN_MTP_DUMP_PATH` and `KILN_MTP_DUMP_HIDDEN_STATES=1`,
+/// the base-model forward records the row-local taps listed in
+/// [`C45_LAYER1_ROW_TAP_NAMES`] and appends them to the MTP dump safetensors
+/// under names `c45__<name>`.
+pub fn is_dump_c45_layer1_row_taps_enabled() -> bool {
+    std::env::var("KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 /// Canonical ordered list of Phase C42 layer-1 pre-norm / input-layernorm tap
 /// names. The comparator (`scripts/mtp_compare.py --c42`) and the HF
 /// reference (`scripts/mtp_h_main_reference_dump.py --c42-taps`) both mirror
@@ -952,6 +978,17 @@ pub const C44_LAYER1_F32_ROW_TAP_NAMES: &[&str] = &[
     "layer_1_residual_input_f32_row",
     "layer_1_input_norm_rms_inv_scalar",
     "layer_1_input_norm_pre_weight_row_scalar_affine",
+];
+
+/// Canonical ordered list of Phase C45 layer-1 row-level normalization tap
+/// names. The comparator (`scripts/mtp_compare.py --c45`) and the HF
+/// reference (`scripts/mtp_h_main_reference_dump.py --c45-taps`) both mirror
+/// this exact order.
+pub const C45_LAYER1_ROW_TAP_NAMES: &[&str] = &[
+    "layer_1_residual_input_f32_row_values",
+    "layer_1_input_norm_rms_inv_scalar",
+    "layer_1_input_norm_pre_weight_row_scalar_values",
+    "layer_1_input_norm_pre_weight_row_reconstructed",
 ];
 
 /// True if the Phase C41 layer-1 capture window is currently armed on this
@@ -1120,6 +1157,48 @@ pub fn capture_c44_layer1_f32_row_tap(name: &str, t: &Tensor) -> Result<()> {
     let (shape, flat) = tensor_to_f32_host(t)
         .with_context(|| format!("capture_c44_layer1_f32_row_tap `{name}`: tensor→f32 host copy"))?;
     C44_LAYER1_F32_ROW_CAPTURE.with(|c| {
+        if let Some(buf) = c.borrow_mut().as_mut() {
+            buf.push((name.to_string(), shape, flat));
+        }
+    });
+    Ok(())
+}
+
+/// True if the Phase C45 layer-1 row-level normalization capture window is
+/// currently armed on this thread.
+pub fn is_c45_layer1_row_capture_armed() -> bool {
+    C45_LAYER1_ROW_CAPTURE.with(|c| c.borrow().is_some())
+}
+
+/// True if a C45 layer-1 row-level normalization capture should happen for
+/// `layer_idx`.
+pub fn should_capture_c45_layer1_row_tap_for_layer(layer_idx: usize) -> bool {
+    layer_idx == 1 && is_c45_layer1_row_capture_armed()
+}
+
+/// Begin a C45 layer-1 row-level normalization capture window.
+pub fn arm_c45_layer1_row_capture() {
+    if !is_dump_c45_layer1_row_taps_enabled() {
+        return;
+    }
+    C45_LAYER1_ROW_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
+}
+
+/// Drain the captured C45 layer-1 row-level normalization taps and disarm.
+pub fn drain_c45_layer1_row_capture() -> Vec<(String, Vec<usize>, Vec<f32>)> {
+    C45_LAYER1_ROW_CAPTURE.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+/// Record one named C45 layer-1 row-level normalization tap if a capture
+/// window is currently open on this thread.
+pub fn capture_c45_layer1_row_tap(name: &str, t: &Tensor) -> Result<()> {
+    let armed = C45_LAYER1_ROW_CAPTURE.with(|c| c.borrow().is_some());
+    if !armed {
+        return Ok(());
+    }
+    let (shape, flat) = tensor_to_f32_host(t)
+        .with_context(|| format!("capture_c45_layer1_row_tap `{name}`: tensor→f32 host copy"))?;
+    C45_LAYER1_ROW_CAPTURE.with(|c| {
         if let Some(buf) = c.borrow_mut().as_mut() {
             buf.push((name.to_string(), shape, flat));
         }
@@ -1760,12 +1839,12 @@ fn tensor_to_f32_host(t: &Tensor) -> Result<(Vec<usize>, Vec<f32>)> {
 /// passing `&[]` for both `b11_taps` and `b12_taps` produce the historical
 /// safetensors layout.
 ///
-/// Phase C41 / C42 / C43 / C44: `c41_taps`, `c42_taps`, `c43_taps`, and
-/// `c44_taps` carry the layer-1 bisect taps captured via their phase-specific
-/// arm/capture/drain helpers. Each slice is serialized as F32 under
-/// `c41__<name>` / `c42__<name>` / `c43__<name>` / `c44__<name>`, with an
-/// accompanying ordered tap-id metadata tensor so the Python side can mirror
-/// the exact tap order from the kiln dump.
+/// Phase C41 / C42 / C43 / C44 / C45: `c41_taps`, `c42_taps`, `c43_taps`,
+/// `c44_taps`, and `c45_taps` carry the layer-1 bisect taps captured via
+/// their phase-specific arm/capture/drain helpers. Each slice is serialized
+/// as F32 under `c41__<name>` / `c42__<name>` / `c43__<name>` / `c44__<name>`
+/// / `c45__<name>`, with an accompanying ordered tap-id metadata tensor so
+/// the Python side can mirror the exact tap order from the kiln dump.
 ///
 /// Phase C6: `c6_taps` carries the pre-RoPE MTP-input taps captured via
 /// [`arm_pre_rope_capture`] / [`capture_pre_rope_tap`] /
@@ -1805,6 +1884,7 @@ pub fn write_mtp_dump(
     c42_taps: &[(String, Vec<usize>, Vec<f32>)],
     c43_taps: &[(String, Vec<usize>, Vec<f32>)],
     c44_taps: &[(String, Vec<usize>, Vec<f32>)],
+    c45_taps: &[(String, Vec<usize>, Vec<f32>)],
     c6_taps: &[(String, Vec<usize>, Vec<f32>)],
     c7_taps: &[(String, Vec<usize>, Vec<f32>)],
     c14_taps: &[(String, Vec<usize>, Vec<f32>)],
@@ -1824,6 +1904,7 @@ pub fn write_mtp_dump(
     let c42_meta_reserve = if c42_taps.is_empty() { 0 } else { 1 };
     let c43_meta_reserve = if c43_taps.is_empty() { 0 } else { 1 };
     let c44_meta_reserve = if c44_taps.is_empty() { 0 } else { 1 };
+    let c45_meta_reserve = if c45_taps.is_empty() { 0 } else { 1 };
     let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> = Vec::with_capacity(
         taps.len()
             + extra_subops.len()
@@ -1841,6 +1922,8 @@ pub fn write_mtp_dump(
             + c43_taps.len()
             + c44_meta_reserve
             + c44_taps.len()
+            + c45_meta_reserve
+            + c45_taps.len()
             + c6_taps.len()
             + c7_taps.len()
             + c14_taps.len(),
@@ -2081,6 +2164,32 @@ pub fn write_mtp_dump(
             bytes.extend_from_slice(&v.to_le_bytes());
         }
         backings.push((format!("c44__{name}"), shape.clone(), Dtype::F32, bytes));
+    }
+
+    if !c45_taps.is_empty() {
+        let mut bytes = Vec::with_capacity(c45_taps.len() * 4);
+        for (name, _shape, _flat) in c45_taps {
+            let idx = C45_LAYER1_ROW_TAP_NAMES
+                .iter()
+                .position(|&tap| tap == name.as_str())
+                .with_context(|| format!("unknown C45 tap `{name}`"))?;
+            let idx_i32 = idx as i32;
+            bytes.extend_from_slice(&idx_i32.to_le_bytes());
+        }
+        backings.push((
+            "meta__c45_tap_ids".into(),
+            vec![c45_taps.len()],
+            Dtype::I32,
+            bytes,
+        ));
+    }
+
+    for (name, shape, flat) in c45_taps {
+        let mut bytes = Vec::with_capacity(flat.len() * 4);
+        for v in flat {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        backings.push((format!("c45__{name}"), shape.clone(), Dtype::F32, bytes));
     }
 
     // Phase C6: serialize the pre-RoPE MTP-input taps under `c6__<name>` so
@@ -2551,6 +2660,7 @@ mod tests {
             /* c42_taps = */ &[],
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2684,6 +2794,7 @@ mod tests {
             /* c42_taps = */ &[],
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2831,6 +2942,7 @@ mod tests {
             /* c42_taps = */ &[],
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3218,6 +3330,7 @@ mod tests {
             /* c42_taps = */ &[],
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3285,6 +3398,7 @@ mod tests {
             /* c42_taps = */ &[],
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3349,6 +3463,7 @@ mod tests {
             &c42,
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3413,6 +3528,7 @@ mod tests {
             /* c42_taps = */ &[],
             &c43,
             /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3479,6 +3595,7 @@ mod tests {
             /* c42_taps = */ &[],
             /* c43_taps = */ &[],
             &c44,
+            /* c45_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3505,6 +3622,73 @@ mod tests {
             .unwrap();
         assert_eq!(out.dtype(), safetensors::Dtype::F32);
         assert_eq!(out.shape(), &[3]);
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn write_mtp_dump_emits_c45_taps_and_metadata_when_provided() {
+        use safetensors::SafeTensors;
+
+        let h = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        let tmp = std::env::temp_dir().join("kiln_mtp_dump_with_c45.safetensors");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let c45 = vec![
+            (
+                "layer_1_residual_input_f32_row_values".to_string(),
+                vec![2],
+                vec![0.31_f32, 0.32],
+            ),
+            (
+                "layer_1_input_norm_pre_weight_row_reconstructed".to_string(),
+                vec![1, 1, 3],
+                vec![0.41_f32, 0.42, 0.43],
+            ),
+        ];
+        write_mtp_dump(
+            &tmp_s,
+            /* draft_token_id = */ 69,
+            /* mtp_pos = */ 0,
+            /* base_pos = */ 0,
+            /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[],
+            &[("h_main", &h)],
+            &[],
+            /* prompt_tokens = */ &[],
+            /* replay_tokens = */ &[],
+            /* b11_taps = */ &[],
+            /* b12_taps = */ &[],
+            /* c41_taps = */ &[],
+            /* c42_taps = */ &[],
+            /* c43_taps = */ &[],
+            /* c44_taps = */ &[],
+            &c45,
+            /* c6_taps = */ &[],
+            /* c7_taps = */ &[],
+            /* c14_taps = */ &[],
+        )
+        .unwrap();
+
+        let raw = std::fs::read(&tmp).unwrap();
+        let st = SafeTensors::deserialize(&raw).unwrap();
+        let names: Vec<&str> = st.names().into_iter().map(|s| s.as_str()).collect();
+        assert!(names.contains(&"c45__layer_1_residual_input_f32_row_values"));
+        assert!(names.contains(&"c45__layer_1_input_norm_pre_weight_row_reconstructed"));
+        assert!(names.contains(&"meta__c45_tap_ids"));
+
+        let ids = st.tensor("meta__c45_tap_ids").unwrap();
+        assert_eq!(ids.dtype(), safetensors::Dtype::I32);
+        assert_eq!(ids.shape(), &[2]);
+        let id0 = i32::from_le_bytes(ids.data()[0..4].try_into().unwrap());
+        let id1 = i32::from_le_bytes(ids.data()[4..8].try_into().unwrap());
+        assert_eq!(id0, 0);
+        assert_eq!(id1, 3);
+
+        let out = st
+            .tensor("c45__layer_1_input_norm_pre_weight_row_reconstructed")
+            .unwrap();
+        assert_eq!(out.dtype(), safetensors::Dtype::F32);
+        assert_eq!(out.shape(), &[1, 1, 3]);
 
         let _ = std::fs::remove_file(&tmp);
     }
@@ -3703,6 +3887,7 @@ mod tests {
             /* c42_taps = */ &[],
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
             &c6,
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3839,6 +4024,7 @@ mod tests {
             /* c42_taps = */ &[],
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
             /* c6_taps = */ &[],
             &c7,
             /* c14_taps = */ &[],
@@ -4001,6 +4187,7 @@ mod tests {
             /* c42_taps = */ &[],
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             &c14,

--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -1,0 +1,99 @@
+# Phase C45 — layer 1 row normalization bisect after PR #431
+
+## Remaining-work preflight
+
+Fresh `origin/main` on 2026-04-23 still satisfied the task gate:
+
+1. PR #431 / Phase C44 was present on `origin/main`.
+2. No newer open or merged kiln PR already localized the shared layer-1
+   row-level normalization boundary beyond C44.
+
+So this task proceeded.
+
+## Scope
+
+The C45 instrumentation adds a dedicated opt-in tap namespace under
+`KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1`:
+
+- `layer_1_residual_input_f32_row_values`
+- `layer_1_input_norm_rms_inv_scalar`
+- `layer_1_input_norm_pre_weight_row_scalar_values`
+- `layer_1_input_norm_pre_weight_row_reconstructed`
+
+This keeps the task diagnostic-only and splits the previously-bad C44 site one
+step further:
+
+- selected residual row values
+- the row-local `rms_inv` scalar
+- the flat row-scalar multiply result
+- the reconstructed row-shaped output right before the existing post-input-norm
+  path
+
+The goal is to tell whether the first shared drift now appears in the selected
+row values, in the scalar multiply itself, or only when reconstructing the row
+shape.
+
+## Local validation
+
+Completed locally before any GPU spend:
+
+```bash
+cargo test --locked -p kiln-model c45 -- --nocapture
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+```
+
+Both passed on 2026-04-23.
+
+## Planned GPU validation
+
+The intended source-of-truth workload stayed exactly aligned with the task:
+
+```bash
+python3 $RP bg $POD_ID /tmp/build.log \
+  'source /root/.kiln-build-env && cd /workspace/kiln && cargo build --release --features cuda --bin kiln-bench'
+python3 $RP wait-file $POD_ID /workspace/kiln/target/release/kiln-bench --timeout 3600
+
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && cargo test --locked -p kiln-model c45 -- --nocapture'
+
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && export KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 && ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training > profiling-artifacts/post431_c45_seed0.bench.json 2> profiling-artifacts/post431_c45_seed0.bench.stderr'
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && export KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 KILN_SEED=1 && ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training > profiling-artifacts/post431_c45_seed1.bench.json 2> profiling-artifacts/post431_c45_seed1.bench.stderr'
+
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && python3 scripts/mtp_h_main_reference_dump.py --c45-taps profiling-artifacts/<fresh-kiln-dump>.safetensors profiling-artifacts/post431_c45_seed0_ref.safetensors'
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && python3 scripts/mtp_compare.py --c45 profiling-artifacts/post431_c45_seed0_compare.txt profiling-artifacts/post431_c45_seed1_compare.txt'
+```
+
+## RunPod blocker
+
+GPU validation did **not** complete on 2026-04-23 because RunPod never
+provided a healthy on-demand pod with a usable runtime / SSH endpoint.
+
+Observed failures:
+
+- direct launches for `NVIDIA RTX A6000`, `NVIDIA A40`, `NVIDIA A100 80GB PCIe`,
+  `NVIDIA RTX 6000 Ada Generation`, and `NVIDIA L40S` all failed immediately
+  with `SUPPLY_CONSTRAINT`
+- fallback launches on `NVIDIA H200 NVL`, `NVIDIA RTX PRO 4500 Blackwell`, and
+  `NVIDIA H100 PCIe` did create pods, but each pod stayed in:
+  `desiredStatus=RUNNING` with `runtime: null`, so `runpod_api.py wait` never
+  returned an SSH endpoint
+
+That means no build, no bench run, no kiln dump, no HF replay dump, and no C45
+compare report were produced in this task.
+
+The raw launch / provisioning evidence is committed in:
+
+- `profiling-artifacts/post431_c45_20260423_local_validation.txt`
+- `profiling-artifacts/post431_c45_20260423_runpod_blocker.txt`
+
+## Verdict
+
+No fresh C45 verdict yet.
+
+The code plumbing and local validation are complete, but the required GPU
+artifact capture was blocked by RunPod provisioning failures on 2026-04-23.
+
+## Recommendation
+
+Re-run the committed C45 workflow on the next healthy on-demand RunPod pod and
+fill in the earliest shared bad C45 tap. The code changes in this PR are ready
+for that rerun; the missing piece is infrastructure, not instrumentation.

--- a/profiling-artifacts/post431_c45_20260423_local_validation.txt
+++ b/profiling-artifacts/post431_c45_20260423_local_validation.txt
@@ -1,0 +1,12 @@
+Phase C45 local validation completed on 2026-04-23 UTC.
+
+Commands:
+- cargo test --locked -p kiln-model c45 -- --nocapture
+- python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+
+Results:
+- cargo test: passed
+- py_compile: passed
+
+Focused Rust test that ran:
+- mtp_debug::tests::write_mtp_dump_emits_c45_taps_and_metadata_when_provided

--- a/profiling-artifacts/post431_c45_20260423_runpod_blocker.txt
+++ b/profiling-artifacts/post431_c45_20260423_runpod_blocker.txt
@@ -1,0 +1,22 @@
+Phase C45 RunPod blocker evidence captured on 2026-04-23 UTC.
+
+Immediate supply-constraint failures:
+- NVIDIA RTX A6000
+- NVIDIA A40
+- NVIDIA A100 80GB PCIe
+- NVIDIA RTX 6000 Ada Generation
+- NVIDIA L40S
+
+Pods that launched but never exposed runtime / SSH:
+- x4v47hy9am3u3r on NVIDIA H200 NVL
+- qaqiog4ntgwtzf on NVIDIA RTX PRO 4500 Blackwell
+- m1seth9emheuxp on NVIDIA H100 PCIe
+
+Observed bad state for each launched pod:
+- desiredStatus = RUNNING
+- runtime = null
+
+Effect on the task:
+- `runpod_api.py wait` never completed
+- `kiln-setup --clone` never ran
+- no GPU build, bench, kiln dump, HF dump, or compare output was produced

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -366,6 +366,24 @@ C44_HYPOTHESIS: Dict[str, str] = {
     "layer_1_input_norm_pre_weight_row_scalar_affine": "the F32 row stays shared-good and divergence first appears when applying normalization to produce the row values",
 }
 
+# Phase C45 — narrowed layer-1 row-level normalization bisect tap set, in
+# forward-graph order. Must stay in lock-step with `C45_LAYER1_ROW_TAP_NAMES`
+# in `crates/kiln-model/src/mtp_debug.rs` and
+# `scripts/mtp_h_main_reference_dump.py`.
+C45_LAYER1_ROW_TAP_NAMES: Tuple[str, ...] = (
+    "layer_1_residual_input_f32_row_values",
+    "layer_1_input_norm_rms_inv_scalar",
+    "layer_1_input_norm_pre_weight_row_scalar_values",
+    "layer_1_input_norm_pre_weight_row_reconstructed",
+)
+
+C45_HYPOTHESIS: Dict[str, str] = {
+    "layer_1_residual_input_f32_row_values": "the selected last-row values are already wrong before row-local normalization is applied",
+    "layer_1_input_norm_rms_inv_scalar": "the row-local RMS inverse scalar diverges even though C44 kept the same scalar shared-good",
+    "layer_1_input_norm_pre_weight_row_scalar_values": "the selected row values and scalar stay shared-good; drift first appears in the flat row-scalar multiply values",
+    "layer_1_input_norm_pre_weight_row_reconstructed": "the flat row-scalar multiply stays shared-good; drift appears only when reconstructing the row-shaped output before the existing post-input-norm path",
+}
+
 # Phase B12 — the cos_sim bar is tighter than B10/B11 because the expected
 # residual drift is small (0.97-0.98) and the goal is to localize it. A
 # per-layer median below this threshold marks the first layer of interest; if
@@ -2032,6 +2050,127 @@ def _emit_c44_summary(
         )
 
 
+def _emit_c45_summary(
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
+    atol: float,
+    rtol: float,
+    emit,
+) -> None:
+    """Phase C45 — layer-1 row-level normalization bisect."""
+    emit("")
+    emit("=" * 78)
+    emit("Phase C45 layer-1 row normalization audit — cos_sim / max|Δ| / mean|Δ| / rel_l2")
+    emit("=" * 78)
+
+    labels = [pr[0] for pr in pair_results]
+    cell: Dict[str, Dict[str, Tuple[float, float, float, float, bool]]] = {
+        n: {} for n in C45_LAYER1_ROW_TAP_NAMES
+    }
+    for label, _ok, _fd, rows, _km, _rm in pair_results:
+        for r in rows:
+            n = r["name"]
+            if not isinstance(n, str) or not n.startswith("c45__"):
+                continue
+            short = n[len("c45__") :]
+            if short not in cell:
+                continue
+            cell[short][label] = (
+                float(r["cos_sim"]),
+                float(r["max_abs_diff"]),
+                float(r["mean_abs_diff"]),
+                float(r.get("rel_l2", float("nan"))),
+                bool(r["allclose"]),
+            )
+
+    header = "  " + "tap".ljust(48) + " ".join(f"{lab:<52}" for lab in labels)
+    emit(header)
+    emit("  " + "-" * (len(header) - 2))
+    captured_any = False
+    for tap in C45_LAYER1_ROW_TAP_NAMES:
+        cells = []
+        for lab in labels:
+            entry = cell[tap].get(lab)
+            if entry is None:
+                cells.append(f"{'<missing>':<52}")
+            else:
+                cs, mxd, mnd, rl2, ok = entry
+                captured_any = True
+                tag = "ok" if ok else "DIV"
+                cells.append(
+                    f"cos={_fmt_sci(cs):<10} max|Δ|={_fmt_sci(mxd):<10} "
+                    f"mean|Δ|={_fmt_sci(mnd):<10} rel_l2={_fmt_sci(rl2):<10} {tag:<3}"
+                )
+        emit(f"  {tap:<48}{' '.join(cells)}")
+
+    emit("")
+    if not captured_any:
+        emit("Phase C45 verdict: no C45 row-level taps present in dumps.")
+        emit("  -> Re-run kiln-bench with KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 and")
+        emit("     re-run mtp_h_main_reference_dump.py with --c45-taps against")
+        emit("     the same kiln dump.")
+        return
+
+    first_shared_bad: Optional[str] = None
+    last_shared_ok: Optional[str] = None
+    first_per_seed: Dict[str, str] = {}
+    for tap in C45_LAYER1_ROW_TAP_NAMES:
+        all_present = True
+        all_ok = True
+        all_bad = True
+        for lab in labels:
+            entry = cell[tap].get(lab)
+            if entry is None:
+                all_present = False
+                all_ok = False
+                all_bad = False
+                continue
+            ok = entry[4]
+            all_ok &= ok
+            all_bad &= not ok
+            if not ok and lab not in first_per_seed:
+                first_per_seed[lab] = tap
+        if all_present and all_ok and first_shared_bad is None:
+            last_shared_ok = tap
+        if all_present and all_bad and first_shared_bad is None:
+            first_shared_bad = tap
+
+    if first_shared_bad is None:
+        emit("Phase C45 verdict: no shared earliest-bad tap across all supplied seeds.")
+        for lab in labels:
+            emit(f"  earliest divergent tap for {lab}: {first_per_seed.get(lab, '<none>')}")
+        emit("  -> Seeds do not yet agree on a single first-bad C45 boundary.")
+        return
+
+    emit(f"  earliest shared bad tap: '{first_shared_bad}'")
+    if last_shared_ok is not None:
+        emit(f"  last shared-good tap: '{last_shared_ok}'")
+    emit(f"Phase C45 verdict: EARLIEST SHARED BAD ROW-LEVEL TAP = '{first_shared_bad}'.")
+    emit(f"    Most-likely cause: {C45_HYPOTHESIS.get(first_shared_bad, '<unknown tap>')}")
+
+    if first_shared_bad == "layer_1_residual_input_f32_row_values":
+        emit(
+            "  -> Divergence is already present in the selected last-row "
+            "values before row-local normalization is applied."
+        )
+    elif first_shared_bad == "layer_1_input_norm_pre_weight_row_scalar_values":
+        emit(
+            "  -> The selected row values and `rms_inv` scalar stay "
+            "shared-good; divergence first appears in the flat row-scalar "
+            "multiply values."
+        )
+    elif first_shared_bad == "layer_1_input_norm_pre_weight_row_reconstructed":
+        emit(
+            "  -> The flat row-scalar multiply stays shared-good; divergence "
+            "appears only when reconstructing the row-shaped output right "
+            "before the existing post-input-norm path."
+        )
+    elif last_shared_ok is not None:
+        emit(
+            "  -> The shared drift is now localized to the boundary between "
+            f"'{last_shared_ok}' and '{first_shared_bad}'."
+        )
+
+
 def _emit_c7_summary(
     pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
@@ -2254,6 +2393,19 @@ def main() -> int:
         ),
     )
     ap.add_argument(
+        "--c45",
+        action="store_true",
+        help=(
+            "Phase C45 mode: emit the narrowed layer-1 row normalization "
+            "audit over the explicit c45__<name> tap set (selected row "
+            "values, matching RMS inverse scalar, flat row-scalar multiply "
+            "values, reconstructed row-shaped output). Defaults atol=1e-2, "
+            "rtol=1e-1 (bf16-appropriate). Verdict names whether divergence "
+            "first appears in the selected row values, the scalar multiply, "
+            "or only after reconstruction."
+        ),
+    )
+    ap.add_argument(
         "--c6",
         action="store_true",
         help=(
@@ -2294,7 +2446,16 @@ def main() -> int:
     # noise; the strict bar stays on to catch real structural drops and the
     # comparator report makes bf16-accumulation drift visible via per-position
     # max|Δ| / rel_l2 columns.
-    bf16_mode = args.b10 or args.b11 or args.b12 or args.c41 or args.c42 or args.c43 or args.c44
+    bf16_mode = (
+        args.b10
+        or args.b11
+        or args.b12
+        or args.c41
+        or args.c42
+        or args.c43
+        or args.c44
+        or args.c45
+    )
     if args.atol is None:
         args.atol = 1e-2 if bf16_mode else 1e-3
     if args.rtol is None:
@@ -2322,6 +2483,8 @@ def main() -> int:
     multi = len(pairs) > 1
     if args.c7:
         mode = "SDPA-internal bisect (C7)"
+    elif args.c45:
+        mode = "layer-1 row normalization audit (C45)"
     elif args.c44:
         mode = "layer-1 row-level audit (C44)"
     elif args.c43:
@@ -2349,7 +2512,9 @@ def main() -> int:
     ] = []
     overall_ok = True
     focus_keys = None
-    if args.c44:
+    if args.c45:
+        focus_keys = [f"c45__{name}" for name in C45_LAYER1_ROW_TAP_NAMES]
+    elif args.c44:
         focus_keys = [f"c44__{name}" for name in C44_LAYER1_F32_ROW_TAP_NAMES]
     elif args.c43:
         focus_keys = [f"c43__{name}" for name in C43_LAYER1_PREWEIGHT_TAP_NAMES]
@@ -2367,6 +2532,8 @@ def main() -> int:
 
     if args.c7:
         _emit_c7_summary(pair_results, args.atol, args.rtol, emit)
+    elif args.c45:
+        _emit_c45_summary(pair_results, args.atol, args.rtol, emit)
     elif args.c44:
         _emit_c44_summary(pair_results, args.atol, args.rtol, emit)
     elif args.c43:

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -234,6 +234,16 @@ C44_LAYER1_F32_ROW_TAP_NAMES: Tuple[str, ...] = (
     "layer_1_input_norm_pre_weight_row_scalar_affine",
 )
 
+# Phase C45 — ordered layer-1 row-level normalization bisect tap names. Must
+# stay in lock-step with `C45_LAYER1_ROW_TAP_NAMES` in
+# `crates/kiln-model/src/mtp_debug.rs`.
+C45_LAYER1_ROW_TAP_NAMES: Tuple[str, ...] = (
+    "layer_1_residual_input_f32_row_values",
+    "layer_1_input_norm_rms_inv_scalar",
+    "layer_1_input_norm_pre_weight_row_scalar_values",
+    "layer_1_input_norm_pre_weight_row_reconstructed",
+)
+
 
 # -----------------------------------------------------------------------------
 # Kiln-dump loader (mirrors mtp_reference_dump.py's loader)
@@ -389,6 +399,36 @@ def resolve_c44_tap_names(kiln_dump: Dict[str, object]) -> List[str]:
         return from_keys
 
     return list(C44_LAYER1_F32_ROW_TAP_NAMES)
+
+
+def resolve_c45_tap_names(kiln_dump: Dict[str, object]) -> List[str]:
+    raw = kiln_dump.get("meta__c45_tap_ids")
+    if isinstance(raw, list) and raw:
+        names: List[str] = []
+        for idx in raw:
+            idx_i = int(idx)
+            if 0 <= idx_i < len(C45_LAYER1_ROW_TAP_NAMES):
+                names.append(C45_LAYER1_ROW_TAP_NAMES[idx_i])
+        if names:
+            return names
+
+    from_keys = sorted(
+        {
+            key[len("c45__") :]
+            for key in kiln_dump.keys()
+            if key.startswith("c45__")
+        },
+        key=lambda name: (
+            C45_LAYER1_ROW_TAP_NAMES.index(name)
+            if name in C45_LAYER1_ROW_TAP_NAMES
+            else len(C45_LAYER1_ROW_TAP_NAMES),
+            name,
+        ),
+    )
+    if from_keys:
+        return from_keys
+
+    return list(C45_LAYER1_ROW_TAP_NAMES)
 
 
 # -----------------------------------------------------------------------------
@@ -1080,6 +1120,36 @@ def _arm_c44_layer1_f32_row_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> 
     return handles
 
 
+def _arm_c45_layer1_row_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List[object]:
+    """Attach hooks for the narrowed Phase C45 row-level normalization audit."""
+    handles: List[object] = []
+    layer = base.layers[1]
+    norm = getattr(layer, "input_layernorm", None)
+    if norm is None:
+        return handles
+
+    eps = float(getattr(norm, "variance_epsilon", getattr(norm, "eps", 1e-6)))
+
+    def _pre_hook(_mod, inputs):
+        tensor = inputs[0][0] if isinstance(inputs[0], tuple) else inputs[0]
+        residual = tensor.detach().clone().to(torch.float32)
+        residual_row = residual[:, -1, :].contiguous()
+        taps_out["layer_1_residual_input_f32_row_values"] = residual_row
+
+        rms_inv = torch.rsqrt(residual.square().mean(dim=-1, keepdim=True) + eps)
+        rms_inv_row = rms_inv[:, -1:, :].contiguous()
+        taps_out["layer_1_input_norm_rms_inv_scalar"] = rms_inv_row
+
+        scalar_values = (residual_row * rms_inv_row.reshape(-1, 1)).contiguous()
+        taps_out["layer_1_input_norm_pre_weight_row_scalar_values"] = scalar_values
+        taps_out["layer_1_input_norm_pre_weight_row_reconstructed"] = (
+            scalar_values.reshape(residual.shape[0], 1, residual.shape[-1]).contiguous()
+        )
+
+    handles.append(norm.register_forward_pre_hook(_pre_hook))
+    return handles
+
+
 # -----------------------------------------------------------------------------
 # Reference forward
 # -----------------------------------------------------------------------------
@@ -1100,6 +1170,8 @@ def run_reference_forward(
     c43_tap_names: Optional[List[str]] = None,
     capture_c44: bool = False,
     c44_tap_names: Optional[List[str]] = None,
+    capture_c45: bool = False,
+    c45_tap_names: Optional[List[str]] = None,
     fp32: bool = False,
 ) -> Dict[str, torch.Tensor]:
     """Run HF Qwen3-Next / Qwen3.5 forward with `output_hidden_states=True`.
@@ -1120,6 +1192,8 @@ def run_reference_forward(
       taps under `c43__<name>` keys.
     - `capture_c44=True`: layer-1 last-row F32 row + scalar + normalized row
       taps under `c44__<name>` keys.
+    - `capture_c45=True`: layer-1 row values + scalar + flat scalar-multiply
+      + reconstructed row taps under `c45__<name>` keys.
     - `fp32=True`: load the HF model in float32 (instead of bfloat16) so the
       comparator can distinguish bf16-accumulation noise from real divergence.
     """
@@ -1158,9 +1232,19 @@ def run_reference_forward(
         file=sys.stderr,
     )
 
-    if sum(bool(v) for v in (capture_b11_layer0, capture_c41, capture_c42, capture_c43, capture_c44)) > 1:
+    if sum(
+        bool(v)
+        for v in (
+            capture_b11_layer0,
+            capture_c41,
+            capture_c42,
+            capture_c43,
+            capture_c44,
+            capture_c45,
+        )
+    ) > 1:
         raise ValueError(
-            "capture_b11_layer0, capture_c41, capture_c42, capture_c43, and capture_c44 are mutually exclusive"
+            "capture_b11_layer0, capture_c41, capture_c42, capture_c43, capture_c44, and capture_c45 are mutually exclusive"
         )
 
     # Set up B11b/C41 instrumentation + forward hooks BEFORE the forward.
@@ -1170,6 +1254,7 @@ def run_reference_forward(
     c42_captures: Dict[str, torch.Tensor] = {}
     c43_captures: Dict[str, torch.Tensor] = {}
     c44_captures: Dict[str, torch.Tensor] = {}
+    c45_captures: Dict[str, torch.Tensor] = {}
     hook_handles: List[object] = []
     orig_gdn_forward = None
     if capture_b11_layer0:
@@ -1240,6 +1325,13 @@ def run_reference_forward(
         print(
             "[mtp_h_main_ref] C44 instrumentation armed: layer 1 row-level "
             "F32-vs-normalized audit hooks",
+            file=sys.stderr,
+        )
+    elif capture_c45:
+        hook_handles.extend(_arm_c45_layer1_row_hooks(base, c45_captures))
+        print(
+            "[mtp_h_main_ref] C45 instrumentation armed: layer 1 row-value / "
+            "scalar-multiply / reconstruction audit hooks",
             file=sys.stderr,
         )
 
@@ -1401,6 +1493,18 @@ def run_reference_forward(
                     tensor = tensor[:, -1:, ...].contiguous()
                 taps[f"c44__{name}"] = tensor
 
+    if capture_c45:
+        wanted = c45_tap_names or list(C45_LAYER1_ROW_TAP_NAMES)
+        missing = [n for n in wanted if n not in c45_captures]
+        if missing:
+            print(
+                f"[mtp_h_main_ref] WARNING: C45 instrumentation missed taps: {missing}",
+                file=sys.stderr,
+            )
+        for name in wanted:
+            if name in c45_captures:
+                taps[f"c45__{name}"] = c45_captures[name].contiguous()
+
     # Free the model and all retained activations before returning.
     del model, out, hs
     if device.type == "cuda":
@@ -1511,6 +1615,19 @@ def main() -> int:
         ),
     )
     ap.add_argument(
+        "--c45-taps",
+        action="store_true",
+        help=(
+            "Also capture the explicit Phase C45 row-level layer-1 audit tap "
+            "set (selected row values, matching RMS inverse scalar, flat "
+            "row-scalar multiplied values, reconstructed row-shaped output). "
+            "Output tensors are emitted under `c45__<name>` keys matching "
+            "C45_LAYER1_ROW_TAP_NAMES in crates/kiln-model/src/mtp_debug.rs. "
+            "The exact tap order is resolved from the kiln dump's "
+            "`meta__c45_tap_ids` when present."
+        ),
+    )
+    ap.add_argument(
         "--fp32",
         action="store_true",
         help=(
@@ -1534,6 +1651,7 @@ def main() -> int:
     c42_tap_names = resolve_c42_tap_names(kiln) if args.c42_taps else None
     c43_tap_names = resolve_c43_tap_names(kiln) if args.c43_taps else None
     c44_tap_names = resolve_c44_tap_names(kiln) if args.c44_taps else None
+    c45_tap_names = resolve_c45_tap_names(kiln) if args.c45_taps else None
     draft_token_id = int(kiln.get("meta__draft_token_id", -1))
     mtp_pos = int(kiln.get("meta__mtp_pos", -1))
     print(
@@ -1606,6 +1724,8 @@ def main() -> int:
         c43_tap_names=c43_tap_names,
         capture_c44=args.c44_taps,
         c44_tap_names=c44_tap_names,
+        capture_c45=args.c45_taps,
+        c45_tap_names=c45_tap_names,
         fp32=args.fp32,
     )
 
@@ -1647,6 +1767,11 @@ def main() -> int:
     if c44_tap_names:
         out_dict["meta__c44_tap_ids"] = torch.tensor(
             [C44_LAYER1_F32_ROW_TAP_NAMES.index(name) for name in c44_tap_names],
+            dtype=torch.int32,
+        )
+    if c45_tap_names:
+        out_dict["meta__c45_tap_ids"] = torch.tensor(
+            [C45_LAYER1_ROW_TAP_NAMES.index(name) for name in c45_tap_names],
             dtype=torch.int32,
         )
     # Also write the resolved prompt tokens so later reruns can reproduce


### PR DESCRIPTION
## Summary
- add a narrow C45 row-level tap lane for layer-1 input-layernorm normalization
- mirror the C45 tap contract in the HF dump and comparator
- commit the fresh local validation evidence plus the RunPod provisioning blocker artifacts and docs

## Verdict
GPU validation was blocked on April 23, 2026 because every allowed on-demand RunPod option either failed with SUPPLY_CONSTRAINT or launched into desiredStatus=RUNNING with runtime=null and no SSH endpoint, so the earliest shared bad C45 tap is still pending rerun on a healthy pod.