### PR TITLE
phase6: rerun C45 row-normalization bisect on healthy RunPod

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -6575,3 +6575,154 @@ Evidence:
 
 - `profiling-artifacts/post431_c45_20260423_local_validation.txt`
 - `profiling-artifacts/post431_c45_20260423_runpod_blocker.txt`
+
+## Phase C45 post-#432 healthy-RunPod rerun (2026-04-23)
+
+Goal: rerun the already-merged C45 tap contract on the first healthy
+on-demand RunPod pod and capture the earliest shared bad C45 tap on current
+`origin/main`.
+
+Remaining-work preflight:
+
+- PR #432 was present on `origin/main` (`5574aed`, merged 2026-04-23 14:34 UTC)
+- no newer open or merged kiln PR had already recorded a successful post-#432
+  C45 rerun or an earlier shared-bad C45 boundary
+- no separate pending/running kiln task overlapped this exact post-#432 rerun
+
+RunPod outcome:
+
+- `NVIDIA RTX A6000` launch failed immediately with `SUPPLY_CONSTRAINT`
+- the next allowed GPU, on-demand `NVIDIA A40`, reached SSH and completed the
+  rerun on `ghcr.io/ericflo/kiln-runpod:latest`
+- hardware used for the final verdict: `NVIDIA A40` (46068 MB VRAM reported by
+  `nvidia-smi`)
+
+Validation completed on pod:
+
+- `cargo build --release --features cuda --bin kiln-bench`
+- `cargo test --locked -p kiln-model c45 -- --nocapture`
+- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
+
+All three passed on the A40 pod.
+
+Actual rerun commands:
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+
+hf download Qwen/Qwen3.5-4B --local-dir /workspace/qwen3.5-4b
+python3 -m pip install transformers sentencepiece
+
+KILN_W4A16=1 \
+KILN_CUDA_GRAPHS=true \
+KILN_SPEC_METHOD=mtp \
+KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_SPLICE=1 \
+KILN_MTP_DUMP_SPLICE_POS=0,2 \
+KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 \
+KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
+KILN_MTP_DUMP_PATH=profiling-artifacts/post432_c45_seed0_captures/mtp_pos-{pos}/step-{step}.safetensors \
+./target/release/kiln-bench \
+  --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+  --seed 0 \
+  > profiling-artifacts/post432_c45_seed0.bench.json \
+  2> profiling-artifacts/post432_c45_seed0.bench.stderr
+
+KILN_W4A16=1 \
+KILN_CUDA_GRAPHS=true \
+KILN_SPEC_METHOD=mtp \
+KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_SPLICE=1 \
+KILN_MTP_DUMP_SPLICE_POS=0,2 \
+KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 \
+KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
+KILN_MTP_DUMP_PATH=profiling-artifacts/post432_c45_seed1_captures/mtp_pos-{pos}/step-{step}.safetensors \
+./target/release/kiln-bench \
+  --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+  --seed 1 \
+  > profiling-artifacts/post432_c45_seed1.bench.json \
+  2> profiling-artifacts/post432_c45_seed1.bench.stderr
+```
+
+Representative compare inputs:
+
+- seed 0 kiln dump: `profiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors`
+- seed 1 kiln dump: `profiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors`
+
+Reference + compare:
+
+```bash
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors \
+  --out profiling-artifacts/post432_c45_seed0_ref.safetensors \
+  --device cuda \
+  --c45-taps
+
+python3 scripts/mtp_compare.py --c45 \
+  --kiln profiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors \
+  --ref profiling-artifacts/post432_c45_seed0_ref.safetensors \
+  > profiling-artifacts/post432_c45_seed0_compare.txt
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors \
+  --out profiling-artifacts/post432_c45_seed1_ref.safetensors \
+  --device cuda \
+  --c45-taps
+
+python3 scripts/mtp_compare.py --c45 \
+  --kiln profiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors \
+  --ref profiling-artifacts/post432_c45_seed1_ref.safetensors \
+  > profiling-artifacts/post432_c45_seed1_compare.txt
+```
+
+Fresh workload check:
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 384.8 | 36.8 | 0.740 |
+| 1 | 508 | 393.4 | 24.2 | 0.296 |
+
+Verdict:
+
+- seed 0 compare: earliest shared bad tap =
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+- seed 1 compare: earliest shared bad tap =
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+- the last shared-good C45 tap on both seeds is
+  `layer_1_input_norm_rms_inv_scalar`
+
+So the post-#432 rerun localizes the first shared layer-1 row-normalization
+drift one step earlier than C44:
+
+- `layer_1_residual_input_f32_row_values` remains shared-good
+- `layer_1_input_norm_rms_inv_scalar` remains shared-good
+- `layer_1_input_norm_pre_weight_row_scalar_values` is the earliest shared-bad
+  C45 tap
+- `layer_1_input_norm_pre_weight_row_reconstructed` also diverges, but only
+  after the scalar-value tap is already bad
+
+Recommendation:
+
+- do not widen to C46 or expand the tap contract
+- focus the next audit inside the row-local scalar multiply that produces
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+- treat row selection and the row-local `rms_inv` scalar as provisionally
+  cleared on current main
+
+Evidence:
+
+- `profiling-artifacts/post432_c45_seed0.bench.json`
+- `profiling-artifacts/post432_c45_seed0.bench.stderr`
+- `profiling-artifacts/post432_c45_seed1.bench.json`
+- `profiling-artifacts/post432_c45_seed1.bench.stderr`
+- `profiling-artifacts/post432_c45_seed0_compare.txt`
+- `profiling-artifacts/post432_c45_seed1_compare.txt`

--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -1,12 +1,14 @@
-# Phase C45 — layer 1 row normalization bisect after PR #431
+# Phase C45 — post-#432 healthy-RunPod rerun
 
 ## Remaining-work preflight
 
-Fresh `origin/main` on 2026-04-23 still satisfied the task gate:
+Fresh `origin/main` on 2026-04-23 still satisfied the rerun gate:
 
-1. PR #431 / Phase C44 was present on `origin/main`.
-2. No newer open or merged kiln PR already localized the shared layer-1
-   row-level normalization boundary beyond C44.
+1. PR #432 / Phase C45 instrumentation was present on `origin/main`
+   (`5574aed`, merged 2026-04-23 14:34 UTC).
+2. No newer open or merged kiln PR had already recorded a successful post-#432
+   C45 rerun or an earlier shared-bad C45 tap.
+3. No separate pending or running kiln task already covered this exact rerun.
 
 So this task proceeded.
 
@@ -44,9 +46,19 @@ python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.p
 
 Both passed on 2026-04-23.
 
-## Planned GPU validation
+## GPU validation
 
-The intended source-of-truth workload stayed exactly aligned with the task:
+The rerun completed on the first healthy allowed pod:
+
+- `NVIDIA RTX A6000`: `SUPPLY_CONSTRAINT`
+- `NVIDIA A40`: healthy on-demand pod, SSH ready, final verdict source
+
+Pod / image:
+
+- image: `ghcr.io/ericflo/kiln-runpod:latest`
+- GPU: `NVIDIA A40` (`46068 MB` VRAM from `nvidia-smi`)
+
+Validation commands run on pod:
 
 ```bash
 python3 $RP bg $POD_ID /tmp/build.log \
@@ -54,46 +66,117 @@ python3 $RP bg $POD_ID /tmp/build.log \
 python3 $RP wait-file $POD_ID /workspace/kiln/target/release/kiln-bench --timeout 3600
 
 python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && cargo test --locked -p kiln-model c45 -- --nocapture'
-
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && export KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 && ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training > profiling-artifacts/post431_c45_seed0.bench.json 2> profiling-artifacts/post431_c45_seed0.bench.stderr'
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && export KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 KILN_SEED=1 && ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training > profiling-artifacts/post431_c45_seed1.bench.json 2> profiling-artifacts/post431_c45_seed1.bench.stderr'
-
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && python3 scripts/mtp_h_main_reference_dump.py --c45-taps profiling-artifacts/<fresh-kiln-dump>.safetensors profiling-artifacts/post431_c45_seed0_ref.safetensors'
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && python3 scripts/mtp_compare.py --c45 profiling-artifacts/post431_c45_seed0_compare.txt profiling-artifacts/post431_c45_seed1_compare.txt'
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py'
 ```
 
-## RunPod blocker
+All three passed.
 
-GPU validation did **not** complete on 2026-04-23 because RunPod never
-provided a healthy on-demand pod with a usable runtime / SSH endpoint.
+Model / Python prep required on the healthy pod:
 
-Observed failures:
+```bash
+python3 $RP ssh $POD_ID 'hf download Qwen/Qwen3.5-4B --local-dir /workspace/qwen3.5-4b'
+python3 $RP ssh $POD_ID 'python3 -m pip install transformers sentencepiece'
+```
 
-- direct launches for `NVIDIA RTX A6000`, `NVIDIA A40`, `NVIDIA A100 80GB PCIe`,
-  `NVIDIA RTX 6000 Ada Generation`, and `NVIDIA L40S` all failed immediately
-  with `SUPPLY_CONSTRAINT`
-- fallback launches on `NVIDIA H200 NVL`, `NVIDIA RTX PRO 4500 Blackwell`, and
-  `NVIDIA H100 PCIe` did create pods, but each pod stayed in:
-  `desiredStatus=RUNNING` with `runtime: null`, so `runpod_api.py wait` never
-  returned an SSH endpoint
+The exact C45 dump rerun that produced the verdict was:
 
-That means no build, no bench run, no kiln dump, no HF replay dump, and no C45
-compare report were produced in this task.
+```bash
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
+  KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 \
+  KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS=0,2 KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+  KILN_MTP_DUMP_HIDDEN_STATES=1 KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+  KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
+  KILN_MTP_DUMP_PATH=profiling-artifacts/post432_c45_seed0_captures/mtp_pos-{pos}/step-{step}.safetensors \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
+  --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed 0 \
+  > profiling-artifacts/post432_c45_seed0.bench.json \
+  2> profiling-artifacts/post432_c45_seed0.bench.stderr'
 
-The raw launch / provisioning evidence is committed in:
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
+  KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 \
+  KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS=0,2 KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+  KILN_MTP_DUMP_HIDDEN_STATES=1 KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+  KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
+  KILN_MTP_DUMP_PATH=profiling-artifacts/post432_c45_seed1_captures/mtp_pos-{pos}/step-{step}.safetensors \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
+  --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed 1 \
+  > profiling-artifacts/post432_c45_seed1.bench.json \
+  2> profiling-artifacts/post432_c45_seed1.bench.stderr'
+```
 
-- `profiling-artifacts/post431_c45_20260423_local_validation.txt`
-- `profiling-artifacts/post431_c45_20260423_runpod_blocker.txt`
+Representative compare inputs:
+
+- seed 0 kiln dump:
+  `profiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors`
+- seed 1 kiln dump:
+  `profiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors`
+
+Reference generation + compare:
+
+```bash
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
+  python3 scripts/mtp_h_main_reference_dump.py \
+    --checkpoint /workspace/qwen3.5-4b \
+    --kiln-dump profiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors \
+    --out profiling-artifacts/post432_c45_seed0_ref.safetensors \
+    --device cuda \
+    --c45-taps'
+
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
+  python3 scripts/mtp_compare.py --c45 \
+    --kiln profiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors \
+    --ref profiling-artifacts/post432_c45_seed0_ref.safetensors \
+    > profiling-artifacts/post432_c45_seed0_compare.txt'
+
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
+  python3 scripts/mtp_h_main_reference_dump.py \
+    --checkpoint /workspace/qwen3.5-4b \
+    --kiln-dump profiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors \
+    --out profiling-artifacts/post432_c45_seed1_ref.safetensors \
+    --device cuda \
+    --c45-taps'
+
+python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
+  python3 scripts/mtp_compare.py --c45 \
+    --kiln profiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors \
+    --ref profiling-artifacts/post432_c45_seed1_ref.safetensors \
+    > profiling-artifacts/post432_c45_seed1_compare.txt'
+```
+
+## Fresh workload check
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 384.8 | 36.8 | 0.740 |
+| 1 | 508 | 393.4 | 24.2 | 0.296 |
 
 ## Verdict
 
-No fresh C45 verdict yet.
+The post-#432 rerun produced a stable two-seed verdict:
 
-The code plumbing and local validation are complete, but the required GPU
-artifact capture was blocked by RunPod provisioning failures on 2026-04-23.
+- seed 0 earliest shared bad tap:
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+- seed 1 earliest shared bad tap:
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+- last shared-good tap on both seeds:
+  `layer_1_input_norm_rms_inv_scalar`
+
+So the first shared C45 drift is **not** in the selected row values and **not**
+in the row-local `rms_inv` scalar. It first appears in the flat row-scalar
+multiply values, then remains bad in the reconstructed row-shaped output.
 
 ## Recommendation
 
-Re-run the committed C45 workflow on the next healthy on-demand RunPod pod and
-fill in the earliest shared bad C45 tap. The code changes in this PR are ready
-for that rerun; the missing piece is infrastructure, not instrumentation.
+Do not widen to C46 or expand the tap contract. The next audit should stay
+inside the row-local scalar multiply that produces
+`layer_1_input_norm_pre_weight_row_scalar_values`; row selection and the
+row-local `rms_inv` scalar are provisionally cleared on current `main`.
+
+## Evidence
+
+- `profiling-artifacts/post432_c45_seed0.bench.json`
+- `profiling-artifacts/post432_c45_seed0.bench.stderr`
+- `profiling-artifacts/post432_c45_seed1.bench.json`
+- `profiling-artifacts/post432_c45_seed1.bench.stderr`
+- `profiling-artifacts/post432_c45_seed0_compare.txt`
+- `profiling-artifacts/post432_c45_seed1_compare.txt`

--- a/profiling-artifacts/post432_c45_seed0.bench.json
+++ b/profiling-artifacts/post432_c45_seed0.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA A40",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 19.653505064,
+    "model_vram_mb": 17527
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 494,
+      "output_tokens": 128,
+      "total_time_secs": 3.026168134,
+      "tokens_per_sec": 42.297715900804604,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 494,
+      "output_tokens": 512,
+      "total_time_secs": 12.672232406,
+      "tokens_per_sec": 40.403299402683004,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 494,
+      "output_tokens": 1024,
+      "total_time_secs": 24.670949247,
+      "tokens_per_sec": 41.506307266410474,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 494,
+      "output_tokens": 2048,
+      "total_time_secs": 48.566207418,
+      "tokens_per_sec": 42.169238836651544,
+      "peak_vram_mb": 17831
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 384.832154,
+    "prefill_tokens_per_sec": 1283.6765194001955,
+    "time_to_first_token_ms": 384.832154,
+    "mean_inter_token_ms": 27.146152236220477,
+    "p50_inter_token_ms": 20.51191,
+    "p99_inter_token_ms": 82.480259,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 36.83763324165417,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7397260273972602,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post432_c45_seed0.bench.stderr
+++ b/profiling-artifacts/post432_c45_seed0.bench.stderr
@@ -1,0 +1,103 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA A40 (46068 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T15:02:44.907697Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T15:02:44.909758Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T15:02:44.910121Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T15:02:44.910135Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T15:02:44.910284Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T15:03:04.558692Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m17831 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 17831 ms (parallel)
+Model loaded in 19.65s (backend: cuda, VRAM: 17527 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=47] (494 prompt tokens)...
+    Prefill (MTP): 384.8ms (1284 tok/s)
+[2m2026-04-23T15:03:05.564440Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m33
+[2m2026-04-23T15:03:05.584021Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m5339 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m494 [3mreplay_tokens_len[0m[2m=[0m494 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:03:05.651314Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m31192 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m495 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:03:05.712190Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m33416 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m496 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:03:05.772699Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m321 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m497 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:03:05.911132Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed0_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m7071 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m502 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 27.1ms (36.8 tok/s), α = 0.740 (54/73)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T15:03:09.487064Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 3026.1ms (42.3 tok/s)
+  => 42.3 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 3000.3ms (42.7 tok/s)
+    Run 2/4: 128 tokens in 3128.4ms (40.9 tok/s)
+    Run 3/4: 128 tokens in 3418.7ms (37.4 tok/s)
+    Run 4/4: 128 tokens in 3124.7ms (41.0 tok/s)
+  => 40.4 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 2963.7ms (43.2 tok/s)
+    Run 2/8: 128 tokens in 2960.4ms (43.2 tok/s)
+    Run 3/8: 128 tokens in 2952.5ms (43.4 tok/s)
+    Run 4/8: 128 tokens in 2984.7ms (42.9 tok/s)
+    Run 5/8: 128 tokens in 2972.3ms (43.1 tok/s)
+    Run 6/8: 128 tokens in 3394.8ms (37.7 tok/s)
+    Run 7/8: 128 tokens in 3402.8ms (37.6 tok/s)
+    Run 8/8: 128 tokens in 3039.5ms (42.1 tok/s)
+  => 41.5 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 3072.6ms (41.7 tok/s)
+    Run 2/16: 128 tokens in 2972.6ms (43.1 tok/s)
+    Run 3/16: 128 tokens in 2974.4ms (43.0 tok/s)
+    Run 4/16: 128 tokens in 2965.6ms (43.2 tok/s)
+    Run 5/16: 128 tokens in 2980.2ms (42.9 tok/s)
+    Run 6/16: 128 tokens in 3052.1ms (41.9 tok/s)
+    Run 7/16: 128 tokens in 2975.3ms (43.0 tok/s)
+    Run 8/16: 128 tokens in 2998.7ms (42.7 tok/s)
+    Run 9/16: 128 tokens in 2994.9ms (42.7 tok/s)
+    Run 10/16: 128 tokens in 3041.8ms (42.1 tok/s)
+    Run 11/16: 128 tokens in 3196.3ms (40.0 tok/s)
+    Run 12/16: 128 tokens in 3393.7ms (37.7 tok/s)
+    Run 13/16: 128 tokens in 2990.6ms (42.8 tok/s)
+    Run 14/16: 128 tokens in 2973.0ms (43.1 tok/s)
+    Run 15/16: 128 tokens in 2975.4ms (43.0 tok/s)
+    Run 16/16: 128 tokens in 3008.3ms (42.5 tok/s)
+  => 42.2 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA A40 (46068 MB VRAM, source: nvidia-smi)
+Model load time: 19.65s (VRAM: 17527 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               494        128         42.3      17831
+4               494        512         40.4      17831
+8               494       1024         41.5      17831
+16              494       2048         42.2      17831
+
+--- Latency (single request) ---
+Prompt tokens:         494
+Prefill time:          384.8 ms (1284 tok/s)
+Time to first token:   384.8 ms
+Mean inter-token:      27.1 ms (36.8 tok/s)
+P50 inter-token:       20.5 ms
+P99 inter-token:       82.5 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.740
+

--- a/profiling-artifacts/post432_c45_seed0_compare.txt
+++ b/profiling-artifacts/post432_c45_seed0_compare.txt
@@ -1,0 +1,38 @@
+MTP numerical bisect — mode: layer-1 row normalization audit (C45), atol=0.01, rtol=0.1
+  kiln dump : /workspace/kiln/profiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : profiling-artifacts/post432_c45_seed0_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     False    9.99e-01   1.35e-01     3.19e-02    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     False    9.99e-01   1.35e-01     3.19e-02    
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   1.14e-01     1.14e-01    
+c45__layer_1_residual_input_f32_row_values 1x2560                 True     True     9.99e-01   1.56e-02     1.59e-03    
+
+  pair verdict: first divergence at tap 'c45__layer_1_input_norm_pre_weight_row_reconstructed'.
+    Most-likely cause: <unknown tap>
+
+==============================================================================
+Phase C45 layer-1 row normalization audit — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                                                                                                 
+  ----------------------------------------------------------------------------------------------------
+  layer_1_residual_input_f32_row_values           cos=9.99e-01   max|Δ|=1.56e-02   mean|Δ|=1.59e-03   rel_l2=4.03e-02   ok 
+  layer_1_input_norm_rms_inv_scalar               cos=1.00e+00   max|Δ|=1.14e-01   mean|Δ|=1.14e-01   rel_l2=5.71e-03   ok 
+  layer_1_input_norm_pre_weight_row_scalar_values cos=9.99e-01   max|Δ|=1.35e-01   mean|Δ|=3.19e-02   rel_l2=4.01e-02   DIV
+  layer_1_input_norm_pre_weight_row_reconstructed cos=9.99e-01   max|Δ|=1.35e-01   mean|Δ|=3.19e-02   rel_l2=4.01e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight_row_scalar_values'
+  last shared-good tap: 'layer_1_input_norm_rms_inv_scalar'
+Phase C45 verdict: EARLIEST SHARED BAD ROW-LEVEL TAP = 'layer_1_input_norm_pre_weight_row_scalar_values'.
+    Most-likely cause: the selected row values and scalar stay shared-good; drift first appears in the flat row-scalar multiply values
+  -> The selected row values and `rms_inv` scalar stay shared-good; divergence first appears in the flat row-scalar multiply values.
+
+Overall verdict: divergence(s) at: ['c45__layer_1_input_norm_pre_weight_row_reconstructed']

--- a/profiling-artifacts/post432_c45_seed1.bench.json
+++ b/profiling-artifacts/post432_c45_seed1.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA A40",
+    "total_vram_mb": 46068,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 19.678420395,
+    "model_vram_mb": 17527
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 508,
+      "output_tokens": 128,
+      "total_time_secs": 2.999353301,
+      "tokens_per_sec": 42.675866146653725,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 508,
+      "output_tokens": 512,
+      "total_time_secs": 11.933673946999999,
+      "tokens_per_sec": 42.90380332778502,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 508,
+      "output_tokens": 1024,
+      "total_time_secs": 23.926686473,
+      "tokens_per_sec": 42.79740118446948,
+      "peak_vram_mb": 17831
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 508,
+      "output_tokens": 2048,
+      "total_time_secs": 47.561013908,
+      "tokens_per_sec": 43.06047814627257,
+      "peak_vram_mb": 17831
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 508,
+    "prefill_time_ms": 393.446913,
+    "prefill_tokens_per_sec": 1291.15258810024,
+    "time_to_first_token_ms": 393.446913,
+    "mean_inter_token_ms": 41.26472456692916,
+    "p50_inter_token_ms": 55.291374999999995,
+    "p99_inter_token_ms": 71.955254,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 24.233773773966526,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.29591836734693877,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post432_c45_seed1.bench.stderr
+++ b/profiling-artifacts/post432_c45_seed1.bench.stderr
@@ -1,0 +1,109 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA A40 (46068 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T15:04:41.452427Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T15:04:41.453427Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T15:04:41.453608Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T15:04:41.453616Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T15:04:41.453697Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T15:05:01.129090Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m18086 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 18086 ms (parallel)
+Model loaded in 19.68s (backend: cuda, VRAM: 17527 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (508 prompt tokens)...
+    Prefill (MTP): 393.4ms (1291 tok/s)
+[2m2026-04-23T15:05:02.150493Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m33
+[2m2026-04-23T15:05:02.170314Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m25015 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m508 [3mreplay_tokens_len[0m[2m=[0m508 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:05:02.246052Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m314 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m509 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:05:02.314843Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m1330 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m510 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:05:02.384098Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m47205 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m511 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:05:02.452848Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-0/step-4.safetensors [3mdraft_token_id[0m[2m=[0m369 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(4) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m512 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:05:02.521676Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-0/step-5.safetensors [3mdraft_token_id[0m[2m=[0m799 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(5) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m513 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:05:02.589325Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-0/step-6.safetensors [3mdraft_token_id[0m[2m=[0m30797 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(6) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m514 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:05:02.649661Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-0/step-7.safetensors [3mdraft_token_id[0m[2m=[0m314 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(7) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m515 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:05:02.780589Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m421 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m520 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:05:02.841022Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors [3mdraft_token_id[0m[2m=[0m3202 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m521 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T15:05:02.901276Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-2.safetensors [3mdraft_token_id[0m[2m=[0m369 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m522 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 41.3ms (24.2 tok/s), α = 0.296 (29/98)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T15:05:07.823499Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 2999.3ms (42.7 tok/s)
+  => 42.7 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 3014.9ms (42.5 tok/s)
+    Run 2/4: 128 tokens in 2982.6ms (42.9 tok/s)
+    Run 3/4: 128 tokens in 2969.2ms (43.1 tok/s)
+    Run 4/4: 128 tokens in 2966.8ms (43.1 tok/s)
+  => 42.9 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 3015.3ms (42.5 tok/s)
+    Run 2/8: 128 tokens in 2979.9ms (43.0 tok/s)
+    Run 3/8: 128 tokens in 2988.1ms (42.8 tok/s)
+    Run 4/8: 128 tokens in 2968.5ms (43.1 tok/s)
+    Run 5/8: 128 tokens in 2985.6ms (42.9 tok/s)
+    Run 6/8: 128 tokens in 2999.1ms (42.7 tok/s)
+    Run 7/8: 128 tokens in 3006.0ms (42.6 tok/s)
+    Run 8/8: 128 tokens in 2983.9ms (42.9 tok/s)
+  => 42.8 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 2992.6ms (42.8 tok/s)
+    Run 2/16: 128 tokens in 2996.0ms (42.7 tok/s)
+    Run 3/16: 128 tokens in 2961.3ms (43.2 tok/s)
+    Run 4/16: 128 tokens in 2995.3ms (42.7 tok/s)
+    Run 5/16: 128 tokens in 3019.0ms (42.4 tok/s)
+    Run 6/16: 128 tokens in 2983.7ms (42.9 tok/s)
+    Run 7/16: 128 tokens in 2978.3ms (43.0 tok/s)
+    Run 8/16: 128 tokens in 2972.8ms (43.1 tok/s)
+    Run 9/16: 128 tokens in 2958.0ms (43.3 tok/s)
+    Run 10/16: 128 tokens in 2938.6ms (43.6 tok/s)
+    Run 11/16: 128 tokens in 2972.7ms (43.1 tok/s)
+    Run 12/16: 128 tokens in 2950.9ms (43.4 tok/s)
+    Run 13/16: 128 tokens in 2947.0ms (43.4 tok/s)
+    Run 14/16: 128 tokens in 2959.7ms (43.2 tok/s)
+    Run 15/16: 128 tokens in 2992.2ms (42.8 tok/s)
+    Run 16/16: 128 tokens in 2942.3ms (43.5 tok/s)
+  => 43.1 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA A40 (46068 MB VRAM, source: nvidia-smi)
+Model load time: 19.68s (VRAM: 17527 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               508        128         42.7      17831
+4               508        512         42.9      17831
+8               508       1024         42.8      17831
+16              508       2048         43.1      17831
+
+--- Latency (single request) ---
+Prompt tokens:         508
+Prefill time:          393.4 ms (1291 tok/s)
+Time to first token:   393.4 ms
+Mean inter-token:      41.3 ms (24.2 tok/s)
+P50 inter-token:       55.3 ms
+P99 inter-token:       72.0 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.296
+

--- a/profiling-artifacts/post432_c45_seed1_compare.txt
+++ b/profiling-artifacts/post432_c45_seed1_compare.txt
@@ -1,0 +1,38 @@
+MTP numerical bisect — mode: layer-1 row normalization audit (C45), atol=0.01, rtol=0.1
+  kiln dump : /workspace/kiln/profiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : profiling-artifacts/post432_c45_seed1_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     False    9.99e-01   1.42e-01     3.14e-02    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     False    9.99e-01   1.42e-01     3.14e-02    
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   9.12e-02     9.12e-02    
+c45__layer_1_residual_input_f32_row_values 1x2560                 True     True     9.99e-01   7.81e-03     1.34e-03    
+
+  pair verdict: first divergence at tap 'c45__layer_1_input_norm_pre_weight_row_reconstructed'.
+    Most-likely cause: <unknown tap>
+
+==============================================================================
+Phase C45 layer-1 row normalization audit — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                                                                                                 
+  ----------------------------------------------------------------------------------------------------
+  layer_1_residual_input_f32_row_values           cos=9.99e-01   max|Δ|=7.81e-03   mean|Δ|=1.34e-03   rel_l2=3.93e-02   ok 
+  layer_1_input_norm_rms_inv_scalar               cos=1.00e+00   max|Δ|=9.12e-02   mean|Δ|=9.12e-02   rel_l2=3.90e-03   ok 
+  layer_1_input_norm_pre_weight_row_scalar_values cos=9.99e-01   max|Δ|=1.42e-01   mean|Δ|=3.14e-02   rel_l2=3.92e-02   DIV
+  layer_1_input_norm_pre_weight_row_reconstructed cos=9.99e-01   max|Δ|=1.42e-01   mean|Δ|=3.14e-02   rel_l2=3.92e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight_row_scalar_values'
+  last shared-good tap: 'layer_1_input_norm_rms_inv_scalar'
+Phase C45 verdict: EARLIEST SHARED BAD ROW-LEVEL TAP = 'layer_1_input_norm_pre_weight_row_scalar_values'.
+    Most-likely cause: the selected row values and scalar stay shared-good; drift first appears in the flat row-scalar multiply values
+  -> The selected row values and `rms_inv` scalar stay shared-good; divergence first appears in the flat row-scalar multiply values.
+
+Overall verdict: divergence(s) at: ['c45__layer_1_input_norm_pre_weight_row_reconstructed']


### PR DESCRIPTION
## Summary
- rerun the post-#432 C45 row-normalization bisect on the first healthy on-demand RunPod pod
- commit the fresh seed-0 / seed-1 bench artifacts plus per-seed C45 compare reports
- replace the prior blocker-only writeup with the actual rerun verdict and next recommendation

## Validation
- `cargo build --release --features cuda --bin kiln-bench` on RunPod `NVIDIA A40` / `ghcr.io/ericflo/kiln-runpod:latest`: passed
- `cargo test --locked -p kiln-model c45 -- --nocapture` on the same pod: passed
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py` on the same pod: passed
- `scripts/mtp_compare.py --c45` completed for both representative seed dumps

## Key Result
- `NVIDIA RTX A6000` was supply-constrained; the rerun completed on the next allowed healthy GPU, `NVIDIA A40`
- seed 0 earliest shared bad tap: `layer_1_input_norm_pre_weight_row_scalar_values`
- seed 1 earliest shared bad tap: `layer_1_input_norm_pre_weight_row_scalar_values`
- last shared-good tap on both seeds: `layer_1_input_norm_rms_inv_scalar`
- recommendation: keep scope inside the row-local scalar multiply that produces `layer_1_input_norm_pre_weight_row_scalar_values`; do not widen to C46 or expand the tap contract yet
