### PR TITLE
phase6: narrow C45 row-local scalar multiply boundary

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1655,11 +1655,12 @@ fn capture_c44_layer1_f32_row_taps(x: &Tensor, eps: f64) -> Result<()> {
     Ok(())
 }
 
-/// Phase C45: split the previously-bad C44 row-level scalar-affine site one
-/// step further so the replay dump can distinguish "selected row values are
-/// already wrong" vs "scalar multiply introduces the drift" vs "flat scalar
-/// multiply stays shared-good and divergence only appears when reconstructing
-/// the row-shaped output".
+/// Phase C45: keep the audit strictly inside the previously-bad row-local
+/// scalar multiply so the replay dump can distinguish "the row-local scalar
+/// tensor is fine", "the scalar extraction path already drifts", "the actual
+/// multiply introduces the drift", or "the multiplied flat row stays
+/// shared-good and divergence only appears when reconstructing the row-shaped
+/// output".
 fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
     let x_f32 = x.to_dtype(DType::F32)?;
     let (batch, seq_len, hidden) = x_f32
@@ -1669,10 +1670,6 @@ fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
 
     let last_row = x_f32.narrow(1, seq_len - 1, 1)?.contiguous()?;
     let residual_values = last_row.reshape((batch, hidden))?.contiguous()?;
-    crate::mtp_debug::capture_c45_layer1_row_tap(
-        "layer_1_residual_input_f32_row_values",
-        &residual_values,
-    )?;
 
     let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
     let rms_inv = (variance + eps)?.sqrt()?.recip()?;
@@ -1682,6 +1679,7 @@ fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
         &rms_inv_row,
     )?;
 
+    let mut extracted_scalars = Vec::with_capacity(batch);
     let mut row_values = Vec::with_capacity(batch);
     let mut reconstructed_rows = Vec::with_capacity(batch);
     for batch_idx in 0..batch {
@@ -1693,10 +1691,19 @@ fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
             "C45 row audit expected one rms_inv scalar per batch row, got {}",
             scale_vals.len()
         );
-        let scaled_values = row.affine(scale_vals[0] as f64, 0.0)?.contiguous()?;
+        let extracted = scale_vals[0];
+        extracted_scalars.push(extracted);
+        let scaled_values = row.affine(extracted as f64, 0.0)?.contiguous()?;
         row_values.push(scaled_values.clone());
         reconstructed_rows.push(scaled_values.reshape((1, 1, hidden))?);
     }
+
+    let extracted_scalars =
+        Tensor::from_slice(&extracted_scalars, (batch,), &Device::Cpu)?.contiguous()?;
+    crate::mtp_debug::capture_c45_layer1_row_tap(
+        "layer_1_input_norm_rms_inv_scalar_extracted_values",
+        &extracted_scalars,
+    )?;
 
     let row_value_refs: Vec<&Tensor> = row_values.iter().collect();
     let scalar_values = Tensor::cat(&row_value_refs, 0)?;

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -985,8 +985,8 @@ pub const C44_LAYER1_F32_ROW_TAP_NAMES: &[&str] = &[
 /// reference (`scripts/mtp_h_main_reference_dump.py --c45-taps`) both mirror
 /// this exact order.
 pub const C45_LAYER1_ROW_TAP_NAMES: &[&str] = &[
-    "layer_1_residual_input_f32_row_values",
     "layer_1_input_norm_rms_inv_scalar",
+    "layer_1_input_norm_rms_inv_scalar_extracted_values",
     "layer_1_input_norm_pre_weight_row_scalar_values",
     "layer_1_input_norm_pre_weight_row_reconstructed",
 ];
@@ -3034,6 +3034,20 @@ mod tests {
     }
 
     #[test]
+    fn c45_layer1_row_tap_names_enumerate_expected_boundaries() {
+        assert_eq!(C45_LAYER1_ROW_TAP_NAMES.len(), 4);
+        assert_eq!(C45_LAYER1_ROW_TAP_NAMES[0], "layer_1_input_norm_rms_inv_scalar");
+        assert_eq!(
+            C45_LAYER1_ROW_TAP_NAMES[1],
+            "layer_1_input_norm_rms_inv_scalar_extracted_values"
+        );
+        assert_eq!(
+            C45_LAYER1_ROW_TAP_NAMES[3],
+            "layer_1_input_norm_pre_weight_row_reconstructed"
+        );
+    }
+
+    #[test]
     fn c41_layer1_capture_records_then_drains() {
         let _guard = test_env_lock();
         unsafe {
@@ -3236,6 +3250,62 @@ mod tests {
         let a = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
         capture_c44_layer1_f32_row_tap("layer_1_residual_input_f32_row", &a).unwrap();
         assert!(drain_c44_layer1_f32_row_capture().is_empty());
+    }
+
+    #[test]
+    fn c45_layer1_row_capture_records_then_drains() {
+        let _guard = test_env_lock();
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS", "1");
+        }
+        let a = Tensor::new(&[1.0_f32, 2.0, 3.0][..], &Device::Cpu).unwrap();
+        let b = Tensor::new(&[10.0_f32][..], &Device::Cpu).unwrap();
+
+        capture_c45_layer1_row_tap("layer_1_input_norm_rms_inv_scalar", &a).unwrap();
+        assert!(drain_c45_layer1_row_capture().is_empty());
+        assert!(!is_c45_layer1_row_capture_armed());
+        assert!(!should_capture_c45_layer1_row_tap_for_layer(1));
+
+        arm_c45_layer1_row_capture();
+        assert!(is_c45_layer1_row_capture_armed());
+        assert!(should_capture_c45_layer1_row_tap_for_layer(1));
+        assert!(!should_capture_c45_layer1_row_tap_for_layer(0));
+        capture_c45_layer1_row_tap("layer_1_input_norm_rms_inv_scalar", &b).unwrap();
+        capture_c45_layer1_row_tap("layer_1_input_norm_rms_inv_scalar_extracted_values", &a)
+            .unwrap();
+        let drained = drain_c45_layer1_row_capture();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].0, "layer_1_input_norm_rms_inv_scalar");
+        assert_eq!(drained[0].1, vec![1]);
+        assert_eq!(drained[0].2, vec![10.0]);
+        assert_eq!(
+            drained[1].0,
+            "layer_1_input_norm_rms_inv_scalar_extracted_values"
+        );
+        assert_eq!(drained[1].1, vec![3]);
+        assert_eq!(drained[1].2, vec![1.0, 2.0, 3.0]);
+
+        assert!(!is_c45_layer1_row_capture_armed());
+        capture_c45_layer1_row_tap("layer_1_input_norm_pre_weight_row_scalar_values", &a)
+            .unwrap();
+        assert!(drain_c45_layer1_row_capture().is_empty());
+
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS");
+        }
+    }
+
+    #[test]
+    fn c45_layer1_row_arm_is_noop_when_env_unset() {
+        let _guard = test_env_lock();
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS");
+        }
+        arm_c45_layer1_row_capture();
+        assert!(!is_c45_layer1_row_capture_armed());
+        let a = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        capture_c45_layer1_row_tap("layer_1_input_norm_rms_inv_scalar", &a).unwrap();
+        assert!(drain_c45_layer1_row_capture().is_empty());
     }
 
     #[test]
@@ -3635,9 +3705,9 @@ mod tests {
         let tmp_s = tmp.to_string_lossy().into_owned();
         let c45 = vec![
             (
-                "layer_1_residual_input_f32_row_values".to_string(),
-                vec![2],
-                vec![0.31_f32, 0.32],
+                "layer_1_input_norm_rms_inv_scalar".to_string(),
+                vec![1, 1, 1],
+                vec![0.31_f32],
             ),
             (
                 "layer_1_input_norm_pre_weight_row_reconstructed".to_string(),
@@ -3672,7 +3742,7 @@ mod tests {
         let raw = std::fs::read(&tmp).unwrap();
         let st = SafeTensors::deserialize(&raw).unwrap();
         let names: Vec<&str> = st.names().into_iter().map(|s| s.as_str()).collect();
-        assert!(names.contains(&"c45__layer_1_residual_input_f32_row_values"));
+        assert!(names.contains(&"c45__layer_1_input_norm_rms_inv_scalar"));
         assert!(names.contains(&"c45__layer_1_input_norm_pre_weight_row_reconstructed"));
         assert!(names.contains(&"meta__c45_tap_ids"));
 

--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -1,66 +1,59 @@
-# Phase C45 — post-#432 healthy-RunPod rerun
-
-## Remaining-work preflight
-
-Fresh `origin/main` on 2026-04-23 still satisfied the rerun gate:
-
-1. PR #432 / Phase C45 instrumentation was present on `origin/main`
-   (`5574aed`, merged 2026-04-23 14:34 UTC).
-2. No newer open or merged kiln PR had already recorded a successful post-#432
-   C45 rerun or an earlier shared-bad C45 tap.
-3. No separate pending or running kiln task already covered this exact rerun.
-
-So this task proceeded.
+# Phase C45 — post-#433 row-local scalar-multiply follow-up
 
 ## Scope
 
-The C45 instrumentation adds a dedicated opt-in tap namespace under
-`KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1`:
+PR #433 localized the first shared bad C45 tap to
+`layer_1_input_norm_pre_weight_row_scalar_values`, with
+`layer_1_input_norm_rms_inv_scalar` as the last shared-good tap. This
+follow-up keeps the audit strictly inside that row-local scalar-multiply
+boundary under `KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1`.
 
-- `layer_1_residual_input_f32_row_values`
+The narrowed tap contract is:
+
 - `layer_1_input_norm_rms_inv_scalar`
+- `layer_1_input_norm_rms_inv_scalar_extracted_values`
 - `layer_1_input_norm_pre_weight_row_scalar_values`
 - `layer_1_input_norm_pre_weight_row_reconstructed`
 
-This keeps the task diagnostic-only and splits the previously-bad C44 site one
-step further:
+Interpretation:
 
-- selected residual row values
-- the row-local `rms_inv` scalar
-- the flat row-scalar multiply result
-- the reconstructed row-shaped output right before the existing post-input-norm
-  path
+- If `layer_1_input_norm_rms_inv_scalar` is first bad, the shared-good PR #433
+  boundary regressed and the problem is upstream of scalar extraction.
+- If `layer_1_input_norm_rms_inv_scalar_extracted_values` is first bad, the
+  row-local scalar tensor is still shared-good and the next target is the
+  Rust-side scalar extraction / per-batch replay path.
+- If `layer_1_input_norm_pre_weight_row_scalar_values` is first bad, scalar
+  extraction is cleared and the next target stays on the actual row-local
+  scalar multiply.
+- If `layer_1_input_norm_pre_weight_row_reconstructed` is first bad, the flat
+  multiply is cleared and the next target stays only on reshape /
+  concatenation of the multiplied row.
 
-The goal is to tell whether the first shared drift now appears in the selected
-row values, in the scalar multiply itself, or only when reconstructing the row
-shape.
+## Commands
 
-## Local validation
-
-Completed locally before any GPU spend:
+Local validation:
 
 ```bash
 cargo test --locked -p kiln-model c45 -- --nocapture
 python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
 ```
 
-Both passed on 2026-04-23.
-
-## GPU validation
-
-The rerun completed on the first healthy allowed pod:
-
-- `NVIDIA RTX A6000`: `SUPPLY_CONSTRAINT`
-- `NVIDIA A40`: healthy on-demand pod, SSH ready, final verdict source
-
-Pod / image:
-
-- image: `ghcr.io/ericflo/kiln-runpod:latest`
-- GPU: `NVIDIA A40` (`46068 MB` VRAM from `nvidia-smi`)
-
-Validation commands run on pod:
+Representative GPU rerun on RunPod:
 
 ```bash
+export RUNPOD_API_KEY=$(ce secret-get --name RUNPOD_API_KEY)
+RP=/data/.clouderic-internal/repos/apps/trajectory-trainer/scripts/runpod_api.py
+
+python3 $RP status
+POD_ID=$(python3 $RP launch --kiln-image --gpu "NVIDIA RTX A6000" \
+  --name kiln-c45-row-scalar-narrow --disk-gb 80 | tail -1 | jq -r .id)
+trap 'python3 $RP terminate $POD_ID 2>/dev/null || true' ERR INT TERM
+python3 $RP wait $POD_ID
+
+B2_KEY_ID=$(ce secret-get --name B2_APPLICATION_KEY_ID)
+B2_KEY=$(ce secret-get --name B2_APPLICATION_KEY)
+python3 $RP ssh $POD_ID \
+  "export B2_APPLICATION_KEY_ID='$B2_KEY_ID' B2_APPLICATION_KEY='$B2_KEY'; kiln-setup --clone"
 python3 $RP bg $POD_ID /tmp/build.log \
   'source /root/.kiln-build-env && cd /workspace/kiln && cargo build --release --features cuda --bin kiln-bench'
 python3 $RP wait-file $POD_ID /workspace/kiln/target/release/kiln-bench --timeout 3600
@@ -69,16 +62,7 @@ python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && c
 python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py'
 ```
 
-All three passed.
-
-Model / Python prep required on the healthy pod:
-
-```bash
-python3 $RP ssh $POD_ID 'hf download Qwen/Qwen3.5-4B --local-dir /workspace/qwen3.5-4b'
-python3 $RP ssh $POD_ID 'python3 -m pip install transformers sentencepiece'
-```
-
-The exact C45 dump rerun that produced the verdict was:
+Representative seed reruns:
 
 ```bash
 python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
@@ -86,30 +70,28 @@ python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
   KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS=0,2 KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
   KILN_MTP_DUMP_HIDDEN_STATES=1 KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
   KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
-  KILN_MTP_DUMP_PATH=profiling-artifacts/post432_c45_seed0_captures/mtp_pos-{pos}/step-{step}.safetensors \
+  KILN_MTP_DUMP_PATH=profiling-artifacts/post433_c45_row_scalar_seed0_captures/mtp_pos-{pos}/step-{step}.safetensors \
   ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
   --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed 0 \
-  > profiling-artifacts/post432_c45_seed0.bench.json \
-  2> profiling-artifacts/post432_c45_seed0.bench.stderr'
+  > profiling-artifacts/post433_c45_row_scalar_seed0.bench.json \
+  2> profiling-artifacts/post433_c45_row_scalar_seed0.bench.stderr'
 
 python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
   KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 \
   KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS=0,2 KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
   KILN_MTP_DUMP_HIDDEN_STATES=1 KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
   KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
-  KILN_MTP_DUMP_PATH=profiling-artifacts/post432_c45_seed1_captures/mtp_pos-{pos}/step-{step}.safetensors \
+  KILN_MTP_DUMP_PATH=profiling-artifacts/post433_c45_row_scalar_seed1_captures/mtp_pos-{pos}/step-{step}.safetensors \
   ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
   --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed 1 \
-  > profiling-artifacts/post432_c45_seed1.bench.json \
-  2> profiling-artifacts/post432_c45_seed1.bench.stderr'
+  > profiling-artifacts/post433_c45_row_scalar_seed1.bench.json \
+  2> profiling-artifacts/post433_c45_row_scalar_seed1.bench.stderr'
 ```
 
 Representative compare inputs:
 
-- seed 0 kiln dump:
-  `profiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors`
-- seed 1 kiln dump:
-  `profiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors`
+- seed 0: `profiling-artifacts/post433_c45_row_scalar_seed0_captures/mtp_pos-0/step-1.safetensors`
+- seed 1: `profiling-artifacts/post433_c45_row_scalar_seed1_captures/mtp_pos-2/step-1.safetensors`
 
 Reference generation + compare:
 
@@ -117,66 +99,33 @@ Reference generation + compare:
 python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
   python3 scripts/mtp_h_main_reference_dump.py \
     --checkpoint /workspace/qwen3.5-4b \
-    --kiln-dump profiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors \
-    --out profiling-artifacts/post432_c45_seed0_ref.safetensors \
+    --kiln-dump profiling-artifacts/post433_c45_row_scalar_seed0_captures/mtp_pos-0/step-1.safetensors \
+    --out profiling-artifacts/post433_c45_row_scalar_seed0_ref.safetensors \
     --device cuda \
     --c45-taps'
 
 python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
-  python3 scripts/mtp_compare.py --c45 \
-    --kiln profiling-artifacts/post432_c45_seed0_captures/mtp_pos-0/step-1.safetensors \
-    --ref profiling-artifacts/post432_c45_seed0_ref.safetensors \
-    > profiling-artifacts/post432_c45_seed0_compare.txt'
+  python3 scripts/mtp_compare.py --c45-row-scalar \
+    --kiln profiling-artifacts/post433_c45_row_scalar_seed0_captures/mtp_pos-0/step-1.safetensors \
+    --ref profiling-artifacts/post433_c45_row_scalar_seed0_ref.safetensors \
+    > profiling-artifacts/post433_c45_row_scalar_seed0_compare.txt'
 
 python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
   python3 scripts/mtp_h_main_reference_dump.py \
     --checkpoint /workspace/qwen3.5-4b \
-    --kiln-dump profiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors \
-    --out profiling-artifacts/post432_c45_seed1_ref.safetensors \
+    --kiln-dump profiling-artifacts/post433_c45_row_scalar_seed1_captures/mtp_pos-2/step-1.safetensors \
+    --out profiling-artifacts/post433_c45_row_scalar_seed1_ref.safetensors \
     --device cuda \
     --c45-taps'
 
 python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
-  python3 scripts/mtp_compare.py --c45 \
-    --kiln profiling-artifacts/post432_c45_seed1_captures/mtp_pos-2/step-1.safetensors \
-    --ref profiling-artifacts/post432_c45_seed1_ref.safetensors \
-    > profiling-artifacts/post432_c45_seed1_compare.txt'
+  python3 scripts/mtp_compare.py --c45-row-scalar \
+    --kiln profiling-artifacts/post433_c45_row_scalar_seed1_captures/mtp_pos-2/step-1.safetensors \
+    --ref profiling-artifacts/post433_c45_row_scalar_seed1_ref.safetensors \
+    > profiling-artifacts/post433_c45_row_scalar_seed1_compare.txt'
 ```
 
-## Fresh workload check
+## Expected Outputs After Rerun
 
-| Seed | prompt tokens | prefill ms | decode tok/s | α |
-| --- | ---: | ---: | ---: | ---: |
-| 0 | 494 | 384.8 | 36.8 | 0.740 |
-| 1 | 508 | 393.4 | 24.2 | 0.296 |
-
-## Verdict
-
-The post-#432 rerun produced a stable two-seed verdict:
-
-- seed 0 earliest shared bad tap:
-  `layer_1_input_norm_pre_weight_row_scalar_values`
-- seed 1 earliest shared bad tap:
-  `layer_1_input_norm_pre_weight_row_scalar_values`
-- last shared-good tap on both seeds:
-  `layer_1_input_norm_rms_inv_scalar`
-
-So the first shared C45 drift is **not** in the selected row values and **not**
-in the row-local `rms_inv` scalar. It first appears in the flat row-scalar
-multiply values, then remains bad in the reconstructed row-shaped output.
-
-## Recommendation
-
-Do not widen to C46 or expand the tap contract. The next audit should stay
-inside the row-local scalar multiply that produces
-`layer_1_input_norm_pre_weight_row_scalar_values`; row selection and the
-row-local `rms_inv` scalar are provisionally cleared on current `main`.
-
-## Evidence
-
-- `profiling-artifacts/post432_c45_seed0.bench.json`
-- `profiling-artifacts/post432_c45_seed0.bench.stderr`
-- `profiling-artifacts/post432_c45_seed1.bench.json`
-- `profiling-artifacts/post432_c45_seed1.bench.stderr`
-- `profiling-artifacts/post432_c45_seed0_compare.txt`
-- `profiling-artifacts/post432_c45_seed1_compare.txt`
+- `profiling-artifacts/post433_c45_row_scalar_seed0_compare.txt`
+- `profiling-artifacts/post433_c45_row_scalar_seed1_compare.txt`

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -371,17 +371,17 @@ C44_HYPOTHESIS: Dict[str, str] = {
 # in `crates/kiln-model/src/mtp_debug.rs` and
 # `scripts/mtp_h_main_reference_dump.py`.
 C45_LAYER1_ROW_TAP_NAMES: Tuple[str, ...] = (
-    "layer_1_residual_input_f32_row_values",
     "layer_1_input_norm_rms_inv_scalar",
+    "layer_1_input_norm_rms_inv_scalar_extracted_values",
     "layer_1_input_norm_pre_weight_row_scalar_values",
     "layer_1_input_norm_pre_weight_row_reconstructed",
 )
 
 C45_HYPOTHESIS: Dict[str, str] = {
-    "layer_1_residual_input_f32_row_values": "the selected last-row values are already wrong before row-local normalization is applied",
-    "layer_1_input_norm_rms_inv_scalar": "the row-local RMS inverse scalar diverges even though C44 kept the same scalar shared-good",
-    "layer_1_input_norm_pre_weight_row_scalar_values": "the selected row values and scalar stay shared-good; drift first appears in the flat row-scalar multiply values",
-    "layer_1_input_norm_pre_weight_row_reconstructed": "the flat row-scalar multiply stays shared-good; drift appears only when reconstructing the row-shaped output before the existing post-input-norm path",
+    "layer_1_input_norm_rms_inv_scalar": "the row-local RMS inverse scalar tensor itself diverges even though PR #433 kept this boundary shared-good",
+    "layer_1_input_norm_rms_inv_scalar_extracted_values": "the row-local scalar tensor stays shared-good, but the scalar extraction path diverges before the multiply runs",
+    "layer_1_input_norm_pre_weight_row_scalar_values": "the scalar tensor and extracted scalar stay shared-good; drift first appears in the actual row-local scalar multiply values",
+    "layer_1_input_norm_pre_weight_row_reconstructed": "the flat row-local scalar multiply stays shared-good; drift appears only when reconstructing the row-shaped output before the existing post-input-norm path",
 }
 
 # Phase B12 — the cos_sim bar is tighter than B10/B11 because the expected
@@ -749,7 +749,7 @@ def _compare_pair(
         emit("  pair verdict: all taps match within tolerance.")
     else:
         base_first_div = first_div
-        for prefix in ("b11__", "b12__", "c41__", "c6__", "c7__"):
+        for prefix in ("b11__", "b12__", "c41__", "c45__", "c6__", "c7__"):
             if base_first_div.startswith(prefix):
                 base_first_div = base_first_div[len(prefix) :]
                 break
@@ -759,6 +759,7 @@ def _compare_pair(
             or B11_HYPOTHESIS.get(base_first_div)
             or B12_HYPOTHESIS.get(base_first_div)
             or C41_HYPOTHESIS.get(base_first_div)
+            or C45_HYPOTHESIS.get(base_first_div)
             or C6_HYPOTHESIS.get(base_first_div)
             or C7_HYPOTHESIS.get(base_first_div)
             or "<unknown tap>"
@@ -2056,10 +2057,10 @@ def _emit_c45_summary(
     rtol: float,
     emit,
 ) -> None:
-    """Phase C45 — layer-1 row-level normalization bisect."""
+    """Phase C45 — layer-1 row-local scalar-multiply bisect."""
     emit("")
     emit("=" * 78)
-    emit("Phase C45 layer-1 row normalization audit — cos_sim / max|Δ| / mean|Δ| / rel_l2")
+    emit("Phase C45 layer-1 row-local scalar-multiply audit — cos_sim / max|Δ| / mean|Δ| / rel_l2")
     emit("=" * 78)
 
     labels = [pr[0] for pr in pair_results]
@@ -2104,7 +2105,7 @@ def _emit_c45_summary(
 
     emit("")
     if not captured_any:
-        emit("Phase C45 verdict: no C45 row-level taps present in dumps.")
+        emit("Phase C45 verdict: no C45 row-local scalar-multiply taps present in dumps.")
         emit("  -> Re-run kiln-bench with KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 and")
         emit("     re-run mtp_h_main_reference_dump.py with --c45-taps against")
         emit("     the same kiln dump.")
@@ -2138,31 +2139,37 @@ def _emit_c45_summary(
         emit("Phase C45 verdict: no shared earliest-bad tap across all supplied seeds.")
         for lab in labels:
             emit(f"  earliest divergent tap for {lab}: {first_per_seed.get(lab, '<none>')}")
-        emit("  -> Seeds do not yet agree on a single first-bad C45 boundary.")
+        emit("  -> Seeds do not yet agree on a single first-bad row-local scalar-multiply boundary.")
         return
 
     emit(f"  earliest shared bad tap: '{first_shared_bad}'")
     if last_shared_ok is not None:
         emit(f"  last shared-good tap: '{last_shared_ok}'")
-    emit(f"Phase C45 verdict: EARLIEST SHARED BAD ROW-LEVEL TAP = '{first_shared_bad}'.")
+    emit(f"Phase C45 verdict: EARLIEST SHARED BAD ROW-LOCAL SCALAR-MULTIPLY TAP = '{first_shared_bad}'.")
     emit(f"    Most-likely cause: {C45_HYPOTHESIS.get(first_shared_bad, '<unknown tap>')}")
 
-    if first_shared_bad == "layer_1_residual_input_f32_row_values":
+    if first_shared_bad == "layer_1_input_norm_rms_inv_scalar":
         emit(
-            "  -> Divergence is already present in the selected last-row "
-            "values before row-local normalization is applied."
+            "  -> Divergence is already present on the row-local `rms_inv` "
+            "tensor before any scalar extraction or multiply replay runs."
+        )
+    elif first_shared_bad == "layer_1_input_norm_rms_inv_scalar_extracted_values":
+        emit(
+            "  -> The row-local `rms_inv` tensor stays shared-good; drift "
+            "first appears when replay extracts one scalar per batch row for "
+            "the Rust-side scalar-affine equivalent."
         )
     elif first_shared_bad == "layer_1_input_norm_pre_weight_row_scalar_values":
         emit(
-            "  -> The selected row values and `rms_inv` scalar stay "
-            "shared-good; divergence first appears in the flat row-scalar "
-            "multiply values."
+            "  -> The row-local `rms_inv` tensor and its extracted scalar "
+            "stay shared-good; divergence first appears in the flat "
+            "row-local scalar multiply values."
         )
     elif first_shared_bad == "layer_1_input_norm_pre_weight_row_reconstructed":
         emit(
-            "  -> The flat row-scalar multiply stays shared-good; divergence "
-            "appears only when reconstructing the row-shaped output right "
-            "before the existing post-input-norm path."
+            "  -> The flat row-local scalar multiply stays shared-good; "
+            "divergence appears only when reconstructing the row-shaped "
+            "output right before the existing post-input-norm path."
         )
     elif last_shared_ok is not None:
         emit(
@@ -2396,13 +2403,22 @@ def main() -> int:
         "--c45",
         action="store_true",
         help=(
-            "Phase C45 mode: emit the narrowed layer-1 row normalization "
-            "audit over the explicit c45__<name> tap set (selected row "
-            "values, matching RMS inverse scalar, flat row-scalar multiply "
-            "values, reconstructed row-shaped output). Defaults atol=1e-2, "
-            "rtol=1e-1 (bf16-appropriate). Verdict names whether divergence "
-            "first appears in the selected row values, the scalar multiply, "
-            "or only after reconstruction."
+            "Phase C45 mode: emit the narrowed layer-1 row-local scalar-"
+            "multiply audit over the explicit c45__<name> tap set (row-local "
+            "RMS inverse scalar tensor, extracted scalar values, flat "
+            "row-scalar multiply values, reconstructed row-shaped output). "
+            "Defaults atol=1e-2, rtol=1e-1 (bf16-appropriate). Verdict names "
+            "whether divergence first appears in the scalar tensor, the "
+            "scalar extraction path, the multiply, or only after "
+            "reconstruction."
+        ),
+    )
+    ap.add_argument(
+        "--c45-row-scalar",
+        action="store_true",
+        help=(
+            "Alias for --c45 with wording that matches the narrowed Phase C45 "
+            "row-local scalar-multiply follow-up."
         ),
     )
     ap.add_argument(
@@ -2455,6 +2471,7 @@ def main() -> int:
         or args.c43
         or args.c44
         or args.c45
+        or args.c45_row_scalar
     )
     if args.atol is None:
         args.atol = 1e-2 if bf16_mode else 1e-3
@@ -2483,8 +2500,8 @@ def main() -> int:
     multi = len(pairs) > 1
     if args.c7:
         mode = "SDPA-internal bisect (C7)"
-    elif args.c45:
-        mode = "layer-1 row normalization audit (C45)"
+    elif args.c45 or args.c45_row_scalar:
+        mode = "layer-1 row-local scalar-multiply audit (C45)"
     elif args.c44:
         mode = "layer-1 row-level audit (C44)"
     elif args.c43:
@@ -2512,7 +2529,7 @@ def main() -> int:
     ] = []
     overall_ok = True
     focus_keys = None
-    if args.c45:
+    if args.c45 or args.c45_row_scalar:
         focus_keys = [f"c45__{name}" for name in C45_LAYER1_ROW_TAP_NAMES]
     elif args.c44:
         focus_keys = [f"c44__{name}" for name in C44_LAYER1_F32_ROW_TAP_NAMES]
@@ -2532,7 +2549,7 @@ def main() -> int:
 
     if args.c7:
         _emit_c7_summary(pair_results, args.atol, args.rtol, emit)
-    elif args.c45:
+    elif args.c45 or args.c45_row_scalar:
         _emit_c45_summary(pair_results, args.atol, args.rtol, emit)
     elif args.c44:
         _emit_c44_summary(pair_results, args.atol, args.rtol, emit)

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -238,8 +238,8 @@ C44_LAYER1_F32_ROW_TAP_NAMES: Tuple[str, ...] = (
 # stay in lock-step with `C45_LAYER1_ROW_TAP_NAMES` in
 # `crates/kiln-model/src/mtp_debug.rs`.
 C45_LAYER1_ROW_TAP_NAMES: Tuple[str, ...] = (
-    "layer_1_residual_input_f32_row_values",
     "layer_1_input_norm_rms_inv_scalar",
+    "layer_1_input_norm_rms_inv_scalar_extracted_values",
     "layer_1_input_norm_pre_weight_row_scalar_values",
     "layer_1_input_norm_pre_weight_row_reconstructed",
 )
@@ -1121,7 +1121,7 @@ def _arm_c44_layer1_f32_row_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> 
 
 
 def _arm_c45_layer1_row_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List[object]:
-    """Attach hooks for the narrowed Phase C45 row-level normalization audit."""
+    """Attach hooks for the narrowed Phase C45 row-local scalar-multiply audit."""
     handles: List[object] = []
     layer = base.layers[1]
     norm = getattr(layer, "input_layernorm", None)
@@ -1134,11 +1134,13 @@ def _arm_c45_layer1_row_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List
         tensor = inputs[0][0] if isinstance(inputs[0], tuple) else inputs[0]
         residual = tensor.detach().clone().to(torch.float32)
         residual_row = residual[:, -1, :].contiguous()
-        taps_out["layer_1_residual_input_f32_row_values"] = residual_row
 
         rms_inv = torch.rsqrt(residual.square().mean(dim=-1, keepdim=True) + eps)
         rms_inv_row = rms_inv[:, -1:, :].contiguous()
         taps_out["layer_1_input_norm_rms_inv_scalar"] = rms_inv_row
+        taps_out["layer_1_input_norm_rms_inv_scalar_extracted_values"] = (
+            rms_inv_row.reshape(-1).contiguous()
+        )
 
         scalar_values = (residual_row * rms_inv_row.reshape(-1, 1)).contiguous()
         taps_out["layer_1_input_norm_pre_weight_row_scalar_values"] = scalar_values
@@ -1192,8 +1194,8 @@ def run_reference_forward(
       taps under `c43__<name>` keys.
     - `capture_c44=True`: layer-1 last-row F32 row + scalar + normalized row
       taps under `c44__<name>` keys.
-    - `capture_c45=True`: layer-1 row values + scalar + flat scalar-multiply
-      + reconstructed row taps under `c45__<name>` keys.
+    - `capture_c45=True`: layer-1 row-local scalar tensor + extracted scalar
+      + flat scalar-multiply + reconstructed row taps under `c45__<name>` keys.
     - `fp32=True`: load the HF model in float32 (instead of bfloat16) so the
       comparator can distinguish bf16-accumulation noise from real divergence.
     """
@@ -1330,8 +1332,8 @@ def run_reference_forward(
     elif capture_c45:
         hook_handles.extend(_arm_c45_layer1_row_hooks(base, c45_captures))
         print(
-            "[mtp_h_main_ref] C45 instrumentation armed: layer 1 row-value / "
-            "scalar-multiply / reconstruction audit hooks",
+            "[mtp_h_main_ref] C45 instrumentation armed: layer 1 row-local "
+            "scalar / extracted-scalar / multiply / reconstruction audit hooks",
             file=sys.stderr,
         )
 


### PR DESCRIPTION
## Summary
- narrow the C45 row-local scalar-multiply tap set so it distinguishes the row-local `rms_inv` tensor from the extracted scalar replay path before the actual multiply/output path
- mirror the narrowed C45 tap contract in the HF reference dump, comparator, and phase doc
- add the focused `--c45-row-scalar` comparator mode and fix pair-verdict hypothesis lookup for `c45__*` taps

## Validation
- `cargo test --locked -p kiln-model c45 -- --nocapture`
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`

## GPU validation blocker
I attempted the required RunPod validation twice on 2026-04-23 using the mandated kiln image and the exact fallback order from the task brief:
- `NVIDIA RTX A6000`
- `NVIDIA A40`
- `NVIDIA A100`
- `RTX 6000 Ada`
- `L40S`

All ten launch attempts failed with RunPod `SUPPLY_CONSTRAINT`, so this PR does **not** yet include the fresh post-change compare artifacts. The last confirmed shared-good tap remains `layer_1_input_norm_rms_inv_scalar` from PR #433, and the next rerun should determine whether the first shared bad sub-step is `layer_1_input_norm_rms_inv_scalar_extracted_values`, `layer_1_input_norm_pre_weight_row_scalar_values`, or `layer_1_input_norm_pre_weight_row_reconstructed`.

## Next recommendation
Re-run the exact pod flow from the updated phase doc once any allowed on-demand GPU becomes available, then commit:
- `profiling-artifacts/post433_c45_row_scalar_seed0_compare.txt`
- `profiling-artifacts/post433_c45_row_scalar_seed1_compare.txt`
