### PR TITLE
phase6: document post-434 C45 rerun blocker

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -6726,3 +6726,56 @@ Evidence:
 - `profiling-artifacts/post432_c45_seed1.bench.stderr`
 - `profiling-artifacts/post432_c45_seed0_compare.txt`
 - `profiling-artifacts/post432_c45_seed1_compare.txt`
+
+## Phase C45 post-#434 narrowed row-scalar rerun blocker (2026-04-23)
+
+Goal: rerun the already-merged narrowed C45 instrumentation from PR #434 on the
+first healthy allowed on-demand RunPod pod and capture the earliest shared bad
+tap among:
+
+- `layer_1_input_norm_rms_inv_scalar_extracted_values`
+- `layer_1_input_norm_pre_weight_row_scalar_values`
+- `layer_1_input_norm_pre_weight_row_reconstructed`
+
+Remaining-work preflight:
+
+- PR #434 was present on `origin/main` (`7808adf`, merged 2026-04-23 15:44 UTC)
+- no newer open or merged kiln PR had already recorded the narrowed
+  three-tap C45 verdict
+- no separate pending or running kiln task overlapped this exact post-#434
+  rerun
+
+RunPod outcome:
+
+- `NVIDIA RTX A6000` failed immediately with `SUPPLY_CONSTRAINT`
+- `NVIDIA A40` launched pod `jbagv24mf1f31l` on
+  `ghcr.io/ericflo/kiln-runpod:latest`, but the pod remained
+  `desiredStatus=RUNNING` with `"runtime": null`; `python3 $RP wait` never
+  reached SSH and ended with `AttributeError: 'NoneType' object has no
+  attribute 'get'` after termination
+- `NVIDIA A100 80GB PCIe` failed immediately with `SUPPLY_CONSTRAINT`
+- `NVIDIA RTX 6000 Ada Generation` failed immediately with `SUPPLY_CONSTRAINT`
+- `NVIDIA L40S` failed immediately with `SUPPLY_CONSTRAINT` ("no longer any
+  instances available with enough disk space")
+- `NVIDIA H100 PCIe` launched pod `zh6zr8z5v0g1tn`, but it also remained
+  `desiredStatus=RUNNING` with `"runtime": null`; `python3 $RP wait` never
+  reached SSH and ended with the same `AttributeError` after termination
+
+Validation outcome:
+
+- none of the required on-pod commands could run because no allowed pod reached
+  SSH:
+  - `cargo build --release --features cuda --bin kiln-bench`
+  - `cargo test --locked -p kiln-model c45 -- --nocapture`
+  - `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
+  - either narrowed `scripts/mtp_compare.py --c45-row-scalar ...` run
+
+Verdict:
+
+- no post-#434 narrowed C45 numerical verdict yet
+- the blocker is RunPod availability/pod health, not missing instrumentation
+- do not change the narrowed tap contract before a healthy allowed pod exists
+
+Evidence:
+
+- `profiling-artifacts/post434_c45_row_scalar_runpod_blocker.txt`

--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -1,131 +1,69 @@
-# Phase C45 — post-#433 row-local scalar-multiply follow-up
+# Phase C45 — post-#434 narrowed row-scalar rerun
 
 ## Scope
 
-PR #433 localized the first shared bad C45 tap to
-`layer_1_input_norm_pre_weight_row_scalar_values`, with
-`layer_1_input_norm_rms_inv_scalar` as the last shared-good tap. This
-follow-up keeps the audit strictly inside that row-local scalar-multiply
-boundary under `KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1`.
+PR #434 narrowed the remaining C45 question to three row-scalar sub-steps:
 
-The narrowed tap contract is:
-
-- `layer_1_input_norm_rms_inv_scalar`
 - `layer_1_input_norm_rms_inv_scalar_extracted_values`
 - `layer_1_input_norm_pre_weight_row_scalar_values`
 - `layer_1_input_norm_pre_weight_row_reconstructed`
 
-Interpretation:
+This rerun attempted to execute that already-merged narrowed tap contract on the
+first healthy allowed on-demand RunPod pod. No code changes were required or
+made in this task; the only goal was to obtain fresh post-#434 evidence.
 
-- If `layer_1_input_norm_rms_inv_scalar` is first bad, the shared-good PR #433
-  boundary regressed and the problem is upstream of scalar extraction.
-- If `layer_1_input_norm_rms_inv_scalar_extracted_values` is first bad, the
-  row-local scalar tensor is still shared-good and the next target is the
-  Rust-side scalar extraction / per-batch replay path.
-- If `layer_1_input_norm_pre_weight_row_scalar_values` is first bad, scalar
-  extraction is cleared and the next target stays on the actual row-local
-  scalar multiply.
-- If `layer_1_input_norm_pre_weight_row_reconstructed` is first bad, the flat
-  multiply is cleared and the next target stays only on reshape /
-  concatenation of the multiplied row.
+## Remaining-work preflight
 
-## Commands
+Before spending GPU time, the fresh `origin/main` preflight was rechecked:
 
-Local validation:
+- PR #434 was present on `origin/main` (`7808adf`, merged 2026-04-23).
+- No newer open or merged kiln PR had already recorded the earliest shared bad
+  narrowed C45 tap among the three post-#434 taps.
+- No separate pending or running kiln task overlapped this exact post-#434
+  rerun.
 
-```bash
-cargo test --locked -p kiln-model c45 -- --nocapture
-python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
-```
+Those checks passed, so the task proceeded to RunPod execution.
 
-Representative GPU rerun on RunPod:
+## Actual RunPod outcome
 
-```bash
-export RUNPOD_API_KEY=$(ce secret-get --name RUNPOD_API_KEY)
-RP=/data/.clouderic-internal/repos/apps/trajectory-trainer/scripts/runpod_api.py
+The rerun never reached a usable SSH endpoint on any allowed GPU class:
 
-python3 $RP status
-POD_ID=$(python3 $RP launch --kiln-image --gpu "NVIDIA RTX A6000" \
-  --name kiln-c45-row-scalar-narrow --disk-gb 80 | tail -1 | jq -r .id)
-trap 'python3 $RP terminate $POD_ID 2>/dev/null || true' ERR INT TERM
-python3 $RP wait $POD_ID
+- `NVIDIA RTX A6000`: launch failed immediately with RunPod
+  `SUPPLY_CONSTRAINT`.
+- `NVIDIA A40`: pod `jbagv24mf1f31l` launched on
+  `ghcr.io/ericflo/kiln-runpod:latest`, but `python3 $RP wait jbagv24mf1f31l`
+  stayed at `status=RUNNING, uptime=N/As` and then crashed after termination
+  because the pod never exposed a runtime/SSH endpoint.
+- `NVIDIA A100 80GB PCIe`: launch failed immediately with RunPod
+  `SUPPLY_CONSTRAINT`.
+- `NVIDIA RTX 6000 Ada Generation`: launch failed immediately with RunPod
+  `SUPPLY_CONSTRAINT`.
+- `NVIDIA L40S`: launch failed immediately with RunPod
+  `SUPPLY_CONSTRAINT` ("no longer any instances available with enough disk
+  space").
+- `NVIDIA H100 PCIe`: pod `zh6zr8z5v0g1tn` launched on the kiln image, but
+  `runpod_api.py info` continued to report `"runtime": null` and
+  `python3 $RP wait zh6zr8z5v0g1tn` never reached SSH before the pod was
+  terminated.
 
-B2_KEY_ID=$(ce secret-get --name B2_APPLICATION_KEY_ID)
-B2_KEY=$(ce secret-get --name B2_APPLICATION_KEY)
-python3 $RP ssh $POD_ID \
-  "export B2_APPLICATION_KEY_ID='$B2_KEY_ID' B2_APPLICATION_KEY='$B2_KEY'; kiln-setup --clone"
-python3 $RP bg $POD_ID /tmp/build.log \
-  'source /root/.kiln-build-env && cd /workspace/kiln && cargo build --release --features cuda --bin kiln-bench'
-python3 $RP wait-file $POD_ID /workspace/kiln/target/release/kiln-bench --timeout 3600
+Because no allowed pod reached SSH, none of the required on-pod validation
+commands could be run:
 
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && cargo test --locked -p kiln-model c45 -- --nocapture'
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py'
-```
+- `cargo build --release --features cuda --bin kiln-bench`
+- `cargo test --locked -p kiln-model c45 -- --nocapture`
+- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
+- either `scripts/mtp_compare.py --c45-row-scalar ...` rerun
 
-Representative seed reruns:
+## Verdict
 
-```bash
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
-  KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 \
-  KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS=0,2 KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
-  KILN_MTP_DUMP_HIDDEN_STATES=1 KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
-  KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
-  KILN_MTP_DUMP_PATH=profiling-artifacts/post433_c45_row_scalar_seed0_captures/mtp_pos-{pos}/step-{step}.safetensors \
-  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
-  --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed 0 \
-  > profiling-artifacts/post433_c45_row_scalar_seed0.bench.json \
-  2> profiling-artifacts/post433_c45_row_scalar_seed0.bench.stderr'
+There is still no post-#434 narrowed C45 numerical verdict. The blocker remains
+RunPod availability and pod health, not missing instrumentation:
 
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
-  KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 \
-  KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS=0,2 KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
-  KILN_MTP_DUMP_HIDDEN_STATES=1 KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
-  KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
-  KILN_MTP_DUMP_PATH=profiling-artifacts/post433_c45_row_scalar_seed1_captures/mtp_pos-{pos}/step-{step}.safetensors \
-  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
-  --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed 1 \
-  > profiling-artifacts/post433_c45_row_scalar_seed1.bench.json \
-  2> profiling-artifacts/post433_c45_row_scalar_seed1.bench.stderr'
-```
+- no earliest shared bad narrowed C45 tap was captured
+- no new bench JSON, stderr, or compare outputs exist for the post-#434 rerun
+- the next step is still to rerun the committed workload on the next healthy
+  allowed on-demand pod without changing the tap contract
 
-Representative compare inputs:
+## Evidence
 
-- seed 0: `profiling-artifacts/post433_c45_row_scalar_seed0_captures/mtp_pos-0/step-1.safetensors`
-- seed 1: `profiling-artifacts/post433_c45_row_scalar_seed1_captures/mtp_pos-2/step-1.safetensors`
-
-Reference generation + compare:
-
-```bash
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
-  python3 scripts/mtp_h_main_reference_dump.py \
-    --checkpoint /workspace/qwen3.5-4b \
-    --kiln-dump profiling-artifacts/post433_c45_row_scalar_seed0_captures/mtp_pos-0/step-1.safetensors \
-    --out profiling-artifacts/post433_c45_row_scalar_seed0_ref.safetensors \
-    --device cuda \
-    --c45-taps'
-
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
-  python3 scripts/mtp_compare.py --c45-row-scalar \
-    --kiln profiling-artifacts/post433_c45_row_scalar_seed0_captures/mtp_pos-0/step-1.safetensors \
-    --ref profiling-artifacts/post433_c45_row_scalar_seed0_ref.safetensors \
-    > profiling-artifacts/post433_c45_row_scalar_seed0_compare.txt'
-
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
-  python3 scripts/mtp_h_main_reference_dump.py \
-    --checkpoint /workspace/qwen3.5-4b \
-    --kiln-dump profiling-artifacts/post433_c45_row_scalar_seed1_captures/mtp_pos-2/step-1.safetensors \
-    --out profiling-artifacts/post433_c45_row_scalar_seed1_ref.safetensors \
-    --device cuda \
-    --c45-taps'
-
-python3 $RP ssh $POD_ID 'source /root/.kiln-build-env && cd /workspace/kiln && \
-  python3 scripts/mtp_compare.py --c45-row-scalar \
-    --kiln profiling-artifacts/post433_c45_row_scalar_seed1_captures/mtp_pos-2/step-1.safetensors \
-    --ref profiling-artifacts/post433_c45_row_scalar_seed1_ref.safetensors \
-    > profiling-artifacts/post433_c45_row_scalar_seed1_compare.txt'
-```
-
-## Expected Outputs After Rerun
-
-- `profiling-artifacts/post433_c45_row_scalar_seed0_compare.txt`
-- `profiling-artifacts/post433_c45_row_scalar_seed1_compare.txt`
+- `profiling-artifacts/post434_c45_row_scalar_runpod_blocker.txt`

--- a/profiling-artifacts/post434_c45_row_scalar_runpod_blocker.txt
+++ b/profiling-artifacts/post434_c45_row_scalar_runpod_blocker.txt
@@ -1,0 +1,106 @@
+Phase C45 post-#434 narrowed row-scalar rerun blocker
+Date: 2026-04-23
+Branch: ce/post434-c45-row-scalar-rerun
+Repo: ericflo/kiln
+Image: ghcr.io/ericflo/kiln-runpod:latest
+Launch name: kiln-post434-c45-row-scalar
+
+Remaining-work preflight:
+- PR #434 present on origin/main: yes (merge commit 7808adf1d60d3ff3bc9b300e0a3ca1a09106e17d)
+- newer PR already records narrowed three-tap verdict: no
+- separate pending/running task already covers this rerun: no
+
+Allowed GPU attempts:
+
+1. NVIDIA RTX A6000
+   Result: launch failed immediately.
+   Exact error:
+   RunPodError: GraphQL errors: [{"message": "There are no longer any instances available with the requested specifications. Please refresh and try again.", "path": ["podFindAndDeployOnDemand"], "extensions": {"code": "SUPPLY_CONSTRAINT", "userId": "auth0|6358da09bf70f1182ebd8138"}}]
+
+2. NVIDIA A40
+   Result: pod launched but never exposed SSH.
+   Pod id: jbagv24mf1f31l
+   Launch summary:
+   - desiredStatus: RUNNING
+   - gpuDisplayName: A40
+   - costPerHr: 0.44
+   - runtime: null
+   Wait evidence:
+   Waiting for pod jbagv24mf1f31l to be ready (timeout: 300s)...
+     [0s] status=RUNNING, uptime=N/As
+     [10s] status=RUNNING, uptime=N/As
+     [21s] status=RUNNING, uptime=N/As
+     [31s] status=RUNNING, uptime=N/As
+     [41s] status=RUNNING, uptime=N/As
+     [52s] status=RUNNING, uptime=N/As
+     [62s] status=RUNNING, uptime=N/As
+     [73s] status=RUNNING, uptime=N/As
+     [83s] status=RUNNING, uptime=N/As
+     [94s] status=RUNNING, uptime=N/As
+     [104s] status=RUNNING, uptime=N/As
+     [115s] status=RUNNING, uptime=N/As
+     [125s] status=RUNNING, uptime=N/As
+     [136s] status=RUNNING, uptime=N/As
+     [146s] status=RUNNING, uptime=N/As
+   Final error after termination:
+   AttributeError: 'NoneType' object has no attribute 'get'
+
+3. NVIDIA A100 80GB PCIe
+   Result: launch failed immediately.
+   Exact error:
+   RunPodError: GraphQL errors: [{"message": "There are no longer any instances available with the requested specifications. Please refresh and try again.", "path": ["podFindAndDeployOnDemand"], "extensions": {"code": "SUPPLY_CONSTRAINT", "userId": "auth0|6358da09bf70f1182ebd8138"}}]
+
+4. NVIDIA RTX 6000 Ada Generation
+   Result: launch failed immediately.
+   Exact error:
+   RunPodError: GraphQL errors: [{"message": "There are no longer any instances available with the requested specifications. Please refresh and try again.", "path": ["podFindAndDeployOnDemand"], "extensions": {"code": "SUPPLY_CONSTRAINT", "userId": "auth0|6358da09bf70f1182ebd8138"}}]
+
+5. NVIDIA L40S
+   Result: launch failed immediately.
+   Exact error:
+   RunPodError: GraphQL errors: [{"message": "There are no longer any instances available with enough disk space.", "path": ["podFindAndDeployOnDemand"], "extensions": {"code": "SUPPLY_CONSTRAINT", "userId": "auth0|6358da09bf70f1182ebd8138"}}]
+
+6. NVIDIA H100 PCIe
+   Result: pod launched but never exposed SSH.
+   Pod id: zh6zr8z5v0g1tn
+   Launch summary:
+   - desiredStatus: RUNNING
+   - gpuDisplayName: H100 PCIe
+   - costPerHr: 2.39
+   - runtime: null
+   Info check at 2026-04-23T16:33:08Z:
+   {
+     "id": "zh6zr8z5v0g1tn",
+     "name": "kiln-post434-c45-row-scalar",
+     "desiredStatus": "RUNNING",
+     "costPerHr": 2.39,
+     "gpuCount": 1,
+     "imageName": "ghcr.io/ericflo/kiln-runpod:latest",
+     "containerDiskInGb": 80,
+     "volumeInGb": 0,
+     "machine": {
+       "gpuDisplayName": "H100 PCIe"
+     },
+     "runtime": null
+   }
+   Wait evidence:
+   Waiting for pod zh6zr8z5v0g1tn to be ready (timeout: 300s)...
+     [0s] status=RUNNING, uptime=N/As
+     [10s] status=RUNNING, uptime=N/As
+     [20s] status=RUNNING, uptime=N/As
+     [31s] status=RUNNING, uptime=N/As
+     [41s] status=RUNNING, uptime=N/As
+     [51s] status=RUNNING, uptime=N/As
+     [61s] status=RUNNING, uptime=N/As
+     [71s] status=RUNNING, uptime=N/As
+   Final error after termination:
+   AttributeError: 'NoneType' object has no attribute 'get'
+
+Impact:
+- No allowed pod reached a usable SSH endpoint.
+- None of the required on-pod validation commands could be run.
+- No post-#434 narrowed C45 bench or compare artifacts were produced.
+
+Recommendation:
+- Re-run the exact post-#434 narrowed C45 workload on the next healthy allowed on-demand pod.
+- Do not change the narrowed tap contract before a healthy pod exists.


### PR DESCRIPTION
## Summary
- document the post-#434 narrowed C45 rerun blocker instead of inventing fresh bench artifacts
- replace the phase C45 placeholder with the actual RunPod failure matrix and required blocker artifact
- append PROFILING.md with the post-#434 status so the next rerun starts from the current infra state

## Validation
- Remaining-work preflight on fresh `origin/main`: passed
- Required on-pod validation commands could not run because no allowed on-demand pod reached SSH
- Allowed GPU attempts exercised: `NVIDIA RTX A6000`, `NVIDIA A40`, `NVIDIA A100 80GB PCIe`, `NVIDIA RTX 6000 Ada Generation`, `NVIDIA L40S`, `NVIDIA H100 PCIe`

## Key Result
- `NVIDIA RTX A6000`, `NVIDIA A100 80GB PCIe`, and `NVIDIA RTX 6000 Ada Generation` failed immediately with `SUPPLY_CONSTRAINT`
- `NVIDIA L40S` failed immediately with `SUPPLY_CONSTRAINT` due to disk-capacity shortage
- `NVIDIA A40` pod `jbagv24mf1f31l` and `NVIDIA H100 PCIe` pod `zh6zr8z5v0g1tn` launched on `ghcr.io/ericflo/kiln-runpod:latest` but both stayed `desiredStatus=RUNNING` with `runtime: null`, never exposed SSH, and `python3 $RP wait` ended with `AttributeError: 'NoneType' object has no attribute 'get'` after termination
- no post-#434 narrowed C45 bench or compare artifacts were produced; the next step is to rerun the committed workload on the next healthy allowed on-demand pod without changing the tap contract
