### PR TITLE
phase6: capture post-435 C45 row-scalar verdict

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -6727,7 +6727,7 @@ Evidence:
 - `profiling-artifacts/post432_c45_seed0_compare.txt`
 - `profiling-artifacts/post432_c45_seed1_compare.txt`
 
-## Phase C45 post-#434 narrowed row-scalar rerun blocker (2026-04-23)
+## Phase C45 post-#435 narrowed row-scalar rerun verdict (2026-04-23)
 
 Goal: rerun the already-merged narrowed C45 instrumentation from PR #434 on the
 first healthy allowed on-demand RunPod pod and capture the earliest shared bad
@@ -6740,42 +6740,132 @@ tap among:
 Remaining-work preflight:
 
 - PR #434 was present on `origin/main` (`7808adf`, merged 2026-04-23 15:44 UTC)
+- PR #435 was present on `origin/main` (`ca474b5`, merged 2026-04-23 16:39 UTC)
 - no newer open or merged kiln PR had already recorded the narrowed
   three-tap C45 verdict
-- no separate pending or running kiln task overlapped this exact post-#434
-  rerun
+- no separate pending or running kiln task overlapped this exact post-#435
+  healthy-pod rerun
 
 RunPod outcome:
 
-- `NVIDIA RTX A6000` failed immediately with `SUPPLY_CONSTRAINT`
-- `NVIDIA A40` launched pod `jbagv24mf1f31l` on
-  `ghcr.io/ericflo/kiln-runpod:latest`, but the pod remained
-  `desiredStatus=RUNNING` with `"runtime": null`; `python3 $RP wait` never
-  reached SSH and ended with `AttributeError: 'NoneType' object has no
-  attribute 'get'` after termination
-- `NVIDIA A100 80GB PCIe` failed immediately with `SUPPLY_CONSTRAINT`
-- `NVIDIA RTX 6000 Ada Generation` failed immediately with `SUPPLY_CONSTRAINT`
-- `NVIDIA L40S` failed immediately with `SUPPLY_CONSTRAINT` ("no longer any
-  instances available with enough disk space")
-- `NVIDIA H100 PCIe` launched pod `zh6zr8z5v0g1tn`, but it also remained
-  `desiredStatus=RUNNING` with `"runtime": null`; `python3 $RP wait` never
-  reached SSH and ended with the same `AttributeError` after termination
+- first healthy allowed pod: `NVIDIA RTX A6000`, image
+  `ghcr.io/ericflo/kiln-runpod:latest`, pod `h2gltnqi6qdjb4`
+- the first healthy pod exposed two concrete bootstrap bugs on current `main`:
+  - `deploy/runpod/kiln-setup.sh` no longer downloaded the expected
+    `/workspace/qwen3.5-4b` checkpoint, so the first seeded bench failed at
+    model load until the setup helper was restored to pull Qwen3.5-4B
+  - `crates/kiln-model/src/mtp_debug.rs` serialized the narrowed splice dump
+    but never created the parent directories for
+    `profiling-artifacts/.../mtp_pos-{pos}/step-{step}.safetensors`, so the
+    C45 dump path warned and emitted no safetensors until the write path grew
+    a `create_dir_all(...)` for its parent directory
+- the reference dump script also required `transformers`, which the current
+  kiln image did not install; the recovery pod installed it ad hoc and this PR
+  adds it to `deploy/runpod/Dockerfile`
+- final artifact-producing recovery pod: `8d7s7t6zxs827r`
+  (`NVIDIA RTX A6000`, same kiln image)
 
-Validation outcome:
+Validation outcome on the healthy A6000 pod after the narrow bootstrap fixes:
 
-- none of the required on-pod commands could run because no allowed pod reached
-  SSH:
-  - `cargo build --release --features cuda --bin kiln-bench`
-  - `cargo test --locked -p kiln-model c45 -- --nocapture`
-  - `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
-  - either narrowed `scripts/mtp_compare.py --c45-row-scalar ...` run
+- `cargo build --release --features cuda --bin kiln-bench`
+- `cargo test --locked -p kiln-model c45 -- --nocapture`
+- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
+- both narrowed `scripts/mtp_compare.py --c45-row-scalar ...` runs completed
+  and emitted the same earliest shared bad tap
+
+Commands used on the artifact-producing pod:
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+
+KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS=0,2 KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
+KILN_MTP_DUMP_PATH=profiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-{pos}/step-{step}.safetensors \
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
+  --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed 0 \
+  > profiling-artifacts/post435_c45_row_scalar_seed0.bench.json \
+  2> profiling-artifacts/post435_c45_row_scalar_seed0.bench.stderr
+
+KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_SPLICE_POS=0,2 KILN_MTP_DUMP_SPLICE_MAX_STEPS=8 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 KILN_MTP_DUMP_EARLY_HMAIN_SWEEP=1 \
+KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
+KILN_MTP_DUMP_PATH=profiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-{pos}/step-{step}.safetensors \
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
+  --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed 1 \
+  > profiling-artifacts/post435_c45_row_scalar_seed1.bench.json \
+  2> profiling-artifacts/post435_c45_row_scalar_seed1.bench.stderr
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-0/step-1.safetensors \
+  --out profiling-artifacts/post435_c45_row_scalar_seed0_ref.safetensors \
+  --device cuda \
+  --c45-taps
+
+python3 scripts/mtp_compare.py --c45-row-scalar \
+  --kiln profiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-0/step-1.safetensors \
+  --ref profiling-artifacts/post435_c45_row_scalar_seed0_ref.safetensors \
+  > profiling-artifacts/post435_c45_row_scalar_seed0_compare.txt
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump profiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-2/step-1.safetensors \
+  --out profiling-artifacts/post435_c45_row_scalar_seed1_ref.safetensors \
+  --device cuda \
+  --c45-taps
+
+python3 scripts/mtp_compare.py --c45-row-scalar \
+  --kiln profiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-2/step-1.safetensors \
+  --ref profiling-artifacts/post435_c45_row_scalar_seed1_ref.safetensors \
+  > profiling-artifacts/post435_c45_row_scalar_seed1_compare.txt
+```
+
+Recovered seed metrics from the final artifact-producing pod:
+
+| Seed | prompt tokens | prefill ms | decode tok/s | α |
+| --- | ---: | ---: | ---: | ---: |
+| 0 | 494 | 9587.5 | 39.8 | 0.7397 |
+| 1 | 508 | 404.8 | 23.9 | 0.2959 |
 
 Verdict:
 
-- no post-#434 narrowed C45 numerical verdict yet
-- the blocker is RunPod availability/pod health, not missing instrumentation
-- do not change the narrowed tap contract before a healthy allowed pod exists
+- seed 0 compare: earliest shared bad tap =
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+- seed 1 compare: earliest shared bad tap =
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+- the last shared-good narrowed C45 tap on both seeds is
+  `layer_1_input_norm_rms_inv_scalar_extracted_values`
+- `layer_1_input_norm_pre_weight_row_reconstructed` also diverges on both
+  seeds, but only after the flat row-local scalar multiply values are already
+  bad
+
+So the post-#435 narrowed rerun clears the extracted scalar replay path and
+localizes the first shared row-local drift one step later:
+
+- `layer_1_input_norm_rms_inv_scalar` remains shared-good
+- `layer_1_input_norm_rms_inv_scalar_extracted_values` remains shared-good
+- `layer_1_input_norm_pre_weight_row_scalar_values` is the earliest shared-bad
+  narrowed C45 tap
+- `layer_1_input_norm_pre_weight_row_reconstructed` also diverges, but only
+  after the multiply-values tap is already bad
+
+Recommendation:
+
+- do not widen to C46 or expand the tap contract
+- focus the next audit inside the row-local scalar multiply that produces
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+- treat the row-local `rms_inv` tensor and its extracted scalar replay as
+  provisionally cleared on current `main`
 
 Evidence:
 
-- `profiling-artifacts/post434_c45_row_scalar_runpod_blocker.txt`
+- `profiling-artifacts/post435_c45_row_scalar_seed0.bench.json`
+- `profiling-artifacts/post435_c45_row_scalar_seed0.bench.stderr`
+- `profiling-artifacts/post435_c45_row_scalar_seed1.bench.json`
+- `profiling-artifacts/post435_c45_row_scalar_seed1.bench.stderr`
+- `profiling-artifacts/post435_c45_row_scalar_seed0_compare.txt`
+- `profiling-artifacts/post435_c45_row_scalar_seed1_compare.txt`

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -2238,6 +2238,12 @@ pub fn write_mtp_dump(
 
     let serialized = safetensors::serialize(views, &None)
         .map_err(|e| anyhow::anyhow!("safetensors::serialize MTP dump: {e:?}"))?;
+    if let Some(parent) = std::path::Path::new(path).parent() {
+        if !parent.as_os_str().is_empty() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create parent dir for MTP dump at {path}"))?;
+        }
+    }
     std::fs::write(path, serialized).with_context(|| format!("write MTP dump to {path}"))?;
     Ok(())
 }

--- a/deploy/runpod/Dockerfile
+++ b/deploy/runpod/Dockerfile
@@ -93,7 +93,7 @@ RUN pip install --no-cache-dir \
         --index-url https://download.pytorch.org/whl/cu124 \
         torch==2.4.1 \
     && pip install --no-cache-dir \
-        'b2[full]' huggingface-hub hf-transfer safetensors numpy
+        'b2[full]' huggingface-hub hf-transfer safetensors numpy transformers
 
 # --- SSH server config (RunPod injects $PUBLIC_KEY at pod boot) ---
 # Also bake PATH into /etc/environment. Dockerfile ENV PATH=... only takes

--- a/deploy/runpod/kiln-setup.sh
+++ b/deploy/runpod/kiln-setup.sh
@@ -15,6 +15,8 @@
 #
 # Optional env vars:
 #   KILN_REPO_DIR          — Path to kiln repo checkout (default: /workspace/kiln)
+#   KILN_MODEL_ID          — Hugging Face model ID to download (default: Qwen/Qwen3.5-4B)
+#   KILN_MODEL_DIR         — Local model dir (default: /workspace/qwen3.5-4b)
 #
 # Writes env exports to $KILN_REPO_DIR/.build-cache-env (if repo exists) and
 # also to /root/.kiln-build-env for agents to source directly.
@@ -22,6 +24,8 @@
 set -euo pipefail
 
 KILN_REPO_DIR="${KILN_REPO_DIR:-/workspace/kiln}"
+KILN_MODEL_ID="${KILN_MODEL_ID:-Qwen/Qwen3.5-4B}"
+KILN_MODEL_DIR="${KILN_MODEL_DIR:-/workspace/qwen3.5-4b}"
 B2_BUCKET="clouderic"
 B2_ENDPOINT="https://s3.us-west-002.backblazeb2.com"
 B2_REGION="us-west-002"
@@ -77,6 +81,14 @@ fi
 if [ "$CLONE_REPO" = "1" ] && [ ! -d "${KILN_REPO_DIR}" ]; then
     echo "Cloning kiln into ${KILN_REPO_DIR}..."
     git clone https://github.com/ericflo/kiln.git "${KILN_REPO_DIR}"
+fi
+
+if [ ! -f "${KILN_MODEL_DIR}/config.json" ]; then
+    echo "Downloading ${KILN_MODEL_ID} into ${KILN_MODEL_DIR}..."
+    HF_HUB_ENABLE_HF_TRANSFER="${HF_HUB_ENABLE_HF_TRANSFER:-1}" \
+        hf download "${KILN_MODEL_ID}" --local-dir "${KILN_MODEL_DIR}"
+else
+    echo "Model already present at ${KILN_MODEL_DIR}"
 fi
 
 # Configure sccache environment

--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -8,9 +8,8 @@ PR #434 narrowed the remaining C45 question to three row-scalar sub-steps:
 - `layer_1_input_norm_pre_weight_row_scalar_values`
 - `layer_1_input_norm_pre_weight_row_reconstructed`
 
-This rerun attempted to execute that already-merged narrowed tap contract on the
-first healthy allowed on-demand RunPod pod. No code changes were required or
-made in this task; the only goal was to obtain fresh post-#434 evidence.
+This rerun executed that already-merged narrowed tap contract on the first
+healthy allowed on-demand RunPod pod and captured fresh post-#435 evidence.
 
 ## Remaining-work preflight
 
@@ -26,44 +25,75 @@ Those checks passed, so the task proceeded to RunPod execution.
 
 ## Actual RunPod outcome
 
-The rerun never reached a usable SSH endpoint on any allowed GPU class:
+The first healthy allowed pod was:
 
-- `NVIDIA RTX A6000`: launch failed immediately with RunPod
-  `SUPPLY_CONSTRAINT`.
-- `NVIDIA A40`: pod `jbagv24mf1f31l` launched on
-  `ghcr.io/ericflo/kiln-runpod:latest`, but `python3 $RP wait jbagv24mf1f31l`
-  stayed at `status=RUNNING, uptime=N/As` and then crashed after termination
-  because the pod never exposed a runtime/SSH endpoint.
-- `NVIDIA A100 80GB PCIe`: launch failed immediately with RunPod
-  `SUPPLY_CONSTRAINT`.
-- `NVIDIA RTX 6000 Ada Generation`: launch failed immediately with RunPod
-  `SUPPLY_CONSTRAINT`.
-- `NVIDIA L40S`: launch failed immediately with RunPod
-  `SUPPLY_CONSTRAINT` ("no longer any instances available with enough disk
-  space").
-- `NVIDIA H100 PCIe`: pod `zh6zr8z5v0g1tn` launched on the kiln image, but
-  `runpod_api.py info` continued to report `"runtime": null` and
-  `python3 $RP wait zh6zr8z5v0g1tn` never reached SSH before the pod was
-  terminated.
+- GPU: `NVIDIA RTX A6000`
+- image: `ghcr.io/ericflo/kiln-runpod:latest`
+- successful evidence pod: `8d7s7t6zxs827r`
 
-Because no allowed pod reached SSH, none of the required on-pod validation
-commands could be run:
+The first healthy A6000 pod exposed two concrete bootstrap bugs on `main` that
+had to be fixed before the rerun could finish:
+
+- `deploy/runpod/kiln-setup.sh` no longer downloaded
+  `/workspace/qwen3.5-4b`, so the bench failed at model load on the first
+  healthy pod until the setup helper was restored to pull the checkpoint.
+- `crates/kiln-model/src/mtp_debug.rs` serialized the narrowed splice dumps
+  but never created the parent directories for
+  `profiling-artifacts/.../mtp_pos-{pos}/step-{step}.safetensors`, so the
+  C45 dump path warned and produced no safetensors until `create_dir_all(...)`
+  was added.
+- The image also lacked the Python `transformers` package required by
+  `scripts/mtp_h_main_reference_dump.py`; the recovery pod installed it and
+  this PR adds it to the RunPod Dockerfile.
+
+## Verdict
+
+The post-#435 narrowed rerun now has a stable two-seed verdict:
+
+- seed 0 (`mtp_pos=0`, `step=1` compare): earliest shared bad narrowed C45 tap
+  = `layer_1_input_norm_pre_weight_row_scalar_values`
+- seed 1 (`mtp_pos=2`, `step=1` compare): earliest shared bad narrowed C45 tap
+  = `layer_1_input_norm_pre_weight_row_scalar_values`
+- the last shared-good narrowed tap on both seeds is
+  `layer_1_input_norm_rms_inv_scalar_extracted_values`
+- `layer_1_input_norm_pre_weight_row_reconstructed` also diverges, but only
+  after the flat row-local scalar multiply values are already bad
+
+So the narrowed post-#434 rerun clears the extracted scalar replay itself and
+localizes the first shared row-local drift to the actual multiply that produces
+the flat scalar-applied row values.
+
+## Validation
+
+These commands completed on the healthy A6000 pod after the two bootstrap
+fixes above:
 
 - `cargo build --release --features cuda --bin kiln-bench`
 - `cargo test --locked -p kiln-model c45 -- --nocapture`
 - `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
-- either `scripts/mtp_compare.py --c45-row-scalar ...` rerun
+- `python3 scripts/mtp_compare.py --c45-row-scalar ...` for both representative
+  seeds
 
-## Verdict
+Recovered seed metrics from the final artifact-producing pod:
 
-There is still no post-#434 narrowed C45 numerical verdict. The blocker remains
-RunPod availability and pod health, not missing instrumentation:
+- seed 0: prompt=494, prefill=`9587.54 ms`, decode=`39.82 tok/s`,
+  `alpha=0.7397`
+- seed 1: prompt=508, prefill=`404.84 ms`, decode=`23.86 tok/s`,
+  `alpha=0.2959`
 
-- no earliest shared bad narrowed C45 tap was captured
-- no new bench JSON, stderr, or compare outputs exist for the post-#434 rerun
-- the next step is still to rerun the committed workload on the next healthy
-  allowed on-demand pod without changing the tap contract
+## Recommendation
+
+- do not widen to C46 or expand the C45 tap contract further
+- focus the next audit inside the row-local scalar multiply that produces
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+- treat the row-local `rms_inv` tensor and its extracted scalar replay as
+  provisionally cleared on current `main`
 
 ## Evidence
 
-- `profiling-artifacts/post434_c45_row_scalar_runpod_blocker.txt`
+- `profiling-artifacts/post435_c45_row_scalar_seed0.bench.json`
+- `profiling-artifacts/post435_c45_row_scalar_seed0.bench.stderr`
+- `profiling-artifacts/post435_c45_row_scalar_seed1.bench.json`
+- `profiling-artifacts/post435_c45_row_scalar_seed1.bench.stderr`
+- `profiling-artifacts/post435_c45_row_scalar_seed0_compare.txt`
+- `profiling-artifacts/post435_c45_row_scalar_seed1_compare.txt`

--- a/profiling-artifacts/post435_c45_row_scalar_seed0.bench.json
+++ b/profiling-artifacts/post435_c45_row_scalar_seed0.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 28.728839375,
+    "model_vram_mb": 17526
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 494,
+      "output_tokens": 128,
+      "total_time_secs": 3.149075801,
+      "tokens_per_sec": 40.646846277677135,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 494,
+      "output_tokens": 512,
+      "total_time_secs": 12.830241081,
+      "tokens_per_sec": 39.90571936783079,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 494,
+      "output_tokens": 1024,
+      "total_time_secs": 25.4408624,
+      "tokens_per_sec": 40.25020787031182,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 494,
+      "output_tokens": 2048,
+      "total_time_secs": 49.835855783,
+      "tokens_per_sec": 41.09490983595417,
+      "peak_vram_mb": 17832
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 9587.537783,
+    "prefill_tokens_per_sec": 51.52522067510688,
+    "time_to_first_token_ms": 9587.537783,
+    "mean_inter_token_ms": 25.114576724409446,
+    "p50_inter_token_ms": 18.2147525,
+    "p99_inter_token_ms": 67.78440099999999,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 39.81751358875488,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7397260273972602,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post435_c45_row_scalar_seed0.bench.stderr
+++ b/profiling-artifacts/post435_c45_row_scalar_seed0.bench.stderr
@@ -1,0 +1,105 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T17:23:15.439822Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T17:23:15.442219Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T17:23:15.442503Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T17:23:15.442517Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T17:23:15.442674Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T17:23:44.166086Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m25073 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 25073 ms (parallel)
+Model loaded in 28.73s (backend: cuda, VRAM: 17526 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=47] (494 prompt tokens)...
+    Prefill (MTP): 9587.5ms (52 tok/s)
+[2m2026-04-23T17:23:54.384088Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m42
+[2m2026-04-23T17:23:54.407435Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m5339 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m494 [3mreplay_tokens_len[0m[2m=[0m494 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:23:54.482279Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m31192 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m495 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:23:54.544475Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m33416 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m496 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:23:54.606510Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m321 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m497 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:23:54.738166Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m7071 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m502 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:23:54.798004Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-2/step-1.safetensors [3mdraft_token_id[0m[2m=[0m10641 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m503 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:23:54.859596Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-2/step-2.safetensors [3mdraft_token_id[0m[2m=[0m11 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m504 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 25.1ms (39.8 tok/s), α = 0.740 (54/73)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T17:23:58.055379Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 3149.0ms (40.6 tok/s)
+  => 40.6 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 3154.2ms (40.6 tok/s)
+    Run 2/4: 128 tokens in 3121.3ms (41.0 tok/s)
+    Run 3/4: 128 tokens in 3112.2ms (41.1 tok/s)
+    Run 4/4: 128 tokens in 3442.1ms (37.2 tok/s)
+  => 39.9 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 3764.7ms (34.0 tok/s)
+    Run 2/8: 128 tokens in 3084.8ms (41.5 tok/s)
+    Run 3/8: 128 tokens in 3124.3ms (41.0 tok/s)
+    Run 4/8: 128 tokens in 3103.4ms (41.2 tok/s)
+    Run 5/8: 128 tokens in 3105.8ms (41.2 tok/s)
+    Run 6/8: 128 tokens in 3083.0ms (41.5 tok/s)
+    Run 7/8: 128 tokens in 3092.9ms (41.4 tok/s)
+    Run 8/8: 128 tokens in 3081.5ms (41.5 tok/s)
+  => 40.3 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 3125.8ms (41.0 tok/s)
+    Run 2/16: 128 tokens in 3078.7ms (41.6 tok/s)
+    Run 3/16: 128 tokens in 3102.4ms (41.3 tok/s)
+    Run 4/16: 128 tokens in 3085.8ms (41.5 tok/s)
+    Run 5/16: 128 tokens in 3198.9ms (40.0 tok/s)
+    Run 6/16: 128 tokens in 3105.8ms (41.2 tok/s)
+    Run 7/16: 128 tokens in 3152.5ms (40.6 tok/s)
+    Run 8/16: 128 tokens in 3134.3ms (40.8 tok/s)
+    Run 9/16: 128 tokens in 3079.1ms (41.6 tok/s)
+    Run 10/16: 128 tokens in 3088.3ms (41.4 tok/s)
+    Run 11/16: 128 tokens in 3067.4ms (41.7 tok/s)
+    Run 12/16: 128 tokens in 3072.8ms (41.7 tok/s)
+    Run 13/16: 128 tokens in 3071.1ms (41.7 tok/s)
+    Run 14/16: 128 tokens in 3111.3ms (41.1 tok/s)
+    Run 15/16: 128 tokens in 3103.1ms (41.2 tok/s)
+    Run 16/16: 128 tokens in 3257.5ms (39.3 tok/s)
+  => 41.1 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 28.73s (VRAM: 17526 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               494        128         40.6      17832
+4               494        512         39.9      17832
+8               494       1024         40.3      17832
+16              494       2048         41.1      17832
+
+--- Latency (single request) ---
+Prompt tokens:         494
+Prefill time:          9587.5 ms (52 tok/s)
+Time to first token:   9587.5 ms
+Mean inter-token:      25.1 ms (39.8 tok/s)
+P50 inter-token:       18.2 ms
+P99 inter-token:       67.8 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.740
+

--- a/profiling-artifacts/post435_c45_row_scalar_seed0_compare.txt
+++ b/profiling-artifacts/post435_c45_row_scalar_seed0_compare.txt
@@ -1,0 +1,38 @@
+MTP numerical bisect — mode: layer-1 row-local scalar-multiply audit (C45), atol=0.01, rtol=0.1
+  kiln dump : profiling-artifacts/post435_c45_row_scalar_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : profiling-artifacts/post435_c45_row_scalar_seed0_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     False    9.99e-01   1.35e-01     3.19e-02    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     False    9.99e-01   1.35e-01     3.19e-02    
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   1.14e-01     1.14e-01    
+c45__layer_1_input_norm_rms_inv_scalar_extracted_values 1                      True     True     1.00e+00   1.14e-01     1.14e-01    
+
+  pair verdict: first divergence at tap 'c45__layer_1_input_norm_pre_weight_row_reconstructed'.
+    Most-likely cause: the flat row-local scalar multiply stays shared-good; drift appears only when reconstructing the row-shaped output before the existing post-input-norm path
+
+==============================================================================
+Phase C45 layer-1 row-local scalar-multiply audit — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                                                                                                 
+  ----------------------------------------------------------------------------------------------------
+  layer_1_input_norm_rms_inv_scalar               cos=1.00e+00   max|Δ|=1.14e-01   mean|Δ|=1.14e-01   rel_l2=5.71e-03   ok 
+  layer_1_input_norm_rms_inv_scalar_extracted_valuescos=1.00e+00   max|Δ|=1.14e-01   mean|Δ|=1.14e-01   rel_l2=5.71e-03   ok 
+  layer_1_input_norm_pre_weight_row_scalar_values cos=9.99e-01   max|Δ|=1.35e-01   mean|Δ|=3.19e-02   rel_l2=4.01e-02   DIV
+  layer_1_input_norm_pre_weight_row_reconstructed cos=9.99e-01   max|Δ|=1.35e-01   mean|Δ|=3.19e-02   rel_l2=4.01e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight_row_scalar_values'
+  last shared-good tap: 'layer_1_input_norm_rms_inv_scalar_extracted_values'
+Phase C45 verdict: EARLIEST SHARED BAD ROW-LOCAL SCALAR-MULTIPLY TAP = 'layer_1_input_norm_pre_weight_row_scalar_values'.
+    Most-likely cause: the scalar tensor and extracted scalar stay shared-good; drift first appears in the actual row-local scalar multiply values
+  -> The row-local `rms_inv` tensor and its extracted scalar stay shared-good; divergence first appears in the flat row-local scalar multiply values.
+
+Overall verdict: divergence(s) at: ['c45__layer_1_input_norm_pre_weight_row_reconstructed']

--- a/profiling-artifacts/post435_c45_row_scalar_seed1.bench.json
+++ b/profiling-artifacts/post435_c45_row_scalar_seed1.bench.json
@@ -1,0 +1,61 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 25.560437426,
+    "model_vram_mb": 17526
+  },
+  "inference": [
+    {
+      "batch_size": 1,
+      "prompt_tokens": 508,
+      "output_tokens": 128,
+      "total_time_secs": 3.106066466,
+      "tokens_per_sec": 41.20967835077873,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 4,
+      "prompt_tokens": 508,
+      "output_tokens": 512,
+      "total_time_secs": 12.560978186,
+      "tokens_per_sec": 40.761156688470024,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 8,
+      "prompt_tokens": 508,
+      "output_tokens": 1024,
+      "total_time_secs": 25.340064037,
+      "tokens_per_sec": 40.410316189604664,
+      "peak_vram_mb": 17832
+    },
+    {
+      "batch_size": 16,
+      "prompt_tokens": 508,
+      "output_tokens": 2048,
+      "total_time_secs": 50.744399484,
+      "tokens_per_sec": 40.35913363494914,
+      "peak_vram_mb": 17832
+    }
+  ],
+  "latency": {
+    "prompt_tokens": 508,
+    "prefill_time_ms": 404.841856,
+    "prefill_tokens_per_sec": 1254.810965000615,
+    "time_to_first_token_ms": 404.841856,
+    "mean_inter_token_ms": 41.91983270078738,
+    "p50_inter_token_ms": 56.797087000000005,
+    "p99_inter_token_ms": 81.012707,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 23.85505703559778,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.29591836734693877,
+    "prompt_subset": "all"
+  },
+  "training": null
+}

--- a/profiling-artifacts/post435_c45_row_scalar_seed1.bench.stderr
+++ b/profiling-artifacts/post435_c45_row_scalar_seed1.bench.stderr
@@ -1,0 +1,110 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-23T17:25:31.943469Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-23T17:25:31.944557Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-23T17:25:31.944730Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected and loaded (k=1 draft depth)
+[2m2026-04-23T17:25:31.944738Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4326M parameters (8252 MB) across 32 layers
+[2m2026-04-23T17:25:31.944831Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-23T17:25:57.501573Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m23747 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 23747 ms (parallel)
+Model loaded in 25.56s (backend: cuda, VRAM: 17526 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (508 prompt tokens)...
+    Prefill (MTP): 404.8ms (1255 tok/s)
+[2m2026-04-23T17:25:58.586161Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m50
+[2m2026-04-23T17:25:58.613962Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-0/step-0.safetensors [3mdraft_token_id[0m[2m=[0m25015 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m508 [3mreplay_tokens_len[0m[2m=[0m508 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:58.684191Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-0/step-1.safetensors [3mdraft_token_id[0m[2m=[0m314 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m509 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:58.747852Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-0/step-2.safetensors [3mdraft_token_id[0m[2m=[0m1330 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m510 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:58.809991Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-0/step-3.safetensors [3mdraft_token_id[0m[2m=[0m47205 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m511 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:58.872986Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-0/step-4.safetensors [3mdraft_token_id[0m[2m=[0m369 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(4) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m512 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:58.935993Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-0/step-5.safetensors [3mdraft_token_id[0m[2m=[0m799 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(5) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m513 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:59.002745Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-0/step-6.safetensors [3mdraft_token_id[0m[2m=[0m30797 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(6) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m514 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:59.078652Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-0/step-7.safetensors [3mdraft_token_id[0m[2m=[0m314 [3mmtp_pos[0m[2m=[0m0 [3msplice_step[0m[2m=[0mSome(7) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m515 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:59.157347Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-2/step-0.safetensors [3mdraft_token_id[0m[2m=[0m321 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(0) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m2 [3mreplay_tokens_len[0m[2m=[0m519 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:59.221765Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-2/step-1.safetensors [3mdraft_token_id[0m[2m=[0m421 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(1) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m520 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:59.283006Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-2/step-2.safetensors [3mdraft_token_id[0m[2m=[0m3202 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(2) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m521 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+[2m2026-04-23T17:25:59.345712Z[0m [32m INFO[0m [2mkiln::mtp_debug[0m[2m:[0m mtp_b7_dump_written [3mpath[0m[2m=[0mprofiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-2/step-3.safetensors [3mdraft_token_id[0m[2m=[0m369 [3mmtp_pos[0m[2m=[0m2 [3msplice_step[0m[2m=[0mSome(3) [3msubops[0m[2m=[0m13 [3mprompt_tokens_len[0m[2m=[0m1 [3mreplay_tokens_len[0m[2m=[0m522 [3mb11_taps[0m[2m=[0m0 [3mb12_taps[0m[2m=[0m0 [3mc41_taps[0m[2m=[0m0 [3mc42_taps[0m[2m=[0m0 [3mc43_taps[0m[2m=[0m0 [3mc44_taps[0m[2m=[0m0 [3mc45_taps[0m[2m=[0m4 [3mc6_taps[0m[2m=[0m5 [3mc7_taps[0m[2m=[0m0 [3mc14_taps[0m[2m=[0m3
+    Decode (MTP): 128 tokens, mean ITL 41.9ms (23.9 tok/s), α = 0.296 (29/98)
+
+--- Training Benchmark (skipped) ---
+[2m2026-04-23T17:26:04.364516Z[0m [32m INFO[0m [2mkiln_model::cuda_graph[0m[2m:[0m CUDA graphs enabled for decode
+
+--- Inference Throughput Benchmarks ---
+
+1 sequential runs:
+  Warmup...
+  Running 1 sequential generations...
+    Run 1/1: 128 tokens in 3106.0ms (41.2 tok/s)
+  => 41.2 tok/s aggregate
+
+4 sequential runs:
+  Warmup...
+  Running 4 sequential generations...
+    Run 1/4: 128 tokens in 3157.5ms (40.5 tok/s)
+    Run 2/4: 128 tokens in 3135.5ms (40.8 tok/s)
+    Run 3/4: 128 tokens in 3130.9ms (40.9 tok/s)
+    Run 4/4: 128 tokens in 3136.8ms (40.8 tok/s)
+  => 40.8 tok/s aggregate
+
+8 sequential runs:
+  Warmup...
+  Running 8 sequential generations...
+    Run 1/8: 128 tokens in 3148.7ms (40.7 tok/s)
+    Run 2/8: 128 tokens in 3137.2ms (40.8 tok/s)
+    Run 3/8: 128 tokens in 3147.7ms (40.7 tok/s)
+    Run 4/8: 128 tokens in 3155.7ms (40.6 tok/s)
+    Run 5/8: 128 tokens in 3215.8ms (39.8 tok/s)
+    Run 6/8: 128 tokens in 3163.5ms (40.5 tok/s)
+    Run 7/8: 128 tokens in 3190.4ms (40.1 tok/s)
+    Run 8/8: 128 tokens in 3180.5ms (40.2 tok/s)
+  => 40.4 tok/s aggregate
+
+16 sequential runs:
+  Warmup...
+  Running 16 sequential generations...
+    Run 1/16: 128 tokens in 3159.6ms (40.5 tok/s)
+    Run 2/16: 128 tokens in 3152.6ms (40.6 tok/s)
+    Run 3/16: 128 tokens in 3148.2ms (40.7 tok/s)
+    Run 4/16: 128 tokens in 3156.9ms (40.5 tok/s)
+    Run 5/16: 128 tokens in 3186.9ms (40.2 tok/s)
+    Run 6/16: 128 tokens in 3134.4ms (40.8 tok/s)
+    Run 7/16: 128 tokens in 3120.3ms (41.0 tok/s)
+    Run 8/16: 128 tokens in 3131.8ms (40.9 tok/s)
+    Run 9/16: 128 tokens in 3133.8ms (40.8 tok/s)
+    Run 10/16: 128 tokens in 3157.3ms (40.5 tok/s)
+    Run 11/16: 128 tokens in 3193.1ms (40.1 tok/s)
+    Run 12/16: 128 tokens in 3176.3ms (40.3 tok/s)
+    Run 13/16: 128 tokens in 3113.0ms (41.1 tok/s)
+    Run 14/16: 128 tokens in 3238.3ms (39.5 tok/s)
+    Run 15/16: 128 tokens in 3251.6ms (39.4 tok/s)
+    Run 16/16: 128 tokens in 3289.1ms (38.9 tok/s)
+  => 40.4 tok/s aggregate
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 25.56s (VRAM: 17526 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+1               508        128         41.2      17832
+4               508        512         40.8      17832
+8               508       1024         40.4      17832
+16              508       2048         40.4      17832
+
+--- Latency (single request) ---
+Prompt tokens:         508
+Prefill time:          404.8 ms (1255 tok/s)
+Time to first token:   404.8 ms
+Mean inter-token:      41.9 ms (23.9 tok/s)
+P50 inter-token:       56.8 ms
+P99 inter-token:       81.0 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.296
+

--- a/profiling-artifacts/post435_c45_row_scalar_seed1_compare.txt
+++ b/profiling-artifacts/post435_c45_row_scalar_seed1_compare.txt
@@ -1,0 +1,38 @@
+MTP numerical bisect — mode: layer-1 row-local scalar-multiply audit (C45), atol=0.01, rtol=0.1
+  kiln dump : profiling-artifacts/post435_c45_row_scalar_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : profiling-artifacts/post435_c45_row_scalar_seed1_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     False    9.99e-01   1.45e-01     2.67e-02    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     False    9.99e-01   1.45e-01     2.67e-02    
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   7.01e-02     7.01e-02    
+c45__layer_1_input_norm_rms_inv_scalar_extracted_values 1                      True     True     1.00e+00   7.01e-02     7.01e-02    
+
+  pair verdict: first divergence at tap 'c45__layer_1_input_norm_pre_weight_row_reconstructed'.
+    Most-likely cause: the flat row-local scalar multiply stays shared-good; drift appears only when reconstructing the row-shaped output before the existing post-input-norm path
+
+==============================================================================
+Phase C45 layer-1 row-local scalar-multiply audit — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                                                                                                 
+  ----------------------------------------------------------------------------------------------------
+  layer_1_input_norm_rms_inv_scalar               cos=1.00e+00   max|Δ|=7.01e-02   mean|Δ|=7.01e-02   rel_l2=2.90e-03   ok 
+  layer_1_input_norm_rms_inv_scalar_extracted_valuescos=1.00e+00   max|Δ|=7.01e-02   mean|Δ|=7.01e-02   rel_l2=2.90e-03   ok 
+  layer_1_input_norm_pre_weight_row_scalar_values cos=9.99e-01   max|Δ|=1.45e-01   mean|Δ|=2.67e-02   rel_l2=3.34e-02   DIV
+  layer_1_input_norm_pre_weight_row_reconstructed cos=9.99e-01   max|Δ|=1.45e-01   mean|Δ|=2.67e-02   rel_l2=3.34e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight_row_scalar_values'
+  last shared-good tap: 'layer_1_input_norm_rms_inv_scalar_extracted_values'
+Phase C45 verdict: EARLIEST SHARED BAD ROW-LOCAL SCALAR-MULTIPLY TAP = 'layer_1_input_norm_pre_weight_row_scalar_values'.
+    Most-likely cause: the scalar tensor and extracted scalar stay shared-good; drift first appears in the actual row-local scalar multiply values
+  -> The row-local `rms_inv` tensor and its extracted scalar stay shared-good; divergence first appears in the flat row-local scalar multiply values.
+
+Overall verdict: divergence(s) at: ['c45__layer_1_input_norm_pre_weight_row_reconstructed']


### PR DESCRIPTION
## Summary
- capture the post-#435 narrowed C45 rerun evidence on a healthy on-demand RunPod A6000 pod and record the stable two-seed verdict in `PROFILING.md` and `docs/phase-c45/c45-layer1-row-normalization-bisect.md`
- add the requested post-#435 bench stderr/json and narrowed compare artifacts for seeds 0 and 1
- fix the two concrete healthy-pod blockers discovered on current `main`: restore the RunPod setup helper's Qwen3.5-4B download, create parent directories before writing MTP splice dumps, and add `transformers` to the kiln RunPod image for the HF reference dump script

## Validation
- on pod: `cargo build --release --features cuda --bin kiln-bench`
- on pod: `cargo test --locked -p kiln-model c45 -- --nocapture`
- on pod: `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- on pod: `python3 scripts/mtp_compare.py --c45-row-scalar ...` for both representative seeds

## Key Result
- healthy evidence pod: on-demand `NVIDIA RTX A6000` on `ghcr.io/ericflo/kiln-runpod:latest`
- seed 0 compare verdict: earliest shared bad narrowed C45 tap = `layer_1_input_norm_pre_weight_row_scalar_values`
- seed 1 compare verdict: earliest shared bad narrowed C45 tap = `layer_1_input_norm_pre_weight_row_scalar_values`
- last shared-good narrowed tap on both seeds = `layer_1_input_norm_rms_inv_scalar_extracted_values`
- next recommendation: keep the tap contract fixed and audit the row-local scalar multiply that produces `layer_1_input_norm_pre_weight_row_scalar_values`
