### PR TITLE
Improve macOS startup and speculative routing

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -94,6 +94,7 @@ pub fn precompile_custom_kernels(device: &Device) -> Result<()> {
     metal_conv1d_update_pipeline(metal_device)?;
     metal_lm_head_pipeline(metal_device)?;
     metal_paged_kv_head_major_read_pipeline(metal_device)?;
+    metal_paged_kv_head_major_read_append_token_major_pipeline(metal_device)?;
     Ok(())
 }
 
@@ -119,6 +120,10 @@ impl BackendRuntime for MetalBackend {
     }
 
     fn supports_paged_kv_head_major_read(&self) -> bool {
+        true
+    }
+
+    fn supports_paged_kv_head_major_read_append_token_major(&self) -> bool {
         true
     }
 
@@ -309,6 +314,27 @@ impl BackendRuntime for MetalBackend {
         metal_paged_kv_head_major_read_bf16(k_pool, v_pool, start_slot, seq_len)
             .map(Some)
             .context("metal paged_kv_head_major_read failed")
+    }
+
+    fn paged_kv_head_major_read_append_token_major(
+        &self,
+        k_pool: &Tensor,
+        v_pool: &Tensor,
+        start_slot: usize,
+        prefix_len: usize,
+        k_tail: &Tensor,
+        v_tail: &Tensor,
+    ) -> Result<Option<(Tensor, Tensor)>> {
+        if !metal_paged_kv_head_major_read_append_token_major_supports(
+            k_pool, v_pool, start_slot, prefix_len, k_tail, v_tail,
+        ) {
+            return Ok(None);
+        }
+        metal_paged_kv_head_major_read_append_token_major_bf16(
+            k_pool, v_pool, start_slot, prefix_len, k_tail, v_tail,
+        )
+        .map(Some)
+        .context("metal paged_kv_head_major_read_append_token_major failed")
     }
 
     fn causal_conv1d_prefill(
@@ -1435,6 +1461,48 @@ kernel void kiln_paged_kv_head_major_read_bf16(
 }
 "#;
 
+const METAL_PAGED_KV_HEAD_MAJOR_READ_APPEND_TOKEN_MAJOR_KERNEL: &str = r#"
+#include <metal_stdlib>
+using namespace metal;
+
+kernel void kiln_paged_kv_head_major_read_append_token_major_bf16(
+    device const bfloat* k_pool [[buffer(0)]],
+    device const bfloat* v_pool [[buffer(1)]],
+    device const bfloat* k_tail [[buffer(2)]],
+    device const bfloat* v_tail [[buffer(3)]],
+    device bfloat* k_out [[buffer(4)]],
+    device bfloat* v_out [[buffer(5)]],
+    constant uint& start_slot [[buffer(6)]],
+    constant uint& prefix_len [[buffer(7)]],
+    constant uint& tail_len [[buffer(8)]],
+    constant uint& heads [[buffer(9)]],
+    constant uint& head_dim [[buffer(10)]],
+    uint gid [[thread_position_in_grid]]
+) {
+    const uint total_len = prefix_len + tail_len;
+    const uint total = total_len * heads * head_dim;
+    if (gid >= total) {
+        return;
+    }
+
+    const uint d = gid % head_dim;
+    const uint h = (gid / head_dim) % heads;
+    const uint t = gid / (head_dim * heads);
+    const uint out_idx = (h * total_len + t) * head_dim + d;
+
+    if (t < prefix_len) {
+        const uint pool_idx = ((start_slot + t) * heads + h) * head_dim + d;
+        k_out[out_idx] = k_pool[pool_idx];
+        v_out[out_idx] = v_pool[pool_idx];
+    } else {
+        const uint tail_t = t - prefix_len;
+        const uint tail_idx = (tail_t * heads + h) * head_dim + d;
+        k_out[out_idx] = k_tail[tail_idx];
+        v_out[out_idx] = v_tail[tail_idx];
+    }
+}
+"#;
+
 fn metal_shared_library(
     device: &candle_core::metal_backend::MetalDevice,
 ) -> Result<candle_metal_kernels::metal::Library> {
@@ -1465,6 +1533,7 @@ fn metal_shared_library(
         METAL_CONV1D_UPDATE_KERNEL,
         METAL_LM_HEAD_KERNEL,
         METAL_PAGED_KV_HEAD_MAJOR_READ_KERNEL,
+        METAL_PAGED_KV_HEAD_MAJOR_READ_APPEND_TOKEN_MAJOR_KERNEL,
     ]
     .join("");
     let library = device
@@ -1645,6 +1714,38 @@ fn metal_paged_kv_head_major_read_pipeline(
         .device()
         .new_compute_pipeline_state_with_function(&function)
         .map_err(|e| anyhow::anyhow!("build metal paged kv read pipeline: {e:?}"))?;
+    cache.insert(device.id(), pipeline.clone());
+    Ok(pipeline)
+}
+
+fn metal_paged_kv_head_major_read_append_token_major_pipeline(
+    device: &candle_core::metal_backend::MetalDevice,
+) -> Result<candle_metal_kernels::metal::ComputePipeline> {
+    use candle_core::metal_backend::DeviceId;
+    use candle_metal_kernels::metal::ComputePipeline;
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    static PIPELINES: OnceLock<Mutex<HashMap<DeviceId, ComputePipeline>>> = OnceLock::new();
+    let cache = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut cache = cache
+        .lock()
+        .map_err(|_| anyhow::anyhow!("metal paged kv read+append pipeline cache poisoned"))?;
+    if let Some(pipeline) = cache.get(&device.id()) {
+        return Ok(pipeline.clone());
+    }
+
+    let library = metal_shared_library(device)?;
+    let function = library
+        .get_function(
+            "kiln_paged_kv_head_major_read_append_token_major_bf16",
+            None,
+        )
+        .map_err(|e| anyhow::anyhow!("load metal paged kv read+append function: {e:?}"))?;
+    let pipeline = device
+        .device()
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(|e| anyhow::anyhow!("build metal paged kv read+append pipeline: {e:?}"))?;
     cache.insert(device.id(), pipeline.clone());
     Ok(pipeline)
 }
@@ -1965,6 +2066,170 @@ fn metal_paged_kv_head_major_read_bf16(
         encoder.set_bytes(7, &head_dim_u32);
 
         let total = seq_len * heads * head_dim;
+        let threads_per_grid = objc2_metal::MTLSize {
+            width: total,
+            height: 1,
+            depth: 1,
+        };
+        let threads_per_threadgroup = objc2_metal::MTLSize {
+            width: 256,
+            height: 1,
+            depth: 1,
+        };
+        encoder.dispatch_threads(threads_per_grid, threads_per_threadgroup);
+    }
+
+    Ok((k_out, v_out))
+}
+
+fn metal_paged_kv_head_major_read_append_token_major_supports(
+    k_pool: &Tensor,
+    v_pool: &Tensor,
+    start_slot: usize,
+    prefix_len: usize,
+    k_tail: &Tensor,
+    v_tail: &Tensor,
+) -> bool {
+    if prefix_len == 0 {
+        return false;
+    }
+    if !metal_paged_kv_head_major_read_supports(k_pool, v_pool, start_slot, prefix_len) {
+        return false;
+    }
+    if k_tail.dtype() != DType::BF16 || v_tail.dtype() != DType::BF16 {
+        return false;
+    }
+    if !matches!(k_tail.device(), Device::Metal(_)) || !matches!(v_tail.device(), Device::Metal(_))
+    {
+        return false;
+    }
+    if !k_tail.is_contiguous() || !v_tail.is_contiguous() {
+        return false;
+    }
+    let Ok((batch, tail_len, heads, head_dim)) = k_tail.dims4() else {
+        return false;
+    };
+    let Ok(v_dims) = v_tail.dims4() else {
+        return false;
+    };
+    let Ok((_, pool_heads, pool_head_dim)) = k_pool.dims3() else {
+        return false;
+    };
+    let Some(total_len) = prefix_len.checked_add(tail_len) else {
+        return false;
+    };
+    let Some(total) = total_len
+        .checked_mul(heads)
+        .and_then(|n| n.checked_mul(head_dim))
+    else {
+        return false;
+    };
+    batch == 1
+        && v_dims == (batch, tail_len, heads, head_dim)
+        && heads == pool_heads
+        && head_dim == pool_head_dim
+        && total_len <= u32::MAX as usize
+        && tail_len <= u32::MAX as usize
+        && heads <= u32::MAX as usize
+        && head_dim <= u32::MAX as usize
+        && total <= u32::MAX as usize
+}
+
+fn metal_paged_kv_head_major_read_append_token_major_bf16(
+    k_pool: &Tensor,
+    v_pool: &Tensor,
+    start_slot: usize,
+    prefix_len: usize,
+    k_tail: &Tensor,
+    v_tail: &Tensor,
+) -> Result<(Tensor, Tensor)> {
+    anyhow::ensure!(
+        metal_paged_kv_head_major_read_append_token_major_supports(
+            k_pool, v_pool, start_slot, prefix_len, k_tail, v_tail,
+        ),
+        "metal paged kv head-major read+append unsupported shape"
+    );
+    let (_, tail_len, heads, head_dim) = k_tail.dims4()?;
+    let total_len = prefix_len + tail_len;
+    let out_shape = (1usize, heads, total_len, head_dim);
+    // SAFETY: the kernel dispatch covers exactly every element in `out_shape`.
+    let k_out = unsafe { Tensor::empty(out_shape, DType::BF16, k_pool.device())? };
+    // SAFETY: the kernel dispatch covers exactly every element in `out_shape`.
+    let v_out = unsafe { Tensor::empty(out_shape, DType::BF16, v_pool.device())? };
+
+    let Device::Metal(device) = k_pool.device() else {
+        anyhow::bail!("metal paged kv read+append requires Metal tensors");
+    };
+    let pipeline = metal_paged_kv_head_major_read_append_token_major_pipeline(device)?;
+    let encoder = device.command_encoder()?;
+    encoder.set_label("kiln_paged_kv_head_major_read_append_token_major_bf16");
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    {
+        let (k_storage, k_layout) = k_pool.storage_and_layout();
+        let (v_storage, v_layout) = v_pool.storage_and_layout();
+        let (kt_storage, kt_layout) = k_tail.storage_and_layout();
+        let (vt_storage, vt_layout) = v_tail.storage_and_layout();
+        let (ko_storage, ko_layout) = k_out.storage_and_layout();
+        let (vo_storage, vo_layout) = v_out.storage_and_layout();
+
+        let k_metal = match &*k_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal paged kv read+append k_pool must be on Metal"),
+        };
+        let v_metal = match &*v_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal paged kv read+append v_pool must be on Metal"),
+        };
+        let kt_metal = match &*kt_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal paged kv read+append k_tail must be on Metal"),
+        };
+        let vt_metal = match &*vt_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal paged kv read+append v_tail must be on Metal"),
+        };
+        let ko_metal = match &*ko_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal paged kv read+append k_out must be on Metal"),
+        };
+        let vo_metal = match &*vo_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal paged kv read+append v_out must be on Metal"),
+        };
+
+        let k_buf =
+            candle_core::metal_backend::buffer_o(k_metal.buffer(), &k_layout, k_pool.dtype());
+        let v_buf =
+            candle_core::metal_backend::buffer_o(v_metal.buffer(), &v_layout, v_pool.dtype());
+        let kt_buf =
+            candle_core::metal_backend::buffer_o(kt_metal.buffer(), &kt_layout, k_tail.dtype());
+        let vt_buf =
+            candle_core::metal_backend::buffer_o(vt_metal.buffer(), &vt_layout, v_tail.dtype());
+        let ko_buf =
+            candle_core::metal_backend::buffer_o(ko_metal.buffer(), &ko_layout, k_out.dtype());
+        let vo_buf =
+            candle_core::metal_backend::buffer_o(vo_metal.buffer(), &vo_layout, v_out.dtype());
+
+        encoder.set_buffer(0, Some(k_buf.buffer), k_buf.offset_in_bytes);
+        encoder.set_buffer(1, Some(v_buf.buffer), v_buf.offset_in_bytes);
+        encoder.set_buffer(2, Some(kt_buf.buffer), kt_buf.offset_in_bytes);
+        encoder.set_buffer(3, Some(vt_buf.buffer), vt_buf.offset_in_bytes);
+        encoder.set_buffer(4, Some(ko_buf.buffer), ko_buf.offset_in_bytes);
+        encoder.set_buffer(5, Some(vo_buf.buffer), vo_buf.offset_in_bytes);
+
+        let start_slot_u32 = start_slot as u32;
+        let prefix_len_u32 = prefix_len as u32;
+        let tail_len_u32 = tail_len as u32;
+        let heads_u32 = heads as u32;
+        let head_dim_u32 = head_dim as u32;
+        encoder.set_bytes(6, &start_slot_u32);
+        encoder.set_bytes(7, &prefix_len_u32);
+        encoder.set_bytes(8, &tail_len_u32);
+        encoder.set_bytes(9, &heads_u32);
+        encoder.set_bytes(10, &head_dim_u32);
+
+        let total = total_len * heads * head_dim;
         let threads_per_grid = objc2_metal::MTLSize {
             width: total,
             height: 1,
@@ -4747,6 +5012,86 @@ mod tests {
         assert!(
             max_abs_diff(&v_fast, &v_ref)? < 1e-6,
             "V fast read diverged from reference"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_paged_kv_head_major_read_append_token_major_matches_reference() -> Result<()> {
+        let Some(device) = try_new_metal() else {
+            return Ok(());
+        };
+
+        let total_slots = 24usize;
+        let heads = 2usize;
+        let head_dim = 16usize;
+        let start_slot = 3usize;
+        let prefix_len = 9usize;
+        let tail_len = 5usize;
+        let elems = total_slots * heads * head_dim;
+        let k_data: Vec<f32> = (0..elems)
+            .map(|i| ((i % 101) as f32 - 50.0) * 0.015625)
+            .collect();
+        let v_data: Vec<f32> = (0..elems)
+            .map(|i| ((i % 83) as f32 - 41.0) * 0.03125)
+            .collect();
+        let k_pool = Tensor::from_slice(&k_data, (total_slots, heads, head_dim), &device)?
+            .to_dtype(DType::BF16)?;
+        let v_pool = Tensor::from_slice(&v_data, (total_slots, heads, head_dim), &device)?
+            .to_dtype(DType::BF16)?;
+
+        let tail_elems = tail_len * heads * head_dim;
+        let k_tail_data: Vec<f32> = (0..tail_elems)
+            .map(|i| ((i % 67) as f32 - 33.0) * 0.0078125)
+            .collect();
+        let v_tail_data: Vec<f32> = (0..tail_elems)
+            .map(|i| ((i % 59) as f32 - 29.0) * 0.015625)
+            .collect();
+        let k_tail =
+            Tensor::from_slice(&k_tail_data, (1usize, tail_len, heads, head_dim), &device)?
+                .to_dtype(DType::BF16)?;
+        let v_tail =
+            Tensor::from_slice(&v_tail_data, (1usize, tail_len, heads, head_dim), &device)?
+                .to_dtype(DType::BF16)?;
+
+        assert!(metal_paged_kv_head_major_read_append_token_major_supports(
+            &k_pool, &v_pool, start_slot, prefix_len, &k_tail, &v_tail
+        ));
+        let (k_fast, v_fast) = metal_paged_kv_head_major_read_append_token_major_bf16(
+            &k_pool, &v_pool, start_slot, prefix_len, &k_tail, &v_tail,
+        )?;
+
+        let prefix_k = k_pool
+            .narrow(0, start_slot, prefix_len)?
+            .transpose(0, 1)?
+            .contiguous()?
+            .unsqueeze(0)?;
+        let prefix_v = v_pool
+            .narrow(0, start_slot, prefix_len)?
+            .transpose(0, 1)?
+            .contiguous()?
+            .unsqueeze(0)?;
+        let current_k = k_tail.transpose(1, 2)?.contiguous()?;
+        let current_v = v_tail.transpose(1, 2)?.contiguous()?;
+        let k_ref = Tensor::cat(&[&prefix_k, &current_k], 2)?;
+        let v_ref = Tensor::cat(&[&prefix_v, &current_v], 2)?;
+
+        assert_eq!(
+            k_fast.dims(),
+            &[1usize, heads, prefix_len + tail_len, head_dim]
+        );
+        assert_eq!(
+            v_fast.dims(),
+            &[1usize, heads, prefix_len + tail_len, head_dim]
+        );
+        assert!(
+            max_abs_diff(&k_fast, &k_ref)? < 1e-6,
+            "K fast read+append diverged from reference"
+        );
+        assert!(
+            max_abs_diff(&v_fast, &v_ref)? < 1e-6,
+            "V fast read+append diverged from reference"
         );
 
         Ok(())

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -54,6 +54,10 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         false
     }
 
+    fn supports_paged_kv_head_major_read_append_token_major(&self) -> bool {
+        false
+    }
+
     fn supports_gdn_forward_substitution(&self) -> bool {
         false
     }
@@ -155,6 +159,25 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         _v_pool: &Tensor,
         _start_slot: usize,
         _seq_len: usize,
+    ) -> Result<Option<(Tensor, Tensor)>> {
+        Ok(None)
+    }
+
+    /// Materialize a contiguous head-major K/V view from a contiguous paged
+    /// cache slot run, then append a contiguous token-major tail directly into
+    /// the same output buffer.
+    ///
+    /// `k_pool`/`v_pool`: `[total_slots, num_kv_heads, head_dim]`.
+    /// `k_tail`/`v_tail`: `[1, tail_len, num_kv_heads, head_dim]`.
+    /// Returns `[1, num_kv_heads, prefix_len + tail_len, head_dim]` tensors.
+    fn paged_kv_head_major_read_append_token_major(
+        &self,
+        _k_pool: &Tensor,
+        _v_pool: &Tensor,
+        _start_slot: usize,
+        _prefix_len: usize,
+        _k_tail: &Tensor,
+        _v_tail: &Tensor,
     ) -> Result<Option<(Tensor, Tensor)>> {
         Ok(None)
     }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -17,7 +17,7 @@ use crate::lora_loader::{
 };
 use crate::paged_kv_cache::{PagedKvCache, contiguous_slot_run_start};
 use crate::transposed_weight_cache::transposed_weight_bytes_2d_cached;
-use crate::weights::{ModelWeights, MtpWeights, TensorDType, WeightTensor};
+use crate::weights::{DeferredMtpSource, ModelWeights, MtpWeights, TensorDType, WeightTensor};
 
 use kiln_core::block::BlockTable;
 
@@ -223,16 +223,31 @@ pub struct MtpGpuWeights {
 /// MTP path that the server uses only for short greedy prompts.
 pub struct MtpGpuWeightsSlot {
     weights: OnceLock<MtpGpuWeights>,
-    source: Option<MtpWeights>,
+    source: Option<MtpGpuSource>,
     device: Device,
     init_lock: Mutex<()>,
+}
+
+#[derive(Clone)]
+enum MtpGpuSource {
+    Loaded(MtpWeights),
+    Deferred(DeferredMtpSource),
 }
 
 impl MtpGpuWeightsSlot {
     pub fn lazy(source: MtpWeights, device: &Device) -> Self {
         Self {
             weights: OnceLock::new(),
-            source: Some(source),
+            source: Some(MtpGpuSource::Loaded(source)),
+            device: device.clone(),
+            init_lock: Mutex::new(()),
+        }
+    }
+
+    pub fn lazy_deferred(source: DeferredMtpSource, device: &Device) -> Self {
+        Self {
+            weights: OnceLock::new(),
+            source: Some(MtpGpuSource::Deferred(source)),
             device: device.clone(),
             init_lock: Mutex::new(()),
         }
@@ -270,10 +285,23 @@ impl MtpGpuWeightsSlot {
             .source
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("native MTP GPU slot is empty and has no CPU source"))?;
+        let mtp_weights = match source {
+            MtpGpuSource::Loaded(weights) => weights.clone(),
+            MtpGpuSource::Deferred(source) => {
+                let load_start = std::time::Instant::now();
+                let loaded = crate::loader::load_deferred_mtp(source)
+                    .context("deferred native MTP CPU load")?;
+                tracing::info!(
+                    load_elapsed_ms = load_start.elapsed().as_millis() as u64,
+                    "deferred native MTP CPU load complete"
+                );
+                loaded
+            }
+        };
         let projection_load_cache =
             ProjectionLoadCache::new(&self.device).context("mtp projection load cache")?;
         let upload_start = std::time::Instant::now();
-        let uploaded = upload_mtp_gpu_weights(source, &self.device, &projection_load_cache)
+        let uploaded = upload_mtp_gpu_weights(&mtp_weights, &self.device, &projection_load_cache)
             .context("lazy native MTP GPU upload")?;
         let upload_elapsed_ms = upload_start.elapsed().as_millis();
         self.weights
@@ -1433,10 +1461,14 @@ impl GpuWeights {
         // during model load. The macOS desktop default only uses native MTP for
         // short greedy prompts; long prompts route to skip-layer, so eager MTP
         // upload slows common startup/readiness without warming the hot path.
-        let mtp = weights
-            .mtp
-            .as_ref()
-            .map(|mtp_w| MtpGpuWeightsSlot::lazy(mtp_w.clone(), device));
+        let mtp = if let Some(mtp_w) = weights.mtp.as_ref() {
+            Some(MtpGpuWeightsSlot::lazy(mtp_w.clone(), device))
+        } else {
+            weights
+                .deferred_mtp
+                .as_ref()
+                .map(|source| MtpGpuWeightsSlot::lazy_deferred(source.clone(), device))
+        };
 
         Ok(Self {
             embed_tokens,
@@ -3894,31 +3926,86 @@ fn gqa_attention_paged_with_rope_tables(
             1usize,
         )
     } else {
-        let fast_read = if seq_len > 1
-            && seq_len >= PAGED_KV_HEAD_MAJOR_READ_MIN_TOKENS
+        let prefix_only_prefill = seq_len > 1
+            && start_pos > 0
             && !paged_cache.is_fp8()
-            && backend.supports_paged_kv_head_major_read()
             && backend.supports_flash_attn_prefill_head_major()
+            && !crate::mtp_debug::is_c7_sdpa_capture_armed();
+        let prefix_append_fast = if prefix_only_prefill
+            && start_pos >= PAGED_KV_HEAD_MAJOR_READ_MIN_TOKENS
+            && backend.supports_paged_kv_head_major_read_append_token_major()
         {
-            contiguous_slot_run_start(block_table, paged_cache.block_size(), 0, total_seq_len)
+            contiguous_slot_run_start(block_table, paged_cache.block_size(), 0, start_pos)
                 .and_then(|start_slot| {
                     paged_cache
                         .pool_tensors(full_attn_layer_idx)
                         .map(|(k_pool, v_pool)| (start_slot, k_pool, v_pool))
                 })
                 .map(|(start_slot, k_pool, v_pool)| {
-                    backend.paged_kv_head_major_read(k_pool, v_pool, start_slot, total_seq_len)
+                    backend.paged_kv_head_major_read_append_token_major(
+                        k_pool,
+                        v_pool,
+                        start_slot,
+                        start_pos,
+                        &k_cache_token_major,
+                        &v_cache_token_major,
+                    )
                 })
                 .transpose()?
                 .flatten()
         } else {
             None
         };
-        let (k, v) = match fast_read {
-            Some((k, v)) => (k, v),
-            None => paged_cache
-                .read(full_attn_layer_idx, block_table, total_seq_len)
-                .context("paged KV cache read failed")?,
+        let fast_read_len = if prefix_only_prefill {
+            start_pos
+        } else {
+            total_seq_len
+        };
+        let fast_read = if seq_len > 1
+            && fast_read_len >= PAGED_KV_HEAD_MAJOR_READ_MIN_TOKENS
+            && !paged_cache.is_fp8()
+            && backend.supports_paged_kv_head_major_read()
+            && backend.supports_flash_attn_prefill_head_major()
+        {
+            contiguous_slot_run_start(block_table, paged_cache.block_size(), 0, fast_read_len)
+                .and_then(|start_slot| {
+                    paged_cache
+                        .pool_tensors(full_attn_layer_idx)
+                        .map(|(k_pool, v_pool)| (start_slot, k_pool, v_pool))
+                })
+                .map(|(start_slot, k_pool, v_pool)| {
+                    backend.paged_kv_head_major_read(k_pool, v_pool, start_slot, fast_read_len)
+                })
+                .transpose()?
+                .flatten()
+        } else {
+            None
+        };
+        let (k, v) = if prefix_only_prefill {
+            match prefix_append_fast {
+                Some((k, v)) => (k, v),
+                None => {
+                    let (prefix_k, prefix_v) = match fast_read {
+                        Some((k, v)) => (k, v),
+                        None => paged_cache
+                            .read(full_attn_layer_idx, block_table, start_pos)
+                            .context("paged KV cache prefix read failed")?,
+                    };
+                    let current_k = k_cache_token_major.transpose(1, 2)?.contiguous()?;
+                    let current_v = v_cache_token_major.transpose(1, 2)?.contiguous()?;
+                    (
+                        Tensor::cat(&[&prefix_k, &current_k], 2)?,
+                        Tensor::cat(&[&prefix_v, &current_v], 2)?,
+                    )
+                }
+            }
+        } else {
+            match fast_read {
+                Some((k, v)) => (k, v),
+                None => paged_cache
+                    .read(full_attn_layer_idx, block_table, total_seq_len)
+                    .context("paged KV cache read failed")?,
+            }
         };
         (k, v, total_seq_len)
     };

--- a/crates/kiln-model/src/loader.rs
+++ b/crates/kiln-model/src/loader.rs
@@ -47,9 +47,9 @@ type TensorMap<'a> = HashMap<&'a str, TensorMapEntry<'a>>;
 pub struct LoadModelOptions {
     /// Load the checkpoint's native MTP head when present.
     ///
-    /// Desktop macOS defaults keep speculative decoding off, so skipping this
-    /// avoids extra CPU allocations and GPU upload/transposes for weights that
-    /// the default serve path will never touch.
+    /// Startup-sensitive callers may set this to `false` and rely on the
+    /// deferred MTP path instead, which keeps routing support visible while
+    /// postponing the CPU load until the first actual native-MTP request.
     pub load_mtp: bool,
 }
 
@@ -168,8 +168,22 @@ fn load_model_dense(
     } else {
         None
     };
+    let deferred_mtp = if options.load_mtp {
+        None
+    } else {
+        detect_mtp_prefix(&tensor_map, &prefix).map(|mtp_prefix| DeferredMtpSource {
+            model_dir: model_dir.to_path_buf(),
+            mtp_prefix,
+            config: config.clone(),
+        })
+    };
     if mtp.is_some() {
         tracing::info!("Native MTP head detected and loaded (k=1 draft depth)");
+    } else if let Some(source) = &deferred_mtp {
+        tracing::info!(
+            mtp_prefix = %source.mtp_prefix,
+            "Native MTP head detected; deferring CPU load until first use"
+        );
     } else if !options.load_mtp {
         tracing::info!("Skipping native MTP head load");
     }
@@ -179,6 +193,7 @@ fn load_model_dense(
         layers,
         final_norm,
         mtp,
+        deferred_mtp,
     };
 
     let total_mb = weights.total_bytes() as f64 / (1024.0 * 1024.0);
@@ -279,6 +294,7 @@ fn load_model_gptq(
         layers,
         final_norm,
         mtp: None,
+        deferred_mtp: None,
     };
 
     let total_mb = weights.total_bytes() as f64 / (1024.0 * 1024.0);
@@ -673,7 +689,14 @@ fn load_mtp_if_present(
         Some(p) => p,
         None => return Ok(None),
     };
+    load_mtp_with_prefix(tensor_map, &mtp_prefix, config).map(Some)
+}
 
+fn load_mtp_with_prefix(
+    tensor_map: &TensorMap<'_>,
+    mtp_prefix: &str,
+    config: &ModelConfig,
+) -> Result<MtpWeights> {
     let ctx = |name: &str| format!("{mtp_prefix}{name}");
 
     let fc = extract_tensor(tensor_map, &format!("{mtp_prefix}fc.weight"))?;
@@ -747,13 +770,51 @@ fn load_mtp_if_present(
         }
     }
 
-    Ok(Some(MtpWeights {
+    Ok(MtpWeights {
         fc,
         pre_fc_norm_embedding,
         pre_fc_norm_hidden,
         layer,
         final_layernorm,
-    }))
+    })
+}
+
+/// Load only the checkpoint's native-MTP tensors from a previously recorded
+/// deferred source.
+pub fn load_deferred_mtp(source: &DeferredMtpSource) -> Result<MtpWeights> {
+    let shards = discover_shards(&source.model_dir)?;
+    let loaded_shards = mmap_shards(&shards)?;
+    let parsed: Vec<SafeTensors<'_>> = loaded_shards
+        .iter()
+        .map(|shard| {
+            SafeTensors::deserialize(&shard.mmap[..]).context("Failed to parse safetensors file")
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut all_tensors: Vec<(String, usize, safetensors::tensor::TensorView<'_>)> = Vec::new();
+    for (shard_idx, st) in parsed.iter().enumerate() {
+        for (name, view) in st.tensors() {
+            all_tensors.push((name, shard_idx, view));
+        }
+    }
+    let mut tensor_map: TensorMap<'_> = HashMap::new();
+    for (name, shard_idx, view) in &all_tensors {
+        tensor_map.insert(
+            name.as_str(),
+            TensorMapEntry {
+                shard: Arc::clone(&loaded_shards[*shard_idx].meta),
+                mmap: Arc::clone(&loaded_shards[*shard_idx].mmap),
+                view,
+            },
+        );
+    }
+
+    load_mtp_with_prefix(&tensor_map, &source.mtp_prefix, &source.config).with_context(|| {
+        format!(
+            "deferred native MTP load from {}",
+            source.model_dir.display()
+        )
+    })
 }
 
 /// Extract a tensor by name from the unified tensor map.
@@ -1751,6 +1812,47 @@ mod tests {
     }
 
     #[test]
+    fn test_load_mtp_can_be_deferred_to_first_use() {
+        let mut tensors = tiny_model_tensors("model.language_model.");
+        tensors.extend(tiny_mtp_tensors("mtp.", "norm"));
+
+        let tensor_refs: Vec<(&str, Vec<usize>, StDtype)> = tensors
+            .iter()
+            .map(|(n, s, d)| (n.as_str(), s.clone(), *d))
+            .collect();
+        let bytes = create_test_safetensors(&tensor_refs);
+
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("model.safetensors"), &bytes).unwrap();
+
+        let config = tiny_model_config();
+        let weights =
+            load_model_with_options(dir.path(), &config, LoadModelOptions { load_mtp: false })
+                .unwrap();
+        assert!(weights.mtp.is_none(), "MTP should stay off the eager path");
+        assert!(
+            weights.deferred_mtp.is_some(),
+            "MTP presence should still be visible via deferred source"
+        );
+
+        let device = candle_core::Device::Cpu;
+        let gpu_weights =
+            crate::forward::GpuWeights::from_model_weights(&weights, &config, &device).unwrap();
+        let slot = gpu_weights
+            .mtp
+            .as_ref()
+            .expect("deferred source should still expose native MTP support");
+        assert!(!slot.is_uploaded(), "deferred MTP must remain lazy");
+
+        let mtp = gpu_weights.mtp_weights().unwrap();
+        assert_eq!(mtp.final_layernorm.dims1().unwrap(), 64);
+        assert!(
+            gpu_weights.mtp.as_ref().unwrap().is_uploaded(),
+            "first native-MTP access should load deferred CPU+GPU tensors"
+        );
+    }
+
+    #[test]
     fn test_load_without_mtp_leaves_none() {
         // Base checkpoint without MTP should leave mtp = None and load fine.
         let tensors = tiny_model_tensors("model.language_model.");
@@ -1768,6 +1870,10 @@ mod tests {
         assert!(
             weights.mtp.is_none(),
             "MTP should be None when tensors are absent"
+        );
+        assert!(
+            weights.deferred_mtp.is_none(),
+            "deferred MTP should also be absent when tensors are absent"
         );
     }
 

--- a/crates/kiln-model/src/weights.rs
+++ b/crates/kiln-model/src/weights.rs
@@ -333,6 +333,18 @@ impl MtpWeights {
     }
 }
 
+/// Deferred native-MTP source for startup-sensitive callers.
+///
+/// Keeps enough information to reopen the checkpoint and load only the
+/// `mtp.*` tensors on demand later, instead of materializing them into
+/// `ModelWeights` during process startup.
+#[derive(Debug, Clone)]
+pub struct DeferredMtpSource {
+    pub model_dir: PathBuf,
+    pub mtp_prefix: String,
+    pub config: kiln_core::config::ModelConfig,
+}
+
 /// Complete Qwen3.5-4B language model weights.
 ///
 /// Note: lm_head is tied to embed_tokens (shared weight matrix),
@@ -348,6 +360,10 @@ pub struct ModelWeights {
     /// `mtp.*` tensors are present in the checkpoint. Consumed by
     /// `KILN_SPEC_METHOD=mtp` at serve time.
     pub mtp: Option<MtpWeights>,
+    /// Optional deferred native-MTP source. When present, the checkpoint ships
+    /// `mtp.*` tensors but the caller elected not to materialize them during
+    /// initial model load.
+    pub deferred_mtp: Option<DeferredMtpSource>,
 }
 
 impl ModelWeights {

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -149,6 +149,7 @@ enum ResolvedSpeculativeMode {
 }
 
 const MTP_MAX_PROMPT_TOKENS_DEFAULT: usize = 128;
+const LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT: usize = 1024;
 const LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS_DEFAULT: usize = 32;
 
 fn resolve_skip_layer_config(
@@ -186,7 +187,7 @@ fn resolve_speculative_mode_from_config(
             {
                 ResolvedSpeculativeMode::Mtp
             } else if greedy_without_lora
-                && prompt_tokens > MTP_MAX_PROMPT_TOKENS_DEFAULT
+                && prompt_tokens >= LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT
                 && sampling.max_tokens >= LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS_DEFAULT
             {
                 skip_layer
@@ -1052,11 +1053,21 @@ mod tests {
             &ModelConfig::qwen3_5_4b(),
             &cfg,
             &make_sampling(0.0),
-            MTP_MAX_PROMPT_TOKENS_DEFAULT + 1,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
             true,
             false,
         );
         assert!(matches!(long_prompt, ResolvedSpeculativeMode::SkipLayer(_)));
+
+        let medium_prompt = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &make_sampling(0.0),
+            512,
+            true,
+            false,
+        );
+        assert!(matches!(medium_prompt, ResolvedSpeculativeMode::Off));
 
         let mut short_output_sampling = make_sampling(0.0);
         short_output_sampling.max_tokens = LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS_DEFAULT - 1;
@@ -1064,7 +1075,7 @@ mod tests {
             &ModelConfig::qwen3_5_4b(),
             &cfg,
             &short_output_sampling,
-            MTP_MAX_PROMPT_TOKENS_DEFAULT + 1,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
             true,
             false,
         );

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -15,21 +15,21 @@ use kiln_core::config::ModelConfig;
 use kiln_core::sampling::SamplingParams;
 use kiln_core::tokenizer::{ChatMessage, KilnTokenizer};
 use kiln_core::vram::detect_vram;
+use kiln_model::ModelRunner;
 use kiln_model::backend as runtime_backend;
 use kiln_model::forward::{
-    model_forward, model_forward_paged, model_forward_paged_last_token,
-    model_forward_paged_last_token_with_last_hidden, model_forward_paged_streaming,
-    model_forward_paged_streaming_last_token_with_last_hidden, streaming_prefill_enabled_for,
-    GpuWeights, LinearAttentionState,
+    GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
+    model_forward_paged_last_token, model_forward_paged_last_token_with_last_hidden,
+    model_forward_paged_streaming, model_forward_paged_streaming_last_token_with_last_hidden,
+    streaming_prefill_enabled_for,
 };
 use kiln_model::kv_cache::KvCache;
 use kiln_model::paged_kv_cache::PagedKvCache;
 use kiln_model::sampling::greedy_sample;
 use kiln_model::speculative::{
-    speculative_decode_step, speculative_decode_step_paged_greedy, speculative_mtp_decode_step,
-    SpeculativeConfig,
+    SpeculativeConfig, speculative_decode_step, speculative_decode_step_paged_greedy,
+    speculative_mtp_decode_step,
 };
-use kiln_model::ModelRunner;
 use kiln_server::config::SpecMethod;
 
 /// Block size used for the paged-path benchmark. Matches the kiln-core default.
@@ -393,7 +393,6 @@ const PROMPT_POOL: [&str; 30] = [
     "Melanie is a door-to-door saleswoman. She sold a third of her vacuum cleaners at a neighborhood on the east side of town during her morning route. She then sold two more to her cousin, who runs a small rental business. She is left with five vacuum cleaners in the boot of her car. We want the number she started with at the beginning of the day. ",
     // 9: mountain round trips
     "Stephen made ten round trips up and down a forty thousand foot tall mountain over the course of the last week. He reached three quarters of the mountain's height on each of his round trips before turning around. We want the total distance in feet he covered across every round trip combined. Compute the effective height per trip, double it for the round trip, then multiply by the number of trips. ",
-
     // === 10-19: HumanEval-style Python function signatures with docstrings ===
     // 10: has_close_elements
     "from typing import List\n\ndef has_close_elements(numbers: List[float], threshold: float) -> bool:\n    \"\"\"Check whether any two numbers in the input list are closer together than the given threshold. Return True if such a pair exists, otherwise return False. Both arguments are guaranteed to be valid, and the threshold is always positive. \"\"\"\n",
@@ -415,7 +414,6 @@ const PROMPT_POOL: [&str; 30] = [
     "from typing import List, Tuple\n\ndef sum_product(numbers: List[int]) -> Tuple[int, int]:\n    \"\"\"Return a tuple consisting of the sum and the product of all integers in the input list. An empty list must yield a sum of zero and a product of one, matching the standard neutral elements. \"\"\"\n",
     // 19: rolling_max
     "from typing import List\n\ndef rolling_max(numbers: List[int]) -> List[int]:\n    \"\"\"Return a list of rolling maxima ending at each prefix of the input sequence. The i-th element of the output is the maximum of all input numbers from index zero through index i inclusive. \"\"\"\n",
-
     // === 20-29: C4-style natural English text fragments ===
     // 20: weather forecast
     "The forecast for next Tuesday calls for widespread thunderstorms across the central plains, with scattered severe cells developing through the late afternoon. Meteorologists have already raised the flood watch for several counties along the river corridor. Local emergency coordinators are urging residents near low-lying creeks to prepare sandbags and monitor updated guidance from the national weather service. ",
@@ -930,6 +928,7 @@ fn read_spec_method_from_env() -> SpecMethod {
 }
 
 const BENCH_MTP_MAX_PROMPT_TOKENS: usize = 128;
+const BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS: usize = 1024;
 const BENCH_LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS: usize = 32;
 
 fn bench_force_raw_mtp() -> bool {
@@ -940,8 +939,10 @@ fn bench_force_raw_mtp() -> bool {
 }
 
 /// Resolve the benchmark arm the same way the server resolves desktop
-/// requests. Native MTP is only the short greedy no-LoRA path; long greedy
-/// desktop-default requests fall back to skip-layer instead of timing raw MTP.
+/// requests. Native MTP is only the short greedy no-LoRA path; medium prompts
+/// stay off because skip-layer regresses there on Apple Silicon, and only
+/// genuinely long greedy requests fall back to skip-layer instead of timing
+/// raw MTP.
 fn resolve_bench_spec_method(
     configured: SpecMethod,
     requested_prompt_tokens: usize,
@@ -978,7 +979,7 @@ fn resolve_bench_spec_method_with_force(
             if mtp_supported && greedy && requested_prompt_tokens <= BENCH_MTP_MAX_PROMPT_TOKENS {
                 SpecMethod::Mtp
             } else if greedy
-                && requested_prompt_tokens > BENCH_MTP_MAX_PROMPT_TOKENS
+                && requested_prompt_tokens >= BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS
                 && max_output_tokens >= BENCH_LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS
             {
                 SpecMethod::SkipLayer
@@ -1004,7 +1005,14 @@ mod tests {
     #[test]
     fn bench_mtp_long_greedy_prompt_falls_back_to_skip_layer() {
         assert_eq!(
-            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 8192, 64, 0.0, true, false),
+            resolve_bench_spec_method_with_force(
+                SpecMethod::Mtp,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS,
+                64,
+                0.0,
+                true,
+                false
+            ),
             SpecMethod::SkipLayer
         );
     }
@@ -1012,11 +1020,33 @@ mod tests {
     #[test]
     fn bench_mtp_long_short_output_or_sampled_prompt_turns_off() {
         assert_eq!(
-            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 8192, 31, 0.0, true, false),
+            resolve_bench_spec_method_with_force(
+                SpecMethod::Mtp,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS,
+                31,
+                0.0,
+                true,
+                false
+            ),
             SpecMethod::Off
         );
         assert_eq!(
-            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 8192, 64, 0.7, true, false),
+            resolve_bench_spec_method_with_force(
+                SpecMethod::Mtp,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS,
+                64,
+                0.7,
+                true,
+                false
+            ),
+            SpecMethod::Off
+        );
+    }
+
+    #[test]
+    fn bench_mtp_medium_prompt_stays_off_until_skip_layer_crossover() {
+        assert_eq!(
+            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 512, 64, 0.0, true, false),
             SpecMethod::Off
         );
     }
@@ -1977,9 +2007,7 @@ fn main() -> Result<()> {
     let model_weights = kiln_model::load_model_with_options(
         model_path,
         &model_config,
-        kiln_model::LoadModelOptions {
-            load_mtp: matches!(spec_method, SpecMethod::Mtp),
-        },
+        kiln_model::LoadModelOptions { load_mtp: false },
     )
     .context("failed to load model weights")?;
 

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -128,19 +128,14 @@ async fn main() -> Result<()> {
     let mut state = if let Some(mp) = model_path {
         // Real inference mode: load model weights and create ModelRunner.
         tracing::info!("loading model weights from {mp}");
-        let load_mtp = matches!(
-            config.speculative.effective_method(),
-            kiln_server::config::SpecMethod::Mtp
-        );
         let device = select_device()?;
-        let metal_kernel_precompile = spawn_metal_kernel_precompile(&device);
+        spawn_metal_kernel_precompile(&device);
         let model_weights = kiln_model::load_model_with_options(
             Path::new(mp),
             &model_config,
-            kiln_model::LoadModelOptions { load_mtp },
+            kiln_model::LoadModelOptions { load_mtp: false },
         )?;
         let gpu_weights = GpuWeights::from_model_weights(&model_weights, &model_config, &device)?;
-        finish_metal_kernel_precompile(metal_kernel_precompile);
 
         let runner = ModelRunner::new_with_options(
             gpu_weights,
@@ -350,49 +345,29 @@ fn warm_tokenizer(tokenizer: &KilnTokenizer) {
 }
 
 #[cfg(feature = "metal")]
-fn spawn_metal_kernel_precompile(
-    device: &candle_core::Device,
-) -> Option<std::thread::JoinHandle<anyhow::Result<std::time::Duration>>> {
+fn spawn_metal_kernel_precompile(device: &candle_core::Device) {
     if !matches!(device, candle_core::Device::Metal(_)) {
-        return None;
+        return;
     }
 
     let device = device.clone();
-    Some(std::thread::spawn(move || {
+    let _ = std::thread::spawn(move || {
         let start = std::time::Instant::now();
-        kiln_model::backend::metal::precompile_custom_kernels(&device)?;
-        Ok(start.elapsed())
-    }))
+        match kiln_model::backend::metal::precompile_custom_kernels(&device) {
+            Ok(()) => tracing::info!(
+                elapsed_ms = start.elapsed().as_millis() as u64,
+                "Metal custom kernels precompiled in background"
+            ),
+            Err(err) => tracing::warn!(
+                error = %err,
+                "Metal custom kernel precompile failed; falling back to lazy compilation"
+            ),
+        }
+    });
 }
 
 #[cfg(not(feature = "metal"))]
-fn spawn_metal_kernel_precompile(
-    _device: &candle_core::Device,
-) -> Option<std::thread::JoinHandle<anyhow::Result<std::time::Duration>>> {
-    None
-}
-
-fn finish_metal_kernel_precompile(
-    handle: Option<std::thread::JoinHandle<anyhow::Result<std::time::Duration>>>,
-) {
-    let Some(handle) = handle else {
-        return;
-    };
-
-    match handle.join() {
-        Ok(Ok(elapsed)) => tracing::info!(
-            elapsed_ms = elapsed.as_millis() as u64,
-            "Metal custom kernels precompiled"
-        ),
-        Ok(Err(err)) => tracing::warn!(
-            error = %err,
-            "Metal custom kernel precompile failed; falling back to lazy compilation"
-        ),
-        Err(_) => tracing::warn!(
-            "Metal custom kernel precompile thread panicked; falling back to lazy compilation"
-        ),
-    }
-}
+fn spawn_metal_kernel_precompile(_device: &candle_core::Device) {}
 
 fn prewarm_kv_dtype(config: &ModelConfig) -> candle_core::DType {
     match config.dtype {


### PR DESCRIPTION
## Summary
- defer native MTP CPU loading until first actual use and stop blocking startup on Metal kernel precompile
- add a fused Metal prefix-read plus token-major tail append path for streaming prefill
- change default `mtp` routing so medium prompts stay on the plain paged path and only genuinely long prompts fall back to skip-layer

## Validation
- `cargo test -p kiln-model --locked --features metal test_paged_kv_head_major_read_append_token_major_matches_reference -- --nocapture`
- `cargo test -p kiln-model --locked --features metal test_streaming_last_hidden_matches_monolithic_cpu -- --nocapture`
- `cargo test -p kiln-server --locked --features metal mtp_requires_greedy_request_and_no_lora -- --nocapture`
- `cargo test -p kiln-server --locked --features metal bench_mtp_medium_prompt_stays_off_until_skip_layer_crossover -- --nocapture`
- `cargo test -p kiln-server --locked --features metal config_check_uses_explicit_file_over_env -- --nocapture`
- Desktop-default bench, medium prompt: `KILN_SPEC_METHOD=mtp ... --prompt-tokens 512 --max-output-tokens 64 --paged --latency-only` now resolves to `off` instead of skip-layer and ran at about `125 tok/s` prefill, `4.2 tok/s` decode on this machine
- Desktop-default bench, longer prompt: `KILN_SPEC_METHOD=mtp ... --prompt-tokens 1024 --max-output-tokens 64 --paged --latency-only` still resolves to `skip_layer` and ran at about `130 tok/s` prefill, `11.8 tok/s` decode on this machine
- Earlier long-prompt 8k runs with the live Metal tail-read improvement were in the `152.3-153.3 tok/s` prefill band with `11.6-11.7 tok/s` decode