### PR TITLE
[codex] Fix C45 compare ordering and C44 summary

### DIFF
--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -653,6 +653,14 @@ def _ordered_taps(
         key = f"c41__{name}"
         if key in common and key not in out:
             out.append(key)
+    for name in C44_LAYER1_F32_ROW_TAP_NAMES:
+        key = f"c44__{name}"
+        if key in common and key not in out:
+            out.append(key)
+    for name in C45_LAYER1_ROW_TAP_NAMES:
+        key = f"c45__{name}"
+        if key in common and key not in out:
+            out.append(key)
     for name in C6_PRE_ROPE_TAP_NAMES:
         key = f"c6__{name}"
         if key in common and key not in out:
@@ -2027,6 +2035,19 @@ def _emit_c44_summary(
     emit(f"Phase C44 verdict: EARLIEST SHARED BAD ROW-LEVEL TAP = '{first_shared_bad}'.")
     emit(f"    Most-likely cause: {C44_HYPOTHESIS.get(first_shared_bad, '<unknown tap>')}")
 
+    residual_row_ok = all(
+        cell["layer_1_residual_input_f32_row"].get(lab, (0.0, 0.0, 0.0, 0.0, False))[4]
+        for lab in labels
+    )
+    rms_inv_ok = all(
+        cell["layer_1_input_norm_rms_inv_scalar"].get(lab, (0.0, 0.0, 0.0, 0.0, False))[4]
+        for lab in labels
+    )
+    affine_ok = all(
+        cell["layer_1_input_norm_pre_weight_row_scalar_affine"].get(lab, (0.0, 0.0, 0.0, 0.0, False))[4]
+        for lab in labels
+    )
+
     if first_shared_bad == "layer_1_residual_input_f32_row":
         emit(
             "  -> Divergence is already present in the last replay row after "
@@ -2038,11 +2059,11 @@ def _emit_c44_summary(
             "shared-good; divergence first appears only when normalization is "
             "applied to produce the row values."
         )
-    elif (not broadcast_ok) and (not affine_ok):
+    elif residual_row_ok and (not rms_inv_ok) and (not affine_ok):
         emit(
-            "  -> Divergence survives the independent scalar-affine equivalent: "
-            "the earliest bad span stays on the pre-weight values themselves, "
-            "not broadcast/layout alone."
+            "  -> The last replay row itself stays shared-good, but both the "
+            "`rms_inv` scalar and the normalized-row replay are bad. The "
+            "earliest shared span is the row-local normalization scalar path."
         )
     elif last_shared_ok is not None:
         emit(


### PR DESCRIPTION
## What changed
- add explicit `c44__*` and `c45__*` tap ordering in `_ordered_taps()` so generic pair verdicts follow the phase tap order instead of alpha-sorting extras
- compute the C44 summary booleans locally inside `_emit_c44_summary()` so the summary path cannot crash with `NameError`

## Why
The C45 row-scalar compare path was emitting the correct phase-specific summary but the generic pair verdict could still name the wrong earliest tap because `_ordered_taps()` had no C45 branch. Separately, the C44 summary path still referenced locals from C43, so a row-level verdict could crash when it hit that branch.

## Validation
- `python3 -m py_compile scripts/mtp_compare.py`
- `python3 -m pip install --quiet numpy safetensors`
- synthetic C45 safetensors pair: verified generic pair verdict now reports `c45__layer_1_input_norm_pre_weight_row_scalar_values` before `...row_reconstructed`
- synthetic C44 safetensors pair: verified the previously crashing summary branch now completes without `NameError`
- attempted the task's artifact commands; this repo snapshot does not contain the referenced `post435_c45_*_captures/*.safetensors` files, and the provided C44 `.bench.json` input is not loadable by `mtp_compare.py` because the CLI expects safetensors dumps
