### PR TITLE
[codex] Align C45 row replay with broadcast_mul

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1687,13 +1687,10 @@ fn capture_c44_layer1_f32_row_taps(x: &Tensor, eps: f64) -> Result<()> {
     Ok(())
 }
 
-/// Phase C45: keep the audit strictly inside the previously-bad row-local
-/// scalar multiply so the replay dump can distinguish "the row-local scalar
-/// tensor is fine", "the scalar extraction path already drifts", "the actual
-/// multiply introduces the drift", or "the multiplied flat row stays
-/// shared-good and divergence only appears when reconstructing the row-shaped
-/// output".
-fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
+fn c45_layer1_row_replay_tensors(
+    x: &Tensor,
+    eps: f64,
+) -> Result<(Tensor, Tensor, Tensor, Tensor)> {
     let x_f32 = x.to_dtype(DType::F32)?;
     let (batch, seq_len, hidden) = x_f32
         .dims3()
@@ -1701,21 +1698,12 @@ fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
     anyhow::ensure!(seq_len > 0, "C45 row audit requires non-empty sequence");
 
     let last_row = x_f32.narrow(1, seq_len - 1, 1)?.contiguous()?;
-    let residual_values = last_row.reshape((batch, hidden))?.contiguous()?;
-
     let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
     let rms_inv = (variance + eps)?.sqrt()?.recip()?;
     let rms_inv_row = rms_inv.narrow(1, seq_len - 1, 1)?.contiguous()?;
-    crate::mtp_debug::capture_c45_layer1_row_tap(
-        "layer_1_input_norm_rms_inv_scalar",
-        &rms_inv_row,
-    )?;
 
     let mut extracted_scalars = Vec::with_capacity(batch);
-    let mut row_values = Vec::with_capacity(batch);
-    let mut reconstructed_rows = Vec::with_capacity(batch);
     for batch_idx in 0..batch {
-        let row = residual_values.narrow(0, batch_idx, 1)?;
         let scale = rms_inv_row.narrow(0, batch_idx, 1)?;
         let scale_vals = scale.flatten_all()?.to_vec1::<f32>()?;
         anyhow::ensure!(
@@ -1723,29 +1711,37 @@ fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
             "C45 row audit expected one rms_inv scalar per batch row, got {}",
             scale_vals.len()
         );
-        let extracted = scale_vals[0];
-        extracted_scalars.push(extracted);
-        let scaled_values = row.affine(extracted as f64, 0.0)?.contiguous()?;
-        row_values.push(scaled_values.clone());
-        reconstructed_rows.push(scaled_values.reshape((1, 1, hidden))?);
+        extracted_scalars.push(scale_vals[0]);
     }
 
     let extracted_scalars =
         Tensor::from_slice(&extracted_scalars, (batch,), &Device::Cpu)?.contiguous()?;
+    let reconstructed = last_row.broadcast_mul(&rms_inv_row)?.contiguous()?;
+    let scalar_values = reconstructed.reshape((batch, hidden))?.contiguous()?;
+    Ok((rms_inv_row, extracted_scalars, scalar_values, reconstructed))
+}
+
+/// Phase C45: keep the audit strictly inside the previously-bad row-local
+/// scalar multiply so the replay dump can distinguish "the row-local scalar
+/// tensor is fine", "the scalar extraction path already drifts", "the actual
+/// multiply introduces the drift", or "the multiplied flat row stays
+/// shared-good and divergence only appears when reconstructing the row-shaped
+/// output".
+fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
+    let (rms_inv_row, extracted_scalars, scalar_values, reconstructed) =
+        c45_layer1_row_replay_tensors(x, eps)?;
+    crate::mtp_debug::capture_c45_layer1_row_tap(
+        "layer_1_input_norm_rms_inv_scalar",
+        &rms_inv_row,
+    )?;
     crate::mtp_debug::capture_c45_layer1_row_tap(
         "layer_1_input_norm_rms_inv_scalar_extracted_values",
         &extracted_scalars,
     )?;
-
-    let row_value_refs: Vec<&Tensor> = row_values.iter().collect();
-    let scalar_values = Tensor::cat(&row_value_refs, 0)?;
     crate::mtp_debug::capture_c45_layer1_row_tap(
         "layer_1_input_norm_pre_weight_row_scalar_values",
         &scalar_values,
     )?;
-
-    let reconstructed_refs: Vec<&Tensor> = reconstructed_rows.iter().collect();
-    let reconstructed = Tensor::cat(&reconstructed_refs, 0)?;
     crate::mtp_debug::capture_c45_layer1_row_tap(
         "layer_1_input_norm_pre_weight_row_reconstructed",
         &reconstructed,
@@ -6419,6 +6415,44 @@ mod tests {
         assert!((vals[0][0] - 1.5).abs() < 1e-4);
         assert!((vals[0][1] - 2.0).abs() < 1e-4);
         assert!((vals[0][2] - 3.0).abs() < 1e-4);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_c45_row_replay_matches_production_broadcast_mul_last_row() -> Result<()> {
+        let device = Device::Cpu;
+        let batch = 2usize;
+        let seq_len = 3usize;
+        let hidden = 4usize;
+        let eps = 1e-6;
+        let x = Tensor::from_slice(
+            &[
+                1.0_f32, 2.0, 3.0, 4.0, 0.5, 1.5, 2.5, 3.5, 4.0, 3.0, 2.0, 1.0, -1.0, -2.0,
+                -3.0, -4.0, 1.0, -1.5, 2.0, -2.5, 0.25, -0.5, 0.75, -1.0,
+            ],
+            (batch, seq_len, hidden),
+            &device,
+        )?;
+
+        let (_rms_inv_row, _extracted_scalars, scalar_values, reconstructed) =
+            c45_layer1_row_replay_tensors(&x, eps)?;
+
+        let x_f32 = x.to_dtype(DType::F32)?;
+        let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
+        let rms_inv = (variance + eps)?.sqrt()?.recip()?;
+        let production = x_f32.broadcast_mul(&rms_inv)?;
+        let production_last_row = production.narrow(1, seq_len - 1, 1)?.contiguous()?;
+        let production_scalar_values = production_last_row.reshape((batch, hidden))?.contiguous()?;
+
+        assert_eq!(
+            reconstructed.to_vec3::<f32>()?,
+            production_last_row.to_vec3::<f32>()?
+        );
+        assert_eq!(
+            scalar_values.to_vec2::<f32>()?,
+            production_scalar_values.to_vec2::<f32>()?
+        );
 
         Ok(())
     }

--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -97,3 +97,21 @@ Recovered seed metrics from the final artifact-producing pod:
 - `profiling-artifacts/post435_c45_row_scalar_seed1.bench.stderr`
 - `profiling-artifacts/post435_c45_row_scalar_seed0_compare.txt`
 - `profiling-artifacts/post435_c45_row_scalar_seed1_compare.txt`
+
+## 2026-04-23 broadcast-mul parity rerun
+
+After aligning the C45 replay helper with the production last-row
+`broadcast_mul` shape path in `forward.rs`, a fresh A6000 rerun on current
+`main` still confirms the same boundary on the representative two-seed check:
+
+- seed 0 (`profiling-artifacts/c45_broadcast_parity_seed0_compare.txt`):
+  earliest shared bad tap remains
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+- seed 1 (`profiling-artifacts/c45_broadcast_parity_seed1_compare.txt`):
+  earliest shared bad tap remains
+  `layer_1_input_norm_pre_weight_row_scalar_values`
+
+So production-op parity for the replay path does **not** move the first-bad
+boundary past the row-local scalar multiply on current `main`; C45 remains
+localized to the multiply itself, and this task stops here without widening the
+tap contract.


### PR DESCRIPTION
## What changed
- align the C45 row-scalar replay helper in `crates/kiln-model/src/forward.rs` with the production last-row `broadcast_mul` path instead of reconstructing the row via per-batch `affine`
- add a focused regression that proves the generated `layer_1_input_norm_pre_weight_row_scalar_values` and `...row_reconstructed` tensors exactly match the production pre-weight last-row slice for a multi-batch CPU input
- append the fresh branch rerun result to `docs/phase-c45/c45-layer1-row-normalization-bisect.md`

## Why
C45 had narrowed the first shared bad boundary to the row-local scalar multiply replay, but the replay helper was still using looser per-row `affine` semantics than the real RMSNorm pre-weight `broadcast_mul` path. This change removes that gap so the replay tap answers the intended question directly.

## Result
The fresh two-seed A6000 rerun on this branch does not move the boundary. Both representative compares still first fail at `layer_1_input_norm_pre_weight_row_scalar_values`, with `layer_1_input_norm_rms_inv_scalar_extracted_values` remaining the last shared-good tap.

## Validation
- `KILN_CUDA_ARCHS=86 cargo test --locked -p kiln-model c45 -- --nocapture`
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- fresh RunPod A6000 rerun using the documented C45 workflow from `PROFILING.md`
  - seed 0 compare: `profiling-artifacts/c45_broadcast_parity_seed0_compare.txt`
  - seed 1 compare: `profiling-artifacts/c45_broadcast_parity_seed1_compare.txt`
