### PR TITLE
Improve macOS startup and short-prompt routing

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -903,6 +903,7 @@ fn dropped_weight_stub(w: &WeightTensor, device: &Device) -> Result<Tensor> {
     Ok(Tensor::zeros((1usize,), weight_dtype(w), device)?)
 }
 
+#[derive(Clone)]
 struct ProjectionLoadCache {
     metal_bf16_stub: Option<Tensor>,
     metal_f16_stub: Option<Tensor>,
@@ -992,15 +993,17 @@ fn projection_tensors_for_load_batch(
         })
         .collect();
 
+    let cache = cache.clone();
+    let device = device.clone();
     transposed?
-        .into_iter()
-        .zip(weights.iter())
+        .into_par_iter()
+        .zip(weights.par_iter())
         .map(|((data, shape), (name, w))| {
-            let transposed = Tensor::from_raw_buffer(&data, weight_dtype(w), &shape, device)
+            let transposed = Tensor::from_raw_buffer(&data, weight_dtype(w), &shape, &device)
                 .with_context(|| format!("{name} transposed projection upload"))?;
             let original_stub = match cache.metal_stub_for(weight_dtype(w)) {
                 Some(stub) => stub,
-                None => dropped_weight_stub(w, device)
+                None => dropped_weight_stub(w, &device)
                     .with_context(|| format!("{name} projection stub"))?,
             };
             Ok((original_stub, transposed))
@@ -1638,7 +1641,9 @@ fn capture_c43_layer1_preweight_taps(x: &Tensor, weight: &Tensor, eps: f64) -> R
 
     let w_f32 = weight.to_dtype(DType::F32)?;
     let w_plus_one = (w_f32.ones_like()? + w_f32)?;
-    let post = pre_weight_broadcast.broadcast_mul(&w_plus_one)?.to_dtype(x.dtype())?;
+    let post = pre_weight_broadcast
+        .broadcast_mul(&w_plus_one)?
+        .to_dtype(x.dtype())?;
     crate::mtp_debug::capture_c43_layer1_preweight_tap("layer_1_post_input_norm", &post)?;
     Ok(())
 }
@@ -5921,8 +5926,7 @@ fn model_forward_paged_inner(
                     anyhow::anyhow!("linear attention state required for GDN layers (layer {i})")
                 })?;
                 let capture_b11_taps = crate::mtp_debug::should_capture_b11_tap_for_layer(i);
-                let capture_c41_taps =
-                    crate::mtp_debug::should_capture_c41_layer1_tap_for_layer(i);
+                let capture_c41_taps = crate::mtp_debug::should_capture_c41_layer1_tap_for_layer(i);
                 let capture_c42_taps =
                     crate::mtp_debug::should_capture_c42_layer1_norm_tap_for_layer(i);
                 let capture_c43_taps =

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -152,6 +152,24 @@ const MTP_MAX_PROMPT_TOKENS_DEFAULT: usize = 128;
 const LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT: usize = 1024;
 const LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS_DEFAULT: usize = 32;
 
+fn native_mtp_enabled_for_metal() -> bool {
+    std::env::var("KILN_ENABLE_METAL_NATIVE_MTP")
+        .ok()
+        .as_deref()
+        .is_some_and(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+}
+
+fn native_mtp_allowed_for_state(state: &AppState) -> bool {
+    let ModelBackend::Real { runner, .. } = state.backend.as_ref() else {
+        return true;
+    };
+    let runner_guard = runner.read().unwrap();
+    match runner_guard.weights.embed_tokens.device() {
+        candle_core::Device::Metal(_) => native_mtp_enabled_for_metal(),
+        _ => true,
+    }
+}
+
 fn resolve_skip_layer_config(
     model_config: &kiln_core::config::ModelConfig,
     speculative: &SpeculativeDecodingConfig,
@@ -171,6 +189,7 @@ fn resolve_speculative_mode_from_config(
     prompt_tokens: usize,
     mtp_supported: bool,
     has_active_lora: bool,
+    native_mtp_allowed: bool,
 ) -> ResolvedSpeculativeMode {
     let skip_layer = resolve_skip_layer_config(model_config, speculative);
 
@@ -182,6 +201,7 @@ fn resolve_speculative_mode_from_config(
         SpecMethod::Mtp => {
             let greedy_without_lora = sampling.temperature == 0.0 && !has_active_lora;
             if mtp_supported
+                && native_mtp_allowed
                 && greedy_without_lora
                 && prompt_tokens <= MTP_MAX_PROMPT_TOKENS_DEFAULT
             {
@@ -215,6 +235,7 @@ fn resolve_speculative_mode(
         prompt_tokens,
         mtp_supported,
         has_active_lora,
+        native_mtp_allowed_for_state(state),
     )
 }
 
@@ -999,6 +1020,7 @@ mod tests {
             16,
             false,
             false,
+            true,
         );
 
         match mode {
@@ -1026,6 +1048,7 @@ mod tests {
             16,
             true,
             false,
+            true,
         );
         assert!(matches!(greedy, ResolvedSpeculativeMode::Mtp));
 
@@ -1036,6 +1059,7 @@ mod tests {
             16,
             true,
             false,
+            true,
         );
         assert!(matches!(sampled, ResolvedSpeculativeMode::Off));
 
@@ -1044,6 +1068,7 @@ mod tests {
             &cfg,
             &make_sampling(0.0),
             16,
+            true,
             true,
             true,
         );
@@ -1056,6 +1081,7 @@ mod tests {
             LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
             true,
             false,
+            true,
         );
         assert!(matches!(long_prompt, ResolvedSpeculativeMode::SkipLayer(_)));
 
@@ -1066,6 +1092,7 @@ mod tests {
             512,
             true,
             false,
+            true,
         );
         assert!(matches!(medium_prompt, ResolvedSpeculativeMode::Off));
 
@@ -1078,11 +1105,33 @@ mod tests {
             LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
             true,
             false,
+            true,
         );
         assert!(matches!(
             long_prompt_short_output,
             ResolvedSpeculativeMode::Off
         ));
+    }
+
+    #[test]
+    fn mtp_short_prompt_stays_off_when_native_mtp_is_disallowed() {
+        let cfg = SpeculativeDecodingConfig {
+            enabled: true,
+            method: SpecMethod::Mtp,
+            num_speculative_tokens: 4,
+            draft_layers: 8,
+        };
+
+        let mode = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &make_sampling(0.0),
+            64,
+            true,
+            false,
+            false,
+        );
+        assert!(matches!(mode, ResolvedSpeculativeMode::Off));
     }
 
     #[test]
@@ -1100,6 +1149,7 @@ mod tests {
             16,
             false,
             false,
+            true,
         );
 
         assert!(matches!(mode, ResolvedSpeculativeMode::Off));

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -932,6 +932,17 @@ const BENCH_MTP_MAX_PROMPT_TOKENS: usize = 128;
 const BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS: usize = 1024;
 const BENCH_LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS: usize = 32;
 
+fn bench_native_mtp_allowed(backend_name: &str) -> bool {
+    if backend_name == "metal" {
+        std::env::var("KILN_ENABLE_METAL_NATIVE_MTP")
+            .ok()
+            .as_deref()
+            .is_some_and(|v| matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"))
+    } else {
+        true
+    }
+}
+
 fn bench_force_raw_mtp() -> bool {
     std::env::var("KILN_BENCH_FORCE_MTP")
         .ok()
@@ -950,6 +961,7 @@ fn resolve_bench_spec_method(
     max_output_tokens: usize,
     temperature: f32,
     mtp_supported: bool,
+    backend_name: &str,
 ) -> SpecMethod {
     resolve_bench_spec_method_with_force(
         configured,
@@ -957,6 +969,7 @@ fn resolve_bench_spec_method(
         max_output_tokens,
         temperature,
         mtp_supported,
+        bench_native_mtp_allowed(backend_name),
         bench_force_raw_mtp(),
     )
 }
@@ -967,6 +980,7 @@ fn resolve_bench_spec_method_with_force(
     max_output_tokens: usize,
     temperature: f32,
     mtp_supported: bool,
+    native_mtp_allowed: bool,
     force_raw_mtp: bool,
 ) -> SpecMethod {
     match configured {
@@ -977,7 +991,11 @@ fn resolve_bench_spec_method_with_force(
                 return SpecMethod::Mtp;
             }
             let greedy = temperature == 0.0;
-            if mtp_supported && greedy && requested_prompt_tokens <= BENCH_MTP_MAX_PROMPT_TOKENS {
+            if mtp_supported
+                && native_mtp_allowed
+                && greedy
+                && requested_prompt_tokens <= BENCH_MTP_MAX_PROMPT_TOKENS
+            {
                 SpecMethod::Mtp
             } else if greedy
                 && requested_prompt_tokens >= BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS
@@ -998,7 +1016,7 @@ mod tests {
     #[test]
     fn bench_mtp_short_prompt_stays_mtp() {
         assert_eq!(
-            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 128, 64, 0.0, true, false),
+            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 128, 64, 0.0, true, true, false),
             SpecMethod::Mtp
         );
     }
@@ -1011,6 +1029,7 @@ mod tests {
                 BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS,
                 64,
                 0.0,
+                true,
                 true,
                 false
             ),
@@ -1027,6 +1046,7 @@ mod tests {
                 31,
                 0.0,
                 true,
+                true,
                 false
             ),
             SpecMethod::Off
@@ -1038,6 +1058,7 @@ mod tests {
                 64,
                 0.7,
                 true,
+                true,
                 false
             ),
             SpecMethod::Off
@@ -1047,7 +1068,15 @@ mod tests {
     #[test]
     fn bench_mtp_medium_prompt_stays_off_until_skip_layer_crossover() {
         assert_eq!(
-            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 512, 64, 0.0, true, false),
+            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 512, 64, 0.0, true, true, false),
+            SpecMethod::Off
+        );
+    }
+
+    #[test]
+    fn bench_mtp_short_prompt_stays_off_when_native_mtp_is_disallowed() {
+        assert_eq!(
+            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 64, 64, 0.0, true, false, false),
             SpecMethod::Off
         );
     }
@@ -1055,7 +1084,7 @@ mod tests {
     #[test]
     fn bench_force_raw_mtp_bypasses_shape_routing() {
         assert_eq!(
-            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 8192, 64, 0.0, true, true),
+            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 8192, 64, 0.0, true, false, true),
             SpecMethod::Mtp
         );
     }
@@ -2067,6 +2096,7 @@ fn main() -> Result<()> {
         args.max_output_tokens,
         args.temperature,
         gpu_weights.mtp.is_some(),
+        backend_name,
     );
     if spec_method != requested_spec_method {
         eprintln!(


### PR DESCRIPTION
## Summary
- parallelize the final Metal projection upload/materialization pass during model load
- keep desktop-default `KILN_SPEC_METHOD=mtp` from choosing native MTP on Metal short prompts unless `KILN_ENABLE_METAL_NATIVE_MTP=1` is set
- mirror the same backend-aware routing rule in `kiln-bench` so bench behavior matches serving

## Validation
- `cargo test -p kiln-server --locked mtp_ -- --nocapture`
- `cargo test -p kiln-model --locked test_streaming_last_hidden_matches_monolithic_cpu -- --nocapture`
- `cargo test -p kiln-model --locked --features metal conv1d_prefill -- --nocapture`
- `cargo build --release -p kiln-server --bin kiln-bench --features metal --target-dir /private/tmp/kiln-perf-followup-target`
- Desktop-default short prompt on Metal now resolves `Mtp -> Off` automatically:
  - `KILN_INFERENCE_MEMORY_FRACTION=0.7 KILN_KV_CACHE_FP8=0 KILN_CUDA_GRAPHS=0 KILN_PREFIX_CACHE_ENABLED=1 KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp /usr/bin/time -l /private/tmp/kiln-perf-followup-target/release/kiln-bench --model-path /private/tmp/qwen3.5-4b --paged --prompt-tokens 64 --max-output-tokens 64 --seed 0 --skip-training --latency-only`
  - resolved to `Off`, `24.51s` real, decode `4.3 tok/s`
- Same build forced back onto raw native MTP for comparison:
  - add `KILN_BENCH_FORCE_MTP=1`
  - `32.82s` real, decode `2.5 tok/s`, `α=0.208`
- Earlier startup-only validation on this branch improved model load from roughly `4.48s` to about `4.21-4.31s` on the desktop-default path