### PR TITLE
[codex] Split C45 last-row broadcast-mul taps

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1695,7 +1695,7 @@ fn capture_c44_layer1_f32_row_taps(x: &Tensor, eps: f64) -> Result<()> {
 fn c45_layer1_row_replay_tensors(
     x: &Tensor,
     eps: f64,
-) -> Result<(Tensor, Tensor, Tensor, Tensor)> {
+) -> Result<(Tensor, Tensor, Tensor, Tensor, Tensor, Tensor)> {
     let x_f32 = x.to_dtype(DType::F32)?;
     let (batch, seq_len, hidden) = x_f32
         .dims3()
@@ -1719,11 +1719,28 @@ fn c45_layer1_row_replay_tensors(
         extracted_scalars.push(scale_vals[0]);
     }
 
+    let extracted_scalar_values = extracted_scalars;
     let extracted_scalars =
-        Tensor::from_slice(&extracted_scalars, (batch,), &Device::Cpu)?.contiguous()?;
-    let reconstructed = last_row.broadcast_mul(&rms_inv_row)?.contiguous()?;
-    let scalar_values = reconstructed.reshape((batch, hidden))?.contiguous()?;
-    Ok((rms_inv_row, extracted_scalars, scalar_values, reconstructed))
+        Tensor::from_slice(&extracted_scalar_values, (batch,), &Device::Cpu)?.contiguous()?;
+    let last_row_values = last_row.reshape((batch, hidden))?.contiguous()?;
+    let broadcast_output = last_row.broadcast_mul(&rms_inv_row)?.contiguous()?;
+
+    let mut flat_rows = Vec::with_capacity(batch);
+    for batch_idx in 0..batch {
+        let row = last_row_values.narrow(0, batch_idx, 1)?;
+        flat_rows.push(row.affine(extracted_scalar_values[batch_idx] as f64, 0.0)?);
+    }
+    let flat_row_refs: Vec<&Tensor> = flat_rows.iter().collect();
+    let scalar_values = Tensor::cat(&flat_row_refs, 0)?.contiguous()?;
+    let reconstructed = scalar_values.reshape((batch, 1, hidden))?.contiguous()?;
+    Ok((
+        rms_inv_row,
+        extracted_scalars,
+        last_row_values,
+        broadcast_output,
+        scalar_values,
+        reconstructed,
+    ))
 }
 
 /// Phase C45: keep the audit strictly inside the previously-bad row-local
@@ -1733,7 +1750,14 @@ fn c45_layer1_row_replay_tensors(
 /// shared-good and divergence only appears when reconstructing the row-shaped
 /// output".
 fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
-    let (rms_inv_row, extracted_scalars, scalar_values, reconstructed) =
+    let (
+        rms_inv_row,
+        extracted_scalars,
+        last_row_values,
+        broadcast_output,
+        scalar_values,
+        reconstructed,
+    ) =
         c45_layer1_row_replay_tensors(x, eps)?;
     crate::mtp_debug::capture_c45_layer1_row_tap(
         "layer_1_input_norm_rms_inv_scalar",
@@ -1742,6 +1766,14 @@ fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
     crate::mtp_debug::capture_c45_layer1_row_tap(
         "layer_1_input_norm_rms_inv_scalar_extracted_values",
         &extracted_scalars,
+    )?;
+    crate::mtp_debug::capture_c45_layer1_row_tap(
+        "layer_1_input_norm_last_row_flat_values",
+        &last_row_values,
+    )?;
+    crate::mtp_debug::capture_c45_layer1_row_tap(
+        "layer_1_input_norm_pre_weight_row_broadcast_output",
+        &broadcast_output,
     )?;
     crate::mtp_debug::capture_c45_layer1_row_tap(
         "layer_1_input_norm_pre_weight_row_scalar_values",
@@ -6439,16 +6471,41 @@ mod tests {
             &device,
         )?;
 
-        let (_rms_inv_row, _extracted_scalars, scalar_values, reconstructed) =
-            c45_layer1_row_replay_tensors(&x, eps)?;
+        let (
+            rms_inv_row,
+            extracted_scalars,
+            last_row_values,
+            broadcast_output,
+            scalar_values,
+            reconstructed,
+        ) = c45_layer1_row_replay_tensors(&x, eps)?;
 
         let x_f32 = x.to_dtype(DType::F32)?;
         let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
         let rms_inv = (variance + eps)?.sqrt()?.recip()?;
         let production = x_f32.broadcast_mul(&rms_inv)?;
         let production_last_row = production.narrow(1, seq_len - 1, 1)?.contiguous()?;
+        let production_last_row_values = x_f32
+            .narrow(1, seq_len - 1, 1)?
+            .contiguous()?
+            .reshape((batch, hidden))?
+            .contiguous()?;
         let production_scalar_values = production_last_row.reshape((batch, hidden))?.contiguous()?;
+        let production_rms_inv_row = rms_inv.narrow(1, seq_len - 1, 1)?.contiguous()?;
 
+        assert_eq!(rms_inv_row.to_vec3::<f32>()?, production_rms_inv_row.to_vec3::<f32>()?);
+        assert_eq!(
+            extracted_scalars.to_vec1::<f32>()?,
+            production_rms_inv_row.reshape((batch,))?.to_vec1::<f32>()?
+        );
+        assert_eq!(
+            last_row_values.to_vec2::<f32>()?,
+            production_last_row_values.to_vec2::<f32>()?
+        );
+        assert_eq!(
+            broadcast_output.to_vec3::<f32>()?,
+            production_last_row.to_vec3::<f32>()?
+        );
         assert_eq!(
             reconstructed.to_vec3::<f32>()?,
             production_last_row.to_vec3::<f32>()?
@@ -6456,6 +6513,14 @@ mod tests {
         assert_eq!(
             scalar_values.to_vec2::<f32>()?,
             production_scalar_values.to_vec2::<f32>()?
+        );
+        assert_eq!(
+            reconstructed.reshape((batch, hidden))?.to_vec2::<f32>()?,
+            scalar_values.to_vec2::<f32>()?
+        );
+        assert_eq!(
+            broadcast_output.reshape((batch, hidden))?.to_vec2::<f32>()?,
+            scalar_values.to_vec2::<f32>()?
         );
 
         Ok(())

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -987,6 +987,8 @@ pub const C44_LAYER1_F32_ROW_TAP_NAMES: &[&str] = &[
 pub const C45_LAYER1_ROW_TAP_NAMES: &[&str] = &[
     "layer_1_input_norm_rms_inv_scalar",
     "layer_1_input_norm_rms_inv_scalar_extracted_values",
+    "layer_1_input_norm_last_row_flat_values",
+    "layer_1_input_norm_pre_weight_row_broadcast_output",
     "layer_1_input_norm_pre_weight_row_scalar_values",
     "layer_1_input_norm_pre_weight_row_reconstructed",
 ];
@@ -3041,14 +3043,18 @@ mod tests {
 
     #[test]
     fn c45_layer1_row_tap_names_enumerate_expected_boundaries() {
-        assert_eq!(C45_LAYER1_ROW_TAP_NAMES.len(), 4);
+        assert_eq!(C45_LAYER1_ROW_TAP_NAMES.len(), 6);
         assert_eq!(C45_LAYER1_ROW_TAP_NAMES[0], "layer_1_input_norm_rms_inv_scalar");
         assert_eq!(
             C45_LAYER1_ROW_TAP_NAMES[1],
             "layer_1_input_norm_rms_inv_scalar_extracted_values"
         );
         assert_eq!(
-            C45_LAYER1_ROW_TAP_NAMES[3],
+            C45_LAYER1_ROW_TAP_NAMES[2],
+            "layer_1_input_norm_last_row_flat_values"
+        );
+        assert_eq!(
+            C45_LAYER1_ROW_TAP_NAMES[5],
             "layer_1_input_norm_pre_weight_row_reconstructed"
         );
     }
@@ -3758,7 +3764,7 @@ mod tests {
         let id0 = i32::from_le_bytes(ids.data()[0..4].try_into().unwrap());
         let id1 = i32::from_le_bytes(ids.data()[4..8].try_into().unwrap());
         assert_eq!(id0, 0);
-        assert_eq!(id1, 3);
+        assert_eq!(id1, 5);
 
         let out = st
             .tensor("c45__layer_1_input_norm_pre_weight_row_reconstructed")

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -373,6 +373,8 @@ C44_HYPOTHESIS: Dict[str, str] = {
 C45_LAYER1_ROW_TAP_NAMES: Tuple[str, ...] = (
     "layer_1_input_norm_rms_inv_scalar",
     "layer_1_input_norm_rms_inv_scalar_extracted_values",
+    "layer_1_input_norm_last_row_flat_values",
+    "layer_1_input_norm_pre_weight_row_broadcast_output",
     "layer_1_input_norm_pre_weight_row_scalar_values",
     "layer_1_input_norm_pre_weight_row_reconstructed",
 )
@@ -380,6 +382,8 @@ C45_LAYER1_ROW_TAP_NAMES: Tuple[str, ...] = (
 C45_HYPOTHESIS: Dict[str, str] = {
     "layer_1_input_norm_rms_inv_scalar": "the row-local RMS inverse scalar tensor itself diverges even though PR #433 kept this boundary shared-good",
     "layer_1_input_norm_rms_inv_scalar_extracted_values": "the row-local scalar tensor stays shared-good, but the scalar extraction path diverges before the multiply runs",
+    "layer_1_input_norm_last_row_flat_values": "the extracted scalar stays shared-good, but the selected last-row flat values already drift before the multiply runs",
+    "layer_1_input_norm_pre_weight_row_broadcast_output": "the selected row and extracted scalar stay shared-good; drift first appears in the row-shaped production broadcast_mul output",
     "layer_1_input_norm_pre_weight_row_scalar_values": "the scalar tensor and extracted scalar stay shared-good; drift first appears in the actual row-local scalar multiply values",
     "layer_1_input_norm_pre_weight_row_reconstructed": "the flat row-local scalar multiply stays shared-good; drift appears only when reconstructing the row-shaped output before the existing post-input-norm path",
 }
@@ -2179,6 +2183,18 @@ def _emit_c45_summary(
             "  -> The row-local `rms_inv` tensor stays shared-good; drift "
             "first appears when replay extracts one scalar per batch row for "
             "the Rust-side scalar-affine equivalent."
+        )
+    elif first_shared_bad == "layer_1_input_norm_last_row_flat_values":
+        emit(
+            "  -> The extracted scalar stays shared-good; drift is already "
+            "present in the selected flat last-row values before either "
+            "multiply path runs."
+        )
+    elif first_shared_bad == "layer_1_input_norm_pre_weight_row_broadcast_output":
+        emit(
+            "  -> The selected flat last row and extracted scalar stay "
+            "shared-good; divergence first appears in the row-shaped "
+            "production `broadcast_mul` output."
         )
     elif first_shared_bad == "layer_1_input_norm_pre_weight_row_scalar_values":
         emit(

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -240,6 +240,8 @@ C44_LAYER1_F32_ROW_TAP_NAMES: Tuple[str, ...] = (
 C45_LAYER1_ROW_TAP_NAMES: Tuple[str, ...] = (
     "layer_1_input_norm_rms_inv_scalar",
     "layer_1_input_norm_rms_inv_scalar_extracted_values",
+    "layer_1_input_norm_last_row_flat_values",
+    "layer_1_input_norm_pre_weight_row_broadcast_output",
     "layer_1_input_norm_pre_weight_row_scalar_values",
     "layer_1_input_norm_pre_weight_row_reconstructed",
 )
@@ -1141,6 +1143,10 @@ def _arm_c45_layer1_row_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List
         taps_out["layer_1_input_norm_rms_inv_scalar_extracted_values"] = (
             rms_inv_row.reshape(-1).contiguous()
         )
+        taps_out["layer_1_input_norm_last_row_flat_values"] = residual_row
+
+        broadcast_output = (residual[:, -1:, :] * rms_inv_row).contiguous()
+        taps_out["layer_1_input_norm_pre_weight_row_broadcast_output"] = broadcast_output
 
         scalar_values = (residual_row * rms_inv_row.reshape(-1, 1)).contiguous()
         taps_out["layer_1_input_norm_pre_weight_row_scalar_values"] = scalar_values


### PR DESCRIPTION
## What changed
- split the C45 last-row RMSNorm multiply path into multiply-local taps around the remaining boundary
- keep the existing `pre_weight_row_scalar_values` and `pre_weight_row_reconstructed` taps, but add:
  - `layer_1_input_norm_last_row_flat_values`
  - `layer_1_input_norm_pre_weight_row_broadcast_output`
- make `pre_weight_row_reconstructed` mean an actual reshape of the flat multiplied values, so the compare flow can distinguish row selection, row-shaped `broadcast_mul`, flat-value multiply, and post-multiply reconstruction
- extend the focused C45 regression in `crates/kiln-model/src/forward.rs` to prove the new intermediates are mutually consistent with the production last-row RMSNorm path on a small multi-batch input
- update the C45 tap-name plumbing in `mtp_debug.rs`, `scripts/mtp_h_main_reference_dump.py`, and `scripts/mtp_compare.py` so the existing C45 dump/compare workflow can consume the new taps

## Why
PR #439 proved the C45 replay helper now matches the production last-row `broadcast_mul` path, but the first shared bad boundary still sat at `layer_1_input_norm_pre_weight_row_scalar_values`. This change keeps the scope strictly inside that multiply path and splits the remaining question into the smallest useful sub-steps.

## Validation
Completed locally:
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- `git diff --check`

Blocked on RunPod capacity / pod health:
- pooled `ce kiln-pod-acquire --gpu-type "NVIDIA RTX A6000"` failed trying to resume hibernated pod `sl53yvx5seviyx` with `There are not enough free GPUs on the host machine to start this pod.`
- pooled fallback `NVIDIA A40` lease returned a ghost pod entry (`zw68eisieczwvd`) that no longer existed in RunPod, so it was released
- direct on-demand launch attempts with kiln image failed or wedged:
  - `NVIDIA RTX A6000`: supply constraint
  - `NVIDIA A40`: launched as `dk7ayuz3xyg7tl` but remained `runtime=null`, then was terminated
  - `NVIDIA A100`: supply constraint
  - `NVIDIA RTX 6000 Ada`: supply constraint
  - `NVIDIA L40S`: supply constraint (`not enough disk space`)
  - `NVIDIA RTX PRO 6000`: supply constraint

Because the required pod-side validation could not be completed, this PR is draft/WIP and does **not** append a new note to `docs/phase-c45/c45-layer1-row-normalization-bisect.md` yet.
