### PR TITLE
Raise Metal skip-layer crossover to 4096

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -150,6 +150,7 @@ enum ResolvedSpeculativeMode {
 
 const MTP_MAX_PROMPT_TOKENS_DEFAULT: usize = 128;
 const LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT: usize = 1024;
+const LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_METAL: usize = 4096;
 const LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS_DEFAULT: usize = 32;
 
 fn native_mtp_enabled_for_metal() -> bool {
@@ -167,6 +168,17 @@ fn native_mtp_allowed_for_state(state: &AppState) -> bool {
     match runner_guard.weights.embed_tokens.device() {
         candle_core::Device::Metal(_) => native_mtp_enabled_for_metal(),
         _ => true,
+    }
+}
+
+fn long_prompt_skip_layer_min_prompt_tokens_for_state(state: &AppState) -> usize {
+    let ModelBackend::Real { runner, .. } = state.backend.as_ref() else {
+        return LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT;
+    };
+    let runner_guard = runner.read().unwrap();
+    match runner_guard.weights.embed_tokens.device() {
+        candle_core::Device::Metal(_) => LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_METAL,
+        _ => LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
     }
 }
 
@@ -190,6 +202,7 @@ fn resolve_speculative_mode_from_config(
     mtp_supported: bool,
     has_active_lora: bool,
     native_mtp_allowed: bool,
+    long_prompt_skip_layer_min_prompt_tokens: usize,
 ) -> ResolvedSpeculativeMode {
     let skip_layer = resolve_skip_layer_config(model_config, speculative);
 
@@ -207,7 +220,7 @@ fn resolve_speculative_mode_from_config(
             {
                 ResolvedSpeculativeMode::Mtp
             } else if greedy_without_lora
-                && prompt_tokens >= LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT
+                && prompt_tokens >= long_prompt_skip_layer_min_prompt_tokens
                 && sampling.max_tokens >= LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS_DEFAULT
             {
                 skip_layer
@@ -236,6 +249,7 @@ fn resolve_speculative_mode(
         mtp_supported,
         has_active_lora,
         native_mtp_allowed_for_state(state),
+        long_prompt_skip_layer_min_prompt_tokens_for_state(state),
     )
 }
 
@@ -1021,6 +1035,7 @@ mod tests {
             false,
             false,
             true,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
         );
 
         match mode {
@@ -1049,6 +1064,7 @@ mod tests {
             true,
             false,
             true,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
         );
         assert!(matches!(greedy, ResolvedSpeculativeMode::Mtp));
 
@@ -1060,6 +1076,7 @@ mod tests {
             true,
             false,
             true,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
         );
         assert!(matches!(sampled, ResolvedSpeculativeMode::Off));
 
@@ -1071,6 +1088,7 @@ mod tests {
             true,
             true,
             true,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
         );
         assert!(matches!(with_lora, ResolvedSpeculativeMode::Off));
 
@@ -1082,6 +1100,7 @@ mod tests {
             true,
             false,
             true,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
         );
         assert!(matches!(long_prompt, ResolvedSpeculativeMode::SkipLayer(_)));
 
@@ -1093,6 +1112,7 @@ mod tests {
             true,
             false,
             true,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
         );
         assert!(matches!(medium_prompt, ResolvedSpeculativeMode::Off));
 
@@ -1106,6 +1126,7 @@ mod tests {
             true,
             false,
             true,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
         );
         assert!(matches!(
             long_prompt_short_output,
@@ -1130,6 +1151,7 @@ mod tests {
             true,
             false,
             false,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
         );
         assert!(matches!(mode, ResolvedSpeculativeMode::Off));
     }
@@ -1150,8 +1172,53 @@ mod tests {
             false,
             false,
             true,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
         );
 
         assert!(matches!(mode, ResolvedSpeculativeMode::Off));
+    }
+
+    #[test]
+    fn mtp_metal_medium_prompt_stays_off_until_4096() {
+        let cfg = SpeculativeDecodingConfig {
+            enabled: true,
+            method: SpecMethod::Mtp,
+            num_speculative_tokens: 4,
+            draft_layers: 8,
+        };
+
+        let mode = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &make_sampling(0.0),
+            2048,
+            true,
+            false,
+            false,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_METAL,
+        );
+        assert!(matches!(mode, ResolvedSpeculativeMode::Off));
+    }
+
+    #[test]
+    fn mtp_metal_4096_prompt_falls_back_to_skip_layer() {
+        let cfg = SpeculativeDecodingConfig {
+            enabled: true,
+            method: SpecMethod::Mtp,
+            num_speculative_tokens: 4,
+            draft_layers: 8,
+        };
+
+        let mode = resolve_speculative_mode_from_config(
+            &ModelConfig::qwen3_5_4b(),
+            &cfg,
+            &make_sampling(0.0),
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_METAL,
+            true,
+            false,
+            false,
+            LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_METAL,
+        );
+        assert!(matches!(mode, ResolvedSpeculativeMode::SkipLayer(_)));
     }
 }

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -929,8 +929,17 @@ fn read_spec_method_from_env() -> SpecMethod {
 }
 
 const BENCH_MTP_MAX_PROMPT_TOKENS: usize = 128;
-const BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS: usize = 1024;
+const BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT: usize = 1024;
+const BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_METAL: usize = 4096;
 const BENCH_LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS: usize = 32;
+
+fn bench_long_prompt_skip_layer_min_prompt_tokens(backend_name: &str) -> usize {
+    if backend_name == "metal" {
+        BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_METAL
+    } else {
+        BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT
+    }
+}
 
 fn bench_native_mtp_allowed(backend_name: &str) -> bool {
     if backend_name == "metal" {
@@ -970,6 +979,7 @@ fn resolve_bench_spec_method(
         temperature,
         mtp_supported,
         bench_native_mtp_allowed(backend_name),
+        bench_long_prompt_skip_layer_min_prompt_tokens(backend_name),
         bench_force_raw_mtp(),
     )
 }
@@ -981,6 +991,7 @@ fn resolve_bench_spec_method_with_force(
     temperature: f32,
     mtp_supported: bool,
     native_mtp_allowed: bool,
+    long_prompt_skip_layer_min_prompt_tokens: usize,
     force_raw_mtp: bool,
 ) -> SpecMethod {
     match configured {
@@ -998,7 +1009,7 @@ fn resolve_bench_spec_method_with_force(
             {
                 SpecMethod::Mtp
             } else if greedy
-                && requested_prompt_tokens >= BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS
+                && requested_prompt_tokens >= long_prompt_skip_layer_min_prompt_tokens
                 && max_output_tokens >= BENCH_LONG_PROMPT_SKIP_LAYER_MIN_OUTPUT_TOKENS
             {
                 SpecMethod::SkipLayer
@@ -1016,7 +1027,16 @@ mod tests {
     #[test]
     fn bench_mtp_short_prompt_stays_mtp() {
         assert_eq!(
-            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 128, 64, 0.0, true, true, false),
+            resolve_bench_spec_method_with_force(
+                SpecMethod::Mtp,
+                128,
+                64,
+                0.0,
+                true,
+                true,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
+                false
+            ),
             SpecMethod::Mtp
         );
     }
@@ -1026,11 +1046,12 @@ mod tests {
         assert_eq!(
             resolve_bench_spec_method_with_force(
                 SpecMethod::Mtp,
-                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
                 64,
                 0.0,
                 true,
                 true,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
                 false
             ),
             SpecMethod::SkipLayer
@@ -1042,11 +1063,12 @@ mod tests {
         assert_eq!(
             resolve_bench_spec_method_with_force(
                 SpecMethod::Mtp,
-                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
                 31,
                 0.0,
                 true,
                 true,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
                 false
             ),
             SpecMethod::Off
@@ -1054,11 +1076,12 @@ mod tests {
         assert_eq!(
             resolve_bench_spec_method_with_force(
                 SpecMethod::Mtp,
-                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
                 64,
                 0.7,
                 true,
                 true,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
                 false
             ),
             SpecMethod::Off
@@ -1068,7 +1091,16 @@ mod tests {
     #[test]
     fn bench_mtp_medium_prompt_stays_off_until_skip_layer_crossover() {
         assert_eq!(
-            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 512, 64, 0.0, true, true, false),
+            resolve_bench_spec_method_with_force(
+                SpecMethod::Mtp,
+                512,
+                64,
+                0.0,
+                true,
+                true,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
+                false
+            ),
             SpecMethod::Off
         );
     }
@@ -1076,7 +1108,16 @@ mod tests {
     #[test]
     fn bench_mtp_short_prompt_stays_off_when_native_mtp_is_disallowed() {
         assert_eq!(
-            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 64, 64, 0.0, true, false, false),
+            resolve_bench_spec_method_with_force(
+                SpecMethod::Mtp,
+                64,
+                64,
+                0.0,
+                true,
+                false,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
+                false
+            ),
             SpecMethod::Off
         );
     }
@@ -1084,8 +1125,51 @@ mod tests {
     #[test]
     fn bench_force_raw_mtp_bypasses_shape_routing() {
         assert_eq!(
-            resolve_bench_spec_method_with_force(SpecMethod::Mtp, 8192, 64, 0.0, true, false, true),
+            resolve_bench_spec_method_with_force(
+                SpecMethod::Mtp,
+                8192,
+                64,
+                0.0,
+                true,
+                false,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_DEFAULT,
+                true
+            ),
             SpecMethod::Mtp
+        );
+    }
+
+    #[test]
+    fn bench_mtp_metal_medium_prompt_stays_off_until_4096() {
+        assert_eq!(
+            resolve_bench_spec_method_with_force(
+                SpecMethod::Mtp,
+                2048,
+                64,
+                0.0,
+                true,
+                false,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_METAL,
+                false
+            ),
+            SpecMethod::Off
+        );
+    }
+
+    #[test]
+    fn bench_mtp_metal_4096_prompt_falls_back_to_skip_layer() {
+        assert_eq!(
+            resolve_bench_spec_method_with_force(
+                SpecMethod::Mtp,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_METAL,
+                64,
+                0.0,
+                true,
+                false,
+                BENCH_LONG_PROMPT_SKIP_LAYER_MIN_PROMPT_TOKENS_METAL,
+                false
+            ),
+            SpecMethod::SkipLayer
         );
     }
 }


### PR DESCRIPTION
## Summary
- make MTP-to-skip-layer routing backend-aware instead of using a single 1024-token crossover everywhere
- keep the existing 1024 crossover for non-Metal backends
- raise the Metal crossover to 4096 in both the server path and `kiln-bench`, with matching unit coverage

## Why
On macOS Metal, the current desktop-default env (`KILN_SPEC_METHOD=mtp`) was routing 2048-token prompts into skip-layer speculation even though that band performs catastrophically:

- `2048` prompt, default routing before this patch: resolved to `skip_layer`, `α=0.003`, `227.27s` real
- same `2048` prompt with `KILN_SPEC_METHOD=off`: `38.40s` real
- `4096` prompt, skip-layer is healthy again: `α=1.0`, `42.97s` real
- same `4096` prompt with `off`: `61.96s` real

That pins the bad band to roughly `1024..4095` on Metal. This patch stops desktop defaults from falling into that region while preserving skip-layer where it is actually faster.

## Validation
- `cargo test -p kiln-server --release --locked mtp_ --target-dir /private/tmp/kiln-perf-followup-target -- --nocapture`
- `KILN_INFERENCE_MEMORY_FRACTION=0.7 KILN_KV_CACHE_FP8=0 KILN_CUDA_GRAPHS=0 KILN_PREFIX_CACHE_ENABLED=1 KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp /usr/bin/time -l /private/tmp/kiln-perf-followup-target/release/kiln-bench --model-path /private/tmp/qwen3.5-4b --paged --prompt-tokens 2048 --max-output-tokens 64 --skip-training --latency-only`
  - after patch: resolves to `Off`, `38.24s` real
