### PR TITLE
phase6: resolve C45 row scalar replay boundary

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1802,13 +1802,7 @@ fn c45_layer1_row_replay_tensors(
     let last_row_values = last_row.reshape((batch, hidden))?.contiguous()?;
     let broadcast_output = last_row.broadcast_mul(&rms_inv_row)?.contiguous()?;
 
-    let mut flat_rows = Vec::with_capacity(batch);
-    for batch_idx in 0..batch {
-        let row = last_row_values.narrow(0, batch_idx, 1)?;
-        flat_rows.push(row.affine(extracted_scalar_values[batch_idx] as f64, 0.0)?);
-    }
-    let flat_row_refs: Vec<&Tensor> = flat_rows.iter().collect();
-    let scalar_values = Tensor::cat(&flat_row_refs, 0)?.contiguous()?;
+    let scalar_values = broadcast_output.reshape((batch, hidden))?.contiguous()?;
     let reconstructed = scalar_values.reshape((batch, 1, hidden))?.contiguous()?;
     Ok((
         rms_inv_row,
@@ -1823,9 +1817,9 @@ fn c45_layer1_row_replay_tensors(
 /// Phase C45: keep the audit strictly inside the previously-bad row-local
 /// scalar multiply so the replay dump can distinguish "the row-local scalar
 /// tensor is fine", "the scalar extraction path already drifts", "the actual
-/// multiply introduces the drift", or "the multiplied flat row stays
-/// shared-good and divergence only appears when reconstructing the row-shaped
-/// output".
+/// multiply introduces the drift", or "the flattened production multiply
+/// output stays shared-good and divergence only appears when reconstructing the
+/// row-shaped output".
 fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
     let (
         rms_inv_row,

--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -115,3 +115,42 @@ So production-op parity for the replay path does **not** move the first-bad
 boundary past the row-local scalar multiply on current `main`; C45 remains
 localized to the multiply itself, and this task stops here without widening the
 tap contract.
+
+## 2026-04-23 row-scalar boundary resolution
+
+Fresh preflight on current `origin/main` (`edcc275`, with PRs #445 and #446)
+confirmed that the latest checked-in C45 verdict still named
+`layer_1_input_norm_pre_weight_row_scalar_values` as the earliest shared bad
+tap after the broadcast-mul parity rerun.
+
+The split-tap ordering added by PR #441 exposed that the previous
+`layer_1_input_norm_pre_weight_row_scalar_values` boundary was partly an
+audit-helper artifact: the helper independently recomputed a flattened
+scalar-affine row even though the production path had already produced the
+row-shaped `broadcast_mul` output. The helper and HF mirror now derive the
+flattened tap directly from that production-shaped output, so the flat tap no
+longer answers a different question from the preceding broadcast tap.
+
+Fresh representative C45 reruns on the fallback A100 pod then moved the
+earliest shared bad tap backward to the real production row-shaped multiply:
+
+- seed 0 (`mtp_pos=0`, `step=1`):
+  `layer_1_input_norm_pre_weight_row_broadcast_output`; last shared-good tap =
+  `layer_1_input_norm_last_row_flat_values`; prompt=494,
+  prefill=`1390.24 ms`, decode=`36.73 tok/s`, `alpha=0.7162`
+- seed 1 (`mtp_pos=2`, `step=1`):
+  `layer_1_input_norm_pre_weight_row_broadcast_output`; last shared-good tap =
+  `layer_1_input_norm_last_row_flat_values`; prompt=508,
+  prefill=`430.97 ms`, decode=`25.00 tok/s`, `alpha=0.2828`
+
+Resolved verdict: the old flat row-scalar boundary should not be treated as a
+standalone production bug, but C45 is not fully cleared. The next real target is
+the production RMSNorm row-shaped `broadcast_mul` result, because both seeds
+agree that the selected last-row values and row-local scalar remain shared-good
+under the current C45 tolerance, while the production multiply output is the
+first shared bad tap.
+
+Evidence:
+
+- `profiling-artifacts/c45_resolution_seed0_compare.txt`
+- `profiling-artifacts/c45_resolution_seed1_compare.txt`

--- a/profiling-artifacts/c45_resolution_seed0_compare.txt
+++ b/profiling-artifacts/c45_resolution_seed0_compare.txt
@@ -1,0 +1,43 @@
+MTP numerical bisect — mode: layer-1 row-local scalar-multiply audit (C45), atol=0.01, rtol=0.1
+  kiln dump : profiling-artifacts/c45_resolution_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : profiling-artifacts/c45_resolution_seed0_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 8, 16, 23, 31] ref=[0, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   1.14e-01     1.14e-01    
+c45__layer_1_input_norm_rms_inv_scalar_extracted_values 1                      True     True     1.00e+00   1.14e-01     1.14e-01    
+c45__layer_1_input_norm_last_row_flat_values 1x2560                 True     True     9.99e-01   1.56e-02     1.59e-03    
+c45__layer_1_input_norm_pre_weight_row_broadcast_output 1x1x2560               True     False    9.99e-01   1.38e-01     3.19e-02    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     False    9.99e-01   1.38e-01     3.19e-02    
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     False    9.99e-01   1.38e-01     3.19e-02    
+
+  pair verdict: first divergence at tap 'c45__layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar stay shared-good; drift first appears in the row-shaped production broadcast_mul output
+
+==============================================================================
+Phase C45 layer-1 row-local scalar-multiply audit — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                                                                                                 
+  ----------------------------------------------------------------------------------------------------
+  layer_1_input_norm_rms_inv_scalar               cos=1.00e+00   max|Δ|=1.14e-01   mean|Δ|=1.14e-01   rel_l2=5.69e-03   ok 
+  layer_1_input_norm_rms_inv_scalar_extracted_valuescos=1.00e+00   max|Δ|=1.14e-01   mean|Δ|=1.14e-01   rel_l2=5.69e-03   ok 
+  layer_1_input_norm_last_row_flat_values         cos=9.99e-01   max|Δ|=1.56e-02   mean|Δ|=1.59e-03   rel_l2=4.03e-02   ok 
+  layer_1_input_norm_pre_weight_row_broadcast_outputcos=9.99e-01   max|Δ|=1.38e-01   mean|Δ|=3.19e-02   rel_l2=4.00e-02   DIV
+  layer_1_input_norm_pre_weight_row_scalar_values cos=9.99e-01   max|Δ|=1.38e-01   mean|Δ|=3.19e-02   rel_l2=4.00e-02   DIV
+  layer_1_input_norm_pre_weight_row_reconstructed cos=9.99e-01   max|Δ|=1.38e-01   mean|Δ|=3.19e-02   rel_l2=4.00e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight_row_broadcast_output'
+  last shared-good tap: 'layer_1_input_norm_last_row_flat_values'
+Phase C45 verdict: EARLIEST SHARED BAD ROW-LOCAL SCALAR-MULTIPLY TAP = 'layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar stay shared-good; drift first appears in the row-shaped production broadcast_mul output
+  -> The selected flat last row and extracted scalar stay shared-good; divergence first appears in the row-shaped production `broadcast_mul` output.
+
+Overall verdict: divergence(s) at: ['c45__layer_1_input_norm_pre_weight_row_broadcast_output']
+

--- a/profiling-artifacts/c45_resolution_seed1_compare.txt
+++ b/profiling-artifacts/c45_resolution_seed1_compare.txt
@@ -1,0 +1,43 @@
+MTP numerical bisect — mode: layer-1 row-local scalar-multiply audit (C45), atol=0.01, rtol=0.1
+  kiln dump : profiling-artifacts/c45_resolution_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : profiling-artifacts/c45_resolution_seed1_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 8, 16, 23, 31] ref=[0, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   1.59e-02     1.59e-02    
+c45__layer_1_input_norm_rms_inv_scalar_extracted_values 1                      True     True     1.00e+00   1.59e-02     1.59e-02    
+c45__layer_1_input_norm_last_row_flat_values 1x2560                 True     True     9.99e-01   6.10e-03     1.34e-03    
+c45__layer_1_input_norm_pre_weight_row_broadcast_output 1x1x2560               True     False    9.99e-01   1.43e-01     3.14e-02    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     False    9.99e-01   1.43e-01     3.14e-02    
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     False    9.99e-01   1.43e-01     3.14e-02    
+
+  pair verdict: first divergence at tap 'c45__layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar stay shared-good; drift first appears in the row-shaped production broadcast_mul output
+
+==============================================================================
+Phase C45 layer-1 row-local scalar-multiply audit — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                                                                                                 
+  ----------------------------------------------------------------------------------------------------
+  layer_1_input_norm_rms_inv_scalar               cos=1.00e+00   max|Δ|=1.59e-02   mean|Δ|=1.59e-02   rel_l2=6.77e-04   ok 
+  layer_1_input_norm_rms_inv_scalar_extracted_valuescos=1.00e+00   max|Δ|=1.59e-02   mean|Δ|=1.59e-02   rel_l2=6.77e-04   ok 
+  layer_1_input_norm_last_row_flat_values         cos=9.99e-01   max|Δ|=6.10e-03   mean|Δ|=1.34e-03   rel_l2=3.93e-02   ok 
+  layer_1_input_norm_pre_weight_row_broadcast_outputcos=9.99e-01   max|Δ|=1.43e-01   mean|Δ|=3.14e-02   rel_l2=3.93e-02   DIV
+  layer_1_input_norm_pre_weight_row_scalar_values cos=9.99e-01   max|Δ|=1.43e-01   mean|Δ|=3.14e-02   rel_l2=3.93e-02   DIV
+  layer_1_input_norm_pre_weight_row_reconstructed cos=9.99e-01   max|Δ|=1.43e-01   mean|Δ|=3.14e-02   rel_l2=3.93e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight_row_broadcast_output'
+  last shared-good tap: 'layer_1_input_norm_last_row_flat_values'
+Phase C45 verdict: EARLIEST SHARED BAD ROW-LOCAL SCALAR-MULTIPLY TAP = 'layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar stay shared-good; drift first appears in the row-shaped production broadcast_mul output
+  -> The selected flat last row and extracted scalar stay shared-good; divergence first appears in the row-shaped production `broadcast_mul` output.
+
+Overall verdict: divergence(s) at: ['c45__layer_1_input_norm_pre_weight_row_broadcast_output']
+

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -384,7 +384,7 @@ C45_HYPOTHESIS: Dict[str, str] = {
     "layer_1_input_norm_rms_inv_scalar_extracted_values": "the row-local scalar tensor stays shared-good, but the scalar extraction path diverges before the multiply runs",
     "layer_1_input_norm_last_row_flat_values": "the extracted scalar stays shared-good, but the selected last-row flat values already drift before the multiply runs",
     "layer_1_input_norm_pre_weight_row_broadcast_output": "the selected row and extracted scalar stay shared-good; drift first appears in the row-shaped production broadcast_mul output",
-    "layer_1_input_norm_pre_weight_row_scalar_values": "the scalar tensor and extracted scalar stay shared-good; drift first appears in the actual row-local scalar multiply values",
+    "layer_1_input_norm_pre_weight_row_scalar_values": "the production broadcast output stays shared-good; drift first appears only in the audit-only flattened replay of that output",
     "layer_1_input_norm_pre_weight_row_reconstructed": "the flat row-local scalar multiply stays shared-good; drift appears only when reconstructing the row-shaped output before the existing post-input-norm path",
 }
 
@@ -2198,9 +2198,9 @@ def _emit_c45_summary(
         )
     elif first_shared_bad == "layer_1_input_norm_pre_weight_row_scalar_values":
         emit(
-            "  -> The row-local `rms_inv` tensor and its extracted scalar "
-            "stay shared-good; divergence first appears in the flat "
-            "row-local scalar multiply values."
+            "  -> The row-shaped production `broadcast_mul` output stays "
+            "shared-good; divergence first appears only in the flattened "
+            "audit replay of that already-good production output."
         )
     elif first_shared_bad == "layer_1_input_norm_pre_weight_row_reconstructed":
         emit(

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -1148,7 +1148,7 @@ def _arm_c45_layer1_row_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List
         broadcast_output = (residual[:, -1:, :] * rms_inv_row).contiguous()
         taps_out["layer_1_input_norm_pre_weight_row_broadcast_output"] = broadcast_output
 
-        scalar_values = (residual_row * rms_inv_row.reshape(-1, 1)).contiguous()
+        scalar_values = broadcast_output.reshape(residual.shape[0], residual.shape[-1]).contiguous()
         taps_out["layer_1_input_norm_pre_weight_row_scalar_values"] = scalar_values
         taps_out["layer_1_input_norm_pre_weight_row_reconstructed"] = (
             scalar_values.reshape(residual.shape[0], 1, residual.shape[-1]).contiguous()


### PR DESCRIPTION
## Summary
- resolve the C45 row-local scalar boundary without opening C46 by removing the audit-only scalar-affine recomputation from `c45_layer1_row_replay_tensors(...)`
- derive `layer_1_input_norm_pre_weight_row_scalar_values` from the already-captured production-shaped `broadcast_mul` output in both Rust and the HF mirror
- update C45 comparator wording/docs and add fresh two-seed compare evidence showing the boundary moves from the old flat row-scalar replay tap to `layer_1_input_norm_pre_weight_row_broadcast_output`

## Verdict
The old `layer_1_input_norm_pre_weight_row_scalar_values` boundary was partly an audit-helper artifact: it independently recomputed a flattened scalar-affine row instead of flattening the production row-shaped output.

After fixing that helper/HF mirror mismatch, C45 is not fully cleared. Fresh seed 0 and seed 1 compares now agree that the next real production boundary is `layer_1_input_norm_pre_weight_row_broadcast_output`. The selected last-row values and row-local scalar remain shared-good under the current C45 tolerance; the row-shaped RMSNorm `broadcast_mul` output is the first shared bad tap.

## Validation
GPU/image:
- pool attempts: A6000 resume failed for host capacity; A40 resume failed for host capacity; RTX 6000 Ada unavailable; L40S allocated but did not become SSH-ready within `runpod_api.py wait`
- completed validation on fallback `NVIDIA A100 80GB PCIe`, image `ghcr.io/ericflo/kiln-runpod:latest`
- note: the task's `KILN_CUDA_ARCHS=86` command was attempted on A100 and failed the representative bench in `kiln_fused_rmsnorm` because A100 is sm80; the evidence rerun rebuilt with `KILN_CUDA_ARCHS=80` for that fallback GPU

Commands run:
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- `rg -n "layer_1_input_norm_pre_weight_row_scalar_values|c45_layer1_row_replay_tensors|capture_c45_layer1_row_taps" crates/kiln-model/src/forward.rs scripts docs`
- `KILN_CUDA_ARCHS=86 KILN_W4A16=1 KILN_CUDA_GRAPHS=true cargo build --release --features cuda --bin kiln-bench`
- `KILN_CUDA_ARCHS=86 KILN_W4A16=1 KILN_CUDA_GRAPHS=true cargo test --locked -p kiln-model c45 -- --nocapture`
- `KILN_CUDA_ARCHS=80 KILN_W4A16=1 KILN_CUDA_GRAPHS=true cargo build --release --features cuda --bin kiln-bench`
- seed 0 and seed 1 `kiln-bench` C45 capture reruns with the existing tap contract
- `python3 scripts/mtp_h_main_reference_dump.py --c45-taps ...` for seed 0 `mtp_pos=0/step=1` and seed 1 `mtp_pos=2/step=1`
- `python3 scripts/mtp_compare.py --c45 ... --out profiling-artifacts/c45_resolution_seed{0,1}_compare.txt`

Seed metrics:
- seed 0: prompt=494, prefill=`1390.24 ms`, decode=`36.73 tok/s`, alpha=`0.7162`; earliest-bad before=`layer_1_input_norm_pre_weight_row_scalar_values`, after=`layer_1_input_norm_pre_weight_row_broadcast_output`
- seed 1: prompt=508, prefill=`430.97 ms`, decode=`25.00 tok/s`, alpha=`0.2828`; earliest-bad before=`layer_1_input_norm_pre_weight_row_scalar_values`, after=`layer_1_input_norm_pre_weight_row_broadcast_output`

Pod cleanup:
- released A100 lease `pod-a252793337e1cfca40bd49e4`
- released L40S lease `pod-e5d4f7cede34bba2d4c4a568` after SSH readiness timeout
