### PR TITLE
phase6: resolve C45 broadcast multiply boundary

### DIFF
--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -154,3 +154,38 @@ Evidence:
 
 - `profiling-artifacts/c45_resolution_seed0_compare.txt`
 - `profiling-artifacts/c45_resolution_seed1_compare.txt`
+
+## 2026-04-23 row-shaped broadcast-mul boundary verdict
+
+Fresh preflight on current `origin/main` (`4512877`, with later unrelated Metal
+PR #449 also present) confirmed that PR #448 is merged and that the checked-in
+C45 evidence still names `layer_1_input_norm_pre_weight_row_broadcast_output`
+as the earliest shared bad tap, with
+`layer_1_input_norm_last_row_flat_values` as the last shared-good tap.
+
+A fresh A100 fallback rerun kept that tap ordering on both representative
+seeds, but the added C45 operand diagnostic closes the boundary as operand-drift
+amplification rather than an independent production `broadcast_mul` bug:
+
+- seed 0 (`profiling-artifacts/c45_broadcast_seed0_compare.txt`): earliest
+  shared bad tap = `layer_1_input_norm_pre_weight_row_broadcast_output`; last
+  shared-good tap = `layer_1_input_norm_last_row_flat_values`; same-side product
+  residuals are tiny (`kiln max=8.34e-07`, `ref max=7.15e-07`); predicted
+  product max diff equals observed output max diff (`1.38e-01`); prompt=494,
+  prefill=`7671.88 ms`, decode=`44.90 tok/s`, `alpha=0.6842`.
+- seed 1 (`profiling-artifacts/c45_broadcast_seed1_compare.txt`): earliest
+  shared bad tap = `layer_1_input_norm_pre_weight_row_broadcast_output`; last
+  shared-good tap = `layer_1_input_norm_last_row_flat_values`; same-side product
+  residuals are tiny (`kiln max=1.19e-06`, `ref max=1.73e-06`); predicted
+  product max diff equals observed output max diff (`1.43e-01`); prompt=508,
+  prefill=`361.04 ms`, decode=`28.74 tok/s`, `alpha=0.2929`.
+
+Resolved verdict: the row-shaped broadcast multiply is not currently evidence
+of a production RMSNorm shape/casting bug or an HF mirror mismatch. Both sides'
+`broadcast_mul` outputs are exactly explained by their own captured row and
+scalar operands; the apparent first-bad multiply output is the current C45
+allclose threshold exposing amplified but previously tolerated operand drift.
+The next exact target is therefore the upstream operand drift budget feeding
+this multiply, starting with the row-local RMS scalar / selected last-row
+provenance under a tighter C45 tolerance or a new operand-error-budget tap, not
+a production `broadcast_mul` code change.

--- a/profiling-artifacts/c45_broadcast_seed0_compare.txt
+++ b/profiling-artifacts/c45_broadcast_seed0_compare.txt
@@ -1,0 +1,48 @@
+MTP numerical bisect — mode: layer-1 row-local scalar-multiply audit (C45), atol=0.01, rtol=0.1
+
+=== seed0 ===
+  kiln dump : profiling-artifacts/c45_broadcast_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : profiling-artifacts/c45_broadcast_seed0_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 8, 16, 23, 31] ref=[0, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   1.14e-01     1.14e-01    
+c45__layer_1_input_norm_rms_inv_scalar_extracted_values 1                      True     True     1.00e+00   1.14e-01     1.14e-01    
+c45__layer_1_input_norm_last_row_flat_values 1x2560                 True     True     9.99e-01   1.56e-02     1.59e-03    
+c45__layer_1_input_norm_pre_weight_row_broadcast_output 1x1x2560               True     False    9.99e-01   1.38e-01     3.19e-02    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     False    9.99e-01   1.38e-01     3.19e-02    
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     False    9.99e-01   1.38e-01     3.19e-02    
+
+  pair verdict: first divergence at tap 'c45__layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar pass the current tolerance separately; the product exposes operand-drift amplification unless the C45 operand diagnostic shows a same-side multiply residual
+  C45 broadcast operand diagnostic:
+    same-side product residual: kiln max=8.34e-07 mean=8.36e-09; ref max=7.15e-07 mean=8.19e-09
+    cross-side operand drift: row max=1.56e-02; scalar max=1.14e-01; predicted product max=1.38e-01; observed output max=1.38e-01; operand-bound max=5.66e-01
+    interpretation: if same-side residual is near zero and observed output matches the predicted product, this boundary is operand-drift amplification, not an independent broadcast multiply mismatch.
+
+==============================================================================
+Phase C45 layer-1 row-local scalar-multiply audit — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                                             seed0                                               
+  ----------------------------------------------------------------------------------------------------
+  layer_1_input_norm_rms_inv_scalar               cos=1.00e+00   max|Δ|=1.14e-01   mean|Δ|=1.14e-01   rel_l2=5.69e-03   ok 
+  layer_1_input_norm_rms_inv_scalar_extracted_valuescos=1.00e+00   max|Δ|=1.14e-01   mean|Δ|=1.14e-01   rel_l2=5.69e-03   ok 
+  layer_1_input_norm_last_row_flat_values         cos=9.99e-01   max|Δ|=1.56e-02   mean|Δ|=1.59e-03   rel_l2=4.03e-02   ok 
+  layer_1_input_norm_pre_weight_row_broadcast_outputcos=9.99e-01   max|Δ|=1.38e-01   mean|Δ|=3.19e-02   rel_l2=4.00e-02   DIV
+  layer_1_input_norm_pre_weight_row_scalar_values cos=9.99e-01   max|Δ|=1.38e-01   mean|Δ|=3.19e-02   rel_l2=4.00e-02   DIV
+  layer_1_input_norm_pre_weight_row_reconstructed cos=9.99e-01   max|Δ|=1.38e-01   mean|Δ|=3.19e-02   rel_l2=4.00e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight_row_broadcast_output'
+  last shared-good tap: 'layer_1_input_norm_last_row_flat_values'
+Phase C45 verdict: EARLIEST SHARED BAD ROW-LOCAL SCALAR-MULTIPLY TAP = 'layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar pass the current tolerance separately; the product exposes operand-drift amplification unless the C45 operand diagnostic shows a same-side multiply residual
+  -> The selected flat last row and extracted scalar pass the current tolerance separately; use the C45 broadcast operand diagnostic above to distinguish a real same-side multiply residual from operand-drift amplification.
+
+Overall verdict: divergence(s) at: ['c45__layer_1_input_norm_pre_weight_row_broadcast_output']

--- a/profiling-artifacts/c45_broadcast_seed1_compare.txt
+++ b/profiling-artifacts/c45_broadcast_seed1_compare.txt
@@ -1,0 +1,48 @@
+MTP numerical bisect — mode: layer-1 row-local scalar-multiply audit (C45), atol=0.01, rtol=0.1
+
+=== seed1 ===
+  kiln dump : profiling-artifacts/c45_broadcast_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : profiling-artifacts/c45_broadcast_seed1_ref.safetensors
+Metadata:
+  meta__draft_token_id: kiln=3202 ref=3202 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 8, 16, 23, 31] ref=[0, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   1.59e-02     1.59e-02    
+c45__layer_1_input_norm_rms_inv_scalar_extracted_values 1                      True     True     1.00e+00   1.59e-02     1.59e-02    
+c45__layer_1_input_norm_last_row_flat_values 1x2560                 True     True     9.99e-01   6.10e-03     1.34e-03    
+c45__layer_1_input_norm_pre_weight_row_broadcast_output 1x1x2560               True     False    9.99e-01   1.43e-01     3.14e-02    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     False    9.99e-01   1.43e-01     3.14e-02    
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     False    9.99e-01   1.43e-01     3.14e-02    
+
+  pair verdict: first divergence at tap 'c45__layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar pass the current tolerance separately; the product exposes operand-drift amplification unless the C45 operand diagnostic shows a same-side multiply residual
+  C45 broadcast operand diagnostic:
+    same-side product residual: kiln max=1.19e-06 mean=7.48e-09; ref max=1.73e-06 mean=7.67e-09
+    cross-side operand drift: row max=6.10e-03; scalar max=1.59e-02; predicted product max=1.43e-01; observed output max=1.43e-01; operand-bound max=1.43e-01
+    interpretation: if same-side residual is near zero and observed output matches the predicted product, this boundary is operand-drift amplification, not an independent broadcast multiply mismatch.
+
+==============================================================================
+Phase C45 layer-1 row-local scalar-multiply audit — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                                             seed1                                               
+  ----------------------------------------------------------------------------------------------------
+  layer_1_input_norm_rms_inv_scalar               cos=1.00e+00   max|Δ|=1.59e-02   mean|Δ|=1.59e-02   rel_l2=6.77e-04   ok 
+  layer_1_input_norm_rms_inv_scalar_extracted_valuescos=1.00e+00   max|Δ|=1.59e-02   mean|Δ|=1.59e-02   rel_l2=6.77e-04   ok 
+  layer_1_input_norm_last_row_flat_values         cos=9.99e-01   max|Δ|=6.10e-03   mean|Δ|=1.34e-03   rel_l2=3.93e-02   ok 
+  layer_1_input_norm_pre_weight_row_broadcast_outputcos=9.99e-01   max|Δ|=1.43e-01   mean|Δ|=3.14e-02   rel_l2=3.93e-02   DIV
+  layer_1_input_norm_pre_weight_row_scalar_values cos=9.99e-01   max|Δ|=1.43e-01   mean|Δ|=3.14e-02   rel_l2=3.93e-02   DIV
+  layer_1_input_norm_pre_weight_row_reconstructed cos=9.99e-01   max|Δ|=1.43e-01   mean|Δ|=3.14e-02   rel_l2=3.93e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight_row_broadcast_output'
+  last shared-good tap: 'layer_1_input_norm_last_row_flat_values'
+Phase C45 verdict: EARLIEST SHARED BAD ROW-LOCAL SCALAR-MULTIPLY TAP = 'layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar pass the current tolerance separately; the product exposes operand-drift amplification unless the C45 operand diagnostic shows a same-side multiply residual
+  -> The selected flat last row and extracted scalar pass the current tolerance separately; use the C45 broadcast operand diagnostic above to distinguish a real same-side multiply residual from operand-drift amplification.
+
+Overall verdict: divergence(s) at: ['c45__layer_1_input_norm_pre_weight_row_broadcast_output']

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -383,7 +383,7 @@ C45_HYPOTHESIS: Dict[str, str] = {
     "layer_1_input_norm_rms_inv_scalar": "the row-local RMS inverse scalar tensor itself diverges even though PR #433 kept this boundary shared-good",
     "layer_1_input_norm_rms_inv_scalar_extracted_values": "the row-local scalar tensor stays shared-good, but the scalar extraction path diverges before the multiply runs",
     "layer_1_input_norm_last_row_flat_values": "the extracted scalar stays shared-good, but the selected last-row flat values already drift before the multiply runs",
-    "layer_1_input_norm_pre_weight_row_broadcast_output": "the selected row and extracted scalar stay shared-good; drift first appears in the row-shaped production broadcast_mul output",
+    "layer_1_input_norm_pre_weight_row_broadcast_output": "the selected row and extracted scalar pass the current tolerance separately; the product exposes operand-drift amplification unless the C45 operand diagnostic shows a same-side multiply residual",
     "layer_1_input_norm_pre_weight_row_scalar_values": "the production broadcast output stays shared-good; drift first appears only in the audit-only flattened replay of that output",
     "layer_1_input_norm_pre_weight_row_reconstructed": "the flat row-local scalar multiply stays shared-good; drift appears only when reconstructing the row-shaped output before the existing post-input-norm path",
 }
@@ -572,6 +572,80 @@ def _compare_tap(
         row["rel_l2"] = float(np.linalg.norm(diff.reshape(-1)) / ref_norm)
     return row
 
+
+
+def _same_side_c45_product_diagnostic(
+    tensors: Dict[str, np.ndarray],
+) -> Optional[Tuple[float, float]]:
+    row = tensors.get("c45__layer_1_input_norm_last_row_flat_values")
+    scalar = tensors.get("c45__layer_1_input_norm_rms_inv_scalar_extracted_values")
+    output = tensors.get("c45__layer_1_input_norm_pre_weight_row_broadcast_output")
+    if row is None or scalar is None or output is None:
+        return None
+    if row.ndim != 2 or scalar.ndim != 1:
+        return None
+    expected_shape = (row.shape[0], 1, row.shape[1])
+    if output.shape != expected_shape or scalar.shape[0] != row.shape[0]:
+        return None
+
+    predicted = row.astype(np.float64) * scalar.astype(np.float64).reshape(-1, 1)
+    actual = output.reshape(row.shape).astype(np.float64)
+    diff = np.abs(predicted - actual)
+    max_abs = float(diff.max()) if diff.size else 0.0
+    mean_abs = float(diff.mean()) if diff.size else 0.0
+    return max_abs, mean_abs
+
+
+def _c45_operand_product_bound_diagnostic(
+    kiln_tensors: Dict[str, np.ndarray],
+    ref_tensors: Dict[str, np.ndarray],
+) -> Optional[Dict[str, float]]:
+    kiln_row = kiln_tensors.get("c45__layer_1_input_norm_last_row_flat_values")
+    kiln_scalar = kiln_tensors.get("c45__layer_1_input_norm_rms_inv_scalar_extracted_values")
+    kiln_output = kiln_tensors.get("c45__layer_1_input_norm_pre_weight_row_broadcast_output")
+    ref_row = ref_tensors.get("c45__layer_1_input_norm_last_row_flat_values")
+    ref_scalar = ref_tensors.get("c45__layer_1_input_norm_rms_inv_scalar_extracted_values")
+    ref_output = ref_tensors.get("c45__layer_1_input_norm_pre_weight_row_broadcast_output")
+    if (
+        kiln_row is None
+        or kiln_scalar is None
+        or kiln_output is None
+        or ref_row is None
+        or ref_scalar is None
+        or ref_output is None
+    ):
+        return None
+    if kiln_row.shape != ref_row.shape or kiln_scalar.shape != ref_scalar.shape:
+        return None
+    if kiln_row.ndim != 2 or kiln_scalar.ndim != 1:
+        return None
+    expected_output_shape = (kiln_row.shape[0], 1, kiln_row.shape[1])
+    if kiln_output.shape != expected_output_shape or ref_output.shape != expected_output_shape:
+        return None
+
+    kr = kiln_row.astype(np.float64)
+    rr = ref_row.astype(np.float64)
+    ks = kiln_scalar.astype(np.float64).reshape(-1, 1)
+    rs = ref_scalar.astype(np.float64).reshape(-1, 1)
+    ko = kiln_output.reshape(kr.shape).astype(np.float64)
+    ro = ref_output.reshape(rr.shape).astype(np.float64)
+
+    predicted_kiln = kr * ks
+    predicted_ref = rr * rs
+    product_diff = np.abs(predicted_kiln - predicted_ref)
+    output_diff = np.abs(ko - ro)
+    row_diff = np.abs(kr - rr)
+    scalar_diff = np.abs(ks - rs)
+    bound = row_diff * np.abs(ks) + np.abs(rr) * scalar_diff
+    side_residual = np.maximum(np.abs(predicted_kiln - ko), np.abs(predicted_ref - ro))
+    return {
+        "row_max_abs_diff": float(row_diff.max()) if row_diff.size else 0.0,
+        "scalar_max_abs_diff": float(scalar_diff.max()) if scalar_diff.size else 0.0,
+        "product_max_abs_diff": float(product_diff.max()) if product_diff.size else 0.0,
+        "output_max_abs_diff": float(output_diff.max()) if output_diff.size else 0.0,
+        "operand_bound_max": float(bound.max()) if bound.size else 0.0,
+        "side_residual_max": float(side_residual.max()) if side_residual.size else 0.0,
+    }
 
 def _load(path: str) -> Tuple[Dict[str, np.ndarray], Dict[str, object]]:
     try:
@@ -778,6 +852,31 @@ def _compare_pair(
         )
         emit(f"  pair verdict: first divergence at tap '{first_div}'.")
         emit(f"    Most-likely cause: {cause}")
+
+    c45_product_bound = _c45_operand_product_bound_diagnostic(kiln_arr, ref_arr)
+    if c45_product_bound is not None:
+        kiln_side = _same_side_c45_product_diagnostic(kiln_arr)
+        ref_side = _same_side_c45_product_diagnostic(ref_arr)
+        emit("  C45 broadcast operand diagnostic:")
+        if kiln_side is not None and ref_side is not None:
+            emit(
+                "    same-side product residual: "
+                f"kiln max={_fmt_sci(kiln_side[0])} mean={_fmt_sci(kiln_side[1])}; "
+                f"ref max={_fmt_sci(ref_side[0])} mean={_fmt_sci(ref_side[1])}"
+            )
+        emit(
+            "    cross-side operand drift: "
+            f"row max={_fmt_sci(c45_product_bound['row_max_abs_diff'])}; "
+            f"scalar max={_fmt_sci(c45_product_bound['scalar_max_abs_diff'])}; "
+            f"predicted product max={_fmt_sci(c45_product_bound['product_max_abs_diff'])}; "
+            f"observed output max={_fmt_sci(c45_product_bound['output_max_abs_diff'])}; "
+            f"operand-bound max={_fmt_sci(c45_product_bound['operand_bound_max'])}"
+        )
+        emit(
+            "    interpretation: if same-side residual is near zero and observed output "
+            "matches the predicted product, this boundary is operand-drift amplification, "
+            "not an independent broadcast multiply mismatch."
+        )
 
     return all_ok, first_div, rows, kiln_meta, ref_meta
 
@@ -2192,9 +2291,10 @@ def _emit_c45_summary(
         )
     elif first_shared_bad == "layer_1_input_norm_pre_weight_row_broadcast_output":
         emit(
-            "  -> The selected flat last row and extracted scalar stay "
-            "shared-good; divergence first appears in the row-shaped "
-            "production `broadcast_mul` output."
+            "  -> The selected flat last row and extracted scalar pass the "
+            "current tolerance separately; use the C45 broadcast operand "
+            "diagnostic above to distinguish a real same-side multiply "
+            "residual from operand-drift amplification."
         )
     elif first_shared_bad == "layer_1_input_norm_pre_weight_row_scalar_values":
         emit(


### PR DESCRIPTION
## Summary
- resolve the C45 row-shaped broadcast-mul boundary as operand-drift amplification, not a production RMSNorm `broadcast_mul` shape/casting bug and not an HF mirror mismatch
- add a C45 comparator operand diagnostic that verifies each side's broadcast output is explained by its own captured row/scalar operands
- add fresh seed0/seed1 compare artifacts and append the dated C45 verdict

## Verdict
`layer_1_input_norm_pre_weight_row_broadcast_output` remains the earliest shared bad C45 tap under the current allclose threshold, with `layer_1_input_norm_last_row_flat_values` as the last shared-good tap.

However, the new diagnostic shows the bad row-shaped output is exactly predicted by the already-captured operands on both sides:
- seed 0: same-side product residual `kiln max=8.34e-07`, `ref max=7.15e-07`; predicted product max diff = observed output max diff = `1.38e-01`
- seed 1: same-side product residual `kiln max=1.19e-06`, `ref max=1.73e-06`; predicted product max diff = observed output max diff = `1.43e-01`

So this is not an independent production multiply bug. It is the current C45 tolerance allowing small operand drift that becomes visible after the multiply. The next exact target is the upstream operand drift budget/provenance for the row-local RMS scalar and selected last-row values under a tighter C45 tolerance or a narrow operand-error-budget tap.

## Preflight
- Confirmed PR #448 is merged into `origin/main` (`4512877 Resolve C45 row scalar replay boundary (#448)`).
- Confirmed `docs/phase-c45/c45-layer1-row-normalization-bisect.md` and both `profiling-artifacts/c45_resolution_seed{0,1}_compare.txt` name `layer_1_input_norm_pre_weight_row_broadcast_output` as earliest shared bad, with `layer_1_input_norm_last_row_flat_values` as last shared-good.
- Checked recent PRs/tasks: newer PR #449 is unrelated Metal work; no open PR or pending/running task supersedes this C45 row-shaped broadcast-mul boundary.
- Confirmed `crates/kiln-model/src/forward.rs` still has `c45_layer1_row_replay_tensors(...)`, `capture_c45_layer1_row_taps(...)`, and the production layer-1 RMSNorm/broadcast path.

## Validation
GPU/image:
- pool attempts: A6000/A40/A100/RTX 6000 Ada/L40S failed due host capacity/supply constraints
- completed validation on direct on-demand `NVIDIA A100 80GB PCIe`, image `ghcr.io/ericflo/kiln-runpod:latest`
- used `KILN_CUDA_ARCHS=80` for A100 fallback

Commands run locally:
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- `rg -n "layer_1_input_norm_pre_weight_row_broadcast_output|layer_1_input_norm_last_row_flat_values|c45_layer1_row_replay_tensors|capture_c45_layer1_row_taps|rms_norm_fallback" crates/kiln-model/src/forward.rs scripts docs profiling-artifacts`

Commands run on RunPod:
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- `KILN_CUDA_ARCHS=80 KILN_W4A16=1 KILN_CUDA_GRAPHS=true cargo test --locked -p kiln-model c45 -- --nocapture`
- `KILN_CUDA_ARCHS=80 KILN_W4A16=1 KILN_CUDA_GRAPHS=true cargo build --release --features cuda --bin kiln-bench`
- seed 0/1 `kiln-bench` C45 capture reruns with `KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_DUMP_SPLICE=1 KILN_MTP_DUMP_HIDDEN_STATES=1 KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1`
- `python3 scripts/mtp_h_main_reference_dump.py --checkpoint /workspace/qwen3.5-4b --c45-taps ...` for seed 0 `mtp_pos=0/step=1` and seed 1 `mtp_pos=2/step=1`
- `python3 scripts/mtp_compare.py --c45 ... --out profiling-artifacts/c45_broadcast_seed{0,1}_compare.txt`

Seed metrics:
- seed 0: prompt=494, prefill=`7671.88 ms`, decode=`44.90 tok/s`, alpha=`0.6842`; earliest-bad before/after=`layer_1_input_norm_pre_weight_row_broadcast_output`; last shared-good=`layer_1_input_norm_last_row_flat_values`
- seed 1: prompt=508, prefill=`361.04 ms`, decode=`28.74 tok/s`, alpha=`0.2929`; earliest-bad before/after=`layer_1_input_norm_pre_weight_row_broadcast_output`; last shared-good=`layer_1_input_norm_last_row_flat_values`

Pod cleanup:
- terminated direct pod `avvvsfos1tajl6`
