### PR TITLE
phase6: add C45 operand drift budget diagnostic

### DIFF
--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -189,3 +189,34 @@ The next exact target is therefore the upstream operand drift budget feeding
 this multiply, starting with the row-local RMS scalar / selected last-row
 provenance under a tighter C45 tolerance or a new operand-error-budget tap, not
 a production `broadcast_mul` code change.
+
+## 2026-04-23 operand drift budget diagnostic (WIP)
+
+This follow-up adds a comparator-only C45 operand budget diagnostic for the
+row-shaped broadcast-multiply boundary. It preserves the existing C45 report and
+adds, for the captured `layer_1_input_norm_last_row_flat_values`,
+`layer_1_input_norm_rms_inv_scalar_extracted_values`, and
+`layer_1_input_norm_pre_weight_row_broadcast_output` tensors:
+
+- row-side, scalar-side, predicted-product, and observed-output max / mean /
+  relative-L2 error;
+- a first-order contribution budget that decomposes the predicted product drift
+  into row term, scalar term, and row×scalar interaction, then labels the
+  dominant side as row-side, scalar-side, or both;
+- a tighter mask check at `atol=1e-3`, `rtol=1e-2`, plus current/tight tolerance
+  ratios for the row, scalar, and predicted product.
+
+Validation status on 2026-04-23: zero-cost local syntax and tap-contract checks
+passed, but fresh GPU reruns for `profiling-artifacts/c45_operand_budget_seed0_compare.txt`
+and `profiling-artifacts/c45_operand_budget_seed1_compare.txt` were blocked by
+RunPod capacity across the required pool/direct fallback list (`NVIDIA RTX A6000`,
+`NVIDIA A40`, `NVIDIA A100 80GB PCIe`, `NVIDIA RTX 6000 Ada`, `NVIDIA L40S`).
+The checked-in compare reports do not include the raw safetensors captures, so
+no fresh operand-budget seed verdict is claimed in this WIP revision.
+
+Pending verdict: rerun the new `scripts/mtp_compare.py --c45-operand-budget`
+diagnostic on fresh seed 0/1 C45 captures. If same-side residual remains tiny and
+predicted product still matches observed output, use the new contribution budget
+to name the next exact upstream boundary as row-side, scalar-side, both, or only
+a comparator tolerance artifact. No production math change is justified until
+that fresh evidence identifies a real mismatch.

--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -190,9 +190,9 @@ this multiply, starting with the row-local RMS scalar / selected last-row
 provenance under a tighter C45 tolerance or a new operand-error-budget tap, not
 a production `broadcast_mul` code change.
 
-## 2026-04-23 operand drift budget diagnostic (WIP)
+## 2026-04-23 operand drift budget diagnostic verdict
 
-This follow-up adds a comparator-only C45 operand budget diagnostic for the
+This follow-up added a comparator-only C45 operand budget diagnostic for the
 row-shaped broadcast-multiply boundary. It preserves the existing C45 report and
 adds, for the captured `layer_1_input_norm_last_row_flat_values`,
 `layer_1_input_norm_rms_inv_scalar_extracted_values`, and
@@ -206,17 +206,45 @@ adds, for the captured `layer_1_input_norm_last_row_flat_values`,
 - a tighter mask check at `atol=1e-3`, `rtol=1e-2`, plus current/tight tolerance
   ratios for the row, scalar, and predicted product.
 
-Validation status on 2026-04-23: zero-cost local syntax and tap-contract checks
-passed, but fresh GPU reruns for `profiling-artifacts/c45_operand_budget_seed0_compare.txt`
-and `profiling-artifacts/c45_operand_budget_seed1_compare.txt` were blocked by
-RunPod capacity across the required pool/direct fallback list (`NVIDIA RTX A6000`,
-`NVIDIA A40`, `NVIDIA A100 80GB PCIe`, `NVIDIA RTX 6000 Ada`, `NVIDIA L40S`).
-The checked-in compare reports do not include the raw safetensors captures, so
-no fresh operand-budget seed verdict is claimed in this WIP revision.
+Fresh GPU validation completed on 2026-04-23 with the mandatory RunPod image:
 
-Pending verdict: rerun the new `scripts/mtp_compare.py --c45-operand-budget`
-diagnostic on fresh seed 0/1 C45 captures. If same-side residual remains tiny and
-predicted product still matches observed output, use the new contribution budget
-to name the next exact upstream boundary as row-side, scalar-side, both, or only
-a comparator tolerance artifact. No production math change is justified until
-that fresh evidence identifies a real mismatch.
+- pod: `flp51y39ddsktx`
+- GPU: `NVIDIA RTX A6000`, driver `550.127.08`, `49140 MiB` VRAM
+- image: `ghcr.io/ericflo/kiln-runpod:latest`
+- CUDA arch: `KILN_CUDA_ARCHS=86`
+- branch: PR #451 (`ce/c45-operand-drift-budget`, commit `9d1ec89`)
+
+Validation commands completed:
+
+- `cargo build --release --features cuda --bin kiln-bench`
+- `cargo test --locked -p kiln-model c45 -- --nocapture`
+- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
+- fresh seed 0/1 C45 captures with `KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1`
+- `python3 scripts/mtp_h_main_reference_dump.py --c45-taps ...` for each seed
+- `python3 scripts/mtp_compare.py --c45-operand-budget ...` for each seed
+
+Seed-specific operand-budget evidence:
+
+- seed 0 (`profiling-artifacts/c45_operand_budget_seed0_compare.txt`): earliest
+  bad tap remains `layer_1_input_norm_pre_weight_row_broadcast_output`; last
+  shared-good tap remains `layer_1_input_norm_last_row_flat_values`; same-side
+  product residuals are tiny (`kiln max=9.54e-07`, `ref max=1.01e-06`);
+  predicted product max diff equals observed output max diff (`1.35e-01`);
+  operand contribution budget is row-side dominant (`row-term max=3.13e-01`,
+  `scalar-term max=2.52e-01`, `interaction max=1.79e-03`); prompt=494,
+  prefill=`9942.70 ms`, decode=`34.14 tok/s`, `alpha=0.6623`.
+- seed 1 (`profiling-artifacts/c45_operand_budget_seed1_compare.txt`): earliest
+  bad tap remains `layer_1_input_norm_pre_weight_row_broadcast_output`; last
+  shared-good tap remains `layer_1_input_norm_last_row_flat_values`; same-side
+  product residuals are tiny (`kiln max=9.54e-07`, `ref max=7.15e-07`);
+  predicted product max diff equals observed output max diff (`1.32e-01`);
+  operand contribution budget is row-side dominant (`row-term max=5.05e-01`,
+  `scalar-term max=3.99e-01`, `interaction max=4.39e-03`); prompt=508,
+  prefill=`392.74 ms`, decode=`23.64 tok/s`, `alpha=0.3196`.
+
+Final verdict: **row-side operand drift**, not scalar-side, not both, and not a
+same-side production multiply or HF mirror mismatch. The scalar operand remains
+within the tighter mask on both seeds, while the selected row fails the tighter
+mask and dominates the first-order contribution budget. The next exact target is
+therefore the provenance of `layer_1_input_norm_last_row_flat_values` feeding the
+row-shaped broadcast multiply.

--- a/profiling-artifacts/c45_operand_budget_seed0_compare.txt
+++ b/profiling-artifacts/c45_operand_budget_seed0_compare.txt
@@ -1,0 +1,51 @@
+MTP numerical bisect — mode: layer-1 row-local operand drift budget (C45), atol=0.01, rtol=0.1
+
+=== seed0 ===
+  kiln dump : profiling-artifacts/c45_operand_budget_seed0_captures/mtp_pos-0/step-1.safetensors
+  ref  dump : profiling-artifacts/c45_operand_budget_seed0_ref_bf16.safetensors
+Metadata:
+  meta__draft_token_id: kiln=31192 ref=31192 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   1.14e-01     1.14e-01    
+c45__layer_1_input_norm_rms_inv_scalar_extracted_values 1                      True     True     1.00e+00   1.14e-01     1.14e-01    
+c45__layer_1_input_norm_last_row_flat_values 1x2560                 True     True     9.99e-01   1.56e-02     1.59e-03    
+c45__layer_1_input_norm_pre_weight_row_broadcast_output 1x1x2560               True     False    9.99e-01   1.35e-01     3.19e-02    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     False    9.99e-01   1.35e-01     3.19e-02    
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     False    9.99e-01   1.35e-01     3.19e-02    
+
+  pair verdict: first divergence at tap 'c45__layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar pass the current tolerance separately; the product exposes operand-drift amplification unless the C45 operand diagnostic shows a same-side multiply residual
+  C45 broadcast operand diagnostic:
+    same-side product residual: kiln max=9.54e-07 mean=8.21e-09; ref max=1.01e-06 mean=8.08e-09
+    cross-side operand drift: row max=1.56e-02 mean=1.59e-03 rel_l2=4.03e-02; scalar max=1.14e-01 mean=1.14e-01 rel_l2=5.71e-03; predicted product max=1.35e-01 mean=3.19e-02 rel_l2=4.01e-02; observed output max=1.35e-01 mean=3.19e-02 rel_l2=4.01e-02; operand-bound max=5.67e-01
+    operand contribution budget: row-term max=3.13e-01 mean=3.19e-02 rel_l2=4.03e-02; scalar-term max=2.52e-01 mean=2.19e-03 rel_l2=5.71e-03; interaction max=1.79e-03 mean=1.82e-04 rel_l2=2.30e-04; dominant=row-side
+    tighter tolerance mask check (atol=0.001, rtol=0.01): row allclose=False current-ratio=6.46e-01 tight-ratio=6.46e+00; scalar allclose=True current-ratio=5.68e-02 tight-ratio=5.68e-01; product allclose=False current-ratio=9.28e+00 tight-ratio=9.28e+01
+    interpretation: if same-side residual is near zero and observed output matches the predicted product, this boundary is operand-drift amplification, not an independent broadcast multiply mismatch; the contribution budget names which tolerated operand dominates the exposed product error.
+
+==============================================================================
+Phase C45 layer-1 row-local scalar-multiply audit — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                                             seed0                                               
+  ----------------------------------------------------------------------------------------------------
+  layer_1_input_norm_rms_inv_scalar               cos=1.00e+00   max|Δ|=1.14e-01   mean|Δ|=1.14e-01   rel_l2=5.71e-03   ok 
+  layer_1_input_norm_rms_inv_scalar_extracted_valuescos=1.00e+00   max|Δ|=1.14e-01   mean|Δ|=1.14e-01   rel_l2=5.71e-03   ok 
+  layer_1_input_norm_last_row_flat_values         cos=9.99e-01   max|Δ|=1.56e-02   mean|Δ|=1.59e-03   rel_l2=4.03e-02   ok 
+  layer_1_input_norm_pre_weight_row_broadcast_outputcos=9.99e-01   max|Δ|=1.35e-01   mean|Δ|=3.19e-02   rel_l2=4.01e-02   DIV
+  layer_1_input_norm_pre_weight_row_scalar_values cos=9.99e-01   max|Δ|=1.35e-01   mean|Δ|=3.19e-02   rel_l2=4.01e-02   DIV
+  layer_1_input_norm_pre_weight_row_reconstructed cos=9.99e-01   max|Δ|=1.35e-01   mean|Δ|=3.19e-02   rel_l2=4.01e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight_row_broadcast_output'
+  last shared-good tap: 'layer_1_input_norm_last_row_flat_values'
+Phase C45 verdict: EARLIEST SHARED BAD ROW-LOCAL SCALAR-MULTIPLY TAP = 'layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar pass the current tolerance separately; the product exposes operand-drift amplification unless the C45 operand diagnostic shows a same-side multiply residual
+  -> The selected flat last row and extracted scalar pass the current tolerance separately; use the C45 broadcast operand diagnostic above to distinguish a real same-side multiply residual from operand-drift amplification.
+
+Overall verdict: divergence(s) at: ['c45__layer_1_input_norm_pre_weight_row_broadcast_output']
+

--- a/profiling-artifacts/c45_operand_budget_seed1_compare.txt
+++ b/profiling-artifacts/c45_operand_budget_seed1_compare.txt
@@ -1,0 +1,51 @@
+MTP numerical bisect — mode: layer-1 row-local operand drift budget (C45), atol=0.01, rtol=0.1
+
+=== seed1 ===
+  kiln dump : profiling-artifacts/c45_operand_budget_seed1_captures/mtp_pos-2/step-1.safetensors
+  ref  dump : profiling-artifacts/c45_operand_budget_seed1_ref_bf16.safetensors
+Metadata:
+  meta__draft_token_id: kiln=11 ref=11 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] ref=[0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   1.40e-01     1.40e-01    
+c45__layer_1_input_norm_rms_inv_scalar_extracted_values 1                      True     True     1.00e+00   1.40e-01     1.40e-01    
+c45__layer_1_input_norm_last_row_flat_values 1x2560                 True     True     9.99e-01   3.12e-02     1.59e-03    
+c45__layer_1_input_norm_pre_weight_row_broadcast_output 1x1x2560               True     False    9.99e-01   1.32e-01     2.59e-02    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     False    9.99e-01   1.32e-01     2.59e-02    
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     False    9.99e-01   1.32e-01     2.59e-02    
+
+  pair verdict: first divergence at tap 'c45__layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar pass the current tolerance separately; the product exposes operand-drift amplification unless the C45 operand diagnostic shows a same-side multiply residual
+  C45 broadcast operand diagnostic:
+    same-side product residual: kiln max=9.54e-07 mean=6.76e-09; ref max=7.15e-07 mean=6.88e-09
+    cross-side operand drift: row max=3.12e-02 mean=1.59e-03 rel_l2=3.35e-02; scalar max=1.40e-01 mean=1.40e-01 rel_l2=8.68e-03; predicted product max=1.32e-01 mean=2.59e-02 rel_l2=3.25e-02; observed output max=1.32e-01 mean=2.59e-02 rel_l2=3.25e-02; operand-bound max=9.09e-01
+    operand contribution budget: row-term max=5.05e-01 mean=2.57e-02 rel_l2=3.35e-02; scalar-term max=3.99e-01 mean=2.76e-03 rel_l2=8.68e-03; interaction max=4.39e-03 mean=2.23e-04 rel_l2=2.91e-04; dominant=row-side
+    tighter tolerance mask check (atol=0.001, rtol=0.01): row allclose=False current-ratio=6.95e-01 tight-ratio=6.95e+00; scalar allclose=True current-ratio=8.62e-02 tight-ratio=8.62e-01; product allclose=False current-ratio=9.39e+00 tight-ratio=9.39e+01
+    interpretation: if same-side residual is near zero and observed output matches the predicted product, this boundary is operand-drift amplification, not an independent broadcast multiply mismatch; the contribution budget names which tolerated operand dominates the exposed product error.
+
+==============================================================================
+Phase C45 layer-1 row-local scalar-multiply audit — cos_sim / max|Δ| / mean|Δ| / rel_l2
+==============================================================================
+  tap                                             seed1                                               
+  ----------------------------------------------------------------------------------------------------
+  layer_1_input_norm_rms_inv_scalar               cos=1.00e+00   max|Δ|=1.40e-01   mean|Δ|=1.40e-01   rel_l2=8.68e-03   ok 
+  layer_1_input_norm_rms_inv_scalar_extracted_valuescos=1.00e+00   max|Δ|=1.40e-01   mean|Δ|=1.40e-01   rel_l2=8.68e-03   ok 
+  layer_1_input_norm_last_row_flat_values         cos=9.99e-01   max|Δ|=3.12e-02   mean|Δ|=1.59e-03   rel_l2=3.35e-02   ok 
+  layer_1_input_norm_pre_weight_row_broadcast_outputcos=9.99e-01   max|Δ|=1.32e-01   mean|Δ|=2.59e-02   rel_l2=3.25e-02   DIV
+  layer_1_input_norm_pre_weight_row_scalar_values cos=9.99e-01   max|Δ|=1.32e-01   mean|Δ|=2.59e-02   rel_l2=3.25e-02   DIV
+  layer_1_input_norm_pre_weight_row_reconstructed cos=9.99e-01   max|Δ|=1.32e-01   mean|Δ|=2.59e-02   rel_l2=3.25e-02   DIV
+
+  earliest shared bad tap: 'layer_1_input_norm_pre_weight_row_broadcast_output'
+  last shared-good tap: 'layer_1_input_norm_last_row_flat_values'
+Phase C45 verdict: EARLIEST SHARED BAD ROW-LOCAL SCALAR-MULTIPLY TAP = 'layer_1_input_norm_pre_weight_row_broadcast_output'.
+    Most-likely cause: the selected row and extracted scalar pass the current tolerance separately; the product exposes operand-drift amplification unless the C45 operand diagnostic shows a same-side multiply residual
+  -> The selected flat last row and extracted scalar pass the current tolerance separately; use the C45 broadcast operand diagnostic above to distinguish a real same-side multiply residual from operand-drift amplification.
+
+Overall verdict: divergence(s) at: ['c45__layer_1_input_norm_pre_weight_row_broadcast_output']
+

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -388,6 +388,9 @@ C45_HYPOTHESIS: Dict[str, str] = {
     "layer_1_input_norm_pre_weight_row_reconstructed": "the flat row-local scalar multiply stays shared-good; drift appears only when reconstructing the row-shaped output before the existing post-input-norm path",
 }
 
+C45_TIGHT_ATOL = 1e-3
+C45_TIGHT_RTOL = 1e-2
+
 # Phase B12 — the cos_sim bar is tighter than B10/B11 because the expected
 # residual drift is small (0.97-0.98) and the goal is to localize it. A
 # per-layer median below this threshold marks the first layer of interest; if
@@ -596,6 +599,43 @@ def _same_side_c45_product_diagnostic(
     return max_abs, mean_abs
 
 
+
+def _diff_l2(diff: np.ndarray) -> float:
+    return float(np.linalg.norm(diff.reshape(-1))) if diff.size else 0.0
+
+
+def _rel_l2(diff: np.ndarray, ref: np.ndarray) -> float:
+    ref_norm = float(np.linalg.norm(ref.reshape(-1)))
+    if ref_norm == 0.0 or not diff.size:
+        return float("nan")
+    return _diff_l2(diff) / ref_norm
+
+
+def _max_tolerance_ratio(
+    diff: np.ndarray, ref: np.ndarray, atol: float, rtol: float
+) -> float:
+    if not diff.size:
+        return 0.0
+    allowed = atol + rtol * np.abs(ref)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratios = np.divide(
+            diff,
+            allowed,
+            out=np.full_like(diff, np.inf),
+            where=allowed != 0.0,
+        )
+    return float(np.nanmax(ratios))
+
+
+def _component_stats(component: np.ndarray, ref: np.ndarray) -> Dict[str, float]:
+    abs_component = np.abs(component)
+    return {
+        "max": float(abs_component.max()) if abs_component.size else 0.0,
+        "mean": float(abs_component.mean()) if abs_component.size else 0.0,
+        "l2": _diff_l2(abs_component),
+        "rel_l2": _rel_l2(abs_component, ref),
+    }
+
 def _c45_operand_product_bound_diagnostic(
     kiln_tensors: Dict[str, np.ndarray],
     ref_tensors: Dict[str, np.ndarray],
@@ -632,19 +672,82 @@ def _c45_operand_product_bound_diagnostic(
 
     predicted_kiln = kr * ks
     predicted_ref = rr * rs
-    product_diff = np.abs(predicted_kiln - predicted_ref)
-    output_diff = np.abs(ko - ro)
-    row_diff = np.abs(kr - rr)
-    scalar_diff = np.abs(ks - rs)
+    signed_row_diff = kr - rr
+    signed_scalar_diff = ks - rs
+    signed_product_diff = predicted_kiln - predicted_ref
+    signed_output_diff = ko - ro
+    product_diff = np.abs(signed_product_diff)
+    output_diff = np.abs(signed_output_diff)
+    row_diff = np.abs(signed_row_diff)
+    scalar_diff = np.abs(signed_scalar_diff)
+    row_component = signed_row_diff * rs
+    scalar_component = rr * signed_scalar_diff
+    interaction_component = signed_row_diff * signed_scalar_diff
     bound = row_diff * np.abs(ks) + np.abs(rr) * scalar_diff
     side_residual = np.maximum(np.abs(predicted_kiln - ko), np.abs(predicted_ref - ro))
+    row_stats = _component_stats(row_component, predicted_ref)
+    scalar_stats = _component_stats(scalar_component, predicted_ref)
+    interaction_stats = _component_stats(interaction_component, predicted_ref)
+    if scalar_stats["l2"] > row_stats["l2"] * 2.0:
+        dominant = "scalar-side"
+    elif row_stats["l2"] > scalar_stats["l2"] * 2.0:
+        dominant = "row-side"
+    else:
+        dominant = "both"
     return {
         "row_max_abs_diff": float(row_diff.max()) if row_diff.size else 0.0,
+        "row_mean_abs_diff": float(row_diff.mean()) if row_diff.size else 0.0,
+        "row_rel_l2": _rel_l2(row_diff, rr),
         "scalar_max_abs_diff": float(scalar_diff.max()) if scalar_diff.size else 0.0,
+        "scalar_mean_abs_diff": float(scalar_diff.mean()) if scalar_diff.size else 0.0,
+        "scalar_rel_l2": _rel_l2(scalar_diff, rs),
         "product_max_abs_diff": float(product_diff.max()) if product_diff.size else 0.0,
+        "product_mean_abs_diff": float(product_diff.mean()) if product_diff.size else 0.0,
+        "product_rel_l2": _rel_l2(product_diff, predicted_ref),
         "output_max_abs_diff": float(output_diff.max()) if output_diff.size else 0.0,
+        "output_mean_abs_diff": float(output_diff.mean()) if output_diff.size else 0.0,
+        "output_rel_l2": _rel_l2(output_diff, ro),
         "operand_bound_max": float(bound.max()) if bound.size else 0.0,
         "side_residual_max": float(side_residual.max()) if side_residual.size else 0.0,
+        "row_component_max": row_stats["max"],
+        "row_component_mean": row_stats["mean"],
+        "row_component_l2": row_stats["l2"],
+        "row_component_rel_l2": row_stats["rel_l2"],
+        "scalar_component_max": scalar_stats["max"],
+        "scalar_component_mean": scalar_stats["mean"],
+        "scalar_component_l2": scalar_stats["l2"],
+        "scalar_component_rel_l2": scalar_stats["rel_l2"],
+        "interaction_component_max": interaction_stats["max"],
+        "interaction_component_mean": interaction_stats["mean"],
+        "interaction_component_l2": interaction_stats["l2"],
+        "interaction_component_rel_l2": interaction_stats["rel_l2"],
+        "dominant_operand_side": dominant,
+        "row_tight_allclose": float(
+            np.allclose(kr, rr, atol=C45_TIGHT_ATOL, rtol=C45_TIGHT_RTOL)
+        ),
+        "scalar_tight_allclose": float(
+            np.allclose(ks, rs, atol=C45_TIGHT_ATOL, rtol=C45_TIGHT_RTOL)
+        ),
+        "product_tight_allclose": float(
+            np.allclose(
+                predicted_kiln,
+                predicted_ref,
+                atol=C45_TIGHT_ATOL,
+                rtol=C45_TIGHT_RTOL,
+            )
+        ),
+        "row_current_tol_ratio": _max_tolerance_ratio(row_diff, rr, 1e-2, 1e-1),
+        "scalar_current_tol_ratio": _max_tolerance_ratio(scalar_diff, rs, 1e-2, 1e-1),
+        "product_current_tol_ratio": _max_tolerance_ratio(product_diff, predicted_ref, 1e-2, 1e-1),
+        "row_tight_tol_ratio": _max_tolerance_ratio(
+            row_diff, rr, C45_TIGHT_ATOL, C45_TIGHT_RTOL
+        ),
+        "scalar_tight_tol_ratio": _max_tolerance_ratio(
+            scalar_diff, rs, C45_TIGHT_ATOL, C45_TIGHT_RTOL
+        ),
+        "product_tight_tol_ratio": _max_tolerance_ratio(
+            product_diff, predicted_ref, C45_TIGHT_ATOL, C45_TIGHT_RTOL
+        ),
     }
 
 def _load(path: str) -> Tuple[Dict[str, np.ndarray], Dict[str, object]]:
@@ -866,16 +969,50 @@ def _compare_pair(
             )
         emit(
             "    cross-side operand drift: "
-            f"row max={_fmt_sci(c45_product_bound['row_max_abs_diff'])}; "
-            f"scalar max={_fmt_sci(c45_product_bound['scalar_max_abs_diff'])}; "
-            f"predicted product max={_fmt_sci(c45_product_bound['product_max_abs_diff'])}; "
-            f"observed output max={_fmt_sci(c45_product_bound['output_max_abs_diff'])}; "
+            f"row max={_fmt_sci(c45_product_bound['row_max_abs_diff'])} "
+            f"mean={_fmt_sci(c45_product_bound['row_mean_abs_diff'])} "
+            f"rel_l2={_fmt_sci(c45_product_bound['row_rel_l2'])}; "
+            f"scalar max={_fmt_sci(c45_product_bound['scalar_max_abs_diff'])} "
+            f"mean={_fmt_sci(c45_product_bound['scalar_mean_abs_diff'])} "
+            f"rel_l2={_fmt_sci(c45_product_bound['scalar_rel_l2'])}; "
+            f"predicted product max={_fmt_sci(c45_product_bound['product_max_abs_diff'])} "
+            f"mean={_fmt_sci(c45_product_bound['product_mean_abs_diff'])} "
+            f"rel_l2={_fmt_sci(c45_product_bound['product_rel_l2'])}; "
+            f"observed output max={_fmt_sci(c45_product_bound['output_max_abs_diff'])} "
+            f"mean={_fmt_sci(c45_product_bound['output_mean_abs_diff'])} "
+            f"rel_l2={_fmt_sci(c45_product_bound['output_rel_l2'])}; "
             f"operand-bound max={_fmt_sci(c45_product_bound['operand_bound_max'])}"
+        )
+        emit(
+            "    operand contribution budget: "
+            f"row-term max={_fmt_sci(c45_product_bound['row_component_max'])} "
+            f"mean={_fmt_sci(c45_product_bound['row_component_mean'])} "
+            f"rel_l2={_fmt_sci(c45_product_bound['row_component_rel_l2'])}; "
+            f"scalar-term max={_fmt_sci(c45_product_bound['scalar_component_max'])} "
+            f"mean={_fmt_sci(c45_product_bound['scalar_component_mean'])} "
+            f"rel_l2={_fmt_sci(c45_product_bound['scalar_component_rel_l2'])}; "
+            f"interaction max={_fmt_sci(c45_product_bound['interaction_component_max'])} "
+            f"mean={_fmt_sci(c45_product_bound['interaction_component_mean'])} "
+            f"rel_l2={_fmt_sci(c45_product_bound['interaction_component_rel_l2'])}; "
+            f"dominant={c45_product_bound['dominant_operand_side']}"
+        )
+        emit(
+            f"    tighter tolerance mask check (atol={C45_TIGHT_ATOL:g}, rtol={C45_TIGHT_RTOL:g}): "
+            f"row allclose={bool(c45_product_bound['row_tight_allclose'])} "
+            f"current-ratio={_fmt_sci(c45_product_bound['row_current_tol_ratio'])} "
+            f"tight-ratio={_fmt_sci(c45_product_bound['row_tight_tol_ratio'])}; "
+            f"scalar allclose={bool(c45_product_bound['scalar_tight_allclose'])} "
+            f"current-ratio={_fmt_sci(c45_product_bound['scalar_current_tol_ratio'])} "
+            f"tight-ratio={_fmt_sci(c45_product_bound['scalar_tight_tol_ratio'])}; "
+            f"product allclose={bool(c45_product_bound['product_tight_allclose'])} "
+            f"current-ratio={_fmt_sci(c45_product_bound['product_current_tol_ratio'])} "
+            f"tight-ratio={_fmt_sci(c45_product_bound['product_tight_tol_ratio'])}"
         )
         emit(
             "    interpretation: if same-side residual is near zero and observed output "
             "matches the predicted product, this boundary is operand-drift amplification, "
-            "not an independent broadcast multiply mismatch."
+            "not an independent broadcast multiply mismatch; the contribution budget names "
+            "which tolerated operand dominates the exposed product error."
         )
 
     return all_ok, first_div, rows, kiln_meta, ref_meta
@@ -2559,6 +2696,14 @@ def main() -> int:
         ),
     )
     ap.add_argument(
+        "--c45-operand-budget",
+        action="store_true",
+        help=(
+            "Alias for --c45 that emphasizes the row/scalar operand "
+            "contribution and tighter-tolerance budget diagnostic."
+        ),
+    )
+    ap.add_argument(
         "--c6",
         action="store_true",
         help=(
@@ -2609,6 +2754,7 @@ def main() -> int:
         or args.c44
         or args.c45
         or args.c45_row_scalar
+        or args.c45_operand_budget
     )
     if args.atol is None:
         args.atol = 1e-2 if bf16_mode else 1e-3
@@ -2637,8 +2783,8 @@ def main() -> int:
     multi = len(pairs) > 1
     if args.c7:
         mode = "SDPA-internal bisect (C7)"
-    elif args.c45 or args.c45_row_scalar:
-        mode = "layer-1 row-local scalar-multiply audit (C45)"
+    elif args.c45 or args.c45_row_scalar or args.c45_operand_budget:
+        mode = "layer-1 row-local operand drift budget (C45)"
     elif args.c44:
         mode = "layer-1 row-level audit (C44)"
     elif args.c43:
@@ -2666,7 +2812,7 @@ def main() -> int:
     ] = []
     overall_ok = True
     focus_keys = None
-    if args.c45 or args.c45_row_scalar:
+    if args.c45 or args.c45_row_scalar or args.c45_operand_budget:
         focus_keys = [f"c45__{name}" for name in C45_LAYER1_ROW_TAP_NAMES]
     elif args.c44:
         focus_keys = [f"c44__{name}" for name in C44_LAYER1_F32_ROW_TAP_NAMES]
@@ -2686,7 +2832,7 @@ def main() -> int:
 
     if args.c7:
         _emit_c7_summary(pair_results, args.atol, args.rtol, emit)
-    elif args.c45 or args.c45_row_scalar:
+    elif args.c45 or args.c45_row_scalar or args.c45_operand_budget:
         _emit_c45_summary(pair_results, args.atol, args.rtol, emit)
     elif args.c44:
         _emit_c44_summary(pair_results, args.atol, args.rtol, emit)


### PR DESCRIPTION
## Summary

- Adds a C45 comparator-only operand drift budget diagnostic around `layer_1_input_norm_last_row_flat_values`, `layer_1_input_norm_rms_inv_scalar_extracted_values`, and `layer_1_input_norm_pre_weight_row_broadcast_output`.
- Preserves the existing C45 output while adding row/scalar/product/output max, mean, and relative-L2 error.
- Decomposes predicted product drift into row term, scalar term, and row×scalar interaction, with a dominant-side label.
- Adds a stricter `--c45-operand-budget` alias and a tighter mask check at `atol=1e-3`, `rtol=1e-2`.
- Documents this as WIP because fresh RunPod seed reruns were blocked by capacity.

## Preflight

- Confirmed PR #450 is merged on fresh `origin/main`.
- Confirmed no open PRs in `ericflo/kiln` and no pending/running Cloud Eric task overlaps this C45 operand-budget scope, aside from this task.
- Confirmed checked-in C45 evidence still shows `layer_1_input_norm_last_row_flat_values` and `layer_1_input_norm_rms_inv_scalar(_extracted_values)` pass current tolerance while `layer_1_input_norm_pre_weight_row_broadcast_output` fails.

## Validation

Completed locally:

```bash
python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
rg -n "C45_LAYER1_ROW_TAP_NAMES|layer_1_input_norm_pre_weight_row_broadcast_output|layer_1_input_norm_last_row_flat_values|layer_1_input_norm_rms_inv_scalar|c45_layer1_row_replay_tensors|capture_c45_layer1_row_taps" scripts crates/kiln-model/src/forward.rs docs profiling-artifacts
```

Blocked by RunPod capacity:

- `ce kiln-pod-acquire --gpu-type "NVIDIA RTX A6000"` failed with host capacity.
- Pool fallback attempts for `NVIDIA A40`, `NVIDIA A100 80GB PCIe`, `NVIDIA RTX 6000 Ada`, and `NVIDIA L40S` also failed with capacity/supply errors.
- Direct on-demand fallback attempts with the mandated `ghcr.io/ericflo/kiln-runpod:latest` image failed for `NVIDIA RTX A6000`, `NVIDIA A40`, `NVIDIA A100 80GB PCIe`, `NVIDIA RTX 6000 Ada`, and `NVIDIA L40S` with `SUPPLY_CONSTRAINT`.

Not completed because no GPU pod could be acquired:

```bash
cargo build --release --features cuda --bin kiln-bench
cargo test --locked -p kiln-model c45 -- --nocapture
# fresh seed 0/1 C45 reruns producing profiling-artifacts/c45_operand_budget_seed{0,1}_compare.txt
```

## Verdict

No production math change is made. This PR does not claim a fresh seed verdict; it adds the diagnostic needed to distinguish whether the exposed product drift is row-side, scalar-side, both, or a comparator tolerance artifact once RunPod capacity is available.