### PR TITLE
Use Metal head-major KV read for decode

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3716,15 +3716,30 @@ fn try_flash_attn_paged_decode(
         if let Some(start_slot) =
             contiguous_slot_run_start(block_table, block_size, 0, total_seq_len)
         {
-            let k_live = k_pool.narrow(0, start_slot, total_seq_len)?.unsqueeze(0)?;
-            let v_live = v_pool.narrow(0, start_slot, total_seq_len)?.unsqueeze(0)?;
+            let fast_head_major = if backend.supports_flash_attn_prefill_head_major()
+                && backend.supports_paged_kv_head_major_read()
+            {
+                kiln_nvtx::range!(c"kiln/kv/head_major_read_decode");
+                backend.paged_kv_head_major_read(k_pool, v_pool, start_slot, total_seq_len)?
+            } else {
+                None
+            };
             let attn_output = if backend.supports_flash_attn_prefill_head_major() {
                 // Q is already head-major at the call site. Keep K/V grouped
                 // instead of routing through `flash_attention_forward`, which
                 // expands GQA K/V before Metal SDPA and defeats Candle's
                 // native vector-attention GQA path.
-                let k_head = k_live.transpose(1, 2)?.contiguous()?;
-                let v_head = v_live.transpose(1, 2)?.contiguous()?;
+                let (k_head, v_head) = match fast_head_major {
+                    Some(kv) => kv,
+                    None => {
+                        let k_live = k_pool.narrow(0, start_slot, total_seq_len)?.unsqueeze(0)?;
+                        let v_live = v_pool.narrow(0, start_slot, total_seq_len)?.unsqueeze(0)?;
+                        (
+                            k_live.transpose(1, 2)?.contiguous()?,
+                            v_live.transpose(1, 2)?.contiguous()?,
+                        )
+                    }
+                };
                 flash_attention_forward_head_major(
                     backend, q, &k_head, &v_head, num_heads, head_dim,
                 )?
@@ -3737,6 +3752,8 @@ fn try_flash_attn_paged_decode(
                 // Reshape Q for the fused-attention APIs only when the
                 // head-major path declined. The common Metal desktop path
                 // returns above and should not pay this transpose/copy.
+                let k_live = k_pool.narrow(0, start_slot, total_seq_len)?.unsqueeze(0)?;
+                let v_live = v_pool.narrow(0, start_slot, total_seq_len)?.unsqueeze(0)?;
                 let q_fa = {
                     kiln_nvtx::range!(c"kiln/attn/q_fa_transpose");
                     q.transpose(1, 2)?.contiguous()?


### PR DESCRIPTION
## Summary

Route the contiguous-run paged decode fast path through the existing Metal head-major KV read kernel instead of materializing K/V by narrowing token-major pool tensors and then transposing them.

This keeps the old narrow/transpose path as a fallback when the backend does not support the specialized read.

## Validation

- `cargo test -p kiln-model --release --locked --features metal backend::metal::tests::test_paged_kv_head_major_read_matches_reference --target-dir /private/tmp/kiln-headmajor-target -- --nocapture`
- `cargo test -p kiln-model --release --locked --features metal test_model_forward_parity_cpu_vs_metal --target-dir /private/tmp/kiln-headmajor-target -- --nocapture`
- `cargo test -p kiln-model --release --locked --features metal backend::metal::tests::test_paged_decode_parity_with_direct_sdpa --target-dir /private/tmp/kiln-headmajor-target -- --nocapture`
- `cargo build -p kiln-server --bin kiln-bench --release --locked --features metal --target-dir /private/tmp/kiln-headmajor-target`

## Benchmarks

Desktop default env: `KILN_INFERENCE_MEMORY_FRACTION=0.7 KILN_KV_CACHE_FP8=0 KILN_CUDA_GRAPHS=0 KILN_PREFIX_CACHE_ENABLED=1 KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp`, `--paged --latency-only --skip-training`.

- 512/128 rerun: main 38.57s real, 4.19 decode tok/s; patched 36.83s real, 4.42 decode tok/s.
- 8192/64: main 65.04s real, 149 prefill tok/s, 11.38 decode tok/s; patched 64.45s real, 150 prefill tok/s, 11.49 decode tok/s.