### PR TITLE
[codex] Guard non-streaming MTP final window

### DIFF
--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1738,6 +1738,16 @@ impl ModelRunner {
                 }
             }
 
+            if generated_tokens.len() >= params.max_tokens {
+                return Ok(MtpGenerationOutput {
+                    text: String::new(),
+                    token_ids: generated_tokens,
+                    finish_reason: FinishReason::MaxTokens,
+                    draft_accepted_count,
+                    total_draft_attempts,
+                });
+            }
+
             total_draft_attempts += 1;
             let mut replay_prefix =
                 Vec::with_capacity(prompt_tokens.len() + generated_tokens.len());


### PR DESCRIPTION
## Summary

Adds the missing max-token guard in the non-streaming native MTP generation loop after an accepted bonus token is emitted. This mirrors the existing streaming path guard and avoids starting another draft window after `max_tokens` has already been reached.

## Validation

- `cargo check -p kiln-model`
- `cargo test -p kiln-model test_generate_from_tokens_max_tokens`
- `git diff --check`

`cargo fmt --check` still reports pre-existing repository formatting drift outside this scoped change, so formatting was not applied.