### PR TITLE
[codex] Use unexpanded GDN QK for Metal decode

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -1102,7 +1102,7 @@ fn metal_gdn_recurrent_prefill_native_head_last_supports(
         && (b_state, h_state, dk_state, dv_state) == (batch, value_heads, dk, dv)
         && value_heads >= q_heads
         && value_heads % q_heads == 0
-        && seq_len > 1
+        && seq_len >= 1
         && seq_len <= METAL_GDN_RECURRENT_PREFILL_MAX_SEQ_LEN
         && dk == 128
         && dv > 0
@@ -5983,6 +5983,7 @@ mod tests {
             .reshape((batch, value_heads, seq_len, dk))?;
 
         let mut out_chunks = Vec::with_capacity(seq_len);
+        let mut state_ref_first = None;
         for t in 0..seq_len {
             let q_t = q_ref.narrow(2, t, 1)?.contiguous()?;
             let k_t = k_ref.narrow(2, t, 1)?.contiguous()?;
@@ -6001,6 +6002,9 @@ mod tests {
             let state_scaled = state_ref.broadcast_mul(&p_u)?;
             let delta_state = k_t_mat.matmul(&w)?;
             state_ref = (state_scaled + delta_state)?;
+            if t == 0 {
+                state_ref_first = Some(state_ref.clone());
+            }
             out_chunks.push(out_t);
         }
         let out_ref = Tensor::cat(&out_chunks, 2)?.transpose(1, 2)?.contiguous()?;
@@ -6077,6 +6081,43 @@ mod tests {
         assert!(
             native_state_mean < 3e-3,
             "GDN recurrent native prefill state mean_abs_diff={native_state_mean:e} exceeds tolerance"
+        );
+
+        let q_native_one = q_native.narrow(1, 0, 1)?.contiguous()?;
+        let k_native_one = k_native.narrow(1, 0, 1)?.contiguous()?;
+        let v_native_one = v_native.narrow(1, 0, 1)?.contiguous()?;
+        let beta_native_one = beta_native.narrow(1, 0, 1)?.contiguous()?;
+        let g_native_one = g_native.narrow(1, 0, 1)?.contiguous()?;
+        let mut state_native_one =
+            Tensor::from_slice(&state_data, (batch, value_heads, dk, dv), &device)?
+                .to_dtype(DType::BF16)?;
+        assert!(metal_gdn_recurrent_prefill_native_head_last_supports(
+            &q_native_one,
+            &k_native_one,
+            &v_native_one,
+            &beta_native_one,
+            &g_native_one,
+            &state_native_one
+        ));
+        let out_native_one = metal_gdn_recurrent_prefill_native_head_last_bf16(
+            &q_native_one,
+            &k_native_one,
+            &v_native_one,
+            &beta_native_one,
+            &g_native_one,
+            &mut state_native_one,
+        )?;
+        let out_ref_one = out_ref.narrow(1, 0, 1)?;
+        let state_ref_first = state_ref_first.expect("first recurrent state reference");
+        let native_one_out_max = max_abs_diff(&out_ref_one, &out_native_one)?;
+        let native_one_state_max = max_abs_diff(&state_ref_first, &state_native_one)?;
+        assert!(
+            native_one_out_max < 3e-2,
+            "GDN recurrent native decode out max_abs_diff={native_one_out_max:e} exceeds tolerance"
+        );
+        assert!(
+            native_one_state_max < 3e-2,
+            "GDN recurrent native decode state max_abs_diff={native_one_state_max:e} exceeds tolerance"
         );
 
         Ok(())

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2856,7 +2856,7 @@ fn gdn_recurrent_prefill_native_head_last(
     state: &mut Tensor, // [B, nv, dk, dv]
 ) -> Result<Option<Tensor>> {
     let (_, seq_len, _, _) = q.dims4()?;
-    if seq_len <= 1
+    if seq_len == 0
         || q.dtype() != DType::BF16
         || state.dtype() != DType::BF16
         || !backend.supports_gdn_recurrent_prefill_native_head_last()
@@ -3126,17 +3126,18 @@ pub fn gated_deltanet_forward(
     // parity oracle exercised by `kiln-rmsnorm-kernel`'s
     // `parity_l2_qk_norm_*` tests.
     let scale = 1.0 / (dk as f64).sqrt();
-    let recurrent_prefill_unexpanded_qk = input_dtype == DType::BF16
-        && seq_len > 1
+    let recurrent_unexpanded_qk = input_dtype == DType::BF16
+        && seq_len >= 1
         && seq_len <= GDN_RECURRENT_PREFILL_MAX_TOKENS
         && dk == 128
         && gqa_ratio > 1
         && !capture_b11_taps
-        && backend.supports_gdn_recurrent_prefill_head_last();
+        && !capture_c41_taps
+        && backend.supports_gdn_recurrent_prefill_native_head_last();
     let (q, k, qk_expanded) = {
         #[cfg(feature = "metal")]
         {
-            if recurrent_prefill_unexpanded_qk {
+            if recurrent_unexpanded_qk {
                 kiln_nvtx::range!(c"kiln/gdn/qk_norm_unexpanded");
                 let (q, k) = gdn_qk_norm(&q, &k, input_dtype, scale)?;
                 (q, k, false)
@@ -3278,7 +3279,7 @@ pub fn gated_deltanet_forward(
         *recurrent_state = recurrent_state.to_dtype(input_dtype)?;
     }
 
-    let native_recurrent_prefill = if recurrent_prefill_unexpanded_qk {
+    let native_recurrent_prefill = if recurrent_unexpanded_qk {
         let v_recur = v.to_dtype(input_dtype)?;
         gdn_recurrent_prefill_native_head_last(
             backend,


### PR DESCRIPTION
## Summary

Extends the Metal native GDN recurrent path to `seq_len == 1` so decode can keep Q/K in their native 16 key-head layout instead of expanding them to 32 value heads before recurrence. The native recurrent kernel already maps each value head back to its source key head, so this removes unnecessary decode QK-normalization/expansion work while keeping the default desktop path flag-free.

## Impact

Same-machine desktop-env 512/128 latency bench (`KILN_SPEC_METHOD=mtp`, resolved to `off` for this shape):

- Baseline before the prior GDN PR: decode ~4.44 tok/s
- After PR #455: warmed decode ~4.54-4.67 tok/s
- This branch: decode 4.61 tok/s first run, then 4.99 and 4.97 tok/s warmed
- Best patched total wall time observed: 32.52s

This gets Kiln decode much closer to the local llama.cpp BF16-KV result (~5.28 tok/s) for this shape.

## Validation

- `cargo test -p kiln-model --release --locked --features metal test_gdn_recurrent_prefill_head_last_matches_sequential --target-dir /private/tmp/kiln-unexpanded-target -- --nocapture`
- `cargo build -p kiln-server --bin kiln-bench --release --locked --features metal --target-dir /private/tmp/kiln-unexpanded-target`
- 512/128 desktop-env `kiln-bench` repeated benchmark runs

`cargo fmt --check` reports pre-existing repository-wide formatting drift, so formatting was not applied.