### PR TITLE
phase6: add C46 row provenance diagnostic

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1887,6 +1887,71 @@ fn capture_c45_layer1_row_taps(x: &Tensor, eps: f64) -> Result<()> {
     Ok(())
 }
 
+fn c46_layer1_row_provenance_tensors(x: &Tensor) -> Result<(Tensor, Tensor, Tensor, Tensor, Tensor)> {
+    let (_batch, seq_len, hidden) = x
+        .dims3()
+        .context("C46 row provenance expects layer-1 hidden to be [batch, seq, hidden]")?;
+    anyhow::ensure!(seq_len > 0, "C46 row provenance requires non-empty sequence");
+
+    let selected_row = x.narrow(1, seq_len - 1, 1)?;
+    let selected_row_f32 = selected_row.to_dtype(DType::F32)?;
+    let selected_row_contiguous = selected_row_f32.contiguous()?;
+    let selected_row_flat = selected_row_contiguous.reshape(((), hidden))?.contiguous()?;
+
+    let x_f32 = x.to_dtype(DType::F32)?;
+    let (_batch, seq_len, hidden) = x_f32
+        .dims3()
+        .context("C46 row provenance expects f32 layer-1 hidden to be [batch, seq, hidden]")?;
+    let c45_last_row = x_f32
+        .narrow(1, seq_len - 1, 1)?
+        .contiguous()?
+        .reshape(((), hidden))?
+        .contiguous()?;
+
+    Ok((
+        selected_row,
+        selected_row_f32,
+        selected_row_contiguous,
+        selected_row_flat,
+        c45_last_row,
+    ))
+}
+
+/// Phase C46: bisect the row-side operand provenance feeding C45's
+/// `layer_1_input_norm_last_row_flat_values` by splitting row selection,
+/// dtype promotion, contiguous materialization, flattening, and the exact C45
+/// operand reconstruction into separate taps.
+fn capture_c46_layer1_row_provenance_taps(x: &Tensor) -> Result<()> {
+    let (
+        selected_row,
+        selected_row_f32,
+        selected_row_contiguous,
+        selected_row_flat,
+        c45_last_row,
+    ) = c46_layer1_row_provenance_tensors(x)?;
+    crate::mtp_debug::capture_c46_layer1_row_provenance_tap(
+        "layer_1_input_norm_selected_row_before_rmsnorm",
+        &selected_row,
+    )?;
+    crate::mtp_debug::capture_c46_layer1_row_provenance_tap(
+        "layer_1_input_norm_selected_row_after_f32_cast",
+        &selected_row_f32,
+    )?;
+    crate::mtp_debug::capture_c46_layer1_row_provenance_tap(
+        "layer_1_input_norm_selected_row_after_contiguous",
+        &selected_row_contiguous,
+    )?;
+    crate::mtp_debug::capture_c46_layer1_row_provenance_tap(
+        "layer_1_input_norm_selected_row_after_flatten",
+        &selected_row_flat,
+    )?;
+    crate::mtp_debug::capture_c46_layer1_row_provenance_tap(
+        "layer_1_input_norm_last_row_flat_values",
+        &c45_last_row,
+    )?;
+    Ok(())
+}
+
 /// Apply Rotary Position Embeddings (RoPE) to query and key tensors.
 ///
 /// `q`: [batch, seq_len, num_heads, head_dim]
@@ -5374,6 +5439,7 @@ pub fn model_forward_paged_with_last_hidden(
     crate::mtp_debug::arm_c43_layer1_preweight_capture();
     crate::mtp_debug::arm_c44_layer1_f32_row_capture();
     crate::mtp_debug::arm_c45_layer1_row_capture();
+    crate::mtp_debug::arm_c46_layer1_row_provenance_capture();
     let (logits, hidden) = model_forward_paged_inner(
         backend,
         token_ids,
@@ -5418,6 +5484,7 @@ pub fn model_forward_paged_last_token_with_last_hidden(
     crate::mtp_debug::arm_c43_layer1_preweight_capture();
     crate::mtp_debug::arm_c44_layer1_f32_row_capture();
     crate::mtp_debug::arm_c45_layer1_row_capture();
+    crate::mtp_debug::arm_c46_layer1_row_provenance_capture();
     let (logits, hidden) = model_forward_paged_inner(
         backend,
         token_ids,
@@ -5828,6 +5895,10 @@ pub fn mtp_forward_step(
             // stashed during the base-model forward. Empty when
             // `KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS` is unset.
             let c45_taps = crate::mtp_debug::drain_c45_layer1_row_capture();
+            // Phase C46: drain the C45 row-side operand provenance taps
+            // stashed during the base-model forward. Empty when
+            // `KILN_MTP_DUMP_C46_ROW_PROVENANCE` is unset.
+            let c46_taps = crate::mtp_debug::drain_c46_layer1_row_provenance_capture();
             // Phase C6: drain the 5 pre-RoPE MTP input taps (token_emb,
             // norm_emb, norm_h, concat, fused) captured above. Empty when
             // `KILN_MTP_DUMP_PRE_ROPE` is unset, which keeps the dump format
@@ -5863,6 +5934,7 @@ pub fn mtp_forward_step(
                 &c43_taps,
                 &c44_taps,
                 &c45_taps,
+                &c46_taps,
                 &c6_taps,
                 &c7_taps,
                 &c14_taps,
@@ -5883,6 +5955,7 @@ pub fn mtp_forward_step(
                     c43_taps = c43_taps.len(),
                     c44_taps = c44_taps.len(),
                     c45_taps = c45_taps.len(),
+                    c46_taps = c46_taps.len(),
                     c6_taps = c6_taps.len(),
                     c7_taps = c7_taps.len(),
                     c14_taps = c14_taps.len(),
@@ -6099,6 +6172,8 @@ fn model_forward_paged_inner(
                     crate::mtp_debug::should_capture_c44_layer1_f32_row_tap_for_layer(i);
                 let capture_c45_taps =
                     crate::mtp_debug::should_capture_c45_layer1_row_tap_for_layer(i);
+                let capture_c46_taps =
+                    crate::mtp_debug::should_capture_c46_layer1_row_provenance_tap_for_layer(i);
                 if capture_c42_taps {
                     capture_c42_layer1_input_norm_taps(
                         &hidden,
@@ -6118,6 +6193,9 @@ fn model_forward_paged_inner(
                 }
                 if capture_c45_taps {
                     capture_c45_layer1_row_taps(&hidden, config.rms_norm_eps)?;
+                }
+                if capture_c46_taps {
+                    capture_c46_layer1_row_provenance_taps(&hidden)?;
                 }
                 let normed = {
                     kiln_nvtx::range!(c"kiln/norm/pre_attn");

--- a/crates/kiln-model/src/mtp_debug.rs
+++ b/crates/kiln-model/src/mtp_debug.rs
@@ -199,6 +199,20 @@ thread_local! {
     static C45_LAYER1_ROW_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
         const { RefCell::new(None) };
 
+    /// Phase C46: thread-local sink for the C45 row-side operand provenance
+    /// bisect. Kept distinct from C45 because this phase looks upstream of
+    /// `layer_1_input_norm_last_row_flat_values`: row selection before
+    /// RMSNorm, dtype promotion, contiguous materialization, flattening, and
+    /// the exact C45 operand reconstruction.
+    ///
+    /// Driven by [`arm_c46_layer1_row_provenance_capture`] /
+    /// [`drain_c46_layer1_row_provenance_capture`] /
+    /// [`capture_c46_layer1_row_provenance_tap`], and gated on
+    /// `KILN_MTP_DUMP_C46_ROW_PROVENANCE=1` so production decode stays on the
+    /// current fast path when unset.
+    static C46_LAYER1_ROW_PROVENANCE_CAPTURE: RefCell<Option<Vec<(String, Vec<usize>, Vec<f32>)>>> =
+        const { RefCell::new(None) };
+
     /// Phase B12: thread-local "current absolute layer index" slot. Set by
     /// the main transformer layer loop around each layer's forward call so
     /// that deep inside `gqa_attention_paged` / `transformer_block_paged`
@@ -947,6 +961,16 @@ pub fn is_dump_c45_layer1_row_taps_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// True when `KILN_MTP_DUMP_C46_ROW_PROVENANCE=1` (or `true`) is set.
+/// Opt-in for the Phase C46 row-side provenance bisect feeding C45's
+/// `layer_1_input_norm_last_row_flat_values`; captured tensors are appended
+/// to the MTP dump safetensors under names `c46__<name>`.
+pub fn is_dump_c46_row_provenance_enabled() -> bool {
+    std::env::var("KILN_MTP_DUMP_C46_ROW_PROVENANCE")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+}
+
 /// Canonical ordered list of Phase C42 layer-1 pre-norm / input-layernorm tap
 /// names. The comparator (`scripts/mtp_compare.py --c42`) and the HF
 /// reference (`scripts/mtp_h_main_reference_dump.py --c42-taps`) both mirror
@@ -991,6 +1015,18 @@ pub const C45_LAYER1_ROW_TAP_NAMES: &[&str] = &[
     "layer_1_input_norm_pre_weight_row_broadcast_output",
     "layer_1_input_norm_pre_weight_row_scalar_values",
     "layer_1_input_norm_pre_weight_row_reconstructed",
+];
+
+/// Canonical ordered list of Phase C46 layer-1 row-side provenance tap names.
+/// The comparator (`scripts/mtp_compare.py --c46-row-provenance`) and the HF
+/// reference (`scripts/mtp_h_main_reference_dump.py --c46-row-provenance-taps`)
+/// both mirror this exact order.
+pub const C46_ROW_PROVENANCE_TAP_NAMES: &[&str] = &[
+    "layer_1_input_norm_selected_row_before_rmsnorm",
+    "layer_1_input_norm_selected_row_after_f32_cast",
+    "layer_1_input_norm_selected_row_after_contiguous",
+    "layer_1_input_norm_selected_row_after_flatten",
+    "layer_1_input_norm_last_row_flat_values",
 ];
 
 /// True if the Phase C41 layer-1 capture window is currently armed on this
@@ -1201,6 +1237,49 @@ pub fn capture_c45_layer1_row_tap(name: &str, t: &Tensor) -> Result<()> {
     let (shape, flat) = tensor_to_f32_host(t)
         .with_context(|| format!("capture_c45_layer1_row_tap `{name}`: tensor→f32 host copy"))?;
     C45_LAYER1_ROW_CAPTURE.with(|c| {
+        if let Some(buf) = c.borrow_mut().as_mut() {
+            buf.push((name.to_string(), shape, flat));
+        }
+    });
+    Ok(())
+}
+
+/// True if the Phase C46 layer-1 row-side provenance capture window is
+/// currently armed on this thread.
+pub fn is_c46_layer1_row_provenance_capture_armed() -> bool {
+    C46_LAYER1_ROW_PROVENANCE_CAPTURE.with(|c| c.borrow().is_some())
+}
+
+/// True if a C46 layer-1 row-side provenance capture should happen for
+/// `layer_idx`.
+pub fn should_capture_c46_layer1_row_provenance_tap_for_layer(layer_idx: usize) -> bool {
+    layer_idx == 1 && is_c46_layer1_row_provenance_capture_armed()
+}
+
+/// Begin a C46 layer-1 row-side provenance capture window.
+pub fn arm_c46_layer1_row_provenance_capture() {
+    if !is_dump_c46_row_provenance_enabled() {
+        return;
+    }
+    C46_LAYER1_ROW_PROVENANCE_CAPTURE.with(|c| *c.borrow_mut() = Some(Vec::new()));
+}
+
+/// Drain the captured C46 layer-1 row-side provenance taps and disarm.
+pub fn drain_c46_layer1_row_provenance_capture() -> Vec<(String, Vec<usize>, Vec<f32>)> {
+    C46_LAYER1_ROW_PROVENANCE_CAPTURE.with(|c| c.borrow_mut().take().unwrap_or_default())
+}
+
+/// Record one named C46 layer-1 row-side provenance tap if a capture window
+/// is currently open on this thread.
+pub fn capture_c46_layer1_row_provenance_tap(name: &str, t: &Tensor) -> Result<()> {
+    let armed = C46_LAYER1_ROW_PROVENANCE_CAPTURE.with(|c| c.borrow().is_some());
+    if !armed {
+        return Ok(());
+    }
+    let (shape, flat) = tensor_to_f32_host(t).with_context(|| {
+        format!("capture_c46_layer1_row_provenance_tap `{name}`: tensor→f32 host copy")
+    })?;
+    C46_LAYER1_ROW_PROVENANCE_CAPTURE.with(|c| {
         if let Some(buf) = c.borrow_mut().as_mut() {
             buf.push((name.to_string(), shape, flat));
         }
@@ -1841,12 +1920,13 @@ fn tensor_to_f32_host(t: &Tensor) -> Result<(Vec<usize>, Vec<f32>)> {
 /// passing `&[]` for both `b11_taps` and `b12_taps` produce the historical
 /// safetensors layout.
 ///
-/// Phase C41 / C42 / C43 / C44 / C45: `c41_taps`, `c42_taps`, `c43_taps`,
-/// `c44_taps`, and `c45_taps` carry the layer-1 bisect taps captured via
-/// their phase-specific arm/capture/drain helpers. Each slice is serialized
-/// as F32 under `c41__<name>` / `c42__<name>` / `c43__<name>` / `c44__<name>`
-/// / `c45__<name>`, with an accompanying ordered tap-id metadata tensor so
-/// the Python side can mirror the exact tap order from the kiln dump.
+/// Phase C41 / C42 / C43 / C44 / C45 / C46: `c41_taps`, `c42_taps`,
+/// `c43_taps`, `c44_taps`, `c45_taps`, and `c46_taps` carry the layer-1
+/// bisect taps captured via their phase-specific arm/capture/drain helpers.
+/// Each slice is serialized as F32 under `c41__<name>` / `c42__<name>` /
+/// `c43__<name>` / `c44__<name>` / `c45__<name>` / `c46__<name>`, with an
+/// accompanying ordered tap-id metadata tensor so the Python side can mirror
+/// the exact tap order from the kiln dump.
 ///
 /// Phase C6: `c6_taps` carries the pre-RoPE MTP-input taps captured via
 /// [`arm_pre_rope_capture`] / [`capture_pre_rope_tap`] /
@@ -1887,6 +1967,7 @@ pub fn write_mtp_dump(
     c43_taps: &[(String, Vec<usize>, Vec<f32>)],
     c44_taps: &[(String, Vec<usize>, Vec<f32>)],
     c45_taps: &[(String, Vec<usize>, Vec<f32>)],
+    c46_taps: &[(String, Vec<usize>, Vec<f32>)],
     c6_taps: &[(String, Vec<usize>, Vec<f32>)],
     c7_taps: &[(String, Vec<usize>, Vec<f32>)],
     c14_taps: &[(String, Vec<usize>, Vec<f32>)],
@@ -1897,8 +1978,8 @@ pub fn write_mtp_dump(
     // TensorViews we build below can borrow from a stable backing store.
     // Capacity: static taps + subops + 4 meta + optional boundary-layer meta
     // + optional prompt/replay token tensors + b11 taps + b12 taps + optional
-    // C41/C42/C43/C44 tap-id meta + c41/c42/c43/c44 taps + c6 taps + c7 taps
-    // + c14 taps.
+    // C41/C42/C43/C44/C45/C46 tap-id meta + c41/c42/c43/c44/c45/c46 taps +
+    // c6 taps + c7 taps + c14 taps.
     let boundary_reserve = if boundary_layers.is_empty() { 0 } else { 1 };
     let prompt_reserve = if prompt_tokens.is_empty() { 0 } else { 2 };
     let replay_reserve = if replay_tokens.is_empty() { 0 } else { 2 };
@@ -1907,6 +1988,7 @@ pub fn write_mtp_dump(
     let c43_meta_reserve = if c43_taps.is_empty() { 0 } else { 1 };
     let c44_meta_reserve = if c44_taps.is_empty() { 0 } else { 1 };
     let c45_meta_reserve = if c45_taps.is_empty() { 0 } else { 1 };
+    let c46_meta_reserve = if c46_taps.is_empty() { 0 } else { 1 };
     let mut backings: Vec<(String, Vec<usize>, Dtype, Vec<u8>)> = Vec::with_capacity(
         taps.len()
             + extra_subops.len()
@@ -1926,6 +2008,8 @@ pub fn write_mtp_dump(
             + c44_taps.len()
             + c45_meta_reserve
             + c45_taps.len()
+            + c46_meta_reserve
+            + c46_taps.len()
             + c6_taps.len()
             + c7_taps.len()
             + c14_taps.len(),
@@ -2192,6 +2276,32 @@ pub fn write_mtp_dump(
             bytes.extend_from_slice(&v.to_le_bytes());
         }
         backings.push((format!("c45__{name}"), shape.clone(), Dtype::F32, bytes));
+    }
+
+    if !c46_taps.is_empty() {
+        let mut bytes = Vec::with_capacity(c46_taps.len() * 4);
+        for (name, _shape, _flat) in c46_taps {
+            let idx = C46_ROW_PROVENANCE_TAP_NAMES
+                .iter()
+                .position(|&tap| tap == name.as_str())
+                .with_context(|| format!("unknown C46 tap `{name}`"))?;
+            let idx_i32 = idx as i32;
+            bytes.extend_from_slice(&idx_i32.to_le_bytes());
+        }
+        backings.push((
+            "meta__c46_tap_ids".into(),
+            vec![c46_taps.len()],
+            Dtype::I32,
+            bytes,
+        ));
+    }
+
+    for (name, shape, flat) in c46_taps {
+        let mut bytes = Vec::with_capacity(flat.len() * 4);
+        for v in flat {
+            bytes.extend_from_slice(&v.to_le_bytes());
+        }
+        backings.push((format!("c46__{name}"), shape.clone(), Dtype::F32, bytes));
     }
 
     // Phase C6: serialize the pre-RoPE MTP-input taps under `c6__<name>` so
@@ -2669,6 +2779,7 @@ mod tests {
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2803,6 +2914,7 @@ mod tests {
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -2951,6 +3063,7 @@ mod tests {
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3056,6 +3169,27 @@ mod tests {
         assert_eq!(
             C45_LAYER1_ROW_TAP_NAMES[5],
             "layer_1_input_norm_pre_weight_row_reconstructed"
+        );
+    }
+
+    #[test]
+    fn c46_row_provenance_tap_names_enumerate_expected_boundaries() {
+        assert_eq!(C46_ROW_PROVENANCE_TAP_NAMES.len(), 5);
+        assert_eq!(
+            C46_ROW_PROVENANCE_TAP_NAMES[0],
+            "layer_1_input_norm_selected_row_before_rmsnorm"
+        );
+        assert_eq!(
+            C46_ROW_PROVENANCE_TAP_NAMES[1],
+            "layer_1_input_norm_selected_row_after_f32_cast"
+        );
+        assert_eq!(
+            C46_ROW_PROVENANCE_TAP_NAMES[3],
+            "layer_1_input_norm_selected_row_after_flatten"
+        );
+        assert_eq!(
+            C46_ROW_PROVENANCE_TAP_NAMES[4],
+            "layer_1_input_norm_last_row_flat_values"
         );
     }
 
@@ -3321,6 +3455,77 @@ mod tests {
     }
 
     #[test]
+    fn c46_row_provenance_capture_records_then_drains() {
+        let _guard = test_env_lock();
+        unsafe {
+            std::env::set_var("KILN_MTP_DUMP_C46_ROW_PROVENANCE", "1");
+        }
+        let a = Tensor::new(&[1.0_f32, 2.0, 3.0][..], &Device::Cpu).unwrap();
+        let b = Tensor::new(&[10.0_f32][..], &Device::Cpu).unwrap();
+
+        capture_c46_layer1_row_provenance_tap(
+            "layer_1_input_norm_selected_row_before_rmsnorm",
+            &a,
+        )
+        .unwrap();
+        assert!(drain_c46_layer1_row_provenance_capture().is_empty());
+        assert!(!is_c46_layer1_row_provenance_capture_armed());
+        assert!(!should_capture_c46_layer1_row_provenance_tap_for_layer(1));
+
+        arm_c46_layer1_row_provenance_capture();
+        assert!(is_c46_layer1_row_provenance_capture_armed());
+        assert!(should_capture_c46_layer1_row_provenance_tap_for_layer(1));
+        assert!(!should_capture_c46_layer1_row_provenance_tap_for_layer(0));
+        capture_c46_layer1_row_provenance_tap(
+            "layer_1_input_norm_selected_row_before_rmsnorm",
+            &b,
+        )
+        .unwrap();
+        capture_c46_layer1_row_provenance_tap(
+            "layer_1_input_norm_last_row_flat_values",
+            &a,
+        )
+        .unwrap();
+        let drained = drain_c46_layer1_row_provenance_capture();
+        assert_eq!(drained.len(), 2);
+        assert_eq!(drained[0].0, "layer_1_input_norm_selected_row_before_rmsnorm");
+        assert_eq!(drained[0].1, vec![1]);
+        assert_eq!(drained[0].2, vec![10.0]);
+        assert_eq!(drained[1].0, "layer_1_input_norm_last_row_flat_values");
+        assert_eq!(drained[1].1, vec![3]);
+        assert_eq!(drained[1].2, vec![1.0, 2.0, 3.0]);
+
+        assert!(!is_c46_layer1_row_provenance_capture_armed());
+        capture_c46_layer1_row_provenance_tap(
+            "layer_1_input_norm_selected_row_after_flatten",
+            &a,
+        )
+        .unwrap();
+        assert!(drain_c46_layer1_row_provenance_capture().is_empty());
+
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C46_ROW_PROVENANCE");
+        }
+    }
+
+    #[test]
+    fn c46_row_provenance_arm_is_noop_when_env_unset() {
+        let _guard = test_env_lock();
+        unsafe {
+            std::env::remove_var("KILN_MTP_DUMP_C46_ROW_PROVENANCE");
+        }
+        arm_c46_layer1_row_provenance_capture();
+        assert!(!is_c46_layer1_row_provenance_capture_armed());
+        let a = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        capture_c46_layer1_row_provenance_tap(
+            "layer_1_input_norm_selected_row_before_rmsnorm",
+            &a,
+        )
+        .unwrap();
+        assert!(drain_c46_layer1_row_provenance_capture().is_empty());
+    }
+
+    #[test]
     fn b12_gqa_capture_records_then_drains() {
         let _guard = test_env_lock();
         // SAFETY: single-threaded test; scoped env mutation.
@@ -3413,6 +3618,7 @@ mod tests {
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3481,6 +3687,7 @@ mod tests {
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3546,6 +3753,7 @@ mod tests {
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3611,6 +3819,7 @@ mod tests {
             &c43,
             /* c44_taps = */ &[],
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3678,6 +3887,7 @@ mod tests {
             /* c43_taps = */ &[],
             &c44,
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3745,6 +3955,7 @@ mod tests {
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
             &c45,
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -3771,6 +3982,74 @@ mod tests {
             .unwrap();
         assert_eq!(out.dtype(), safetensors::Dtype::F32);
         assert_eq!(out.shape(), &[1, 1, 3]);
+
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn write_mtp_dump_emits_c46_taps_and_metadata_when_provided() {
+        use safetensors::SafeTensors;
+
+        let h = Tensor::new(&[1.0_f32, 2.0][..], &Device::Cpu).unwrap();
+        let tmp = std::env::temp_dir().join("kiln_mtp_dump_with_c46.safetensors");
+        let tmp_s = tmp.to_string_lossy().into_owned();
+        let c46 = vec![
+            (
+                "layer_1_input_norm_selected_row_before_rmsnorm".to_string(),
+                vec![1, 1, 3],
+                vec![0.11_f32, 0.12, 0.13],
+            ),
+            (
+                "layer_1_input_norm_last_row_flat_values".to_string(),
+                vec![1, 3],
+                vec![0.21_f32, 0.22, 0.23],
+            ),
+        ];
+        write_mtp_dump(
+            &tmp_s,
+            /* draft_token_id = */ 70,
+            /* mtp_pos = */ 0,
+            /* base_pos = */ 0,
+            /* swap_fc_norms = */ false,
+            /* boundary_layers = */ &[],
+            &[("h_main", &h)],
+            &[],
+            /* prompt_tokens = */ &[],
+            /* replay_tokens = */ &[],
+            /* b11_taps = */ &[],
+            /* b12_taps = */ &[],
+            /* c41_taps = */ &[],
+            /* c42_taps = */ &[],
+            /* c43_taps = */ &[],
+            /* c44_taps = */ &[],
+            /* c45_taps = */ &[],
+            &c46,
+            /* c6_taps = */ &[],
+            /* c7_taps = */ &[],
+            /* c14_taps = */ &[],
+        )
+        .unwrap();
+
+        let raw = std::fs::read(&tmp).unwrap();
+        let st = SafeTensors::deserialize(&raw).unwrap();
+        let names: Vec<&str> = st.names().into_iter().map(|s| s.as_str()).collect();
+        assert!(names.contains(&"c46__layer_1_input_norm_selected_row_before_rmsnorm"));
+        assert!(names.contains(&"c46__layer_1_input_norm_last_row_flat_values"));
+        assert!(names.contains(&"meta__c46_tap_ids"));
+
+        let ids = st.tensor("meta__c46_tap_ids").unwrap();
+        assert_eq!(ids.dtype(), safetensors::Dtype::I32);
+        assert_eq!(ids.shape(), &[2]);
+        let id0 = i32::from_le_bytes(ids.data()[0..4].try_into().unwrap());
+        let id1 = i32::from_le_bytes(ids.data()[4..8].try_into().unwrap());
+        assert_eq!(id0, 0);
+        assert_eq!(id1, 4);
+
+        let out = st
+            .tensor("c46__layer_1_input_norm_last_row_flat_values")
+            .unwrap();
+        assert_eq!(out.dtype(), safetensors::Dtype::F32);
+        assert_eq!(out.shape(), &[1, 3]);
 
         let _ = std::fs::remove_file(&tmp);
     }
@@ -3970,6 +4249,7 @@ mod tests {
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             &c6,
             /* c7_taps = */ &[],
             /* c14_taps = */ &[],
@@ -4107,6 +4387,7 @@ mod tests {
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             &c7,
             /* c14_taps = */ &[],
@@ -4270,6 +4551,7 @@ mod tests {
             /* c43_taps = */ &[],
             /* c44_taps = */ &[],
             /* c45_taps = */ &[],
+            /* c46_taps = */ &[],
             /* c6_taps = */ &[],
             /* c7_taps = */ &[],
             &c14,

--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -248,3 +248,94 @@ within the tighter mask on both seeds, while the selected row fails the tighter
 mask and dominates the first-order contribution budget. The next exact target is
 therefore the provenance of `layer_1_input_norm_last_row_flat_values` feeding the
 row-shaped broadcast multiply.
+
+## 2026-04-24 C46 row-side provenance verdict
+
+PR #451 left the next exact target as the row-side operand feeding
+`layer_1_input_norm_last_row_flat_values`, because the C45 operand budget showed
+row-side drift dominated the otherwise-correct row-shaped broadcast multiply.
+C46 adds a minimal upstream provenance slice for that operand only:
+
+- `layer_1_input_norm_selected_row_before_rmsnorm`: layer-1 input row selected
+  before RMSNorm replay or dtype promotion;
+- `layer_1_input_norm_selected_row_after_f32_cast`: the same row after F32
+  promotion;
+- `layer_1_input_norm_selected_row_after_contiguous`: the row after contiguous
+  materialization;
+- `layer_1_input_norm_selected_row_after_flatten`: the flattened row operand;
+- `layer_1_input_norm_last_row_flat_values`: the exact C45 row operand
+  reconstruction.
+
+GPU validation used the mandatory RunPod image on pod `98ez1btmml8eu5`
+(`NVIDIA RTX A6000`, CUDA 12.4 image `ghcr.io/ericflo/kiln-runpod:latest`) with
+`KILN_BENCH_FORCE_MTP=1` so the representative 512-token prompt shape stayed on
+native MTP for the diagnostic dump.
+
+Commands run on the pod:
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+cargo build --release --features cuda --bin kiln-bench
+cargo test --locked -p kiln-model c45 -- --nocapture
+cargo test --locked -p kiln-model c46 -- --nocapture
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+
+KILN_SPEC_METHOD=mtp \
+KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_PATH='profiling-artifacts/c46_row_provenance_seed0_captures/mtp_pos-{pos}/step-{step}.safetensors' \
+KILN_MTP_DUMP_POS=0 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 \
+KILN_MTP_DUMP_C46_ROW_PROVENANCE=1 \
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 8 --skip-training --seed 0
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump 'profiling-artifacts/c46_row_provenance_seed0_captures/mtp_pos-0/step-{step}.safetensors' \
+  --out profiling-artifacts/c46_row_provenance_seed0_ref_bf16.safetensors \
+  --c46-row-provenance-taps --seed 0
+python3 scripts/mtp_compare.py --c46-row-provenance \
+  --kiln 'profiling-artifacts/c46_row_provenance_seed0_captures/mtp_pos-0/step-{step}.safetensors' \
+  --ref profiling-artifacts/c46_row_provenance_seed0_ref_bf16.safetensors \
+  > profiling-artifacts/c46_row_provenance_seed0_compare.txt
+
+KILN_SPEC_METHOD=mtp \
+KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_PATH='profiling-artifacts/c46_row_provenance_seed1_captures/mtp_pos-{pos}/step-{step}.safetensors' \
+KILN_MTP_DUMP_POS=2 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 \
+KILN_MTP_DUMP_C46_ROW_PROVENANCE=1 \
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed 1
+
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump 'profiling-artifacts/c46_row_provenance_seed1_captures/mtp_pos-2/step-{step}.safetensors' \
+  --out profiling-artifacts/c46_row_provenance_seed1_ref_bf16.safetensors \
+  --c46-row-provenance-taps --seed 1
+python3 scripts/mtp_compare.py --c46-row-provenance \
+  --kiln 'profiling-artifacts/c46_row_provenance_seed1_captures/mtp_pos-2/step-{step}.safetensors' \
+  --ref profiling-artifacts/c46_row_provenance_seed1_ref_bf16.safetensors \
+  > profiling-artifacts/c46_row_provenance_seed1_compare.txt
+```
+
+Seed-specific evidence:
+
+- seed 0 (`mtp_pos=0`): all C46 row-provenance taps pass both the current C45
+  tolerance (`atol=1e-2`, `rtol=1e-1`) and the tighter C45 mask
+  (`atol=1e-3`, `rtol=1e-2`); each tap has `max|Δ|=9.77e-04`,
+  `mean|Δ|=6.67e-05`, `rel_l2=2.65e-03`; prompt=494,
+  prefill=`328.3 ms`, mean ITL=`47.1 ms`, `alpha=0.333`.
+- seed 1 (`mtp_pos=2`): all C46 row-provenance taps pass both tolerances;
+  each tap has `max|Δ|=7.32e-04`, `mean|Δ|=1.08e-04`,
+  `rel_l2=3.47e-03`; prompt=508, prefill=`349.5 ms`, mean ITL=`43.7 ms`,
+  `alpha=0.309`.
+
+Final C46 verdict: there is no row-selection, dtype-cast, contiguous, flatten,
+or exact C45 row-operand reconstruction bug at this boundary. Under the tighter
+mask, the entire C46 row-side provenance slice remains shared-good on both
+representative seeds. Because the fresh C46 replay cannot reproduce a local
+row-provenance failure, no production math fix is justified here; the next
+boundary classification is the existing C45 tolerance artifact rather than row
+selection, dtype cast, flatten/contiguous, or exact operand construction.

--- a/profiling-artifacts/c46_row_provenance_seed0_compare.txt
+++ b/profiling-artifacts/c46_row_provenance_seed0_compare.txt
@@ -1,0 +1,42 @@
+MTP numerical bisect — mode: layer-1 row-side provenance audit (C46), atol=0.01, rtol=0.1
+
+=== pair ===
+  kiln dump : profiling-artifacts/c46_row_provenance_seed0_captures/mtp_pos-0/step-{step}.safetensors
+  ref  dump : profiling-artifacts/c46_row_provenance_seed0_ref_bf16.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 8, 16, 23, 31] ref=[0, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c46__layer_1_input_norm_last_row_flat_values 1x2560                 True     True     1.00e+00   9.77e-04     6.67e-05    
+c46__layer_1_input_norm_selected_row_after_contiguous 1x1x2560               True     True     1.00e+00   9.77e-04     6.67e-05    
+c46__layer_1_input_norm_selected_row_after_f32_cast 1x1x2560               True     True     1.00e+00   9.77e-04     6.67e-05    
+c46__layer_1_input_norm_selected_row_after_flatten 1x2560                 True     True     1.00e+00   9.77e-04     6.67e-05    
+c46__layer_1_input_norm_selected_row_before_rmsnorm 1x1x2560               True     True     1.00e+00   9.77e-04     6.67e-05    
+
+  pair verdict: all taps match within tolerance.
+
+==============================================================================
+Phase C46 layer-1 row-side provenance audit — current and tight tolerance
+==============================================================================
+  current tolerance: atol=0.01, rtol=0.1
+  tight tolerance  : atol=0.001, rtol=0.01
+  tap                                                   pair                                                      
+  ----------------------------------------------------------------------------------------------------------------
+  layer_1_input_norm_selected_row_before_rmsnorm        cur=ok  tight=ok  max|Δ|=9.77e-04   mean|Δ|=6.67e-05   rel_l2=2.65e-03   cos=1.00e+00  
+  layer_1_input_norm_selected_row_after_f32_cast        cur=ok  tight=ok  max|Δ|=9.77e-04   mean|Δ|=6.67e-05   rel_l2=2.65e-03   cos=1.00e+00  
+  layer_1_input_norm_selected_row_after_contiguous      cur=ok  tight=ok  max|Δ|=9.77e-04   mean|Δ|=6.67e-05   rel_l2=2.65e-03   cos=1.00e+00  
+  layer_1_input_norm_selected_row_after_flatten         cur=ok  tight=ok  max|Δ|=9.77e-04   mean|Δ|=6.67e-05   rel_l2=2.65e-03   cos=1.00e+00  
+  layer_1_input_norm_last_row_flat_values               cur=ok  tight=ok  max|Δ|=9.77e-04   mean|Δ|=6.67e-05   rel_l2=2.65e-03   cos=1.00e+00  
+Phase C46 current-tolerance verdict: no shared earliest-bad row-provenance tap.
+  current earliest divergent tap for pair: <none>
+Phase C46 tight-tolerance verdict: no shared earliest-bad row-provenance tap.
+  tight earliest divergent tap for pair: <none>
+
+Overall verdict: all taps match within tolerance.
+

--- a/profiling-artifacts/c46_row_provenance_seed1_compare.txt
+++ b/profiling-artifacts/c46_row_provenance_seed1_compare.txt
@@ -1,0 +1,42 @@
+MTP numerical bisect — mode: layer-1 row-side provenance audit (C46), atol=0.01, rtol=0.1
+
+=== pair ===
+  kiln dump : profiling-artifacts/c46_row_provenance_seed1_captures/mtp_pos-2/step-{step}.safetensors
+  ref  dump : profiling-artifacts/c46_row_provenance_seed1_ref_bf16.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 8, 16, 23, 31] ref=[0, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c46__layer_1_input_norm_last_row_flat_values 1x2560                 True     True     1.00e+00   7.32e-04     1.08e-04    
+c46__layer_1_input_norm_selected_row_after_contiguous 1x1x2560               True     True     1.00e+00   7.32e-04     1.08e-04    
+c46__layer_1_input_norm_selected_row_after_f32_cast 1x1x2560               True     True     1.00e+00   7.32e-04     1.08e-04    
+c46__layer_1_input_norm_selected_row_after_flatten 1x2560                 True     True     1.00e+00   7.32e-04     1.08e-04    
+c46__layer_1_input_norm_selected_row_before_rmsnorm 1x1x2560               True     True     1.00e+00   7.32e-04     1.08e-04    
+
+  pair verdict: all taps match within tolerance.
+
+==============================================================================
+Phase C46 layer-1 row-side provenance audit — current and tight tolerance
+==============================================================================
+  current tolerance: atol=0.01, rtol=0.1
+  tight tolerance  : atol=0.001, rtol=0.01
+  tap                                                   pair                                                      
+  ----------------------------------------------------------------------------------------------------------------
+  layer_1_input_norm_selected_row_before_rmsnorm        cur=ok  tight=ok  max|Δ|=7.32e-04   mean|Δ|=1.08e-04   rel_l2=3.47e-03   cos=1.00e+00  
+  layer_1_input_norm_selected_row_after_f32_cast        cur=ok  tight=ok  max|Δ|=7.32e-04   mean|Δ|=1.08e-04   rel_l2=3.47e-03   cos=1.00e+00  
+  layer_1_input_norm_selected_row_after_contiguous      cur=ok  tight=ok  max|Δ|=7.32e-04   mean|Δ|=1.08e-04   rel_l2=3.47e-03   cos=1.00e+00  
+  layer_1_input_norm_selected_row_after_flatten         cur=ok  tight=ok  max|Δ|=7.32e-04   mean|Δ|=1.08e-04   rel_l2=3.47e-03   cos=1.00e+00  
+  layer_1_input_norm_last_row_flat_values               cur=ok  tight=ok  max|Δ|=7.32e-04   mean|Δ|=1.08e-04   rel_l2=3.47e-03   cos=1.00e+00  
+Phase C46 current-tolerance verdict: no shared earliest-bad row-provenance tap.
+  current earliest divergent tap for pair: <none>
+Phase C46 tight-tolerance verdict: no shared earliest-bad row-provenance tap.
+  tight earliest divergent tap for pair: <none>
+
+Overall verdict: all taps match within tolerance.
+

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -391,6 +391,24 @@ C45_HYPOTHESIS: Dict[str, str] = {
 C45_TIGHT_ATOL = 1e-3
 C45_TIGHT_RTOL = 1e-2
 
+# Phase C46 — row-side provenance taps feeding C45's
+# `layer_1_input_norm_last_row_flat_values`, in forward-graph order.
+C46_ROW_PROVENANCE_TAP_NAMES: Tuple[str, ...] = (
+    "layer_1_input_norm_selected_row_before_rmsnorm",
+    "layer_1_input_norm_selected_row_after_f32_cast",
+    "layer_1_input_norm_selected_row_after_contiguous",
+    "layer_1_input_norm_selected_row_after_flatten",
+    "layer_1_input_norm_last_row_flat_values",
+)
+
+C46_HYPOTHESIS: Dict[str, str] = {
+    "layer_1_input_norm_selected_row_before_rmsnorm": "upstream residual-row drift is already present before RMSNorm row selection/cast replay",
+    "layer_1_input_norm_selected_row_after_f32_cast": "row selection is within tolerance, but dtype promotion exposes the first row-side drift",
+    "layer_1_input_norm_selected_row_after_contiguous": "dtype-promoted row is within tolerance, but contiguous materialization changes the row values",
+    "layer_1_input_norm_selected_row_after_flatten": "row-shaped contiguous values are within tolerance, but flattening changes the row-side operand",
+    "layer_1_input_norm_last_row_flat_values": "the exact C45 operand reconstruction is the first boundary that exceeds tolerance",
+}
+
 # Phase B12 — the cos_sim bar is tighter than B10/B11 because the expected
 # residual drift is small (0.97-0.98) and the goal is to localize it. A
 # per-layer median below this threshold marks the first layer of interest; if
@@ -938,7 +956,7 @@ def _compare_pair(
         emit("  pair verdict: all taps match within tolerance.")
     else:
         base_first_div = first_div
-        for prefix in ("b11__", "b12__", "c41__", "c45__", "c6__", "c7__"):
+        for prefix in ("b11__", "b12__", "c41__", "c45__", "c46__", "c6__", "c7__"):
             if base_first_div.startswith(prefix):
                 base_first_div = base_first_div[len(prefix) :]
                 break
@@ -949,6 +967,7 @@ def _compare_pair(
             or B12_HYPOTHESIS.get(base_first_div)
             or C41_HYPOTHESIS.get(base_first_div)
             or C45_HYPOTHESIS.get(base_first_div)
+            or C46_HYPOTHESIS.get(base_first_div)
             or C6_HYPOTHESIS.get(base_first_div)
             or C7_HYPOTHESIS.get(base_first_div)
             or "<unknown tap>"
@@ -2312,6 +2331,143 @@ def _emit_c44_summary(
         )
 
 
+def _emit_c46_summary(
+    pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
+    atol: float,
+    rtol: float,
+    emit,
+) -> None:
+    """Phase C46 — row-side provenance bisect for C45 selected-row operand."""
+    emit("")
+    emit("=" * 78)
+    emit("Phase C46 layer-1 row-side provenance audit — current and tight tolerance")
+    emit("=" * 78)
+    emit(f"  current tolerance: atol={atol:g}, rtol={rtol:g}")
+    emit(f"  tight tolerance  : atol={C45_TIGHT_ATOL:g}, rtol={C45_TIGHT_RTOL:g}")
+
+    labels = [pr[0] for pr in pair_results]
+    current_cell: Dict[str, Dict[str, Tuple[float, float, float, float, bool]]] = {
+        n: {} for n in C46_ROW_PROVENANCE_TAP_NAMES
+    }
+    tight_cell: Dict[str, Dict[str, Tuple[float, float, float, float, bool]]] = {
+        n: {} for n in C46_ROW_PROVENANCE_TAP_NAMES
+    }
+    for label, _ok, _fd, rows, kiln_tensors, ref_tensors in pair_results:
+        for r in rows:
+            n = r["name"]
+            if not isinstance(n, str) or not n.startswith("c46__"):
+                continue
+            short = n[len("c46__") :]
+            if short not in current_cell:
+                continue
+            current_cell[short][label] = (
+                float(r["cos_sim"]),
+                float(r["max_abs_diff"]),
+                float(r["mean_abs_diff"]),
+                float(r.get("rel_l2", float("nan"))),
+                bool(r["allclose"]),
+            )
+            key = f"c46__{short}"
+            if key in kiln_tensors and key in ref_tensors:
+                tr = _compare_tap(
+                    key,
+                    kiln_tensors[key],
+                    ref_tensors[key],
+                    C45_TIGHT_ATOL,
+                    C45_TIGHT_RTOL,
+                )
+                tight_cell[short][label] = (
+                    float(tr["cos_sim"]),
+                    float(tr["max_abs_diff"]),
+                    float(tr["mean_abs_diff"]),
+                    float(tr.get("rel_l2", float("nan"))),
+                    bool(tr["allclose"]),
+                )
+
+    for tap, by_label in current_cell.items():
+        for lab, cur in by_label.items():
+            if lab not in tight_cell[tap]:
+                cs, mxd, mnd, rl2, _ok = cur
+                tight_cell[tap][lab] = (cs, mxd, mnd, rl2, mxd <= C45_TIGHT_ATOL)
+
+    header = "  " + "tap".ljust(54) + " ".join(f"{lab:<58}" for lab in labels)
+    emit(header)
+    emit("  " + "-" * (len(header) - 2))
+    captured_any = False
+    for tap in C46_ROW_PROVENANCE_TAP_NAMES:
+        cells = []
+        for lab in labels:
+            cur = current_cell[tap].get(lab)
+            tight = tight_cell[tap].get(lab)
+            if cur is None:
+                cells.append(f"{'<missing>':<58}")
+                continue
+            cs, mxd, mnd, rl2, ok = cur
+            captured_any = True
+            tight_ok = tight[4] if tight is not None else False
+            cells.append(
+                f"cur={'ok' if ok else 'DIV':<3} tight={'ok' if tight_ok else 'DIV':<3} "
+                f"max|Δ|={_fmt_sci(mxd):<10} mean|Δ|={_fmt_sci(mnd):<10} "
+                f"rel_l2={_fmt_sci(rl2):<10} cos={_fmt_sci(cs):<10}"
+            )
+        emit(f"  {tap:<54}{' '.join(cells)}")
+
+    if not captured_any:
+        emit("Phase C46 verdict: no C46 row-provenance taps present in dumps.")
+        emit("  -> Re-run kiln-bench with KILN_MTP_DUMP_C46_ROW_PROVENANCE=1 and")
+        emit("     re-run mtp_h_main_reference_dump.py with --c46-row-provenance-taps.")
+        return
+
+    def first_shared_bad(cell: Dict[str, Dict[str, Tuple[float, float, float, float, bool]]]) -> Tuple[Optional[str], Optional[str], Dict[str, str]]:
+        first_bad: Optional[str] = None
+        last_ok: Optional[str] = None
+        per_seed: Dict[str, str] = {}
+        for tap in C46_ROW_PROVENANCE_TAP_NAMES:
+            all_present = True
+            all_ok = True
+            all_bad = True
+            for lab in labels:
+                entry = cell[tap].get(lab)
+                if entry is None:
+                    all_present = False
+                    all_ok = False
+                    all_bad = False
+                    continue
+                ok = entry[4]
+                all_ok &= ok
+                all_bad &= not ok
+                if not ok and lab not in per_seed:
+                    per_seed[lab] = tap
+            if all_present and all_ok and first_bad is None:
+                last_ok = tap
+            if all_present and all_bad and first_bad is None:
+                first_bad = tap
+        return first_bad, last_ok, per_seed
+
+    current_bad, current_last_ok, current_per_seed = first_shared_bad(current_cell)
+    tight_bad, tight_last_ok, tight_per_seed = first_shared_bad(tight_cell)
+
+    if current_bad is None:
+        emit("Phase C46 current-tolerance verdict: no shared earliest-bad row-provenance tap.")
+        for lab in labels:
+            emit(f"  current earliest divergent tap for {lab}: {current_per_seed.get(lab, '<none>')}")
+    else:
+        emit(f"Phase C46 current-tolerance verdict: earliest shared bad tap = '{current_bad}'.")
+        if current_last_ok is not None:
+            emit(f"  current last shared-good tap: '{current_last_ok}'")
+        emit(f"  Most-likely cause: {C46_HYPOTHESIS.get(current_bad, '<unknown tap>')}")
+
+    if tight_bad is None:
+        emit("Phase C46 tight-tolerance verdict: no shared earliest-bad row-provenance tap.")
+        for lab in labels:
+            emit(f"  tight earliest divergent tap for {lab}: {tight_per_seed.get(lab, '<none>')}")
+    else:
+        emit(f"Phase C46 tight-tolerance verdict: earliest shared bad tap = '{tight_bad}'.")
+        if tight_last_ok is not None:
+            emit(f"  tight last shared-good tap: '{tight_last_ok}'")
+        emit(f"  Most-likely cause: {C46_HYPOTHESIS.get(tight_bad, '<unknown tap>')}")
+
+
 def _emit_c45_summary(
     pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
@@ -2704,6 +2860,16 @@ def main() -> int:
         ),
     )
     ap.add_argument(
+        "--c46-row-provenance",
+        action="store_true",
+        help=(
+            "Phase C46 mode: emit the row-side provenance audit over the "
+            "explicit c46__<name> tap set feeding C45's "
+            "layer_1_input_norm_last_row_flat_values. Defaults atol=1e-2, "
+            "rtol=1e-1 and also reports tight atol=1e-3, rtol=1e-2 verdicts."
+        ),
+    )
+    ap.add_argument(
         "--c6",
         action="store_true",
         help=(
@@ -2755,6 +2921,7 @@ def main() -> int:
         or args.c45
         or args.c45_row_scalar
         or args.c45_operand_budget
+        or args.c46_row_provenance
     )
     if args.atol is None:
         args.atol = 1e-2 if bf16_mode else 1e-3
@@ -2772,7 +2939,7 @@ def main() -> int:
         if not (args.kiln and args.ref):
             print("ERROR: must specify --kiln and --ref, or one or more --pair args", file=sys.stderr)
             return 2
-        pairs.append(("", args.kiln, args.ref))
+        pairs.append(("pair", args.kiln, args.ref))
 
     lines: List[str] = []
 
@@ -2783,6 +2950,8 @@ def main() -> int:
     multi = len(pairs) > 1
     if args.c7:
         mode = "SDPA-internal bisect (C7)"
+    elif args.c46_row_provenance:
+        mode = "layer-1 row-side provenance audit (C46)"
     elif args.c45 or args.c45_row_scalar or args.c45_operand_budget:
         mode = "layer-1 row-local operand drift budget (C45)"
     elif args.c44:
@@ -2812,7 +2981,9 @@ def main() -> int:
     ] = []
     overall_ok = True
     focus_keys = None
-    if args.c45 or args.c45_row_scalar or args.c45_operand_budget:
+    if args.c46_row_provenance:
+        focus_keys = [f"c46__{name}" for name in C46_ROW_PROVENANCE_TAP_NAMES]
+    elif args.c45 or args.c45_row_scalar or args.c45_operand_budget:
         focus_keys = [f"c45__{name}" for name in C45_LAYER1_ROW_TAP_NAMES]
     elif args.c44:
         focus_keys = [f"c44__{name}" for name in C44_LAYER1_F32_ROW_TAP_NAMES]
@@ -2832,6 +3003,8 @@ def main() -> int:
 
     if args.c7:
         _emit_c7_summary(pair_results, args.atol, args.rtol, emit)
+    elif args.c46_row_provenance:
+        _emit_c46_summary(pair_results, args.atol, args.rtol, emit)
     elif args.c45 or args.c45_row_scalar or args.c45_operand_budget:
         _emit_c45_summary(pair_results, args.atol, args.rtol, emit)
     elif args.c44:

--- a/scripts/mtp_h_main_reference_dump.py
+++ b/scripts/mtp_h_main_reference_dump.py
@@ -246,6 +246,17 @@ C45_LAYER1_ROW_TAP_NAMES: Tuple[str, ...] = (
     "layer_1_input_norm_pre_weight_row_reconstructed",
 )
 
+# Phase C46 — ordered layer-1 row-side provenance bisect tap names. Must stay
+# in lock-step with `C46_ROW_PROVENANCE_TAP_NAMES` in
+# `crates/kiln-model/src/mtp_debug.rs`.
+C46_ROW_PROVENANCE_TAP_NAMES: Tuple[str, ...] = (
+    "layer_1_input_norm_selected_row_before_rmsnorm",
+    "layer_1_input_norm_selected_row_after_f32_cast",
+    "layer_1_input_norm_selected_row_after_contiguous",
+    "layer_1_input_norm_selected_row_after_flatten",
+    "layer_1_input_norm_last_row_flat_values",
+)
+
 
 # -----------------------------------------------------------------------------
 # Kiln-dump loader (mirrors mtp_reference_dump.py's loader)
@@ -431,6 +442,37 @@ def resolve_c45_tap_names(kiln_dump: Dict[str, object]) -> List[str]:
         return from_keys
 
     return list(C45_LAYER1_ROW_TAP_NAMES)
+
+
+
+def resolve_c46_tap_names(kiln_dump: Dict[str, object]) -> List[str]:
+    raw = kiln_dump.get("meta__c46_tap_ids")
+    if isinstance(raw, list) and raw:
+        names: List[str] = []
+        for idx in raw:
+            idx_i = int(idx)
+            if 0 <= idx_i < len(C46_ROW_PROVENANCE_TAP_NAMES):
+                names.append(C46_ROW_PROVENANCE_TAP_NAMES[idx_i])
+        if names:
+            return names
+
+    from_keys = sorted(
+        {
+            key[len("c46__") :]
+            for key in kiln_dump.keys()
+            if key.startswith("c46__")
+        },
+        key=lambda name: (
+            C46_ROW_PROVENANCE_TAP_NAMES.index(name)
+            if name in C46_ROW_PROVENANCE_TAP_NAMES
+            else len(C46_ROW_PROVENANCE_TAP_NAMES),
+            name,
+        ),
+    )
+    if from_keys:
+        return from_keys
+
+    return list(C46_ROW_PROVENANCE_TAP_NAMES)
 
 
 # -----------------------------------------------------------------------------
@@ -1158,6 +1200,39 @@ def _arm_c45_layer1_row_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List
     return handles
 
 
+
+def _arm_c46_row_provenance_hooks(base, taps_out: Dict[str, "torch.Tensor"]) -> List[object]:
+    """Attach hooks for the Phase C46 C45 row-side operand provenance audit."""
+    handles: List[object] = []
+    layer = base.layers[1]
+    norm = getattr(layer, "input_layernorm", None)
+    if norm is None:
+        return handles
+
+    def _pre_hook(_mod, inputs):
+        tensor = inputs[0][0] if isinstance(inputs[0], tuple) else inputs[0]
+        residual = tensor.detach().clone()
+        selected_row = residual[:, -1:, :]
+        selected_row_f32 = selected_row.to(torch.float32)
+        selected_row_contiguous = selected_row_f32.contiguous()
+        selected_row_flat = selected_row_contiguous.reshape(
+            residual.shape[0], residual.shape[-1]
+        ).contiguous()
+
+        c45_last_row = residual.to(torch.float32)[:, -1:, :].contiguous().reshape(
+            residual.shape[0], residual.shape[-1]
+        ).contiguous()
+
+        taps_out["layer_1_input_norm_selected_row_before_rmsnorm"] = selected_row
+        taps_out["layer_1_input_norm_selected_row_after_f32_cast"] = selected_row_f32
+        taps_out["layer_1_input_norm_selected_row_after_contiguous"] = selected_row_contiguous
+        taps_out["layer_1_input_norm_selected_row_after_flatten"] = selected_row_flat
+        taps_out["layer_1_input_norm_last_row_flat_values"] = c45_last_row
+
+    handles.append(norm.register_forward_pre_hook(_pre_hook))
+    return handles
+
+
 # -----------------------------------------------------------------------------
 # Reference forward
 # -----------------------------------------------------------------------------
@@ -1180,6 +1255,8 @@ def run_reference_forward(
     c44_tap_names: Optional[List[str]] = None,
     capture_c45: bool = False,
     c45_tap_names: Optional[List[str]] = None,
+    capture_c46: bool = False,
+    c46_tap_names: Optional[List[str]] = None,
     fp32: bool = False,
 ) -> Dict[str, torch.Tensor]:
     """Run HF Qwen3-Next / Qwen3.5 forward with `output_hidden_states=True`.
@@ -1202,6 +1279,8 @@ def run_reference_forward(
       taps under `c44__<name>` keys.
     - `capture_c45=True`: layer-1 row-local scalar tensor + extracted scalar
       + flat scalar-multiply + reconstructed row taps under `c45__<name>` keys.
+    - `capture_c46=True`: layer-1 row-side provenance taps feeding C45's
+      `layer_1_input_norm_last_row_flat_values` under `c46__<name>` keys.
     - `fp32=True`: load the HF model in float32 (instead of bfloat16) so the
       comparator can distinguish bf16-accumulation noise from real divergence.
     """
@@ -1249,10 +1328,11 @@ def run_reference_forward(
             capture_c43,
             capture_c44,
             capture_c45,
+            capture_c46,
         )
     ) > 1:
         raise ValueError(
-            "capture_b11_layer0, capture_c41, capture_c42, capture_c43, capture_c44, and capture_c45 are mutually exclusive"
+            "capture_b11_layer0, capture_c41, capture_c42, capture_c43, capture_c44, capture_c45, and capture_c46 are mutually exclusive"
         )
 
     # Set up B11b/C41 instrumentation + forward hooks BEFORE the forward.
@@ -1263,6 +1343,7 @@ def run_reference_forward(
     c43_captures: Dict[str, torch.Tensor] = {}
     c44_captures: Dict[str, torch.Tensor] = {}
     c45_captures: Dict[str, torch.Tensor] = {}
+    c46_captures: Dict[str, torch.Tensor] = {}
     hook_handles: List[object] = []
     orig_gdn_forward = None
     if capture_b11_layer0:
@@ -1340,6 +1421,13 @@ def run_reference_forward(
         print(
             "[mtp_h_main_ref] C45 instrumentation armed: layer 1 row-local "
             "scalar / extracted-scalar / multiply / reconstruction audit hooks",
+            file=sys.stderr,
+        )
+    elif capture_c46:
+        hook_handles.extend(_arm_c46_row_provenance_hooks(base, c46_captures))
+        print(
+            "[mtp_h_main_ref] C46 instrumentation armed: layer 1 row-side "
+            "selection / cast / contiguous / flatten provenance hooks",
             file=sys.stderr,
         )
 
@@ -1513,6 +1601,18 @@ def run_reference_forward(
             if name in c45_captures:
                 taps[f"c45__{name}"] = c45_captures[name].contiguous()
 
+    if capture_c46:
+        wanted = c46_tap_names or list(C46_ROW_PROVENANCE_TAP_NAMES)
+        missing = [n for n in wanted if n not in c46_captures]
+        if missing:
+            print(
+                f"[mtp_h_main_ref] WARNING: C46 instrumentation missed taps: {missing}",
+                file=sys.stderr,
+            )
+        for name in wanted:
+            if name in c46_captures:
+                taps[f"c46__{name}"] = c46_captures[name].contiguous()
+
     # Free the model and all retained activations before returning.
     del model, out, hs
     if device.type == "cuda":
@@ -1636,6 +1736,18 @@ def main() -> int:
         ),
     )
     ap.add_argument(
+        "--c46-row-provenance-taps",
+        action="store_true",
+        help=(
+            "Also capture the explicit Phase C46 layer-1 row-side provenance "
+            "tap set feeding C45's layer_1_input_norm_last_row_flat_values. "
+            "Output tensors are emitted under `c46__<name>` keys matching "
+            "C46_ROW_PROVENANCE_TAP_NAMES in crates/kiln-model/src/mtp_debug.rs. "
+            "The exact tap order is resolved from the kiln dump's "
+            "`meta__c46_tap_ids` when present."
+        ),
+    )
+    ap.add_argument(
         "--fp32",
         action="store_true",
         help=(
@@ -1660,6 +1772,9 @@ def main() -> int:
     c43_tap_names = resolve_c43_tap_names(kiln) if args.c43_taps else None
     c44_tap_names = resolve_c44_tap_names(kiln) if args.c44_taps else None
     c45_tap_names = resolve_c45_tap_names(kiln) if args.c45_taps else None
+    c46_tap_names = (
+        resolve_c46_tap_names(kiln) if args.c46_row_provenance_taps else None
+    )
     draft_token_id = int(kiln.get("meta__draft_token_id", -1))
     mtp_pos = int(kiln.get("meta__mtp_pos", -1))
     print(
@@ -1734,6 +1849,8 @@ def main() -> int:
         c44_tap_names=c44_tap_names,
         capture_c45=args.c45_taps,
         c45_tap_names=c45_tap_names,
+        capture_c46=args.c46_row_provenance_taps,
+        c46_tap_names=c46_tap_names,
         fp32=args.fp32,
     )
 
@@ -1780,6 +1897,11 @@ def main() -> int:
     if c45_tap_names:
         out_dict["meta__c45_tap_ids"] = torch.tensor(
             [C45_LAYER1_ROW_TAP_NAMES.index(name) for name in c45_tap_names],
+            dtype=torch.int32,
+        )
+    if c46_tap_names:
+        out_dict["meta__c46_tap_ids"] = torch.tensor(
+            [C46_ROW_PROVENANCE_TAP_NAMES.index(name) for name in c46_tap_names],
             dtype=torch.int32,
         )
     # Also write the resolved prompt tokens so later reruns can reproduce


### PR DESCRIPTION
## Summary

Adds the Phase C46 diagnostic slice for the row-side operand feeding C45's `layer_1_input_norm_last_row_flat_values`:

- captures layer-1 selected row before RMSNorm, after F32 cast, after contiguous materialization, after flatten, and the exact C45 row operand reconstruction
- mirrors the tap contract in the HF reference dumper and adds `--c46-row-provenance` compare mode
- records fresh seed 0/1 GPU comparator artifacts and appends the design + verdict to `docs/phase-c45/c45-layer1-row-normalization-bisect.md`

No production inference math is changed.

## Seed Verdicts

- Seed 0 (`mtp_pos=0`): all C46 row-provenance taps pass current C45 tolerance (`atol=1e-2`, `rtol=1e-1`) and the tighter mask (`atol=1e-3`, `rtol=1e-2`); every tap reports `max|Δ|=9.77e-04`, `mean|Δ|=6.67e-05`, `rel_l2=2.65e-03`.
- Seed 1 (`mtp_pos=2`): all C46 row-provenance taps pass both tolerance bars; every tap reports `max|Δ|=7.32e-04`, `mean|Δ|=1.08e-04`, `rel_l2=3.47e-03`.

Boundary classification: C46 clears row selection, dtype cast, contiguous materialization, flatten, and exact operand reconstruction. The next boundary is the existing C45 tolerance artifact / reproducer classification, not a tiny local row-provenance production bug.

## Validation

Run on RunPod pod `98ez1btmml8eu5` (`NVIDIA RTX A6000`, mandatory `ghcr.io/ericflo/kiln-runpod:latest` image), then terminated before PR creation:

- `cargo build --release --features cuda --bin kiln-bench`
- `cargo test --locked -p kiln-model c45 -- --nocapture`
- `cargo test --locked -p kiln-model c46 -- --nocapture`
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- fresh C46 seed 0/1 kiln dumps + HF reference dumps + `scripts/mtp_compare.py --c46-row-provenance`

Note: `cargo fmt` could not be run on the pod because the baked stable toolchain lacks `cargo-fmt`; targeted tests and `git diff --check` passed locally / on-pod where applicable.