### PR TITLE
phase6: classify C45 tolerance artifact boundary

### DIFF
--- a/docs/phase-c45/c45-layer1-row-normalization-bisect.md
+++ b/docs/phase-c45/c45-layer1-row-normalization-bisect.md
@@ -339,3 +339,103 @@ representative seeds. Because the fresh C46 replay cannot reproduce a local
 row-provenance failure, no production math fix is justified here; the next
 boundary classification is the existing C45 tolerance artifact rather than row
 selection, dtype cast, flatten/contiguous, or exact operand construction.
+
+## 2026-04-24 C47 C45 tolerance/reproducer artifact classification
+
+C46 proved that row selection, F32 promotion, contiguous materialization,
+flattening, and exact reconstruction of the C45 row operand are shared-good
+under both the current C45 tolerance (`atol=1e-2`, `rtol=1e-1`) and the tighter
+mask (`atol=1e-3`, `rtol=1e-2`). C47 therefore adds a comparator-only classifier
+for the remaining `layer_1_input_norm_pre_weight_row_broadcast_output` boundary:
+it recomputes the expected product from the captured C45 row operand and scalar
+operand on each side, compares predicted-vs-observed residuals, reports current
+and tight mask verdicts, and prints the top offending hidden indices by tight
+product tolerance ratio. No production inference math changed.
+
+GPU validation used the mandatory RunPod image through the pool lease
+`pod-c11fe496c432600caf0baa6a` on pod `sl53yvx5seviyx` (`NVIDIA RTX A6000`,
+CUDA image `ghcr.io/ericflo/kiln-runpod:latest`) after direct on-demand capacity
+failed for A6000/A100/L40S and produced pre-SSH runtime wedges for A40 and RTX
+6000 Ada. The validation branch was based on `origin/main` at PR #457
+(`c9f5332`).
+
+Commands run on the pod:
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench
+cargo test --locked -p kiln-model c45 -- --nocapture
+cargo test --locked -p kiln-model c46 -- --nocapture
+python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py
+
+KILN_SPEC_METHOD=mtp \
+KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_PATH='profiling-artifacts/c47_c45_tolerance_artifact_seed0_captures/mtp_pos-{pos}/step-{step}.safetensors' \
+KILN_MTP_DUMP_POS=0 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 \
+KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
+KILN_MTP_DUMP_C46_ROW_PROVENANCE=1 \
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 8 --skip-training --seed 0
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump 'profiling-artifacts/c47_c45_tolerance_artifact_seed0_captures/mtp_pos-0/step-{step}.safetensors' \
+  --out profiling-artifacts/c47_c45_tolerance_artifact_seed0_ref_bf16.safetensors \
+  --c45-taps --seed 0
+python3 scripts/mtp_compare.py --c47-c45-tolerance-artifact \
+  --kiln 'profiling-artifacts/c47_c45_tolerance_artifact_seed0_captures/mtp_pos-0/step-{step}.safetensors' \
+  --ref profiling-artifacts/c47_c45_tolerance_artifact_seed0_ref_bf16.safetensors \
+  > profiling-artifacts/c47_c45_tolerance_artifact_seed0_compare.txt
+
+KILN_SPEC_METHOD=mtp \
+KILN_BENCH_FORCE_MTP=1 \
+KILN_MTP_DUMP_PATH='profiling-artifacts/c47_c45_tolerance_artifact_seed1_captures/mtp_pos-{pos}/step-{step}.safetensors' \
+KILN_MTP_DUMP_POS=2 \
+KILN_MTP_DUMP_HIDDEN_STATES=1 \
+KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 \
+KILN_MTP_DUMP_C46_ROW_PROVENANCE=1 \
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed 1
+python3 scripts/mtp_h_main_reference_dump.py \
+  --checkpoint /workspace/qwen3.5-4b \
+  --kiln-dump 'profiling-artifacts/c47_c45_tolerance_artifact_seed1_captures/mtp_pos-2/step-{step}.safetensors' \
+  --out profiling-artifacts/c47_c45_tolerance_artifact_seed1_ref_bf16.safetensors \
+  --c45-taps --seed 1
+python3 scripts/mtp_compare.py --c47-c45-tolerance-artifact \
+  --kiln 'profiling-artifacts/c47_c45_tolerance_artifact_seed1_captures/mtp_pos-2/step-{step}.safetensors' \
+  --ref profiling-artifacts/c47_c45_tolerance_artifact_seed1_ref_bf16.safetensors \
+  > profiling-artifacts/c47_c45_tolerance_artifact_seed1_compare.txt
+```
+
+Seed-specific evidence:
+
+- seed 0 (`mtp_pos=0`, `profiling-artifacts/c47_c45_tolerance_artifact_seed0_compare.txt`):
+  row and scalar operands pass the current and tight masks; predicted and
+  observed product both pass the current mask but fail the tight mask
+  (`max|Δ|=2.83e-02`, `mean|Δ|=1.93e-03`, `rel_l2=2.65e-03`, tight
+  `tol_ratio=8.43`). The output is fully predicted by operands
+  (`observed=2.83e-02`, `predicted=2.83e-02`, residual=`2.32e-06`), same-side
+  product residuals are tiny (`kiln max=1.40e-06`, `ref max=9.24e-07`), and the
+  contribution budget is row-side dominant. Prompt=494, prefill=`7704.9 ms`,
+  `alpha=0.333`.
+- seed 1 (`mtp_pos=2`, `profiling-artifacts/c47_c45_tolerance_artifact_seed1_compare.txt`):
+  row and scalar operands pass the current and tight masks; predicted and
+  observed product both pass the current mask but fail the tight mask
+  (`max|Δ|=1.86e-02`, `mean|Δ|=2.60e-03`, `rel_l2=3.44e-03`, tight
+  `tol_ratio=7.78`). The output is fully predicted by operands
+  (`observed=1.86e-02`, `predicted=1.86e-02`, residual=`2.26e-06`), same-side
+  product residuals are tiny (`kiln max=1.91e-06`, `ref max=3.58e-07`), and the
+  contribution budget is row-side dominant. Prompt=508, prefill=`351.0 ms`,
+  `alpha=0.309`.
+
+Final C47 verdict: the fresh C45/C46-compatible reproducer no longer fails the
+current C45 mask at `layer_1_input_norm_pre_weight_row_broadcast_output`, so the
+remaining checked-in C45 current-mask failure should be classified as a
+reproducer/tolerance-boundary artifact rather than a production RMSNorm
+`broadcast_mul` bug. Under the tighter mask, both seeds still expose the same
+boundary, and C47 fully predicts that tighter failure from captured row/scalar
+operand drift with only ~1e-6 same-side residuals. Stop condition: do not change
+production inference math at the C45 broadcast boundary; any future work should
+only revisit this area if a fresh current-main reproducer again fails the current
+mask and C47 reports a non-negligible predicted-vs-observed residual.

--- a/profiling-artifacts/c47_c45_tolerance_artifact_seed0_compare.txt
+++ b/profiling-artifacts/c47_c45_tolerance_artifact_seed0_compare.txt
@@ -1,0 +1,67 @@
+MTP numerical bisect — mode: C45 tolerance/reproducer artifact classifier (C47), atol=0.01, rtol=0.1
+
+=== pair ===
+  kiln dump : profiling-artifacts/c47_c45_tolerance_artifact_seed0_captures/mtp_pos-0/step-{step}.safetensors
+  ref  dump : profiling-artifacts/c47_c45_tolerance_artifact_seed0_ref_bf16.safetensors
+Metadata:
+  meta__draft_token_id: kiln=5339 ref=5339 [OK]
+  meta__mtp_pos: kiln=0 ref=0 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 8, 16, 23, 31] ref=[0, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   1.26e-03     1.26e-03    
+c45__layer_1_input_norm_rms_inv_scalar_extracted_values 1                      True     True     1.00e+00   1.26e-03     1.26e-03    
+c45__layer_1_input_norm_last_row_flat_values 1x2560                 True     True     1.00e+00   9.77e-04     6.67e-05    
+c45__layer_1_input_norm_pre_weight_row_broadcast_output 1x1x2560               True     True     1.00e+00   2.83e-02     1.93e-03    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     True     1.00e+00   2.83e-02     1.93e-03    
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     True     1.00e+00   2.83e-02     1.93e-03    
+
+  pair verdict: all taps match within tolerance.
+  C45 broadcast operand diagnostic:
+    same-side product residual: kiln max=1.40e-06 mean=4.68e-09; ref max=9.24e-07 mean=4.51e-09
+    cross-side operand drift: row max=9.77e-04 mean=6.67e-05 rel_l2=2.65e-03; scalar max=1.26e-03 mean=1.26e-03 rel_l2=4.38e-05; predicted product max=2.83e-02 mean=1.93e-03 rel_l2=2.65e-03; observed output max=2.83e-02 mean=1.93e-03 rel_l2=2.65e-03; operand-bound max=2.83e-02
+    operand contribution budget: row-term max=2.82e-02 mean=1.92e-03 rel_l2=2.65e-03; scalar-term max=2.11e-03 mean=9.33e-06 rel_l2=4.38e-05; interaction max=1.23e-06 mean=8.43e-08 rel_l2=1.16e-07; dominant=row-side
+    tighter tolerance mask check (atol=0.001, rtol=0.01): row allclose=True current-ratio=5.39e-02 tight-ratio=5.39e-01; scalar allclose=True current-ratio=4.36e-04 tight-ratio=4.36e-03; product allclose=False current-ratio=8.43e-01 tight-ratio=8.43e+00
+    interpretation: if same-side residual is near zero and observed output matches the predicted product, this boundary is operand-drift amplification, not an independent broadcast multiply mismatch; the contribution budget names which tolerated operand dominates the exposed product error.
+
+==============================================================================
+Phase C47 C45 tolerance/reproducer artifact classifier
+==============================================================================
+  current tolerance: atol=0.01, rtol=0.1
+  tight tolerance  : atol=0.001, rtol=0.01
+
+  [pair] C47 artifact boundary details
+    current-mask operand/output stats:
+    row operand          max|Δ|=9.77e-04 mean|Δ|=6.67e-05 rel_l2=2.65e-03 allclose=PASS tol_ratio=5.39e-02
+    scalar operand       max|Δ|=1.26e-03 mean|Δ|=1.26e-03 rel_l2=4.38e-05 allclose=PASS tol_ratio=4.36e-04
+    predicted product    max|Δ|=2.83e-02 mean|Δ|=1.93e-03 rel_l2=2.65e-03 allclose=PASS tol_ratio=8.43e-01
+    observed output      max|Δ|=2.83e-02 mean|Δ|=1.93e-03 rel_l2=2.65e-03 allclose=PASS tol_ratio=8.43e-01
+    tight-mask operand/output stats:
+    row operand          max|Δ|=9.77e-04 mean|Δ|=6.67e-05 rel_l2=2.65e-03 allclose=PASS tol_ratio=5.39e-01
+    scalar operand       max|Δ|=1.26e-03 mean|Δ|=1.26e-03 rel_l2=4.38e-05 allclose=PASS tol_ratio=4.36e-03
+    predicted product    max|Δ|=2.83e-02 mean|Δ|=1.93e-03 rel_l2=2.65e-03 allclose=FAIL tol_ratio=8.43e+00
+    observed output      max|Δ|=2.83e-02 mean|Δ|=1.93e-03 rel_l2=2.65e-03 allclose=FAIL tol_ratio=8.43e+00
+    prediction residual:
+    predicted-vs-observed max|Δ|=2.32e-06 mean|Δ|=6.59e-09 rel_l2=1.78e-05 allclose=FAIL tol_ratio=2.28e+00
+    same-side product residual: kiln max=1.40e-06 mean=4.68e-09; ref max=9.24e-07 mean=4.51e-09
+    output/prediction max diff: observed=2.83e-02 predicted=2.83e-02 residual=2.32e-06
+    contribution budget: row max=2.82e-02 mean=1.92e-03 rel_l2=2.65e-03; scalar max=2.11e-03 mean=9.33e-06 rel_l2=4.38e-05; interaction max=1.23e-06 mean=8.43e-08 rel_l2=1.16e-07; dominant=row-side
+    top offending indices by predicted-product tight tolerance ratio:
+      idx=(0,297) tight_ratio=8.43e+00 row_k=1.44e-03 row_r=1.06e-03 row_Δ=3.81e-04 scalar_k=2.88e+01 scalar_r=2.88e+01 scalar_Δ=1.26e-03 pred_Δ=1.10e-02 out_Δ=1.10e-02 resid=3.49e-10 terms(row=1.10e-02, scalar=1.34e-06, inter=4.82e-07)
+      idx=(0,234) tight_ratio=6.37e+00 row_k=-6.10e-04 row_r=-3.66e-04 row_Δ=-2.44e-04 scalar_k=2.88e+01 scalar_r=2.88e+01 scalar_Δ=1.26e-03 pred_Δ=-7.04e-03 out_Δ=-7.04e-03 resid=0.00e+00 terms(row=-7.04e-03, scalar=-4.62e-07, inter=-3.08e-07)
+      idx=(0,587) tight_ratio=6.19e+00 row_k=1.51e-03 row_r=1.22e-03 row_Δ=2.90e-04 scalar_k=2.88e+01 scalar_r=2.88e+01 scalar_Δ=1.26e-03 pred_Δ=8.36e-03 out_Δ=8.36e-03 resid=-1.19e-09 terms(row=8.36e-03, scalar=1.54e-06, inter=3.66e-07)
+      idx=(0,718) tight_ratio=5.61e+00 row_k=1.54e-03 row_r=1.84e-03 row_Δ=-2.98e-04 scalar_k=2.88e+01 scalar_r=2.88e+01 scalar_Δ=1.26e-03 pred_Δ=-8.58e-03 out_Δ=-8.58e-03 resid=2.18e-10 terms(row=-8.58e-03, scalar=2.32e-06, inter=-3.76e-07)
+      idx=(0,40) tight_ratio=5.53e+00 row_k=6.10e-04 row_r=3.97e-04 row_Δ=2.14e-04 scalar_k=2.88e+01 scalar_r=2.88e+01 scalar_Δ=1.26e-03 pred_Δ=6.16e-03 out_Δ=6.16e-03 resid=-1.75e-10 terms(row=6.16e-03, scalar=5.01e-07, inter=2.70e-07)
+      idx=(0,957) tight_ratio=5.14e+00 row_k=-9.00e-04 row_r=-6.87e-04 row_Δ=-2.14e-04 scalar_k=2.88e+01 scalar_r=2.88e+01 scalar_Δ=1.26e-03 pred_Δ=-6.16e-03 out_Δ=-6.16e-03 resid=-6.98e-10 terms(row=-6.16e-03, scalar=-8.67e-07, inter=-2.70e-07)
+      idx=(0,59) tight_ratio=5.07e+00 row_k=1.10e-03 row_r=1.34e-03 row_Δ=-2.44e-04 scalar_k=2.88e+01 scalar_r=2.88e+01 scalar_Δ=1.26e-03 pred_Δ=-7.04e-03 out_Δ=-7.04e-03 resid=9.31e-10 terms(row=-7.04e-03, scalar=1.70e-06, inter=-3.08e-07)
+      idx=(0,61) tight_ratio=4.81e+00 row_k=2.11e-04 row_r=3.97e-04 row_Δ=-1.86e-04 scalar_k=2.88e+01 scalar_r=2.88e+01 scalar_Δ=1.26e-03 pred_Δ=-5.36e-03 out_Δ=-5.36e-03 resid=-1.87e-10 terms(row=-5.36e-03, scalar=5.01e-07, inter=-2.35e-07)
+    seed verdict: FULLY_PREDICTED operand-drift/tolerance amplification artifact
+
+Phase C47 verdict: output is fully predicted, but supplied pairs do not reproduce the current-mask C45 failure.
+  -> Treat this as a reproducer alignment issue before changing production math.
+
+Overall verdict: all taps match within tolerance.

--- a/profiling-artifacts/c47_c45_tolerance_artifact_seed1_compare.txt
+++ b/profiling-artifacts/c47_c45_tolerance_artifact_seed1_compare.txt
@@ -1,0 +1,67 @@
+MTP numerical bisect — mode: C45 tolerance/reproducer artifact classifier (C47), atol=0.01, rtol=0.1
+
+=== pair ===
+  kiln dump : profiling-artifacts/c47_c45_tolerance_artifact_seed1_captures/mtp_pos-2/step-{step}.safetensors
+  ref  dump : profiling-artifacts/c47_c45_tolerance_artifact_seed1_ref_bf16.safetensors
+Metadata:
+  meta__draft_token_id: kiln=421 ref=421 [OK]
+  meta__mtp_pos: kiln=2 ref=2 [OK]
+  meta__swap_fc_norms: kiln=0 ref=<missing> [MISMATCH]
+  meta__kiln_mtp_pos: kiln=<missing> ref=<missing> [OK]
+  meta__capture_subops: kiln=<missing> ref=<missing> [OK]
+  meta__boundary_layers: kiln=[0, 8, 16, 23, 31] ref=[0, 8, 16, 23, 31] [OK]
+
+tap                    shape                  shape_ok allclose cos_sim    max|Δ|       mean|Δ|     
+----------------------------------------------------------------------------------------------------
+c45__layer_1_input_norm_rms_inv_scalar 1x1x1                  True     True     1.00e+00   9.62e-03     9.62e-03    
+c45__layer_1_input_norm_rms_inv_scalar_extracted_values 1                      True     True     1.00e+00   9.62e-03     9.62e-03    
+c45__layer_1_input_norm_last_row_flat_values 1x2560                 True     True     1.00e+00   7.32e-04     1.08e-04    
+c45__layer_1_input_norm_pre_weight_row_broadcast_output 1x1x2560               True     True     1.00e+00   1.86e-02     2.60e-03    
+c45__layer_1_input_norm_pre_weight_row_scalar_values 1x2560                 True     True     1.00e+00   1.86e-02     2.60e-03    
+c45__layer_1_input_norm_pre_weight_row_reconstructed 1x1x2560               True     True     1.00e+00   1.86e-02     2.60e-03    
+
+  pair verdict: all taps match within tolerance.
+  C45 broadcast operand diagnostic:
+    same-side product residual: kiln max=1.91e-06 mean=6.63e-09; ref max=3.58e-07 mean=6.00e-09
+    cross-side operand drift: row max=7.32e-04 mean=1.08e-04 rel_l2=3.47e-03; scalar max=9.62e-03 mean=9.62e-03 rel_l2=3.97e-04; predicted product max=1.86e-02 mean=2.60e-03 rel_l2=3.44e-03; observed output max=1.86e-02 mean=2.60e-03 rel_l2=3.44e-03; operand-bound max=1.86e-02
+    operand contribution budget: row-term max=1.77e-02 mean=2.60e-03 rel_l2=3.47e-03; scalar-term max=1.86e-02 mean=1.16e-04 rel_l2=3.97e-04; interaction max=7.04e-06 mean=1.03e-06 rel_l2=1.38e-06; dominant=row-side
+    tighter tolerance mask check (atol=0.001, rtol=0.01): row allclose=True current-ratio=5.27e-02 tight-ratio=5.27e-01; scalar allclose=True current-ratio=3.96e-03 tight-ratio=3.96e-02; product allclose=False current-ratio=7.78e-01 tight-ratio=7.78e+00
+    interpretation: if same-side residual is near zero and observed output matches the predicted product, this boundary is operand-drift amplification, not an independent broadcast multiply mismatch; the contribution budget names which tolerated operand dominates the exposed product error.
+
+==============================================================================
+Phase C47 C45 tolerance/reproducer artifact classifier
+==============================================================================
+  current tolerance: atol=0.01, rtol=0.1
+  tight tolerance  : atol=0.001, rtol=0.01
+
+  [pair] C47 artifact boundary details
+    current-mask operand/output stats:
+    row operand          max|Δ|=7.32e-04 mean|Δ|=1.08e-04 rel_l2=3.47e-03 allclose=PASS tol_ratio=5.27e-02
+    scalar operand       max|Δ|=9.62e-03 mean|Δ|=9.62e-03 rel_l2=3.97e-04 allclose=PASS tol_ratio=3.96e-03
+    predicted product    max|Δ|=1.86e-02 mean|Δ|=2.60e-03 rel_l2=3.44e-03 allclose=PASS tol_ratio=7.78e-01
+    observed output      max|Δ|=1.86e-02 mean|Δ|=2.60e-03 rel_l2=3.44e-03 allclose=PASS tol_ratio=7.78e-01
+    tight-mask operand/output stats:
+    row operand          max|Δ|=7.32e-04 mean|Δ|=1.08e-04 rel_l2=3.47e-03 allclose=PASS tol_ratio=5.27e-01
+    scalar operand       max|Δ|=9.62e-03 mean|Δ|=9.62e-03 rel_l2=3.97e-04 allclose=PASS tol_ratio=3.96e-02
+    predicted product    max|Δ|=1.86e-02 mean|Δ|=2.60e-03 rel_l2=3.44e-03 allclose=FAIL tol_ratio=7.78e+00
+    observed output      max|Δ|=1.86e-02 mean|Δ|=2.60e-03 rel_l2=3.44e-03 allclose=FAIL tol_ratio=7.78e+00
+    prediction residual:
+    predicted-vs-observed max|Δ|=2.26e-06 mean|Δ|=8.62e-09 rel_l2=1.35e-05 allclose=FAIL tol_ratio=1.91e+00
+    same-side product residual: kiln max=1.91e-06 mean=6.63e-09; ref max=3.58e-07 mean=6.00e-09
+    output/prediction max diff: observed=1.86e-02 predicted=1.86e-02 residual=2.26e-06
+    contribution budget: row max=1.77e-02 mean=2.60e-03 rel_l2=3.47e-03; scalar max=1.86e-02 mean=1.16e-04 rel_l2=3.97e-04; interaction max=7.04e-06 mean=1.03e-06 rel_l2=1.38e-06; dominant=row-side
+    top offending indices by predicted-product tight tolerance ratio:
+      idx=(0,1001) tight_ratio=7.78e+00 row_k=2.14e-04 row_r=5.80e-04 row_Δ=-3.66e-04 scalar_k=2.42e+01 scalar_r=2.42e+01 scalar_Δ=-9.62e-03 pred_Δ=-8.87e-03 out_Δ=-8.87e-03 resid=-4.07e-10 terms(row=-8.87e-03, scalar=-5.58e-06, inter=3.52e-06)
+      idx=(0,93) tight_ratio=7.07e+00 row_k=-1.22e-04 row_r=1.83e-04 row_Δ=-3.05e-04 scalar_k=2.42e+01 scalar_r=2.42e+01 scalar_Δ=-9.62e-03 pred_Δ=-7.39e-03 out_Δ=-7.39e-03 resid=1.16e-10 terms(row=-7.39e-03, scalar=-1.76e-06, inter=2.94e-06)
+      idx=(0,734) tight_ratio=7.07e+00 row_k=-1.22e-04 row_r=1.83e-04 row_Δ=-3.05e-04 scalar_k=2.42e+01 scalar_r=2.42e+01 scalar_Δ=-9.62e-03 pred_Δ=-7.39e-03 out_Δ=-7.39e-03 resid=1.16e-10 terms(row=-7.39e-03, scalar=-1.76e-06, inter=2.94e-06)
+      idx=(0,2481) tight_ratio=5.70e+00 row_k=-3.97e-04 row_r=-1.53e-04 row_Δ=-2.44e-04 scalar_k=2.42e+01 scalar_r=2.42e+01 scalar_Δ=-9.62e-03 pred_Δ=-5.91e-03 out_Δ=-5.91e-03 resid=5.82e-11 terms(row=-5.91e-03, scalar=1.47e-06, inter=2.35e-06)
+      idx=(0,1484) tight_ratio=5.66e+00 row_k=-4.27e-04 row_r=-1.83e-04 row_Δ=-2.44e-04 scalar_k=2.42e+01 scalar_r=2.42e+01 scalar_Δ=-9.62e-03 pred_Δ=-5.91e-03 out_Δ=-5.91e-03 resid=-1.16e-10 terms(row=-5.91e-03, scalar=1.76e-06, inter=2.35e-06)
+      idx=(0,40) tight_ratio=5.58e+00 row_k=4.88e-04 row_r=2.44e-04 row_Δ=2.44e-04 scalar_k=2.42e+01 scalar_r=2.42e+01 scalar_Δ=-9.62e-03 pred_Δ=5.91e-03 out_Δ=5.91e-03 resid=0.00e+00 terms(row=5.91e-03, scalar=-2.35e-06, inter=-2.35e-06)
+      idx=(0,975) tight_ratio=5.47e+00 row_k=8.85e-04 row_r=1.17e-03 row_Δ=-2.90e-04 scalar_k=2.42e+01 scalar_r=2.42e+01 scalar_Δ=-9.62e-03 pred_Δ=-7.03e-03 out_Δ=-7.03e-03 resid=1.14e-09 terms(row=-7.02e-03, scalar=-1.13e-05, inter=2.79e-06)
+      idx=(0,420) tight_ratio=5.42e+00 row_k=-6.10e-04 row_r=-3.66e-04 row_Δ=-2.44e-04 scalar_k=2.42e+01 scalar_r=2.42e+01 scalar_Δ=-9.62e-03 pred_Δ=-5.90e-03 out_Δ=-5.90e-03 resid=-2.33e-10 terms(row=-5.91e-03, scalar=3.52e-06, inter=2.35e-06)
+    seed verdict: FULLY_PREDICTED operand-drift/tolerance amplification artifact
+
+Phase C47 verdict: output is fully predicted, but supplied pairs do not reproduce the current-mask C45 failure.
+  -> Treat this as a reproducer alignment issue before changing production math.
+
+Overall verdict: all taps match within tolerance.

--- a/scripts/mtp_compare.py
+++ b/scripts/mtp_compare.py
@@ -654,6 +654,26 @@ def _component_stats(component: np.ndarray, ref: np.ndarray) -> Dict[str, float]
         "rel_l2": _rel_l2(abs_component, ref),
     }
 
+
+def _allclose_stats(
+    kiln: np.ndarray,
+    ref: np.ndarray,
+    atol: float,
+    rtol: float,
+) -> Tuple[float, float, float, bool, float]:
+    diff = np.abs(kiln - ref)
+    return (
+        float(diff.max()) if diff.size else 0.0,
+        float(diff.mean()) if diff.size else 0.0,
+        _rel_l2(diff, ref),
+        bool(np.allclose(kiln, ref, atol=atol, rtol=rtol)),
+        _max_tolerance_ratio(diff, ref, atol, rtol),
+    )
+
+
+def _fmt_verdict(ok: bool) -> str:
+    return "PASS" if ok else "FAIL"
+
 def _c45_operand_product_bound_diagnostic(
     kiln_tensors: Dict[str, np.ndarray],
     ref_tensors: Dict[str, np.ndarray],
@@ -766,6 +786,153 @@ def _c45_operand_product_bound_diagnostic(
         "product_tight_tol_ratio": _max_tolerance_ratio(
             product_diff, predicted_ref, C45_TIGHT_ATOL, C45_TIGHT_RTOL
         ),
+    }
+
+
+def _c47_c45_tolerance_artifact_diagnostic(
+    kiln_tensors: Dict[str, np.ndarray],
+    ref_tensors: Dict[str, np.ndarray],
+    top_n: int = 8,
+) -> Optional[Dict[str, object]]:
+    kiln_row = kiln_tensors.get("c45__layer_1_input_norm_last_row_flat_values")
+    kiln_scalar = kiln_tensors.get("c45__layer_1_input_norm_rms_inv_scalar_extracted_values")
+    kiln_output = kiln_tensors.get("c45__layer_1_input_norm_pre_weight_row_broadcast_output")
+    ref_row = ref_tensors.get("c45__layer_1_input_norm_last_row_flat_values")
+    ref_scalar = ref_tensors.get("c45__layer_1_input_norm_rms_inv_scalar_extracted_values")
+    ref_output = ref_tensors.get("c45__layer_1_input_norm_pre_weight_row_broadcast_output")
+    if (
+        kiln_row is None
+        or kiln_scalar is None
+        or kiln_output is None
+        or ref_row is None
+        or ref_scalar is None
+        or ref_output is None
+    ):
+        return None
+    if kiln_row.shape != ref_row.shape or kiln_scalar.shape != ref_scalar.shape:
+        return None
+    if kiln_row.ndim != 2 or kiln_scalar.ndim != 1:
+        return None
+    expected_output_shape = (kiln_row.shape[0], 1, kiln_row.shape[1])
+    if kiln_output.shape != expected_output_shape or ref_output.shape != expected_output_shape:
+        return None
+
+    kr = kiln_row.astype(np.float64)
+    rr = ref_row.astype(np.float64)
+    ks = kiln_scalar.astype(np.float64).reshape(-1, 1)
+    rs = ref_scalar.astype(np.float64).reshape(-1, 1)
+    ko = kiln_output.reshape(kr.shape).astype(np.float64)
+    ro = ref_output.reshape(rr.shape).astype(np.float64)
+
+    predicted_kiln = kr * ks
+    predicted_ref = rr * rs
+    output_delta = ko - ro
+    predicted_delta = predicted_kiln - predicted_ref
+    predicted_vs_observed = output_delta - predicted_delta
+    same_side_kiln = predicted_kiln - ko
+    same_side_ref = predicted_ref - ro
+    row_delta = kr - rr
+    scalar_delta = ks - rs
+    row_component = row_delta * rs
+    scalar_component = rr * scalar_delta
+    interaction_component = row_delta * scalar_delta
+    output_abs = np.abs(output_delta)
+    predicted_abs = np.abs(predicted_delta)
+    residual_abs = np.abs(predicted_vs_observed)
+    allowed = C45_TIGHT_ATOL + C45_TIGHT_RTOL * np.abs(predicted_ref)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        ratios = np.divide(
+            predicted_abs,
+            allowed,
+            out=np.full_like(predicted_abs, np.inf),
+            where=allowed != 0.0,
+        )
+
+    row_current = _allclose_stats(kr, rr, 1e-2, 1e-1)
+    row_tight = _allclose_stats(kr, rr, C45_TIGHT_ATOL, C45_TIGHT_RTOL)
+    scalar_current = _allclose_stats(ks, rs, 1e-2, 1e-1)
+    scalar_tight = _allclose_stats(ks, rs, C45_TIGHT_ATOL, C45_TIGHT_RTOL)
+    product_current = _allclose_stats(predicted_kiln, predicted_ref, 1e-2, 1e-1)
+    product_tight = _allclose_stats(predicted_kiln, predicted_ref, C45_TIGHT_ATOL, C45_TIGHT_RTOL)
+    output_current = _allclose_stats(ko, ro, 1e-2, 1e-1)
+    output_tight = _allclose_stats(ko, ro, C45_TIGHT_ATOL, C45_TIGHT_RTOL)
+    residual_current = _allclose_stats(output_delta, predicted_delta, 1e-6, 1e-5)
+
+    side_residual_max = max(
+        float(np.abs(same_side_kiln).max()) if same_side_kiln.size else 0.0,
+        float(np.abs(same_side_ref).max()) if same_side_ref.size else 0.0,
+    )
+    predicted_vs_observed_max = residual_current[0]
+    explained = (
+        predicted_vs_observed_max <= max(1e-5, output_current[0] * 1e-4)
+        and side_residual_max <= max(1e-5, output_current[0] * 1e-4)
+        and product_current[3] == output_current[3]
+        and product_tight[3] == output_tight[3]
+    )
+
+    flat_order = np.argsort(ratios.reshape(-1))[::-1]
+    offenders = []
+    rows, hidden = kr.shape
+    for flat_idx in flat_order[:top_n]:
+        batch_idx = int(flat_idx // hidden)
+        hidden_idx = int(flat_idx % hidden)
+        offenders.append(
+            {
+                "index": (batch_idx, hidden_idx),
+                "tight_ratio": float(ratios[batch_idx, hidden_idx]),
+                "row_kiln": float(kr[batch_idx, hidden_idx]),
+                "row_ref": float(rr[batch_idx, hidden_idx]),
+                "row_delta": float(row_delta[batch_idx, hidden_idx]),
+                "scalar_kiln": float(ks[batch_idx, 0]),
+                "scalar_ref": float(rs[batch_idx, 0]),
+                "scalar_delta": float(scalar_delta[batch_idx, 0]),
+                "pred_kiln": float(predicted_kiln[batch_idx, hidden_idx]),
+                "pred_ref": float(predicted_ref[batch_idx, hidden_idx]),
+                "pred_delta": float(predicted_delta[batch_idx, hidden_idx]),
+                "out_kiln": float(ko[batch_idx, hidden_idx]),
+                "out_ref": float(ro[batch_idx, hidden_idx]),
+                "out_delta": float(output_delta[batch_idx, hidden_idx]),
+                "pred_vs_obs_residual": float(predicted_vs_observed[batch_idx, hidden_idx]),
+                "row_component": float(row_component[batch_idx, hidden_idx]),
+                "scalar_component": float(scalar_component[batch_idx, hidden_idx]),
+                "interaction_component": float(interaction_component[batch_idx, hidden_idx]),
+            }
+        )
+
+    row_stats = _component_stats(row_component, predicted_ref)
+    scalar_stats = _component_stats(scalar_component, predicted_ref)
+    interaction_stats = _component_stats(interaction_component, predicted_ref)
+    if scalar_stats["l2"] > row_stats["l2"] * 2.0:
+        dominant = "scalar-side"
+    elif row_stats["l2"] > scalar_stats["l2"] * 2.0:
+        dominant = "row-side"
+    else:
+        dominant = "both"
+
+    return {
+        "row_current": row_current,
+        "row_tight": row_tight,
+        "scalar_current": scalar_current,
+        "scalar_tight": scalar_tight,
+        "product_current": product_current,
+        "product_tight": product_tight,
+        "output_current": output_current,
+        "output_tight": output_tight,
+        "predicted_vs_observed": residual_current,
+        "side_residual_max": side_residual_max,
+        "same_side_kiln_max": float(np.abs(same_side_kiln).max()) if same_side_kiln.size else 0.0,
+        "same_side_kiln_mean": float(np.abs(same_side_kiln).mean()) if same_side_kiln.size else 0.0,
+        "same_side_ref_max": float(np.abs(same_side_ref).max()) if same_side_ref.size else 0.0,
+        "same_side_ref_mean": float(np.abs(same_side_ref).mean()) if same_side_ref.size else 0.0,
+        "output_max_abs_diff": float(output_abs.max()) if output_abs.size else 0.0,
+        "predicted_max_abs_diff": float(predicted_abs.max()) if predicted_abs.size else 0.0,
+        "residual_max_abs_diff": float(residual_abs.max()) if residual_abs.size else 0.0,
+        "row_component": row_stats,
+        "scalar_component": scalar_stats,
+        "interaction_component": interaction_stats,
+        "dominant_operand_side": dominant,
+        "fully_predicted": explained,
+        "top_offenders": offenders,
     }
 
 def _load(path: str) -> Tuple[Dict[str, np.ndarray], Dict[str, object]]:
@@ -2468,6 +2635,119 @@ def _emit_c46_summary(
         emit(f"  Most-likely cause: {C46_HYPOTHESIS.get(tight_bad, '<unknown tap>')}")
 
 
+def _emit_c47_summary_from_paths(
+    pairs: List[Tuple[str, str, str]],
+    emit,
+) -> None:
+    emit("")
+    emit("=" * 78)
+    emit("Phase C47 C45 tolerance/reproducer artifact classifier")
+    emit("=" * 78)
+    emit(f"  current tolerance: atol={1e-2:g}, rtol={1e-1:g}")
+    emit(f"  tight tolerance  : atol={C45_TIGHT_ATOL:g}, rtol={C45_TIGHT_RTOL:g}")
+
+    captured_any = False
+    all_fully_predicted = True
+    any_product_current_fail = False
+
+    def emit_stats(name: str, stats: Tuple[float, float, float, bool, float]) -> None:
+        max_abs, mean_abs, rel_l2, ok, ratio = stats
+        emit(
+            f"    {name:<20} max|Δ|={_fmt_sci(max_abs)} "
+            f"mean|Δ|={_fmt_sci(mean_abs)} rel_l2={_fmt_sci(rel_l2)} "
+            f"allclose={_fmt_verdict(ok)} tol_ratio={_fmt_sci(ratio)}"
+        )
+
+    for label, kpath, rpath in pairs:
+        kiln_arr, _kiln_meta = _load(kpath)
+        ref_arr, _ref_meta = _load(rpath)
+        diag = _c47_c45_tolerance_artifact_diagnostic(kiln_arr, ref_arr)
+        emit("")
+        emit(f"  [{label}] C47 artifact boundary details")
+        if diag is None:
+            emit("    missing required C45 taps; capture both dumps with C45 taps enabled")
+            all_fully_predicted = False
+            continue
+        captured_any = True
+        all_fully_predicted &= bool(diag["fully_predicted"])
+        any_product_current_fail |= not bool(diag["product_current"][3])
+
+        emit("    current-mask operand/output stats:")
+        emit_stats("row operand", diag["row_current"])
+        emit_stats("scalar operand", diag["scalar_current"])
+        emit_stats("predicted product", diag["product_current"])
+        emit_stats("observed output", diag["output_current"])
+        emit("    tight-mask operand/output stats:")
+        emit_stats("row operand", diag["row_tight"])
+        emit_stats("scalar operand", diag["scalar_tight"])
+        emit_stats("predicted product", diag["product_tight"])
+        emit_stats("observed output", diag["output_tight"])
+        emit("    prediction residual:")
+        emit_stats("predicted-vs-observed", diag["predicted_vs_observed"])
+        emit(
+            "    same-side product residual: "
+            f"kiln max={_fmt_sci(diag['same_side_kiln_max'])} "
+            f"mean={_fmt_sci(diag['same_side_kiln_mean'])}; "
+            f"ref max={_fmt_sci(diag['same_side_ref_max'])} "
+            f"mean={_fmt_sci(diag['same_side_ref_mean'])}"
+        )
+        emit(
+            "    output/prediction max diff: "
+            f"observed={_fmt_sci(diag['output_max_abs_diff'])} "
+            f"predicted={_fmt_sci(diag['predicted_max_abs_diff'])} "
+            f"residual={_fmt_sci(diag['residual_max_abs_diff'])}"
+        )
+        emit(
+            "    contribution budget: "
+            f"row max={_fmt_sci(diag['row_component']['max'])} "
+            f"mean={_fmt_sci(diag['row_component']['mean'])} "
+            f"rel_l2={_fmt_sci(diag['row_component']['rel_l2'])}; "
+            f"scalar max={_fmt_sci(diag['scalar_component']['max'])} "
+            f"mean={_fmt_sci(diag['scalar_component']['mean'])} "
+            f"rel_l2={_fmt_sci(diag['scalar_component']['rel_l2'])}; "
+            f"interaction max={_fmt_sci(diag['interaction_component']['max'])} "
+            f"mean={_fmt_sci(diag['interaction_component']['mean'])} "
+            f"rel_l2={_fmt_sci(diag['interaction_component']['rel_l2'])}; "
+            f"dominant={diag['dominant_operand_side']}"
+        )
+        emit("    top offending indices by predicted-product tight tolerance ratio:")
+        for offender in diag["top_offenders"]:
+            batch_idx, hidden_idx = offender["index"]
+            emit(
+                f"      idx=({batch_idx},{hidden_idx}) "
+                f"tight_ratio={_fmt_sci(offender['tight_ratio'])} "
+                f"row_k={_fmt_sci(offender['row_kiln'])} row_r={_fmt_sci(offender['row_ref'])} "
+                f"row_Δ={_fmt_sci(offender['row_delta'])} "
+                f"scalar_k={_fmt_sci(offender['scalar_kiln'])} scalar_r={_fmt_sci(offender['scalar_ref'])} "
+                f"scalar_Δ={_fmt_sci(offender['scalar_delta'])} "
+                f"pred_Δ={_fmt_sci(offender['pred_delta'])} "
+                f"out_Δ={_fmt_sci(offender['out_delta'])} "
+                f"resid={_fmt_sci(offender['pred_vs_obs_residual'])} "
+                f"terms(row={_fmt_sci(offender['row_component'])}, "
+                f"scalar={_fmt_sci(offender['scalar_component'])}, "
+                f"inter={_fmt_sci(offender['interaction_component'])})"
+            )
+        if diag["fully_predicted"]:
+            emit("    seed verdict: FULLY_PREDICTED operand-drift/tolerance amplification artifact")
+        else:
+            emit("    seed verdict: NOT_FULLY_PREDICTED; inspect same-side product/reproducer alignment")
+
+    emit("")
+    if not captured_any:
+        emit("Phase C47 verdict: no C45 C47-compatible taps present in supplied dumps.")
+        emit("  -> Re-run kiln-bench with KILN_MTP_DUMP_C45_LAYER1_ROW_TAPS=1 and")
+        emit("     mtp_h_main_reference_dump.py with --c45-taps.")
+    elif all_fully_predicted and any_product_current_fail:
+        emit("Phase C47 verdict: C45 broadcast-output failure is fully predicted by operand drift/tolerance amplification.")
+        emit("  -> Stop condition: no production math change is justified at the C45 broadcast boundary.")
+    elif all_fully_predicted:
+        emit("Phase C47 verdict: output is fully predicted, but supplied pairs do not reproduce the current-mask C45 failure.")
+        emit("  -> Treat this as a reproducer alignment issue before changing production math.")
+    else:
+        emit("Phase C47 verdict: output is not fully predicted by captured operands.")
+        emit("  -> Next boundary: same-side product residual or dump/reproducer alignment around C45 broadcast output.")
+
+
 def _emit_c45_summary(
     pair_results: List[Tuple[str, bool, str, List[Dict[str, object]], Dict[str, object], Dict[str, object]]],
     atol: float,
@@ -2869,6 +3149,18 @@ def main() -> int:
             "rtol=1e-1 and also reports tight atol=1e-3, rtol=1e-2 verdicts."
         ),
     )
+
+    ap.add_argument(
+        "--c47-c45-tolerance-artifact",
+        action="store_true",
+        help=(
+            "Phase C47 mode: classify the remaining C45 "
+            "layer_1_input_norm_pre_weight_row_broadcast_output failure as "
+            "operand-drift/tolerance amplification, dump/reproducer mismatch, "
+            "or a concrete same-side product residual. Consumes the existing "
+            "C45 tap set from kiln and HF reference dumps."
+        ),
+    )
     ap.add_argument(
         "--c6",
         action="store_true",
@@ -2922,6 +3214,7 @@ def main() -> int:
         or args.c45_row_scalar
         or args.c45_operand_budget
         or args.c46_row_provenance
+        or args.c47_c45_tolerance_artifact
     )
     if args.atol is None:
         args.atol = 1e-2 if bf16_mode else 1e-3
@@ -2948,7 +3241,9 @@ def main() -> int:
         lines.append(s)
 
     multi = len(pairs) > 1
-    if args.c7:
+    if args.c47_c45_tolerance_artifact:
+        mode = "C45 tolerance/reproducer artifact classifier (C47)"
+    elif args.c7:
         mode = "SDPA-internal bisect (C7)"
     elif args.c46_row_provenance:
         mode = "layer-1 row-side provenance audit (C46)"
@@ -2981,7 +3276,9 @@ def main() -> int:
     ] = []
     overall_ok = True
     focus_keys = None
-    if args.c46_row_provenance:
+    if args.c47_c45_tolerance_artifact:
+        focus_keys = [f"c45__{name}" for name in C45_LAYER1_ROW_TAP_NAMES]
+    elif args.c46_row_provenance:
         focus_keys = [f"c46__{name}" for name in C46_ROW_PROVENANCE_TAP_NAMES]
     elif args.c45 or args.c45_row_scalar or args.c45_operand_budget:
         focus_keys = [f"c45__{name}" for name in C45_LAYER1_ROW_TAP_NAMES]
@@ -3001,7 +3298,9 @@ def main() -> int:
         if not ok:
             overall_ok = False
 
-    if args.c7:
+    if args.c47_c45_tolerance_artifact:
+        _emit_c47_summary_from_paths(pairs, emit)
+    elif args.c7:
         _emit_c7_summary(pair_results, args.atol, args.rtol, emit)
     elif args.c46_row_provenance:
         _emit_c46_summary(pair_results, args.atol, args.rtol, emit)
@@ -3031,7 +3330,7 @@ def main() -> int:
     # captured" note when the dump didn't include the B9 sub-ops (e.g.
     # legacy dumps from before this PR). Skipped in explicit --b10/--b11/--b12/--c6
     # mode so the per-phase report isn't cluttered by unrelated sub-op tables.
-    if not args.b10 and not args.b11 and not args.b12 and not args.c41 and not args.c42 and not args.c6 and not args.c7:
+    if not args.b10 and not args.b11 and not args.b12 and not args.c41 and not args.c42 and not args.c6 and not args.c7 and not args.c47_c45_tolerance_artifact:
         have_b9_taps = any(
             any(r["name"] in B9_H2_ZONE or r["name"] in B9_H3_ZONE for r in pr[3])
             for pr in pair_results


### PR DESCRIPTION
## Summary

- Add `scripts/mtp_compare.py --c47-c45-tolerance-artifact`, a focused comparator-only classifier for the remaining C45 `layer_1_input_norm_pre_weight_row_broadcast_output` boundary.
- Report current/tight mask verdicts for row operand, scalar operand, predicted product, and observed output; predicted-vs-observed residual; same-side product residuals; contribution budget; and top offending hidden indices.
- Append the C47 design, commands, seed 0/1 verdicts, and stop condition to `docs/phase-c45/c45-layer1-row-normalization-bisect.md`.
- Commit fresh GPU comparator outputs for seed 0/1.

## Verdict

C47 classifies the remaining boundary as a reproducer/tolerance-boundary artifact, not a production `broadcast_mul` math bug.

- Seed 0 (`mtp_pos=0`): current mask no longer reproduces the C45 failure; tight mask fails for predicted/observed product (`max|Δ|=2.83e-02`, tight `tol_ratio=8.43`), and output is fully predicted from operands (`observed=2.83e-02`, `predicted=2.83e-02`, residual `2.32e-06`). Same-side residuals are tiny (`kiln max=1.40e-06`, `ref max=9.24e-07`), contribution is row-side dominant.
- Seed 1 (`mtp_pos=2`): current mask no longer reproduces the C45 failure; tight mask fails for predicted/observed product (`max|Δ|=1.86e-02`, tight `tol_ratio=7.78`), and output is fully predicted from operands (`observed=1.86e-02`, `predicted=1.86e-02`, residual `2.26e-06`). Same-side residuals are tiny (`kiln max=1.91e-06`, `ref max=3.58e-07`), contribution is row-side dominant.

Stop condition: do not change production inference math at the C45 broadcast boundary. Revisit only if a fresh current-main reproducer again fails the current mask and C47 reports a non-negligible predicted-vs-observed residual.

## Validation

Run on RunPod pool pod `sl53yvx5seviyx` (`NVIDIA RTX A6000`) using `ghcr.io/ericflo/kiln-runpod:latest`:

- `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench`
- `cargo test --locked -p kiln-model c45 -- --nocapture`
- `cargo test --locked -p kiln-model c46 -- --nocapture`
- `python3 -m py_compile scripts/mtp_h_main_reference_dump.py scripts/mtp_compare.py`
- Fresh seed 0/1 C45/C46-compatible dumps and HF C45 reference dumps
- `python3 scripts/mtp_compare.py --c47-c45-tolerance-artifact ... > profiling-artifacts/c47_c45_tolerance_artifact_seed{0,1}_compare.txt`

Capacity note: direct on-demand A6000/A100/L40S were supply-constrained, and A40/RTX 6000 Ada direct launches wedged before SSH runtime. The A6000 pool lease completed validation and was released.
