### PR TITLE
Document C50 C40f MTP decode profile

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -7151,3 +7151,21 @@ C49 compares the C48-style forced-MTP command against C40f-style harness flags o
 Result: C40f-style flags restore the median acceptance rate from `0.391` to `0.707` and median decode from `28.73 tok/s` to `42.45 tok/s`. The restored arm clears both gates: α ≥ `0.65`, and decode is `1.11x` the C40f historical median of `38.25 tok/s` rather than outside the allowed 10% band.
 
 Recommendation: treat C48 as a harness/workload comparability artifact and resume Phase 6 MTP performance/profiling work from the C40f-style harness anchor. Do not reopen model-math investigation based on C48 alone.
+
+## Phase 6 C50 C40f-style native MTP decode profile (2026-04-24)
+
+C50 re-ran the restored C40f-style native-MTP harness from C49 on current
+`origin/main` at `7c638e7e2d69cb16772619a2a32d6114767bf7e2` on an on-demand
+A6000. The three-seed median remained healthy: α `0.707`, decode `44.00 tok/s`,
+and mean ITL `22.73 ms`, so do not reopen the C48 model-math investigation.
+
+Artifact: `docs/phase-c50/mtp-c40f-decode-profile.md`; machine summary:
+`docs/phase-c50/summary.json`.
+
+The baked Nsight Systems 2023.4.4 importer failed C50 `.qdstrm` import with a
+QuadD wrong-event-order error before stats export, so C50 carries forward the
+latest successful current-main decode NVTX attribution from post-#442 for the
+hotspot table: `:kiln/gdn/gates` `17.9%`, `:kiln/gdn/gated_norm` `17.3%`, and
+`:kiln/gdn/qk_norm` `15.0%`. Next implementation target: fuse or vendor the GDN
+gate/gated-norm decode path; it is higher leverage than FlashInfer/full-attn
+decode and C50 does not justify retrying C48 model-math work.

--- a/docs/phase-c50/bench-seed-0.json
+++ b/docs/phase-c50/bench-seed-0.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 1.825366016,
+    "model_vram_mb": 16342
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 496,
+    "prefill_time_ms": 362.845716,
+    "prefill_tokens_per_sec": 1366.9721816420729,
+    "time_to_first_token_ms": 362.845716,
+    "mean_inter_token_ms": 20.649514692913396,
+    "p50_inter_token_ms": 15.650579500000001,
+    "p99_inter_token_ms": 53.616467,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 48.42728823758676,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7887323943661971,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c50/bench-seed-0.log
+++ b/docs/phase-c50/bench-seed-0.log
@@ -1,0 +1,67 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-24T02:23:35.146256Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-24T02:23:35.147424Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-24T02:23:35.147768Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected; deferring CPU load until first use [3mmtp_prefix[0m[2m=[0mmtp.
+[2m2026-04-24T02:23:35.147796Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4206M parameters (8022 MB) across 32 layers
+[2m2026-04-24T02:23:35.147935Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+Model loaded in 1.83s (backend: cuda, VRAM: 16342 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=47] (496 prompt tokens)...
+    Prefill (MTP): 362.8ms (1367 tok/s)
+[2m2026-04-24T02:23:37.831226Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m deferred native MTP CPU load complete [3mload_elapsed_ms[0m[2m=[0m1
+[2m2026-04-24T02:23:37.864079Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m32
+    Decode (MTP): 128 tokens, mean ITL 20.6ms (48.4 tok/s), α = 0.789 (56/71)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 1.83s (VRAM: 16342 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         496
+Prefill time:          362.8 ms (1367 tok/s)
+Time to first token:   362.8 ms
+Mean inter-token:      20.6 ms (48.4 tok/s)
+P50 inter-token:       15.7 ms
+P99 inter-token:       53.6 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.789
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 1.825366016,
+    "model_vram_mb": 16342
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 496,
+    "prefill_time_ms": 362.845716,
+    "prefill_tokens_per_sec": 1366.9721816420729,
+    "time_to_first_token_ms": 362.845716,
+    "mean_inter_token_ms": 20.649514692913396,
+    "p50_inter_token_ms": 15.650579500000001,
+    "p99_inter_token_ms": 53.616467,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 48.42728823758676,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7887323943661971,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c50/bench-seed-1.json
+++ b/docs/phase-c50/bench-seed-1.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 1.842018533,
+    "model_vram_mb": 16342
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 371.44883899999996,
+    "prefill_tokens_per_sec": 1386.4628070623746,
+    "time_to_first_token_ms": 371.44883899999996,
+    "mean_inter_token_ms": 22.72799512992126,
+    "p50_inter_token_ms": 15.816839,
+    "p99_inter_token_ms": 55.050601,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 43.99860147292562,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7066666666666667,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c50/bench-seed-1.log
+++ b/docs/phase-c50/bench-seed-1.log
@@ -1,0 +1,67 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-24T02:23:41.061202Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-24T02:23:41.062369Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-24T02:23:41.062629Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected; deferring CPU load until first use [3mmtp_prefix[0m[2m=[0mmtp.
+[2m2026-04-24T02:23:41.062663Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4206M parameters (8022 MB) across 32 layers
+[2m2026-04-24T02:23:41.062825Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+Model loaded in 1.84s (backend: cuda, VRAM: 16342 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=49] (515 prompt tokens)...
+    Prefill (MTP): 371.4ms (1386 tok/s)
+[2m2026-04-24T02:23:43.772502Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m deferred native MTP CPU load complete [3mload_elapsed_ms[0m[2m=[0m1
+[2m2026-04-24T02:23:43.803400Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m30
+    Decode (MTP): 128 tokens, mean ITL 22.7ms (44.0 tok/s), α = 0.707 (53/75)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 1.84s (VRAM: 16342 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         515
+Prefill time:          371.4 ms (1386 tok/s)
+Time to first token:   371.4 ms
+Mean inter-token:      22.7 ms (44.0 tok/s)
+P50 inter-token:       15.8 ms
+P99 inter-token:       55.1 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.707
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 1.842018533,
+    "model_vram_mb": 16342
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 371.44883899999996,
+    "prefill_tokens_per_sec": 1386.4628070623746,
+    "time_to_first_token_ms": 371.44883899999996,
+    "mean_inter_token_ms": 22.72799512992126,
+    "p50_inter_token_ms": 15.816839,
+    "p99_inter_token_ms": 55.050601,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 43.99860147292562,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7066666666666667,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c50/bench-seed-2.json
+++ b/docs/phase-c50/bench-seed-2.json
@@ -1,0 +1,28 @@
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 1.801834932,
+    "model_vram_mb": 16342
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 510,
+    "prefill_time_ms": 350.409227,
+    "prefill_tokens_per_sec": 1455.4411262692008,
+    "time_to_first_token_ms": 350.409227,
+    "mean_inter_token_ms": 26.03486565354331,
+    "p50_inter_token_ms": 18.7639895,
+    "p99_inter_token_ms": 54.249324,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 38.41003112162791,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.5875,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c50/bench-seed-2.log
+++ b/docs/phase-c50/bench-seed-2.log
@@ -1,0 +1,67 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-24T02:23:47.235328Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-24T02:23:47.236463Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-24T02:23:47.236792Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected; deferring CPU load until first use [3mmtp_prefix[0m[2m=[0mmtp.
+[2m2026-04-24T02:23:47.236828Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4206M parameters (8022 MB) across 32 layers
+[2m2026-04-24T02:23:47.236980Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+Model loaded in 1.80s (backend: cuda, VRAM: 16342 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (510 prompt tokens)...
+    Prefill (MTP): 350.4ms (1455 tok/s)
+[2m2026-04-24T02:23:49.864925Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m deferred native MTP CPU load complete [3mload_elapsed_ms[0m[2m=[0m1
+[2m2026-04-24T02:23:49.897317Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m32
+    Decode (MTP): 128 tokens, mean ITL 26.0ms (38.4 tok/s), α = 0.588 (47/80)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 1.80s (VRAM: 16342 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         510
+Prefill time:          350.4 ms (1455 tok/s)
+Time to first token:   350.4 ms
+Mean inter-token:      26.0 ms (38.4 tok/s)
+P50 inter-token:       18.8 ms
+P99 inter-token:       54.2 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.588
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 1.801834932,
+    "model_vram_mb": 16342
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 510,
+    "prefill_time_ms": 350.409227,
+    "prefill_tokens_per_sec": 1455.4411262692008,
+    "time_to_first_token_ms": 350.409227,
+    "mean_inter_token_ms": 26.03486565354331,
+    "p50_inter_token_ms": 18.7639895,
+    "p99_inter_token_ms": 54.249324,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 38.41003112162791,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.5875,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c50/cargo-test-bench.log
+++ b/docs/phase-c50/cargo-test-bench.log
@@ -1,0 +1,92 @@
+warning: value assigned to `prev_hash` is never read
+   --> crates/kiln-core/src/prefix_cache.rs:159:25
+    |
+159 |                         prev_hash = chain_hash;
+    |                         ^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: maybe it is overwritten before being read?
+    = note: `#[warn(unused_assignments)]` (part of `#[warn(unused)]`) on by default
+
+warning: field `chain_hash` is never read
+  --> crates/kiln-core/src/prefix_cache.rs:39:5
+   |
+35 | struct BlockCacheEntry {
+   |        --------------- field in this struct
+...
+39 |     chain_hash: u64,
+   |     ^^^^^^^^^^
+   |
+   = note: `BlockCacheEntry` has derived impls for the traits `Clone` and `Debug`, but these are intentionally ignored during dead code analysis
+   = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+
+warning: `kiln-core` (lib) generated 2 warnings
+   Compiling kiln-model v0.1.2 (/workspace/kiln/crates/kiln-model)
+warning: function `compute_chunk_body_reference` is never used
+    --> crates/kiln-model/src/forward.rs:2571:4
+     |
+2571 | fn compute_chunk_body_reference(
+     |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     |
+     = note: `#[warn(dead_code)]` (part of `#[warn(unused)]`) on by default
+
+warning: function `apply_causal_mask` is never used
+    --> crates/kiln-model/src/forward.rs:4740:4
+     |
+4740 | fn apply_causal_mask(scores: &Tensor, seq_len: usize) -> Result<Tensor> {
+     |    ^^^^^^^^^^^^^^^^^
+
+warning: field `fp8_scales` is never read
+  --> crates/kiln-model/src/paged_kv_cache.rs:35:5
+   |
+23 | pub struct PagedKvCache {
+   |            ------------ field in this struct
+...
+35 |     fp8_scales: Vec<(f32, f32)>,
+   |     ^^^^^^^^^^
+
+   Compiling kiln-train v0.1.2 (/workspace/kiln/crates/kiln-train)
+   Compiling kiln-server v0.1.2 (/workspace/kiln/crates/kiln-server)
+warning: `kiln-model` (lib) generated 3 warnings
+warning: unused import: `Context`
+ --> crates/kiln-server/src/device.rs:8:14
+  |
+8 | use anyhow::{Context, Result};
+  |              ^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+warning: `kiln-server` (lib) generated 1 warning (run `cargo fix --lib -p kiln-server` to apply 1 suggestion)
+warning: `kiln-server` (lib test) generated 1 warning (1 duplicate)
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 6.97s
+     Running unittests src/lib.rs (target/debug/deps/kiln_server-36094a7f7a41896f)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 52 filtered out; finished in 0.00s
+
+     Running unittests src/main.rs (target/debug/deps/kiln-3e2afa2acec6e698)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running unittests src/bench.rs (target/debug/deps/kiln_bench-a8419b709b75d064)
+
+running 8 tests
+test tests::bench_force_raw_mtp_bypasses_shape_routing ... ok
+test tests::bench_mtp_long_greedy_prompt_falls_back_to_skip_layer ... ok
+test tests::bench_mtp_metal_4096_prompt_falls_back_to_skip_layer ... ok
+test tests::bench_mtp_metal_medium_prompt_stays_off_until_4096 ... ok
+test tests::bench_mtp_short_prompt_stays_mtp ... ok
+test tests::bench_mtp_medium_prompt_stays_off_until_skip_layer_crossover ... ok
+test tests::bench_mtp_long_short_output_or_sampled_prompt_turns_off ... ok
+test tests::bench_mtp_short_prompt_stays_off_when_native_mtp_is_disallowed ... ok
+
+test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+
+     Running tests/real_model_integration.rs (target/debug/deps/real_model_integration-3847a7064ada83db)
+
+running 0 tests
+
+test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 5 filtered out; finished in 0.00s
+

--- a/docs/phase-c50/mtp-c40f-decode-profile.md
+++ b/docs/phase-c50/mtp-c40f-decode-profile.md
@@ -1,0 +1,80 @@
+# C50 C40f-Style Native MTP Decode Profile
+
+Date: 2026-04-24
+
+Commit: `7c638e7e2d69cb16772619a2a32d6114767bf7e2`
+
+GPU: RunPod on-demand NVIDIA RTX A6000, `ghcr.io/ericflo/kiln-runpod:latest`.
+
+## Purpose
+
+C49 showed that the C48 native-MTP regression was a harness/workload comparability artifact. C50 re-runs the restored C40f-style native-MTP harness on current `origin/main`, records the new benchmark anchor, and selects the next Phase 6 implementation target from the freshest comparable data.
+
+## Setup
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+git fetch origin
+git reset --hard origin/main
+KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench
+cargo test --locked -p kiln-server bench -- --nocapture || true
+python3 -m py_compile scripts/mtp_compare.py scripts/mtp_h_main_reference_dump.py
+```
+
+`cargo test --locked -p kiln-server bench -- --nocapture` exited successfully; the filtered bench tests reported `8 passed`. The Python compile check also passed.
+
+## Benchmark Command
+
+```bash
+env KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed <seed> \
+  --chat-template --latency-only --prompt-subset humaneval --temperature 0.0
+```
+
+## Benchmark Summary
+
+| Seed | Prompt subset | α | Decode tok/s | Mean ITL ms | Prefill ms |
+| ---: | --- | ---: | ---: | ---: | ---: |
+| 0 | humaneval | 0.789 | 48.43 | 20.65 | 362.85 |
+| 1 | humaneval | 0.707 | 44.00 | 22.73 | 371.45 |
+| 2 | humaneval | 0.588 | 38.41 | 26.03 | 350.41 |
+
+| Metric | Median | Mean |
+| --- | ---: | ---: |
+| Acceptance α | 0.707 | 0.694 |
+| Decode tok/s | 44.00 | 43.61 |
+| Mean ITL ms | 22.73 | 23.14 |
+| Prefill ms | 362.85 | 361.57 |
+
+The C40f-style harness still clears both C49 gates: median α `0.707` is above `0.65`, and median decode `44.00 tok/s` is above the 10%-below-`38.25 tok/s` floor (`34.43 tok/s`). This means C50 should not reopen C48 model-math investigation.
+
+## Nsight Status
+
+The requested `nsys profile` command ran on the restored C40f-style native-MTP workload, but the baked Nsight Systems 2023.4.4 importer failed before producing a `.nsys-rep` stats database:
+
+```text
+Importer error status: Importation failed.
+ErrorText = "Wrong event order has been detected when adding events to the collection"
+```
+
+This happened for full-run capture, CUDA-only capture, CUDA-graph-granularity capture, no-CUDA-graphs capture, and a decode-window capture. `nvprof` is unsupported on the A6000, and `ncu` could not access performance counters under the pod permissions. The committed `nsys-profile.log`, `nsys-stats.txt`, `nsys-gpu-kernsum.txt`, and `nsys-cuda-api.txt` preserve the failed C50 capture attempt rather than committing multi-MB `.qdstrm` files.
+
+## Top Decode Hotspots
+
+Because the C50 `.nsys-rep` importer failed, the decode hotspot table uses the latest successful current-main decode NVTX attribution already checked in from the post-#442 profile, while C50 supplies the restored-harness MTP benchmark anchor on current main.
+
+| Rank | Decode range | Wall-clock share | Interpretation |
+| ---: | --- | ---: | --- |
+| 1 | `:kiln/gdn/gates` | 17.9% | Largest GDN-side decode bucket. |
+| 2 | `:kiln/gdn/gated_norm` | 17.3% | Adjacent GDN normalization bucket with near-equal cost. |
+| 3 | `:kiln/gdn/qk_norm` | 15.0% | Third GDN normalization bucket; still larger than full-attention decode. |
+
+Kernel-level post-#442 cross-check had `Marlin<(256,1,8,8,4,8)>` at `14.4%`, `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_256x64...` at `11.6%`, and `ampere_bf16_s16816gemm_bf16_128x64...` at `9.7%`. The full-attention projection ranges remained much smaller (`:kiln/proj/qkv` `3.1%`, `:kiln/proj/o` `0.9%`).
+
+## Recommendation
+
+Queue exactly one next implementation target: **fuse or vendor the GDN gate/gated-norm decode path**.
+
+Rationale: C50 restores native MTP to a usable harness anchor (median α `0.707`, median decode `44.00 tok/s`), so the next speed work should target the dominant GDN decode wall-clock cluster instead of C48 model-math. The top two ranges, `:kiln/gdn/gates` and `:kiln/gdn/gated_norm`, are adjacent and together account for `35.2%` of the last successful current-main decode NVTX attribution; they are higher leverage than FlashInfer/full-attention decode or another acceptance-rate investigation unless a future C40f-style run falls below the gates.

--- a/docs/phase-c50/nsys-cuda-api.txt
+++ b/docs/phase-c50/nsys-cuda-api.txt
@@ -1,0 +1,1 @@
+ERROR: Specified input file (/tmp/c50-mtp-c40f-retry.nsys-rep) does not exist.

--- a/docs/phase-c50/nsys-gpu-kernsum.txt
+++ b/docs/phase-c50/nsys-gpu-kernsum.txt
@@ -1,0 +1,1 @@
+ERROR: Specified input file (/tmp/c50-mtp-c40f-retry.nsys-rep) does not exist.

--- a/docs/phase-c50/nsys-profile.log
+++ b/docs/phase-c50/nsys-profile.log
@@ -1,0 +1,104 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-24T02:42:42.480409Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-24T02:42:42.482529Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-24T02:42:42.482859Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected; deferring CPU load until first use [3mmtp_prefix[0m[2m=[0mmtp.
+[2m2026-04-24T02:42:42.482890Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4206M parameters (8022 MB) across 32 layers
+[2m2026-04-24T02:42:42.483037Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+Model loaded in 2.86s (backend: cuda, VRAM: 16367 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=49] (515 prompt tokens)...
+    Prefill (MTP): 421.8ms (1221 tok/s)
+[2m2026-04-24T02:42:46.280903Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m deferred native MTP CPU load complete [3mload_elapsed_ms[0m[2m=[0m3
+[2m2026-04-24T02:42:46.329178Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m48
+    Decode (MTP): 128 tokens, mean ITL 39.9ms (25.1 tok/s), α = 0.707 (53/75)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 2.86s (VRAM: 16367 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         515
+Prefill time:          421.8 ms (1221 tok/s)
+Time to first token:   421.8 ms
+Mean inter-token:      39.9 ms (25.1 tok/s)
+P50 inter-token:       28.8 ms
+P99 inter-token:       100.1 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.707
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 2.858273815,
+    "model_vram_mb": 16367
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 421.794046,
+    "prefill_tokens_per_sec": 1220.9750348159255,
+    "time_to_first_token_ms": 421.794046,
+    "mean_inter_token_ms": 39.89365402362206,
+    "p50_inter_token_ms": 28.777122,
+    "p99_inter_token_ms": 100.142286,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 25.06664341671671,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7066666666666667,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}
+Generating '/tmp/nsys-report-10c3.qdstrm'
+[1/1] [0%                          ] c50-mtp-window.nsys-rep[1/1] [0%                          ] c50-mtp-window.nsys-rep[1/1] [===22%                      ] c50-mtp-window.nsys-rep[1/1] [=17%                        ] c50-mtp-window.nsys-rep[1/1] [14%                         ] c50-mtp-window.nsys-rep[1/1] [=====29%                    ] c50-mtp-window.nsys-rep[1/1] [====25%                     ] c50-mtp-window.nsys-rep[1/1] [===22%                      ] c50-mtp-window.nsys-rep[1/1] [==19%                       ] c50-mtp-window.nsys-rep[1/1] [=17%                        ] c50-mtp-window.nsys-rep[1/1] [=16%                        ] c50-mtp-window.nsys-rep[1/1] [14%                         ] c50-mtp-window.nsys-rep[1/1] [13%                         ] c50-mtp-window.nsys-rep[1/1] [12%                         ] c50-mtp-window.nsys-rep[1/1] [11%                         ] c50-mtp-window.nsys-rep[1/1] [10%                         ] c50-mtp-window.nsys-rep[1/1] [9%                          ] c50-mtp-window.nsys-rep[1/1] [8%                          ] c50-mtp-window.nsys-rep[1/1] [7%                          ] c50-mtp-window.nsys-rep[1/1] [6%                          ] c50-mtp-window.nsys-rep[1/1] [5%                          ] c50-mtp-window.nsys-rep[1/1] [0%                          ] c50-mtp-window.nsys-rep[1/1] [5%                          ] c50-mtp-window.nsys-rep[1/1] [6%                          ] c50-mtp-window.nsys-rep[1/1] [7%                          ] c50-mtp-window.nsys-rep[1/1] [8%                          ] c50-mtp-window.nsys-rep[1/1] [9%                          ] c50-mtp-window.nsys-rep[1/1] [10%                         ] c50-mtp-window.nsys-rep[1/1] [11%                         ] c50-mtp-window.nsys-rep[1/1] [12%                         ] c50-mtp-window.nsys-rep[1/1] [13%                         ] c50-mtp-window.nsys-rep[1/1] [14%                         ] c50-mtp-window.nsys-rep[1/1] [=15%                        ] c50-mtp-window.nsys-rep[1/1] [=16%                        ] c50-mtp-window.nsys-rep[1/1] [=17%                        ] c50-mtp-window.nsys-rep[1/1] [==18%                       ] c50-mtp-window.nsys-rep[1/1] [==19%                       ] c50-mtp-window.nsys-rep[1/1] [==20%                       ] c50-mtp-window.nsys-rep[1/1] [==21%                       ] c50-mtp-window.nsys-rep[1/1] [===22%                      ] c50-mtp-window.nsys-rep[1/1] [===23%                      ] c50-mtp-window.nsys-rep[1/1] [===24%                      ] c50-mtp-window.nsys-rep[1/1] [====25%                     ] c50-mtp-window.nsys-rep[1/1] [====26%                     ] c50-mtp-window.nsys-rep[1/1] [====27%                     ] c50-mtp-window.nsys-rep[1/1] [====28%                     ] c50-mtp-window.nsys-rep[1/1] [=====29%                    ] c50-mtp-window.nsys-rep[1/1] [=====30%                    ] c50-mtp-window.nsys-rep[1/1] [=====31%                    ] c50-mtp-window.nsys-rep[1/1] [=====32%                    ] c50-mtp-window.nsys-rep[1/1] [======33%                   ] c50-mtp-window.nsys-rep[1/1] [======34%                   ] c50-mtp-window.nsys-rep[1/1] [======35%                   ] c50-mtp-window.nsys-rep[1/1] [=======36%                  ] c50-mtp-window.nsys-rep[1/1] [=======37%                  ] c50-mtp-window.nsys-rep[1/1] [=======38%                  ] c50-mtp-window.nsys-rep[1/1] [=======39%                  ] c50-mtp-window.nsys-rep[1/1] [========40%                 ] c50-mtp-window.nsys-rep[1/1] [========41%                 ] c50-mtp-window.nsys-rep[1/1] [========42%                 ] c50-mtp-window.nsys-rep[1/1] [=========43%                ] c50-mtp-window.nsys-rep[1/1] [=========44%                ] c50-mtp-window.nsys-rep[1/1] [=========45%                ] c50-mtp-window.nsys-rep[1/1] [=========46%                ] c50-mtp-window.nsys-rep[1/1] [==========47%               ] c50-mtp-window.nsys-rep[1/1] [==========48%               ] c50-mtp-window.nsys-rep[1/1] [==========49%               ] c50-mtp-window.nsys-rep[1/1] [===========50%              ] c50-mtp-window.nsys-rep[1/1] [===========51%              ] c50-mtp-window.nsys-rep[1/1] [===========52%              ] c50-mtp-window.nsys-rep[1/1] [===========53%              ] c50-mtp-window.nsys-rep[1/1] [============54%             ] c50-mtp-window.nsys-rep[1/1] [============55%             ] c50-mtp-window.nsys-rep[1/1] [============56%             ] c50-mtp-window.nsys-rep[1/1] [============57%             ] c50-mtp-window.nsys-rep[1/1] [=============58%            ] c50-mtp-window.nsys-rep[1/1] [=============59%            ] c50-mtp-window.nsys-rep[1/1] [=============60%            ] c50-mtp-window.nsys-rep[1/1] [==============61%           ] c50-mtp-window.nsys-rep
+Importer error status: Importation failed.
+Import Failed with unexpected exception: /dvs/p4/build/sw/devtools/Agora/Rel/CUDA12.4/QuadD/Host/QdstrmImporter/main.cpp(34): Throw in function {anonymous}::Importer::Importer(const boost::filesystem::path&, const boost::filesystem::path&)
+Dynamic exception type: boost::wrapexcept<QuadDCommon::RuntimeException>
+std::exception::what: RuntimeException
+[QuadDCommon::tag_message*] = Status: AnalysisFailed
+Error {
+  Type: RuntimeError
+  SubError {
+    Type: InvalidArgument
+    Props {
+      Items {
+        Type: OriginalExceptionClass
+        Value: "N5boost10wrapexceptIN11QuadDCommon24InvalidArgumentExceptionEEE"
+      }
+      Items {
+        Type: OriginalFile
+        Value: "/dvs/p4/build/sw/devtools/Agora/Rel/CUDA12.4/QuadD/Host/Analysis/Modules/EventCollection.cpp"
+      }
+      Items {
+        Type: OriginalLine
+        Value: "1048"
+      }
+      Items {
+        Type: OriginalFunction
+        Value: "void QuadDAnalysis::EventCollection::CheckOrder(QuadDAnalysis::EventCollectionHelper::EventContainer&, const QuadDAnalysis::ConstEvent&) const"
+      }
+      Items {
+        Type: ErrorText
+        Value: "Wrong event order has been detected when adding events to the collection:\nnew event ={ StartNs=3293547706 StopNs=3293547906 GlobalId=282319910913210 Event={ TraceProcessEvent=[{ Correlation=5143063 EventClass=1 TextId=48 ReturnValue=0 },] } Type=48 }\nlast event ={ StartNs=3346952524 StopNs=3346952674 GlobalId=282319910913210 Event={ TraceProcessEvent=[{ Correlation=5222087 EventClass=1 TextId=48 ReturnValue=0 },] } Type=48 }"
+      }
+    }
+  }
+}
+Generated:
+    /tmp/c50-mtp-window.qdstrm

--- a/docs/phase-c50/nsys-stats.txt
+++ b/docs/phase-c50/nsys-stats.txt
@@ -1,0 +1,1 @@
+ERROR: Specified input file (/tmp/c50-mtp-graph.nsys-rep) does not exist.

--- a/docs/phase-c50/summary.json
+++ b/docs/phase-c50/summary.json
@@ -1,0 +1,64 @@
+{
+  "commit": "7c638e7e2d69cb16772619a2a32d6114767bf7e2",
+  "gpu": "NVIDIA RTX A6000",
+  "command": "env KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed <seed> --chat-template --latency-only --prompt-subset humaneval --temperature 0.0",
+  "rows": [
+    {
+      "seed": 0,
+      "acceptance_rate": 0.7887323943661971,
+      "decode_tokens_per_sec": 48.42728823758676,
+      "mean_inter_token_ms": 20.649514692913396,
+      "prefill_time_ms": 362.845716
+    },
+    {
+      "seed": 1,
+      "acceptance_rate": 0.7066666666666667,
+      "decode_tokens_per_sec": 43.99860147292562,
+      "mean_inter_token_ms": 22.72799512992126,
+      "prefill_time_ms": 371.44883899999996
+    },
+    {
+      "seed": 2,
+      "acceptance_rate": 0.5875,
+      "decode_tokens_per_sec": 38.41003112162791,
+      "mean_inter_token_ms": 26.03486565354331,
+      "prefill_time_ms": 350.409227
+    }
+  ],
+  "summary": {
+    "n": 3,
+    "median_acceptance_rate": 0.7066666666666667,
+    "mean_acceptance_rate": 0.6942996870109546,
+    "median_decode_tokens_per_sec": 43.99860147292562,
+    "mean_decode_tokens_per_sec": 43.61197361071343,
+    "median_mean_inter_token_ms": 22.72799512992126,
+    "mean_mean_inter_token_ms": 23.13745849212599,
+    "median_prefill_time_ms": 362.845716,
+    "mean_prefill_time_ms": 361.56792733333333
+  },
+  "top_hotspots": [
+    {
+      "rank": 1,
+      "range": ":kiln/gdn/gates",
+      "wall_clock_share_pct": 17.9,
+      "source": "post442_decode_nvtx_pushpop_sum.csv; C50 nsys importer failed on baked nsys 2023.4.4"
+    },
+    {
+      "rank": 2,
+      "range": ":kiln/gdn/gated_norm",
+      "wall_clock_share_pct": 17.3,
+      "source": "post442_decode_nvtx_pushpop_sum.csv; C50 nsys importer failed on baked nsys 2023.4.4"
+    },
+    {
+      "rank": 3,
+      "range": ":kiln/gdn/qk_norm",
+      "wall_clock_share_pct": 15.0,
+      "source": "post442_decode_nvtx_pushpop_sum.csv; C50 nsys importer failed on baked nsys 2023.4.4"
+    }
+  ],
+  "profile_notes": {
+    "nsys_capture": "C50 nsys capture ran on the restored C40f-style MTP command, but baked nsys 2023.4.4 failed qdstrm import with QuadD EventCollection wrong-event-order before producing .nsys-rep stats.",
+    "hotspot_attribution": "The top hotspot table therefore carries forward the latest successful current-main decode NVTX attribution from post-#442, while C50 establishes that the restored C40f MTP harness remains above alpha/decode gates on current main.",
+    "next_target": "GDN gate/gated-norm fusion or vendored GDN decode-side reduction, not C48 model-math investigation."
+  }
+}


### PR DESCRIPTION
## Summary

Adds the C50 current-main C40f-style native-MTP decode profile artifact under `docs/phase-c50/` and appends a short `PROFILING.md` pointer.

## C50 benchmark anchor

Command shape:

```bash
env KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 \
  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed <seed> \
  --chat-template --latency-only --prompt-subset humaneval --temperature 0.0
```

Three-seed medians on A6000:

- Acceptance α: `0.7067`
- Decode: `43.9986 tok/s`
- Mean ITL: `22.7280 ms`

These clear the C49 gates (`α >= 0.65`, decode within 10% of `38.25 tok/s`), so this PR does not recommend retrying C48 model-math investigation.

## Decode hotspots

The C50 `nsys profile` runs executed against the restored C40f-style native-MTP command, but baked Nsight Systems 2023.4.4 failed `.qdstrm` import with QuadD `Wrong event order` before producing `.nsys-rep` stats. The PR preserves the failure logs and carries forward the latest successful current-main post-#442 decode NVTX attribution for hotspot ranking:

| Rank | Range | Share |
| ---: | --- | ---: |
| 1 | `:kiln/gdn/gates` | `17.9%` |
| 2 | `:kiln/gdn/gated_norm` | `17.3%` |
| 3 | `:kiln/gdn/qk_norm` | `15.0%` |

## Recommendation

Choose exactly one next implementation target: **fuse or vendor the GDN gate/gated-norm decode path**.

Justification: the restored MTP harness is healthy on current main, and the dominant decode cluster is still GDN-side. `:kiln/gdn/gates` + `:kiln/gdn/gated_norm` account for `35.2%` of the latest successful current-main decode NVTX attribution, which is higher leverage than FlashInfer/full-attention decode or another C48-style model-math investigation.

## Validation

- `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench`
- `cargo test --locked -p kiln-server bench -- --nocapture` (`8 passed` filtered bench tests)
- `python3 -m py_compile scripts/mtp_compare.py scripts/mtp_h_main_reference_dump.py`
- Three C40f-style MTP benchmark seeds (`0`, `1`, `2`)
- `nsys profile` attempted; import failure documented in `docs/phase-c50/nsys-profile.log`
