### PR TITLE
Fuse CUDA GDN gated RMSNorm

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -7169,3 +7169,24 @@ hotspot table: `:kiln/gdn/gates` `17.9%`, `:kiln/gdn/gated_norm` `17.3%`, and
 `:kiln/gdn/qk_norm` `15.0%`. Next implementation target: fuse or vendor the GDN
 gate/gated-norm decode path; it is higher leverage than FlashInfer/full-attn
 decode and C50 does not justify retrying C48 model-math work.
+
+## 2026-04-24 — GDN gated RMSNorm CUDA fusion result (PR TBD)
+
+Implemented a minimal CUDA bf16 fused `rms_norm(x, weight, eps) * silu(z)` kernel for the Qwen3.5 GDN `hidden=128` envelope and wired it through `BackendRuntime::gdn_gated_rms_norm` behind `KILN_DISABLE_FUSED_GDN_GATED_RMS_NORM=1`.
+
+Validation on RunPod A6000 (`KILN_CUDA_ARCHS=86`) passed:
+
+- `cargo test -p kiln-gdn-kernel --release -- --nocapture`
+- `cargo test -p kiln-model --release --features cuda test_cuda_gdn_gated_rms_norm_matches_fallback -- --nocapture`
+- `cargo build --release --features cuda,nvtx --bin kiln-bench`
+
+Parity was exact at the model backend test shape (`max_abs_diff=0`, `mean_abs_diff=0`) versus the Candle fallback rounded to bf16.
+
+C40f-style MTP decode A/B (`--prompt-subset humaneval --prompt-tokens 512 --max-output-tokens 128 --temperature 0.0`) did not clear the speedup floor:
+
+| Path | Seeds | Median decode tok/s | Median mean ITL |
+| --- | --- | ---: | ---: |
+| Candle fallback (`KILN_DISABLE_FUSED_GDN_GATED_RMS_NORM=1`) | 1,2,3 | 37.54 tok/s | 26.64 ms |
+| Fused CUDA default | 1,2,3 | 38.58 tok/s | 25.92 ms |
+
+Overall decode median improved ~2.8%, which is safely below the requested `kiln/gdn/gated_norm` 25% local floor and consistent with prior CUDA-graphs fusion-null notes. The fused kernel remains safe to ship because parity passed and the kill switch preserves fallback behavior, but the next optimization task should target a different hotspot or a memory-traffic-reducing extension of an existing on-chip GDN kernel rather than retrying standalone gated-norm fusion.

--- a/crates/kiln-gdn-kernel/build.rs
+++ b/crates/kiln-gdn-kernel/build.rs
@@ -43,6 +43,7 @@ fn main() {
     build.file(csrc_dir.join("gdn_fwd_sub.cu"));
     build.file(csrc_dir.join("recurrent_gdn_fwd.cu"));
     build.file(csrc_dir.join("gdn_gates.cu"));
+    build.file(csrc_dir.join("gdn_gated_rms_norm.cu"));
     build.file(csrc_dir.join("gdn_chunk_prep.cu"));
     build.file(csrc_dir.join("gdn_chunk_scan.cu"));
     build.file(csrc_dir.join("gdn_full_chunk_forward.cu"));

--- a/crates/kiln-gdn-kernel/csrc/gdn_gated_rms_norm.cu
+++ b/crates/kiln-gdn-kernel/csrc/gdn_gated_rms_norm.cu
@@ -1,0 +1,93 @@
+// kiln-gdn-kernel: fused GDN gated RMSNorm kernel
+//
+// Collapses the `kiln/gdn/gated_norm` bf16 decode/prefill body from the
+// portable candle chain:
+//
+//   x_f32 -> rms_norm(x, weight, eps) -> silu(z_f32) -> mul -> bf16
+//
+// into one CUDA launch. Scope is intentionally narrow for Qwen3.5 GDN:
+// bf16 inputs/weight, hidden=128, contiguous row-major last dimension.
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cmath>
+
+#include "gdn_gated_rms_norm.h"
+
+namespace {
+
+constexpr int kHidden = 128;
+
+__device__ __forceinline__ float silu(float x) {
+    return x / (1.0f + expf(-x));
+}
+
+// One CUDA block computes one contiguous row of length 128.
+__global__ void gdn_gated_rms_norm_bf16_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ z,
+    const __nv_bfloat16* __restrict__ weight,
+    __nv_bfloat16* __restrict__ out,
+    int rows,
+    float eps
+) {
+    __shared__ float scratch[kHidden];
+
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (row >= rows) return;
+
+    const int base = row * kHidden;
+    const float x_val = __bfloat162float(x[base + tid]);
+    scratch[tid] = x_val * x_val;
+    __syncthreads();
+
+    for (int stride = kHidden / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            scratch[tid] += scratch[tid + stride];
+        }
+        __syncthreads();
+    }
+
+    const float rms_inv = rsqrtf((scratch[0] / static_cast<float>(kHidden)) + eps);
+    const float z_val = __bfloat162float(z[base + tid]);
+    const float w_val = __bfloat162float(weight[tid]);
+    const float out_val = x_val * rms_inv * w_val * silu(z_val);
+    out[base + tid] = __float2bfloat16(out_val);
+}
+
+}  // namespace
+
+extern "C" int32_t kiln_gdn_gated_rms_norm_bf16(
+    const void* x,
+    const void* z,
+    const void* weight,
+    void* out,
+    int32_t rows,
+    int32_t hidden,
+    float eps,
+    void* stream_raw
+) {
+    if (rows <= 0) return 0;
+    if (hidden != kHidden) return 2;
+
+    cudaStream_t stream = reinterpret_cast<cudaStream_t>(stream_raw);
+    dim3 grid(rows);
+    dim3 block(kHidden);
+
+    gdn_gated_rms_norm_bf16_kernel<<<grid, block, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(z),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(out),
+        rows,
+        eps
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 1;
+    }
+    return 0;
+}

--- a/crates/kiln-gdn-kernel/csrc/gdn_gated_rms_norm.h
+++ b/crates/kiln-gdn-kernel/csrc/gdn_gated_rms_norm.h
@@ -1,0 +1,39 @@
+#ifndef KILN_GDN_GATED_RMS_NORM_H
+#define KILN_GDN_GATED_RMS_NORM_H
+
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Fused GDN gated RMSNorm kernel (bf16 activations, bf16 weight).
+//
+// Reads `x`, `z` of shape [rows, hidden] and `weight` of shape [hidden],
+// all bf16. Writes bf16:
+//
+//   out = rms_norm(x, weight, eps) * silu(z)
+//
+// Intermediates are F32 inside the kernel, matching kiln-model's portable
+// fallback before the caller casts the result back to the model dtype.
+//
+// Return codes:
+//   0 — success
+//   1 — CUDA launch error (see cudaGetLastError)
+//   2 — envelope violation (hidden != 128)
+int32_t kiln_gdn_gated_rms_norm_bf16(
+    const void* x,       // [rows, hidden] bf16
+    const void* z,       // [rows, hidden] bf16
+    const void* weight,  // [hidden] bf16
+    void* out,           // [rows, hidden] bf16
+    int32_t rows,
+    int32_t hidden,
+    float eps,
+    void* stream_raw     // cudaStream_t (raw)
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // KILN_GDN_GATED_RMS_NORM_H

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -483,6 +483,19 @@ unsafe extern "C" {
     ) -> i32;
 }
 
+unsafe extern "C" {
+    fn kiln_gdn_gated_rms_norm_bf16(
+        x: *const core::ffi::c_void,
+        z: *const core::ffi::c_void,
+        weight: *const core::ffi::c_void,
+        out: *mut core::ffi::c_void,
+        rows: i32,
+        hidden: i32,
+        eps: f32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+}
+
 /// Cheap shape / dtype check so callers can skip allocating the outputs
 /// (and materialising contiguous copies) when they know they'd fall back.
 ///
@@ -634,6 +647,110 @@ pub fn gdn_gates(
     }
 
     Ok((beta, g))
+}
+
+// ---------------------------------------------------------------------------
+// Fused GDN gated RMSNorm kernel.
+//
+// Collapses the `kiln/gdn/gated_norm` body for Qwen3.5 GDN from the
+// candle F32 `rms_norm(x, weight, eps) * silu(z)` op chain into one CUDA
+// launch. The envelope is intentionally narrow: CUDA bf16 tensors,
+// matching contiguous-last-dim shapes, and hidden=128.
+// ---------------------------------------------------------------------------
+
+pub fn gdn_gated_rms_norm_supports(x: &Tensor, z: &Tensor, weight: &Tensor) -> bool {
+    if !matches!(x.device(), candle_core::Device::Cuda(_)) {
+        return false;
+    }
+    if x.dtype() != DType::BF16 || z.dtype() != DType::BF16 || weight.dtype() != DType::BF16 {
+        return false;
+    }
+    if x.shape() != z.shape() {
+        return false;
+    }
+    let Some(hidden) = x.dims().last().copied() else {
+        return false;
+    };
+    hidden == 128 && weight.dims() == &[hidden]
+}
+
+pub fn gdn_gated_rms_norm(x: &Tensor, z: &Tensor, weight: &Tensor, eps: f32) -> Result<Tensor> {
+    if !gdn_gated_rms_norm_supports(x, z, weight) {
+        candle_core::bail!(
+            "kiln-gdn-kernel: gdn_gated_rms_norm: envelope violation \
+             (x={:?}, z={:?}, weight={:?}, x.dtype={:?})",
+            x.shape(), z.shape(), weight.shape(), x.dtype()
+        );
+    }
+
+    let device = x.device();
+    let shape = x.dims().to_vec();
+    let hidden = *shape.last().unwrap();
+    let rows: usize = shape.iter().take(shape.len() - 1).product();
+    if rows > i32::MAX as usize {
+        candle_core::bail!("kiln-gdn-kernel: gdn_gated_rms_norm rows exceed i32");
+    }
+
+    let x = x.contiguous()?;
+    let z = z.contiguous()?;
+    let weight = weight.contiguous()?;
+    let out = Tensor::zeros(shape, DType::BF16, device)?;
+
+    {
+        let (x_storage, x_layout) = x.storage_and_layout();
+        let (z_storage, z_layout) = z.storage_and_layout();
+        let (w_storage, w_layout) = weight.storage_and_layout();
+        let (out_storage, out_layout) = out.storage_and_layout();
+
+        let x_cuda = match &*x_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: x must be on CUDA"),
+        };
+        let z_cuda = match &*z_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: z must be on CUDA"),
+        };
+        let w_cuda = match &*w_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: weight must be on CUDA"),
+        };
+        let out_cuda = match &*out_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: out must be on CUDA"),
+        };
+
+        let stream = x_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let x_slice = x_cuda.as_cuda_slice::<bf16>()?.slice(x_layout.start_offset()..);
+        let z_slice = z_cuda.as_cuda_slice::<bf16>()?.slice(z_layout.start_offset()..);
+        let w_slice = w_cuda.as_cuda_slice::<bf16>()?.slice(w_layout.start_offset()..);
+        let out_slice = out_cuda.as_cuda_slice::<bf16>()?.slice(out_layout.start_offset()..);
+
+        unsafe {
+            let (x_ptr, _g1) = x_slice.device_ptr(&stream);
+            let (z_ptr, _g2) = z_slice.device_ptr(&stream);
+            let (w_ptr, _g3) = w_slice.device_ptr(&stream);
+            let (out_ptr, _g4) = out_slice.device_ptr(&stream);
+
+            let status = kiln_gdn_gated_rms_norm_bf16(
+                x_ptr as *const _,
+                z_ptr as *const _,
+                w_ptr as *const _,
+                out_ptr as *mut _,
+                rows as i32,
+                hidden as i32,
+                eps,
+                raw_stream,
+            );
+
+            if status != 0 {
+                candle_core::bail!("kiln_gdn_gated_rms_norm_bf16 failed with status {status}");
+            }
+        }
+    }
+
+    Ok(out)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/kiln-gdn-kernel/tests/gated_rms_norm_parity.rs
+++ b/crates/kiln-gdn-kernel/tests/gated_rms_norm_parity.rs
@@ -1,0 +1,106 @@
+//! Parity test for the fused GDN gated RMSNorm CUDA kernel.
+//!
+//! The kernel in `kiln_gdn_kernel::gdn_gated_rms_norm` replaces the
+//! candle chain `to_f32 -> rms_norm -> silu -> mul -> bf16` used by
+//! `kiln-model` in the `kiln/gdn/gated_norm` NVTX range.
+
+use candle_core::{DType, Device, Tensor};
+use kiln_gdn_kernel::{gdn_gated_rms_norm, gdn_gated_rms_norm_supports};
+
+fn lcg_seed(state: &mut u64) -> f32 {
+    *state = state
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
+    let bits = ((*state >> 33) as u32) & 0x7fff_ffff;
+    (bits as f32 / (i32::MAX as f32)) - 0.5
+}
+
+fn fill(seed: u64, n: usize, scale: f32) -> Vec<f32> {
+    let mut state = seed;
+    (0..n).map(|_| lcg_seed(&mut state) * scale).collect()
+}
+
+fn sigmoid(x: &Tensor) -> candle_core::Result<Tensor> {
+    let neg_x = x.neg()?;
+    let exp_neg_x = neg_x.exp()?;
+    let one_plus = (exp_neg_x + 1.0)?;
+    one_plus.recip()
+}
+
+fn silu(x: &Tensor) -> candle_core::Result<Tensor> {
+    Ok((x * sigmoid(x)?)?)
+}
+
+fn reference(x: &Tensor, z: &Tensor, weight: &Tensor, eps: f64) -> candle_core::Result<Tensor> {
+    let x_f32 = x.to_dtype(DType::F32)?;
+    let z_f32 = z.to_dtype(DType::F32)?;
+    let w_f32 = weight.to_dtype(DType::F32)?;
+    let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
+    let rms_inv = (variance + eps)?.sqrt()?.recip()?;
+    let normed = x_f32.broadcast_mul(&rms_inv)?.broadcast_mul(&w_f32)?;
+    Ok((normed * silu(&z_f32)?)?)
+}
+
+fn run_case(device: &Device, batch: usize, seq_len: usize, heads: usize, hidden: usize, seed: u64, label: &str) {
+    let elems = batch * seq_len * heads * hidden;
+    let x_data = fill(seed ^ 0xA11C_E5, elems, 2.0);
+    let z_data = fill(seed ^ 0x6A7E, elems, 4.0);
+    let w_data: Vec<f32> = fill(seed ^ 0xBEEF, hidden, 0.5)
+        .into_iter()
+        .map(|v| v + 1.0)
+        .collect();
+
+    let x = Tensor::from_vec(x_data, (batch, seq_len, heads, hidden), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let z = Tensor::from_vec(z_data, (batch, seq_len, heads, hidden), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+    let weight = Tensor::from_vec(w_data, (hidden,), &Device::Cpu)
+        .unwrap()
+        .to_dtype(DType::BF16)
+        .unwrap()
+        .to_device(device)
+        .unwrap();
+
+    assert!(
+        gdn_gated_rms_norm_supports(&x, &z, &weight),
+        "{label}: envelope check failed"
+    );
+
+    let fused = gdn_gated_rms_norm(&x, &z, &weight, 1e-6).expect("fused gated RMSNorm");
+    let fallback = reference(&x, &z, &weight, 1e-6).expect("fallback gated RMSNorm");
+
+    assert_eq!(fused.dims(), fallback.dims());
+    assert_eq!(fused.dtype(), DType::BF16);
+
+    let diff = (fused.to_dtype(DType::F32).unwrap()
+        - fallback.to_dtype(DType::BF16).unwrap().to_dtype(DType::F32).unwrap())
+    .unwrap();
+    let abs = diff.abs().unwrap();
+    let max = abs.flatten_all().unwrap().max(0).unwrap().to_scalar::<f32>().unwrap();
+    let mean = abs.flatten_all().unwrap().mean(0).unwrap().to_scalar::<f32>().unwrap();
+    println!("[{label}] shape=[{batch},{seq_len},{heads},{hidden}] max_abs={max:.3e} mean_abs={mean:.3e}");
+    assert!(max < 5e-3, "{label}: max_abs_diff {max} exceeds tolerance");
+    assert!(mean < 5e-4, "{label}: mean_abs_diff {mean} exceeds tolerance");
+}
+
+#[test]
+fn gdn_gated_rms_norm_parity_vs_candle_reference() {
+    let device = match Device::new_cuda(0) {
+        Ok(device) => device,
+        Err(err) => {
+            eprintln!("Skipping gdn_gated_rms_norm parity test: no CUDA device ({err})");
+            return;
+        }
+    };
+
+    run_case(&device, 1, 1, 32, 128, 0xCAFE_F00D, "decode");
+    run_case(&device, 1, 64, 32, 128, 0xDEAD_BEEF, "prefill/T=64");
+}

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -17,6 +17,9 @@ pub struct CudaBackend {
     /// Same pattern: cache the env-var read. The fused gates kernel is
     /// gated behind its own kill switch so it can be disabled independently.
     gdn_gates_enabled: bool,
+    /// Kill switch for the fused GDN gated RMSNorm kernel (decode/prefill
+    /// kiln/gdn/gated_norm region).
+    gdn_gated_rms_norm_enabled: bool,
     /// Kill switch for the fused causal_conv1d_update kernel (decode
     /// kiln/gdn/conv region). When off, forward.rs falls back to the
     /// candle to_f32/cat/sum/narrow chain.
@@ -29,11 +32,14 @@ impl CudaBackend {
         let gdn_enabled = std::env::var("KILN_DISABLE_GDN_KERNEL").is_err();
         let gdn_gates_enabled =
             gdn_enabled && std::env::var("KILN_DISABLE_FUSED_GDN_GATES").is_err();
+        let gdn_gated_rms_norm_enabled = gdn_enabled
+            && std::env::var("KILN_DISABLE_FUSED_GDN_GATED_RMS_NORM").is_err();
         let fused_conv1d_enabled = std::env::var("KILN_DISABLE_FUSED_CONV1D").is_err();
         Self {
             device,
             gdn_enabled,
             gdn_gates_enabled,
+            gdn_gated_rms_norm_enabled,
             fused_conv1d_enabled,
         }
     }
@@ -243,6 +249,28 @@ impl BackendRuntime for CudaBackend {
         let (beta, g) = kiln_gdn_kernel::gdn_gates(a, b, a_log, dt_bias)
             .context("gdn_gates kernel failed")?;
         Ok(Some((beta, g)))
+    }
+
+    fn supports_gdn_gated_rms_norm(&self) -> bool {
+        self.gdn_gated_rms_norm_enabled
+    }
+
+    fn gdn_gated_rms_norm(
+        &self,
+        x: &Tensor,
+        z: &Tensor,
+        weight: &Tensor,
+        eps: f64,
+    ) -> Result<Option<Tensor>> {
+        if !self.gdn_gated_rms_norm_enabled {
+            return Ok(None);
+        }
+        if !kiln_gdn_kernel::gdn_gated_rms_norm_supports(x, z, weight) {
+            return Ok(None);
+        }
+        let out = kiln_gdn_kernel::gdn_gated_rms_norm(x, z, weight, eps as f32)
+            .context("gdn_gated_rms_norm kernel failed")?;
+        Ok(Some(out))
     }
 
     fn supports_causal_conv1d_update(&self) -> bool {

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -6753,6 +6753,68 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn test_cuda_gdn_gated_rms_norm_matches_fallback() -> Result<()> {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let device = match Device::new_cuda(0) {
+            Ok(device) => device,
+            Err(err) => {
+                eprintln!("CUDA unavailable, skipping test_cuda_gdn_gated_rms_norm_matches_fallback: {err}");
+                return Ok(());
+            }
+        };
+        let backend = crate::backend::for_device(&device);
+        if !backend.supports_gdn_gated_rms_norm() {
+            eprintln!("CUDA gated RMSNorm disabled, skipping parity test");
+            return Ok(());
+        }
+
+        let batch = 1usize;
+        let seq_len = 3usize;
+        let heads = 32usize;
+        let hidden = 128usize;
+        let elems = batch * seq_len * heads * hidden;
+
+        let mut rng = StdRng::seed_from_u64(0xC0DA_6A7E);
+        let x_data: Vec<f32> = (0..elems).map(|_| rng.gen_range(-1.0f32..1.0f32)).collect();
+        let z_data: Vec<f32> = (0..elems).map(|_| rng.gen_range(-2.0f32..2.0f32)).collect();
+        let w_data: Vec<f32> = (0..hidden).map(|_| rng.gen_range(0.5f32..1.5f32)).collect();
+
+        let x = Tensor::from_slice(&x_data, (batch, seq_len, heads, hidden), &device)?
+            .to_dtype(DType::BF16)?;
+        let z = Tensor::from_slice(&z_data, (batch, seq_len, heads, hidden), &device)?
+            .to_dtype(DType::BF16)?;
+        let weight = Tensor::from_slice(&w_data, (hidden,), &device)?.to_dtype(DType::BF16)?;
+
+        let fallback = gated_rms_norm_fallback(&x, &z, &weight, 1e-6)?;
+        let fused = backend
+            .gdn_gated_rms_norm(&x, &z, &weight, 1e-6)?
+            .context("CUDA backend declined gated RMSNorm test shape")?;
+
+        assert_eq!(fused.dims(), fallback.dims());
+        assert_eq!(fused.dtype(), DType::BF16);
+
+        let diff = (fused.to_dtype(DType::F32)?
+            - fallback.to_dtype(DType::BF16)?.to_dtype(DType::F32)?)?;
+        let abs = diff.abs()?;
+        let max = abs.flatten_all()?.max(0)?.to_scalar::<f32>()?;
+        let mean = abs.flatten_all()?.mean(0)?.to_scalar::<f32>()?;
+        eprintln!("gated_rms_norm cuda vs fallback: max_abs_diff={max:e} mean_abs_diff={mean:e}");
+        assert!(
+            max < 5e-3,
+            "CUDA gated_rms_norm max_abs_diff={max:e} exceeds 5e-3"
+        );
+        assert!(
+            mean < 5e-4,
+            "CUDA gated_rms_norm mean_abs_diff={mean:e} exceeds 5e-4"
+        );
+
+        Ok(())
+    }
+
     #[cfg(feature = "metal")]
     #[test]
     fn test_metal_gated_rms_norm_matches_fallback() -> Result<()> {


### PR DESCRIPTION
## Summary

- Adds a minimal bf16 CUDA C ABI kernel for Qwen3.5 GDN gated RMSNorm: `rms_norm(x, weight, eps) * silu(z)` over contiguous `hidden=128` rows.
- Wires CUDA `BackendRuntime::gdn_gated_rms_norm` through `kiln-gdn-kernel`, default-on with `KILN_DISABLE_FUSED_GDN_GATED_RMS_NORM=1` fallback.
- Adds crate-level CUDA parity coverage plus a `kiln-model` backend parity test against the existing Candle fallback.
- Appends the measured A6000 result note to `PROFILING.md`.

## Benchmark

RunPod A6000, `KILN_CUDA_ARCHS=86`, C40f-style MTP decode command shape:

```bash
KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 \
  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
  --seed <seed> --chat-template --latency-only --prompt-subset humaneval \
  --temperature 0.0
```

Three alternating seeds (`1`, `2`, `3`):

| Path | Median decode tok/s | Median mean ITL |
| --- | ---: | ---: |
| Candle fallback (`KILN_DISABLE_FUSED_GDN_GATED_RMS_NORM=1`) | 37.54 tok/s | 26.64 ms |
| Fused CUDA default | 38.58 tok/s | 25.92 ms |

Overall decode median improved ~2.8%, below the requested local speedup floor. This is safe to ship because parity passed and the kill switch keeps the fallback available, but the next optimization task should target a different hotspot / DRAM-traffic-reducing kernel extension rather than retrying standalone gated-norm fusion.

## Validation

```bash
cargo test -p kiln-gdn-kernel --release -- --nocapture
cargo test -p kiln-model --release --features cuda test_cuda_gdn_gated_rms_norm_matches_fallback -- --nocapture
cargo build --release --features cuda,nvtx --bin kiln-bench
```

Validation log highlights:

- `gdn_gated_rms_norm_parity_vs_candle_reference ... ok`
- `test_cuda_gdn_gated_rms_norm_matches_fallback ... ok`
- backend parity: `max_abs_diff=0`, `mean_abs_diff=0`

Note: `cargo fmt --check` was attempted on the RunPod image, but the stable toolchain there does not include `cargo-fmt` (`rustup component add rustfmt` would be required).