### PR TITLE
release: kiln-v0.2.0 + desktop-v0.2.0 aligned cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Kiln Server Changelog
+
+## kiln-v0.2.0 — 2026-04-24
+
+Coordinated release aligned with desktop-v0.2.0. Headline work is the Metal
+decode path for Apple Silicon: a new fused GDN kernel family, MTP speculative
+decoding improvements, and a batch of macOS startup and prefill reductions.
+
+### Metal GDN kernel fusion
+- Fuse Metal GDN decode input projections
+- Fuse Metal GDN chunk prep
+- Fuse Metal RoPE for prefill (#418)
+- Fuse Metal GQA qk norm expansion (#393)
+- Default Metal MLP gate-up fusion (#447)
+- Add Metal full-chunk GDN prefill (#394), head-last layout (#395)
+- Speed up Metal GDN recurrent prefill (#398) and avoid zeroing recurrent outputs (#419)
+- Use direct GDN chunk slices on Metal (#391); read full chunks from strided views (#455)
+- Use unexpanded GDN QK for Metal decode (#456)
+- Use head-major KV read for Metal decode (#452) and head-major SDPA for paged decode (#342)
+- Use uninitialized Metal outputs for full-write kernels (#449)
+- Parallelize Metal conv1d prefill
+
+### MTP (multi-token prediction) decode
+- Route MTP prefill through Metal streaming (#400)
+- Speed up macOS default MTP decode
+- Mirror desktop speculative routing in bench (#404)
+- Align skip-layer bench draft state (#410)
+- Defer MTP upload and trim draft state (#408)
+- Avoid native MTP during Metal prewarm (#402)
+- Guard non-streaming MTP final window (#454)
+- Raise Metal skip-layer crossover to 4096 (#442)
+- Route long macOS decode through paged skip-layer
+
+### macOS startup and prefill
+- Reduce macOS startup and KV prefill overhead
+- Speed up macOS startup and skip-layer prefill
+- Improve macOS startup and short-prompt routing (#440) and speculative routing (#437)
+- Defer Metal precompile until background prewarm (#453); precompile Metal kernels during startup
+- Move tokenizer warmup after listen (#460)
+- Prewarm macOS speculative path (#386) and make prewarm opportunistic
+- Tune macOS Metal hot paths (#385) and streaming prefill defaults (#377)
+- Enable tiled prefill by default on Metal (#367)
+- Route Metal prefix attention through head-major SDPA (#366)
+- Optimize Metal paged KV prefill reads (#416)
+- Speed up Metal LM head decode
+- Gate Metal readiness prewarm (#332)
+- Harden Metal prewarm and KV auto-sizing
+- Drop redundant Metal embedding upload (#335)
+- Batch Metal auxiliary weight uploads (#443); stream transposed weight cache reads (#445); mmap transposed weight cache hits (#461)
+
+### Server runtime
+- Keep default GPU sampling on device (#336); speed up default sampling and fix speculative KV advance (#328)
+- Avoid zero-filling server KV pools (#337)
+- Hoist paged decode debug gates (#333)
+
+### Profiling and phase 6 kernel work
+- Extensive phase 6 decode profiling work (C35–C50) and MTP α-stability re-benches documented in PROFILING.md and PROFILING-MTP-*.md
+
+## kiln-v0.1.2 — 2026-04-20
+- See the GitHub release for details.
+
+## kiln-v0.1.1 — 2026-04-20
+- See the GitHub release for details.
+
+## kiln-v0.1.0 — 2026-04-18
+- Initial public release.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "candle-core",
  "cc",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "candle-core",
  "cc",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "candle-core",
  "cc",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1801,11 +1801,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.1.2"
+version = "0.2.0"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "candle-core",
  "cc",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.1.2"
+version = "0.2.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Kiln Desktop Changelog
 
+## desktop-v0.2.0 — 2026-04-24
+- Coordinated release aligned with kiln-v0.2.0 server
+- Picks up macOS startup and KV prefill overhead reductions
+- Gate desktop readiness on inference prewarm so the tray "server ready" state reflects actual readiness
+- Speed up macOS default MTP decode
+
 ## desktop-v0.1.11 — 2026-04-21
 - Notify when the Dashboard Copy URL button fails (#315)
 - Notify when the About window Copy Diagnostics fails (#312)

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-desktop"
-version = "0.1.11"
+version = "0.2.0"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kiln-desktop"
-version = "0.1.11"
+version = "0.2.0"
 edition = "2021"
 description = "Kiln Desktop — system tray app for the kiln local LLM server"
 authors = ["Eric Florenzano <eric@eflorenzano.com>"]

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kiln Desktop",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "identifier": "com.eflorenzano.kiln.desktop",
   "build": {
     "frontendDist": "ui",


### PR DESCRIPTION
## Summary

Aligned release point: cut `kiln-v0.2.0` (server) and `desktop-v0.2.0` (desktop) from the same commit.

This PR bumps the three version files in lockstep to guard against the stale-asset-stamp bug (e.g. modelrelay v0.1.6→v0.1.7 where one file was missed and assets shipped with the wrong version):

- `Cargo.toml` — workspace package `0.1.2` → `0.2.0`
- `desktop/Cargo.toml` — kiln-desktop package `0.1.11` → `0.2.0`
- `desktop/tauri.conf.json` — tauri version `0.1.11` → `0.2.0`

Both lockfiles regenerated (`Cargo.lock` and `desktop/Cargo.lock`).

## CHANGELOG

- New top-level `CHANGELOG.md` documenting kiln-v0.2.0 server-side work (Metal GDN fusion, MTP decode, macOS startup and prefill reductions, phase 6 kernel work) grouped thematically from 200+ commits since kiln-v0.1.2.
- New `desktop-v0.2.0` entry in `desktop/CHANGELOG.md` covering the macOS startup, readiness gating, and MTP decode changes since desktop-v0.1.11.

## Release plan

After this PR lands, the following tags will be pushed sequentially:

1. `kiln-v0.2.0` — triggers `server-release.yml` (macOS Metal signed/notarized + Linux/Windows CUDA 12.4 tarballs). Draft release will need `gh release edit --draft=false`.
2. `desktop-v0.2.0` — triggers `desktop-build.yml` (ubuntu/macos/windows matrix via tauri-action). Draft release will need `gh release edit --draft=false`; watch for tauri-action matrix race creating duplicate drafts and consolidate if it happens.

Both tags are pushed separately (not simultaneously) so the release list ordering stays clear.