### PR TITLE
Document post-466 MTP decode profile

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -7190,3 +7190,40 @@ C40f-style MTP decode A/B (`--prompt-subset humaneval --prompt-tokens 512 --max-
 | Fused CUDA default | 1,2,3 | 38.58 tok/s | 25.92 ms |
 
 Overall decode median improved ~2.8%, which is safely below the requested `kiln/gdn/gated_norm` 25% local floor and consistent with prior CUDA-graphs fusion-null notes. The fused kernel remains safe to ship because parity passed and the kill switch preserves fallback behavior, but the next optimization task should target a different hotspot or a memory-traffic-reducing extension of an existing on-chip GDN kernel rather than retrying standalone gated-norm fusion.
+
+## Phase 6 — post-#466 C40f-style native MTP decode profile
+
+C51 re-ran the C40f-style native-MTP decode workload on current `origin/main`
+after PR #466 landed the fused CUDA GDN gated RMSNorm kernel. RunPod used the
+mandatory `ghcr.io/ericflo/kiln-runpod:latest` image on an on-demand NVIDIA RTX
+A6000 at commit `831d879d2ddb2500fd49f76c9b5df89aedd923b1`.
+
+Artifact: `docs/phase-c51/post-466-mtp-decode-profile.md`; machine summary:
+`docs/phase-c51/summary.json`.
+
+Benchmark command shape: `KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1
+KILN_MTP_ARGMAX_FP32=1`, paged, 512 prompt tokens, 128 output tokens,
+`--prompt-subset humaneval`, chat template, temperature `0.0`, seeds `1,2,3`.
+Median decode was `37.07 tok/s`, median mean ITL was `26.97 ms`, and median α
+was `0.588`. The per-seed decode tok/s values were `41.41`, `37.07`, and
+`32.06`.
+
+Profiler status: `nsys profile` exited `0` and generated a `94M` `.qdstrm`, but
+the baked Nsight Systems `2023.4.4` importer failed with the known QuadD
+wrong-event-order error before producing `/tmp/kiln-post466-mtp.nsys-rep`. The
+committed `docs/phase-c51/nsys-profile.log`, `nsys-nvtxsum.txt`,
+`nsys-gpu-kernsum.txt`, and `nsys-cuda-api.txt` preserve the failed capture and
+missing-stats evidence; the multi-MB raw `.qdstrm` is intentionally not
+committed.
+
+Top decode hotspots: unavailable for post-#466. Do not invent wall-clock
+percentages or treat the C50 post-#442 carry-forward table as fresh after PR
+#466. For context only, the freshest successful attribution before #466 had
+`:kiln/gdn/gates` `17.9%`, `:kiln/gdn/gated_norm` `17.3%`, and
+`:kiln/gdn/qk_norm` `15.0%`; those numbers are now stale.
+
+Recommended next implementation target: conditional GDN gate/gated-norm cluster
+work only if a successful post-#466 profiler capture confirms it remains the top
+decode cluster. Otherwise, first repair or bypass the Nsight importer failure
+with a compatible newer `nsys`, smaller decode-window capture, or alternate
+profiler path that yields current NVTX/kernel attribution.

--- a/docs/phase-c51/bench-seed-1.log
+++ b/docs/phase-c51/bench-seed-1.log
@@ -1,0 +1,67 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+2026-04-24T03:19:25.129490Z  INFO kiln_model::loader: Loading model from /workspace/qwen3.5-4b (2 shards)
+2026-04-24T03:19:25.130580Z  INFO kiln_model::loader: Using weight name prefix: "model.language_model."
+2026-04-24T03:19:25.130727Z  INFO kiln_model::loader: Native MTP head detected; deferring CPU load until first use mtp_prefix=mtp.
+2026-04-24T03:19:25.130736Z  INFO kiln_model::loader: Loaded 4206M parameters (8022 MB) across 32 layers
+2026-04-24T03:19:25.130829Z  INFO kiln_server::device: CUDA available — using GPU device 0
+Model loaded in 3.98s (backend: cuda, VRAM: 16342 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=49] (515 prompt tokens)...
+    Prefill (MTP): 10162.1ms (51 tok/s)
+2026-04-24T03:19:39.823339Z  INFO kiln_model::forward: deferred native MTP CPU load complete load_elapsed_ms=2
+2026-04-24T03:19:39.864634Z  INFO kiln_model::forward: lazy native MTP GPU upload complete upload_elapsed_ms=41
+    Decode (MTP): 128 tokens, mean ITL 24.1ms (41.4 tok/s), α = 0.707 (53/75)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 3.98s (VRAM: 16342 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         515
+Prefill time:          10162.1 ms (51 tok/s)
+Time to first token:   10162.1 ms
+Mean inter-token:      24.1 ms (41.4 tok/s)
+P50 inter-token:       17.4 ms
+P99 inter-token:       55.9 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.707
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 3.978726517,
+    "model_vram_mb": 16342
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 10162.14346,
+    "prefill_tokens_per_sec": 50.67828475627523,
+    "time_to_first_token_ms": 10162.14346,
+    "mean_inter_token_ms": 24.14945162204724,
+    "p50_inter_token_ms": 17.4445295,
+    "p99_inter_token_ms": 55.942876000000005,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 41.408807771313946,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7066666666666667,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c51/bench-seed-2.log
+++ b/docs/phase-c51/bench-seed-2.log
@@ -1,0 +1,67 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+2026-04-24T03:19:43.451192Z  INFO kiln_model::loader: Loading model from /workspace/qwen3.5-4b (2 shards)
+2026-04-24T03:19:43.452811Z  INFO kiln_model::loader: Using weight name prefix: "model.language_model."
+2026-04-24T03:19:43.453028Z  INFO kiln_model::loader: Native MTP head detected; deferring CPU load until first use mtp_prefix=mtp.
+2026-04-24T03:19:43.453041Z  INFO kiln_model::loader: Loaded 4206M parameters (8022 MB) across 32 layers
+2026-04-24T03:19:43.453139Z  INFO kiln_server::device: CUDA available — using GPU device 0
+Model loaded in 2.71s (backend: cuda, VRAM: 16342 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=48] (510 prompt tokens)...
+    Prefill (MTP): 370.0ms (1378 tok/s)
+2026-04-24T03:19:47.074443Z  INFO kiln_model::forward: deferred native MTP CPU load complete load_elapsed_ms=2
+2026-04-24T03:19:47.113834Z  INFO kiln_model::forward: lazy native MTP GPU upload complete upload_elapsed_ms=39
+    Decode (MTP): 128 tokens, mean ITL 27.0ms (37.1 tok/s), α = 0.588 (47/80)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 2.71s (VRAM: 16342 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         510
+Prefill time:          370.0 ms (1378 tok/s)
+Time to first token:   370.0 ms
+Mean inter-token:      27.0 ms (37.1 tok/s)
+P50 inter-token:       18.1 ms
+P99 inter-token:       59.3 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.588
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 2.711826329,
+    "model_vram_mb": 16342
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 510,
+    "prefill_time_ms": 369.988001,
+    "prefill_tokens_per_sec": 1378.4230802663246,
+    "time_to_first_token_ms": 369.988001,
+    "mean_inter_token_ms": 26.972797984251965,
+    "p50_inter_token_ms": 18.1282855,
+    "p99_inter_token_ms": 59.261309999999995,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 37.074388818833285,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.5875,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c51/bench-seed-3.log
+++ b/docs/phase-c51/bench-seed-3.log
@@ -1,0 +1,67 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+2026-04-24T03:19:51.075323Z  INFO kiln_model::loader: Loading model from /workspace/qwen3.5-4b (2 shards)
+2026-04-24T03:19:51.077553Z  INFO kiln_model::loader: Using weight name prefix: "model.language_model."
+2026-04-24T03:19:51.077865Z  INFO kiln_model::loader: Native MTP head detected; deferring CPU load until first use mtp_prefix=mtp.
+2026-04-24T03:19:51.077881Z  INFO kiln_model::loader: Loaded 4206M parameters (8022 MB) across 32 layers
+2026-04-24T03:19:51.078063Z  INFO kiln_server::device: CUDA available — using GPU device 0
+Model loaded in 2.33s (backend: cuda, VRAM: 16342 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=47] (494 prompt tokens)...
+    Prefill (MTP): 375.7ms (1315 tok/s)
+2026-04-24T03:19:54.356179Z  INFO kiln_model::forward: deferred native MTP CPU load complete load_elapsed_ms=2
+2026-04-24T03:19:54.409952Z  INFO kiln_model::forward: lazy native MTP GPU upload complete upload_elapsed_ms=53
+    Decode (MTP): 128 tokens, mean ITL 31.2ms (32.1 tok/s), α = 0.568 (46/81)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 2.33s (VRAM: 16342 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         494
+Prefill time:          375.7 ms (1315 tok/s)
+Time to first token:   375.7 ms
+Mean inter-token:      31.2 ms (32.1 tok/s)
+P50 inter-token:       20.0 ms
+P99 inter-token:       67.7 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.568
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 2.334617255,
+    "model_vram_mb": 16342
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 494,
+    "prefill_time_ms": 375.734893,
+    "prefill_tokens_per_sec": 1314.75678517832,
+    "time_to_first_token_ms": 375.734893,
+    "mean_inter_token_ms": 31.195535897637818,
+    "p50_inter_token_ms": 20.0031335,
+    "p99_inter_token_ms": 67.651762,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 32.0558686114997,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.5679012345679012,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}

--- a/docs/phase-c51/environment.txt
+++ b/docs/phase-c51/environment.txt
@@ -1,0 +1,9 @@
+date_utc=2026-04-24T03:19:24Z
+commit=831d879d2ddb2500fd49f76c9b5df89aedd923b1
+branch=ce/post466-mtp-profile
+gpu=NVIDIA RTX A6000
+driver=550.127.08
+cuda=Build cuda_12.4.r12.4/compiler.34097967_0
+rustc=rustc 1.95.0 (59807616e 2026-04-14)
+nsys=NVIDIA Nsight Systems version 2023.4.4.54-234433681190v0
+env=KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 KILN_CUDA_ARCHS=86

--- a/docs/phase-c51/nsys-cuda-api.txt
+++ b/docs/phase-c51/nsys-cuda-api.txt
@@ -1,0 +1,4 @@
+ERROR: Specified input file (/tmp/kiln-post466-mtp.nsys-rep) does not exist.
+
+usage: nsys stats [<args>] <input-file>
+Try 'nsys stats --help' for more information.

--- a/docs/phase-c51/nsys-gpu-kernsum.txt
+++ b/docs/phase-c51/nsys-gpu-kernsum.txt
@@ -1,0 +1,4 @@
+ERROR: Specified input file (/tmp/kiln-post466-mtp.nsys-rep) does not exist.
+
+usage: nsys stats [<args>] <input-file>
+Try 'nsys stats --help' for more information.

--- a/docs/phase-c51/nsys-nvtxsum.txt
+++ b/docs/phase-c51/nsys-nvtxsum.txt
@@ -1,0 +1,4 @@
+ERROR: Specified input file (/tmp/kiln-post466-mtp.nsys-rep) does not exist.
+
+usage: nsys stats [<args>] <input-file>
+Try 'nsys stats --help' for more information.

--- a/docs/phase-c51/nsys-profile.log
+++ b/docs/phase-c51/nsys-profile.log
@@ -1,0 +1,130 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+2026-04-24T03:19:59.988522Z  INFO kiln_model::loader: Loading model from /workspace/qwen3.5-4b (2 shards)
+2026-04-24T03:19:59.989837Z  INFO kiln_model::loader: Using weight name prefix: "model.language_model."
+2026-04-24T03:19:59.990040Z  INFO kiln_model::loader: Native MTP head detected; deferring CPU load until first use mtp_prefix=mtp.
+2026-04-24T03:19:59.990054Z  INFO kiln_model::loader: Loaded 4206M parameters (8022 MB) across 32 layers
+2026-04-24T03:19:59.990216Z  INFO kiln_server::device: CUDA available — using GPU device 0
+Model loaded in 2.50s (backend: cuda, VRAM: 16367 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=49] (515 prompt tokens)...
+    Prefill (MTP): 440.1ms (1170 tok/s)
+2026-04-24T03:20:04.141247Z  INFO kiln_model::forward: deferred native MTP CPU load complete load_elapsed_ms=2
+2026-04-24T03:20:04.190898Z  INFO kiln_model::forward: lazy native MTP GPU upload complete upload_elapsed_ms=49
+    Decode (MTP): 128 tokens, mean ITL 45.7ms (21.9 tok/s), α = 0.707 (53/75)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 2.50s (VRAM: 16367 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         515
+Prefill time:          440.1 ms (1170 tok/s)
+Time to first token:   440.1 ms
+Mean inter-token:      45.7 ms (21.9 tok/s)
+P50 inter-token:       32.3 ms
+P99 inter-token:       118.0 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.707
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 2.5025469129999998,
+    "model_vram_mb": 16367
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 440.089777,
+    "prefill_tokens_per_sec": 1170.2157762233137,
+    "time_to_first_token_ms": 440.089777,
+    "mean_inter_token_ms": 45.745464389763775,
+    "p50_inter_token_ms": 32.282146,
+    "p99_inter_token_ms": 117.974034,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 21.86009068526944,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7066666666666667,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}
+Generating '/tmp/nsys-report-b42f.qdstrm'
+
+[1/1] [0%                          ] kiln-post466-mtp.nsys-rep
+[1/1] [0%                          ] kiln-post466-mtp.nsys-rep
+[1/1] [5%                          ] kiln-post466-mtp.nsys-rep
+[1/1] [6%                          ] kiln-post466-mtp.nsys-rep
+[1/1] [7%                          ] kiln-post466-mtp.nsys-rep
+[1/1] [8%                          ] kiln-post466-mtp.nsys-rep
+[1/1] [9%                          ] kiln-post466-mtp.nsys-rep
+[1/1] [10%                         ] kiln-post466-mtp.nsys-rep
+[1/1] [11%                         ] kiln-post466-mtp.nsys-rep
+[1/1] [12%                         ] kiln-post466-mtp.nsys-rep
+[1/1] [13%                         ] kiln-post466-mtp.nsys-rep
+[1/1] [14%                         ] kiln-post466-mtp.nsys-rep
+[1/1] [=15%                        ] kiln-post466-mtp.nsys-rep
+[1/1] [=16%                        ] kiln-post466-mtp.nsys-rep
+[1/1] [=17%                        ] kiln-post466-mtp.nsys-rep
+[1/1] [==18%                       ] kiln-post466-mtp.nsys-rep
+[1/1] [==19%                       ] kiln-post466-mtp.nsys-rep
+[1/1] [==20%                       ] kiln-post466-mtp.nsys-rep
+[1/1] [==21%                       ] kiln-post466-mtp.nsys-rep
+[1/1] [===22%                      ] kiln-post466-mtp.nsys-rep
+[1/1] [===23%                      ] kiln-post466-mtp.nsys-rep
+[1/1] [===24%                      ] kiln-post466-mtp.nsys-rep
+[1/1] [====25%                     ] kiln-post466-mtp.nsys-rep
+[1/1] [====26%                     ] kiln-post466-mtp.nsys-rep
+[1/1] [====27%                     ] kiln-post466-mtp.nsys-rep
+[1/1] [====28%                     ] kiln-post466-mtp.nsys-rep
+Importer error status: Importation failed.
+Import Failed with unexpected exception: /dvs/p4/build/sw/devtools/Agora/Rel/CUDA12.4/QuadD/Host/QdstrmImporter/main.cpp(34): Throw in function {anonymous}::Importer::Importer(const boost::filesystem::path&, const boost::filesystem::path&)
+Dynamic exception type: boost::wrapexcept<QuadDCommon::RuntimeException>
+std::exception::what: RuntimeException
+[QuadDCommon::tag_message*] = Status: AnalysisFailed
+Error {
+  Type: RuntimeError
+  SubError {
+    Type: InvalidArgument
+    Props {
+      Items {
+        Type: OriginalExceptionClass
+        Value: "N5boost10wrapexceptIN11QuadDCommon24InvalidArgumentExceptionEEE"
+      }
+      Items {
+        Type: OriginalFile
+        Value: "/dvs/p4/build/sw/devtools/Agora/Rel/CUDA12.4/QuadD/Host/Analysis/Modules/EventCollection.cpp"
+      }
+      Items {
+        Type: OriginalLine
+        Value: "1048"
+      }
+      Items {
+        Type: OriginalFunction
+        Value: "void QuadDAnalysis::EventCollection::CheckOrder(QuadDAnalysis::EventCollectionHelper::EventContainer&, const QuadDAnalysis::ConstEvent&) const"
+      }
+      Items {
+        Type: ErrorText
+        Value: "Wrong event order has been detected when adding events to the collection:\nnew event ={ StartNs=6310866305 StopNs=6310869305 GlobalId=281722457438623 Event={ TraceProcessEvent=[{ Correlation=2608736 EventClass=1 TextId=595 ReturnValue=0 },] } Type=48 }\nlast event ={ StartNs=6358907422 StopNs=6358907742 GlobalId=281722457438623 Event={ TraceProcessEvent=[{ Correlation=2679247 EventClass=1 TextId=596 ReturnValue=0 },] } Type=48 }"
+      }
+    }
+  }
+}
+Generated:
+    /tmp/kiln-post466-mtp.qdstrm

--- a/docs/phase-c51/nsys-raw-files.txt
+++ b/docs/phase-c51/nsys-raw-files.txt
@@ -1,0 +1,1 @@
+-rw-rw-r-- 1 root root 94M Apr 24 03:20 /tmp/kiln-post466-mtp.qdstrm

--- a/docs/phase-c51/post-466-mtp-decode-profile.md
+++ b/docs/phase-c51/post-466-mtp-decode-profile.md
@@ -1,0 +1,122 @@
+# Phase C51 Post-#466 C40f-Style Native MTP Decode Profile
+
+Date: 2026-04-24
+
+Commit: `831d879d2ddb2500fd49f76c9b5df89aedd923b1`
+
+GPU: RunPod on-demand NVIDIA RTX A6000, `ghcr.io/ericflo/kiln-runpod:latest`.
+
+## Purpose
+
+PR #466 landed the fused CUDA GDN gated RMSNorm kernel. This C51 artifact re-runs the C40f-style native-MTP decode workload on current `origin/main` so the next Phase 6 optimization decision does not rely on the stale post-#442/C50 decode hotspot table.
+
+## Environment
+
+Captured in `docs/phase-c51/environment.txt`:
+
+| Field | Value |
+| --- | --- |
+| GPU | NVIDIA RTX A6000 |
+| Driver | 550.127.08 |
+| CUDA | Build cuda_12.4.r12.4/compiler.34097967_0 |
+| Rust | rustc 1.95.0 (59807616e 2026-04-14) |
+| Nsight Systems | NVIDIA Nsight Systems version 2023.4.4.54-234433681190v0 |
+| Build arch | `KILN_CUDA_ARCHS=86` |
+
+## Setup Commands
+
+```bash
+export RUNPOD_API_KEY=$(ce secret-get --name RUNPOD_API_KEY)
+RP=/data/.clouderic-internal/repos/apps/trajectory-trainer/scripts/runpod_api.py
+python3 $RP launch --kiln-image --gpu "NVIDIA RTX A6000" \
+  --name kiln-post466-mtp-profile --disk-gb 80
+python3 $RP wait eyu0zh4ilfa2kh
+
+B2_KEY_ID=$(ce secret-get --name B2_APPLICATION_KEY_ID)
+B2_KEY=$(ce secret-get --name B2_APPLICATION_KEY)
+python3 $RP ssh eyu0zh4ilfa2kh \
+  "export B2_APPLICATION_KEY_ID='$B2_KEY_ID' B2_APPLICATION_KEY='$B2_KEY'; kiln-setup --clone"
+
+python3 $RP bg eyu0zh4ilfa2kh /tmp/build.log \
+  'source /root/.kiln-build-env && cd /workspace/kiln && git fetch origin main && git checkout -B ce/post466-mtp-profile origin/main && KILN_CUDA_ARCHS=86 cargo build --release --features cuda,nvtx --bin kiln-bench'
+python3 $RP wait-file eyu0zh4ilfa2kh /workspace/kiln/target/release/kiln-bench --timeout 3600
+```
+
+## Benchmark Command
+
+```bash
+env KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+  --seed <seed> --chat-template --latency-only --prompt-subset humaneval \
+  --temperature 0.0
+```
+
+## Raw Benchmark Table
+
+| Seed | Prompt tokens | α | Decode tok/s | Mean ITL ms | P50 ITL ms | P99 ITL ms | Prefill ms |
+| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 1 | 515 | 0.707 | 41.41 | 24.15 | 17.44 | 55.94 | 10162.14 |
+| 2 | 510 | 0.588 | 37.07 | 26.97 | 18.13 | 59.26 | 369.99 |
+| 3 | 494 | 0.568 | 32.06 | 31.20 | 20.00 | 67.65 | 375.73 |
+
+| Metric | Median | Mean |
+| --- | ---: | ---: |
+| Acceptance α | 0.588 | 0.621 |
+| Decode tok/s | 37.07 | 36.85 |
+| Mean ITL ms | 26.97 | 27.44 |
+| P50 ITL ms | 18.13 | 18.53 |
+| P99 ITL ms | 59.26 | 60.95 |
+| Prefill ms | 375.73 | 3635.96 |
+
+Seed 1 includes a cold prefill outlier from the first benchmark process after build/model setup; decode metrics are the artifact of interest for this task.
+
+## Profiler Command
+
+```bash
+env KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 \
+  nsys profile --force-overwrite=true --trace=cuda,nvtx,osrt \
+  --output /tmp/kiln-post466-mtp \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
+  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+  --seed 1 --chat-template --latency-only --prompt-subset humaneval \
+  --temperature 0.0
+
+nsys stats --report nvtxsum /tmp/kiln-post466-mtp.nsys-rep | tee docs/phase-c51/nsys-nvtxsum.txt || true
+nsys stats --report gpukernsum /tmp/kiln-post466-mtp.nsys-rep | tee docs/phase-c51/nsys-gpu-kernsum.txt || true
+nsys stats --report cudaapisum /tmp/kiln-post466-mtp.nsys-rep | tee docs/phase-c51/nsys-cuda-api.txt || true
+```
+
+## Profiler Summary
+
+The `nsys profile` process exited `0` and generated `/tmp/kiln-post466-mtp.qdstrm`, but the Nsight Systems 2023.4.4 importer failed before producing `/tmp/kiln-post466-mtp.nsys-rep`. The committed stats files therefore contain the expected missing-input error rather than decode attribution.
+
+Failure excerpt from `docs/phase-c51/nsys-profile.log`:
+
+```text
+Importer error status: Importation failed.
+Import Failed with unexpected exception: ... QuadDCommon::RuntimeException
+ErrorText = "Wrong event order has been detected when adding events to the collection"
+Generated:
+    /tmp/kiln-post466-mtp.qdstrm
+```
+
+Raw profiler breadcrumb from `docs/phase-c51/nsys-raw-files.txt`:
+
+```text
+-rw-rw-r-- 1 root root 94M Apr 24 03:20 /tmp/kiln-post466-mtp.qdstrm
+```
+
+The `.qdstrm` file is intentionally not committed because it is a multi-MB raw profiler artifact and the importer failure makes it unusable by `nsys stats` in this environment.
+
+## Top Decode Hotspots
+
+No fresh post-#466 wall-clock percentages are available from this run. The top-three decode range fields in `docs/phase-c51/summary.json` are intentionally `null` rather than carrying stale percentages forward as if they were current.
+
+For context only, C50 carried forward the latest successful current-main decode NVTX attribution from the post-#442 profile: `:kiln/gdn/gates` `17.9%`, `:kiln/gdn/gated_norm` `17.3%`, and `:kiln/gdn/qk_norm` `15.0%`. Those percentages predate the PR #466 fused gated RMSNorm change and should be treated as stale until a profiler capture imports successfully.
+
+## Recommendation
+
+Do not start a new kernel implementation from invented post-#466 percentages. The single next implementation target is conditional: continue with the GDN gate/gated-norm cluster only if a successful post-#466 profiler capture confirms it remains dominant. Otherwise, first repair or bypass the Nsight importer failure by using a compatible newer `nsys`, a smaller decode-window capture, or another profiler path that can produce current NVTX/kernel attribution.
+
+This artifact replaces C50 as the benchmark anchor for post-#466 C40f-style native MTP decode medians, but it does not replace C50 with fresh hotspot percentages because the importer failed again.

--- a/docs/phase-c51/status.txt
+++ b/docs/phase-c51/status.txt
@@ -1,0 +1,4 @@
+bench_seed_1_status=0
+bench_seed_2_status=0
+bench_seed_3_status=0
+nsys_profile_status=0

--- a/docs/phase-c51/summary.json
+++ b/docs/phase-c51/summary.json
@@ -1,0 +1,131 @@
+{
+  "phase": "c51",
+  "title": "post-#466 C40f-style native MTP decode profile",
+  "date_utc": "2026-04-24T03:19:24Z",
+  "commit": "831d879d2ddb2500fd49f76c9b5df89aedd923b1",
+  "gpu": "NVIDIA RTX A6000",
+  "driver": "550.127.08",
+  "cuda": "Build cuda_12.4.r12.4/compiler.34097967_0",
+  "rustc": "rustc 1.95.0 (59807616e 2026-04-14)",
+  "nsys_version": "NVIDIA Nsight Systems version 2023.4.4.54-234433681190v0",
+  "seeds": [
+    1,
+    2,
+    3
+  ],
+  "command": "env KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --seed <seed> --chat-template --latency-only --prompt-subset humaneval --temperature 0.0",
+  "rows": [
+    {
+      "seed": 1,
+      "prompt_tokens": 515,
+      "acceptance_rate": 0.7066666666666667,
+      "decode_tokens_per_sec": 41.408807771313946,
+      "mean_inter_token_ms": 24.14945162204724,
+      "p50_inter_token_ms": 17.4445295,
+      "p99_inter_token_ms": 55.942876000000005,
+      "prefill_time_ms": 10162.14346,
+      "num_tokens_generated": 128,
+      "spec_method": "mtp",
+      "prompt_subset": "humaneval"
+    },
+    {
+      "seed": 2,
+      "prompt_tokens": 510,
+      "acceptance_rate": 0.5875,
+      "decode_tokens_per_sec": 37.074388818833285,
+      "mean_inter_token_ms": 26.972797984251965,
+      "p50_inter_token_ms": 18.1282855,
+      "p99_inter_token_ms": 59.261309999999995,
+      "prefill_time_ms": 369.988001,
+      "num_tokens_generated": 128,
+      "spec_method": "mtp",
+      "prompt_subset": "humaneval"
+    },
+    {
+      "seed": 3,
+      "prompt_tokens": 494,
+      "acceptance_rate": 0.5679012345679012,
+      "decode_tokens_per_sec": 32.0558686114997,
+      "mean_inter_token_ms": 31.195535897637818,
+      "p50_inter_token_ms": 20.0031335,
+      "p99_inter_token_ms": 67.651762,
+      "prefill_time_ms": 375.734893,
+      "num_tokens_generated": 128,
+      "spec_method": "mtp",
+      "prompt_subset": "humaneval"
+    }
+  ],
+  "summary": {
+    "n": 3,
+    "median_acceptance_rate": 0.5875,
+    "mean_acceptance_rate": 0.6206893004115226,
+    "median_decode_tokens_per_sec": 37.074388818833285,
+    "mean_decode_tokens_per_sec": 36.84635506721564,
+    "median_mean_inter_token_ms": 26.972797984251965,
+    "mean_mean_inter_token_ms": 27.439261834645674,
+    "median_prefill_time_ms": 375.734893,
+    "mean_prefill_time_ms": 3635.9554513333333,
+    "median_p50_inter_token_ms": 18.1282855,
+    "median_p99_inter_token_ms": 59.261309999999995
+  },
+  "profiler": {
+    "tool": "nsys",
+    "status": "import_failed",
+    "profile_exit_status": 0,
+    "stats_exit_status": "not_available_no_nsys_rep",
+    "failure": "Nsight Systems 2023.4.4 generated /tmp/kiln-post466-mtp.qdstrm but failed import with QuadD EventCollection wrong-event-order before producing /tmp/kiln-post466-mtp.nsys-rep.",
+    "raw_report_committed": false,
+    "committed_logs": [
+      "docs/phase-c51/nsys-profile.log",
+      "docs/phase-c51/nsys-nvtxsum.txt",
+      "docs/phase-c51/nsys-gpu-kernsum.txt",
+      "docs/phase-c51/nsys-cuda-api.txt",
+      "docs/phase-c51/nsys-raw-files.txt"
+    ]
+  },
+  "top_decode_ranges": [
+    {
+      "rank": 1,
+      "range": null,
+      "wall_clock_share_pct": null,
+      "source": "unavailable: post-#466 nsys import failed"
+    },
+    {
+      "rank": 2,
+      "range": null,
+      "wall_clock_share_pct": null,
+      "source": "unavailable: post-#466 nsys import failed"
+    },
+    {
+      "rank": 3,
+      "range": null,
+      "wall_clock_share_pct": null,
+      "source": "unavailable: post-#466 nsys import failed"
+    }
+  ],
+  "freshest_successful_attribution": {
+    "source": "docs/phase-c50/summary.json carried forward post-#442 current-main decode NVTX attribution; stale after PR #466 and not used as fresh percentages.",
+    "ranges": [
+      {
+        "rank": 1,
+        "range": ":kiln/gdn/gates",
+        "wall_clock_share_pct": 17.9
+      },
+      {
+        "rank": 2,
+        "range": ":kiln/gdn/gated_norm",
+        "wall_clock_share_pct": 17.3
+      },
+      {
+        "rank": 3,
+        "range": ":kiln/gdn/qk_norm",
+        "wall_clock_share_pct": 15.0
+      }
+    ]
+  },
+  "recommended_next_target": {
+    "target": "GDN gate/gated-norm cluster only if a successful post-#466 profiler capture confirms it remains dominant; otherwise repair/circumvent nsys import before implementing another kernel.",
+    "conditional": true,
+    "rationale": "PR #466 fused the standalone gated RMSNorm path and moved the hotspot table stale. The post-#466 benchmark median is available, but no fresh wall-clock attribution survived import, so percentages must not be invented."
+  }
+}


### PR DESCRIPTION
## Summary

- Appends the Phase 6 post-#466 C40f-style native MTP decode profile section to `PROFILING.md`.
- Adds detailed C51 profiling artifacts under `docs/phase-c51/`, including benchmark logs, environment/status breadcrumbs, failed Nsight import logs, and `summary.json`.
- Records that post-#466 benchmark medians are available but fresh decode hotspot percentages are unavailable because Nsight Systems import failed again.

## Benchmark medians

RunPod on-demand NVIDIA RTX A6000, current `origin/main` at `831d879d2ddb2500fd49f76c9b5df89aedd923b1`.

Command shape:

```bash
KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 \
  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b \
  --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training \
  --seed <seed> --chat-template --latency-only --prompt-subset humaneval \
  --temperature 0.0
```

Seeds `1,2,3`:

| Metric | Median |
| --- | ---: |
| Decode tok/s | 37.07 |
| Mean ITL | 26.97 ms |
| Acceptance α | 0.588 |
| Prefill | 375.73 ms |

## Profiler status

`nsys profile` exited `0` and generated a 94 MiB `.qdstrm`, but baked Nsight Systems `2023.4.4` failed import with the known QuadD wrong-event-order error before producing `/tmp/kiln-post466-mtp.nsys-rep`. The PR commits the failed logs and missing-stats outputs, but not the raw multi-MB `.qdstrm`.

## Top decode ranges

Fresh post-#466 decode range percentages are unavailable. `summary.json` intentionally stores the top-three post-#466 ranges as `null` instead of inventing percentages or presenting C50's post-#442 carry-forward table as current.

Context only: the freshest successful pre-#466 attribution had `:kiln/gdn/gates` 17.9%, `:kiln/gdn/gated_norm` 17.3%, and `:kiln/gdn/qk_norm` 15.0%; those values are stale after #466.

## Recommended next target

Conditional GDN gate/gated-norm cluster work only if a successful post-#466 profiler capture confirms it remains dominant. Otherwise, first repair or bypass the Nsight importer failure with a compatible newer `nsys`, smaller decode-window capture, or alternate profiler path that yields current attribution.

## Validation

- Built `kiln-bench` on RunPod with `KILN_CUDA_ARCHS=86 cargo build --release --features cuda,nvtx --bin kiln-bench`.
- Ran the required C40f-style native MTP benchmark for seeds `1`, `2`, and `3`.
- Ran the required `nsys profile` command and `nsys stats` attempts; stats failed because no `.nsys-rep` was produced.
- Validated `docs/phase-c51/summary.json` with `python3 -m json.tool`.
- Terminated RunPod pod `eyu0zh4ilfa2kh` after artifact collection.