### PR TITLE
ci: fix CUDA 12.4 toolkit install for Linux + Windows

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -189,12 +189,20 @@ jobs:
         # NVIDIA's apt repo (faster than the 4 GB local installer). The
         # -dev variants bring headers and import libs that kiln-flash-attn
         # / kiln-marlin-gemm / kiln-gdn-kernel need at link time.
+        #
+        # NVIDIA renamed the cuBLAS / cuRAND apt packages from
+        # `cuda-cublas-*` / `cuda-curand-*` to `libcublas-*` / `libcurand-*`.
+        # Jimver's action auto-prefixes entries in `sub-packages` with
+        # `cuda-`, so those two have to be listed under
+        # `non-cuda-sub-packages` (Linux-only input) which skips the prefix
+        # but still appends `-12-4`.
         uses: Jimver/cuda-toolkit@v0.2.19
         id: cuda-toolkit
         with:
           cuda: '12.4.1'
           method: 'network'
-          sub-packages: '["nvcc", "cudart", "cudart-dev", "nvrtc", "nvrtc-dev", "cublas", "cublas-dev", "curand", "curand-dev", "cccl", "profiler-api"]'
+          sub-packages: '["nvcc", "cudart", "cudart-dev", "nvrtc", "nvrtc-dev", "cccl", "profiler-api"]'
+          non-cuda-sub-packages: '["libcublas", "libcublas-dev", "libcurand", "libcurand-dev"]'
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2
@@ -250,7 +258,11 @@ jobs:
 
   windows-cuda:
     name: Windows / x86_64 / CUDA 12.4
-    runs-on: windows-latest
+    # Pinned to Windows Server 2022. `windows-latest` now points at Server
+    # 2025 (build 10.0.26100), which NVIDIA's CUDA 12.4.1 installer refuses
+    # (silent exit 3772776473 == 0xE0CF2D39). kiln-v0.1.1 shipped green on
+    # Server 2022 with this same config. Revisit when we move to CUDA 13.
+    runs-on: windows-2022
     # See linux-cuda for the rationale on the arch list. Blackwell (SM 120)
     # is excluded because CUDA 12.4's nvcc can't emit it.
     env:
@@ -264,10 +276,12 @@ jobs:
           targets: x86_64-pc-windows-msvc
 
       - name: Install CUDA 12.4 toolkit
-        # Same sub-package set as the Linux job. Jimver/cuda-toolkit
-        # normalizes the hyphen/underscore naming across platforms, so
-        # `cudart-dev` resolves to `cudart_dev` on the Windows network
-        # installer automatically.
+        # Same sub-package set as the Linux job, minus the two packages
+        # that only exist under their `lib*` names in the Linux apt repo
+        # (cuBLAS, cuRAND). On Windows those ship inside the bundled
+        # `cublas` / `curand` installer components, so we list them here.
+        # `non-cuda-sub-packages` is a Linux-only input and is ignored by
+        # the Windows installer path.
         uses: Jimver/cuda-toolkit@v0.2.19
         id: cuda-toolkit
         with:

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -160,6 +160,14 @@ jobs:
     # trimming the list to 4 arches keeps CI under ~30 min.
     env:
       KILN_CUDA_ARCHS: '80;86;89;90'
+      # candle-kernels' build.rs shells out to `nvidia-smi` to pick the SM
+      # to compile for. GitHub runners don't have GPUs, so it fails with
+      # `ComputeCapDetectionFailed`. Pin SM80 (Ampere baseline) — the
+      # resulting PTX is forward-compatible via JIT to every arch we
+      # target (86/89/90). kiln's own kernel crates compile the full
+      # `KILN_CUDA_ARCHS` list, so this only affects candle's baseline
+      # kernels, not the perf-critical ones.
+      CUDA_COMPUTE_CAP: '80'
     steps:
       - name: Free disk space
         # The CUDA 12.4 toolkit (~5 GB installed) plus the cargo target dir
@@ -258,15 +266,19 @@ jobs:
 
   windows-cuda:
     name: Windows / x86_64 / CUDA 12.4
-    # Pinned to Windows Server 2022. `windows-latest` now points at Server
-    # 2025 (build 10.0.26100), which NVIDIA's CUDA 12.4.1 installer refuses
-    # (silent exit 3772776473 == 0xE0CF2D39). kiln-v0.1.1 shipped green on
-    # Server 2022 with this same config. Revisit when we move to CUDA 13.
+    # Pinned to Windows Server 2022. CUDA 12.4.1 predates Windows Server
+    # 2025 and NVIDIA hasn't shipped a 12.4 installer that knows how to
+    # run there. Server 2022 is supported through 2031, so there's no
+    # rush to move until we bump to CUDA 13.
     runs-on: windows-2022
     # See linux-cuda for the rationale on the arch list. Blackwell (SM 120)
     # is excluded because CUDA 12.4's nvcc can't emit it.
     env:
       KILN_CUDA_ARCHS: '80;86;89;90'
+      # Same reason as linux-cuda: candle-kernels runs `nvidia-smi` at
+      # build time to pick an SM and the CI runner has no GPU. SM80 PTX
+      # JIT-compiles to every arch we target.
+      CUDA_COMPUTE_CAP: '80'
     steps:
       - uses: actions/checkout@v4
 
@@ -276,18 +288,24 @@ jobs:
           targets: x86_64-pc-windows-msvc
 
       - name: Install CUDA 12.4 toolkit
-        # Same sub-package set as the Linux job, minus the two packages
-        # that only exist under their `lib*` names in the Linux apt repo
-        # (cuBLAS, cuRAND). On Windows those ship inside the bundled
-        # `cublas` / `curand` installer components, so we list them here.
-        # `non-cuda-sub-packages` is a Linux-only input and is ignored by
-        # the Windows installer path.
+        # Install the full toolkit rather than filtering with
+        # `sub-packages`. NVIDIA's Windows installer only accepts a fixed
+        # set of component names (`nvcc_12.4`, `cudart_12.4`,
+        # `cublas_dev_12.4`, etc., all underscore-separated), while
+        # Jimver/cuda-toolkit passes whatever we hand it with `_<major>.
+        # <minor>` appended. Our Linux-style hyphenated names
+        # (`cudart-dev` -> `cudart-dev_12.4`) don't match any component
+        # and the installer bails silently with exit 3772776473
+        # (0xE0CF2D39). Public workflows (kokkos, green-sky's llama.cpp
+        # fork) confirm `_dev` sub-packages have long been broken on
+        # Windows with this action; the working pattern is a full
+        # `method: local` install. That's only ~3 GB extra on the runner
+        # and we already have the disk headroom.
         uses: Jimver/cuda-toolkit@v0.2.19
         id: cuda-toolkit
         with:
           cuda: '12.4.1'
-          method: 'network'
-          sub-packages: '["nvcc", "cudart", "cudart-dev", "nvrtc", "nvrtc-dev", "cublas", "cublas-dev", "curand", "curand-dev", "cccl", "profiler-api"]'
+          method: 'local'
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
## What

Fix three independent bugs that together caused every release since
kiln-v0.1.1 to ship with only macOS Metal binaries (the Linux and
Windows CUDA jobs were failing silently since the CUDA matrix was added
after v0.1.1).

### Bug 1 — Linux: stale NVIDIA apt package names

`cuda-cublas-12-4` / `cuda-curand-12-4` don't exist in NVIDIA's apt repo
anymore; they were renamed to `libcublas-12-4` / `libcurand-12-4`. The
Jimver action prefixes `sub-packages` entries with `cuda-`, so the fix
is to move the renamed packages to `non-cuda-sub-packages` (which skips
the prefix but still appends the `-12-4` version suffix).

### Bug 2 — Linux: candle-kernels wants a GPU at build time

`candle-kernels` build.rs shells out to `nvidia-smi` to pick a compute
capability. GitHub runners have no GPU, so the build fails with
`ComputeCapDetectionFailed`. Fix: set `CUDA_COMPUTE_CAP=80` (Ampere
baseline). The resulting PTX JIT-compiles forward to every arch we
target at runtime (SM 86/89/90). kiln's own kernel crates still compile
the full `KILN_CUDA_ARCHS` list; this override only scopes candle's
baseline kernels.

### Bug 3 — Windows: hyphenated sub-package names silently rejected

NVIDIA's Windows installer only accepts a fixed set of underscore-
separated component names (`nvcc_12.4`, `cudart_12.4`, `cublas_dev_12.4`,
...). Jimver passes whatever we hand it with `_<major>.<minor>`
appended verbatim, so our Linux-style `cudart-dev` becomes
`cudart-dev_12.4`, which matches nothing, and the installer bails with
exit 3772776473 (0xE0CF2D39). This is a long-standing footgun — see
green-sky's note (`# TODO(green-sky): _dev seems to fail, and non dev
are not enough`) in multiple llama.cpp-fork workflows. Fix: drop the
sub-packages filter and install the full toolkit with
`method: 'local'`. Only ~3 GB extra on the runner and we already
free-disk-space at the top of the job. Proven pattern in kokkos.

Also keeps `runs-on: windows-2022` as belt-and-suspenders: CUDA 12.4.1
predates Windows Server 2025 (`windows-latest`) and NVIDIA hasn't
shipped a 12.4 installer that knows how to run there. Revisit when we
move to CUDA 13.

### What this PR does not change

- Does **not** bump `Jimver/cuda-toolkit` (v0.2.19 → v0.2.25). Reading
  `installer.ts` in both versions confirms the literal-pass-through
  behavior on Windows is identical — a version bump would not fix
  anything.
- Does **not** cut a new `kiln-v*` tag. The `workflow_dispatch` trigger
  gate at the top of the workflow lets us validate this branch without
  tagging.

## Validation

- [x] Linux CUDA install step goes green (validated on workflow_dispatch
      run 24870804726 — install passed, build failed on bug 2 which is
      now also fixed)
- [ ] Linux CUDA build goes green (pending this commit's validation run)
- [ ] Windows CUDA install + build go green (pending)