### PR TITLE
[codex] Fuse Metal LM-head argmax for greedy decode

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -25,6 +25,7 @@ const DISABLE_RMSNORM_KERNEL: &str = "KILN_DISABLE_RMSNORM_KERNEL";
 const DISABLE_METAL_RMSNORM: &str = "KILN_DISABLE_METAL_RMSNORM";
 const DISABLE_METAL_MLP_GATE_UP_FUSION: &str = "KILN_DISABLE_METAL_MLP_GATE_UP_FUSION";
 const DISABLE_METAL_GDN_IN_PROJ_FUSION: &str = "KILN_DISABLE_METAL_GDN_IN_PROJ_FUSION";
+const DISABLE_METAL_LM_HEAD_ARGMAX: &str = "KILN_DISABLE_METAL_LM_HEAD_ARGMAX";
 
 #[derive(Debug)]
 pub struct MetalBackend {
@@ -98,6 +99,9 @@ pub fn precompile_custom_kernels(device: &Device) -> Result<()> {
     metal_conv1d_prefill_pipeline(metal_device)?;
     metal_conv1d_update_pipeline(metal_device)?;
     metal_lm_head_pipeline(metal_device)?;
+    if !metal_lm_head_argmax_disabled() {
+        metal_lm_head_argmax_pipeline(metal_device)?;
+    }
     if !metal_mlp_gate_up_fusion_disabled() {
         metal_mlp_gate_up_pipeline(metal_device)?;
     }
@@ -598,6 +602,10 @@ fn metal_rms_norm_disabled() -> bool {
 
 pub(crate) fn metal_mlp_gate_up_fusion_disabled() -> bool {
     env_truthy(DISABLE_METAL_MLP_GATE_UP_FUSION)
+}
+
+pub(crate) fn metal_lm_head_argmax_disabled() -> bool {
+    env_truthy(DISABLE_METAL_LM_HEAD_ARGMAX)
 }
 
 fn env_present(var: &str) -> bool {
@@ -1525,6 +1533,53 @@ kernel void kiln_lm_head_bf16(
     }
     out[gid] = static_cast<bfloat>(acc);
 }
+
+kernel void kiln_lm_head_argmax_chunks_bf16(
+    device const bfloat* x [[buffer(0)]],
+    device const bfloat* weight_t [[buffer(1)]],
+    device float* partial_scores [[buffer(2)]],
+    device float* partial_indices [[buffer(3)]],
+    constant uint& hidden [[buffer(4)]],
+    constant uint& vocab [[buffer(5)]],
+    uint tid [[thread_index_in_threadgroup]],
+    uint group [[threadgroup_position_in_grid]]
+) {
+    threadgroup float scores[256];
+    threadgroup float indices[256];
+
+    const uint col = group * 256 + tid;
+    float score = -INFINITY;
+    float index = 0.0f;
+    if (col < vocab) {
+        float acc = 0.0f;
+        for (uint i = 0; i < hidden; ++i) {
+            acc += static_cast<float>(x[i]) * static_cast<float>(weight_t[i * vocab + col]);
+        }
+        score = static_cast<float>(static_cast<bfloat>(acc));
+        index = static_cast<float>(col);
+    }
+    scores[tid] = score;
+    indices[tid] = index;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (uint stride = 128; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            const float other_score = scores[tid + stride];
+            const float other_index = indices[tid + stride];
+            if (other_score > scores[tid] ||
+                (other_score == scores[tid] && other_index < indices[tid])) {
+                scores[tid] = other_score;
+                indices[tid] = other_index;
+            }
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    if (tid == 0) {
+        partial_scores[group] = scores[0];
+        partial_indices[group] = indices[0];
+    }
+}
 "#;
 
 const METAL_MLP_GATE_UP_KERNEL: &str = r#"
@@ -1878,6 +1933,35 @@ fn metal_lm_head_pipeline(
     Ok(pipeline)
 }
 
+fn metal_lm_head_argmax_pipeline(
+    device: &candle_core::metal_backend::MetalDevice,
+) -> Result<candle_metal_kernels::metal::ComputePipeline> {
+    use candle_core::metal_backend::DeviceId;
+    use candle_metal_kernels::metal::ComputePipeline;
+    use std::collections::HashMap;
+    use std::sync::{Mutex, OnceLock};
+
+    static PIPELINES: OnceLock<Mutex<HashMap<DeviceId, ComputePipeline>>> = OnceLock::new();
+    let cache = PIPELINES.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut cache = cache
+        .lock()
+        .map_err(|_| anyhow::anyhow!("metal lm head argmax pipeline cache poisoned"))?;
+    if let Some(pipeline) = cache.get(&device.id()) {
+        return Ok(pipeline.clone());
+    }
+
+    let library = metal_shared_library(device)?;
+    let function = library
+        .get_function("kiln_lm_head_argmax_chunks_bf16", None)
+        .map_err(|e| anyhow::anyhow!("load metal lm head argmax function: {e:?}"))?;
+    let pipeline = device
+        .device()
+        .new_compute_pipeline_state_with_function(&function)
+        .map_err(|e| anyhow::anyhow!("build metal lm head argmax pipeline: {e:?}"))?;
+    cache.insert(device.id(), pipeline.clone());
+    Ok(pipeline)
+}
+
 fn metal_mlp_gate_up_pipeline(
     device: &candle_core::metal_backend::MetalDevice,
 ) -> Result<candle_metal_kernels::metal::ComputePipeline> {
@@ -2020,6 +2104,22 @@ pub(crate) fn metal_lm_head_supports(x: &Tensor, weight_t: &Tensor) -> bool {
         && vocab <= u32::MAX as usize
 }
 
+pub(crate) fn metal_lm_head_argmax_supports(x: &Tensor, weight_t: &Tensor) -> bool {
+    if metal_lm_head_argmax_disabled() {
+        return false;
+    }
+    if !metal_lm_head_supports(x, weight_t) {
+        return false;
+    }
+    let Ok((_, vocab)) = weight_t.dims2() else {
+        return false;
+    };
+    let num_groups = vocab.div_ceil(256);
+    // The final reduction is intentionally bounded to one threadgroup for the
+    // Qwen3.5-4B vocab path; larger vocabs fall back to materialized logits.
+    num_groups > 0 && num_groups <= 1024
+}
+
 pub(crate) fn metal_lm_head_bf16(x: &Tensor, weight_t: &Tensor) -> Result<Tensor> {
     anyhow::ensure!(
         metal_lm_head_supports(x, weight_t),
@@ -2086,6 +2186,110 @@ pub(crate) fn metal_lm_head_bf16(x: &Tensor, weight_t: &Tensor) -> Result<Tensor
     }
 
     Ok(out)
+}
+
+pub(crate) fn metal_lm_head_argmax_bf16(x: &Tensor, weight_t: &Tensor) -> Result<u32> {
+    anyhow::ensure!(
+        metal_lm_head_argmax_supports(x, weight_t),
+        "metal lm head argmax supports only BF16 [1,1,H] x [H,V] on Metal with <= 262144 vocab"
+    );
+    let (_, _, hidden) = x.dims3()?;
+    let (_, vocab) = weight_t.dims2()?;
+
+    let chunk_width = 256usize;
+    let num_groups = vocab.div_ceil(chunk_width);
+    let partial_scores = unsafe { Tensor::empty((num_groups,), DType::F32, x.device())? };
+    let partial_indices = unsafe { Tensor::empty((num_groups,), DType::F32, x.device())? };
+
+    let Device::Metal(device) = x.device() else {
+        anyhow::bail!("metal lm head argmax requires Metal tensors");
+    };
+    let pipeline = metal_lm_head_argmax_pipeline(device)?;
+    let encoder = device.command_encoder()?;
+    encoder.set_label("kiln_lm_head_argmax_chunks_bf16");
+    encoder.set_compute_pipeline_state(&pipeline);
+
+    {
+        let (x_storage, x_layout) = x.storage_and_layout();
+        let (w_storage, w_layout) = weight_t.storage_and_layout();
+        let (ps_storage, ps_layout) = partial_scores.storage_and_layout();
+        let (pi_storage, pi_layout) = partial_indices.storage_and_layout();
+
+        let x_metal = match &*x_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal lm head argmax x must be on Metal"),
+        };
+        let w_metal = match &*w_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal lm head argmax weight must be on Metal"),
+        };
+        let ps_metal = match &*ps_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal lm head argmax partial scores must be on Metal"),
+        };
+        let pi_metal = match &*pi_storage {
+            candle_core::Storage::Metal(s) => s,
+            _ => anyhow::bail!("metal lm head argmax partial indices must be on Metal"),
+        };
+
+        let x_buf = candle_core::metal_backend::buffer_o(x_metal.buffer(), &x_layout, x.dtype());
+        let w_buf =
+            candle_core::metal_backend::buffer_o(w_metal.buffer(), &w_layout, weight_t.dtype());
+        let ps_buf = candle_core::metal_backend::buffer_o(
+            ps_metal.buffer(),
+            &ps_layout,
+            partial_scores.dtype(),
+        );
+        let pi_buf = candle_core::metal_backend::buffer_o(
+            pi_metal.buffer(),
+            &pi_layout,
+            partial_indices.dtype(),
+        );
+
+        encoder.set_buffer(0, Some(x_buf.buffer), x_buf.offset_in_bytes);
+        encoder.set_buffer(1, Some(w_buf.buffer), w_buf.offset_in_bytes);
+        encoder.set_buffer(2, Some(ps_buf.buffer), ps_buf.offset_in_bytes);
+        encoder.set_buffer(3, Some(pi_buf.buffer), pi_buf.offset_in_bytes);
+
+        let hidden_u32 = hidden as u32;
+        let vocab_u32 = vocab as u32;
+        encoder.set_bytes(4, &hidden_u32);
+        encoder.set_bytes(5, &vocab_u32);
+
+        let threadgroups_per_grid = objc2_metal::MTLSize {
+            width: num_groups,
+            height: 1,
+            depth: 1,
+        };
+        let threads_per_threadgroup = objc2_metal::MTLSize {
+            width: chunk_width,
+            height: 1,
+            depth: 1,
+        };
+        encoder.dispatch_thread_groups(threadgroups_per_grid, threads_per_threadgroup);
+    }
+
+    // Commit the argmax dispatch before synchronously reading the tiny list of
+    // per-chunk winners back to the CPU for the final reduction.
+    drop(encoder);
+
+    let scores = partial_scores
+        .to_vec1::<f32>()
+        .context("read metal lm head argmax partial scores")?;
+    let indices = partial_indices
+        .to_vec1::<f32>()
+        .context("read metal lm head argmax partial indices")?;
+
+    let mut best_score = f32::NEG_INFINITY;
+    let mut best_idx = 0u32;
+    for (&score, &idx_f) in scores.iter().zip(indices.iter()) {
+        let idx = idx_f as u32;
+        if score > best_score || (score == best_score && idx < best_idx) {
+            best_score = score;
+            best_idx = idx;
+        }
+    }
+    Ok(best_idx)
 }
 
 pub(crate) fn metal_mlp_gate_up_supports(x: &Tensor, gate_t: &Tensor, up_t: &Tensor) -> bool {
@@ -5605,6 +5809,35 @@ mod tests {
             "Metal LM-head mean_abs_diff={mean:e} exceeds tolerance"
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_lm_head_argmax_matches_materialized_logits() -> Result<()> {
+        let Some(device) = try_new_metal() else {
+            return Ok(());
+        };
+
+        let hidden = 128usize;
+        let vocab = 257usize;
+        let x_data: Vec<f32> = (0..hidden)
+            .map(|i| ((i % 23) as f32 - 11.0) * 0.0234375)
+            .collect();
+        let weight_data: Vec<f32> = (0..(hidden * vocab))
+            .map(|i| ((i % 31) as f32 - 15.0) * 0.01953125)
+            .collect();
+
+        let x = Tensor::from_slice(&x_data, (1usize, 1usize, hidden), &device)?
+            .to_dtype(DType::BF16)?;
+        let weight_t =
+            Tensor::from_slice(&weight_data, (hidden, vocab), &device)?.to_dtype(DType::BF16)?;
+
+        assert!(metal_lm_head_argmax_supports(&x, &weight_t));
+        let logits = metal_lm_head_bf16(&x, &weight_t)?;
+        let reference = crate::sampling::greedy_sample(&logits)?;
+        let fused = metal_lm_head_argmax_bf16(&x, &weight_t)?;
+
+        assert_eq!(fused, reference);
         Ok(())
     }
 

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2279,6 +2279,18 @@ fn lm_head_forward(x: &Tensor, embed_tokens_t: &Tensor) -> Result<Tensor> {
     Ok(x.broadcast_matmul(embed_tokens_t)?)
 }
 
+fn lm_head_argmax(x: &Tensor, embed_tokens_t: &Tensor) -> Result<u32> {
+    #[cfg(feature = "metal")]
+    {
+        if crate::backend::metal::metal_lm_head_argmax_supports(x, embed_tokens_t) {
+            return crate::backend::metal::metal_lm_head_argmax_bf16(x, embed_tokens_t)
+                .context("metal lm_head argmax kernel failed");
+        }
+    }
+    let logits = lm_head_forward(x, embed_tokens_t)?;
+    Ok(logits.flatten_all()?.argmax(0)?.to_scalar::<u32>()?)
+}
+
 // ---------------------------------------------------------------------------
 // Gated DeltaNet (GDN) linear attention primitives
 // ---------------------------------------------------------------------------
@@ -5342,7 +5354,7 @@ pub fn model_forward_paged(
     lora: Option<&LoraWeights>,
     positions_gpu: Option<&Tensor>,
 ) -> Result<Tensor> {
-    let (logits, _hidden) = model_forward_paged_inner(
+    let (logits, _hidden, _token) = model_forward_paged_inner(
         backend,
         token_ids,
         weights,
@@ -5377,7 +5389,7 @@ pub fn model_forward_paged_last_token(
     lora: Option<&LoraWeights>,
     positions_gpu: Option<&Tensor>,
 ) -> Result<Tensor> {
-    let (logits, _hidden) = model_forward_paged_inner(
+    let (logits, _hidden, _token) = model_forward_paged_inner(
         backend,
         token_ids,
         weights,
@@ -5391,6 +5403,39 @@ pub fn model_forward_paged_last_token(
         LmHeadMode::LastRowOnly,
     )?;
     Ok(logits.expect("LmHeadMode::LastRowOnly always produces logits"))
+}
+
+/// Paged-KV single-token decode for greedy sampling.
+///
+/// This keeps the existing logits APIs intact but, on the Metal BF16 decode
+/// path, fuses the LM-head projection with argmax so generation does not
+/// materialize `[1, 1, vocab_size]` logits only to immediately reduce them.
+pub fn model_forward_paged_next_token_greedy(
+    backend: &dyn BackendRuntime,
+    token_id: u32,
+    weights: &GpuWeights,
+    config: &kiln_core::config::ModelConfig,
+    paged_cache: &mut PagedKvCache,
+    block_table: &BlockTable,
+    start_pos: usize,
+    linear_state: Option<&mut LinearAttentionState>,
+    lora: Option<&LoraWeights>,
+    positions_gpu: Option<&Tensor>,
+) -> Result<u32> {
+    let (_logits, _hidden, token) = model_forward_paged_inner(
+        backend,
+        &[token_id],
+        weights,
+        config,
+        paged_cache,
+        block_table,
+        start_pos,
+        linear_state,
+        lora,
+        positions_gpu,
+        LmHeadMode::LastRowArgmaxOnly,
+    )?;
+    token.context("LmHeadMode::LastRowArgmaxOnly always produces a token")
 }
 
 /// Paged-KV forward pass that ALSO returns the last-row pre-final-norm hidden state.
@@ -5453,7 +5498,7 @@ pub fn model_forward_paged_with_last_hidden(
     crate::mtp_debug::arm_c44_layer1_f32_row_capture();
     crate::mtp_debug::arm_c45_layer1_row_capture();
     crate::mtp_debug::arm_c46_layer1_row_provenance_capture();
-    let (logits, hidden) = model_forward_paged_inner(
+    let (logits, hidden, _token) = model_forward_paged_inner(
         backend,
         token_ids,
         weights,
@@ -5498,7 +5543,7 @@ pub fn model_forward_paged_last_token_with_last_hidden(
     crate::mtp_debug::arm_c44_layer1_f32_row_capture();
     crate::mtp_debug::arm_c45_layer1_row_capture();
     crate::mtp_debug::arm_c46_layer1_row_provenance_capture();
-    let (logits, hidden) = model_forward_paged_inner(
+    let (logits, hidden, _token) = model_forward_paged_inner(
         backend,
         token_ids,
         weights,
@@ -6055,6 +6100,10 @@ enum LmHeadMode {
     /// of `Full` because RMSNorm is per-position and the matmul reduces
     /// along `hidden_size` only.
     LastRowOnly,
+    /// Compute the final token's greedy argmax without materializing logits
+    /// when a backend-specific fused head supports it. Used only by greedy
+    /// single-token decode.
+    LastRowArgmaxOnly,
     /// Compute the LM head over every position AND return the last-row
     /// pre-final-norm hidden state. Used by
     /// [`model_forward_paged_with_last_hidden`] to surface per-position logits
@@ -6091,7 +6140,7 @@ fn model_forward_paged_inner(
     lora: Option<&LoraWeights>,
     positions_gpu: Option<&Tensor>,
     lm_head_mode: LmHeadMode,
-) -> Result<(Option<Tensor>, Option<Tensor>)> {
+) -> Result<(Option<Tensor>, Option<Tensor>, Option<u32>)> {
     let seq_len = token_ids.len();
     let device = weights.embed_tokens.device();
 
@@ -6294,7 +6343,7 @@ fn model_forward_paged_inner(
                 hidden = rms_norm(&hidden, &weights.final_norm, config.rms_norm_eps)?;
                 lm_head_forward(&hidden, &weights.embed_tokens_t)?
             };
-            Ok((Some(logits), None))
+            Ok((Some(logits), None, None))
         }
         LmHeadMode::LastRowOnly => {
             let logits = {
@@ -6303,7 +6352,16 @@ fn model_forward_paged_inner(
                 let normed = rms_norm(&last, &weights.final_norm, config.rms_norm_eps)?;
                 lm_head_forward(&normed, &weights.embed_tokens_t)?
             };
-            Ok((Some(logits), None))
+            Ok((Some(logits), None, None))
+        }
+        LmHeadMode::LastRowArgmaxOnly => {
+            let token = {
+                kiln_nvtx::range!(c"kiln/lm_head_argmax");
+                let last = hidden.narrow(1, seq_len - 1, 1)?;
+                let normed = rms_norm(&last, &weights.final_norm, config.rms_norm_eps)?;
+                lm_head_argmax(&normed, &weights.embed_tokens_t)?
+            };
+            Ok((None, None, Some(token)))
         }
         LmHeadMode::FullWithLastHidden => {
             // Phase C18: `h_prev` must be returned POST-final-norm.
@@ -6326,7 +6384,7 @@ fn model_forward_paged_inner(
                 kiln_nvtx::range!(c"kiln/lm_head");
                 lm_head_forward(&normed, &weights.embed_tokens_t)?
             };
-            Ok((Some(logits), Some(last_hidden)))
+            Ok((Some(logits), Some(last_hidden), None))
         }
         LmHeadMode::LastRowWithLastHidden => {
             // Phase C18: same frame fix as `FullWithLastHidden`. For the
@@ -6345,9 +6403,9 @@ fn model_forward_paged_inner(
                 kiln_nvtx::range!(c"kiln/lm_head");
                 lm_head_forward(&last_hidden, &weights.embed_tokens_t)?
             };
-            Ok((Some(logits), Some(last_hidden)))
+            Ok((Some(logits), Some(last_hidden), None))
         }
-        LmHeadMode::Skip => Ok((None, None)),
+        LmHeadMode::Skip => Ok((None, None, None)),
     }
 }
 
@@ -6469,7 +6527,7 @@ pub fn model_forward_paged_streaming_last_token_with_last_hidden_with(
         };
 
         let state_for_tile: Option<&mut LinearAttentionState> = linear_state.as_deref_mut();
-        let (tile_logits, tile_hidden) = model_forward_paged_inner(
+        let (tile_logits, tile_hidden, _token) = model_forward_paged_inner(
             backend,
             &token_ids[cursor..end],
             weights,
@@ -6551,7 +6609,7 @@ pub fn model_forward_paged_streaming_with(
         // `Option<&mut T>::as_deref_mut()` produces `Option<&mut T>` again.
         let state_for_tile: Option<&mut LinearAttentionState> = linear_state.as_deref_mut();
 
-        let (tile_logits, _tile_hidden) = model_forward_paged_inner(
+        let (tile_logits, _tile_hidden, _token) = model_forward_paged_inner(
             backend,
             &token_ids[cursor..end],
             weights,

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -18,8 +18,8 @@ use crate::cuda_graph::CudaGraphRunner;
 use crate::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
     model_forward_paged_last_token, model_forward_paged_last_token_with_last_hidden,
-    model_forward_paged_streaming, model_forward_paged_streaming_last_token_with_last_hidden,
-    streaming_prefill_enabled_for,
+    model_forward_paged_next_token_greedy, model_forward_paged_streaming,
+    model_forward_paged_streaming_last_token_with_last_hidden, streaming_prefill_enabled_for,
 };
 use crate::kv_cache::KvCache;
 use crate::lora_loader::LoraWeights;
@@ -1272,23 +1272,37 @@ impl ModelRunner {
                 break;
             }
 
-            // Decode step: use CUDA graph runner (captures/replays when enabled)
-            let logits = graph_runner.decode_step_paged(
-                &*self.backend,
-                next_token,
-                &self.weights,
-                &self.config,
-                paged_cache,
-                block_table,
-                seq_len,
-                &mut linear_state,
-                self.active_lora.as_ref(),
-            )?;
-            seq_len += 1;
-
-            next_token = if params.temperature == 0.0 {
-                greedy_sample(&logits)?
+            next_token = if params.temperature == 0.0
+                && matches!(self.backend.device(), candle_core::Device::Metal(_))
+            {
+                let token = model_forward_paged_next_token_greedy(
+                    &*self.backend,
+                    next_token,
+                    &self.weights,
+                    &self.config,
+                    paged_cache,
+                    block_table,
+                    seq_len,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )?;
+                seq_len += 1;
+                token
             } else {
+                // Decode step: use CUDA graph runner (captures/replays when enabled)
+                let logits = graph_runner.decode_step_paged(
+                    &*self.backend,
+                    next_token,
+                    &self.weights,
+                    &self.config,
+                    paged_cache,
+                    block_table,
+                    seq_len,
+                    &mut linear_state,
+                    self.active_lora.as_ref(),
+                )?;
+                seq_len += 1;
                 sample_with_params(
                     &logits,
                     params.temperature,
@@ -2859,29 +2873,49 @@ impl ModelRunner {
                 break;
             }
 
-            // Decode step: use CUDA graph runner
-            let logits = match graph_runner.decode_step_paged(
-                &*self.backend,
-                next_token,
-                &self.weights,
-                &self.config,
-                paged_cache,
-                &block_table,
-                seq_len,
-                &mut linear_state,
-                self.active_lora.as_ref(),
-            ) {
-                Ok(l) => l,
-                Err(e) => {
-                    block_manager.free_all(&allocated_blocks);
-                    return Err(e.context("decode forward pass (paged) failed"));
-                }
-            };
-            seq_len += 1;
-
-            next_token = if params.temperature == 0.0 {
-                greedy_sample(&logits)?
+            next_token = if params.temperature == 0.0
+                && matches!(self.backend.device(), candle_core::Device::Metal(_))
+            {
+                let token = match model_forward_paged_next_token_greedy(
+                    &*self.backend,
+                    next_token,
+                    &self.weights,
+                    &self.config,
+                    paged_cache,
+                    &block_table,
+                    seq_len,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                ) {
+                    Ok(token) => token,
+                    Err(e) => {
+                        block_manager.free_all(&allocated_blocks);
+                        return Err(e.context("decode forward pass (paged greedy) failed"));
+                    }
+                };
+                seq_len += 1;
+                token
             } else {
+                // Decode step: use CUDA graph runner
+                let logits = match graph_runner.decode_step_paged(
+                    &*self.backend,
+                    next_token,
+                    &self.weights,
+                    &self.config,
+                    paged_cache,
+                    &block_table,
+                    seq_len,
+                    &mut linear_state,
+                    self.active_lora.as_ref(),
+                ) {
+                    Ok(l) => l,
+                    Err(e) => {
+                        block_manager.free_all(&allocated_blocks);
+                        return Err(e.context("decode forward pass (paged) failed"));
+                    }
+                };
+                seq_len += 1;
                 sample_with_params(
                     &logits,
                     params.temperature,

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -21,8 +21,8 @@ use kiln_model::backend as runtime_backend;
 use kiln_model::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
     model_forward_paged_last_token, model_forward_paged_last_token_with_last_hidden,
-    model_forward_paged_streaming, model_forward_paged_streaming_last_token_with_last_hidden,
-    streaming_prefill_enabled_for,
+    model_forward_paged_next_token_greedy, model_forward_paged_streaming,
+    model_forward_paged_streaming_last_token_with_last_hidden, streaming_prefill_enabled_for,
 };
 use kiln_model::kv_cache::KvCache;
 use kiln_model::paged_kv_cache::PagedKvCache;
@@ -814,21 +814,37 @@ fn bench_latency_paged(
         }
 
         let step_start = Instant::now();
-        let logits = model_forward_paged(
-            &*backend,
-            &[next_token],
-            weights,
-            config,
-            &mut paged_cache,
-            &block_table,
-            current_pos,
-            Some(&mut linear_state),
-            None,
-            None,
-        )
-        .context("paged decode forward pass failed")?;
+        next_token = if matches!(device, candle_core::Device::Metal(_)) {
+            model_forward_paged_next_token_greedy(
+                &*backend,
+                next_token,
+                weights,
+                config,
+                &mut paged_cache,
+                &block_table,
+                current_pos,
+                Some(&mut linear_state),
+                None,
+                None,
+            )
+            .context("paged greedy decode forward pass failed")?
+        } else {
+            let logits = model_forward_paged(
+                &*backend,
+                &[next_token],
+                weights,
+                config,
+                &mut paged_cache,
+                &block_table,
+                current_pos,
+                Some(&mut linear_state),
+                None,
+                None,
+            )
+            .context("paged decode forward pass failed")?;
+            greedy_sample(&logits)?
+        };
         current_pos += 1;
-        next_token = greedy_sample(&logits)?;
         let step_time = step_start.elapsed();
 
         inter_token_ms.push(step_time.as_secs_f64() * 1000.0);


### PR DESCRIPTION
## Summary

- Adds a Metal BF16 LM-head argmax fast path for single-token greedy decode.
- Routes default Metal paged greedy decode through `model_forward_paged_next_token_greedy`, avoiding materializing `[1, 1, vocab]` logits only to immediately reduce them.
- Keeps the existing logits APIs intact and adds `KILN_DISABLE_METAL_LM_HEAD_ARGMAX=1` as a rollback/A-B switch while leaving the optimization enabled by default.

## Validation

- `cargo test -p kiln-model --locked --features metal test_lm_head_argmax_matches_materialized_logits --target-dir /private/tmp/kiln-lmhead-argmax-check-target -- --nocapture`
- `cargo test -p kiln-model --locked --features metal test_lm_head_matches_broadcast_matmul --target-dir /private/tmp/kiln-lmhead-argmax-check-target -- --nocapture`
- `cargo check -p kiln-server --locked --features metal --bin kiln-bench --target-dir /private/tmp/kiln-lmhead-argmax-check-target`
- `git diff --check`

## Benchmark

Default desktop env (`KILN_INFERENCE_MEMORY_FRACTION=0.7 KILN_KV_CACHE_FP8=0 KILN_CUDA_GRAPHS=0 KILN_PREFIX_CACHE_ENABLED=1 KILN_SPEC_ENABLED=1 KILN_SPEC_METHOD=mtp`), Qwen3.5-4B, paged 512/128 latency-only:

- `origin/main` at `55a5d9f`: real `44.63s`, load `13.73s`, prefill `140 tok/s`, decode `4.836 tok/s`.
- This PR: real `40.79s`, load `12.11s`, prefill `138 tok/s`, decode `5.285 tok/s`.

llama.cpp `master` BF16/Metal comparison remains faster at decode `6.05 tok/s`, so this is an incremental win rather than the endpoint.