### PR TITLE
phase6: audit GDN conv decode hotspot

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -7289,3 +7289,37 @@ Start with a static audit of `:kiln/gdn/conv` so we do not retry an already
 exhausted causal-conv/chunk-vendoring path; if that audit shows low leverage,
 move to the adjacent `:kiln/gdn/gates` + `:kiln/gdn/gated_norm` cluster. Do not
 choose a next kernel from stale C50/C51 carry-forward percentages.
+
+## Phase 6 C53 GDN conv decode hotspot audit (2026-04-24)
+
+C53 audited the C52 rank-1 decode hotspot, `:kiln/gdn/conv`, before attempting
+another causal-conv optimization. Artifact:
+`docs/phase-c53/gdn-conv-decode-audit.md`; machine summary:
+`docs/phase-c53/summary.json`.
+
+Conclusion: **audit-only, no implementation**. The current CUDA path already
+routes supported native-MTP single-token decode calls through
+`backend.causal_conv1d_update` and the vendored `kiln-conv1d-kernel` update
+kernel for the Qwen3.5 envelope (BF16 activations/weights, F32 state,
+`seq_len == 1`, `kernel_size == 4`). The portable
+`causal_conv1d_decode` fallback is not expected for the C52 workload unless the
+`KILN_DISABLE_FUSED_CONV1D` kill switch is set or the support envelope changes.
+
+C53 adds measurement-only child NVTX ranges under `:kiln/gdn/conv`:
+`:kiln/gdn/conv/layout`, `:kiln/gdn/conv/update`,
+`:kiln/gdn/conv/prefill_update`, `:kiln/gdn/conv/fallback_decode`, and
+`:kiln/gdn/conv/fallback_prefill`. These ranges split the remaining hotspot
+into layout/contiguity, fused update wrapper/kernel launch, and explicit
+fallback time without changing tensor behavior.
+
+Required RunPod validation/profiling was attempted on RTX A6000 pods
+`nszu2wno80dvef` and `efeldsa2tpx69s`, but both runs hit SSH failures during
+validation (`wait-file` timeout followed by SSH reset/no-output state checks).
+Both pods were terminated. No C53 before/after speedup is claimed.
+
+Recommendation: re-run the C52 native-MTP decode workload with the C53 child
+NVTX ranges when RunPod SSH is healthy. If `:kiln/gdn/conv/update` dominates,
+treat causal-conv as already kernel/runtime-bound and move to the adjacent
+`:kiln/gdn/gates` + `:kiln/gdn/gated_norm` cluster. If
+`:kiln/gdn/conv/layout` dominates, open a separate minimal layout/contiguity
+fix task.

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3113,16 +3113,24 @@ pub fn gated_deltanet_forward(
     let mixed_qkv = {
         kiln_nvtx::range!(c"kiln/gdn/conv");
         // Transpose to [B, channels, T] for conv
-        let mixed_qkv_ct = mixed_qkv.transpose(1, 2)?.contiguous()?;
+        let mixed_qkv_ct = {
+            kiln_nvtx::range!(c"kiln/gdn/conv/layout");
+            mixed_qkv.transpose(1, 2)?.contiguous()?
+        };
         let post_silu = if seq_len == 1 && backend.supports_causal_conv1d_update() {
-            match backend.causal_conv1d_update(
-                &mixed_qkv_ct,
-                &weights.conv1d,
-                conv_state,
-                kernel_size,
-            )? {
+            let conv_update = {
+                kiln_nvtx::range!(c"kiln/gdn/conv/update");
+                backend.causal_conv1d_update(
+                    &mixed_qkv_ct,
+                    &weights.conv1d,
+                    conv_state,
+                    kernel_size,
+                )?
+            };
+            match conv_update {
                 Some(out) => out, // F32, SiLU fused into the kernel epilogue
                 None => {
+                    kiln_nvtx::range!(c"kiln/gdn/conv/fallback_decode");
                     let y = causal_conv1d_decode(
                         &mixed_qkv_ct,
                         &weights.conv1d,
@@ -3134,14 +3142,19 @@ pub fn gated_deltanet_forward(
             }
         } else if seq_len > 1 {
             if backend.supports_causal_conv1d_prefill() {
-                match backend.causal_conv1d_prefill(
-                    &mixed_qkv_ct,
-                    &weights.conv1d,
-                    conv_state,
-                    kernel_size,
-                )? {
+                let conv_prefill = {
+                    kiln_nvtx::range!(c"kiln/gdn/conv/prefill_update");
+                    backend.causal_conv1d_prefill(
+                        &mixed_qkv_ct,
+                        &weights.conv1d,
+                        conv_state,
+                        kernel_size,
+                    )?
+                };
+                match conv_prefill {
                     Some(out) => out, // F32, SiLU fused into the kernel epilogue
                     None => {
+                        kiln_nvtx::range!(c"kiln/gdn/conv/fallback_prefill");
                         let y = causal_conv1d_prefill(
                             &mixed_qkv_ct,
                             &weights.conv1d,
@@ -3152,11 +3165,13 @@ pub fn gated_deltanet_forward(
                     }
                 }
             } else {
+                kiln_nvtx::range!(c"kiln/gdn/conv/fallback_prefill");
                 let y =
                     causal_conv1d_prefill(&mixed_qkv_ct, &weights.conv1d, conv_state, kernel_size)?;
                 cuda_silu(&y)?
             }
         } else {
+            kiln_nvtx::range!(c"kiln/gdn/conv/fallback_decode");
             let y = causal_conv1d_decode(&mixed_qkv_ct, &weights.conv1d, conv_state, kernel_size)?;
             cuda_silu(&y.to_dtype(DType::F32)?)?
         };

--- a/docs/phase-c53/gdn-conv-decode-audit.md
+++ b/docs/phase-c53/gdn-conv-decode-audit.md
@@ -1,0 +1,56 @@
+# Phase 6 C53 GDN conv decode hotspot audit
+
+Date: 2026-04-24
+Base: current `main` after C52 (`3ea3747`, with C52 artifact commit `55a5d9f`).
+Scope: audit `:kiln/gdn/conv` in the native-MTP decode workload before attempting any new causal-conv implementation.
+
+## Precondition
+
+The C52 recommendation is still the live profiling recommendation in `PROFILING.md`: `:kiln/gdn/conv` is the rank-1 decode NVTX range at 15.4% wall-clock, 562.361 ms over 2328 instances. No open PR was found targeting `:kiln/gdn/conv`, `kiln/gdn/conv`, `causal_conv1d`, or C53. No newer profiling artifact supersedes `docs/phase-c52/summary.json`.
+
+## Static call-path audit
+
+Current CUDA decode uses the vendored causal-conv update path for the C52 native-MTP decode shape:
+
+- `crates/kiln-model/src/forward.rs` enters `:kiln/gdn/conv`, transposes `mixed_qkv` to `[B, C, T]`, and for `seq_len == 1` calls `backend.causal_conv1d_update(...)` when `backend.supports_causal_conv1d_update()` is true.
+- `crates/kiln-model/src/backend/cuda.rs` returns true unless `KILN_DISABLE_FUSED_CONV1D` is set, then declines only if `kiln_conv1d_kernel::supports(...)` rejects the exact envelope.
+- `crates/kiln-conv1d-kernel/src/lib.rs` supports the Qwen3.5 decode envelope: BF16 `x`, BF16 weights, F32 state, `[B, C, 1]`, kernel size 4, CUDA storage, and contiguous inputs.
+- `crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu` launches `kiln_conv1d_update_k4_kernel` with one thread per `(batch, channel)`, updates F32 state in place, and fuses SiLU.
+
+For the C52 workload, native-MTP decode forwards are single-token decode calls (`seq_len == 1`) on CUDA with the normal kill switch unset. The fallback `causal_conv1d_decode` path is therefore not expected for supported CUDA decode; remaining `:kiln/gdn/conv` wall-clock is expected to be layout/contiguity, wrapper/output allocation, and the vendored update kernel itself.
+
+## Instrumentation shipped
+
+C53 adds child NVTX ranges under `:kiln/gdn/conv`:
+
+- `:kiln/gdn/conv/layout` for `transpose(1, 2)?.contiguous()` into `[B, C, T]`.
+- `:kiln/gdn/conv/update` for the backend fused update call, including wrapper checks, output allocation, and CUDA launch.
+- `:kiln/gdn/conv/prefill_update` for the analogous prefill fused call.
+- `:kiln/gdn/conv/fallback_decode` and `:kiln/gdn/conv/fallback_prefill` for explicit fallback attribution if support checks ever decline.
+
+This is intentionally measurement-only instrumentation. It does not change tensor values, backend selection, or kernel dispatch.
+
+## GPU attempt record
+
+Required RunPod validation/profiling could not complete because both A6000 pods developed SSH failures during the build/validation phase. Both pods were terminated immediately to stop spend.
+
+| Pod | GPU | Outcome | Termination |
+| --- | --- | --- | --- |
+| `nszu2wno80dvef` | RTX A6000 | `cargo test`/build started with sccache hits, then `wait-file` timed out and SSH began resetting connections. | Terminated |
+| `efeldsa2tpx69s` | RTX A6000 | Fresh retry reached the same `wait-file` SSH timeout during validation; subsequent bounded SSH state check produced no output. | Terminated |
+
+Commands attempted on each retry followed the required pattern:
+
+```bash
+cargo test -p kiln-conv1d-kernel
+cargo test -p kiln-model test_causal_conv1d_update_matches_fallback --features cuda -- --nocapture
+cargo build --release --features cuda --bin kiln-bench
+```
+
+No C53 before/after benchmark is claimed.
+
+## Conclusion
+
+Audit-only, no implementation. The existing `kiln-conv1d-kernel` vendored causal-conv update already covers the C52 native-MTP decode shape. Without a successful child-range profile, there is no evidence for a minimal wrapper/layout fix, and forcing another causal-conv implementation would violate the vendor-first/minimal-scope rule.
+
+Next target recommendation: profile with the new C53 child NVTX ranges when RunPod SSH is healthy. If `:kiln/gdn/conv/update` dominates, treat causal-conv as kernel/runtime-bound and move to the adjacent `:kiln/gdn/gates` + `:kiln/gdn/gated_norm` cluster. If `:kiln/gdn/conv/layout` dominates, scope a separate minimal layout/contiguity task.

--- a/docs/phase-c53/summary.json
+++ b/docs/phase-c53/summary.json
@@ -1,0 +1,65 @@
+{
+  "phase": "C53",
+  "date": "2026-04-24",
+  "type": "audit-only",
+  "base": {
+    "current_head": "3ea3747",
+    "c52_profile_commit": "55a5d9f26e6ca4be3d5f448935786d6a97e16a24",
+    "c52_summary": "docs/phase-c52/summary.json"
+  },
+  "precondition": {
+    "c52_recommendation_still_live": true,
+    "open_conv_pr_found": false,
+    "newer_profile_supersedes_c52": false
+  },
+  "c52_anchor": {
+    "range": ":kiln/gdn/conv",
+    "rank": 1,
+    "decode_wall_clock_share_percent": 15.4,
+    "total_ms": 562.361,
+    "instances": 2328
+  },
+  "static_audit": {
+    "native_mtp_decode_expected_fast_path": "backend.causal_conv1d_update",
+    "fallback_expected": false,
+    "reason": "CUDA backend supports fused conv1d unless KILN_DISABLE_FUSED_CONV1D is set, and kiln-conv1d-kernel supports the Qwen3.5 bf16/F32 state, seq_len=1, kernel_size=4 envelope."
+  },
+  "instrumentation": {
+    "code_path": "crates/kiln-model/src/forward.rs",
+    "nvtx_child_ranges": [
+      ":kiln/gdn/conv/layout",
+      ":kiln/gdn/conv/update",
+      ":kiln/gdn/conv/prefill_update",
+      ":kiln/gdn/conv/fallback_decode",
+      ":kiln/gdn/conv/fallback_prefill"
+    ]
+  },
+  "implementation": {
+    "shipped_speed_fix": false,
+    "conclusion": "No minimal implementation was justified by completed measurement; this PR ships attribution instrumentation and audit docs only."
+  },
+  "validation": {
+    "completed": false,
+    "reason": "RunPod SSH failures during required validation/build phase prevented tests and benchmark collection.",
+    "attempted_commands": [
+      "cargo test -p kiln-conv1d-kernel",
+      "cargo test -p kiln-model test_causal_conv1d_update_matches_fallback --features cuda -- --nocapture",
+      "cargo build --release --features cuda --bin kiln-bench"
+    ],
+    "pods": [
+      {
+        "id": "nszu2wno80dvef",
+        "gpu": "RTX A6000",
+        "status": "terminated",
+        "failure": "wait-file timed out; SSH reset connections"
+      },
+      {
+        "id": "efeldsa2tpx69s",
+        "gpu": "RTX A6000",
+        "status": "terminated",
+        "failure": "wait-file timed out; bounded SSH state check produced no output"
+      }
+    ]
+  },
+  "recommendation": "Re-run C52 native-MTP decode with C53 child NVTX ranges. If update dominates, move to gates + gated_norm; if layout dominates, open a separate minimal layout task."
+}


### PR DESCRIPTION
## Summary

- Audit-only C53 pass for the C52 `:kiln/gdn/conv` decode hotspot.
- Adds child NVTX attribution ranges under `:kiln/gdn/conv` for layout, fused update, prefill update, and explicit fallback timing.
- Documents that the existing `kiln-conv1d-kernel` vendored causal-conv update already covers the native-MTP single-token CUDA decode envelope; no speed fix is claimed.

## Artifacts

- C52 anchor: `docs/phase-c52/summary.json`
- C53 report: `docs/phase-c53/gdn-conv-decode-audit.md`
- C53 machine summary: `docs/phase-c53/summary.json`
- Profiling update: `PROFILING.md`

## Validation

Required commands were attempted on RunPod RTX A6000 pods, but did not complete due SSH failures during validation/build:

```bash
cargo test -p kiln-conv1d-kernel
cargo test -p kiln-model test_causal_conv1d_update_matches_fallback --features cuda -- --nocapture
cargo build --release --features cuda --bin kiln-bench
```

Pod attempts:

- `nszu2wno80dvef` — RTX A6000 — validation started, then `wait-file` timed out and SSH reset connections — terminated.
- `efeldsa2tpx69s` — RTX A6000 — fresh retry hit the same `wait-file` SSH timeout; bounded SSH state check produced no output — terminated.

Local checks:

- `jq . docs/phase-c53/summary.json` passed.
- `cargo fmt --check` could not run locally because this environment has no `cargo`; no local CUDA build/test was attempted per project policy.

## Conclusion

Audit-only, no implementation. Re-run the C52 native-MTP decode workload with these C53 child NVTX ranges when RunPod SSH is healthy. If `:kiln/gdn/conv/update` dominates, move to the adjacent `:kiln/gdn/gates` + `:kiln/gdn/gated_norm` target. If `:kiln/gdn/conv/layout` dominates, open a separate minimal layout/contiguity fix task.
