### PR TITLE
runpod: cap build parallelism to prevent sshd OOM wedge

### DIFF
--- a/deploy/runpod/kiln-setup.sh
+++ b/deploy/runpod/kiln-setup.sh
@@ -107,6 +107,13 @@ sccache --start-server
 echo "sccache server started"
 sccache --show-stats | head -8
 
+echo ""
+echo "=== pod resources ==="
+free -h || true
+echo "cpus: $(nproc)"
+nvidia-smi --query-gpu=name,memory.total,driver_version --format=csv,noheader 2>/dev/null || echo "no nvidia-smi"
+echo ""
+
 # Restore flash-attn artifacts if a kiln checkout is present
 if [ -d "${KILN_REPO_DIR}" ]; then
     b2 account authorize "${B2_APPLICATION_KEY_ID}" "${B2_APPLICATION_KEY}" >/dev/null 2>&1
@@ -133,6 +140,11 @@ export AWS_SECRET_ACCESS_KEY="${B2_APPLICATION_KEY}"
 export RUSTC_WRAPPER=sccache
 export PATH="/usr/local/cuda/bin:\${PATH}"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+# Cap build parallelism: nvcc -O3 can use 4-8GB per TU, and 5 CUDA kernel
+# crates × 24 default cargo jobs × multi-arch was OOM-killing sshd.
+export CARGO_BUILD_JOBS=4
+export NVCC_THREADS=1
+export KILN_CUDA_ARCHS=86
 ENVEOF
     echo "Wrote ${ENV_FILE}"
 fi
@@ -149,9 +161,27 @@ export AWS_SECRET_ACCESS_KEY="${B2_APPLICATION_KEY}"
 export RUSTC_WRAPPER=sccache
 export PATH="/usr/local/cuda/bin:\${PATH}"
 export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
+# Cap build parallelism: nvcc -O3 can use 4-8GB per TU, and 5 CUDA kernel
+# crates × 24 default cargo jobs × multi-arch was OOM-killing sshd.
+export CARGO_BUILD_JOBS=4
+export NVCC_THREADS=1
+export KILN_CUDA_ARCHS=86
 ENVEOF
+
+# Postmortem helper — run after any build wedge / failure to capture state
+cat > /root/kiln-postmortem.sh <<'POSTEOF'
+#!/usr/bin/env bash
+echo "=== free -h ==="; free -h
+echo "=== dmesg tail (OOM?) ==="; dmesg 2>/dev/null | tail -200
+echo "=== top procs ==="; ps auxf --sort=-%mem | head -30
+echo "=== disk ==="; df -h /workspace /tmp 2>/dev/null
+POSTEOF
+chmod +x /root/kiln-postmortem.sh
 
 echo ""
 echo "Build cache ready. Source the env file and build:"
 echo "  source /root/.kiln-build-env"
 echo "  cargo build --release --features cuda"
+echo ""
+echo "If a build wedges or sshd dies mid-build, run:"
+echo "  /root/kiln-postmortem.sh"


### PR DESCRIPTION
## Why

PR #473's RunPod validation has been wedging sshd mid-build. The likely cause is a system-RAM OOM: the global cargo config defaults to `build.jobs = 24`, and nvcc at -O3 can eat 4-8GB per translation unit. Five CUDA kernel crates × 24 parallel nvcc jobs × multi-arch easily blows past pod sysram, triggering the OOM-killer which takes sshd with it.

Symptom matches: no clean error, sshd just stops responding. Documented in agent notes `runpod-ssh-long-builds`, `runpod-cargo-test-flash-attn-oom`, and `kiln-ssh-polling-deadlock`.

This is the cheapest fix to unblock #473 without touching the kernel work.

## What

`deploy/runpod/kiln-setup.sh`:

1. **Caps build parallelism** in both `$KILN_REPO_DIR/.build-cache-env` and `/root/.kiln-build-env`:
   - `CARGO_BUILD_JOBS=4`
   - `NVCC_THREADS=1`
   - `KILN_CUDA_ARCHS=86` (was relying on agents remembering to set this)

2. **Logs pod resources** (free -h, nproc, nvidia-smi) before writing the env files so the setup log shows the starting point.

3. **Writes `/root/kiln-postmortem.sh`** — captures `free -h`, dmesg tail (for OOM kill messages), top procs by memory, and disk usage. The next wedge can be diagnosed instead of guessed.

4. Final echo points agents at the postmortem helper.

## Validation

`bash -n deploy/runpod/kiln-setup.sh` passes. No pod needed for this change.