### PR TITLE
phase6: document C54 conv child NVTX profile

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -7323,3 +7323,73 @@ treat causal-conv as already kernel/runtime-bound and move to the adjacent
 `:kiln/gdn/gates` + `:kiln/gdn/gated_norm` cluster. If
 `:kiln/gdn/conv/layout` dominates, open a separate minimal layout/contiguity
 fix task.
+
+## Phase 6 C54 GDN conv child NVTX profile (2026-04-24)
+
+C54 reran the C52 C40f-style native-MTP decode profile on current `origin/main`
+at `13a2a3d437680d299a1f4a17029cbca8b700701f`, after C53 added child NVTX
+ranges under `:kiln/gdn/conv`. Artifact:
+`docs/phase-c54/conv-child-nvtx-profile.md`; machine summary:
+`docs/phase-c54/summary.json`.
+
+Validation passed on an on-demand RTX A6000 RunPod pool lease
+`pod-c11fe496c432600caf0baa6a` / `sl53yvx5seviyx`: `cargo test -p
+kiln-conv1d-kernel --release -- --nocapture`, `cargo test -p kiln-model
+--release --features cuda test_causal_conv1d_update_matches_fallback --
+--nocapture`, and `cargo build --release --features cuda,nvtx --bin
+kiln-bench`. The pod was released after artifacts were copied; the subsequent
+RunPod status check showed no active pods.
+
+Profiler setup matched the C52 Nsight repair: the baked image had Nsight Systems
+`2023.4.4`, so C54 installed only `nsight-systems-2024.5.1` from the existing
+NVIDIA CUDA apt repo and used
+`/opt/nvidia/nsight-systems/2024.5.1/target-linux-x64/nsys`. The retained
+workload used `KILN_SPEC_METHOD=mtp`, `KILN_BENCH_FORCE_MTP=1`,
+`KILN_MTP_ARGMAX_FP32=1`, `KILN_W4A16=1`, `KILN_CUDA_GRAPHS=true`,
+`--model-path /workspace/qwen3.5-4b`, paged 512-token Humaneval prompt, 128
+generated tokens, `--skip-training`, `--chat-template`, `--latency-only`,
+temperature `0.0`, and seed `1`.
+
+The profiled run produced α `0.693`, decode `22.16 tok/s`, mean ITL `45.13 ms`,
+P50 ITL `31.74 ms`, and P99 ITL `105.52 ms`. Treat those as profiled
+attribution context only.
+
+Decode window attribution uses the same C52 method: first `:kiln/mtp/step` start
+through final decode NVTX end (`5880.202 ms`, 75 MTP steps), excluding the
+`:kiln/mtp/step` parent wrapper from the NVTX-duration denominator
+(`4848.439 ms`).
+
+| Rank | Decode range | Wall-clock share | Total time | Instances |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | `:kiln/gdn/conv` | 12.45% | 603.799 ms | 2352 |
+| 2 | `:kiln/gdn/gates` | 11.47% | 555.891 ms | 2352 |
+| 3 | `:kiln/gdn/conv/fallback_prefill` | 11.11% | 538.451 ms | 1800 |
+| 4 | `:kiln/gdn/gated_norm` | 10.79% | 523.019 ms | 2352 |
+| 5 | `:kiln/gdn/qk_norm` | 8.76% | 424.748 ms | 2352 |
+
+Child attribution under `:kiln/gdn/conv`:
+
+| Child range | Decode-window share | Total time | Instances | Share of conv parent |
+| --- | ---: | ---: | ---: | ---: |
+| `:kiln/gdn/conv/fallback_prefill` | 11.11% | 538.451 ms | 1800 | 89.18% |
+| `:kiln/gdn/conv/layout` | 0.90% | 43.672 ms | 2352 | 7.23% |
+| `:kiln/gdn/conv/update` | 0.23% | 11.114 ms | 552 | 1.84% |
+| `:kiln/gdn/conv/prefill_update` | 0.00% | 0.000 ms | 0 | 0.00% |
+| `:kiln/gdn/conv/fallback_decode` | 0.00% | 0.000 ms | 0 | 0.00% |
+
+Conclusion: C53's single-token decode audit was correct — `fallback_decode` is
+absent and the existing `causal_conv1d_update` wrapper is not the bottleneck.
+The material fallback is the native-MTP draft path: CUDA does not yet implement
+`supports_causal_conv1d_prefill` / `causal_conv1d_prefill`, so each `seq_len >
+1` GDN draft forward falls back to the portable prefill path. The 1800 fallback
+instances equal 24 GDN layers × 75 MTP steps.
+
+Recommendation: target a minimal CUDA `causal_conv1d_prefill` path for the
+native-MTP draft GDN conv shape before moving to `:kiln/gdn/gates` +
+`:kiln/gdn/gated_norm`. Suggested files are `crates/kiln-conv1d-kernel/src/lib.rs`,
+`crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu`,
+`crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.h`,
+`crates/kiln-model/src/backend/cuda.rs`, and `crates/kiln-model/src/forward.rs`.
+Do not retry the existing `seq_len == 1` update kernel; if the minimal CUDA
+prefill support envelope cannot cover the MTP draft shape, retarget to the
+gates/gated-norm cluster instead.

--- a/docs/phase-c54/conv-child-nvtx-profile.md
+++ b/docs/phase-c54/conv-child-nvtx-profile.md
@@ -1,0 +1,141 @@
+# Phase 6 C54 Conv Child NVTX Profile
+
+Date: 2026-04-24
+
+Commit: `13a2a3d437680d299a1f4a17029cbca8b700701f`
+
+GPU: NVIDIA RTX A6000 (`sl53yvx5seviyx`, lease `pod-c11fe496c432600caf0baa6a`)
+
+## Goal
+
+C54 reruns the C52 C40f-style native-MTP decode profile after C53 added child
+NVTX ranges under `:kiln/gdn/conv`. The goal is to split the C52 rank-1 GDN
+conv hotspot into layout, fused update, prefill update, and fallback ranges
+before choosing the next Phase 6 implementation target.
+
+Preconditions were satisfied on current `origin/main`: `docs/phase-c53/summary.json`
+is present, no `docs/phase-c54` or later profile existed, and no open PR already
+reran the C53 child attribution.
+
+## Validation
+
+RunPod pool lease `pod-c11fe496c432600caf0baa6a` used the required
+`ghcr.io/ericflo/kiln-runpod:latest` image on an on-demand RTX A6000. The pod
+was released after copying artifacts; `runpod_api.py status` reported no active
+pods afterward.
+
+Required commands:
+
+```bash
+cd /workspace/kiln
+git fetch origin main && git reset --hard origin/main
+source /root/.kiln-build-env
+export KILN_CUDA_ARCHS=86
+cargo test -p kiln-conv1d-kernel --release -- --nocapture
+cargo test -p kiln-model --release --features cuda test_causal_conv1d_update_matches_fallback -- --nocapture
+cargo build --release --features cuda,nvtx --bin kiln-bench
+```
+
+Results:
+
+- `kiln-conv1d-kernel`: 3 tests passed in release mode.
+- `kiln-model test_causal_conv1d_update_matches_fallback`: 1 test passed with CUDA.
+- `kiln-bench`: built successfully with `cuda,nvtx`.
+
+The baked image had Nsight Systems `2023.4.4`; C54 installed only
+`nsight-systems-2024.5.1` from the already-configured NVIDIA CUDA apt repo and
+used `/opt/nvidia/nsight-systems/2024.5.1/target-linux-x64/nsys` for capture and
+stats.
+
+## Profile Command
+
+The first literal command from the task brief omitted the currently required
+`--model-path` argument and produced an empty no-CUDA/no-NVTX report. The
+retained profile reran the same C52 workload with the C52 model path restored:
+
+```bash
+mkdir -p docs/phase-c54 /tmp/kiln-c54
+NSYS=/opt/nvidia/nsight-systems/2024.5.1/target-linux-x64/nsys
+$NSYS profile --force-overwrite=true --trace=cuda,nvtx,osrt --sample=none --cpuctxsw=none --cuda-memory-usage=false --output /tmp/kiln-c54/c54-conv-child-ranges \
+  env KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 KILN_W4A16=1 KILN_CUDA_GRAPHS=true \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1 \
+  2>&1 | tee docs/phase-c54/nsys-profile.log
+$NSYS stats --report nvtx_sum,nvtx_pushpop_trace,cuda_gpu_kern_sum,cuda_api_sum,cuda_kern_exec_sum --format csv --output docs/phase-c54/c54 /tmp/kiln-c54/c54-conv-child-ranges.nsys-rep \
+  2>&1 | tee docs/phase-c54/nsys-stats.log
+jq . docs/phase-c53/summary.json >/dev/null
+```
+
+Nsight generated the retained `.nsys-rep`. A stale SQLite export warning during
+stats processing required a stats-only rerun with `--force-export=true`; the
+final reports used the 2024.5.1 report names and imported successfully.
+
+The profiled run produced 128 tokens with α `0.693`, decode `22.16 tok/s`, mean
+ITL `45.13 ms`, P50 ITL `31.74 ms`, and P99 ITL `105.52 ms`. Treat those as
+profiled attribution context, not unprofiled throughput anchors.
+
+## Decode Window Method
+
+The reduction matches C52: use the first `:kiln/mtp/step` start through the
+final decode NVTX end, then exclude the `:kiln/mtp/step` parent wrapper from the
+NVTX-duration denominator. For C54 that window is `5880.202 ms`; the summed
+non-parent NVTX denominator is `4848.439 ms` across 75 MTP steps.
+
+The full `nvtx_pushpop_trace` CSV was used locally for reduction but is not
+committed because it is a multi-MB raw trace-like artifact. The committed
+summary is `docs/phase-c54/conv-child-ranges.csv`.
+
+## Top Decode NVTX Ranges
+
+| Rank | Decode range | Wall-clock share | Total time | Instances |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | `:kiln/gdn/conv` | 12.45% | 603.799 ms | 2352 |
+| 2 | `:kiln/gdn/gates` | 11.47% | 555.891 ms | 2352 |
+| 3 | `:kiln/gdn/conv/fallback_prefill` | 11.11% | 538.451 ms | 1800 |
+| 4 | `:kiln/gdn/gated_norm` | 10.79% | 523.019 ms | 2352 |
+| 5 | `:kiln/gdn/qk_norm` | 8.76% | 424.748 ms | 2352 |
+
+## Conv Child Attribution
+
+| Child range | Decode-window share | Total time | Instances | Share of conv parent |
+| --- | ---: | ---: | ---: | ---: |
+| `:kiln/gdn/conv/fallback_prefill` | 11.11% | 538.451 ms | 1800 | 89.18% |
+| `:kiln/gdn/conv/layout` | 0.90% | 43.672 ms | 2352 | 7.23% |
+| `:kiln/gdn/conv/update` | 0.23% | 11.114 ms | 552 | 1.84% |
+| `:kiln/gdn/conv/prefill_update` | 0.00% | 0.000 ms | 0 | 0.00% |
+| `:kiln/gdn/conv/fallback_decode` | 0.00% | 0.000 ms | 0 | 0.00% |
+
+The dominant child is not the `seq_len == 1` fused update wrapper and not the
+layout transpose. It is `fallback_prefill`, which accounts for nearly all of the
+remaining conv parent time.
+
+## Fallback Reason
+
+The C53 static audit was correct for single-token decode: CUDA implements
+`supports_causal_conv1d_update` and `causal_conv1d_update`, and C54 saw no
+material `:kiln/gdn/conv/fallback_decode` time.
+
+The material fallback is a different support-envelope gap. Native MTP decode
+invokes a `seq_len > 1` GDN forward for the draft path during each MTP step. The
+CUDA backend does not override `supports_causal_conv1d_prefill` or
+`causal_conv1d_prefill`, so `forward.rs` routes those draft-path conv calls
+through the portable prefill fallback. The 1800 `fallback_prefill` instances are
+exactly 24 GDN layers × 75 MTP steps.
+
+## Recommendation
+
+Next target: add a minimal CUDA `causal_conv1d_prefill` path for the native-MTP
+draft GDN conv shape before moving to `:kiln/gdn/gates` +
+`:kiln/gdn/gated_norm`.
+
+Suggested files:
+
+- `crates/kiln-conv1d-kernel/src/lib.rs`
+- `crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu`
+- `crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.h`
+- `crates/kiln-model/src/backend/cuda.rs`
+- `crates/kiln-model/src/forward.rs`
+
+Scope guard: this is not a retry of the existing `seq_len == 1` update kernel.
+If preflight shows the minimal CUDA prefill support envelope cannot cover bf16
+`[B,C,T]` with F32 state and `kernel_size == 4` for the MTP draft shape, stop
+and retarget to the adjacent gates/gated-norm cluster.

--- a/docs/phase-c54/conv-child-ranges.csv
+++ b/docs/phase-c54/conv-child-ranges.csv
@@ -1,0 +1,7 @@
+range,total_time_ms,instances,decode_window_share_pct,conv_parent_share_pct
+:kiln/gdn/conv,603.799,2352,12.45,100.00
+:kiln/gdn/conv/fallback_prefill,538.451,1800,11.11,89.18
+:kiln/gdn/conv/layout,43.672,2352,0.90,7.23
+:kiln/gdn/conv/update,11.114,552,0.23,1.84
+:kiln/gdn/conv/prefill_update,0.000,0,0.00,0.00
+:kiln/gdn/conv/fallback_decode,0.000,0,0.00,0.00

--- a/docs/phase-c54/nsys-profile.log
+++ b/docs/phase-c54/nsys-profile.log
@@ -1,0 +1,74 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-24T05:55:19.461534Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-24T05:55:19.462630Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-24T05:55:19.462768Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected; deferring CPU load until first use [3mmtp_prefix[0m[2m=[0mmtp.
+[2m2026-04-24T05:55:19.462777Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4206M parameters (8022 MB) across 32 layers
+[2m2026-04-24T05:55:19.462862Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-24T05:55:43.364765Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m21777 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 21777 ms (parallel)
+Model loaded in 24.65s (backend: cuda, VRAM: 0 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=49] (515 prompt tokens)...
+    Prefill (MTP): 430.9ms (1195 tok/s)
+[2m2026-04-24T05:55:45.062299Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m deferred native MTP CPU load complete [3mload_elapsed_ms[0m[2m=[0m1
+[2m2026-04-24T05:55:45.110752Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m48
+    Decode (MTP): 128 tokens, mean ITL 45.1ms (22.2 tok/s), α = 0.693 (52/75)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 24.65s (VRAM: 0 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         515
+Prefill time:          430.9 ms (1195 tok/s)
+Time to first token:   430.9 ms
+Mean inter-token:      45.1 ms (22.2 tok/s)
+P50 inter-token:       31.7 ms
+P99 inter-token:       105.5 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.693
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 24.649866308,
+    "model_vram_mb": 0
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 430.933435,
+    "prefill_tokens_per_sec": 1195.0801635988166,
+    "time_to_first_token_ms": 430.933435,
+    "mean_inter_token_ms": 45.13283295275591,
+    "p50_inter_token_ms": 31.7372225,
+    "p99_inter_token_ms": 105.52075900000001,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 22.15681876311152,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.6933333333333334,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}
+Collecting data...
+Generating '/tmp/nsys-report-35f5.qdstrm'
+[1/1] [0%                          ] c54-conv-child-ranges.nsys-rep[1/1] [0%                          ] c54-conv-child-ranges.nsys-rep[1/1] [0%                          ] c54-conv-child-ranges.nsys-rep[1/1] [7%                          ] c54-conv-child-ranges.nsys-rep[1/1] [6%                          ] c54-conv-child-ranges.nsys-rep[1/1] [12%                         ] c54-conv-child-ranges.nsys-rep[1/1] [11%                         ] c54-conv-child-ranges.nsys-rep[1/1] [10%                         ] c54-conv-child-ranges.nsys-rep[1/1] [9%                          ] c54-conv-child-ranges.nsys-rep[1/1] [8%                          ] c54-conv-child-ranges.nsys-rep[1/1] [7%                          ] c54-conv-child-ranges.nsys-rep[1/1] [6%                          ] c54-conv-child-ranges.nsys-rep[1/1] [5%                          ] c54-conv-child-ranges.nsys-rep[1/1] [0%                          ] c54-conv-child-ranges.nsys-rep[1/1] [5%                          ] c54-conv-child-ranges.nsys-rep[1/1] [6%                          ] c54-conv-child-ranges.nsys-rep[1/1] [7%                          ] c54-conv-child-ranges.nsys-rep[1/1] [8%                          ] c54-conv-child-ranges.nsys-rep[1/1] [9%                          ] c54-conv-child-ranges.nsys-rep[1/1] [10%                         ] c54-conv-child-ranges.nsys-rep[1/1] [11%                         ] c54-conv-child-ranges.nsys-rep[1/1] [12%                         ] c54-conv-child-ranges.nsys-rep[1/1] [13%                         ] c54-conv-child-ranges.nsys-rep[1/1] [14%                         ] c54-conv-child-ranges.nsys-rep[1/1] [=15%                        ] c54-conv-child-ranges.nsys-rep[1/1] [=16%                        ] c54-conv-child-ranges.nsys-rep[1/1] [=17%                        ] c54-conv-child-ranges.nsys-rep[1/1] [==18%                       ] c54-conv-child-ranges.nsys-rep[1/1] [==19%                       ] c54-conv-child-ranges.nsys-rep[1/1] [==20%                       ] c54-conv-child-ranges.nsys-rep[1/1] [==21%                       ] c54-conv-child-ranges.nsys-rep[1/1] [===22%                      ] c54-conv-child-ranges.nsys-rep[1/1] [===23%                      ] c54-conv-child-ranges.nsys-rep[1/1] [===24%                      ] c54-conv-child-ranges.nsys-rep[1/1] [====25%                     ] c54-conv-child-ranges.nsys-rep[1/1] [====26%                     ] c54-conv-child-ranges.nsys-rep[1/1] [====27%                     ] c54-conv-child-ranges.nsys-rep[1/1] [====28%                     ] c54-conv-child-ranges.nsys-rep[1/1] [=====29%                    ] c54-conv-child-ranges.nsys-rep[1/1] [=====30%                    ] c54-conv-child-ranges.nsys-rep[1/1] [=====31%                    ] c54-conv-child-ranges.nsys-rep[1/1] [=====32%                    ] c54-conv-child-ranges.nsys-rep[1/1] [======33%                   ] c54-conv-child-ranges.nsys-rep[1/1] [======34%                   ] c54-conv-child-ranges.nsys-rep[1/1] [======35%                   ] c54-conv-child-ranges.nsys-rep[1/1] [=======36%                  ] c54-conv-child-ranges.nsys-rep[1/1] [=======37%                  ] c54-conv-child-ranges.nsys-rep[1/1] [=======38%                  ] c54-conv-child-ranges.nsys-rep[1/1] [=======39%                  ] c54-conv-child-ranges.nsys-rep[1/1] [========40%                 ] c54-conv-child-ranges.nsys-rep[1/1] [========41%                 ] c54-conv-child-ranges.nsys-rep[1/1] [========42%                 ] c54-conv-child-ranges.nsys-rep[1/1] [=========43%                ] c54-conv-child-ranges.nsys-rep[1/1] [=========44%                ] c54-conv-child-ranges.nsys-rep[1/1] [=========45%                ] c54-conv-child-ranges.nsys-rep[1/1] [=========46%                ] c54-conv-child-ranges.nsys-rep[1/1] [==========47%               ] c54-conv-child-ranges.nsys-rep[1/1] [==========48%               ] c54-conv-child-ranges.nsys-rep[1/1] [==========49%               ] c54-conv-child-ranges.nsys-rep[1/1] [===========50%              ] c54-conv-child-ranges.nsys-rep[1/1] [===========51%              ] c54-conv-child-ranges.nsys-rep[1/1] [===========52%              ] c54-conv-child-ranges.nsys-rep[1/1] [===========53%              ] c54-conv-child-ranges.nsys-rep[1/1] [============54%             ] c54-conv-child-ranges.nsys-rep[1/1] [============55%             ] c54-conv-child-ranges.nsys-rep[1/1] [============56%             ] c54-conv-child-ranges.nsys-rep[1/1] [============57%             ] c54-conv-child-ranges.nsys-rep[1/1] [=============58%            ] c54-conv-child-ranges.nsys-rep[1/1] [=============59%            ] c54-conv-child-ranges.nsys-rep[1/1] [=============60%            ] c54-conv-child-ranges.nsys-rep[1/1] [==============61%           ] c54-conv-child-ranges.nsys-rep[1/1] [==============62%           ] c54-conv-child-ranges.nsys-rep[1/1] [==============63%           ] c54-conv-child-ranges.nsys-rep[1/1] [==============64%           ] c54-conv-child-ranges.nsys-rep[1/1] [===============65%          ] c54-conv-child-ranges.nsys-rep[1/1] [===============66%          ] c54-conv-child-ranges.nsys-rep[1/1] [===============67%          ] c54-conv-child-ranges.nsys-rep[1/1] [================68%         ] c54-conv-child-ranges.nsys-rep[1/1] [================69%         ] c54-conv-child-ranges.nsys-rep[1/1] [================70%         ] c54-conv-child-ranges.nsys-rep[1/1] [================71%         ] c54-conv-child-ranges.nsys-rep[1/1] [=================72%        ] c54-conv-child-ranges.nsys-rep[1/1] [=================73%        ] c54-conv-child-ranges.nsys-rep[1/1] [=================74%        ] c54-conv-child-ranges.nsys-rep[1/1] [==================75%       ] c54-conv-child-ranges.nsys-rep[1/1] [==================76%       ] c54-conv-child-ranges.nsys-rep[1/1] [==================77%       ] c54-conv-child-ranges.nsys-rep[1/1] [==================78%       ] c54-conv-child-ranges.nsys-rep[1/1] [===================79%      ] c54-conv-child-ranges.nsys-rep[1/1] [===================80%      ] c54-conv-child-ranges.nsys-rep[1/1] [===================81%      ] c54-conv-child-ranges.nsys-rep[1/1] [===================82%      ] c54-conv-child-ranges.nsys-rep[1/1] [====================83%     ] c54-conv-child-ranges.nsys-rep[1/1] [====================84%     ] c54-conv-child-ranges.nsys-rep[1/1] [====================85%     ] c54-conv-child-ranges.nsys-rep[1/1] [=====================86%    ] c54-conv-child-ranges.nsys-rep[1/1] [=====================87%    ] c54-conv-child-ranges.nsys-rep[1/1] [=====================88%    ] c54-conv-child-ranges.nsys-rep[1/1] [=====================89%    ] c54-conv-child-ranges.nsys-rep[1/1] [========================100%] c54-conv-child-ranges.nsys-rep[1/1] [========================100%] c54-conv-child-ranges.nsys-rep
+Generated:
+    /tmp/kiln-c54/c54-conv-child-ranges.nsys-rep

--- a/docs/phase-c54/nsys-stats.log
+++ b/docs/phase-c54/nsys-stats.log
@@ -1,0 +1,10 @@
+Generating SQLite file /tmp/kiln-c54/c54-conv-child-ranges.sqlite from /tmp/kiln-c54/c54-conv-child-ranges.nsys-rep
+Processing [/tmp/kiln-c54/c54-conv-child-ranges.sqlite] with [/opt/nvidia/nsight-systems/2024.5.1/host-linux-x64/reports/nvtx_sum.py] to [docs/phase-c54/c54_nvtx_sum.csv]... SKIPPED: output file docs/phase-c54/c54_nvtx_sum.csv exists.
+
+Processing [/tmp/kiln-c54/c54-conv-child-ranges.sqlite] with [/opt/nvidia/nsight-systems/2024.5.1/host-linux-x64/reports/nvtx_pushpop_trace.py] to [docs/phase-c54/c54_nvtx_pushpop_trace.csv]... SKIPPED: output file docs/phase-c54/c54_nvtx_pushpop_trace.csv exists.
+
+Processing [/tmp/kiln-c54/c54-conv-child-ranges.sqlite] with [/opt/nvidia/nsight-systems/2024.5.1/host-linux-x64/reports/cuda_gpu_kern_sum.py] to [docs/phase-c54/c54_cuda_gpu_kern_sum.csv]... SKIPPED: output file docs/phase-c54/c54_cuda_gpu_kern_sum.csv exists.
+
+Processing [/tmp/kiln-c54/c54-conv-child-ranges.sqlite] with [/opt/nvidia/nsight-systems/2024.5.1/host-linux-x64/reports/cuda_api_sum.py] to [docs/phase-c54/c54_cuda_api_sum.csv]... SKIPPED: output file docs/phase-c54/c54_cuda_api_sum.csv exists.
+
+Processing [/tmp/kiln-c54/c54-conv-child-ranges.sqlite] with [/opt/nvidia/nsight-systems/2024.5.1/host-linux-x64/reports/cuda_kern_exec_sum.py] to [docs/phase-c54/c54_cuda_kern_exec_sum.csv]... SKIPPED: output file docs/phase-c54/c54_cuda_kern_exec_sum.csv exists.

--- a/docs/phase-c54/summary.json
+++ b/docs/phase-c54/summary.json
@@ -1,0 +1,119 @@
+{
+  "phase": "C54",
+  "date_utc": "2026-04-24T05:56:00Z",
+  "type": "conv-child-nvtx-profile",
+  "commit": "13a2a3d437680d299a1f4a17029cbca8b700701f",
+  "base": {
+    "required_c53_summary": "docs/phase-c53/summary.json",
+    "c53_present": true,
+    "newer_phase_profile_found": false,
+    "open_rerun_pr_found": false
+  },
+  "gpu": "NVIDIA RTX A6000",
+  "pod": {
+    "lease_id": "pod-c11fe496c432600caf0baa6a",
+    "runpod_pod_id": "sl53yvx5seviyx",
+    "image": "ghcr.io/ericflo/kiln-runpod:latest",
+    "released_or_terminated": true,
+    "post_release_status": "No active pods"
+  },
+  "tool_versions": {
+    "cuda": "Build cuda_12.4.r12.4/compiler.34097967_0",
+    "selected_nsys": "NVIDIA Nsight Systems version 2024.5.1.113-245134619542v0",
+    "baked_nsys": "NVIDIA Nsight Systems version 2023.4.4.54-234433681190v0"
+  },
+  "validation": {
+    "status": "passed",
+    "commands": [
+      "cargo test -p kiln-conv1d-kernel --release -- --nocapture",
+      "cargo test -p kiln-model --release --features cuda test_causal_conv1d_update_matches_fallback -- --nocapture",
+      "cargo build --release --features cuda,nvtx --bin kiln-bench"
+    ],
+    "notes": [
+      "Nsight Systems 2024.5.1 was installed from the already-configured NVIDIA CUDA apt repository because the baked 2023.4.4 nsys was present.",
+      "The first required profile command omitted --model-path and produced empty stats; the retained C54 profile was rerun with the C52 model path /workspace/qwen3.5-4b.",
+      "The retained stats reports were generated with Nsight Systems 2024.5.1 report names. A stale SQLite warning required a stats-only rerun with --force-export=true."
+    ]
+  },
+  "benchmark_shape": {
+    "env": {
+      "KILN_SPEC_METHOD": "mtp",
+      "KILN_BENCH_FORCE_MTP": "1",
+      "KILN_MTP_ARGMAX_FP32": "1",
+      "KILN_W4A16": "1",
+      "KILN_CUDA_GRAPHS": "true"
+    },
+    "command": "./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1",
+    "prompt_tokens": 515,
+    "max_output_tokens": 128,
+    "temperature": 0.0,
+    "seed": 1,
+    "prompt_subset": "humaneval"
+  },
+  "benchmark_result": {
+    "prefill_time_ms": 430.933435,
+    "decode_tokens_per_sec": 22.15681876311152,
+    "mean_inter_token_ms": 45.13283295275591,
+    "p50_inter_token_ms": 31.7372225,
+    "p99_inter_token_ms": 105.52075900000001,
+    "acceptance_rate": 0.6933333333333334,
+    "tokens_generated": 128
+  },
+  "profiler_status": {
+    "primary": "success",
+    "decode_window_start_ns": 25513530562,
+    "decode_window_end_ns": 31393732841,
+    "decode_window_ms": 5880.202279,
+    "nvtx_denominator_ms_excluding_mtp_step_parent": 4848.439064,
+    "mtp_steps": 75,
+    "reports": [
+      "nvtx_sum",
+      "nvtx_pushpop_trace",
+      "cuda_gpu_kern_sum",
+      "cuda_api_sum",
+      "cuda_kern_exec_sum"
+    ],
+    "committed_artifacts": [
+      "docs/phase-c54/conv-child-nvtx-profile.md",
+      "docs/phase-c54/conv-child-ranges.csv",
+      "docs/phase-c54/nsys-profile.log",
+      "docs/phase-c54/nsys-stats.log"
+    ],
+    "uncommitted_artifacts": [
+      "/tmp/kiln-c54/c54-conv-child-ranges.nsys-rep",
+      "/tmp/kiln-c54/c54-conv-child-ranges.sqlite",
+      "full nvtx_pushpop_trace CSV used for reduction"
+    ]
+  },
+  "top_decode_ranges": [
+    {"rank": 1, "range": ":kiln/gdn/conv", "wall_clock_share_pct": 12.45, "total_time_ms": 603.799, "instances": 2352},
+    {"rank": 2, "range": ":kiln/gdn/gates", "wall_clock_share_pct": 11.47, "total_time_ms": 555.891, "instances": 2352},
+    {"rank": 3, "range": ":kiln/gdn/conv/fallback_prefill", "wall_clock_share_pct": 11.11, "total_time_ms": 538.451, "instances": 1800},
+    {"rank": 4, "range": ":kiln/gdn/gated_norm", "wall_clock_share_pct": 10.79, "total_time_ms": 523.019, "instances": 2352},
+    {"rank": 5, "range": ":kiln/gdn/qk_norm", "wall_clock_share_pct": 8.76, "total_time_ms": 424.748, "instances": 2352}
+  ],
+  "conv_child_ranges": [
+    {"range": ":kiln/gdn/conv/fallback_prefill", "total_time_ms": 538.451, "instances": 1800, "decode_window_share_pct": 11.11, "conv_parent_share_pct": 89.18},
+    {"range": ":kiln/gdn/conv/layout", "total_time_ms": 43.672, "instances": 2352, "decode_window_share_pct": 0.90, "conv_parent_share_pct": 7.23},
+    {"range": ":kiln/gdn/conv/update", "total_time_ms": 11.114, "instances": 552, "decode_window_share_pct": 0.23, "conv_parent_share_pct": 1.84},
+    {"range": ":kiln/gdn/conv/prefill_update", "total_time_ms": 0.0, "instances": 0, "decode_window_share_pct": 0.0, "conv_parent_share_pct": 0.0},
+    {"range": ":kiln/gdn/conv/fallback_decode", "total_time_ms": 0.0, "instances": 0, "decode_window_share_pct": 0.0, "conv_parent_share_pct": 0.0}
+  ],
+  "fallback_analysis": {
+    "material_fallback_ranges": [":kiln/gdn/conv/fallback_prefill"],
+    "reason": "The CUDA backend implements supports_causal_conv1d_update/causal_conv1d_update for seq_len == 1, but it does not override supports_causal_conv1d_prefill or causal_conv1d_prefill. Native MTP decode invokes a seq_len > 1 GDN forward for the draft path once per MTP step, so each of the 24 GDN layers routes through the portable prefill fallback. The 1800 fallback_prefill instances equal 24 GDN layers × 75 MTP steps.",
+    "fallback_decode_instances": 0,
+    "prefill_update_instances": 0
+  },
+  "recommendation": {
+    "next_target": "Add a minimal CUDA causal_conv1d_prefill path for the native-MTP draft GDN conv shape before moving to gates/gated_norm.",
+    "target_files": [
+      "crates/kiln-conv1d-kernel/src/lib.rs",
+      "crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu",
+      "crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.h",
+      "crates/kiln-model/src/backend/cuda.rs",
+      "crates/kiln-model/src/forward.rs"
+    ],
+    "abort_threshold": "If a preflight shows the minimal CUDA prefill support envelope cannot cover bf16 [B,C,T] with F32 state, kernel_size=4 for the MTP draft shape, stop and retarget to :kiln/gdn/gates + :kiln/gdn/gated_norm. Do not retry the existing seq_len==1 update kernel."
+  }
+}


### PR DESCRIPTION
## Summary

- Appends the Phase 6 C54 profile section to `PROFILING.md`.
- Adds `docs/phase-c54/conv-child-nvtx-profile.md` and `summary.json` for the C53 child NVTX rerun.
- Reduces the full `nvtx_pushpop_trace` locally into `docs/phase-c54/conv-child-ranges.csv` instead of committing multi-MB raw traces or `.nsys-rep` artifacts.

## Result

C54 shows `:kiln/gdn/conv/fallback_prefill` dominates the conv parent:

- `:kiln/gdn/conv`: 603.799 ms, 12.45% decode-window share, 2352 instances
- `:kiln/gdn/conv/fallback_prefill`: 538.451 ms, 11.11% decode-window share, 1800 instances, 89.18% of conv parent
- `:kiln/gdn/conv/layout`: 43.672 ms, 0.90% decode-window share
- `:kiln/gdn/conv/update`: 11.114 ms, 0.23% decode-window share
- `:kiln/gdn/conv/fallback_decode`: 0 instances

The fallback reason is the CUDA support envelope: CUDA has the `seq_len == 1` `causal_conv1d_update` path, but does not implement `supports_causal_conv1d_prefill` / `causal_conv1d_prefill`. Native MTP decode invokes a `seq_len > 1` GDN draft forward once per MTP step, so 24 GDN layers × 75 MTP steps route through the portable prefill fallback.

## Recommendation

Next target: add a minimal CUDA `causal_conv1d_prefill` path for the native-MTP draft GDN conv shape before moving to `:kiln/gdn/gates` + `:kiln/gdn/gated_norm`.

Suggested files:

- `crates/kiln-conv1d-kernel/src/lib.rs`
- `crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu`
- `crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.h`
- `crates/kiln-model/src/backend/cuda.rs`
- `crates/kiln-model/src/forward.rs`

Scope guard: do not retry the existing `seq_len == 1` update kernel. If preflight shows the minimal CUDA prefill envelope cannot cover bf16 `[B,C,T]` with F32 state and `kernel_size == 4` for the MTP draft shape, retarget to gates/gated-norm.

## Validation

RunPod:

- Lease id: `pod-c11fe496c432600caf0baa6a`
- Pod id: `sl53yvx5seviyx`
- GPU: `NVIDIA RTX A6000`
- Image: `ghcr.io/ericflo/kiln-runpod:latest`
- Cleanup: released/terminated; follow-up `runpod_api.py status` reported `No active pods`

Commands:

```bash
cargo test -p kiln-conv1d-kernel --release -- --nocapture
cargo test -p kiln-model --release --features cuda test_causal_conv1d_update_matches_fallback -- --nocapture
cargo build --release --features cuda,nvtx --bin kiln-bench
```

Profile command used Nsight Systems 2024.5.1 and the C52 workload with `--model-path /workspace/qwen3.5-4b`; details are in `docs/phase-c54/conv-child-nvtx-profile.md`.
