### PR TITLE
phase6: add CUDA conv1d prefill fast path

### DIFF
--- a/crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu
+++ b/crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu
@@ -105,6 +105,76 @@ __global__ __launch_bounds__(kThreadsPerBlock) void kiln_conv1d_update_k4_kernel
     out[xy_row] = acc;
 }
 
+template <bool kSilu>
+__global__ __launch_bounds__(kThreadsPerBlock) void kiln_conv1d_prefill_k4_kernel(
+    const __nv_bfloat16 *__restrict__ x,        // [B, C, T]
+    const __nv_bfloat16 *__restrict__ weight,   // [C, K]
+    float *__restrict__ conv_state,             // [B, C, K-1]
+    float *__restrict__ out,                    // [B, C, T]
+    int batch,
+    int channels,
+    int seq_len) {
+    const int bc = blockIdx.x;
+    const int tid = threadIdx.x;
+    const int total_channels = batch * channels;
+    if (bc >= total_channels) return;
+
+    const int c = bc % channels;
+    const size_t x_base = static_cast<size_t>(bc) * seq_len;
+    const size_t state_base = static_cast<size_t>(bc) * (kWidth - 1);
+    const size_t weight_base = static_cast<size_t>(c) * kWidth;
+
+    __shared__ float entry_state[kWidth - 1];
+    if (tid < kWidth - 1) {
+        entry_state[tid] = conv_state[state_base + tid];
+    }
+    __syncthreads();
+
+    float w[kWidth];
+#pragma unroll
+    for (int i = 0; i < kWidth; ++i) {
+        w[i] = __bfloat162float(weight[weight_base + i]);
+    }
+
+    for (int t = tid; t < seq_len; t += blockDim.x) {
+        float acc = 0.0f;
+#pragma unroll
+        for (int j = 0; j < kWidth; ++j) {
+            const int padded_idx = t + j;
+            float v;
+            if (padded_idx < kWidth - 1) {
+                v = entry_state[padded_idx];
+            } else {
+                v = __bfloat162float(x[x_base + padded_idx - (kWidth - 1)]);
+            }
+            acc += v * w[j];
+        }
+        if constexpr (kSilu) {
+            acc = acc / (1.0f + __expf(-acc));
+        }
+        out[x_base + t] = acc;
+    }
+    __syncthreads();
+
+    if (tid == 0) {
+        if (seq_len >= kWidth - 1) {
+#pragma unroll
+            for (int i = 0; i < kWidth - 1; ++i) {
+                conv_state[state_base + i] =
+                    __bfloat162float(x[x_base + seq_len - (kWidth - 1) + i]);
+            }
+        } else if (seq_len == 2) {
+            conv_state[state_base + 0] = entry_state[2];
+            conv_state[state_base + 1] = __bfloat162float(x[x_base + 0]);
+            conv_state[state_base + 2] = __bfloat162float(x[x_base + 1]);
+        } else if (seq_len == 1) {
+            conv_state[state_base + 0] = entry_state[1];
+            conv_state[state_base + 1] = entry_state[2];
+            conv_state[state_base + 2] = __bfloat162float(x[x_base]);
+        }
+    }
+}
+
 }  // namespace
 
 extern "C" kiln_conv1d_status_t kiln_causal_conv1d_update_bf16_f32(
@@ -139,6 +209,49 @@ extern "C" kiln_conv1d_status_t kiln_causal_conv1d_update_bf16_f32(
     } else {
         kiln_conv1d_update_k4_kernel<false><<<grid, block, 0, cu_stream>>>(
             x_bf, w_bf, state_f, out_f, batch, channels);
+    }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 3;
+    }
+    return 0;
+}
+
+extern "C" kiln_conv1d_status_t kiln_causal_conv1d_prefill_bf16_f32(
+    const void *x,
+    const void *weight,
+    void *conv_state,
+    void *out,
+    int batch,
+    int channels,
+    int seq_len,
+    int kernel_width,
+    int silu,
+    void *stream) {
+    if (kernel_width != kWidth) {
+        return 1;  // unsupported width (only K=4 compiled)
+    }
+    if (batch <= 0 || channels <= 0 || seq_len <= 1) {
+        return 2;
+    }
+
+    const int threads = seq_len <= 32 ? 32 : (seq_len <= 64 ? 64 : (seq_len <= 128 ? 128 : 256));
+    dim3 grid(batch * channels);
+    dim3 block(threads);
+    cudaStream_t cu_stream = static_cast<cudaStream_t>(stream);
+
+    const auto *x_bf = reinterpret_cast<const __nv_bfloat16 *>(x);
+    const auto *w_bf = reinterpret_cast<const __nv_bfloat16 *>(weight);
+    auto *state_f = reinterpret_cast<float *>(conv_state);
+    auto *out_f = reinterpret_cast<float *>(out);
+
+    if (silu != 0) {
+        kiln_conv1d_prefill_k4_kernel<true><<<grid, block, 0, cu_stream>>>(
+            x_bf, w_bf, state_f, out_f, batch, channels, seq_len);
+    } else {
+        kiln_conv1d_prefill_k4_kernel<false><<<grid, block, 0, cu_stream>>>(
+            x_bf, w_bf, state_f, out_f, batch, channels, seq_len);
     }
 
     cudaError_t err = cudaGetLastError();

--- a/crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.h
+++ b/crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.h
@@ -64,6 +64,34 @@ kiln_conv1d_status_t kiln_causal_conv1d_update_bf16_f32(
     void *stream
 );
 
+// Multi-token causal depthwise conv1d prefill with fused SiLU.
+//
+// All pointers are CUDA device memory, contiguous.
+//   x          : bf16, [B, C, T], T > 1
+//   weight     : bf16, [C, K]  (flat; caller's [C, 1, K] view is already contiguous)
+//   conv_state : f32,  [B, C, K-1] — read as the entry state, then written
+//   out        : f32,  [B, C, T]
+// Shape:
+//   B    = batch
+//   C    = channels
+//   T    = sequence length (must be > 1)
+//   K    = kernel width (must be 4 for the current specialisation)
+//   silu = 1 to fuse SiLU, 0 to leave the raw accumulator (parity-test mode)
+//
+// Returns 0 on success, non-zero on launch/config failure.
+kiln_conv1d_status_t kiln_causal_conv1d_prefill_bf16_f32(
+    const void *x,
+    const void *weight,
+    void *conv_state,
+    void *out,
+    int batch,
+    int channels,
+    int seq_len,
+    int kernel_width,
+    int silu,
+    void *stream
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/kiln-conv1d-kernel/src/lib.rs
+++ b/crates/kiln-conv1d-kernel/src/lib.rs
@@ -68,6 +68,19 @@ unsafe extern "C" {
         silu: i32,
         stream: *mut core::ffi::c_void,
     ) -> i32;
+
+    fn kiln_causal_conv1d_prefill_bf16_f32(
+        x: *const core::ffi::c_void,
+        weight: *const core::ffi::c_void,
+        conv_state: *mut core::ffi::c_void,
+        out: *mut core::ffi::c_void,
+        batch: i32,
+        channels: i32,
+        seq_len: i32,
+        kernel_width: i32,
+        silu: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
 }
 
 /// Whether the fused kernel can handle this call.
@@ -76,6 +89,16 @@ unsafe extern "C" {
 /// kernel was specialised for. All other shapes/dtypes should take the
 /// candle fallback path.
 pub fn supports(x: &Tensor, weight: &Tensor, conv_state: &Tensor, kernel_size: usize) -> bool {
+    supports_update(x, weight, conv_state, kernel_size)
+}
+
+/// Whether the fused single-token update kernel can handle this call.
+pub fn supports_update(
+    x: &Tensor,
+    weight: &Tensor,
+    conv_state: &Tensor,
+    kernel_size: usize,
+) -> bool {
     if kernel_size != 4 {
         return false;
     }
@@ -89,20 +112,68 @@ pub fn supports(x: &Tensor, weight: &Tensor, conv_state: &Tensor, kernel_size: u
         return false;
     }
     // x: [B, C, 1]
-    let Ok((_b, _c, t)) = x.dims3() else {
+    let Ok((batch, channels, t)) = x.dims3() else {
         return false;
     };
     if t != 1 {
         return false;
     }
     // conv_state: [B, C, K-1]
-    let Ok((_, _, ks)) = conv_state.dims3() else {
+    let Ok((bs, cs, ks)) = conv_state.dims3() else {
         return false;
     };
-    if ks != kernel_size - 1 {
+    if (bs, cs, ks) != (batch, channels, kernel_size - 1) {
         return false;
     }
-    true
+    weight_supports(weight, channels, kernel_size)
+}
+
+/// Whether the fused multi-token prefill kernel can handle this call.
+pub fn supports_prefill(
+    x: &Tensor,
+    weight: &Tensor,
+    conv_state: &Tensor,
+    kernel_size: usize,
+) -> bool {
+    if kernel_size != 4 {
+        return false;
+    }
+    if !matches!(x.device(), Device::Cuda(_)) {
+        return false;
+    }
+    if x.dtype() != DType::BF16 || weight.dtype() != DType::BF16 {
+        return false;
+    }
+    if conv_state.dtype() != DType::F32 {
+        return false;
+    }
+    // x: [B, C, T], T > 1
+    let Ok((batch, channels, t)) = x.dims3() else {
+        return false;
+    };
+    if t <= 1 {
+        return false;
+    }
+    // conv_state: [B, C, K-1]
+    let Ok((bs, cs, ks)) = conv_state.dims3() else {
+        return false;
+    };
+    if (bs, cs, ks) != (batch, channels, kernel_size - 1) {
+        return false;
+    }
+    weight_supports(weight, channels, kernel_size)
+}
+
+fn weight_supports(weight: &Tensor, channels: usize, kernel_size: usize) -> bool {
+    match weight.rank() {
+        3 => weight
+            .dims3()
+            .is_ok_and(|(c, one, k)| c == channels && one == 1 && k == kernel_size),
+        2 => weight
+            .dims2()
+            .is_ok_and(|(c, k)| c == channels && k == kernel_size),
+        _ => false,
+    }
 }
 
 /// Run the fused causal_conv1d_update kernel.
@@ -260,6 +331,162 @@ pub fn causal_conv1d_update(
     Ok(out)
 }
 
+/// Run the fused causal_conv1d prefill kernel.
+///
+/// Inputs:
+///   - `x`: bf16 `[B, C, T]`, `T > 1`.
+///   - `weight`: bf16 `[C, 1, K]` (or `[C, K]`) conv weights.
+///   - `conv_state`: F32 `[B, C, K-1]` — entry state, mutated after output.
+///   - `kernel_size`: must be 4.
+///
+/// Output: F32 `[B, C, T]` with SiLU fused inline. On return,
+/// `conv_state` contains the last K-1 input positions exactly like the
+/// portable prefill fallback.
+pub fn causal_conv1d_prefill(
+    x: &Tensor,
+    weight: &Tensor,
+    conv_state: &mut Tensor,
+    kernel_size: usize,
+) -> Result<Tensor> {
+    if kernel_size != 4 {
+        candle_core::bail!(
+            "kiln-conv1d-kernel: only kernel_size=4 is supported (got {kernel_size})"
+        );
+    }
+
+    let device = x.device();
+    let (batch, channels, seq_len) = x.dims3()?;
+    if seq_len <= 1 {
+        candle_core::bail!(
+            "kiln-conv1d-kernel: prefill path requires seq_len > 1 (got {seq_len})"
+        );
+    }
+
+    let weight_flat = match weight.rank() {
+        3 => {
+            let (c, one, k) = weight.dims3()?;
+            if c != channels || one != 1 || k != kernel_size {
+                candle_core::bail!(
+                    "kiln-conv1d-kernel: weight shape [{c}, {one}, {k}] does not match channels={channels} kernel_size={kernel_size}"
+                );
+            }
+            weight.reshape((channels, kernel_size))?
+        }
+        2 => {
+            let (c, k) = weight.dims2()?;
+            if c != channels || k != kernel_size {
+                candle_core::bail!(
+                    "kiln-conv1d-kernel: weight shape [{c}, {k}] does not match channels={channels} kernel_size={kernel_size}"
+                );
+            }
+            weight.clone()
+        }
+        r => {
+            candle_core::bail!("kiln-conv1d-kernel: weight must be rank 2 or 3 (got rank {r})")
+        }
+    };
+
+    let (bs, cs, ks) = conv_state.dims3()?;
+    if (bs, cs, ks) != (batch, channels, kernel_size - 1) {
+        candle_core::bail!(
+            "kiln-conv1d-kernel: conv_state shape [{bs}, {cs}, {ks}] mismatch with [{batch}, {channels}, {}] ",
+            kernel_size - 1
+        );
+    }
+
+    if x.dtype() != DType::BF16 {
+        candle_core::bail!("kiln-conv1d-kernel: x must be bf16 (got {:?})", x.dtype());
+    }
+    if weight_flat.dtype() != DType::BF16 {
+        candle_core::bail!(
+            "kiln-conv1d-kernel: weight must be bf16 (got {:?})",
+            weight_flat.dtype()
+        );
+    }
+    if conv_state.dtype() != DType::F32 {
+        candle_core::bail!(
+            "kiln-conv1d-kernel: conv_state must be f32 (got {:?})",
+            conv_state.dtype()
+        );
+    }
+
+    let x = x.contiguous()?;
+    let weight_flat = weight_flat.contiguous()?;
+    if !conv_state.is_contiguous() {
+        *conv_state = conv_state.contiguous()?;
+    }
+
+    let out = Tensor::zeros((batch, channels, seq_len), DType::F32, device)?;
+
+    {
+        let (x_storage, x_layout) = x.storage_and_layout();
+        let (w_storage, w_layout) = weight_flat.storage_and_layout();
+        let (s_storage, s_layout) = conv_state.storage_and_layout();
+        let (o_storage, o_layout) = out.storage_and_layout();
+
+        let x_cuda = match &*x_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-conv1d-kernel: x must be on CUDA"),
+        };
+        let w_cuda = match &*w_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-conv1d-kernel: weight must be on CUDA"),
+        };
+        let s_cuda = match &*s_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-conv1d-kernel: conv_state must be on CUDA"),
+        };
+        let o_cuda = match &*o_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-conv1d-kernel: out must be on CUDA"),
+        };
+
+        let stream = x_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let x_slice = x_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(x_layout.start_offset()..);
+        let w_slice = w_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(w_layout.start_offset()..);
+        let s_slice = s_cuda
+            .as_cuda_slice::<f32>()?
+            .slice(s_layout.start_offset()..);
+        let o_slice = o_cuda
+            .as_cuda_slice::<f32>()?
+            .slice(o_layout.start_offset()..);
+
+        unsafe {
+            let (x_ptr, _g1) = x_slice.device_ptr(&stream);
+            let (w_ptr, _g2) = w_slice.device_ptr(&stream);
+            let (s_ptr, _g3) = s_slice.device_ptr(&stream);
+            let (o_ptr, _g4) = o_slice.device_ptr(&stream);
+
+            let status = kiln_causal_conv1d_prefill_bf16_f32(
+                x_ptr as *const _,
+                w_ptr as *const _,
+                s_ptr as *mut _,
+                o_ptr as *mut _,
+                batch as i32,
+                channels as i32,
+                seq_len as i32,
+                kernel_size as i32,
+                1,
+                raw_stream,
+            );
+
+            if status != 0 {
+                candle_core::bail!(
+                    "kiln_causal_conv1d_prefill_bf16_f32 failed with status {status}"
+                );
+            }
+        }
+    }
+
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -281,6 +508,41 @@ mod tests {
         let output = window.broadcast_mul(&w_expanded)?.sum(2)?.unsqueeze(2)?;
         *conv_state = window.narrow(2, 1, kernel_size - 1)?.contiguous()?;
         // SiLU: x / (1 + exp(-x))
+        let ones = output.ones_like()?;
+        let silu = (&output / (ones.clone() + output.neg()?.exp()?)?)?;
+        Ok(silu)
+    }
+
+    fn reference_prefill_with_silu(
+        x: &Tensor,
+        weight: &Tensor,
+        conv_state: &mut Tensor,
+        kernel_size: usize,
+    ) -> Result<Tensor> {
+        let (_batch, channels, seq_len) = x.dims3()?;
+        let x_f32 = x.to_dtype(DType::F32)?;
+        let w_f32 = weight.to_dtype(DType::F32)?.reshape((channels, kernel_size))?;
+        let x_padded = Tensor::cat(&[&conv_state.clone(), &x_f32], 2)?;
+        let mut outs = Vec::with_capacity(seq_len);
+        for t in 0..seq_len {
+            let window = x_padded.narrow(2, t, kernel_size)?;
+            let out_t = window
+                .broadcast_mul(&w_f32.unsqueeze(0)?)?
+                .sum(2)?
+                .unsqueeze(2)?;
+            outs.push(out_t);
+        }
+        let outs_ref: Vec<&Tensor> = outs.iter().collect();
+        let output = Tensor::cat(&outs_ref, 2)?;
+        *conv_state = if seq_len >= kernel_size - 1 {
+            x_f32
+                .narrow(2, seq_len - (kernel_size - 1), kernel_size - 1)?
+                .contiguous()?
+        } else {
+            let keep = kernel_size - 1 - seq_len;
+            let old_part = conv_state.narrow(2, seq_len, keep)?;
+            Tensor::cat(&[&old_part, &x_f32], 2)?.contiguous()?
+        };
         let ones = output.ones_like()?;
         let silu = (&output / (ones.clone() + output.neg()?.exp()?)?)?;
         Ok(silu)
@@ -364,6 +626,65 @@ mod tests {
     }
 
     #[test]
+    fn parity_qwen35_prefill_shape() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        let batch = 1;
+        let channels = 8192;
+        let seq_len = 16;
+        let kernel_size = 4;
+
+        let raw_x = seeded(batch * channels * seq_len, 0x1234_9876, 0.5);
+        let raw_w = seeded(channels * kernel_size, 0xface_feed, 0.1);
+        let raw_state = seeded(batch * channels * (kernel_size - 1), 0xbeef_cafe, 0.3);
+
+        let x_f32 = Tensor::from_vec(raw_x, (batch, channels, seq_len), &device).unwrap();
+        let w_f32 = Tensor::from_vec(raw_w, (channels, 1, kernel_size), &device).unwrap();
+        let state_ref_f32 =
+            Tensor::from_vec(raw_state.clone(), (batch, channels, kernel_size - 1), &device)
+                .unwrap();
+
+        let x = x_f32.to_dtype(DType::BF16).unwrap();
+        let w = w_f32.to_dtype(DType::BF16).unwrap();
+        let mut state_ref = state_ref_f32.clone();
+        let mut state_fused = state_ref_f32.clone();
+
+        let y_ref = reference_prefill_with_silu(&x, &w, &mut state_ref, kernel_size).unwrap();
+        let y_fused = causal_conv1d_prefill(&x, &w, &mut state_fused, kernel_size).unwrap();
+
+        let diff = (&y_ref - &y_fused)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+
+        assert!(
+            diff < 2e-3,
+            "prefill output parity failed: max_abs_diff={diff} exceeds 2e-3"
+        );
+
+        let state_diff = (&state_ref - &state_fused)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+
+        assert!(
+            state_diff < 1e-5,
+            "prefill conv_state parity failed: max_abs_diff={state_diff} exceeds 1e-5"
+        );
+    }
+
+    #[test]
     fn supports_rejects_wrong_width() {
         let Some(device) = try_cuda_device() else {
             eprintln!("skipping: no CUDA device");
@@ -387,5 +708,8 @@ mod tests {
         let w = Tensor::zeros((8192, 1, 4), DType::BF16, &device).unwrap();
         let s = Tensor::zeros((1, 8192, 3), DType::F32, &device).unwrap();
         assert!(supports(&x, &w, &s, 4));
+
+        let x_prefill = Tensor::zeros((1, 8192, 16), DType::BF16, &device).unwrap();
+        assert!(supports_prefill(&x_prefill, &w, &s, 4));
     }
 }

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -277,6 +277,10 @@ impl BackendRuntime for CudaBackend {
         self.fused_conv1d_enabled
     }
 
+    fn supports_causal_conv1d_prefill(&self) -> bool {
+        self.fused_conv1d_enabled
+    }
+
     fn causal_conv1d_update(
         &self,
         x: &Tensor,
@@ -292,6 +296,24 @@ impl BackendRuntime for CudaBackend {
         }
         let out = kiln_conv1d_kernel::causal_conv1d_update(x, weight, conv_state, kernel_size)
             .context("causal_conv1d_update kernel failed")?;
+        Ok(Some(out))
+    }
+
+    fn causal_conv1d_prefill(
+        &self,
+        x: &Tensor,
+        weight: &Tensor,
+        conv_state: &mut Tensor,
+        kernel_size: usize,
+    ) -> Result<Option<Tensor>> {
+        if !self.fused_conv1d_enabled {
+            return Ok(None);
+        }
+        if !kiln_conv1d_kernel::supports_prefill(x, weight, conv_state, kernel_size) {
+            return Ok(None);
+        }
+        let out = kiln_conv1d_kernel::causal_conv1d_prefill(x, weight, conv_state, kernel_size)
+            .context("causal_conv1d_prefill kernel failed")?;
         Ok(Some(out))
     }
 }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -9824,6 +9824,90 @@ mod tests {
         Ok(())
     }
 
+    /// Parity check for the fused CUDA causal_conv1d prefill kernel against
+    /// the portable `causal_conv1d_prefill` + `cuda_silu` chain, at the native
+    /// MTP draft shape that exercises `seq_len > 1`.
+    #[cfg(feature = "cuda")]
+    #[test]
+    fn test_causal_conv1d_prefill_matches_fallback() -> Result<()> {
+        use rand::rngs::StdRng;
+        use rand::{Rng, SeedableRng};
+
+        let device = match Device::new_cuda(0) {
+            Ok(d) => d,
+            Err(_) => {
+                eprintln!(
+                    "CUDA not available, skipping test_causal_conv1d_prefill_matches_fallback"
+                );
+                return Ok(());
+            }
+        };
+
+        let batch = 1usize;
+        let channels = 8192usize; // Qwen3.5-4B linear_qkv_dim
+        let seq_len = 16usize;
+        let kernel_size = 4usize;
+
+        let mut rng = StdRng::seed_from_u64(0xC0_1DC0DE);
+        let n_x = batch * channels * seq_len;
+        let n_w = channels * kernel_size;
+        let n_s = batch * channels * (kernel_size - 1);
+
+        let x_data: Vec<f32> = (0..n_x).map(|_| rng.gen_range(-0.5f32..0.5f32)).collect();
+        let w_data: Vec<f32> = (0..n_w).map(|_| rng.gen_range(-0.1f32..0.1f32)).collect();
+        let s_data: Vec<f32> = (0..n_s).map(|_| rng.gen_range(-0.3f32..0.3f32)).collect();
+
+        let x = Tensor::from_slice(&x_data, (batch, channels, seq_len), &device)?
+            .to_dtype(DType::BF16)?;
+        let w = Tensor::from_slice(&w_data, (channels, 1, kernel_size), &device)?
+            .to_dtype(DType::BF16)?;
+        let s_init = Tensor::from_slice(&s_data, (batch, channels, kernel_size - 1), &device)?;
+
+        let mut s_fb = s_init.clone();
+        let out_fb = causal_conv1d_prefill_with_dtype(&x, &w, &mut s_fb, kernel_size, DType::F32)?;
+        let out_fb = cuda_silu(&out_fb)?;
+
+        let backend = crate::backend::for_device(&device);
+        if !backend.supports_causal_conv1d_prefill() {
+            eprintln!(
+                "backend declines causal_conv1d_prefill (KILN_DISABLE_FUSED_CONV1D?); skipping"
+            );
+            return Ok(());
+        }
+        let mut s_k = s_init.clone();
+        let out_k = match backend.causal_conv1d_prefill(&x, &w, &mut s_k, kernel_size)? {
+            Some(t) => t,
+            None => {
+                eprintln!("backend declined causal_conv1d_prefill at Qwen3.5 envelope; skipping");
+                return Ok(());
+            }
+        };
+
+        let diff = (out_k.to_dtype(DType::F32)? - out_fb.to_dtype(DType::F32)?)?;
+        let abs = diff.abs()?;
+        let max = abs.flatten_all()?.max(0)?.to_scalar::<f32>()?;
+        let mean = abs.flatten_all()?.mean(0)?.to_scalar::<f32>()?;
+        eprintln!("conv1d_prefill vs fallback: max_abs_diff={max:e} mean_abs_diff={mean:e}");
+        assert!(
+            max < 2e-3,
+            "fused conv1d_prefill output max_abs_diff={max:e} exceeds 2e-3"
+        );
+        assert!(
+            mean < 5e-4,
+            "fused conv1d_prefill output mean_abs_diff={mean:e} exceeds 5e-4"
+        );
+
+        let sdiff = (s_k.to_dtype(DType::F32)? - s_fb.to_dtype(DType::F32)?)?;
+        let smax = sdiff.abs()?.flatten_all()?.max(0)?.to_scalar::<f32>()?;
+        eprintln!("conv1d_prefill state parity: max_abs_diff={smax:e}");
+        assert!(
+            smax < 1e-5,
+            "fused conv1d_prefill state max_abs_diff={smax:e} exceeds 1e-5"
+        );
+
+        Ok(())
+    }
+
     /// Metal parity check for `backend.causal_conv1d_update` against the same
     /// portable `causal_conv1d_decode` + `cuda_silu` oracle used by CUDA.
     #[cfg(feature = "metal")]


### PR DESCRIPTION
## Summary
- add a minimal CUDA bf16/F32 K=4 `causal_conv1d_prefill` C ABI and Rust wrapper in `kiln-conv1d-kernel`
- wire CUDA backend `supports_causal_conv1d_prefill` / `causal_conv1d_prefill` through the existing `KILN_DISABLE_FUSED_CONV1D` kill switch
- add CUDA parity coverage against the portable prefill + SiLU fallback and crate-level prefill parity/support checks

## Scope
- fixed Qwen3.5 GDN envelope only: bf16 `[B, C, T]`, bf16 `[C, 1, 4]`/`[C, 4]`, F32 `[B, C, 3]`, F32 output with fused SiLU
- no bias, arbitrary width, arbitrary dtype, circular buffer, or backward path

## Validation
- `git diff --check` passed locally
- RunPod validation blocked before SSH/runtime assignment: two pool A6000 leases and one direct `ghcr.io/ericflo/kiln-runpod:latest` A6000 launch all remained `runtime: null`; all pods were released/terminated to avoid spend
- 2026-04-24 retry blocked before SSH/runtime assignment again:
  - direct A6000 `l7ro619fnttux6` (`kiln-pr476-validate`) stayed `runtime: null`; terminated
  - direct A40 `69vwbc0pqkujl3` (`kiln-pr476-validate-a40`, same sm_86 fallback) stayed `runtime: null`; terminated
  - pool A6000 lease `pod-369bfcf41bd03e59b6d22aa6` / pod `hwt8k608akvcpv` stayed `runtime: null`; released and terminated
  - direct RTX 6000 Ada `nk07g8aeq3324l` (`kiln-pr476-validate-ada`) stayed `runtime: null`; terminated
- Not run due blocked pod runtime: `cargo test -p kiln-conv1d-kernel --release -- --nocapture`
- Not run due blocked pod runtime: `cargo test -p kiln-model --release --features cuda test_causal_conv1d_update_matches_fallback -- --nocapture`
- Not run due blocked pod runtime: `cargo test -p kiln-model --release --features cuda causal_conv1d_prefill -- --nocapture`
- Not run due blocked pod runtime: `cargo build --release --features cuda,nvtx --bin kiln-bench`
- 2026-04-24 A6000 GPU validation passed:
  - pod `al3q30l81esd0u` (`kiln-pr476-validate`), `NVIDIA RTX A6000`, `KILN_CUDA_ARCHS=86`
  - `cargo test -p kiln-conv1d-kernel --release -- --nocapture` passed: 4 tests passed
  - `cargo test -p kiln-model --release --features cuda test_causal_conv1d_update_matches_fallback -- --nocapture` passed: 1 test passed, 243 filtered
  - `cargo test -p kiln-model --release --features cuda causal_conv1d_prefill -- --nocapture` passed: 1 test passed, 243 filtered
  - `cargo build --release --features cuda,nvtx --bin kiln-bench` passed; release build finished successfully
