### PR TITLE
ci: force static MSVC CRT on Windows CUDA build

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -307,6 +307,15 @@ jobs:
           cuda: '12.4.1'
           method: 'local'
 
+      - name: Set up MSVC dev environment
+        # candle-kernels compiles .cu files with nvcc, which shells out
+        # to MSVC's cl.exe for host-side code. Server 2022 has MSVC
+        # installed but not on PATH by default; this action runs
+        # vcvarsall.bat and exports the env vars to subsequent steps.
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
+
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -279,6 +279,14 @@ jobs:
       # build time to pick an SM and the CI runner has no GPU. SM80 PTX
       # JIT-compiles to every arch we target.
       CUDA_COMPUTE_CAP: '80'
+      # Force the static MSVC runtime (`/MT`) across the whole build.
+      # The Rust default is `/MD` (dynamic), but `esaxx-rs` (pulled in
+      # via `tokenizers`) compiles its C++ with `/MT`, and CUDA 12.4's
+      # `cudart_static.lib` is also `/MT`. Mixing produces
+      # `LNK2038: mismatch detected for 'RuntimeLibrary'`. Picking `/MT`
+      # everywhere also means the shipped `kiln.exe` doesn't require
+      # `msvcr*.dll` on end-user machines — a nice distribution win.
+      RUSTFLAGS: '-C target-feature=+crt-static'
     steps:
       - uses: actions/checkout@v4
 

--- a/crates/kiln-flash-attn/build.rs
+++ b/crates/kiln-flash-attn/build.rs
@@ -43,6 +43,7 @@ fn main() {
     build.flag("--expt-extended-lambda");
     build.flag("-Xcompiler").flag("-fPIC");
     build.flag("-DFLASH_NAMESPACE=kiln_flash");
+    build.flag("-D_USE_MATH_DEFINES");
 
     // Suppress noisy warnings from CUTLASS templates
     build.flag("-diag-suppress=177");  // variable declared but never referenced


### PR DESCRIPTION
## What

Adds `RUSTFLAGS: '-C target-feature=+crt-static'` to the `windows-cuda` job env block.

## Why

With PR #469 (CUDA toolkit install) + PR #472 (MSVC PATH + M_LOG2E) merged, the Windows build now reaches the link step. The final blocker is an MSVC runtime-library mismatch:

```
libesaxx_rs-....rlib(esaxx.o) : error LNK2038: mismatch detected for 'RuntimeLibrary':
  value 'MT_StaticRelease' doesn't match value 'MD_DynamicRelease' in
  libkiln_marlin_gemm-....rlib(marlin_kernel.o)
```

Rust defaults to `/MD` (dynamic CRT) on `x86_64-pc-windows-msvc`, but:

- **esaxx-rs** (C++, pulled in via `tokenizers`) compiles with `/MT` (static)
- **CUDA 12.4's `cudart_static.lib`** is also `/MT`

Mixing `/MT` and `/MD` in the same final `.exe` is not allowed by the MSVC linker. Setting `target-feature=+crt-static` tells rustc (and the `cc` crate) to pick `/MT` everywhere, so they all agree.

Side benefit: the shipped `kiln.exe` no longer depends on `msvcr*.dll` or `vcruntime140.dll` being present on the end user's machine — slightly more robust distribution.

## Validation

Triggered via `workflow_dispatch` on this branch (run 24876010951). Linux CUDA + macOS Metal already re-validated green on PR #472's last run (24873133121). Windows CUDA was the only remaining red job.

## Follow-ups

Once green and merged, the `kiln-v0.2.0` release needs a workflow dispatch against that tag to backfill the missing Linux + Windows assets (release currently only has the macOS tarball).
