### PR TITLE
phase6: fix conv1d prefill launch bounds

### DIFF
--- a/crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu
+++ b/crates/kiln-conv1d-kernel/csrc/causal_conv1d_update.cu
@@ -50,6 +50,7 @@
 namespace {
 
 constexpr int kThreadsPerBlock = 64;
+constexpr int kPrefillThreadsPerBlock = 256;
 constexpr int kWidth = 4;  // specialisation — Qwen3.5 GDN
 
 template <bool kSilu>
@@ -106,7 +107,7 @@ __global__ __launch_bounds__(kThreadsPerBlock) void kiln_conv1d_update_k4_kernel
 }
 
 template <bool kSilu>
-__global__ __launch_bounds__(kThreadsPerBlock) void kiln_conv1d_prefill_k4_kernel(
+__global__ __launch_bounds__(kPrefillThreadsPerBlock) void kiln_conv1d_prefill_k4_kernel(
     const __nv_bfloat16 *__restrict__ x,        // [B, C, T]
     const __nv_bfloat16 *__restrict__ weight,   // [C, K]
     float *__restrict__ conv_state,             // [B, C, K-1]
@@ -236,7 +237,9 @@ extern "C" kiln_conv1d_status_t kiln_causal_conv1d_prefill_bf16_f32(
         return 2;
     }
 
-    const int threads = seq_len <= 32 ? 32 : (seq_len <= 64 ? 64 : (seq_len <= 128 ? 128 : 256));
+    const int threads = seq_len <= 32 ? 32
+                        : (seq_len <= 64 ? 64
+                                          : (seq_len <= 128 ? 128 : kPrefillThreadsPerBlock));
     dim3 grid(batch * channels);
     dim3 block(threads);
     cudaStream_t cu_stream = static_cast<cudaStream_t>(stream);

--- a/crates/kiln-conv1d-kernel/src/lib.rs
+++ b/crates/kiln-conv1d-kernel/src/lib.rs
@@ -83,6 +83,15 @@ unsafe extern "C" {
     ) -> i32;
 }
 
+fn conv1d_status_description(status: i32) -> &'static str {
+    match status {
+        1 => "unsupported kernel width (only kernel_size=4 is compiled)",
+        2 => "invalid launch dimensions",
+        3 => "CUDA launch failed; check the kernel launch bounds and requested block size",
+        _ => "unknown CUDA conv1d kernel failure",
+    }
+}
+
 /// Whether the fused kernel can handle this call.
 ///
 /// Returns `true` only for the exact bf16/f32/K=4 envelope the vendored
@@ -322,7 +331,8 @@ pub fn causal_conv1d_update(
 
             if status != 0 {
                 candle_core::bail!(
-                    "kiln_causal_conv1d_update_bf16_f32 failed with status {status}"
+                    "kiln_causal_conv1d_update_bf16_f32 failed with status {status}: {} (batch={batch}, channels={channels}, kernel_size={kernel_size})",
+                    conv1d_status_description(status)
                 );
             }
         }
@@ -478,7 +488,8 @@ pub fn causal_conv1d_prefill(
 
             if status != 0 {
                 candle_core::bail!(
-                    "kiln_causal_conv1d_prefill_bf16_f32 failed with status {status}"
+                    "kiln_causal_conv1d_prefill_bf16_f32 failed with status {status}: {} (batch={batch}, channels={channels}, seq_len={seq_len}, kernel_size={kernel_size})",
+                    conv1d_status_description(status)
                 );
             }
         }
@@ -634,7 +645,7 @@ mod tests {
 
         let batch = 1;
         let channels = 8192;
-        let seq_len = 16;
+        let seq_len = 512;
         let kernel_size = 4;
 
         let raw_x = seeded(batch * channels * seq_len, 0x1234_9876, 0.5);


### PR DESCRIPTION
## Summary
- fixes the CUDA prefill kernel launch bounds mismatch by giving the prefill kernel a 256-thread launch bound
- keeps the decode kernel at its 64-thread launch bound
- expands the Qwen3.5 conv1d prefill parity test from seq_len=16 to seq_len=512 so it exercises the 256-thread launch path that failed native-MTP prefill
- adds actionable status context to conv1d kernel launch errors

## Validation
- Not run: local environment has no Cargo/CUDA (`cargo` is not installed here, and project rules forbid local CUDA builds).
- Blocked: RunPod on-demand capacity was unavailable for A6000, pool A6000, A40, A100, RTX 6000 Ada, and L40S attempts on 2026-04-24.

## Required follow-up when capacity returns
Run the task's required commands on A6000:

```bash
export KILN_CUDA_ARCHS=86
cargo test -p kiln-conv1d-kernel --release -- --nocapture
cargo test -p kiln-model --release --features cuda test_causal_conv1d_update_matches_fallback -- --nocapture
cargo test -p kiln-model --release --features cuda test_causal_conv1d_prefill_matches_fallback -- --nocapture
cargo test -p kiln-model --release --features cuda causal_conv1d_prefill -- --nocapture
cargo build --release --features cuda,nvtx --bin kiln-bench
env KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 KILN_W4A16=1 KILN_CUDA_GRAPHS=true \
  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 16 --skip-training --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1 \
  2>&1 | tee /tmp/kiln-mtp-prefill-fix.log
```
