### PR TITLE
phase6: enable fused GDN qk norm by default

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,5 +1,39 @@
 # Kiln Profiling Report
 
+## Phase 6 default-on fused GDN qk_norm validation (2026-04-24)
+
+PR scope: make the existing CUDA fused L2 Q/K norm path the default for bf16
+CUDA tensors supported by `kiln_rmsnorm_kernel::fused_l2_qk_norm`, with
+`KILN_DISABLE_FUSED_L2_QK_NORM=1` as the candle fallback opt-out.
+
+Validation ran on an on-demand RTX A6000 RunPod pod
+`ztru3dal6px398` using `ghcr.io/ericflo/kiln-runpod:latest`,
+`KILN_CUDA_ARCHS=86`, `KILN_W4A16=1`, and `KILN_CUDA_GRAPHS=true`.
+
+- `cargo test -p kiln-rmsnorm-kernel --release -- --nocapture`: passed, 6
+  tests including all `parity_l2_qk_norm_*` coverage.
+- `cargo test -p kiln-model --release --features cuda gdn -- --nocapture`:
+  7/8 matching tests passed; `test_gdn_chunk_body_matches_fallback` failed
+  with `max_abs_diff 2.109375e0`, and the same focused test still failed
+  with `KILN_DISABLE_FUSED_L2_QK_NORM=1`, so this is not attributable to
+  the default-on qk_norm dispatch.
+- `cargo build --release --features cuda,nvtx --bin kiln-bench`: passed.
+- Default-on latency arm (`--paged --prompt-tokens 512 --max-output-tokens 64`):
+  494 prompt tokens, 65 generated tokens, prefill 1736.8 ms, mean ITL 24.3 ms,
+  decode 41.1 tok/s. This was the first post-load arm and includes cold-start
+  noise.
+- Opt-out latency arm (`KILN_DISABLE_FUSED_L2_QK_NORM=1`, same command): 494
+  prompt tokens, 65 generated tokens, prefill 352.8 ms, mean ITL 19.9 ms,
+  decode 50.2 tok/s. Treat the paired wall-clock comparison as noisy because
+  it ran second after model/kernel warmup.
+
+A short default-on NVTX profile on the same A6000 run reported
+`:kiln/gdn/qk_norm` at **11.4%** of total NVTX push/pop time
+(`277.014 ms`, 1560 instances). That is below the post-#481 plain-decode
+source-of-truth share of **24.4%**, but the run was a short validation profile
+under Nsight Systems 2023.4.4 and is not a strict replacement for the
+post-#481 decode-window methodology.
+
 ## Phase 6 post-#481 current-main profile refresh (2026-04-24)
 
 **Scope:** refresh the Phase 6 source of truth after PR

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2438,8 +2438,8 @@ fn gdn_qk_norm(q: &Tensor, k: &Tensor, input_dtype: DType, scale: f64) -> Result
 
     #[cfg(feature = "cuda")]
     {
-        let enabled = std::env::var("KILN_ENABLE_FUSED_L2_QK_NORM").is_ok();
-        if enabled && input_dtype == DType::BF16 && kiln_rmsnorm_kernel::supports_l2_qk_norm(q, k) {
+        let disabled = std::env::var("KILN_DISABLE_FUSED_L2_QK_NORM").is_ok();
+        if !disabled && input_dtype == DType::BF16 && kiln_rmsnorm_kernel::supports_l2_qk_norm(q, k) {
             return kiln_rmsnorm_kernel::fused_l2_qk_norm(q, k, scale as f32, 1e-6)
                 .context("fused_l2_qk_norm kernel failed");
         }
@@ -3414,24 +3414,11 @@ fn gated_deltanet_forward_decode_if(
 
         // --- Step 4/5: GQA head repeat (nk → nv), L2 normalize Q/K, scale Q ---
         //
-        // Fast paths: Metal defaults to a fused F32->BF16 kernel for the desktop
-        // hot path, and CUDA keeps its opt-in `kiln_rmsnorm_kernel::fused_l2_qk_norm`.
-        // Both collapse the l2-normalize(Q) + scale(Q) + l2-normalize(K) +
-        // dtype-cast chain (~11 candle launches on tiny per-row tensors at decode
-        // shape) into a single launch.
-        //
-        // The CUDA fused kernel remains **opt-in via
-        // `KILN_ENABLE_FUSED_L2_QK_NORM=1`**. Phase 6 wallclock validation on Arm B
-        // (RTX A6000, KILN_W4A16=1
-        // KILN_CUDA_GRAPHS=true, paged 512/128, 3 paired runs) measured a
-        // median speedup of 1.0093x — well below the task's 1.05x abort floor.
-        // Mean ITL improved by 0.18ms (0.92%); only p99 ITL showed a
-        // meaningful win (24.78ms -> 20.25ms, -18% tail latency) and the
-        // run-to-run variance tightened. The kernel is correct (parity tests
-        // and the full nextest suite pass) but the wallclock impact at the
-        // Qwen3.5-4B GDN decode shape does not meet
-        // the bar to engage by default. See PROFILING.md "Phase 6 fused
-        // qk_norm null result" for the full numbers and analysis.
+        // Fast paths: Metal and CUDA default to fused F32->BF16 kernels for
+        // supported bf16 tensors. Both collapse the l2-normalize(Q) + scale(Q) +
+        // l2-normalize(K) + dtype-cast chain (~11 candle launches on tiny per-row
+        // tensors at decode shape) into a single launch. CUDA can be forced back
+        // to the candle parity path with `KILN_DISABLE_FUSED_L2_QK_NORM=1`.
         //
         // Both paths produce bf16 outputs in `input_dtype`; only the kernel
         // path skips the F32 round-trip through HBM. The candle path is the


### PR DESCRIPTION
## Summary
- make CUDA `kiln_rmsnorm_kernel::fused_l2_qk_norm` the default for supported BF16 GDN Q/K tensors
- replace the old opt-in env with `KILN_DISABLE_FUSED_L2_QK_NORM=1` as the emergency fallback
- document RunPod validation and short NVTX profile in `PROFILING.md`

## Validation
RunPod on-demand RTX A6000 pod `ztru3dal6px398`, `ghcr.io/ericflo/kiln-runpod:latest`, `KILN_CUDA_ARCHS=86`, `KILN_W4A16=1`, `KILN_CUDA_GRAPHS=true`.

- `cargo test -p kiln-rmsnorm-kernel --release -- --nocapture` ✅ 6 passed, including all `parity_l2_qk_norm_*` tests
- `cargo test -p kiln-model --release --features cuda gdn -- --nocapture` ⚠️ 7/8 passed; `forward::tests::test_gdn_chunk_body_matches_fallback` failed with `chunk-body out_chunk max_abs_diff 2.109375e0 exceeds 2e-2`
- Re-ran the focused failing test with `KILN_DISABLE_FUSED_L2_QK_NORM=1`; it failed the same way, so the failure is not caused by the default-on qk_norm path
- `cargo build --release --features cuda,nvtx --bin kiln-bench` ✅
- Default-on bench: prefill `1736.8 ms`, mean ITL `24.3 ms`, decode `41.1 tok/s` (first post-load arm; cold-start noisy)
- Opt-out bench: prefill `352.8 ms`, mean ITL `19.9 ms`, decode `50.2 tok/s` (second arm; warmed, not an apples-to-apples speed claim)

## Profiling
- Short default-on NVTX profile: `:kiln/gdn/qk_norm` was `11.4%` of total NVTX push/pop time (`277.014 ms`, 1560 instances)
- This is below the post-#481 source-of-truth `24.4%`, but the short profile used Nsight Systems 2023.4.4 and does not replace the post-#481 decode-window method
