### PR TITLE
release: kiln-v0.2.1 server re-cut with CI fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Kiln Server Changelog
 
+## kiln-v0.2.1 — 2026-04-24
+
+Server re-cut to include CI fixes that were missing from kiln-v0.2.0. No
+user-facing behavior changes from v0.2.0 in the core server; this cut also
+picks up phase-6 Metal and CUDA kernel work landed on main between v0.2.0 and
+v0.2.1.
+
+### CI fixes shipped for the full platform matrix
+- Bump Jimver/cuda-toolkit from v0.2.19 to v0.2.35 to handle NVIDIA's renamed
+  installer URLs (#469)
+- Install MSVC dev env on Windows before CUDA build; fixes M_LOG2E undefined
+  in flash_api_c.cu under MSVC (#472)
+- Force static MSVC CRT on Windows CUDA build; fixes CRT mismatch between
+  esaxx-rs and kiln-marlin-gemm (#477)
+
+### Phase 6 CUDA decode work
+- Fuse CUDA GDN gated RMSNorm (#466)
+- Add CUDA conv1d prefill fast path and fix conv1d prefill launch bounds
+  (#481)
+- Document post-466 and post-468 MTP decode profiles and post-476 MTP profile
+  failure (#468, #480)
+- Audit GDN conv decode hotspot and refresh post-#481 current-main profile
+  (#473, #483)
+
+### Phase 6 Metal decode work
+- Fuse Metal LM-head argmax for greedy decode and reduce Metal LM-head argmax
+  on GPU (#471)
+- Speed up Metal decode GEMV and route GDN out-proj through Metal decode GEMV
+- Fuse Metal full-attention QKV projections and fuse Metal GDN decode QKV
+  conv norm
+- Persist transposed weight cache asynchronously
+
+### Infrastructure
+- Cap cargo and nvcc parallelism and add OOM postmortem helper for RunPod
+  builds (#474)
+
 ## kiln-v0.2.0 — 2026-04-24
 
 Coordinated release aligned with desktop-v0.2.0. Headline work is the Metal

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "candle-core",
  "cc",
@@ -1722,7 +1722,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1735,7 +1735,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "candle-core",
  "cc",
@@ -1744,7 +1744,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1753,7 +1753,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "candle-core",
  "cc",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1801,11 +1801,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.0"
+version = "0.2.1"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "candle-core",
  "cc",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1823,7 +1823,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## What

Re-cuts the kiln server release as **kiln-v0.2.1** to ship the full platform
binary set (Linux CUDA + macOS Metal + Windows CUDA) that kiln-v0.2.0 was
supposed to ship.

Desktop stays at **desktop-v0.2.0**. This is a server-only cut.

## Why

kiln-v0.2.0 only shipped the macOS Metal tarball because the Linux and Windows
CUDA build jobs in the release workflow were broken — NVIDIA had renamed
installer URLs out from under Jimver/cuda-toolkit, MSVC's `<cmath>` needed
`_USE_MATH_DEFINES`, and there was a CRT mismatch between esaxx-rs and
kiln-marlin-gemm.

Three CI fixes have since landed on main, and a manual `workflow_dispatch` run
(24876010951) on the fix branch confirmed all three platforms now build green.
Because those fixes themselves landed new commits, the right move is a fresh
tag that picks up the CI fixes plus the phase-6 work that landed in parallel
on main.

## Changes in this PR

- `Cargo.toml`: bump `[workspace.package].version` 0.2.0 → 0.2.1 (single
  source of truth; all kiln crates inherit via `version.workspace = true`)
- `Cargo.lock`: regenerated to match
- `CHANGELOG.md`: new kiln-v0.2.1 entry summarizing CI fixes + phase 6 work

`desktop/` is intentionally untouched.

## CI fixes shipped for the full platform matrix

- #469 — bump Jimver/cuda-toolkit v0.2.19 → v0.2.35 (NVIDIA URL rename)
- #472 — install MSVC dev env on Windows before CUDA build (M_LOG2E fix)
- #477 — force static MSVC CRT (CRT mismatch between esaxx-rs and
  kiln-marlin-gemm)

## Phase 6 work landed between v0.2.0 and v0.2.1

See CHANGELOG.md for the full grouped list.

## Release workflow

After this PR merges, tag `kiln-v0.2.1` on main will trigger
`.github/workflows/server-release.yml`. Expect:
- 3 signed+notarized tarballs: macOS Metal (arm64), Linux CUDA 12.4 (x86_64),
  Windows CUDA 12.4 (x86_64)
- 3 matching .sha256 files
- Draft release → publish with `gh release edit kiln-v0.2.1 --draft=false`
- Mark kiln-v0.2.0 as superseded