### PR TITLE
runpod: don't pin KILN_CUDA_ARCHS in build env

### DIFF
--- a/deploy/runpod/kiln-setup.sh
+++ b/deploy/runpod/kiln-setup.sh
@@ -144,7 +144,6 @@ export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 # crates × 24 default cargo jobs × multi-arch was OOM-killing sshd.
 export CARGO_BUILD_JOBS=4
 export NVCC_THREADS=1
-export KILN_CUDA_ARCHS=86
 ENVEOF
     echo "Wrote ${ENV_FILE}"
 fi
@@ -165,7 +164,6 @@ export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 # crates × 24 default cargo jobs × multi-arch was OOM-killing sshd.
 export CARGO_BUILD_JOBS=4
 export NVCC_THREADS=1
-export KILN_CUDA_ARCHS=86
 ENVEOF
 
 # Postmortem helper — run after any build wedge / failure to capture state


### PR DESCRIPTION
## Why

PR #474 shipped the OOM parallelism caps to `deploy/runpod/kiln-setup.sh` but also pinned `KILN_CUDA_ARCHS=86` in both `.build-cache-env` and `/root/.kiln-build-env`. That pin was not intended to ship.

- `KILN_CUDA_ARCHS=86` is an A6000-only iteration-time speedup, not a correctness setting. Kiln is supposed to work on sm80 (A100), sm86 (A6000/3090/4090), sm89 (L40S/RTX 6000 Ada), and sm90 (H100/H200).
- Baking `=86` into the env hides latent sm80/89/90 regressions because builds never exercise those paths.
- The kiln pool already falls back off A6000 regularly (A100 80GB PCIe is the reliable fallback). A hardcoded `=86` would silently produce broken binaries on fallback pods — the fused RMSNorm kernel has no soft fallback and crashes on first launch.

## What

Delete both `export KILN_CUDA_ARCHS=86` lines from the two heredocs in `deploy/runpod/kiln-setup.sh`.

The real OOM fix from #474 stays:
- `export CARGO_BUILD_JOBS=4` — kept
- `export NVCC_THREADS=1` — kept
- Pre-build logging and `/root/kiln-postmortem.sh` — kept

## Note

The kiln-runpod image rebuild workflow (`.github/workflows/runpod-image.yml`) auto-triggers on changes under `deploy/runpod/**`, so this PR will trigger a fresh image build.