### PR TITLE
phase6: recover C57 native MTP conv prefill profile

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,5 +1,78 @@
 # Kiln Profiling Report
 
+## Phase 6 C57 native-MTP conv1d prefill recovery profile (2026-04-24)
+
+**Scope:** verify that the C56 CUDA `causal_conv1d_prefill` status-3 blocker is
+cleared on current `main`, keep regression coverage on the real C56 prefill
+envelope, and refresh the native-MTP decode-window source of truth.
+
+**Precondition outcome:** proceed. `PROFILING.md` had a newer post-#486 plain
+decode/prefill profile, but no newer artifact than C56 that both exercised the
+CUDA conv1d prefill fast path and reached native-MTP decode (`:kiln/mtp/step`).
+
+**Root-cause status:** current `main` already includes PR #481 (`7227b4c`),
+which fixed the C56 root cause by matching the prefill kernel
+`__launch_bounds__` to the largest 256-thread launch path. C57 adds model-level
+regression coverage by running the CUDA prefill parity test at `seq_len=512`,
+the C56 native-MTP prompt prefill envelope.
+
+**Hardware / image:** RunPod on-demand `NVIDIA RTX A6000`, pod
+`6lv4pu241ofanf`, `ghcr.io/ericflo/kiln-runpod:latest`, driver `550.127.08`,
+CUDA toolkit `12.4`, `KILN_CUDA_ARCHS=86`. The pod was terminated after
+artifacts were copied.
+
+**Validation:**
+
+- `cargo test -p kiln-conv1d-kernel --release -- --nocapture`: 4 passed.
+- `cargo test -p kiln-model --release --features cuda causal_conv1d_prefill -- --nocapture`: 1 passed at the 512-token C56 prefill envelope.
+- `cargo test -p kiln-model --release --features cuda test_causal_conv1d_update_matches_fallback -- --nocapture`: 1 passed.
+- `cargo build --release --features cuda,nvtx --bin kiln-bench`: succeeded.
+
+**Profile command:**
+
+```bash
+nsys profile --force-overwrite=true --trace=cuda,nvtx --sample=none --cpuctxsw=none --cuda-memory-usage=false --output /tmp/kiln-c57/c57-mtp-conv-prefill-v2 \
+  env KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 KILN_W4A16=1 KILN_CUDA_GRAPHS=true \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1
+```
+
+**Result:** the profile reached `:kiln/mtp/step`; the C56 prefill status-3
+failure did not reproduce on current `main`. Latency metrics were 515 prompt
+tokens, 417.7 ms prefill (1233 tok/s), 128 generated tokens, **26.5 decode
+tok/s**, **37.8 ms mean ITL**, and **MTP α = 0.764**.
+
+### C57 top native-MTP decode hotspots
+
+Source: `docs/phase-c57/top_decode_nvtx.csv`. Decode window is first
+`:kiln/mtp/step` start through final decode NVTX end, excluding the
+`:kiln/mtp/step` parent wrapper.
+
+| Rank | NVTX range | Wall-clock share |
+| ---: | --- | ---: |
+| 1 | `:kiln/gdn/gates` | **14.45%** |
+| 2 | `:kiln/gdn/gated_norm` | **13.55%** |
+| 3 | `:kiln/gdn/qk_norm` | **11.02%** |
+
+### C57 top native-MTP prefill hotspots
+
+Source: `docs/phase-c57/top_prefill_nvtx.csv`.
+
+| Rank | NVTX range | Wall-clock share |
+| ---: | --- | ---: |
+| 1 | `:kiln/gdn/in_proj` | **59.49%** |
+| 2 | `:kiln/attn/full/prefill_initial` | **12.67%** |
+| 3 | `:kiln/gdn/qk_norm` | **4.47%** |
+
+**Verdict:** C56's profiling blocker is cleared on current `main`, and Phase 6
+should use C57, not failed C56, when selecting the next native-MTP decode target.
+The top native-MTP decode buckets are now GDN gates, gated_norm, and qk_norm.
+
+Committed artifacts: `docs/phase-c57/conv-prefill-mtp-profile.md`,
+`docs/phase-c57/summary.json`, `docs/phase-c57/top_decode_nvtx.csv`,
+`docs/phase-c57/top_prefill_nvtx.csv`,
+`docs/phase-c57/c57-mtp-conv-prefill-v2_cuda_gpu_kern_sum.csv`,
+`docs/phase-c57/nsys-profile-v2.log`, and `docs/phase-c57/nsys-stats-v2.log`.
+
 ## Phase 6 post-#486 current-main profile refresh (2026-04-24)
 
 **Scope:** refresh the Phase 6 CUDA source of truth after PR

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -10175,7 +10175,7 @@ mod tests {
 
         let batch = 1usize;
         let channels = 8192usize; // Qwen3.5-4B linear_qkv_dim
-        let seq_len = 16usize;
+        let seq_len = 512usize;
         let kernel_size = 4usize;
 
         let mut rng = StdRng::seed_from_u64(0xC0_1DC0DE);

--- a/docs/phase-c57/c57-mtp-conv-prefill-v2_cuda_gpu_kern_sum.csv
+++ b/docs/phase-c57/c57-mtp-conv-prefill-v2_cuda_gpu_kern_sum.csv
@@ -1,0 +1,67 @@
+Time (%),Total Time (ns),Instances,Avg (ns),Med (ns),Min (ns),Max (ns),StdDev (ns),Name
+18.7,374274332,20329,18410.9,2816.0,1856,97191558,683660.0,ucopy_bf16
+9.9,197546870,9256,21342.6,21024.0,18688,23360,1114.8,"void Marlin<(int)256, (int)1, (int)8, (int)8, (int)4, (int)8>(const int4 *, const int4 *, int4 *, const int4 *, int, int, int, int *)"
+8.6,173320418,234,740685.5,76352.0,74880,1810020,842870.9,void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_256x64_32x4_nn_align8>(T1::Params)
+6.5,129522292,72,1798920.7,1798260.5,1794373,1804261,2639.7,void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_128x64_32x6_nn_align8>(T1::Params)
+5.6,111677366,1728,64628.1,64448.0,64096,68929,820.9,ampere_bf16_s16816gemm_bf16_128x64_sliced1x2_ldg8_f2f_stages_64x3_nn
+4.9,98624300,2712,36365.9,37280.0,33345,38336,1431.7,ampere_bf16_s16816gemm_bf16_64x64_sliced1x2_ldg8_f2f_stages_64x5_nn
+3.5,70903760,3456,20516.1,20512.0,19903,21216,298.6,void cutlass::Kernel2<cutlass_80_wmma_tensorop_bf16_s161616gemm_bf16_32x32_128x2_nn_align8>(T1::Params)
+3.4,67274380,192,350387.4,350289.0,349665,352161,432.0,"<unnamed>::gdn_full_chunk_forward_kernel(const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, __nv_bfloat16 *, __nv_bfloat16 *, int, int)"
+2.9,57959790,1728,33541.5,33505.0,32992,34272,217.7,ampere_bf16_s16816gemm_bf16_64x64_ldg8_f2f_stages_64x5_nn
+2.7,53297656,12633,4218.9,1376.0,1151,250305,22172.0,cast_bf16_f32
+2.5,50098435,17298,2896.2,2912.0,1311,74337,4152.1,bmul_f32
+2.4,48692217,2328,20915.9,10944.0,10239,71776,15559.9,void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_64x64_32x6_nn_align8>(T1::Params)
+2.3,46768930,14328,3264.2,2560.0,2176,75552,5303.7,ucopy_f32
+2.1,42453831,8448,5025.3,1536.0,1279,55968,7583.3,bmul_bf16
+2.0,40996122,7794,5260.0,6048.0,1600,22464,1902.2,"<unnamed>::fused_rmsnorm_kernel(const __nv_bfloat16 *, const __nv_bfloat16 *, __nv_bfloat16 *, int, float)"
+1.7,33215426,14544,2283.8,1312.0,1151,60672,2773.6,cast_f32_bf16
+1.5,30266296,480,63054.8,62912.0,62560,66303,577.5,ampere_bf16_s16816gemm_bf16_128x64_ldg8_f2f_stages_64x3_nn
+1.1,23040155,145,158897.6,116640.0,100800,217633,55885.2,fast_argmax_f32
+1.1,21433649,720,29769.0,30320.5,27424,63584,3826.2,"void kiln_flash::flash_fwd_kernel<Flash_fwd_kernel_traits<(int)256, (int)64, (int)64, (int)4, (bool)0, (bool)0, cutlass::bfloat16_t, Flash_kernel_traits<(int)256, (int)64, (int)64, (int)4, cutlass::bfloat16_t>>, (bool)0, (bool)1, (bool)0, (bool)0, (bool)0, (bool)1, (bool)0, (bool)0>(kiln_flash::Flash_fwd_params)"
+1.0,20818602,104,200178.9,200464.5,175904,208480,7355.0,"void Marlin<(int)256, (int)4, (int)16, (int)4, (int)4, (int)8>(const int4 *, const int4 *, int4 *, const int4 *, int, int, int, int *)"
+1.0,20766427,15120,1373.4,1280.0,1183,28448,1512.7,affine_f32
+0.9,18891518,7656,2467.5,1887.0,1247,16192,1845.8,badd_bf16
+0.9,18419138,6480,2842.5,2368.0,2303,44385,4382.4,fast_sum_f32
+0.9,17797090,4320,4119.7,3392.0,3072,69024,6814.1,bdiv_f32
+0.8,15701623,4272,3675.5,3456.0,3327,5888,601.9,void cutlass::Kernel2<cutlass_80_wmma_tensorop_bf16_s161616gemm_bf16_32x32_64x1_nn_align8>(T1::Params)
+0.8,15227751,9360,1626.9,1248.0,1184,45984,3865.4,cast_f16_bf16
+0.7,14646652,1752,8360.0,7871.0,7680,44928,4262.0,"void <unnamed>::kiln_conv1d_prefill_k4_kernel<(bool)1>(const __nv_bfloat16 *, const __nv_bfloat16 *, float *, float *, int, int, int)"
+0.7,14069203,9360,1503.1,1280.0,1183,46592,2785.8,cast_bf16_f16
+0.7,13694945,8064,1698.3,1248.0,1184,3744,750.4,badd_f32
+0.6,11610658,8640,1343.8,1248.0,1152,28353,1415.6,uneg_f32
+0.5,10715726,6480,1653.7,1376.0,1248,28640,2804.8,usqr_f32
+0.5,10390808,1752,5930.8,5888.0,5760,8769,330.7,"void <unnamed>::gdn_chunk_scan_kernel<(int)64>(const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, __nv_bfloat16 *, __nv_bfloat16 *, int, int)"
+0.5,10290860,3456,2977.7,2912.5,2719,3328,231.0,void cutlass::Kernel2<cutlass_80_wmma_tensorop_bf16_s161616gemm_bf16_32x32_128x1_nn_align2>(T1::Params)
+0.5,10081640,5976,1687.0,1376.0,1280,49185,3565.0,uexp_bf16
+0.5,10072770,5904,1706.1,1344.0,1248,47936,3485.9,uneg_bf16
+0.5,9825586,5904,1664.2,1376.0,1280,50272,3646.0,urecip_bf16
+0.5,9637145,5976,1612.6,1344.0,1247,47649,3449.5,affine_bf16
+0.5,9570633,6480,1476.9,1376.0,1279,28512,1635.2,uexp_f32
+0.4,8320404,6480,1284.0,1280.0,1215,1856,53.3,usqrt_f32
+0.4,7520975,56,134303.1,159856.5,99552,160449,30037.4,ampere_bf16_s16816gemm_bf16_256x128_ldg8_f2f_stages_32x3_nn
+0.3,6685667,1728,3869.0,3872.0,3776,3969,32.9,void cutlass::Kernel2<cutlass_80_wmma_tensorop_bf16_s161616gemm_bf16_32x32_32x1_nn_align2>(T1::Params)
+0.3,6492023,4320,1502.8,1344.0,1247,28480,2000.6,urecip_f32
+0.3,6071993,408,14882.3,14880.0,14401,15040,69.8,"void <unnamed>::recurrent_gdn_fwd_kernel<(int)128>(const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, __nv_bfloat16 *, __nv_bfloat16 *, int, int)"
+0.3,5929496,4320,1372.6,1440.0,1183,1824,145.8,bmaximum_f32
+0.2,4806828,24,200284.5,200272.5,199808,200801,236.9,void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_256x128_32x3_nn_align8>(T1::Params)
+0.2,3710761,1752,2118.0,2112.0,2079,2528,48.5,"void <unnamed>::gdn_chunk_prep_kernel<(int)64>(const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, __nv_bfloat16 *, __nv_bfloat16 *, __nv_bfloat16 *, __nv_bfloat16 *, __nv_bfloat16 *, __nv_bfloat16 *, int, int)"
+0.2,3025202,1800,1680.7,1312.0,1247,7745,1089.9,copy2d_bf16
+0.1,2927969,1760,1663.6,1536.0,1312,3136,392.1,"void cublasLt::splitKreduce_kernel<(int)32, (int)16, int, __nv_bfloat16, __nv_bfloat16, float, __nv_bfloat16, (bool)1, (bool)0, (bool)0>(cublasLt::cublasSplitKParams<T6>, const T4 *, const T5 *, T5 *, const T6 *, const T6 *, const T7 *, const T4 *, T7 *, void *, long, T6 *, int *)"
+0.1,2833142,2160,1311.6,1312.0,1279,1600,31.6,ulog_f32
+0.1,2742594,104,26371.1,25536.0,22657,30080,1981.5,"void Marlin<(int)256, (int)1, (int)16, (int)4, (int)4, (int)8>(const int4 *, const int4 *, int4 *, const int4 *, int, int, int, int *)"
+0.1,2512310,816,3078.8,3056.0,2591,3680,416.6,void cutlass::Kernel2<cutlass_80_wmma_tensorop_s161616gemm_bf16_16x16_128x1_nn_align8>(T1::Params)
+0.1,2302750,1584,1453.8,1536.0,1215,3745,239.7,bsub_f32
+0.1,1427121,816,1748.9,1744.5,1535,2080,201.5,"void cublasLt::splitKreduce_kernel<(int)32, (int)16, int, float, __nv_bfloat16, float, __nv_bfloat16, (bool)1, (bool)0, (bool)0>(cublasLt::cublasSplitKParams<T6>, const T4 *, const T5 *, T5 *, const T6 *, const T6 *, const T7 *, const T4 *, T7 *, void *, long, T6 *, int *)"
+0.0,693505,408,1699.8,1696.0,1600,1889,63.4,"void <unnamed>::kiln_conv1d_update_k4_kernel<(bool)1>(const __nv_bfloat16 *, const __nv_bfloat16 *, float *, float *, int, int)"
+0.0,532128,16,33258.0,33232.0,32895,34144,312.9,ampere_bf16_s16816gemm_bf16_128x64_ldg8_f2f_stages_32x6_nn
+0.0,436736,162,2695.9,2528.0,2304,26048,1852.2,is_u32_bf16
+0.0,336420,48,7008.8,6896.5,4992,9216,1920.8,void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_64x64_32x10_nn_align8>(T1::Params)
+0.0,276003,72,3833.4,3424.0,3200,4928,713.7,void cutlass::Kernel2<cutlass_75_wmma_tensorop_bf16_s161616gemm_bf16_32x32_32x1_nn_align1>(T1::Params)
+0.0,227138,162,1402.1,1408.0,1344,1664,28.8,usin_f32
+0.0,226304,162,1396.9,1408.0,1375,1632,25.8,ucos_f32
+0.0,145631,72,2022.7,2016.0,1983,2049,16.1,fast_max_bf16
+0.0,145063,72,2014.8,2016.0,1984,2049,15.7,fast_sum_bf16
+0.0,138752,72,1927.1,1920.0,1888,1953,16.3,"void gemvNSP_kernel<__nv_bfloat16, __nv_bfloat16, __nv_bfloat16, float, (int)1, (int)32, (int)4, (int)1024, (bool)0, cublasGemvParamsEx<int, cublasGemvTensorStridedBatched<const __nv_bfloat16>, cublasGemvTensorStridedBatched<const __nv_bfloat16>, cublasGemvTensorStridedBatched<__nv_bfloat16>, float>>(T10)"
+0.0,109499,72,1520.8,1536.0,1377,1568,28.8,bdiv_bf16
+0.0,108160,72,1502.2,1504.0,1471,1537,16.1,"void gemmk1_kernel<int, float, (int)256, (int)5, (bool)0, (bool)0, (bool)0, (bool)0, cublasGemvTensorStridedBatched<const __nv_bfloat16>, cublasGemvTensorStridedBatched<const __nv_bfloat16>, cublasGemvTensorStridedBatched<__nv_bfloat16>, float, (int)0>(cublasGemmk1Params<T2, T9, T10, T11, T12, biasType<T11::value_type, T12>::type>)"
+0.0,107169,72,1488.5,1504.0,1312,1536,28.9,bsub_bf16

--- a/docs/phase-c57/conv-prefill-mtp-profile.md
+++ b/docs/phase-c57/conv-prefill-mtp-profile.md
@@ -1,0 +1,139 @@
+# Phase 6 C57 Conv1d Prefill MTP Profile Recovery
+
+Date: 2026-04-24
+
+Commit: `b63e241` plus this PR's test-only regression change
+
+GPU: NVIDIA RTX A6000 (`6lv4pu241ofanf`)
+
+## Goal
+
+C57 verifies that the CUDA `causal_conv1d_prefill` fast path no longer blocks
+the C56 native-MTP profile workload, and refreshes the native-MTP decode source
+of truth after the status-3 prefill failure documented in `docs/phase-c56/`.
+
+## Precondition
+
+Current `main` had no newer artifact than C56 that both used the CUDA
+causal-conv1d prefill fast path and reached native-MTP decode
+(`:kiln/mtp/step`). `PROFILING.md` had a newer post-#486 plain decode/prefill
+profile, but that was not a native-MTP decode-window profile.
+
+Current `main` already includes PR #481 (`7227b4c`), which fixed the C56 root
+cause by matching the prefill kernel `__launch_bounds__` to the largest
+256-thread launch path. This PR therefore adds a focused model-level regression
+coverage increase for the C56 prefill envelope and records the recovered C57
+profile.
+
+## Validation
+
+RunPod pod `6lv4pu241ofanf` used the required `ghcr.io/ericflo/kiln-runpod:latest`
+image on an on-demand RTX A6000. The pod reported driver `550.127.08`, CUDA
+12.4, and 49140 MiB VRAM.
+
+Commands run from `/workspace/kiln` with `source /root/.kiln-build-env` and
+`KILN_CUDA_ARCHS=86`:
+
+```bash
+cargo test -p kiln-conv1d-kernel --release -- --nocapture
+cargo test -p kiln-model --release --features cuda causal_conv1d_prefill -- --nocapture
+cargo test -p kiln-model --release --features cuda test_causal_conv1d_update_matches_fallback -- --nocapture
+cargo build --release --features cuda,nvtx --bin kiln-bench
+```
+
+Results:
+
+- `kiln-conv1d-kernel`: 4 tests passed.
+- `causal_conv1d_prefill`: 1 CUDA model test passed at the C56 512-token prefill envelope, max abs diff `1.4901161e-8`, state parity `0`.
+- `test_causal_conv1d_update_matches_fallback`: 1 CUDA model test passed, max abs diff `7.450581e-9`, state parity `0`.
+- `kiln-bench`: built successfully with `cuda,nvtx`.
+
+## Profile Command
+
+The task brief's `--latency-paged` / `--max-new-tokens` spelling is not present
+in the current bench CLI, so C57 used the existing C52/C54/C56 native-MTP
+workload spelling:
+
+```bash
+nsys profile --force-overwrite=true --trace=cuda,nvtx --sample=none \
+  --cpuctxsw=none --cuda-memory-usage=false \
+  --output /tmp/kiln-c57/c57-mtp-conv-prefill-v2 \
+  env KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 KILN_W4A16=1 KILN_CUDA_GRAPHS=true \
+  ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
+    --prompt-tokens 512 --max-output-tokens 128 --skip-training \
+    --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1
+nsys stats --force-export=true \
+  --report nvtx_sum,nvtx_pushpop_trace,cuda_gpu_kern_sum,cuda_api_sum,cuda_kern_exec_sum \
+  --format csv --output docs/phase-c57/c57-mtp-conv-prefill-v2 \
+  /tmp/kiln-c57/c57-mtp-conv-prefill-v2.nsys-rep
+```
+
+The first attempt with `--trace=cuda,nvtx,osrt` hit a Nsight 2023.4.4 importer
+wrong-event-order error after the benchmark had completed successfully. The
+retained run removed `osrt`; it generated a valid `.nsys-rep` and CSV exports.
+
+## Result
+
+C57 reached native-MTP decode. The profile contains `:kiln/mtp/step` ranges and
+no `kiln_causal_conv1d_prefill_bf16_f32` status-3 failure.
+
+Latency metrics from `nsys-profile-v2.log`:
+
+- Prompt tokens: 515
+- Prefill: 417.7 ms (1233 tok/s)
+- Generated tokens: 128
+- Decode: 26.5 tok/s
+- Mean ITL: 37.8 ms
+- MTP alpha: 0.764
+
+## Decode Window Method
+
+The reduction follows C52/C54: first `:kiln/mtp/step` start through final decode
+NVTX end, excluding the `:kiln/mtp/step` parent wrapper from the denominator.
+C57's decode window is 4737.861 ms and the summed non-parent NVTX denominator is
+3383.625 ms.
+
+## Top Decode NVTX Ranges
+
+Source: `top_decode_nvtx.csv`.
+
+| Rank | Decode range | Wall-clock share | Total time | Instances |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | `:kiln/gdn/gates` | 14.45% | 489.003 ms | 2088 |
+| 2 | `:kiln/gdn/gated_norm` | 13.55% | 458.578 ms | 2088 |
+| 3 | `:kiln/gdn/qk_norm` | 11.02% | 372.938 ms | 2088 |
+| 4 | `:kiln/attn/rope` | 8.56% | 289.762 ms | 768 |
+| 5 | `:kiln/mlp/gate` | 4.70% | 159.151 ms | 2856 |
+
+## Top Prefill NVTX Ranges
+
+Source: `top_prefill_nvtx.csv`.
+
+| Rank | Prefill range | Wall-clock share | Total time | Instances |
+| ---: | --- | ---: | ---: | ---: |
+| 1 | `:kiln/gdn/in_proj` | 59.49% | 172.210 ms | 24 |
+| 2 | `:kiln/attn/full/prefill_initial` | 12.67% | 36.662 ms | 8 |
+| 3 | `:kiln/gdn/qk_norm` | 4.47% | 12.941 ms | 24 |
+| 4 | `:kiln/gdn/gates` | 3.37% | 9.751 ms | 24 |
+| 5 | `:kiln/mlp/down` | 2.52% | 7.286 ms | 32 |
+
+## Artifacts
+
+Committed reduced artifacts:
+
+- `summary.json`
+- `top_decode_nvtx.csv`
+- `top_prefill_nvtx.csv`
+- `c57-mtp-conv-prefill-v2_cuda_gpu_kern_sum.csv`
+- `nsys-profile-v2.log`
+- `nsys-stats-v2.log`
+
+The raw `.nsys-rep`, `.sqlite`, and full `nvtx_pushpop_trace` export were not
+committed.
+
+## Recommendation
+
+The C56 blocker is cleared on current `main`; Phase 6 can again use a native-MTP
+decode profile as source of truth. The next material native-MTP decode targets
+are `:kiln/gdn/gates`, `:kiln/gdn/gated_norm`, and `:kiln/gdn/qk_norm`; do not
+select a new optimization from the failed C56 artifact.

--- a/docs/phase-c57/nsys-profile-v2.log
+++ b/docs/phase-c57/nsys-profile-v2.log
@@ -1,0 +1,73 @@
+=== Kiln Benchmark Suite ===
+
+GPU: NVIDIA RTX A6000 (49140 MB)
+Loading model from /workspace/qwen3.5-4b...
+[2m2026-04-24T11:22:10.867585Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-24T11:22:10.869242Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-24T11:22:10.869439Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected; deferring CPU load until first use [3mmtp_prefix[0m[2m=[0mmtp.
+[2m2026-04-24T11:22:10.869461Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4206M parameters (8022 MB) across 32 layers
+[2m2026-04-24T11:22:10.869588Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+[2m2026-04-24T11:22:37.591333Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m marlin batch pack complete [3mn_inputs[0m[2m=[0m104 [3mn_packed[0m[2m=[0m104 [3mpack_elapsed_ms[0m[2m=[0m22494 [3mparallel[0m[2m=[0mtrue
+[kiln] marlin batch pack: 104/104 projections in 22494 ms (parallel)
+Model loaded in 27.87s (backend: cuda, VRAM: 17551 MB)
+
+--- Latency Benchmark (MTP — native speculative, paged) ---
+  Measuring latency [MTP, paged, blocks=49] (515 prompt tokens)...
+    Prefill (MTP): 417.7ms (1233 tok/s)
+[2m2026-04-24T11:22:39.721062Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m deferred native MTP CPU load complete [3mload_elapsed_ms[0m[2m=[0m1
+[2m2026-04-24T11:22:39.782679Z[0m [32m INFO[0m [2mkiln_model::forward[0m[2m:[0m lazy native MTP GPU upload complete [3mupload_elapsed_ms[0m[2m=[0m61
+    Decode (MTP): 128 tokens, mean ITL 37.8ms (26.5 tok/s), α = 0.764 (55/72)
+
+============================================================
+  KILN BENCHMARK RESULTS
+============================================================
+
+GPU: NVIDIA RTX A6000 (49140 MB VRAM, source: nvidia-smi)
+Model load time: 27.87s (VRAM: 17551 MB)
+
+--- Inference Throughput ---
+Runs         Prompt     Output        tok/s    VRAM MB
+
+--- Latency (single request) ---
+Prompt tokens:         515
+Prefill time:          417.7 ms (1233 tok/s)
+Time to first token:   417.7 ms
+Mean inter-token:      37.8 ms (26.5 tok/s)
+P50 inter-token:       27.9 ms
+P99 inter-token:       100.7 ms
+Tokens generated:      128
+Spec method:           mtp
+Draft acceptance α:    0.764
+
+{
+  "backend": "cuda",
+  "gpu_info": {
+    "name": "NVIDIA RTX A6000",
+    "total_vram_mb": 49140,
+    "vram_source": "nvidia-smi"
+  },
+  "model_load": {
+    "load_time_secs": 27.865969299,
+    "model_vram_mb": 17551
+  },
+  "inference": [],
+  "latency": {
+    "prompt_tokens": 515,
+    "prefill_time_ms": 417.745026,
+    "prefill_tokens_per_sec": 1232.809412313625,
+    "time_to_first_token_ms": 417.745026,
+    "mean_inter_token_ms": 37.789477629921265,
+    "p50_inter_token_ms": 27.863319,
+    "p99_inter_token_ms": 100.692662,
+    "num_tokens_generated": 128,
+    "decode_tokens_per_sec": 26.462392780158773,
+    "spec_method": "mtp",
+    "acceptance_rate": 0.7638888888888888,
+    "prompt_subset": "humaneval"
+  },
+  "training": null
+}
+Generating '/tmp/nsys-report-e9c1.qdstrm'
+[1/1] [0%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [0%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [0%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=====29%                    ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===22%                      ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=17%                        ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [======35%                   ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=====29%                    ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [====25%                     ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===22%                      ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==19%                       ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=17%                        ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=16%                        ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [14%                         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [13%                         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [12%                         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [11%                         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [10%                         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [9%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [8%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [7%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [6%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [5%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [0%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [5%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [6%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [7%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [8%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [9%                          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [10%                         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [11%                         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [12%                         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [13%                         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [14%                         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=15%                        ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=16%                        ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=17%                        ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==18%                       ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==19%                       ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==20%                       ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==21%                       ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===22%                      ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===23%                      ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===24%                      ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [====25%                     ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [====26%                     ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [====27%                     ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [====28%                     ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=====29%                    ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=====30%                    ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=====31%                    ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=====32%                    ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [======33%                   ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [======34%                   ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [======35%                   ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=======36%                  ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=======37%                  ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=======38%                  ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=======39%                  ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [========40%                 ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [========41%                 ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [========42%                 ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=========43%                ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=========44%                ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=========45%                ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=========46%                ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==========47%               ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==========48%               ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==========49%               ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===========50%              ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===========51%              ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===========52%              ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===========53%              ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [============54%             ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [============55%             ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [============56%             ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [============57%             ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=============58%            ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=============59%            ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=============60%            ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==============61%           ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==============62%           ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==============63%           ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==============64%           ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===============65%          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===============66%          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===============67%          ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [================68%         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [================69%         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [================70%         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [================71%         ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=================72%        ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=================73%        ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=================74%        ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==================75%       ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==================76%       ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==================77%       ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [==================78%       ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===================79%      ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===================80%      ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===================81%      ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [===================82%      ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [====================83%     ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [====================84%     ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [====================85%     ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=====================86%    ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=====================87%    ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=====================88%    ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [=====================89%    ] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [========================100%] c57-mtp-conv-prefill-v2.nsys-rep[1/1] [========================100%] c57-mtp-conv-prefill-v2.nsys-rep
+Generated:
+    /tmp/kiln-c57/c57-mtp-conv-prefill-v2.nsys-rep

--- a/docs/phase-c57/nsys-stats-v2.log
+++ b/docs/phase-c57/nsys-stats-v2.log
@@ -1,0 +1,11 @@
+Generating SQLite file /tmp/kiln-c57/c57-mtp-conv-prefill-v2.sqlite from /tmp/kiln-c57/c57-mtp-conv-prefill-v2.nsys-rep
+Processing [/tmp/kiln-c57/c57-mtp-conv-prefill-v2.sqlite] with [/opt/nvidia/nsight-systems/2023.4.4/host-linux-x64/reports/nvtx_sum.py] to [docs/phase-c57/c57-mtp-conv-prefill-v2_nvtx_sum.csv]... PROCESSED
+
+Processing [/tmp/kiln-c57/c57-mtp-conv-prefill-v2.sqlite] with [/opt/nvidia/nsight-systems/2023.4.4/host-linux-x64/reports/nvtx_pushpop_trace.py] to [docs/phase-c57/c57-mtp-conv-prefill-v2_nvtx_pushpop_trace.csv]... PROCESSED
+
+Processing [/tmp/kiln-c57/c57-mtp-conv-prefill-v2.sqlite] with [/opt/nvidia/nsight-systems/2023.4.4/host-linux-x64/reports/cuda_gpu_kern_sum.py] to [docs/phase-c57/c57-mtp-conv-prefill-v2_cuda_gpu_kern_sum.csv]... PROCESSED
+
+Processing [/tmp/kiln-c57/c57-mtp-conv-prefill-v2.sqlite] with [/opt/nvidia/nsight-systems/2023.4.4/host-linux-x64/reports/cuda_api_sum.py] to [docs/phase-c57/c57-mtp-conv-prefill-v2_cuda_api_sum.csv]... PROCESSED
+
+Processing [/tmp/kiln-c57/c57-mtp-conv-prefill-v2.sqlite] with [/opt/nvidia/nsight-systems/2023.4.4/host-linux-x64/reports/cuda_kern_exec_sum.py] to [docs/phase-c57/c57-mtp-conv-prefill-v2_cuda_kern_exec_sum.csv]... PROCESSED
+

--- a/docs/phase-c57/summary.json
+++ b/docs/phase-c57/summary.json
@@ -1,0 +1,240 @@
+{
+  "phase": "c57-conv-prefill-fix",
+  "date": "2026-04-24",
+  "commit": "b63e241 plus this PR test-only regression change",
+  "pod_id": "6lv4pu241ofanf",
+  "gpu": "NVIDIA RTX A6000",
+  "reached_mtp_step": true,
+  "decode_window_ms": 4737.861,
+  "decode_denominator_ms": 3383.625,
+  "prefill_denominator_ms": 289.467,
+  "metrics": {
+    "prompt_tokens": 515,
+    "prefill_ms": 417.7,
+    "mean_itl_ms": 37.8,
+    "decode_tok_s": 26.5,
+    "tokens_generated": 128,
+    "alpha": 0.764
+  },
+  "top_decode_nvtx": [
+    {
+      "range": ":kiln/gdn/gates",
+      "total_ms": 489.003,
+      "share_pct": 14.45,
+      "instances": 2088
+    },
+    {
+      "range": ":kiln/gdn/gated_norm",
+      "total_ms": 458.578,
+      "share_pct": 13.55,
+      "instances": 2088
+    },
+    {
+      "range": ":kiln/gdn/qk_norm",
+      "total_ms": 372.938,
+      "share_pct": 11.02,
+      "instances": 2088
+    },
+    {
+      "range": ":kiln/attn/rope",
+      "total_ms": 289.762,
+      "share_pct": 8.56,
+      "instances": 768
+    },
+    {
+      "range": ":kiln/mlp/gate",
+      "total_ms": 159.151,
+      "share_pct": 4.7,
+      "instances": 2856
+    },
+    {
+      "range": ":kiln/gdn/in_proj",
+      "total_ms": 158.758,
+      "share_pct": 4.69,
+      "instances": 2088
+    },
+    {
+      "range": ":kiln/mlp/up",
+      "total_ms": 156.102,
+      "share_pct": 4.61,
+      "instances": 2856
+    },
+    {
+      "range": ":kiln/mlp/down",
+      "total_ms": 147.346,
+      "share_pct": 4.35,
+      "instances": 2856
+    },
+    {
+      "range": ":kiln/attn/full/prefill",
+      "total_ms": 122.761,
+      "share_pct": 3.63,
+      "instances": 568
+    },
+    {
+      "range": ":kiln/attn/gdn/chunk_prep",
+      "total_ms": 109.84,
+      "share_pct": 3.25,
+      "instances": 1704
+    },
+    {
+      "range": ":kiln/gdn/qkv_split",
+      "total_ms": 94.232,
+      "share_pct": 2.78,
+      "instances": 2088
+    },
+    {
+      "range": ":kiln/gdn/conv",
+      "total_ms": 92.213,
+      "share_pct": 2.73,
+      "instances": 2088
+    }
+  ],
+  "top_prefill_nvtx": [
+    {
+      "range": ":kiln/gdn/in_proj",
+      "total_ms": 172.21,
+      "share_pct": 59.49,
+      "instances": 24
+    },
+    {
+      "range": ":kiln/attn/full/prefill_initial",
+      "total_ms": 36.662,
+      "share_pct": 12.67,
+      "instances": 8
+    },
+    {
+      "range": ":kiln/gdn/qk_norm",
+      "total_ms": 12.941,
+      "share_pct": 4.47,
+      "instances": 24
+    },
+    {
+      "range": ":kiln/gdn/gates",
+      "total_ms": 9.751,
+      "share_pct": 3.37,
+      "instances": 24
+    },
+    {
+      "range": ":kiln/mlp/down",
+      "total_ms": 7.286,
+      "share_pct": 2.52,
+      "instances": 32
+    },
+    {
+      "range": ":kiln/gdn/gated_norm",
+      "total_ms": 5.644,
+      "share_pct": 1.95,
+      "instances": 24
+    },
+    {
+      "range": ":kiln/attn/rope",
+      "total_ms": 5.203,
+      "share_pct": 1.8,
+      "instances": 8
+    },
+    {
+      "range": ":kiln/gdn/head_expand",
+      "total_ms": 4.901,
+      "share_pct": 1.69,
+      "instances": 24
+    },
+    {
+      "range": ":kiln/attn/gdn/chunk_prep",
+      "total_ms": 4.75,
+      "share_pct": 1.64,
+      "instances": 24
+    },
+    {
+      "range": ":kiln/gdn/qkv_split",
+      "total_ms": 4.343,
+      "share_pct": 1.5,
+      "instances": 24
+    },
+    {
+      "range": ":kiln/mlp/up",
+      "total_ms": 3.769,
+      "share_pct": 1.3,
+      "instances": 32
+    },
+    {
+      "range": ":kiln/mlp/gate",
+      "total_ms": 3.376,
+      "share_pct": 1.17,
+      "instances": 32
+    }
+  ],
+  "top_profile_cuda_kernels": [
+    {
+      "rank": 1,
+      "kernel": "ucopy_bf16",
+      "total_ms": 374.274,
+      "share_pct": 18.7,
+      "instances": 20329
+    },
+    {
+      "rank": 2,
+      "kernel": "void Marlin<(int)256, (int)1, (int)8, (int)8, (int)4, (int)8>(const int4 *, const int4 *, int4 *, const int4 *, int, int, int, int *)",
+      "total_ms": 197.547,
+      "share_pct": 9.9,
+      "instances": 9256
+    },
+    {
+      "rank": 3,
+      "kernel": "void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_256x64_32x4_nn_align8>(T1::Params)",
+      "total_ms": 173.32,
+      "share_pct": 8.6,
+      "instances": 234
+    },
+    {
+      "rank": 4,
+      "kernel": "void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_128x64_32x6_nn_align8>(T1::Params)",
+      "total_ms": 129.522,
+      "share_pct": 6.5,
+      "instances": 72
+    },
+    {
+      "rank": 5,
+      "kernel": "ampere_bf16_s16816gemm_bf16_128x64_sliced1x2_ldg8_f2f_stages_64x3_nn",
+      "total_ms": 111.677,
+      "share_pct": 5.6,
+      "instances": 1728
+    },
+    {
+      "rank": 6,
+      "kernel": "ampere_bf16_s16816gemm_bf16_64x64_sliced1x2_ldg8_f2f_stages_64x5_nn",
+      "total_ms": 98.624,
+      "share_pct": 4.9,
+      "instances": 2712
+    },
+    {
+      "rank": 7,
+      "kernel": "void cutlass::Kernel2<cutlass_80_wmma_tensorop_bf16_s161616gemm_bf16_32x32_128x2_nn_align8>(T1::Params)",
+      "total_ms": 70.904,
+      "share_pct": 3.5,
+      "instances": 3456
+    },
+    {
+      "rank": 8,
+      "kernel": "<unnamed>::gdn_full_chunk_forward_kernel(const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, const __nv_bfloat16 *, __nv_bfloat16 *, __nv_bfloat16 *, int, int)",
+      "total_ms": 67.274,
+      "share_pct": 3.4,
+      "instances": 192
+    },
+    {
+      "rank": 9,
+      "kernel": "ampere_bf16_s16816gemm_bf16_64x64_ldg8_f2f_stages_64x5_nn",
+      "total_ms": 57.96,
+      "share_pct": 2.9,
+      "instances": 1728
+    },
+    {
+      "rank": 10,
+      "kernel": "cast_bf16_f32",
+      "total_ms": 53.298,
+      "share_pct": 2.7,
+      "instances": 12633
+    }
+  ],
+  "workload": "KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_MTP_ARGMAX_FP32=1 KILN_W4A16=1 KILN_CUDA_GRAPHS=true ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1"
+}

--- a/docs/phase-c57/top_decode_nvtx.csv
+++ b/docs/phase-c57/top_decode_nvtx.csv
@@ -1,0 +1,13 @@
+rank,range,total_ms,share_pct,instances
+1,:kiln/gdn/gates,489.003,14.45,2088
+2,:kiln/gdn/gated_norm,458.578,13.55,2088
+3,:kiln/gdn/qk_norm,372.938,11.02,2088
+4,:kiln/attn/rope,289.762,8.56,768
+5,:kiln/mlp/gate,159.151,4.7,2856
+6,:kiln/gdn/in_proj,158.758,4.69,2088
+7,:kiln/mlp/up,156.102,4.61,2856
+8,:kiln/mlp/down,147.346,4.35,2856
+9,:kiln/attn/full/prefill,122.761,3.63,568
+10,:kiln/attn/gdn/chunk_prep,109.84,3.25,1704
+11,:kiln/gdn/qkv_split,94.232,2.78,2088
+12,:kiln/gdn/conv,92.213,2.73,2088

--- a/docs/phase-c57/top_prefill_nvtx.csv
+++ b/docs/phase-c57/top_prefill_nvtx.csv
@@ -1,0 +1,13 @@
+rank,range,total_ms,share_pct,instances
+1,:kiln/gdn/in_proj,172.21,59.49,24
+2,:kiln/attn/full/prefill_initial,36.662,12.67,8
+3,:kiln/gdn/qk_norm,12.941,4.47,24
+4,:kiln/gdn/gates,9.751,3.37,24
+5,:kiln/mlp/down,7.286,2.52,32
+6,:kiln/gdn/gated_norm,5.644,1.95,24
+7,:kiln/attn/rope,5.203,1.8,8
+8,:kiln/gdn/head_expand,4.901,1.69,24
+9,:kiln/attn/gdn/chunk_prep,4.75,1.64,24
+10,:kiln/gdn/qkv_split,4.343,1.5,24
+11,:kiln/mlp/up,3.769,1.3,32
+12,:kiln/mlp/gate,3.376,1.17,32


### PR DESCRIPTION
## Summary

- Confirms the C56 CUDA `causal_conv1d_prefill` status-3 blocker is cleared on current `main` after PR #481's launch-bounds fix.
- Raises the CUDA model prefill parity regression from `seq_len=16` to the C56 native-MTP prefill envelope (`seq_len=512`).
- Adds C57 native-MTP profile artifacts and updates `PROFILING.md` with the recovered source of truth.

## Validation

RunPod pod/GPU/image:

- Pod: `6lv4pu241ofanf`
- GPU: on-demand `NVIDIA RTX A6000`, 49140 MiB VRAM, driver `550.127.08`, CUDA 12.4
- Image: `ghcr.io/ericflo/kiln-runpod:latest`
- Pod status: terminated after artifacts were copied

Commands run from `/workspace/kiln` with `source /root/.kiln-build-env` and `KILN_CUDA_ARCHS=86`:

```bash
cargo test -p kiln-conv1d-kernel --release -- --nocapture
cargo test -p kiln-model --release --features cuda causal_conv1d_prefill -- --nocapture
cargo test -p kiln-model --release --features cuda test_causal_conv1d_update_matches_fallback -- --nocapture
cargo build --release --features cuda,nvtx --bin kiln-bench
```

Results:

- `kiln-conv1d-kernel`: 4 passed.
- `causal_conv1d_prefill`: 1 passed at `seq_len=512`, max abs diff `1.4901161e-8`, state parity `0`.
- `test_causal_conv1d_update_matches_fallback`: 1 passed, max abs diff `7.450581e-9`, state parity `0`.
- `kiln-bench`: built successfully with `cuda,nvtx`.

## C57 Profile

Retained workload:

```bash
KILN_SPEC_METHOD=mtp \
KILN_BENCH_FORCE_MTP=1 \
KILN_MTP_ARGMAX_FP32=1 \
KILN_W4A16=1 \
KILN_CUDA_GRAPHS=true \
./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
  --prompt-tokens 512 --max-output-tokens 128 --skip-training \
  --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1
```

Outcome:

- Reached `:kiln/mtp/step`: yes.
- Prompt tokens: 515.
- Prefill: 417.7 ms, 1233 tok/s.
- Decode: 26.5 tok/s.
- Mean ITL: 37.8 ms.
- MTP alpha: 0.764.

Top native-MTP decode NVTX ranges:

1. `:kiln/gdn/gates`: 14.45%
2. `:kiln/gdn/gated_norm`: 13.55%
3. `:kiln/gdn/qk_norm`: 11.02%

Top native-MTP prefill NVTX ranges:

1. `:kiln/gdn/in_proj`: 59.49%
2. `:kiln/attn/full/prefill_initial`: 12.67%
3. `:kiln/gdn/qk_norm`: 4.47%

Artifacts are under `docs/phase-c57/`.
