### PR TITLE
[codex] add opt-in CUDA GDN decode fuse hook

### DIFF
--- a/crates/kiln-gdn-kernel/csrc/recurrent_gdn_fwd.cu
+++ b/crates/kiln-gdn-kernel/csrc/recurrent_gdn_fwd.cu
@@ -134,6 +134,95 @@ __global__ void recurrent_gdn_fwd_kernel(
     out_base[tid] = f32_to_bf16(out_acc);
 }
 
+__device__ __forceinline__ float stable_sigmoid(float x) {
+    if (x >= 0.0f) {
+        float z = expf(-x);
+        return 1.0f / (1.0f + z);
+    }
+    float z = expf(x);
+    return z / (1.0f + z);
+}
+
+__device__ __forceinline__ float stable_softplus(float x) {
+    if (x > 20.0f) return x;
+    if (x < -20.0f) return expf(x);
+    return log1pf(expf(x));
+}
+
+__device__ __forceinline__ float silu(float x) {
+    return x / (1.0f + expf(-x));
+}
+
+__global__ void gdn_decode_gates_recurrent_rmsnorm_bf16_kernel(
+    const __nv_bfloat16 *__restrict__ q,        // [B, 1, q_heads, dk]
+    const __nv_bfloat16 *__restrict__ k,        // [B, 1, q_heads, dk]
+    const __nv_bfloat16 *__restrict__ v,        // [B, 1, value_heads, dv]
+    const __nv_bfloat16 *__restrict__ a,        // [B, 1, value_heads]
+    const __nv_bfloat16 *__restrict__ b,        // [B, 1, value_heads]
+    const __nv_bfloat16 *__restrict__ a_log,    // [value_heads]
+    const __nv_bfloat16 *__restrict__ dt_bias,  // [value_heads]
+    __nv_bfloat16 *__restrict__ state,          // [B, value_heads, dk, dv]
+    const __nv_bfloat16 *__restrict__ z,        // [B, 1, value_heads, dv]
+    const __nv_bfloat16 *__restrict__ weight,   // [dv]
+    __nv_bfloat16 *__restrict__ out,            // [B, 1, value_heads, dv]
+    int q_heads,
+    int value_heads,
+    float eps
+) {
+    __shared__ float k_smem[128];
+    __shared__ float sq_smem[128];
+    __shared__ float scalars[2];
+
+    const int bh = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (tid >= 128) return;
+
+    const int batch_idx = bh / value_heads;
+    const int head_idx = bh - batch_idx * value_heads;
+    const int q_group = value_heads / q_heads;
+    const int q_head_idx = head_idx / q_group;
+
+    const size_t qk_base = ((size_t)batch_idx * q_heads + q_head_idx) * 128;
+    const size_t v_base = ((size_t)batch_idx * value_heads + head_idx) * 128;
+    const size_t gate_idx = (size_t)batch_idx * value_heads + head_idx;
+    const size_t state_base = (size_t)bh * 128 * 128;
+
+    k_smem[tid] = bf16_to_f32(k[qk_base + tid]);
+
+    if (tid == 0) {
+        const float beta = stable_sigmoid(bf16_to_f32(b[gate_idx]));
+        const float g = -expf(bf16_to_f32(a_log[head_idx]))
+            * stable_softplus(bf16_to_f32(a[gate_idx]) + bf16_to_f32(dt_bias[head_idx]));
+        scalars[0] = expf(bf16_to_f32(f32_to_bf16(g)));
+        scalars[1] = bf16_to_f32(f32_to_bf16(beta));
+    }
+    __syncthreads();
+
+    const float decay = scalars[0];
+    const float beta_t = scalars[1];
+
+    float s_local[128];
+    float v_pred = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 128; ++i) {
+        const float d = decay * bf16_to_f32(state[state_base + (size_t)i * 128 + tid]);
+        s_local[i] = d;
+        v_pred += k_smem[i] * d;
+    }
+
+    const float delta = beta_t * (bf16_to_f32(v[v_base + tid]) - v_pred);
+    float y = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 128; ++i) {
+        const float new_s = s_local[i] + k_smem[i] * delta;
+        state[state_base + (size_t)i * 128 + tid] = f32_to_bf16(new_s);
+        y += bf16_to_f32(q[qk_base + i]) * new_s;
+    }
+
+    out[v_base + tid] = f32_to_bf16(y);
+
+}
+
 } // namespace
 
 extern "C" kiln_gdn_recurrent_status_t kiln_gdn_recurrent_forward(
@@ -197,5 +286,52 @@ extern "C" kiln_gdn_recurrent_status_t kiln_gdn_recurrent_forward(
     if (err != cudaSuccess) {
         return (int)err;
     }
+    return 0;
+}
+
+extern "C" kiln_gdn_recurrent_status_t kiln_gdn_decode_gates_recurrent_bf16(
+    const void *q,
+    const void *k,
+    const void *v,
+    const void *a,
+    const void *b,
+    const void *a_log,
+    const void *dt_bias,
+    void *state,
+    const void *z,
+    const void *weight,
+    void *out,
+    int batch,
+    int q_heads,
+    int value_heads,
+    int dk,
+    int dv,
+    float eps,
+    void *stream
+) {
+    if (batch <= 0 || q_heads <= 0 || value_heads <= 0) return -1;
+    if (dk != 128 || dv != 128) return -2;
+    if (value_heads < q_heads || (value_heads % q_heads) != 0) return -3;
+
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+    gdn_decode_gates_recurrent_rmsnorm_bf16_kernel<<<batch * value_heads, 128, 0, s>>>(
+        reinterpret_cast<const __nv_bfloat16 *>(q),
+        reinterpret_cast<const __nv_bfloat16 *>(k),
+        reinterpret_cast<const __nv_bfloat16 *>(v),
+        reinterpret_cast<const __nv_bfloat16 *>(a),
+        reinterpret_cast<const __nv_bfloat16 *>(b),
+        reinterpret_cast<const __nv_bfloat16 *>(a_log),
+        reinterpret_cast<const __nv_bfloat16 *>(dt_bias),
+        reinterpret_cast<__nv_bfloat16 *>(state),
+        reinterpret_cast<const __nv_bfloat16 *>(z),
+        reinterpret_cast<const __nv_bfloat16 *>(weight),
+        reinterpret_cast<__nv_bfloat16 *>(out),
+        q_heads,
+        value_heads,
+        eps
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) return (int)err;
     return 0;
 }

--- a/crates/kiln-gdn-kernel/csrc/recurrent_gdn_fwd.h
+++ b/crates/kiln-gdn-kernel/csrc/recurrent_gdn_fwd.h
@@ -50,6 +50,27 @@ kiln_gdn_recurrent_status_t kiln_gdn_recurrent_forward(
     void *stream
 );
 
+kiln_gdn_recurrent_status_t kiln_gdn_decode_gates_recurrent_bf16(
+    const void *q,
+    const void *k,
+    const void *v,
+    const void *a,
+    const void *b,
+    const void *a_log,
+    const void *dt_bias,
+    void *state,
+    const void *z,
+    const void *weight,
+    void *out,
+    int batch,
+    int q_heads,
+    int value_heads,
+    int dk,
+    int dv,
+    float eps,
+    void *stream
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -59,9 +59,7 @@
 //! chunkwise recurrence and are *not* covered by this crate.
 
 use candle_core::{
-    backend::BackendStorage,
-    cuda_backend::cudarc::driver::DevicePtr,
-    DType, Result, Tensor,
+    DType, Result, Tensor, backend::BackendStorage, cuda_backend::cudarc::driver::DevicePtr,
 };
 use half::bf16;
 
@@ -88,6 +86,27 @@ unsafe extern "C" {
         batch_heads: i32,
         dk: i32,
         dv: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
+    fn kiln_gdn_decode_gates_recurrent_bf16(
+        q: *const core::ffi::c_void,
+        k: *const core::ffi::c_void,
+        v: *const core::ffi::c_void,
+        a: *const core::ffi::c_void,
+        b: *const core::ffi::c_void,
+        a_log: *const core::ffi::c_void,
+        dt_bias: *const core::ffi::c_void,
+        state: *mut core::ffi::c_void,
+        z: *const core::ffi::c_void,
+        weight: *const core::ffi::c_void,
+        out: *mut core::ffi::c_void,
+        batch: i32,
+        q_heads: i32,
+        value_heads: i32,
+        dk: i32,
+        dv: i32,
+        eps: f32,
         stream: *mut core::ffi::c_void,
     ) -> i32;
 
@@ -193,14 +212,10 @@ pub fn gdn_forward_substitution(
     }
 
     if c > 128 {
-        candle_core::bail!(
-            "kiln-gdn-kernel: chunk_size must be <= 128 (got {c})"
-        );
+        candle_core::bail!("kiln-gdn-kernel: chunk_size must be <= 128 (got {c})");
     }
     if dv > 1024 {
-        candle_core::bail!(
-            "kiln-gdn-kernel: dv must be <= 1024 (got {dv})"
-        );
+        candle_core::bail!("kiln-gdn-kernel: dv must be <= 1024 (got {dv})");
     }
 
     let a_strict = a_strict.contiguous()?;
@@ -263,9 +278,7 @@ pub fn gdn_forward_substitution(
             );
 
             if status != 0 {
-                candle_core::bail!(
-                    "kiln_gdn_forward_substitution failed with status {status}"
-                );
+                candle_core::bail!("kiln_gdn_forward_substitution failed with status {status}");
             }
         }
     }
@@ -323,9 +336,7 @@ pub fn gdn_recurrent_forward(
 
     let (b_g, h_g) = g.dims2()?;
     if (b_g, h_g) != (b, h) {
-        candle_core::bail!(
-            "kiln-gdn-kernel: g shape [{b_g}, {h_g}] mismatch with q [{b}, {h}, *]"
-        );
+        candle_core::bail!("kiln-gdn-kernel: g shape [{b_g}, {h_g}] mismatch with q [{b}, {h}, *]");
     }
 
     let (b_s, h_s, dk_s, dv_s) = state.dims4()?;
@@ -344,7 +355,12 @@ pub fn gdn_recurrent_forward(
     {
         candle_core::bail!(
             "kiln-gdn-kernel: all inputs must be bf16 (got q={:?}, k={:?}, v={:?}, beta={:?}, g={:?}, state={:?})",
-            q.dtype(), k.dtype(), v.dtype(), beta.dtype(), g.dtype(), state.dtype()
+            q.dtype(),
+            k.dtype(),
+            v.dtype(),
+            beta.dtype(),
+            g.dtype(),
+            state.dtype()
         );
     }
 
@@ -410,13 +426,27 @@ pub fn gdn_recurrent_forward(
         let stream = q_cuda.device().cuda_stream();
         let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
 
-        let q_slice = q_cuda.as_cuda_slice::<bf16>()?.slice(q_layout.start_offset()..);
-        let k_slice = k_cuda.as_cuda_slice::<bf16>()?.slice(k_layout.start_offset()..);
-        let v_slice = v_cuda.as_cuda_slice::<bf16>()?.slice(v_layout.start_offset()..);
-        let beta_slice = beta_cuda.as_cuda_slice::<bf16>()?.slice(beta_layout.start_offset()..);
-        let g_slice = g_cuda.as_cuda_slice::<bf16>()?.slice(g_layout.start_offset()..);
-        let s_slice = s_cuda.as_cuda_slice::<bf16>()?.slice(s_layout.start_offset()..);
-        let out_slice = out_cuda.as_cuda_slice::<bf16>()?.slice(out_layout.start_offset()..);
+        let q_slice = q_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(q_layout.start_offset()..);
+        let k_slice = k_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(k_layout.start_offset()..);
+        let v_slice = v_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(v_layout.start_offset()..);
+        let beta_slice = beta_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(beta_layout.start_offset()..);
+        let g_slice = g_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(g_layout.start_offset()..);
+        let s_slice = s_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(s_layout.start_offset()..);
+        let out_slice = out_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(out_layout.start_offset()..);
 
         unsafe {
             let (q_ptr, _g1) = q_slice.device_ptr(&stream);
@@ -442,8 +472,245 @@ pub fn gdn_recurrent_forward(
             );
 
             if status != 0 {
+                candle_core::bail!("kiln_gdn_recurrent_forward failed with status {status}");
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+pub fn gdn_decode_gates_recurrent_supports(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    a: &Tensor,
+    b: &Tensor,
+    a_log: &Tensor,
+    dt_bias: &Tensor,
+    state: &Tensor,
+    z: &Tensor,
+    weight: &Tensor,
+) -> bool {
+    if !matches!(q.device(), candle_core::Device::Cuda(_)) {
+        return false;
+    }
+    if q.dtype() != DType::BF16
+        || k.dtype() != DType::BF16
+        || v.dtype() != DType::BF16
+        || a.dtype() != DType::BF16
+        || b.dtype() != DType::BF16
+        || a_log.dtype() != DType::BF16
+        || dt_bias.dtype() != DType::BF16
+        || state.dtype() != DType::BF16
+        || z.dtype() != DType::BF16
+        || weight.dtype() != DType::BF16
+    {
+        return false;
+    }
+
+    let Ok((batch, seq_len, q_heads, dk)) = q.dims4() else {
+        return false;
+    };
+    let Ok((b_k, t_k, h_k, dk_k)) = k.dims4() else {
+        return false;
+    };
+    let Ok((b_v, t_v, value_heads, dv)) = v.dims4() else {
+        return false;
+    };
+    let Ok((b_a, t_a, h_a)) = a.dims3() else {
+        return false;
+    };
+    let Ok((b_b, t_b, h_b)) = b.dims3() else {
+        return false;
+    };
+    let Ok((b_s, h_s, dk_s, dv_s)) = state.dims4() else {
+        return false;
+    };
+
+    batch >= 1
+        && seq_len == 1
+        && (b_k, t_k, h_k, dk_k) == (batch, seq_len, q_heads, dk)
+        && (b_v, t_v) == (batch, seq_len)
+        && (b_a, t_a, h_a) == (batch, seq_len, value_heads)
+        && (b_b, t_b, h_b) == (batch, seq_len, value_heads)
+        && z.dims() == [batch, seq_len, value_heads, dv]
+        && a_log.dims() == [value_heads]
+        && dt_bias.dims() == [value_heads]
+        && weight.dims() == [dv]
+        && (b_s, h_s, dk_s, dv_s) == (batch, value_heads, dk, dv)
+        && q_heads > 0
+        && value_heads >= q_heads
+        && value_heads % q_heads == 0
+        && dk == 128
+        && dv == 128
+        && state.is_contiguous()
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gdn_decode_gates_recurrent(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    a: &Tensor,
+    b: &Tensor,
+    a_log: &Tensor,
+    dt_bias: &Tensor,
+    state: &mut Tensor,
+    z: &Tensor,
+    weight: &Tensor,
+    eps: f32,
+) -> Result<Tensor> {
+    if !gdn_decode_gates_recurrent_supports(q, k, v, a, b, a_log, dt_bias, state, z, weight) {
+        candle_core::bail!("kiln-gdn-kernel: gdn_decode_gates_recurrent envelope violation");
+    }
+
+    let device = q.device();
+    let (batch, _, q_heads, dk) = q.dims4()?;
+    let (_, _, value_heads, dv) = v.dims4()?;
+
+    let q = q.contiguous()?;
+    let k = k.contiguous()?;
+    let v = v.contiguous()?;
+    let a = a.contiguous()?;
+    let b = b.contiguous()?;
+    let a_log = a_log.contiguous()?;
+    let dt_bias = dt_bias.contiguous()?;
+    let z = z.contiguous()?;
+    let weight = weight.contiguous()?;
+    let out = Tensor::zeros((batch, 1, value_heads, dv), DType::BF16, device)?;
+
+    {
+        let (q_storage, q_layout) = q.storage_and_layout();
+        let (k_storage, k_layout) = k.storage_and_layout();
+        let (v_storage, v_layout) = v.storage_and_layout();
+        let (a_storage, a_layout) = a.storage_and_layout();
+        let (b_storage, b_layout) = b.storage_and_layout();
+        let (al_storage, al_layout) = a_log.storage_and_layout();
+        let (dt_storage, dt_layout) = dt_bias.storage_and_layout();
+        let (s_storage, s_layout) = state.storage_and_layout();
+        let (z_storage, z_layout) = z.storage_and_layout();
+        let (w_storage, w_layout) = weight.storage_and_layout();
+        let (out_storage, out_layout) = out.storage_and_layout();
+
+        let q_cuda = match &*q_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: q must be on CUDA"),
+        };
+        let k_cuda = match &*k_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: k must be on CUDA"),
+        };
+        let v_cuda = match &*v_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: v must be on CUDA"),
+        };
+        let a_cuda = match &*a_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: a must be on CUDA"),
+        };
+        let b_cuda = match &*b_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: b must be on CUDA"),
+        };
+        let al_cuda = match &*al_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: a_log must be on CUDA"),
+        };
+        let dt_cuda = match &*dt_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: dt_bias must be on CUDA"),
+        };
+        let s_cuda = match &*s_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: state must be on CUDA"),
+        };
+        let z_cuda = match &*z_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: z must be on CUDA"),
+        };
+        let w_cuda = match &*w_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: weight must be on CUDA"),
+        };
+        let out_cuda = match &*out_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-gdn-kernel: out must be on CUDA"),
+        };
+
+        let stream = q_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let q_slice = q_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(q_layout.start_offset()..);
+        let k_slice = k_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(k_layout.start_offset()..);
+        let v_slice = v_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(v_layout.start_offset()..);
+        let a_slice = a_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(a_layout.start_offset()..);
+        let b_slice = b_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(b_layout.start_offset()..);
+        let al_slice = al_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(al_layout.start_offset()..);
+        let dt_slice = dt_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(dt_layout.start_offset()..);
+        let s_slice = s_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(s_layout.start_offset()..);
+        let z_slice = z_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(z_layout.start_offset()..);
+        let w_slice = w_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(w_layout.start_offset()..);
+        let out_slice = out_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(out_layout.start_offset()..);
+
+        unsafe {
+            let (q_ptr, _g1) = q_slice.device_ptr(&stream);
+            let (k_ptr, _g2) = k_slice.device_ptr(&stream);
+            let (v_ptr, _g3) = v_slice.device_ptr(&stream);
+            let (a_ptr, _g4) = a_slice.device_ptr(&stream);
+            let (b_ptr, _g5) = b_slice.device_ptr(&stream);
+            let (al_ptr, _g6) = al_slice.device_ptr(&stream);
+            let (dt_ptr, _g7) = dt_slice.device_ptr(&stream);
+            let (s_ptr, _g8) = s_slice.device_ptr(&stream);
+            let (z_ptr, _g9) = z_slice.device_ptr(&stream);
+            let (w_ptr, _g10) = w_slice.device_ptr(&stream);
+            let (out_ptr, _g11) = out_slice.device_ptr(&stream);
+
+            let status = kiln_gdn_decode_gates_recurrent_bf16(
+                q_ptr as *const _,
+                k_ptr as *const _,
+                v_ptr as *const _,
+                a_ptr as *const _,
+                b_ptr as *const _,
+                al_ptr as *const _,
+                dt_ptr as *const _,
+                s_ptr as *mut _,
+                z_ptr as *const _,
+                w_ptr as *const _,
+                out_ptr as *mut _,
+                batch as i32,
+                q_heads as i32,
+                value_heads as i32,
+                dk as i32,
+                dv as i32,
+                eps,
+                raw_stream,
+            );
+            if status != 0 {
                 candle_core::bail!(
-                    "kiln_gdn_recurrent_forward failed with status {status}"
+                    "kiln_gdn_decode_gates_recurrent_bf16 failed with status {status}"
                 );
             }
         }
@@ -503,12 +770,7 @@ unsafe extern "C" {
 ///   - `a`, `b` of shape `[.., nv]`, bf16, CUDA
 ///   - `A_log`, `dt_bias` of shape `[nv]`, bf16, CUDA
 ///   - `nv <= 256`
-pub fn gdn_gates_supports(
-    a: &Tensor,
-    b: &Tensor,
-    a_log: &Tensor,
-    dt_bias: &Tensor,
-) -> bool {
+pub fn gdn_gates_supports(a: &Tensor, b: &Tensor, a_log: &Tensor, dt_bias: &Tensor) -> bool {
     if !matches!(a.device(), candle_core::Device::Cuda(_)) {
         return false;
     }
@@ -560,7 +822,11 @@ pub fn gdn_gates(
         candle_core::bail!(
             "kiln-gdn-kernel: gdn_gates: envelope violation \
              (a={:?}, b={:?}, a_log={:?}, dt_bias={:?}, a.dtype={:?})",
-            a.shape(), b.shape(), a_log.shape(), dt_bias.shape(), a.dtype()
+            a.shape(),
+            b.shape(),
+            a_log.shape(),
+            dt_bias.shape(),
+            a.dtype()
         );
     }
 
@@ -613,12 +879,24 @@ pub fn gdn_gates(
         let stream = a_cuda.device().cuda_stream();
         let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
 
-        let a_slice = a_cuda.as_cuda_slice::<bf16>()?.slice(a_layout.start_offset()..);
-        let b_slice = b_cuda.as_cuda_slice::<bf16>()?.slice(b_layout.start_offset()..);
-        let al_slice = al_cuda.as_cuda_slice::<bf16>()?.slice(al_layout.start_offset()..);
-        let dt_slice = dt_cuda.as_cuda_slice::<bf16>()?.slice(dt_layout.start_offset()..);
-        let beta_slice = beta_cuda.as_cuda_slice::<bf16>()?.slice(beta_layout.start_offset()..);
-        let g_slice = g_cuda.as_cuda_slice::<bf16>()?.slice(g_layout.start_offset()..);
+        let a_slice = a_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(a_layout.start_offset()..);
+        let b_slice = b_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(b_layout.start_offset()..);
+        let al_slice = al_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(al_layout.start_offset()..);
+        let dt_slice = dt_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(dt_layout.start_offset()..);
+        let beta_slice = beta_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(beta_layout.start_offset()..);
+        let g_slice = g_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(g_layout.start_offset()..);
 
         unsafe {
             let (a_ptr, _g1) = a_slice.device_ptr(&stream);
@@ -679,7 +957,10 @@ pub fn gdn_gated_rms_norm(x: &Tensor, z: &Tensor, weight: &Tensor, eps: f32) -> 
         candle_core::bail!(
             "kiln-gdn-kernel: gdn_gated_rms_norm: envelope violation \
              (x={:?}, z={:?}, weight={:?}, x.dtype={:?})",
-            x.shape(), z.shape(), weight.shape(), x.dtype()
+            x.shape(),
+            z.shape(),
+            weight.shape(),
+            x.dtype()
         );
     }
 
@@ -722,10 +1003,18 @@ pub fn gdn_gated_rms_norm(x: &Tensor, z: &Tensor, weight: &Tensor, eps: f32) -> 
         let stream = x_cuda.device().cuda_stream();
         let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
 
-        let x_slice = x_cuda.as_cuda_slice::<bf16>()?.slice(x_layout.start_offset()..);
-        let z_slice = z_cuda.as_cuda_slice::<bf16>()?.slice(z_layout.start_offset()..);
-        let w_slice = w_cuda.as_cuda_slice::<bf16>()?.slice(w_layout.start_offset()..);
-        let out_slice = out_cuda.as_cuda_slice::<bf16>()?.slice(out_layout.start_offset()..);
+        let x_slice = x_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(x_layout.start_offset()..);
+        let z_slice = z_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(z_layout.start_offset()..);
+        let w_slice = w_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(w_layout.start_offset()..);
+        let out_slice = out_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(out_layout.start_offset()..);
 
         unsafe {
             let (x_ptr, _g1) = x_slice.device_ptr(&stream);
@@ -823,9 +1112,7 @@ pub fn gdn_chunk_prep_supports(
     {
         return false;
     }
-    if ks_entry.dims().last().copied() != Some(dv)
-        || q_s.dims().last().copied() != Some(dv)
-    {
+    if ks_entry.dims().last().copied() != Some(dv) || q_s.dims().last().copied() != Some(dv) {
         return false;
     }
     true
@@ -861,8 +1148,12 @@ pub fn gdn_chunk_prep(
         candle_core::bail!(
             "kiln-gdn-kernel: gdn_chunk_prep: envelope violation \
              (g={:?}, v={:?}, kkt={:?}, qkt={:?}, ks_entry={:?}, q_s={:?})",
-            g.shape(), v.shape(), kkt.shape(), qkt.shape(),
-            ks_entry.shape(), q_s.shape()
+            g.shape(),
+            v.shape(),
+            kkt.shape(),
+            qkt.shape(),
+            ks_entry.shape(),
+            q_s.shape()
         );
     }
 
@@ -950,18 +1241,42 @@ pub fn gdn_chunk_prep(
         let stream = g_cuda.device().cuda_stream();
         let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
 
-        let g_slice = g_cuda.as_cuda_slice::<bf16>()?.slice(g_layout.start_offset()..);
-        let v_slice = v_cuda.as_cuda_slice::<bf16>()?.slice(v_layout.start_offset()..);
-        let kkt_slice = kkt_cuda.as_cuda_slice::<bf16>()?.slice(kkt_layout.start_offset()..);
-        let qkt_slice = qkt_cuda.as_cuda_slice::<bf16>()?.slice(qkt_layout.start_offset()..);
-        let ks_slice = ks_cuda.as_cuda_slice::<bf16>()?.slice(ks_layout.start_offset()..);
-        let qs_slice = qs_cuda.as_cuda_slice::<bf16>()?.slice(qs_layout.start_offset()..);
-        let a_slice = a_cuda.as_cuda_slice::<bf16>()?.slice(a_layout.start_offset()..);
-        let b_slice = b_cuda.as_cuda_slice::<bf16>()?.slice(b_layout.start_offset()..);
-        let vp_slice = vp_cuda.as_cuda_slice::<bf16>()?.slice(vp_layout.start_offset()..);
-        let qss_slice = qss_cuda.as_cuda_slice::<bf16>()?.slice(qss_layout.start_offset()..);
-        let dl_slice = dl_cuda.as_cuda_slice::<bf16>()?.slice(dl_layout.start_offset()..);
-        let pl_slice = pl_cuda.as_cuda_slice::<bf16>()?.slice(pl_layout.start_offset()..);
+        let g_slice = g_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(g_layout.start_offset()..);
+        let v_slice = v_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(v_layout.start_offset()..);
+        let kkt_slice = kkt_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(kkt_layout.start_offset()..);
+        let qkt_slice = qkt_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(qkt_layout.start_offset()..);
+        let ks_slice = ks_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(ks_layout.start_offset()..);
+        let qs_slice = qs_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(qs_layout.start_offset()..);
+        let a_slice = a_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(a_layout.start_offset()..);
+        let b_slice = b_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(b_layout.start_offset()..);
+        let vp_slice = vp_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(vp_layout.start_offset()..);
+        let qss_slice = qss_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(qss_layout.start_offset()..);
+        let dl_slice = dl_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(dl_layout.start_offset()..);
+        let pl_slice = pl_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(pl_layout.start_offset()..);
 
         unsafe {
             let (g_ptr, _g1) = g_slice.device_ptr(&stream);
@@ -1002,7 +1317,14 @@ pub fn gdn_chunk_prep(
         }
     }
 
-    Ok((a_strict, b_mask, v_prime, q_s_scaled, decay_last_col, p_last))
+    Ok((
+        a_strict,
+        b_mask,
+        v_prime,
+        q_s_scaled,
+        decay_last_col,
+        p_last,
+    ))
 }
 
 pub fn gdn_chunk_scan_supports(
@@ -1069,14 +1391,7 @@ pub fn gdn_chunk_scan(
     beta: &Tensor,
     decay_last_col: &Tensor,
 ) -> Result<(Tensor, Tensor)> {
-    if !gdn_chunk_scan_supports(
-        a_strict,
-        b_mask,
-        v_prime,
-        q_s_scaled,
-        beta,
-        decay_last_col,
-    ) {
+    if !gdn_chunk_scan_supports(a_strict, b_mask, v_prime, q_s_scaled, beta, decay_last_col) {
         candle_core::bail!(
             "kiln-gdn-kernel: gdn_chunk_scan: envelope violation \
              (a={:?}, b={:?}, v_prime={:?}, q_s_scaled={:?}, beta={:?}, decay_last_col={:?})",
@@ -1149,10 +1464,18 @@ pub fn gdn_chunk_scan(
         let stream = a_cuda.device().cuda_stream();
         let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
 
-        let a_slice = a_cuda.as_cuda_slice::<bf16>()?.slice(a_layout.start_offset()..);
-        let b_slice = b_cuda.as_cuda_slice::<bf16>()?.slice(b_layout.start_offset()..);
-        let vp_slice = vp_cuda.as_cuda_slice::<bf16>()?.slice(vp_layout.start_offset()..);
-        let qss_slice = qss_cuda.as_cuda_slice::<bf16>()?.slice(qss_layout.start_offset()..);
+        let a_slice = a_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(a_layout.start_offset()..);
+        let b_slice = b_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(b_layout.start_offset()..);
+        let vp_slice = vp_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(vp_layout.start_offset()..);
+        let qss_slice = qss_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(qss_layout.start_offset()..);
         let beta_slice = beta_cuda
             .as_cuda_slice::<bf16>()?
             .slice(beta_layout.start_offset()..);
@@ -1380,16 +1703,30 @@ pub fn gdn_full_chunk_forward(
         let stream = g_cuda.device().cuda_stream();
         let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
 
-        let g_slice = g_cuda.as_cuda_slice::<bf16>()?.slice(g_layout.start_offset()..);
-        let v_slice = v_cuda.as_cuda_slice::<bf16>()?.slice(v_layout.start_offset()..);
-        let kkt_slice = kkt_cuda.as_cuda_slice::<bf16>()?.slice(kkt_layout.start_offset()..);
-        let qkt_slice = qkt_cuda.as_cuda_slice::<bf16>()?.slice(qkt_layout.start_offset()..);
-        let ks_slice = ks_cuda.as_cuda_slice::<bf16>()?.slice(ks_layout.start_offset()..);
-        let qs_slice = qs_cuda.as_cuda_slice::<bf16>()?.slice(qs_layout.start_offset()..);
+        let g_slice = g_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(g_layout.start_offset()..);
+        let v_slice = v_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(v_layout.start_offset()..);
+        let kkt_slice = kkt_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(kkt_layout.start_offset()..);
+        let qkt_slice = qkt_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(qkt_layout.start_offset()..);
+        let ks_slice = ks_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(ks_layout.start_offset()..);
+        let qs_slice = qs_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(qs_layout.start_offset()..);
         let beta_slice = beta_cuda
             .as_cuda_slice::<bf16>()?
             .slice(beta_layout.start_offset()..);
-        let kt_slice = kt_cuda.as_cuda_slice::<bf16>()?.slice(kt_layout.start_offset()..);
+        let kt_slice = kt_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(kt_layout.start_offset()..);
         let state_slice = state_cuda
             .as_cuda_slice::<bf16>()?
             .slice(state_layout.start_offset()..);

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -1772,3 +1772,151 @@ pub fn gdn_full_chunk_forward(
     *state = state_c;
     Ok(out_chunk)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    fn patterned_data(len: usize, scale: f32, phase: f32) -> Vec<f32> {
+        (0..len)
+            .map(|i| {
+                let x = i as f32;
+                ((x * 0.013 + phase).sin() * 0.7 + (x * 0.007 + phase * 0.5).cos() * 0.3)
+                    * scale
+            })
+            .collect()
+    }
+
+    fn max_mean_abs_diff(lhs: &Tensor, rhs: &Tensor) -> Result<(f32, f32)> {
+        let diff = (lhs.to_dtype(DType::F32)? - rhs.to_dtype(DType::F32)?)?.abs()?;
+        let flat = diff.flatten_all()?;
+        Ok((
+            flat.max(0)?.to_scalar::<f32>()?,
+            flat.mean(0)?.to_scalar::<f32>()?,
+        ))
+    }
+
+    #[test]
+    fn test_cuda_decode_gates_recurrent_matches_split_path() -> Result<()> {
+        let device = match Device::new_cuda(0) {
+            Ok(device) => device,
+            Err(err) => {
+                eprintln!("CUDA unavailable, skipping decode gates+recurrent parity test: {err}");
+                return Ok(());
+            }
+        };
+
+        let batch = 1usize;
+        let seq_len = 1usize;
+        let heads = 32usize;
+        let dk = 128usize;
+        let dv = 128usize;
+
+        let q = Tensor::from_slice(
+            &patterned_data(batch * seq_len * heads * dk, 0.35, 0.1),
+            (batch, seq_len, heads, dk),
+            &device,
+        )?
+        .to_dtype(DType::BF16)?;
+        let k = Tensor::from_slice(
+            &patterned_data(batch * seq_len * heads * dk, 0.25, 0.7),
+            (batch, seq_len, heads, dk),
+            &device,
+        )?
+        .to_dtype(DType::BF16)?;
+        let v = Tensor::from_slice(
+            &patterned_data(batch * seq_len * heads * dv, 0.5, 1.3),
+            (batch, seq_len, heads, dv),
+            &device,
+        )?
+        .to_dtype(DType::BF16)?;
+        let a = Tensor::from_slice(
+            &patterned_data(batch * seq_len * heads, 0.4, 2.1),
+            (batch, seq_len, heads),
+            &device,
+        )?
+        .to_dtype(DType::BF16)?;
+        let b = Tensor::from_slice(
+            &patterned_data(batch * seq_len * heads, 0.6, 2.9),
+            (batch, seq_len, heads),
+            &device,
+        )?
+        .to_dtype(DType::BF16)?;
+        let a_log = Tensor::from_slice(&patterned_data(heads, 0.15, 3.7), (heads,), &device)?
+            .to_dtype(DType::BF16)?;
+        let dt_bias = Tensor::from_slice(&patterned_data(heads, 0.2, 4.3), (heads,), &device)?
+            .to_dtype(DType::BF16)?;
+        let z = Tensor::from_slice(
+            &patterned_data(batch * seq_len * heads * dv, 0.45, 4.9),
+            (batch, seq_len, heads, dv),
+            &device,
+        )?
+        .to_dtype(DType::BF16)?;
+        let weight = Tensor::from_slice(&patterned_data(dv, 0.3, 5.5), (dv,), &device)?
+            .to_dtype(DType::BF16)?;
+        let state = Tensor::from_slice(
+            &patterned_data(batch * heads * dk * dv, 0.08, 6.1),
+            (batch, heads, dk, dv),
+            &device,
+        )?
+        .to_dtype(DType::BF16)?;
+
+        let (beta, g) = gdn_gates(&a, &b, &a_log, &dt_bias)?;
+        let q_split = q.squeeze(1)?.contiguous()?;
+        let k_split = k.squeeze(1)?.contiguous()?;
+        let v_split = v.squeeze(1)?.contiguous()?;
+        let beta_split = beta.squeeze(1)?.contiguous()?;
+        let g_split = g.squeeze(1)?.contiguous()?;
+        let mut state_split = state.copy()?;
+        let out_split = gdn_recurrent_forward(
+            &q_split,
+            &k_split,
+            &v_split,
+            &beta_split,
+            &g_split,
+            &mut state_split,
+        )?
+        .unsqueeze(1)?;
+
+        let mut state_fused = state.copy()?;
+        let out_fused = gdn_decode_gates_recurrent(
+            &q,
+            &k,
+            &v,
+            &a,
+            &b,
+            &a_log,
+            &dt_bias,
+            &mut state_fused,
+            &z,
+            &weight,
+            1e-6,
+        )?;
+
+        let (out_max, out_mean) = max_mean_abs_diff(&out_fused, &out_split)?;
+        let (state_max, state_mean) = max_mean_abs_diff(&state_fused, &state_split)?;
+        eprintln!(
+            "cuda decode gates+recurrent vs split: out max={out_max:e} mean={out_mean:e}, state max={state_max:e} mean={state_mean:e}"
+        );
+
+        assert!(
+            out_max == 0.0,
+            "fused decode recurrent output max_abs_diff={out_max:e}"
+        );
+        assert!(
+            out_mean == 0.0,
+            "fused decode recurrent output mean_abs_diff={out_mean:e}"
+        );
+        assert!(
+            state_max == 0.0,
+            "fused decode recurrent state max_abs_diff={state_max:e}"
+        );
+        assert!(
+            state_mean == 0.0,
+            "fused decode recurrent state mean_abs_diff={state_mean:e}"
+        );
+
+        Ok(())
+    }
+}

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -20,6 +20,9 @@ pub struct CudaBackend {
     /// Kill switch for the fused GDN gated RMSNorm kernel (decode/prefill
     /// kiln/gdn/gated_norm region).
     gdn_gated_rms_norm_enabled: bool,
+    /// Experimental fused native-MTP decode GDN gates + recurrent update.
+    /// Opt-in only until output parity is proven.
+    gdn_decode_fused_enabled: bool,
     /// Kill switch for the fused causal_conv1d_update kernel (decode
     /// kiln/gdn/conv region). When off, forward.rs falls back to the
     /// candle to_f32/cat/sum/narrow chain.
@@ -32,14 +35,19 @@ impl CudaBackend {
         let gdn_enabled = std::env::var("KILN_DISABLE_GDN_KERNEL").is_err();
         let gdn_gates_enabled =
             gdn_enabled && std::env::var("KILN_DISABLE_FUSED_GDN_GATES").is_err();
-        let gdn_gated_rms_norm_enabled = gdn_enabled
-            && std::env::var("KILN_DISABLE_FUSED_GDN_GATED_RMS_NORM").is_err();
+        let gdn_gated_rms_norm_enabled =
+            gdn_enabled && std::env::var("KILN_DISABLE_FUSED_GDN_GATED_RMS_NORM").is_err();
         let fused_conv1d_enabled = std::env::var("KILN_DISABLE_FUSED_CONV1D").is_err();
+        let gdn_decode_fused_enabled = gdn_gates_enabled
+            && gdn_gated_rms_norm_enabled
+            && std::env::var("KILN_ENABLE_FUSED_GDN_DECODE").is_ok()
+            && std::env::var("KILN_DISABLE_FUSED_GDN_DECODE").is_err();
         Self {
             device,
             gdn_enabled,
             gdn_gates_enabled,
             gdn_gated_rms_norm_enabled,
+            gdn_decode_fused_enabled,
             fused_conv1d_enabled,
         }
     }
@@ -230,6 +238,36 @@ impl BackendRuntime for CudaBackend {
         Ok(Some(out))
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn gdn_decode_gates_recurrent(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        a: &Tensor,
+        b: &Tensor,
+        a_log: &Tensor,
+        dt_bias: &Tensor,
+        state: &mut Tensor,
+        z: &Tensor,
+        weight: &Tensor,
+        eps: f64,
+    ) -> Result<Option<Tensor>> {
+        if !self.gdn_decode_fused_enabled {
+            return Ok(None);
+        }
+        if !kiln_gdn_kernel::gdn_decode_gates_recurrent_supports(
+            q, k, v, a, b, a_log, dt_bias, state, z, weight,
+        ) {
+            return Ok(None);
+        }
+        let out = kiln_gdn_kernel::gdn_decode_gates_recurrent(
+            q, k, v, a, b, a_log, dt_bias, state, z, weight, eps as f32,
+        )
+        .context("gdn_decode_gates_recurrent kernel failed")?;
+        Ok(Some(out))
+    }
+
     fn supports_gdn_gates(&self) -> bool {
         self.gdn_gates_enabled
     }
@@ -246,8 +284,8 @@ impl BackendRuntime for CudaBackend {
         if !kiln_gdn_kernel::gdn_gates_supports(a, b, a_log, dt_bias) {
             return Ok(None);
         }
-        let (beta, g) = kiln_gdn_kernel::gdn_gates(a, b, a_log, dt_bias)
-            .context("gdn_gates kernel failed")?;
+        let (beta, g) =
+            kiln_gdn_kernel::gdn_gates(a, b, a_log, dt_bias).context("gdn_gates kernel failed")?;
         Ok(Some((beta, g)))
     }
 

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -321,6 +321,30 @@ pub trait BackendRuntime: Send + Sync + std::fmt::Debug {
         Ok(None)
     }
 
+    /// Fused native-MTP GDN decode gates + recurrent update.
+    ///
+    /// Narrow CUDA/Metal decode path for `seq_len == 1` bf16 tensors. Returns
+    /// `[B, 1, value_heads, dv]` before gated RMSNorm, mutating `state` in
+    /// place. `Ok(None)` means the backend declines and the caller should use
+    /// the split gates/recurrent/gated_norm path.
+    #[allow(clippy::too_many_arguments)]
+    fn gdn_decode_gates_recurrent(
+        &self,
+        _q: &Tensor,
+        _k: &Tensor,
+        _v: &Tensor,
+        _a: &Tensor,
+        _b: &Tensor,
+        _a_log: &Tensor,
+        _dt_bias: &Tensor,
+        _state: &mut Tensor,
+        _z: &Tensor,
+        _weight: &Tensor,
+        _eps: f64,
+    ) -> Result<Option<Tensor>> {
+        Ok(None)
+    }
+
     /// Fused GDN decode input projections.
     ///
     /// Collapses the four single-token `broadcast_matmul` calls in Step 1

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3585,44 +3585,65 @@ fn gated_deltanet_forward_decode_if(
     };
 
     let fused_decode_gates_recurrent = {
-        #[cfg(feature = "metal")]
+        if fused_decode_gates_recurrent_rmsnorm.is_none()
+            && seq_len == 1
+            && !capture_b11_taps
+            && !capture_c41_taps
         {
-            if fused_decode_gates_recurrent_rmsnorm.is_none()
-                && recurrent_unexpanded_qk
-                && seq_len == 1
-                && !capture_b11_taps
-                && !capture_c41_taps
-                && crate::backend::metal::metal_gdn_decode_gates_recurrent_supports(
-                    &q,
-                    &k,
-                    &v,
-                    &a,
-                    &b,
-                    &weights.a_log,
-                    &weights.dt_bias,
-                    recurrent_state,
-                )
-            {
+            if let Some(out) = backend.gdn_decode_gates_recurrent(
+                &q,
+                &k,
+                &v,
+                &a,
+                &b,
+                &weights.a_log,
+                &weights.dt_bias,
+                recurrent_state,
+                &z,
+                &weights.norm,
+                config.rms_norm_eps,
+            )? {
                 kiln_nvtx::range!(c"kiln/gdn/gates_recur");
-                Some(
-                    crate::backend::metal::metal_gdn_decode_gates_recurrent_bf16(
-                        &q,
-                        &k,
-                        &v,
-                        &a,
-                        &b,
-                        &weights.a_log,
-                        &weights.dt_bias,
-                        recurrent_state,
-                    )
-                    .context("metal gdn decode gates+recurrent kernel failed")?,
-                )
+                Some(out)
             } else {
-                None
+                #[cfg(feature = "metal")]
+                {
+                    if recurrent_unexpanded_qk
+                        && crate::backend::metal::metal_gdn_decode_gates_recurrent_supports(
+                            &q,
+                            &k,
+                            &v,
+                            &a,
+                            &b,
+                            &weights.a_log,
+                            &weights.dt_bias,
+                            recurrent_state,
+                        )
+                    {
+                        kiln_nvtx::range!(c"kiln/gdn/gates_recur");
+                        Some(
+                            crate::backend::metal::metal_gdn_decode_gates_recurrent_bf16(
+                                &q,
+                                &k,
+                                &v,
+                                &a,
+                                &b,
+                                &weights.a_log,
+                                &weights.dt_bias,
+                                recurrent_state,
+                            )
+                            .context("metal gdn decode gates+recurrent kernel failed")?,
+                        )
+                    } else {
+                        None
+                    }
+                }
+                #[cfg(not(feature = "metal"))]
+                {
+                    None
+                }
             }
-        }
-        #[cfg(not(feature = "metal"))]
-        {
+        } else {
             None
         }
     };

--- a/docs/phase-c58/cuda-gdn-decode-fuse.md
+++ b/docs/phase-c58/cuda-gdn-decode-fuse.md
@@ -1,38 +1,49 @@
-# Phase C58 CUDA GDN Decode Fusion Attempt
+# Phase C58 CUDA GDN Decode Fusion
 
 Date: 2026-04-24
-Pod: `yzf1plx0m6z092` (`NVIDIA A40`, `ghcr.io/ericflo/kiln-runpod:latest`)
+Pod: `mfk88l8i8tab02` (`NVIDIA RTX A6000`, `ghcr.io/ericflo/kiln-runpod:latest`)
 
 ## Scope
 
-Added a narrow CUDA C-ABI entry point for native-MTP `seq_len == 1` GDN decode that computes gates and advances the recurrent GDN state in one launch for bf16 `dk == dv == 128` tensors. The hook is wired through `BackendRuntime::gdn_decode_gates_recurrent` and the CUDA backend.
+PR #498 adds a narrow opt-in CUDA C-ABI entry point for native-MTP `seq_len == 1` GDN decode that computes gates and advances the recurrent state in one launch for bf16 `dk == dv == 128` tensors. The hook is wired through `BackendRuntime::gdn_decode_gates_recurrent` and the CUDA backend.
 
-## Current Status
+The production path remains disabled by default and is only selected when `KILN_ENABLE_FUSED_GDN_DECODE=1` is set.
 
-The CUDA hook is guarded behind `KILN_ENABLE_FUSED_GDN_DECODE=1` and remains disabled by default. During validation, the state update matched the split CUDA path exactly, but the recurrent output did not:
+## Parity Resolution
+
+The reported output mismatch was caused by the parity probe using `Tensor::clone()` for mutable recurrent state. Candle tensor clones share storage, so the split path advanced the same state storage before the fused path ran. The fused kernel was then compared from an already-mutated input state, which produced a recurrent output mismatch while making the final state appear identical.
+
+The restored GPU parity test now deep-copies state with `Tensor::copy()` before each arm and proves exact parity against the existing split CUDA path:
 
 ```text
-cuda decode gates+recurrent vs split: max_abs_diff=4.1328125e0 mean_abs_diff=5.352731e-1 state_max=0e0
+cuda decode gates+recurrent vs split: out max=0e0 mean=0e0, state max=0e0 mean=0e0
 ```
 
-Because output parity is not proven, the production path continues to use the existing split `gdn/gates` + `gdn/recurrent` + `gdn/gated_norm` kernels unless explicitly opted in for debugging.
+The fused hook only covers gates + recurrent state/output. Gated RMSNorm remains on the existing standalone kernel, per the earlier combined-RMSNorm fusion risk.
 
-## Validation Notes
+## Validation
 
-Passing:
+RunPod A6000 validation passed:
 
 ```bash
 cargo test -p kiln-gdn-kernel --release -- --nocapture
+KILN_ENABLE_FUSED_GDN_DECODE=1 cargo test -p kiln-model --release --features cuda gdn_decode -- --nocapture
+cargo build --release --features cuda,nvtx --bin kiln-bench
 ```
 
-Known failing during this attempt:
+## Benchmark Result
+
+Focused A6000 decode benchmark command:
 
 ```bash
-cargo test -p kiln-model --release --features cuda gdn -- --nocapture
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1
 ```
 
-The command included an existing `test_gdn_chunk_body_matches_fallback` failure on this A40 run, and the experimental fused-output parity test failed before it was removed from the default suite.
+Results:
 
-## Next Step
+| Path | Mean ITL | Decode tok/s |
+| --- | ---: | ---: |
+| Default | 22.493 ms | 44.458 |
+| `KILN_ENABLE_FUSED_GDN_DECODE=1` | 22.501 ms | 44.442 |
 
-Do not retry standalone gates/recurrent/gated-norm fusion blindly. First isolate the recurrent output discrepancy with a tiny debug kernel or compare the existing `kiln_gdn_recurrent_forward` output against a C-ABI variant fed the exact `[B, 1, H, D]` layout. If this remains below a 5% decode throughput gain, pivot to `:kiln/gdn/qk_norm` or `:kiln/attn/rope` per the C57 profile guidance.
+The measured decode delta is effectively parity and below the 5% enable-by-default floor. Leave `KILN_ENABLE_FUSED_GDN_DECODE` opt-in and pivot to `:kiln/gdn/qk_norm` or `:kiln/attn/rope` rather than retrying this fusion shape.

--- a/docs/phase-c58/cuda-gdn-decode-fuse.md
+++ b/docs/phase-c58/cuda-gdn-decode-fuse.md
@@ -1,0 +1,38 @@
+# Phase C58 CUDA GDN Decode Fusion Attempt
+
+Date: 2026-04-24
+Pod: `yzf1plx0m6z092` (`NVIDIA A40`, `ghcr.io/ericflo/kiln-runpod:latest`)
+
+## Scope
+
+Added a narrow CUDA C-ABI entry point for native-MTP `seq_len == 1` GDN decode that computes gates and advances the recurrent GDN state in one launch for bf16 `dk == dv == 128` tensors. The hook is wired through `BackendRuntime::gdn_decode_gates_recurrent` and the CUDA backend.
+
+## Current Status
+
+The CUDA hook is guarded behind `KILN_ENABLE_FUSED_GDN_DECODE=1` and remains disabled by default. During validation, the state update matched the split CUDA path exactly, but the recurrent output did not:
+
+```text
+cuda decode gates+recurrent vs split: max_abs_diff=4.1328125e0 mean_abs_diff=5.352731e-1 state_max=0e0
+```
+
+Because output parity is not proven, the production path continues to use the existing split `gdn/gates` + `gdn/recurrent` + `gdn/gated_norm` kernels unless explicitly opted in for debugging.
+
+## Validation Notes
+
+Passing:
+
+```bash
+cargo test -p kiln-gdn-kernel --release -- --nocapture
+```
+
+Known failing during this attempt:
+
+```bash
+cargo test -p kiln-model --release --features cuda gdn -- --nocapture
+```
+
+The command included an existing `test_gdn_chunk_body_matches_fallback` failure on this A40 run, and the experimental fused-output parity test failed before it was removed from the default suite.
+
+## Next Step
+
+Do not retry standalone gates/recurrent/gated-norm fusion blindly. First isolate the recurrent output discrepancy with a tiny debug kernel or compare the existing `kiln_gdn_recurrent_forward` output against a C-ABI variant fed the exact `[B, 1, H, D]` layout. If this remains below a 5% decode throughput gain, pivot to `:kiln/gdn/qk_norm` or `:kiln/attn/rope` per the C57 profile guidance.


### PR DESCRIPTION
## Summary

- Adds a narrow CUDA C-ABI hook for native-MTP `seq_len == 1` GDN decode that computes gates and advances recurrent state in one launch for bf16 `dk == dv == 128` tensors.
- Wires the hook through `BackendRuntime::gdn_decode_gates_recurrent` and the CUDA backend.
- Keeps the hook opt-in via `KILN_ENABLE_FUSED_GDN_DECODE=1` because the focused benchmark did not clear the 5% enable-by-default floor.
- Restores a GPU parity test in `kiln-gdn-kernel` proving fused decode output and recurrent state match the existing split CUDA path exactly.
- Updates `docs/phase-c58/cuda-gdn-decode-fuse.md` with the parity root cause, validation, and benchmark result.

## Parity Resolution

The previous mismatch was a parity-probe bug: it used `Tensor::clone()` for mutable recurrent state. Candle tensor clones share storage, so the split arm advanced the same state storage before the fused arm ran. Replacing those parity arms with `Tensor::copy()` proves exact output and state parity:

```text
cuda decode gates+recurrent vs split: out max=0e0 mean=0e0, state max=0e0 mean=0e0
```

## Validation

RunPod:
- Pod: `mfk88l8i8tab02`
- GPU: `NVIDIA RTX A6000`
- Image: `ghcr.io/ericflo/kiln-runpod:latest`

Commands:
- ✅ `cargo test -p kiln-gdn-kernel --release -- --nocapture`
- ✅ `KILN_ENABLE_FUSED_GDN_DECODE=1 cargo test -p kiln-model --release --features cuda gdn_decode -- --nocapture`
- ✅ `cargo build --release --features cuda,nvtx --bin kiln-bench`

## Benchmark Result

Command:

```bash
./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1
```

Results:

| Path | Mean ITL | Decode tok/s |
| --- | ---: | ---: |
| Default | 22.493 ms | 44.458 |
| `KILN_ENABLE_FUSED_GDN_DECODE=1` | 22.501 ms | 44.442 |

The measured decode delta is effectively parity and below the 5% enable-by-default floor, so the hook remains opt-in. Recommended next pivot: `:kiln/gdn/qk_norm` or `:kiln/attn/rope`, not another retry of this fusion shape.

## Cleanup

Pod lease `pod-66eb55349e1403350e6c342d` / pod `mfk88l8i8tab02` released after validation.