### PR TITLE
[codex] add CUDA GDN qk_norm GQA fast path

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -3523,27 +3523,61 @@ fn gated_deltanet_forward_decode_if(
             }
             #[cfg(not(feature = "metal"))]
             {
-                let (q, k) = {
-                    kiln_nvtx::range!(c"kiln/gdn/head_expand");
-                    if gqa_ratio > 1 {
-                        let q = q
-                            .unsqueeze(3)?
-                            .expand(&[batch, seq_len, nk, gqa_ratio, dk])?
-                            .contiguous()?
-                            .reshape((batch, seq_len, nv, dk))?;
-                        let k = k
-                            .unsqueeze(3)?
-                            .expand(&[batch, seq_len, nk, gqa_ratio, dk])?
-                            .contiguous()?
-                            .reshape((batch, seq_len, nv, dk))?;
-                        (q, k)
-                    } else {
-                        (q.contiguous()?, k.contiguous()?)
+                let fused_gqa = {
+                    #[cfg(feature = "cuda")]
+                    {
+                        let disabled = std::env::var("KILN_DISABLE_FUSED_L2_QK_NORM").is_ok();
+                        if !disabled
+                            && input_dtype == DType::BF16
+                            && gqa_ratio > 1
+                            && kiln_rmsnorm_kernel::supports_l2_qk_norm_gqa(&q, &k, nv)
+                        {
+                            kiln_nvtx::range!(c"kiln/gdn/qk_norm_gqa");
+                            Some(
+                                kiln_rmsnorm_kernel::fused_l2_qk_norm_gqa(
+                                    &q,
+                                    &k,
+                                    nv,
+                                    scale as f32,
+                                    1e-6,
+                                )
+                                .context("fused_l2_qk_norm_gqa kernel failed")?,
+                            )
+                        } else {
+                            None
+                        }
+                    }
+                    #[cfg(not(feature = "cuda"))]
+                    {
+                        None
                     }
                 };
-                kiln_nvtx::range!(c"kiln/gdn/qk_norm");
-                let (q, k) = gdn_qk_norm(&q, &k, input_dtype, scale)?;
-                (q, k, true)
+
+                if let Some((q, k)) = fused_gqa {
+                    (q, k, true)
+                } else {
+                    let (q, k) = {
+                        kiln_nvtx::range!(c"kiln/gdn/head_expand");
+                        if gqa_ratio > 1 {
+                            let q = q
+                                .unsqueeze(3)?
+                                .expand(&[batch, seq_len, nk, gqa_ratio, dk])?
+                                .contiguous()?
+                                .reshape((batch, seq_len, nv, dk))?;
+                            let k = k
+                                .unsqueeze(3)?
+                                .expand(&[batch, seq_len, nk, gqa_ratio, dk])?
+                                .contiguous()?
+                                .reshape((batch, seq_len, nv, dk))?;
+                            (q, k)
+                        } else {
+                            (q.contiguous()?, k.contiguous()?)
+                        }
+                    };
+                    kiln_nvtx::range!(c"kiln/gdn/qk_norm");
+                    let (q, k) = gdn_qk_norm(&q, &k, input_dtype, scale)?;
+                    (q, k, true)
+                }
             }
         };
         (q, k, v, z, qk_expanded)

--- a/crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.cu
+++ b/crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.cu
@@ -129,6 +129,63 @@ __global__ void fused_l2_qk_norm_kernel(
     }
 }
 
+__global__ void fused_l2_qk_norm_gqa_kernel(
+    const __nv_bfloat16 *__restrict__ q_in,
+    const __nv_bfloat16 *__restrict__ k_in,
+    __nv_bfloat16 *__restrict__ q_out,
+    __nv_bfloat16 *__restrict__ k_out,
+    int nk,
+    int ratio,
+    int hidden,
+    float q_scale,
+    float eps
+) {
+    int row = blockIdx.x;
+    int head = row % nk;
+    int token = row / nk;
+
+    const __nv_bfloat16 *q_row = q_in + static_cast<size_t>(row) * hidden;
+    const __nv_bfloat16 *k_row = k_in + static_cast<size_t>(row) * hidden;
+
+    float q_ss = 0.0f;
+    float k_ss = 0.0f;
+    for (int j = threadIdx.x; j < hidden; j += blockDim.x) {
+        float qj = __bfloat162float(q_row[j]);
+        float kj = __bfloat162float(k_row[j]);
+        q_ss += qj * qj;
+        k_ss += kj * kj;
+    }
+
+    __shared__ float smem[kMaxWarps];
+    __shared__ float s_inv_q;
+    __shared__ float s_inv_k;
+
+    float q_sum = block_reduce_sum(q_ss, smem);
+    float k_sum = block_reduce_sum(k_ss, smem);
+
+    if (threadIdx.x == 0) {
+        s_inv_q = q_scale * rsqrtf(q_sum + eps);
+        s_inv_k = rsqrtf(k_sum + eps);
+    }
+    __syncthreads();
+
+    float inv_q = s_inv_q;
+    float inv_k = s_inv_k;
+    int nv = nk * ratio;
+    size_t out_base = (static_cast<size_t>(token) * nv + static_cast<size_t>(head) * ratio) * hidden;
+
+    for (int r = 0; r < ratio; ++r) {
+        __nv_bfloat16 *q_out_row = q_out + out_base + static_cast<size_t>(r) * hidden;
+        __nv_bfloat16 *k_out_row = k_out + out_base + static_cast<size_t>(r) * hidden;
+        for (int j = threadIdx.x; j < hidden; j += blockDim.x) {
+            float qj = __bfloat162float(q_row[j]) * inv_q;
+            float kj = __bfloat162float(k_row[j]) * inv_k;
+            q_out_row[j] = __float2bfloat16(qj);
+            k_out_row[j] = __float2bfloat16(kj);
+        }
+    }
+}
+
 }  // namespace
 
 extern "C" kiln_l2_qk_norm_status_t kiln_fused_l2_qk_norm(
@@ -161,6 +218,51 @@ extern "C" kiln_l2_qk_norm_status_t kiln_fused_l2_qk_norm(
         reinterpret_cast<const __nv_bfloat16 *>(k_in),
         reinterpret_cast<__nv_bfloat16 *>(q_out),
         reinterpret_cast<__nv_bfloat16 *>(k_out),
+        hidden,
+        q_scale,
+        eps
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 1;
+    }
+    return 0;
+}
+
+
+extern "C" kiln_l2_qk_norm_status_t kiln_fused_l2_qk_norm_gqa(
+    const void *q_in,
+    const void *k_in,
+    void *q_out,
+    void *k_out,
+    int rows,
+    int nk,
+    int ratio,
+    int hidden,
+    float q_scale,
+    float eps,
+    void *stream
+) {
+    if (rows <= 0 || nk <= 0 || ratio <= 0 || hidden <= 0) {
+        return 0;
+    }
+    if (hidden != 128 || rows % nk != 0) {
+        return 2;
+    }
+
+    dim3 grid(rows);
+    dim3 block(kThreadsPerBlock);
+
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+
+    fused_l2_qk_norm_gqa_kernel<<<grid, block, 0, s>>>(
+        reinterpret_cast<const __nv_bfloat16 *>(q_in),
+        reinterpret_cast<const __nv_bfloat16 *>(k_in),
+        reinterpret_cast<__nv_bfloat16 *>(q_out),
+        reinterpret_cast<__nv_bfloat16 *>(k_out),
+        nk,
+        ratio,
         hidden,
         q_scale,
         eps

--- a/crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.h
+++ b/crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.h
@@ -71,6 +71,29 @@ kiln_l2_qk_norm_status_t kiln_fused_l2_qk_norm(
     void *stream
 );
 
+// Fused GQA head-expand + L2-norm(Q) + scale(Q) + L2-norm(K).
+//
+// Input layout:  q_in, k_in   [batch, seq, nk, hidden] bf16 contiguous.
+// Output layout: q_out, k_out [batch, seq, nv, hidden] bf16 contiguous,
+// where `nv = nk * ratio` and each normalized input head is repeated `ratio`
+// times in the output head axis.
+//
+// Scope is intentionally narrow for Qwen3.5 GDN: bf16, forward-only,
+// hidden == 128, nv a positive multiple of nk.
+kiln_l2_qk_norm_status_t kiln_fused_l2_qk_norm_gqa(
+    const void *q_in,
+    const void *k_in,
+    void *q_out,
+    void *k_out,
+    int rows,
+    int nk,
+    int ratio,
+    int hidden,
+    float q_scale,
+    float eps,
+    void *stream
+);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/kiln-rmsnorm-kernel/src/lib.rs
+++ b/crates/kiln-rmsnorm-kernel/src/lib.rs
@@ -8,6 +8,9 @@
 //! 2. [`fused_l2_qk_norm`] — fused L2-norm(Q) + scale(Q) + L2-norm(K) used by
 //!    GDN linear attention. Replaces the ~11 candle ops behind the
 //!    `kiln/gdn/qk_norm` block in `forward.rs`.
+//! 3. [`fused_l2_qk_norm_gqa`] — CUDA GDN GQA fast path that normalizes
+//!    unexpanded `[B, T, nk, dk]` Q/K and emits expanded `[B, T, nv, dk]`
+//!    outputs in one launch.
 //!
 //! # Why
 //!
@@ -37,21 +40,22 @@
 //! - [`fused_l2_qk_norm`] — candle-compatible wrapper around the GDN QK
 //!   fused-norm kernel. Returns `(q_out, k_out)`.
 //! - [`supports_l2_qk_norm`] — capability check for the QK kernel.
+//! - [`fused_l2_qk_norm_gqa`] / [`supports_l2_qk_norm_gqa`] — GDN GQA
+//!   head-expand + QK norm CUDA path.
 //!
 //! # Envelope
 //!
 //! - bf16 activations, bf16 weights, bf16 outputs.
 //! - Contiguous CUDA tensors only.
-//! - Last dim (`hidden`) must be <= 8192.
+//! - Last dim (`hidden`) must be <= 8192 for expanded QK norm; exactly 128
+//!   for the GQA head-expand fast path.
 //! - `eps` is F32 — kiln uses 1e-6 for both kernels.
 //!
 //! Out of scope: backward pass, fused GEMM prologue, non-bf16 dtypes,
 //! non-contiguous input.
 
 use candle_core::{
-    backend::BackendStorage,
-    cuda_backend::cudarc::driver::DevicePtr,
-    DType, Device, Result, Tensor,
+    DType, Device, Result, Tensor, backend::BackendStorage, cuda_backend::cudarc::driver::DevicePtr,
 };
 use half::bf16;
 
@@ -72,6 +76,20 @@ unsafe extern "C" {
         q_out: *mut core::ffi::c_void,
         k_out: *mut core::ffi::c_void,
         rows: i32,
+        hidden: i32,
+        q_scale: f32,
+        eps: f32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
+    fn kiln_fused_l2_qk_norm_gqa(
+        q_in: *const core::ffi::c_void,
+        k_in: *const core::ffi::c_void,
+        q_out: *mut core::ffi::c_void,
+        k_out: *mut core::ffi::c_void,
+        rows: i32,
+        nk: i32,
+        ratio: i32,
         hidden: i32,
         q_scale: f32,
         eps: f32,
@@ -347,6 +365,163 @@ pub fn fused_l2_qk_norm(
     Ok((q_out, k_out))
 }
 
+/// Whether the fused GQA head-expand + L2 QK-norm kernel is available.
+///
+/// Inputs must be CUDA + bf16 with shape `[batch, seq, nk, dk]`; the wrapper
+/// materializes contiguous inputs before launch when needed.
+/// `nv` must be a positive multiple of `nk`; `dk` is intentionally limited to
+/// Qwen3.5 GDN's `128` so this remains a narrow forward-only CUDA path.
+pub fn supports_l2_qk_norm_gqa(q: &Tensor, k: &Tensor, nv: usize) -> bool {
+    if !matches!(q.device(), Device::Cuda(_))
+        || !matches!(k.device(), Device::Cuda(_))
+        || q.dtype() != DType::BF16
+        || k.dtype() != DType::BF16
+        || q.dims() != k.dims()
+        || q.rank() != 4
+    {
+        return false;
+    }
+
+    let dims = q.dims();
+    let nk = dims[2];
+    let dk = dims[3];
+    nk > 0 && dk == 128 && nv >= nk && nv % nk == 0
+}
+
+/// Run fused GQA head-expand + L2 QK-norm.
+///
+/// Inputs are unexpanded GDN Q/K tensors `[batch, seq, nk, dk]`; outputs are
+/// freshly allocated bf16 tensors `[batch, seq, nv, dk]`, with each normalized
+/// input head repeated `nv / nk` times. Semantics match explicit Candle
+/// `expand(...).contiguous().reshape(...)` followed by [`fused_l2_qk_norm`].
+pub fn fused_l2_qk_norm_gqa(
+    q: &Tensor,
+    k: &Tensor,
+    nv: usize,
+    q_scale: f32,
+    eps: f32,
+) -> Result<(Tensor, Tensor)> {
+    if q.dtype() != DType::BF16 || k.dtype() != DType::BF16 {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: l2_qk_norm_gqa requires bf16 inputs (got {:?}, {:?})",
+            q.dtype(),
+            k.dtype()
+        );
+    }
+    if q.dims() != k.dims() {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: l2_qk_norm_gqa requires q.dims == k.dims (got {:?}, {:?})",
+            q.dims(),
+            k.dims()
+        );
+    }
+    if q.rank() != 4 {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: l2_qk_norm_gqa requires rank-4 [B,T,nk,dk] input (got {:?})",
+            q.dims()
+        );
+    }
+
+    let dims = q.dims();
+    let batch = dims[0];
+    let seq = dims[1];
+    let nk = dims[2];
+    let dk = dims[3];
+
+    if nk == 0 || nv < nk || nv % nk != 0 {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: l2_qk_norm_gqa requires nv to be a positive multiple of nk (nk={nk}, nv={nv})"
+        );
+    }
+    if dk != 128 {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: l2_qk_norm_gqa dk {dk} outside envelope (expected 128)"
+        );
+    }
+
+    let ratio = nv / nk;
+    let rows = batch * seq * nk;
+    let device = q.device();
+    let out_dims = [batch, seq, nv, dk];
+
+    let q_out = Tensor::zeros(&out_dims, DType::BF16, device)?;
+    let k_out = Tensor::zeros(&out_dims, DType::BF16, device)?;
+
+    if rows == 0 {
+        return Ok((q_out, k_out));
+    }
+
+    let q = q.contiguous()?;
+    let k = k.contiguous()?;
+
+    {
+        let (q_storage, q_layout) = q.storage_and_layout();
+        let (k_storage, k_layout) = k.storage_and_layout();
+        let (qo_storage, qo_layout) = q_out.storage_and_layout();
+        let (ko_storage, ko_layout) = k_out.storage_and_layout();
+
+        let q_cuda = match &*q_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: q must be on CUDA"),
+        };
+        let k_cuda = match &*k_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: k must be on CUDA"),
+        };
+        let qo_cuda = match &*qo_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: q_out must be on CUDA"),
+        };
+        let ko_cuda = match &*ko_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: k_out must be on CUDA"),
+        };
+
+        let stream = q_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let q_slice = q_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(q_layout.start_offset()..);
+        let k_slice = k_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(k_layout.start_offset()..);
+        let qo_slice = qo_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(qo_layout.start_offset()..);
+        let ko_slice = ko_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(ko_layout.start_offset()..);
+
+        unsafe {
+            let (q_ptr, _g1) = q_slice.device_ptr(&stream);
+            let (k_ptr, _g2) = k_slice.device_ptr(&stream);
+            let (qo_ptr, _g3) = qo_slice.device_ptr(&stream);
+            let (ko_ptr, _g4) = ko_slice.device_ptr(&stream);
+
+            let status = kiln_fused_l2_qk_norm_gqa(
+                q_ptr as *const _,
+                k_ptr as *const _,
+                qo_ptr as *mut _,
+                ko_ptr as *mut _,
+                rows as i32,
+                nk as i32,
+                ratio as i32,
+                dk as i32,
+                q_scale,
+                eps,
+                raw_stream,
+            );
+
+            if status != 0 {
+                candle_core::bail!("kiln_fused_l2_qk_norm_gqa failed with status {status}");
+            }
+        }
+    }
+
+    Ok((q_out, k_out))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -604,8 +779,7 @@ mod tests {
         let k = k_f32.to_dtype(DType::BF16).unwrap();
 
         let (q_ref, k_ref) = reference_l2_qk_norm(&q, &k, q_scale, eps).unwrap();
-        let (q_fused, k_fused) =
-            fused_l2_qk_norm(&q, &k, q_scale as f32, eps as f32).unwrap();
+        let (q_fused, k_fused) = fused_l2_qk_norm(&q, &k, q_scale as f32, eps as f32).unwrap();
 
         assert_eq!(q_fused.dims(), &[batch, seq, nv, dk]);
         assert_eq!(k_fused.dims(), &[batch, seq, nv, dk]);
@@ -654,8 +828,7 @@ mod tests {
         let k = k_f32.to_dtype(DType::BF16).unwrap();
 
         let (q_ref, k_ref) = reference_l2_qk_norm(&q, &k, q_scale, eps).unwrap();
-        let (q_fused, k_fused) =
-            fused_l2_qk_norm(&q, &k, q_scale as f32, eps as f32).unwrap();
+        let (q_fused, k_fused) = fused_l2_qk_norm(&q, &k, q_scale as f32, eps as f32).unwrap();
 
         assert_eq!(q_fused.dims(), &[batch, seq, nv, dk]);
         assert_eq!(k_fused.dims(), &[batch, seq, nv, dk]);
@@ -670,6 +843,145 @@ mod tests {
         assert!(
             k_diff < 1e-2,
             "K parity failed: max_abs_diff={k_diff} exceeds 1e-2 tolerance"
+        );
+    }
+
+    #[test]
+    fn parity_l2_qk_norm_gqa_decode_shape() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        let batch = 1usize;
+        let seq = 1usize;
+        let nk = 8usize;
+        let nv = 16usize;
+        let dk = 128usize;
+        let total = batch * seq * nk * dk;
+        let q_scale = 1.0 / (dk as f64).sqrt();
+        let eps = 1e-6;
+
+        let mut q_raw = Vec::with_capacity(total);
+        let mut k_raw = Vec::with_capacity(total);
+        fill_pseudo_random(&mut q_raw, total, 0x3141_5926, 0.5);
+        fill_pseudo_random(&mut k_raw, total, 0x2718_2818, 0.5);
+
+        let q = Tensor::from_vec(q_raw, (batch, seq, nk, dk), &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let k = Tensor::from_vec(k_raw, (batch, seq, nk, dk), &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+
+        assert!(supports_l2_qk_norm_gqa(&q, &k, nv));
+
+        let ratio = nv / nk;
+        let q_expanded = q
+            .unsqueeze(3)
+            .unwrap()
+            .expand(&[batch, seq, nk, ratio, dk])
+            .unwrap()
+            .contiguous()
+            .unwrap()
+            .reshape((batch, seq, nv, dk))
+            .unwrap();
+        let k_expanded = k
+            .unsqueeze(3)
+            .unwrap()
+            .expand(&[batch, seq, nk, ratio, dk])
+            .unwrap()
+            .contiguous()
+            .unwrap()
+            .reshape((batch, seq, nv, dk))
+            .unwrap();
+
+        let (q_ref, k_ref) = reference_l2_qk_norm(&q_expanded, &k_expanded, q_scale, eps).unwrap();
+        let (q_fused, k_fused) =
+            fused_l2_qk_norm_gqa(&q, &k, nv, q_scale as f32, eps as f32).unwrap();
+
+        assert_eq!(q_fused.dims(), &[batch, seq, nv, dk]);
+        assert_eq!(k_fused.dims(), &[batch, seq, nv, dk]);
+
+        let q_diff = max_abs_diff(&q_ref, &q_fused);
+        let k_diff = max_abs_diff(&k_ref, &k_fused);
+
+        assert!(
+            q_diff < 1e-2,
+            "GQA Q parity failed: max_abs_diff={q_diff} exceeds 1e-2 tolerance"
+        );
+        assert!(
+            k_diff < 1e-2,
+            "GQA K parity failed: max_abs_diff={k_diff} exceeds 1e-2 tolerance"
+        );
+    }
+
+    #[test]
+    fn parity_l2_qk_norm_gqa_prefill_shape() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        let batch = 2usize;
+        let seq = 17usize;
+        let nk = 8usize;
+        let nv = 16usize;
+        let dk = 128usize;
+        let total = batch * seq * nk * dk;
+        let q_scale = 1.0 / (dk as f64).sqrt();
+        let eps = 1e-6;
+
+        let mut q_raw = Vec::with_capacity(total);
+        let mut k_raw = Vec::with_capacity(total);
+        fill_pseudo_random(&mut q_raw, total, 0x0bad_f00d, 0.7);
+        fill_pseudo_random(&mut k_raw, total, 0x00c0_ffee, 0.7);
+
+        let q = Tensor::from_vec(q_raw, (batch, seq, nk, dk), &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let k = Tensor::from_vec(k_raw, (batch, seq, nk, dk), &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+
+        let ratio = nv / nk;
+        let q_expanded = q
+            .unsqueeze(3)
+            .unwrap()
+            .expand(&[batch, seq, nk, ratio, dk])
+            .unwrap()
+            .contiguous()
+            .unwrap()
+            .reshape((batch, seq, nv, dk))
+            .unwrap();
+        let k_expanded = k
+            .unsqueeze(3)
+            .unwrap()
+            .expand(&[batch, seq, nk, ratio, dk])
+            .unwrap()
+            .contiguous()
+            .unwrap()
+            .reshape((batch, seq, nv, dk))
+            .unwrap();
+
+        let (q_ref, k_ref) = reference_l2_qk_norm(&q_expanded, &k_expanded, q_scale, eps).unwrap();
+        let (q_fused, k_fused) =
+            fused_l2_qk_norm_gqa(&q, &k, nv, q_scale as f32, eps as f32).unwrap();
+
+        let q_diff = max_abs_diff(&q_ref, &q_fused);
+        let k_diff = max_abs_diff(&k_ref, &k_fused);
+
+        assert!(
+            q_diff < 1e-2,
+            "GQA prefill Q parity failed: max_abs_diff={q_diff} exceeds 1e-2 tolerance"
+        );
+        assert!(
+            k_diff < 1e-2,
+            "GQA prefill K parity failed: max_abs_diff={k_diff} exceeds 1e-2 tolerance"
         );
     }
 
@@ -700,8 +1012,7 @@ mod tests {
         let k = k_f32.to_dtype(DType::BF16).unwrap();
 
         let (q_ref, k_ref) = reference_l2_qk_norm(&q, &k, q_scale, eps).unwrap();
-        let (q_fused, k_fused) =
-            fused_l2_qk_norm(&q, &k, q_scale as f32, eps as f32).unwrap();
+        let (q_fused, k_fused) = fused_l2_qk_norm(&q, &k, q_scale as f32, eps as f32).unwrap();
 
         let q_diff = max_abs_diff(&q_ref, &q_fused);
         let k_diff = max_abs_diff(&k_ref, &k_fused);

--- a/docs/phase-c59/cuda-gdn-qk-norm-gqa.md
+++ b/docs/phase-c59/cuda-gdn-qk-norm-gqa.md
@@ -1,0 +1,49 @@
+# Phase C59 — CUDA GDN qk_norm GQA Fast Path
+
+## Goal
+
+Add a minimal CUDA equivalent of the Metal `metal_gdn_qk_norm_gqa_f32_bf16` path for GDN Q/K normalization. The fast path consumes unexpanded GQA Q/K tensors shaped `[batch, seq_len, nk, dk]`, normalizes each source head in F32, applies the Q scale, casts to bf16, and writes expanded `[batch, seq_len, nv, dk]` outputs in one CUDA launch.
+
+## Implementation
+
+- Added `kiln_fused_l2_qk_norm_gqa` in `crates/kiln-rmsnorm-kernel/csrc/fused_l2_qk_norm.cu` with a thin C ABI declaration in `fused_l2_qk_norm.h`.
+- Kept the CUDA envelope intentionally narrow: bf16 inputs/outputs, forward-only, contiguous rank-4 tensors, `dk == 128`, and `nv = nk * ratio`.
+- Added Rust wrappers `supports_l2_qk_norm_gqa` and `fused_l2_qk_norm_gqa` in `crates/kiln-rmsnorm-kernel/src/lib.rs`.
+- Routed the non-Metal CUDA GDN path in `crates/kiln-model/src/forward.rs` through `:kiln/gdn/qk_norm_gqa` before the separate `:kiln/gdn/head_expand` + `:kiln/gdn/qk_norm` fallback.
+- Preserved `KILN_DISABLE_FUSED_L2_QK_NORM=1` as the kill switch for both expanded and GQA fused QK normalization.
+
+## Validation
+
+Commands run on RunPod A6000 with `ghcr.io/ericflo/kiln-runpod:latest`:
+
+```bash
+cargo test -p kiln-rmsnorm-kernel --release -- --nocapture
+cargo test -p kiln-model --release --features cuda gdn_qk_norm -- --nocapture
+cargo build --release --features cuda,nvtx --bin kiln-bench
+```
+
+Results:
+
+- `cargo test -p kiln-rmsnorm-kernel --release -- --nocapture`: pass, 8 tests.
+- `cargo test -p kiln-model --release --features cuda gdn_qk_norm -- --nocapture`: pass, 0 matching tests run after successful `kiln-model` CUDA build (245 lib tests filtered).
+
+## Benchmark
+
+Benchmark command:
+
+```bash
+./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1
+```
+
+A6000 single-run results:
+
+| Path | Mean ITL | Decode tok/s | Prefill |
+| --- | ---: | ---: | ---: |
+| default fused GQA | 22.4 ms | 44.7 tok/s | 351.5 ms |
+| `KILN_DISABLE_FUSED_L2_QK_NORM=1` | 22.7 ms | 44.0 tok/s | 350.4 ms |
+
+Decode speedup: `44.7 / 44.0 = 1.015x` (~1.5%), above the 1% floor but small enough to treat as a modest decode-path cleanup, not a new fusion frontier.
+
+## Default Decision
+
+Keep the path default-on behind the existing kill switch. The measured single-run decode gain is ~1.5%, above the 1% floor, and the implementation removes the separate CUDA `:kiln/gdn/head_expand` materialization before QK norm. Do not retry this same fusion shape for larger wins; the next pivot should target a different current top hotspot.


### PR DESCRIPTION
## Summary

- Add `kiln_fused_l2_qk_norm_gqa` CUDA C ABI/kernel for unexpanded GDN Q/K `[B,T,nk,128]` -> expanded normalized `[B,T,nv,128]` bf16 outputs.
- Add Rust support/wrapper APIs and CUDA parity tests against explicit GQA head expansion + L2 QK norm reference.
- Route the non-Metal CUDA GDN path through `:kiln/gdn/qk_norm_gqa` before the separate `:kiln/gdn/head_expand` + `:kiln/gdn/qk_norm` fallback, preserving `KILN_DISABLE_FUSED_L2_QK_NORM=1`.
- Document validation, benchmark, and default-on decision in `docs/phase-c59/cuda-gdn-qk-norm-gqa.md`.

## Precondition

- Searched open PRs for CUDA/GDN/qk_norm/GQA coverage: no open PR already covers this path.
- Current `main` had Metal `metal_gdn_qk_norm_gqa_f32_bf16`, but no CUDA equivalent in `kiln-rmsnorm-kernel` before this branch.

## Validation

RunPod A6000 (`ghcr.io/ericflo/kiln-runpod:latest`, lease `pod-66eb55349e1403350e6c342d`):

- `cargo test -p kiln-rmsnorm-kernel --release -- --nocapture` — pass, 8 tests.
- `cargo test -p kiln-model --release --features cuda gdn_qk_norm -- --nocapture` — pass after successful CUDA `kiln-model` build; 0 matching tests run, 245 lib tests filtered.
- `cargo build --release --features cuda,nvtx --bin kiln-bench` — pass.

## Benchmark

Command:

```bash
./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 512 --max-output-tokens 128 --skip-training --prompt-subset humaneval --chat-template --latency-only --temperature 0.0 --seed 1
```

Single-run A6000 results:

| Path | Mean ITL | Decode tok/s | Prefill |
| --- | ---: | ---: | ---: |
| default fused GQA | 22.4 ms | 44.7 tok/s | 351.5 ms |
| `KILN_DISABLE_FUSED_L2_QK_NORM=1` | 22.7 ms | 44.0 tok/s | 350.4 ms |

Decode speedup: `44.7 / 44.0 = 1.015x` (~1.5%), above the 1% floor.

## Pod Cleanup

- Released RunPod pool lease `pod-66eb55349e1403350e6c342d`; pod returned to `idle_warm`.