### PR TITLE
[codex] precompile Metal kernels before prewarm lock

### DIFF
--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -255,14 +255,18 @@ fn spawn_backend_prewarm(state: AppState) {
         tracing::info!("starting background inference prewarm");
         let prewarm_start = std::time::Instant::now();
         let prewarm = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+            // Pipeline compilation does not allocate KV/model working buffers, so
+            // keep it outside the opportunistic GPU lock. If the first live
+            // request wins the lock, it should still benefit from compiled
+            // custom kernels rather than paying lazy compile latency itself.
+            precompile_metal_custom_kernels(&device);
+
             // Prewarm is opportunistic. If a live request or training job has
             // the GPU first, skip prewarm rather than sitting in front of it.
             let Ok(_gpu_guard) = gpu_lock.try_write() else {
                 tracing::info!("skipping inference prewarm because GPU is already busy");
                 return Ok(());
             };
-
-            precompile_metal_custom_kernels(&device);
 
             let runner_guard = runner.read().unwrap();
             let params = SamplingParams {


### PR DESCRIPTION
## Summary

Move Metal custom-kernel precompilation ahead of the opportunistic background inference prewarm GPU lock.

If a first live request grabs the GPU before background prewarm can acquire the write lock, Kiln previously skipped both the model prewarm and custom Metal pipeline precompile. That left the request paying lazy pipeline compilation. This keeps the heavy model/KV warmup opportunistic, but precompiles custom kernels first because pipeline compilation does not allocate the prewarm KV/model working buffers.

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln-startup-transposed-cache-bg-persist/target cargo test -p kiln-server --features metal test_health_ok_while_inference_prewarm_is_running -- --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln-startup-transposed-cache-bg-persist/target cargo test -p kiln-server --features metal mtp -- --nocapture`