### PR TITLE
[codex] defer transposed cache writer

### DIFF
--- a/crates/kiln-model/src/transposed_weight_cache.rs
+++ b/crates/kiln-model/src/transposed_weight_cache.rs
@@ -9,6 +9,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::{Arc, OnceLock};
 use std::thread;
+use std::time::Duration;
 
 use anyhow::{Context, Result};
 use memmap2::Mmap;
@@ -19,6 +20,10 @@ use crate::weights::WeightTensor;
 const CACHE_VERSION: u32 = 2;
 const CACHE_MAGIC: &[u8; 8] = b"KILNTRP1";
 const CACHE_PAYLOAD_ALIGN: usize = 8;
+const CACHE_WRITE_INITIAL_DELAY_MS: u64 = 120_000;
+const CACHE_WRITE_SPACING_MS: u64 = 50;
+const CACHE_WRITE_INITIAL_DELAY_ENV: &str = "KILN_TRANSPOSED_CACHE_WRITE_DELAY_MS";
+const CACHE_WRITE_SPACING_ENV: &str = "KILN_TRANSPOSED_CACHE_WRITE_SPACING_MS";
 
 static CACHE_WRITE_ENQUEUED: AtomicU64 = AtomicU64::new(0);
 static CACHE_WRITE_DISCONNECTED: AtomicU64 = AtomicU64::new(0);
@@ -205,6 +210,16 @@ fn cache_write_sender() -> Option<&'static Sender<CacheWrite>> {
 }
 
 fn cache_writer_loop(receiver: Receiver<CacheWrite>) {
+    let initial_delay = cache_write_initial_delay();
+    if !initial_delay.is_zero() {
+        tracing::debug!(
+            delay_ms = initial_delay.as_millis() as u64,
+            "deferring transposed weight cache background writes"
+        );
+        thread::sleep(initial_delay);
+    }
+
+    let spacing = cache_write_spacing();
     for CacheWrite { cache_key, weight } in receiver {
         if cache_key.file_path.exists() {
             continue;
@@ -221,7 +236,28 @@ fn cache_writer_loop(receiver: Receiver<CacheWrite>) {
                 tracing::debug!(error = %err, "failed to write transposed weight cache entry");
             }
         }
+        if !spacing.is_zero() {
+            thread::sleep(spacing);
+        }
     }
+}
+
+fn cache_write_initial_delay() -> Duration {
+    Duration::from_millis(env_u64(
+        CACHE_WRITE_INITIAL_DELAY_ENV,
+        CACHE_WRITE_INITIAL_DELAY_MS,
+    ))
+}
+
+fn cache_write_spacing() -> Duration {
+    Duration::from_millis(env_u64(CACHE_WRITE_SPACING_ENV, CACHE_WRITE_SPACING_MS))
+}
+
+fn env_u64(var: &str, default: u64) -> u64 {
+    env::var(var)
+        .ok()
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(default)
 }
 
 #[cfg(test)]
@@ -592,6 +628,12 @@ mod tests {
 
     #[test]
     fn queue_cache_write_persists_payload_on_background_writer() -> Result<()> {
+        // Each nextest test process is isolated. Keep this unit test fast while
+        // production defers cache writes away from startup/first-request load.
+        unsafe {
+            std::env::set_var(CACHE_WRITE_INITIAL_DELAY_ENV, "0");
+            std::env::set_var(CACHE_WRITE_SPACING_ENV, "0");
+        }
         let dir = tempfile::tempdir()?;
         let mut cache_key = test_cache_key(4);
         cache_key.file_path = dir.path().join("entry.bin");
@@ -614,6 +656,10 @@ mod tests {
         let mut file = std::fs::File::open(&cache_key.file_path)?;
         let got = read_cached_payload(&cache_key, &mut file)?;
         assert_eq!(got, payload.as_slice());
+        unsafe {
+            std::env::remove_var(CACHE_WRITE_INITIAL_DELAY_ENV);
+            std::env::remove_var(CACHE_WRITE_SPACING_ENV);
+        }
         Ok(())
     }
 

--- a/crates/kiln-server/src/api/health.rs
+++ b/crates/kiln-server/src/api/health.rs
@@ -215,8 +215,7 @@ mod tests {
         };
         let scheduler = Scheduler::new(sched_config, 256);
         let engine = MockEngine::new(config.clone());
-        let tokenizer =
-            kiln_core::tokenizer::KilnTokenizer::from_pretrained("Qwen/Qwen3.5-4B").unwrap();
+        let tokenizer = crate::api::test_tokenizer();
         AppState::new_mock(
             config,
             scheduler,

--- a/crates/kiln-server/src/api/mod.rs
+++ b/crates/kiln-server/src/api/mod.rs
@@ -14,6 +14,19 @@ mod training;
 mod config;
 mod ui;
 
+#[cfg(test)]
+pub(crate) fn test_tokenizer() -> kiln_core::tokenizer::KilnTokenizer {
+    let json = br#"{
+        "version": "1.0",
+        "model": {
+            "type": "BPE",
+            "vocab": {"a": 0, "b": 1},
+            "merges": []
+        }
+    }"#;
+    kiln_core::tokenizer::KilnTokenizer::from_bytes(json).unwrap()
+}
+
 pub fn router(state: AppState) -> Router {
     let trace_layer = TraceLayer::new_for_http()
         .make_span_with(|request: &axum::http::Request<_>| {

--- a/crates/kiln-server/src/api/models.rs
+++ b/crates/kiln-server/src/api/models.rs
@@ -53,8 +53,7 @@ mod tests {
         };
         let scheduler = Scheduler::new(sched_config, 256);
         let engine = MockEngine::new(config.clone());
-        let tokenizer =
-            kiln_core::tokenizer::KilnTokenizer::from_pretrained("Qwen/Qwen3.5-4B").unwrap();
+        let tokenizer = crate::api::test_tokenizer();
         AppState::new_mock(
             config,
             scheduler,


### PR DESCRIPTION
## Summary

This fixes the first-request regression introduced by the reliable transposed-cache writer in #506.

#506 correctly stopped dropping cache-miss write jobs, but the new lightweight writer immediately recomputed hundreds of Qwen3.5-4B transposes in the background. On macOS unified memory/CPU this competed with the foreground first request: a clean 512x128 run regressed to 19.44s load and 33 tok/s prefill.

This PR keeps the reliable queue but defers background cache population by default for 120 seconds and spaces write jobs by 50ms. The unit test overrides those values to zero so coverage remains fast. Long-running desktop sessions still populate the v2 cache, but startup and the first prompt no longer fight the cache writer.

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln-startup-transposed-cache-bg-persist/target cargo test -p kiln-model transposed_weight_cache -- --nocapture`
- `git diff --check`
- 512x128 Metal bench after #506 regression: load 19.44s, prefill 33 tok/s, decode 5.69 tok/s
- 512x128 Metal bench with this PR: load 11.22s, prefill 151 tok/s, decode 5.56 tok/s