### PR TITLE
Default CUDA streaming prefill for long prompts

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,5 +1,28 @@
 # Kiln Profiling Report
 
+## Phase 7 CUDA streaming prefill default A/B (2026-04-24)
+
+**Scope:** decide whether to flip the existing CUDA streaming/tiled prefill path from opt-in to default-on for long prompts after PR #507 showed the memory win at 128k.
+
+**Hardware:** RunPod on-demand `NVIDIA A40` fallback, 48 GiB VRAM, sm_86, `ghcr.io/ericflo/kiln-runpod:latest`. The requested A6000 was supply-constrained; A40 is the documented same-VRAM/sm_86 fallback.
+
+**Build:** current main base `76c7614`, `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench`.
+
+**A/B command shape:** interleaved `KILN_STREAMING_PREFILL=0` vs `1` at 32768, 65536, and 131072 prompt tokens with `KILN_W4A16=1 KILN_KV_CACHE_FP8=1 KILN_CUDA_GRAPHS=true`, `--paged`, `--max-output-tokens 1`, `--skip-training`, and `--latency-only`. Peak VRAM came from 200 ms `nvidia-smi` sampling.
+
+| Prompt tokens | Mode | Exit | Peak VRAM | TTFT / prefill | Prefill tok/s | First decode ITL |
+| ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 32768 | monolithic (`KILN_STREAMING_PREFILL=0`) | 0 | 25319 MiB | 20075.7 ms | 1632 | 102.3 ms |
+| 32768 | streaming (`KILN_STREAMING_PREFILL=1`) | 0 | 20071 MiB | 12881.7 ms | 2544 | 101.1 ms |
+| 65536 | monolithic (`KILN_STREAMING_PREFILL=0`) | 0 | 33063 MiB | 28482.0 ms | 2301 | 169.3 ms |
+| 65536 | streaming (`KILN_STREAMING_PREFILL=1`) | 0 | 21863 MiB | 27693.8 ms | 2366 | 170.7 ms |
+| 131072 | monolithic (`KILN_STREAMING_PREFILL=0`) | 1 | 44455 MiB sampled before OOM | OOM in GDN layer 0 | n/a | n/a |
+| 131072 | streaming (`KILN_STREAMING_PREFILL=1`) | 0 | 25383 MiB | 62930.8 ms | 2083 | 310.6 ms |
+
+**Decision:** enable CUDA streaming prefill by default at `>= 65533` actual prompt tokens. The 65k arm reduced peak memory by 11200 MiB and did not materially regress TTFT or first decode ITL; the 128k monolithic arm OOMed while streaming completed. `KILN_STREAMING_PREFILL=0` remains the kill switch, `KILN_STREAMING_PREFILL=1` remains the force-on override below threshold, and `KILN_STREAMING_TILE_TOKENS` remains the tile-size override.
+
+Detailed artifact: `docs/phase-c63/cuda-streaming-prefill-default.md`.
+
 ## Phase 6 FlashInfer-style paged GQA decode preflight (2026-04-24)
 
 **Scope:** decide whether current `main` still lacks a native CUDA paged GQA

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1207,7 +1207,9 @@ fn marlin_bf16_drop_disabled() -> bool {
 // ---------------------------------------------------------------------------
 // Phase 7: streaming/tiled GDN prefill — env-derived configuration.
 //
-// Dispatch is opt-in via `KILN_STREAMING_PREFILL=1`. When enabled, prefill is
+// Dispatch can be forced on/off via `KILN_STREAMING_PREFILL=1|0`. Without an
+// override, CUDA and Metal enable streaming for long prompts where tiled
+// prefill materially reduces peak activation memory. When enabled, prefill is
 // performed as a sequence of fixed-size tiles (default 8192 tokens) so the
 // per-layer materialized GDN intermediates only ever cover one tile at a time.
 // The recurrent state in `LinearAttentionState` already provides the O(1)
@@ -1218,9 +1220,25 @@ fn marlin_bf16_drop_disabled() -> bool {
 /// `GDN_CHUNK_SIZE` (64) so the chunkwise kernel never sees a partial tail
 /// chunk from a tile boundary.
 pub const STREAMING_PREFILL_DEFAULT_TILE: usize = 8192;
+pub const STREAMING_PREFILL_CUDA_DEFAULT_THRESHOLD: usize = 65533;
 pub const STREAMING_PREFILL_METAL_DEFAULT_TILE: usize = 2048;
 pub const STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD: usize = 4096;
 const PAGED_KV_HEAD_MAJOR_READ_MIN_TOKENS: usize = 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StreamingPrefillDeviceKind {
+    Cpu,
+    Cuda,
+    Metal,
+}
+
+fn streaming_prefill_device_kind(device: &Device) -> StreamingPrefillDeviceKind {
+    match device {
+        Device::Cuda(_) => StreamingPrefillDeviceKind::Cuda,
+        Device::Metal(_) => StreamingPrefillDeviceKind::Metal,
+        _ => StreamingPrefillDeviceKind::Cpu,
+    }
+}
 
 fn streaming_prefill_env_override() -> Option<bool> {
     std::env::var("KILN_STREAMING_PREFILL")
@@ -1242,16 +1260,24 @@ pub fn streaming_prefill_enabled() -> bool {
     streaming_prefill_env_override().unwrap_or(false)
 }
 
+fn streaming_prefill_default_for(kind: StreamingPrefillDeviceKind, seq_len: usize) -> bool {
+    match kind {
+        StreamingPrefillDeviceKind::Cuda => seq_len >= STREAMING_PREFILL_CUDA_DEFAULT_THRESHOLD,
+        StreamingPrefillDeviceKind::Metal => seq_len >= STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD,
+        StreamingPrefillDeviceKind::Cpu => false,
+    }
+}
+
 /// Device-aware streaming prefill policy for production prefill dispatch.
 ///
-/// Env overrides win. Without an override, long Metal prompts use tiled
-/// prefill by default because it reduces peak intermediates and improves TTFT
-/// on the macOS desktop path.
+/// Env overrides win. Without an override, long CUDA prompts use tiled prefill
+/// by default because it cuts peak GDN activation memory enough to make 128k
+/// prefill fit on 48 GiB GPUs; long Metal prompts keep the desktop default.
 pub fn streaming_prefill_enabled_for(device: &Device, seq_len: usize) -> bool {
     if let Some(enabled) = streaming_prefill_env_override() {
         return enabled;
     }
-    matches!(device, Device::Metal(_)) && seq_len >= STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD
+    streaming_prefill_default_for(streaming_prefill_device_kind(device), seq_len)
 }
 
 fn streaming_tile_tokens_env_override() -> Option<usize> {
@@ -11317,6 +11343,26 @@ mod tests {
             std::env::remove_var("KILN_STREAMING_LAST_TOKEN_LM_HEAD");
         }
         assert!(!streaming_prefill_enabled(), "default must be disabled");
+        assert!(!streaming_prefill_default_for(
+            StreamingPrefillDeviceKind::Cpu,
+            STREAMING_PREFILL_CUDA_DEFAULT_THRESHOLD
+        ));
+        assert!(!streaming_prefill_default_for(
+            StreamingPrefillDeviceKind::Cuda,
+            STREAMING_PREFILL_CUDA_DEFAULT_THRESHOLD - 1
+        ));
+        assert!(streaming_prefill_default_for(
+            StreamingPrefillDeviceKind::Cuda,
+            STREAMING_PREFILL_CUDA_DEFAULT_THRESHOLD
+        ));
+        assert!(!streaming_prefill_default_for(
+            StreamingPrefillDeviceKind::Metal,
+            STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD - 1
+        ));
+        assert!(streaming_prefill_default_for(
+            StreamingPrefillDeviceKind::Metal,
+            STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD
+        ));
         assert!(!streaming_prefill_enabled_for(
             &Device::Cpu,
             STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -191,12 +191,14 @@ pub struct SpeculativeDecodingConfig {
 ///
 /// Dispatch is driven by reading these environment variables directly from
 /// `kiln-model` helpers; this struct is the documentation / TOML-config
-/// mirror. The generic config default keeps streaming OFF, while the runtime
-/// Metal policy enables streaming by default for long desktop prompts.
+/// mirror. The generic config default keeps streaming OFF unless explicitly set,
+/// while runtime device policy enables streaming by default for long CUDA and
+/// Metal prompts after device-specific thresholds.
 #[derive(Debug, Deserialize)]
 #[serde(default)]
 pub struct StreamingPrefillConfig {
-    /// Enable tiled/streaming prefill (default: false).
+    /// Force tiled/streaming prefill on through config/env. Runtime device
+    /// policy may still enable it for long CUDA/Metal prompts when unset.
     pub enabled: bool,
     /// Tile size in tokens (generic default: 8192). Must be a positive
     /// multiple of 64.

--- a/docs/phase-c63/cuda-streaming-prefill-default.md
+++ b/docs/phase-c63/cuda-streaming-prefill-default.md
@@ -1,0 +1,77 @@
+# Phase C63: CUDA streaming prefill default
+
+Date: 2026-04-24
+Branch: `c63-cuda-streaming-prefill-default`
+Current-main base: `76c7614`
+Hardware: RunPod on-demand `NVIDIA A40` fallback, 48 GiB VRAM, sm_86
+Image: `ghcr.io/ericflo/kiln-runpod:latest`
+
+## Decision
+
+Enable CUDA streaming prefill by default at `>= 65533` actual prompt tokens while preserving `KILN_STREAMING_PREFILL=0` as a monolithic-path kill switch and `KILN_STREAMING_PREFILL=1` as a force-on override below the threshold.
+
+The A6000 requested by the task was supply-constrained. The run used the documented A40 fallback: same 48 GiB class and sm_86 target, with lower absolute throughput than A6000 but enough to validate memory and regression direction. The decision threshold follows the task rule: 65k streaming was within noise/slightly faster, 128k monolithic failed with CUDA OOM, and 128k streaming completed.
+
+## Commands
+
+```bash
+export RUNPOD_API_KEY=$(ce secret-get --name RUNPOD_API_KEY)
+RP=/data/.clouderic-internal/repos/apps/trajectory-trainer/scripts/runpod_api.py
+python3 $RP status
+python3 $RP launch --kiln-image --gpu "NVIDIA RTX A6000" \
+  --name kiln-cuda-streaming-prefill-c63 --disk-gb 80
+# A6000 was supply-constrained, so fallback used:
+python3 $RP launch --kiln-image --gpu "NVIDIA A40" \
+  --name kiln-cuda-streaming-prefill-c63-a40 --disk-gb 80
+python3 $RP wait 4jnrcnwyn4btpl
+B2_KEY_ID=$(ce secret-get --name B2_APPLICATION_KEY_ID)
+B2_KEY=$(ce secret-get --name B2_APPLICATION_KEY)
+python3 $RP ssh 4jnrcnwyn4btpl \
+  "export B2_APPLICATION_KEY_ID='$B2_KEY_ID' B2_APPLICATION_KEY='$B2_KEY'; kiln-setup --clone"
+python3 $RP ssh 4jnrcnwyn4btpl \
+  "export B2_APPLICATION_KEY_ID='$B2_KEY_ID' B2_APPLICATION_KEY='$B2_KEY'; kiln-setup --repo /workspace/kiln"
+python3 $RP bg 4jnrcnwyn4btpl /tmp/c63_build.log \
+  'source /root/.kiln-build-env && cd /workspace/kiln && KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench'
+python3 $RP wait-file 4jnrcnwyn4btpl /workspace/kiln/target/release/kiln-bench --timeout 3600
+```
+
+The interleaved matrix used `--latency-only` and sampled peak memory with `nvidia-smi` every 200 ms:
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+for tokens in 32768 65536 131072; do
+  for stream in 0 1; do
+    KILN_W4A16=1 KILN_KV_CACHE_FP8=1 KILN_CUDA_GRAPHS=true KILN_STREAMING_PREFILL=$stream \
+      ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged \
+      --prompt-tokens $tokens --max-output-tokens 1 --skip-training --latency-only \
+      2>&1 | tee /tmp/c63_${tokens}_stream${stream}.log
+  done
+done
+```
+
+## Results
+
+| Prompt tokens | Actual tokens | Mode | Exit | Peak VRAM | Prefill / TTFT | Prefill tok/s | First decode ITL |
+| ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |
+| 32768 | 32768 | monolithic (`KILN_STREAMING_PREFILL=0`) | 0 | 25319 MiB | 20075.7 ms | 1632 | 102.3 ms |
+| 32768 | 32768 | streaming (`KILN_STREAMING_PREFILL=1`) | 0 | 20071 MiB | 12881.7 ms | 2544 | 101.1 ms |
+| 65536 | 65533 | monolithic (`KILN_STREAMING_PREFILL=0`) | 0 | 33063 MiB | 28482.0 ms | 2301 | 169.3 ms |
+| 65536 | 65533 | streaming (`KILN_STREAMING_PREFILL=1`) | 0 | 21863 MiB | 27693.8 ms | 2366 | 170.7 ms |
+| 131072 | 131065 | monolithic (`KILN_STREAMING_PREFILL=0`) | 1 | 44455 MiB sampled before OOM | OOM in GDN layer 0 | n/a | n/a |
+| 131072 | 131065 | streaming (`KILN_STREAMING_PREFILL=1`) | 0 | 25383 MiB | 62930.8 ms | 2083 | 310.6 ms |
+
+Notes:
+
+- The raw summary script accidentally included timestamp rows in its first peak calculation; the table above uses the corrected `nvidia-smi` memory rows only.
+- 65k streaming reduced sampled peak memory by 11200 MiB and improved prefill by 2.8% on this single interleaved run.
+- 128k monolithic OOMed on the A40 fallback, while streaming completed with a peak near the prior PR #507 A6000 128k streaming result.
+- Decode ITL was unchanged within measurement noise at 32k and 65k; 128k has no monolithic decode comparator because the arm OOMed before decode.
+
+## Threshold rationale
+
+The default threshold is `65533` actual prompt tokens, which is the bench harness's realized prompt length for the requested `--prompt-tokens 65536` case. It is conservative enough to leave shorter prompts on their historical path unless explicitly forced, while covering the first prompt size where PR #507 showed monolithic peak growth becoming material. The C63 A/B did not show a material 65k latency or first-decode regression; it showed a small prefill win and a large memory win. At 128k, streaming is the only successful mode on the fallback 48 GiB GPU.
+
+## Cleanup
+
+Pod `4jnrcnwyn4btpl` (`kiln-cuda-streaming-prefill-c63-a40`) was explicitly terminated after validation.


### PR DESCRIPTION
## Summary

- Enables CUDA streaming/tiled prefill by default for long prompts at `>= 65533` actual prompt tokens.
- Preserves `KILN_STREAMING_PREFILL=0` as the monolithic-path kill switch and `KILN_STREAMING_PREFILL=1` as the force-on override below threshold.
- Documents the Phase C63 A/B run in `PROFILING.md` and `docs/phase-c63/cuda-streaming-prefill-default.md`.

## A/B Results

RunPod A6000 on-demand was supply-constrained, so this used the documented A40 fallback (`NVIDIA A40`, 48 GiB, sm_86) with `ghcr.io/ericflo/kiln-runpod:latest`.

| Prompt tokens | Actual tokens | Mode | Exit | Peak VRAM | Prefill / TTFT | Prefill tok/s | First decode ITL |
| ---: | ---: | --- | ---: | ---: | ---: | ---: | ---: |
| 32768 | 32768 | monolithic (`KILN_STREAMING_PREFILL=0`) | 0 | 25319 MiB | 20075.7 ms | 1632 | 102.3 ms |
| 32768 | 32768 | streaming (`KILN_STREAMING_PREFILL=1`) | 0 | 20071 MiB | 12881.7 ms | 2544 | 101.1 ms |
| 65536 | 65533 | monolithic (`KILN_STREAMING_PREFILL=0`) | 0 | 33063 MiB | 28482.0 ms | 2301 | 169.3 ms |
| 65536 | 65533 | streaming (`KILN_STREAMING_PREFILL=1`) | 0 | 21863 MiB | 27693.8 ms | 2366 | 170.7 ms |
| 131072 | 131065 | monolithic (`KILN_STREAMING_PREFILL=0`) | 1 | 44455 MiB sampled before OOM | OOM in GDN layer 0 | n/a | n/a |
| 131072 | 131065 | streaming (`KILN_STREAMING_PREFILL=1`) | 0 | 25383 MiB | 62930.8 ms | 2083 | 310.6 ms |

## Threshold Decision

Chose `65533` actual prompt tokens to operationalize the requested 65k default threshold because `kiln-bench --prompt-tokens 65536` realizes 65533 actual prompt tokens in the paged latency path. A literal 65536 would not trigger for the required no-env validation command.

The 65k streaming arm reduced peak memory by 11200 MiB and did not materially regress TTFT or first decode ITL; the 128k monolithic arm OOMed while streaming completed.

## Validation

Run on RunPod pod `4jnrcnwyn4btpl` (`kiln-cuda-streaming-prefill-c63-a40`), which was explicitly terminated after validation.

- `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench` ✅
- `KILN_CUDA_ARCHS=86 cargo test --release -p kiln-model streaming_prefill --features cuda` ✅
- No-env default proof: `KILN_W4A16=1 KILN_KV_CACHE_FP8=1 KILN_CUDA_GRAPHS=true ./target/release/kiln-bench --model-path /workspace/qwen3.5-4b --paged --prompt-tokens 65536 --max-output-tokens 1 --skip-training --latency-only` ✅
  - Peak VRAM: 21863 MiB
  - Prefill / TTFT: 27606.0 ms (2374 tok/s)
  - First decode ITL: 171.2 ms
- `git diff --check` ✅
- `git diff --cached --check` ✅

Note: the exact debug-profile command `cargo test -p kiln-model streaming_prefill --features cuda` was attempted and failed before running tests because `kiln-flash-attn` debug CUDA compilation hit existing `ptxas terminated (signal: 9)` / `sccache: Compiler killed by signal 9` on the pod, even when scoped to `KILN_CUDA_ARCHS=86`. The release-profile CUDA test above passed.