### PR TITLE
[codex] route shared Metal greedy decode through argmax

### DIFF
--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -789,6 +789,65 @@ impl ModelRunner {
         result
     }
 
+    fn decode_next_token_paged_interleaved(
+        &self,
+        params: &SamplingParams,
+        input_token: TokenId,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+        seq_len: usize,
+        linear_state: &mut LinearAttentionState,
+        step_seed: Option<u64>,
+    ) -> Result<TokenId> {
+        if params.temperature == 0.0
+            && matches!(self.backend.device(), candle_core::Device::Metal(_))
+        {
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            return model_forward_paged_next_token_greedy(
+                &*self.backend,
+                input_token,
+                &self.weights,
+                &self.config,
+                &mut pc_guard,
+                block_table,
+                seq_len,
+                Some(linear_state),
+                self.active_lora.as_ref(),
+                None,
+            )
+            .context("greedy decode forward pass (paged) failed");
+        }
+
+        let logits = {
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            model_forward_paged(
+                &*self.backend,
+                &[input_token],
+                &self.weights,
+                &self.config,
+                &mut pc_guard,
+                block_table,
+                seq_len,
+                Some(linear_state),
+                self.active_lora.as_ref(),
+                None,
+            )
+            .context("decode forward pass (paged) failed")?
+        };
+
+        if params.temperature == 0.0 {
+            greedy_sample(&logits)
+        } else {
+            sample_with_params(
+                &logits,
+                params.temperature,
+                params.top_p,
+                params.top_k,
+                step_seed,
+            )
+        }
+    }
+
     pub fn generate_paged_speculative_shared_tokens(
         &self,
         prompt_tokens: &[TokenId],
@@ -948,35 +1007,16 @@ impl ModelRunner {
                 break;
             }
 
-            let logits = {
-                let mut pc_guard = lock_paged_cache(paged_cache)?;
-                model_forward_paged(
-                    &*self.backend,
-                    &[next_token],
-                    &self.weights,
-                    &self.config,
-                    &mut pc_guard,
-                    block_table,
-                    seq_len,
-                    Some(&mut linear_state),
-                    self.active_lora.as_ref(),
-                    None,
-                )
-                .context("decode forward pass (paged) failed")?
-            };
+            next_token = self.decode_next_token_paged_interleaved(
+                params,
+                next_token,
+                paged_cache,
+                block_table,
+                seq_len,
+                &mut linear_state,
+                step_seed,
+            )?;
             seq_len += 1;
-
-            next_token = if params.temperature == 0.0 {
-                greedy_sample(&logits)?
-            } else {
-                sample_with_params(
-                    &logits,
-                    params.temperature,
-                    params.top_p,
-                    params.top_k,
-                    step_seed,
-                )?
-            };
         }
 
         Ok(GenerationOutput {
@@ -2516,35 +2556,16 @@ impl ModelRunner {
                 break;
             }
 
-            let logits = {
-                let mut pc_guard = lock_paged_cache(paged_cache)?;
-                model_forward_paged(
-                    &*self.backend,
-                    &[next_token],
-                    &self.weights,
-                    &self.config,
-                    &mut pc_guard,
-                    block_table,
-                    seq_len,
-                    Some(&mut linear_state),
-                    self.active_lora.as_ref(),
-                    None,
-                )
-                .context("decode forward pass (paged) failed")?
-            };
+            next_token = self.decode_next_token_paged_interleaved(
+                params,
+                next_token,
+                paged_cache,
+                block_table,
+                seq_len,
+                &mut linear_state,
+                step_seed,
+            )?;
             seq_len += 1;
-
-            next_token = if params.temperature == 0.0 {
-                greedy_sample(&logits)?
-            } else {
-                sample_with_params(
-                    &logits,
-                    params.temperature,
-                    params.top_p,
-                    params.top_k,
-                    step_seed,
-                )?
-            };
         }
 
         let _ = tx.send(StreamEvent::Done(StreamDone {


### PR DESCRIPTION
## Summary

Routes shared paged generation decode through the existing Metal greedy next-token helper when `temperature == 0.0`.

This affects the desktop/default streaming path, which uses shared paged generation. Previously that loop materialized last-token logits and then sampled; now Metal greedy decode uses `model_forward_paged_next_token_greedy`, matching the direct non-shared Metal path and avoiding per-token logits materialization in that route.

Non-greedy sampling, CPU/CUDA fallback behavior, stop checks, EOS checks, and prefill behavior remain unchanged.

## Validation

- `cargo check --locked -p kiln-model --features metal`
- `cargo test --locked -p kiln-model generate -- --nocapture`
- `cargo test --locked -p kiln-server --test real_model_integration test_real_model_streaming_chat_completion -- --nocapture`
- `cargo test --locked -p kiln-model --features metal test_lm_head_argmax_matches_materialized_logits -- --nocapture`
- `cargo build --locked --release --features metal --bin kiln`
- Full-model local streaming smoke against `/v1/chat/completions` on Metal: 32 streamed tokens completed successfully in 7.04s wall time

Rejected experiments before this patch:

- Cooperative MLP gate/up kernel regressed decode to 4.62 tok/s.
- Scalar GDN prefill in-proj fusion regressed 512-token prefill to 33 tok/s.

Those experiments were reverted and are not included in this PR.