### PR TITLE
Expose prefix cache metrics

### DIFF
--- a/crates/kiln-scheduler/src/lib.rs
+++ b/crates/kiln-scheduler/src/lib.rs
@@ -1,3 +1,5 @@
 mod scheduler;
 
-pub use scheduler::{Scheduler, SchedulerConfig, SchedulerOutput, ScheduledRequest};
+pub use scheduler::{
+    PrefixCacheStats, Scheduler, SchedulerConfig, SchedulerOutput, ScheduledRequest,
+};

--- a/crates/kiln-scheduler/src/scheduler.rs
+++ b/crates/kiln-scheduler/src/scheduler.rs
@@ -59,6 +59,17 @@ pub struct SchedulerOutput {
     pub completed_ids: Vec<RequestId>,
 }
 
+/// Prefix-cache effectiveness counters and gauges exposed by the scheduler.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PrefixCacheStats {
+    pub lookup_hits: u64,
+    pub lookup_misses: u64,
+    pub hit_tokens: u64,
+    pub hit_blocks: u64,
+    pub cached_blocks: usize,
+    pub max_blocks: usize,
+}
+
 /// Iteration-level continuous batching scheduler.
 ///
 /// Implements the Sarathi-style chunked prefill algorithm:
@@ -77,6 +88,7 @@ pub struct Scheduler {
     running: Vec<Request>,
     block_manager: BlockManager,
     prefix_cache: Option<PrefixCache>,
+    prefix_cache_stats: PrefixCacheStats,
     /// Tracks which blocks per request came from prefix cache (should not be freed).
     cached_block_counts: std::collections::HashMap<RequestId, usize>,
 }
@@ -84,11 +96,13 @@ pub struct Scheduler {
 impl Scheduler {
     pub fn new(config: SchedulerConfig, num_blocks: usize) -> Self {
         let block_manager = BlockManager::new(num_blocks, config.block_size);
+        let prefix_cache_max_blocks = if config.prefix_cache_enabled {
+            config.prefix_cache_max_blocks.unwrap_or(num_blocks / 4)
+        } else {
+            0
+        };
         let prefix_cache = if config.prefix_cache_enabled {
-            let max_blocks = config
-                .prefix_cache_max_blocks
-                .unwrap_or(num_blocks / 4);
-            Some(PrefixCache::new(config.block_size, max_blocks))
+            Some(PrefixCache::new(config.block_size, prefix_cache_max_blocks))
         } else {
             None
         };
@@ -98,6 +112,10 @@ impl Scheduler {
             running: Vec::new(),
             block_manager,
             prefix_cache,
+            prefix_cache_stats: PrefixCacheStats {
+                max_blocks: prefix_cache_max_blocks,
+                ..Default::default()
+            },
             cached_block_counts: std::collections::HashMap::new(),
         }
     }
@@ -222,12 +240,17 @@ impl Scheduler {
                     cached_blocks = cached_block_ids.len();
                     tokens_already_cached = cached_tokens;
                     req.block_ids = cached_block_ids;
+                    self.prefix_cache_stats.lookup_hits += 1;
+                    self.prefix_cache_stats.hit_tokens += cached_tokens as u64;
+                    self.prefix_cache_stats.hit_blocks += cached_blocks as u64;
                     tracing::debug!(
                         id = %req.id,
                         cached_tokens,
                         cached_blocks,
                         "prefix cache hit"
                     );
+                } else {
+                    self.prefix_cache_stats.lookup_misses += 1;
                 }
             }
 
@@ -390,6 +413,14 @@ impl Scheduler {
 
     pub fn prefix_cache(&self) -> Option<&PrefixCache> {
         self.prefix_cache.as_ref()
+    }
+
+    pub fn prefix_cache_stats(&self) -> PrefixCacheStats {
+        let mut stats = self.prefix_cache_stats;
+        if let Some(prefix_cache) = self.prefix_cache.as_ref() {
+            stats.cached_blocks = prefix_cache.total_cached_blocks();
+        }
+        stats
     }
 }
 
@@ -640,6 +671,47 @@ mod tests {
         assert_eq!(output.scheduled.len(), 1);
         assert!(output.scheduled[0].is_prefill);
         assert_eq!(output.scheduled[0].num_tokens, 8); // full prefill
+
+        let stats = sched.prefix_cache_stats();
+        assert_eq!(stats.lookup_hits, 0);
+        assert_eq!(stats.lookup_misses, 2);
+        assert_eq!(stats.hit_tokens, 0);
+        assert_eq!(stats.hit_blocks, 0);
+        assert_eq!(stats.cached_blocks, 2);
+        assert_eq!(stats.max_blocks, 100);
+    }
+
+    #[test]
+    fn prefix_cache_stats_track_hits() {
+        let config = SchedulerConfig {
+            max_batch_tokens: 200,
+            max_batch_size: 8,
+            block_size: 4,
+            prefix_cache_enabled: true,
+            prefix_cache_max_blocks: Some(100),
+        };
+        let mut sched = Scheduler::new(config, 200);
+
+        let tokens: Vec<TokenId> = (0..8).collect();
+        let req1 = make_request_with_tokens(tokens.clone());
+        let id1 = req1.id;
+        sched.add_request(req1);
+        sched.step();
+        sched.update_request(&id1, None, false, Some(8));
+        sched.update_request(&id1, Some(42), true, None);
+        sched.step();
+
+        let req2 = make_request_with_tokens(tokens);
+        sched.add_request(req2);
+        sched.step();
+
+        let stats = sched.prefix_cache_stats();
+        assert_eq!(stats.lookup_hits, 1);
+        assert_eq!(stats.lookup_misses, 1);
+        assert_eq!(stats.hit_tokens, 8);
+        assert_eq!(stats.hit_blocks, 2);
+        assert_eq!(stats.cached_blocks, 2);
+        assert_eq!(stats.max_blocks, 100);
     }
 
     #[test]

--- a/crates/kiln-server/src/api/metrics.rs
+++ b/crates/kiln-server/src/api/metrics.rs
@@ -9,12 +9,13 @@ use axum::{
 };
 
 use crate::metrics::SnapshotGauges;
+use kiln_scheduler::PrefixCacheStats;
 use crate::state::{AppState, ModelBackend};
 use kiln_train::TrainingState;
 
 async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
     // Snapshot scheduler gauges.
-    let (scheduler_waiting, scheduler_running, blocks_used, blocks_total) =
+    let (scheduler_waiting, scheduler_running, blocks_used, blocks_total, prefix_cache) =
         match state.backend.as_ref() {
             ModelBackend::Mock { scheduler, .. } => {
                 let sched = scheduler.lock().await;
@@ -24,11 +25,12 @@ async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
                     sched.num_running(),
                     bm.num_used(),
                     bm.num_blocks(),
+                    sched.prefix_cache_stats(),
                 )
             }
             ModelBackend::Real { block_manager, .. } => {
                 let bm = block_manager.lock().unwrap();
-                (0, 0, bm.num_used(), bm.num_blocks())
+                (0, 0, bm.num_used(), bm.num_blocks(), PrefixCacheStats::default())
             }
         };
 
@@ -53,6 +55,7 @@ async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
         vram_model: state.memory_budget.model_memory_bytes,
         vram_kv_cache: state.memory_budget.kv_cache_bytes,
         vram_training_budget: state.memory_budget.training_budget_bytes,
+        prefix_cache,
         training_active,
         active_adapter,
     };

--- a/crates/kiln-server/src/metrics.rs
+++ b/crates/kiln-server/src/metrics.rs
@@ -3,6 +3,7 @@
 //! Uses atomic counters and gauges — no external dependencies.
 //! The `/metrics` endpoint renders all metrics in Prometheus text exposition format.
 
+use kiln_scheduler::PrefixCacheStats;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Atomically tracked metrics for the kiln server.
@@ -173,6 +174,64 @@ impl Metrics {
         out.push_str("# TYPE kiln_vram_training_budget_bytes gauge\n");
         push_line(&mut out, &format!("kiln_vram_training_budget_bytes {}", gauges.vram_training_budget));
 
+        // --- Prefix cache ---
+        out.push_str("# HELP kiln_prefix_cache_lookups_total Total prefix cache lookups.\n");
+        out.push_str("# TYPE kiln_prefix_cache_lookups_total counter\n");
+        prom_counter(
+            &mut out,
+            "kiln_prefix_cache_lookups_total",
+            "result",
+            "hit",
+            gauges.prefix_cache.lookup_hits,
+        );
+        prom_counter(
+            &mut out,
+            "kiln_prefix_cache_lookups_total",
+            "result",
+            "miss",
+            gauges.prefix_cache.lookup_misses,
+        );
+
+        out.push_str("# HELP kiln_prefix_cache_hit_tokens_total Total prompt tokens skipped by prefix cache hits.\n");
+        out.push_str("# TYPE kiln_prefix_cache_hit_tokens_total counter\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_prefix_cache_hit_tokens_total {}",
+                gauges.prefix_cache.hit_tokens
+            ),
+        );
+
+        out.push_str("# HELP kiln_prefix_cache_hit_blocks_total Total KV blocks reused by prefix cache hits.\n");
+        out.push_str("# TYPE kiln_prefix_cache_hit_blocks_total counter\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_prefix_cache_hit_blocks_total {}",
+                gauges.prefix_cache.hit_blocks
+            ),
+        );
+
+        out.push_str("# HELP kiln_prefix_cache_cached_blocks KV blocks currently retained by the prefix cache.\n");
+        out.push_str("# TYPE kiln_prefix_cache_cached_blocks gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_prefix_cache_cached_blocks {}",
+                gauges.prefix_cache.cached_blocks
+            ),
+        );
+
+        out.push_str("# HELP kiln_prefix_cache_max_blocks Maximum KV blocks retainable by the prefix cache.\n");
+        out.push_str("# TYPE kiln_prefix_cache_max_blocks gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_prefix_cache_max_blocks {}",
+                gauges.prefix_cache.max_blocks
+            ),
+        );
+
         // --- Training ---
         out.push_str("# HELP kiln_training_jobs_total Total training jobs.\n");
         out.push_str("# TYPE kiln_training_jobs_total counter\n");
@@ -210,6 +269,7 @@ pub struct SnapshotGauges {
     pub vram_model: u64,
     pub vram_kv_cache: u64,
     pub vram_training_budget: u64,
+    pub prefix_cache: PrefixCacheStats,
     pub training_active: u8,
     pub active_adapter: Option<String>,
 }
@@ -270,6 +330,14 @@ mod tests {
             vram_model: 8_000_000_000,
             vram_kv_cache: 2_000_000_000,
             vram_training_budget: 14_000_000_000,
+            prefix_cache: PrefixCacheStats {
+                lookup_hits: 7,
+                lookup_misses: 3,
+                hit_tokens: 112,
+                hit_blocks: 7,
+                cached_blocks: 64,
+                max_blocks: 128,
+            },
             training_active: 0,
             active_adapter: Some("my-adapter".to_string()),
         };
@@ -283,6 +351,12 @@ mod tests {
         assert!(output.contains("kiln_scheduler_waiting 3"));
         assert!(output.contains("kiln_blocks_total 256"));
         assert!(output.contains("kiln_vram_total_bytes 24000000000"));
+        assert!(output.contains("kiln_prefix_cache_lookups_total{result=\"hit\"} 7"));
+        assert!(output.contains("kiln_prefix_cache_lookups_total{result=\"miss\"} 3"));
+        assert!(output.contains("kiln_prefix_cache_hit_tokens_total 112"));
+        assert!(output.contains("kiln_prefix_cache_hit_blocks_total 7"));
+        assert!(output.contains("kiln_prefix_cache_cached_blocks 64"));
+        assert!(output.contains("kiln_prefix_cache_max_blocks 128"));
         assert!(output.contains("kiln_active_adapter{name=\"my-adapter\"} 1"));
         assert!(output.contains("kiln_request_duration_seconds_count 1"));
         assert!(output.contains("kiln_request_duration_seconds_sum 0.5"));
@@ -300,6 +374,7 @@ mod tests {
             vram_model: 0,
             vram_kv_cache: 0,
             vram_training_budget: 0,
+            prefix_cache: PrefixCacheStats::default(),
             training_active: 0,
             active_adapter: None,
         };


### PR DESCRIPTION
## Summary
- Adds `PrefixCacheStats` to the scheduler with lookup hit/miss counters, reused token/block counters, current cached block gauge, and max block gauge.
- Updates `/metrics` rendering to expose:
  - `kiln_prefix_cache_lookups_total{result="hit|miss"}`
  - `kiln_prefix_cache_hit_tokens_total`
  - `kiln_prefix_cache_hit_blocks_total`
  - `kiln_prefix_cache_cached_blocks`
  - `kiln_prefix_cache_max_blocks`
- Threads the scheduler prefix-cache snapshot into `SnapshotGauges` for metrics rendering.

## Behavior
Prefix-cache scheduling behavior is unchanged. This only records stats at the existing lookup hit/miss decision point and snapshots existing cached block state for Prometheus output.

## Validation
RunPod pod: `743uyq940kgz0j` (`kiln-prefix-cache-metrics-nvidia-h200-nvl`, `NVIDIA H200 NVL`; A6000/A40/A100/L40S unavailable due supply constraints).

Commands run on RunPod:
- `source /root/.kiln-build-env && cd /workspace/kiln && cargo test -p kiln-scheduler prefix_cache` — passed, 6 tests.
- `source /root/.kiln-build-env && cd /workspace/kiln && cargo test -p kiln-server metrics` — passed, 2 metrics tests plus filtered test binaries.
- `source /root/.kiln-build-env && cd /workspace/kiln && git diff --check` — passed.

Cleanup: terminated RunPod pod `743uyq940kgz0j` successfully.
