### PR TITLE
Wire real append prefix cache

### DIFF
--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -58,6 +58,27 @@ pub struct GenerationOutput {
     pub finish_reason: FinishReason,
 }
 
+/// A block-aligned paged prefix that can be reused by a later prompt.
+pub struct PagedPrefixReuse {
+    pub cached_tokens: usize,
+    pub block_ids: Vec<u32>,
+    pub linear_state: LinearAttentionState,
+}
+
+/// A completed block-aligned prompt prefix produced by generation.
+pub struct PagedPrefixRegistration {
+    pub prompt_tokens: Vec<TokenId>,
+    pub block_ids: Vec<u32>,
+    pub linear_state: LinearAttentionState,
+}
+
+/// Result of paged generation plus an optional prefix-cache registration.
+pub struct PrefixCachedGenerationOutput {
+    pub output: GenerationOutput,
+    pub registration: Option<PagedPrefixRegistration>,
+    pub allocated_blocks: Vec<u32>,
+}
+
 /// Output from a native MTP speculative generation call.
 ///
 /// Carries everything [`GenerationOutput`] does plus the per-call MTP draft
@@ -141,6 +162,17 @@ fn lock_paged_cache(
     paged_cache
         .lock()
         .map_err(|e| anyhow::anyhow!("failed to lock paged KV cache: {e}"))
+}
+
+pub fn append_prefix_block_table(cached_blocks: &[u32], allocated_blocks: &[u32]) -> BlockTable {
+    let mut block_table = BlockTable::new();
+    for &block_id in cached_blocks {
+        block_table.push(block_id);
+    }
+    for &block_id in allocated_blocks {
+        block_table.push(block_id);
+    }
+    block_table
 }
 
 fn emit_stream_token(
@@ -325,6 +357,14 @@ impl ModelRunner {
     fn new_linear_state(&self) -> Result<LinearAttentionState> {
         let device = self.weights.embed_tokens.device();
         LinearAttentionState::new(&self.config, device)
+    }
+
+    pub fn cuda_graph_enabled(&self) -> Result<bool> {
+        Ok(self
+            .cuda_graph
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?
+            .is_enabled())
     }
 
     /// Generate text token-by-token, sending each token to a channel as it is produced.
@@ -703,6 +743,42 @@ impl ModelRunner {
         })
     }
 
+    /// Same as [`generate_paged_shared`], but optionally reuses a
+    /// block-aligned cached prefix and returns a completed prompt snapshot that
+    /// the caller may register after successful generation.
+    pub fn generate_paged_shared_tokens_with_prefix_cache(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+        cached_prefix: Option<PagedPrefixReuse>,
+    ) -> Result<PrefixCachedGenerationOutput> {
+        let output = self.generate_from_tokens_paged_interleaved_with_prefix_cache(
+            prompt_tokens,
+            params,
+            block_manager,
+            paged_cache,
+            cached_prefix,
+        )?;
+
+        let text = self
+            .tokenizer
+            .decode(&output.output.token_ids)
+            .map_err(|e| anyhow::anyhow!("{e}"))
+            .context("failed to decode output tokens")?;
+
+        Ok(PrefixCachedGenerationOutput {
+            output: GenerationOutput {
+                text,
+                token_ids: output.output.token_ids,
+                finish_reason: output.output.finish_reason,
+            },
+            registration: output.registration,
+            allocated_blocks: output.allocated_blocks,
+        })
+    }
+
     /// Same as [`generate_paged_shared`], but accepts an already-tokenized
     /// prompt so API callers do not render/tokenize the same prompt twice.
     pub fn generate_paged_shared_tokens(
@@ -787,6 +863,244 @@ impl ModelRunner {
 
         drop(reservation);
         result
+    }
+
+    fn generate_from_tokens_paged_interleaved_with_prefix_cache(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+        cached_prefix: Option<PagedPrefixReuse>,
+    ) -> Result<PrefixCachedGenerationOutput> {
+        anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
+
+        let cuda_graph_enabled = self
+            .cuda_graph
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?
+            .is_enabled();
+        anyhow::ensure!(
+            !cuda_graph_enabled,
+            "prefix cache path does not support CUDA graph replay"
+        );
+
+        let block_size = {
+            let bm_guard = lock_block_manager(block_manager)?;
+            bm_guard.block_size()
+        };
+
+        let cached_prefix = cached_prefix.filter(|prefix| {
+            prefix.cached_tokens > 0
+                && prefix.cached_tokens < prompt_tokens.len()
+                && prefix.cached_tokens % block_size == 0
+                && prefix.block_ids.len() == prefix.cached_tokens / block_size
+        });
+
+        let cached_blocks = cached_prefix
+            .as_ref()
+            .map(|prefix| prefix.block_ids.as_slice())
+            .unwrap_or(&[]);
+
+        let max_total = prompt_tokens.len() + params.max_tokens;
+        let total_blocks = Self::blocks_needed(max_total, block_size);
+        let additional_blocks_needed = total_blocks.saturating_sub(cached_blocks.len());
+        let allocated_blocks = {
+            let mut bm_guard = lock_block_manager(block_manager)?;
+            bm_guard
+                .allocate(additional_blocks_needed)
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+        };
+        let block_table = append_prefix_block_table(cached_blocks, &allocated_blocks);
+
+        let result = self.generate_from_tokens_paged_interleaved_with_prefix_blocks(
+            prompt_tokens,
+            params,
+            paged_cache,
+            &block_table,
+            cached_prefix,
+            block_size,
+        );
+
+        match result {
+            Ok(mut output) => {
+                output.allocated_blocks = allocated_blocks;
+                Ok(output)
+            }
+            Err(err) => {
+                if !allocated_blocks.is_empty() {
+                    let mut bm_guard = lock_block_manager(block_manager)?;
+                    bm_guard.free_all(&allocated_blocks);
+                }
+                Err(err)
+            }
+        }
+    }
+
+    fn generate_from_tokens_paged_interleaved_with_prefix_blocks(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+        cached_prefix: Option<PagedPrefixReuse>,
+        block_size: usize,
+    ) -> Result<PrefixCachedGenerationOutput> {
+        let cached_tokens = cached_prefix
+            .as_ref()
+            .map(|prefix| prefix.cached_tokens)
+            .unwrap_or(0);
+        let mut linear_state = match cached_prefix {
+            Some(prefix) => prefix.linear_state,
+            None => self.new_linear_state()?,
+        };
+
+        let prefill_tokens = &prompt_tokens[cached_tokens..];
+        anyhow::ensure!(
+            !prefill_tokens.is_empty(),
+            "prefix cache hit must leave at least one suffix token"
+        );
+
+        let logits = {
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            model_forward_paged_last_token(
+                &*self.backend,
+                prefill_tokens,
+                &self.weights,
+                &self.config,
+                &mut pc_guard,
+                block_table,
+                cached_tokens,
+                Some(&mut linear_state),
+                self.active_lora.as_ref(),
+                None,
+            )
+            .context("prefill forward pass (paged prefix cache) failed")?
+        };
+
+        let registration = self.completed_prompt_registration(
+            prompt_tokens,
+            block_table,
+            &linear_state,
+            block_size,
+        )?;
+
+        let output = self.decode_from_prefill_logits(
+            logits,
+            prompt_tokens.len(),
+            params,
+            paged_cache,
+            block_table,
+            &mut linear_state,
+        )?;
+
+        Ok(PrefixCachedGenerationOutput {
+            output,
+            registration,
+            allocated_blocks: Vec::new(),
+        })
+    }
+
+    fn completed_prompt_registration(
+        &self,
+        prompt_tokens: &[TokenId],
+        block_table: &BlockTable,
+        linear_state: &LinearAttentionState,
+        block_size: usize,
+    ) -> Result<Option<PagedPrefixRegistration>> {
+        if prompt_tokens.is_empty() || prompt_tokens.len() % block_size != 0 {
+            return Ok(None);
+        }
+        let num_prompt_blocks = prompt_tokens.len() / block_size;
+        if num_prompt_blocks == 0 || block_table.blocks.len() < num_prompt_blocks {
+            return Ok(None);
+        }
+        Ok(Some(PagedPrefixRegistration {
+            prompt_tokens: prompt_tokens.to_vec(),
+            block_ids: block_table.blocks[..num_prompt_blocks].to_vec(),
+            linear_state: linear_state.snapshot()?,
+        }))
+    }
+
+    fn decode_from_prefill_logits(
+        &self,
+        logits: candle_core::Tensor,
+        mut seq_len: usize,
+        params: &SamplingParams,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+        linear_state: &mut LinearAttentionState,
+    ) -> Result<GenerationOutput> {
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
+        let mut step_seed = params.seed;
+
+        let mut next_token = if params.temperature == 0.0 {
+            greedy_sample(&logits)?
+        } else {
+            sample_with_params(
+                &logits,
+                params.temperature,
+                params.top_p,
+                params.top_k,
+                step_seed,
+            )?
+        };
+
+        for _step in 0..params.max_tokens {
+            if let Some(s) = step_seed.as_mut() {
+                *s = s.wrapping_add(1);
+            }
+
+            if self.eos_token_ids.contains(&next_token) {
+                return Ok(GenerationOutput {
+                    text: String::new(),
+                    token_ids: generated_tokens,
+                    finish_reason: FinishReason::Eos,
+                });
+            }
+
+            generated_tokens.push(next_token);
+
+            if !params.stop.is_empty() {
+                let decoded_so_far = self
+                    .tokenizer
+                    .decode(&generated_tokens)
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+                    .ok();
+                if let Some(text) = &decoded_so_far {
+                    for stop_seq in &params.stop {
+                        if text.contains(stop_seq.as_str()) {
+                            return Ok(GenerationOutput {
+                                text: String::new(),
+                                token_ids: generated_tokens,
+                                finish_reason: FinishReason::StopSequence(stop_seq.clone()),
+                            });
+                        }
+                    }
+                }
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            next_token = self.decode_next_token_paged_interleaved(
+                params,
+                next_token,
+                paged_cache,
+                block_table,
+                seq_len,
+                linear_state,
+                step_seed,
+            )?;
+            seq_len += 1;
+        }
+
+        Ok(GenerationOutput {
+            text: String::new(),
+            token_ids: generated_tokens,
+            finish_reason: FinishReason::MaxTokens,
+        })
     }
 
     fn decode_next_token_paged_interleaved(
@@ -2786,32 +3100,33 @@ impl ModelRunner {
 
         // Prefill. Long Metal prompts use tiled streaming prefill by default;
         // env overrides can force either path.
-        let prefill_result = if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
-            model_forward_paged_streaming(
-                &*self.backend,
-                &prompt_tokens,
-                &self.weights,
-                &self.config,
-                paged_cache,
-                &block_table,
-                0,
-                Some(&mut linear_state),
-                self.active_lora.as_ref(),
-            )
-        } else {
-            model_forward_paged_last_token(
-                &*self.backend,
-                &prompt_tokens,
-                &self.weights,
-                &self.config,
-                paged_cache,
-                &block_table,
-                0,
-                Some(&mut linear_state),
-                self.active_lora.as_ref(),
-                None,
-            )
-        };
+        let prefill_result =
+            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
+                model_forward_paged_streaming(
+                    &*self.backend,
+                    &prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    paged_cache,
+                    &block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                )
+            } else {
+                model_forward_paged_last_token(
+                    &*self.backend,
+                    &prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    paged_cache,
+                    &block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+            };
         let logits = match prefill_result {
             Ok(l) => l,
             Err(e) => {
@@ -3515,6 +3830,15 @@ mod tests {
         assert_eq!(block_manager.lock().unwrap().num_free(), num_blocks);
 
         Ok(())
+    }
+
+    #[test]
+    fn prefix_block_table_appends_allocated_suffix_after_cached_blocks() {
+        let table = append_prefix_block_table(&[7, 8], &[20, 21, 22]);
+        assert_eq!(table.blocks, vec![7, 8, 20, 21, 22]);
+        assert_eq!(table.lookup(0, 16), Some((7, 0)));
+        assert_eq!(table.lookup(31, 16), Some((8, 15)));
+        assert_eq!(table.lookup(32, 16), Some((20, 0)));
     }
 
     #[test]

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -23,8 +23,8 @@ pub use backend::{BackendRuntime, for_device as backend_for_device};
 pub use engine::Engine;
 pub use forward::LinearAttentionState;
 pub use generate::{
-    FinishReason, GenerationOutput, ModelRunner, MtpGenerationOutput, StreamDone, StreamEvent,
-    StreamToken,
+    FinishReason, GenerationOutput, ModelRunner, MtpGenerationOutput, PagedPrefixRegistration,
+    PagedPrefixReuse, PrefixCachedGenerationOutput, StreamDone, StreamEvent, StreamToken,
 };
 pub use kv_cache::KvCache;
 pub use loader::{LoadModelOptions, load_model, load_model_with_options};

--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -122,8 +122,9 @@ async fn load_adapter(
     .map_err(|e| ApiError::internal(format!("join error: {e}")))?
     .map_err(ApiError::adapter_load_failed)?;
 
-    // Update the shared active adapter name.
+    // Update the shared active adapter name and drop stale real-backend prefix state.
     *state.active_adapter_name.write().unwrap() = Some(req.name.clone());
+    state.clear_real_prefix_cache();
 
     tracing::info!(adapter = %req.name, path = %adapter_path.display(), operation = "load", "loaded LoRA adapter");
 
@@ -152,8 +153,9 @@ async fn unload_adapter(
     .await
     .map_err(|e| ApiError::internal(format!("join error: {e}")))?;
 
-    // Clear the shared active adapter name.
+    // Clear the shared active adapter name and drop stale real-backend prefix state.
     *state.active_adapter_name.write().unwrap() = None;
+    state.clear_real_prefix_cache();
 
     tracing::info!(operation = "unload", "unloaded LoRA adapter — reverted to base model");
 

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -16,12 +16,12 @@ use kiln_core::sampling::SamplingParams;
 use kiln_core::token::TokenId;
 use kiln_core::tokenizer::ChatMessage;
 use kiln_model::lora_loader::LoraWeights;
-use kiln_model::{GenerationOutput, ModelRunner, SpeculativeConfig, StreamEvent};
+use kiln_model::{GenerationOutput, ModelRunner, PagedPrefixReuse, SpeculativeConfig, StreamEvent};
 
 use crate::config::{SpecMethod, SpeculativeDecodingConfig};
 use crate::error::ApiError;
 use crate::metrics::RequestStatus;
-use crate::state::{AppState, ModelBackend};
+use crate::state::{AppState, ModelBackend, RealPrefixCache};
 
 /// OpenAI-compatible chat completion request.
 #[derive(Debug, Deserialize)]
@@ -325,6 +325,7 @@ async fn chat_completions_inner(
                 runner,
                 block_manager,
                 paged_cache,
+                ..
             } => {
                 generate_real_streaming(
                     state,
@@ -346,12 +347,14 @@ async fn chat_completions_inner(
                 runner,
                 block_manager,
                 paged_cache,
+                prefix_cache,
             } => {
                 let resp = generate_real(
                     state,
                     runner,
                     block_manager,
                     paged_cache,
+                    prefix_cache,
                     &prompt_text,
                     &prompt_tokens,
                     &sampling,
@@ -427,6 +430,7 @@ async fn ensure_adapter(
             .await
             .map_err(|e| ApiError::internal(format!("join error: {e}")))?
             .map_err(ApiError::adapter_load_failed)?;
+            state.clear_real_prefix_cache();
         }
         None => {
             // Revert to base model.
@@ -440,6 +444,7 @@ async fn ensure_adapter(
             })
             .await
             .map_err(|e| ApiError::internal(format!("join error: {e}")))?;
+            state.clear_real_prefix_cache();
         }
     }
 
@@ -452,6 +457,7 @@ async fn generate_real(
     runner: &std::sync::Arc<std::sync::RwLock<kiln_model::ModelRunner>>,
     block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
     paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
+    prefix_cache: &std::sync::Arc<std::sync::Mutex<RealPrefixCache>>,
     prompt_text: &str,
     prompt_tokens: &[TokenId],
     sampling: &SamplingParams,
@@ -476,9 +482,11 @@ async fn generate_real(
     let runner = runner.clone();
     let bm = block_manager.clone();
     let pc = paged_cache.clone();
+    let prefix_cache = prefix_cache.clone();
     let prompt = prompt_text.to_owned();
     let prompt_tokens = prompt_tokens.to_vec();
     let params = sampling.clone();
+    let adapter = req.adapter.clone();
 
     let gpu_lock = state.gpu_lock.clone();
     let timeout = state.request_timeout;
@@ -488,12 +496,77 @@ async fn generate_real(
         let _gpu_guard = gpu_lock.read().unwrap();
         let runner_guard = runner.read().unwrap();
         match speculative_mode {
-            ResolvedSpeculativeMode::Off => runner_guard.generate_paged_shared_tokens(
-                &prompt_tokens,
-                &params,
-                bm.as_ref(),
-                pc.as_ref(),
-            ),
+            ResolvedSpeculativeMode::Off => {
+                let prefix_enabled = {
+                    let cache = prefix_cache.lock().unwrap();
+                    cache.is_enabled()
+                };
+                if !prefix_enabled || runner_guard.cuda_graph_enabled()? {
+                    runner_guard.generate_paged_shared_tokens(
+                        &prompt_tokens,
+                        &params,
+                        bm.as_ref(),
+                        pc.as_ref(),
+                    )
+                } else {
+                    let hit = {
+                        let mut cache = prefix_cache.lock().unwrap();
+                        cache.lookup(&adapter, &prompt_tokens)?
+                    };
+                    let hit_entry_id = hit.as_ref().map(|hit| hit.entry_id);
+                    let cached_prefix = hit.map(|hit| PagedPrefixReuse {
+                        cached_tokens: hit.cached_tokens,
+                        block_ids: hit.block_ids,
+                        linear_state: hit.linear_state,
+                    });
+
+                    let result = runner_guard.generate_paged_shared_tokens_with_prefix_cache(
+                        &prompt_tokens,
+                        &params,
+                        bm.as_ref(),
+                        pc.as_ref(),
+                        cached_prefix,
+                    );
+
+                    let mut output = match result {
+                        Ok(output) => output,
+                        Err(err) => {
+                            if let Some(entry_id) = hit_entry_id {
+                                let mut cache = prefix_cache.lock().unwrap();
+                                cache.release_hit(entry_id);
+                            }
+                            return Err(err);
+                        }
+                    };
+                    let registration = output.registration.take();
+                    let allocated_blocks = std::mem::take(&mut output.allocated_blocks);
+                    let mut retained_blocks = Vec::new();
+                    let mut evicted_blocks = Vec::new();
+                    {
+                        let mut cache = prefix_cache.lock().unwrap();
+                        if let Some(entry_id) = hit_entry_id {
+                            cache.release_hit(entry_id);
+                        }
+                        if let Some(registration) = registration {
+                            let outcome = cache.register(adapter.clone(), registration);
+                            retained_blocks = outcome.retained_blocks;
+                            evicted_blocks = outcome.evicted_blocks;
+                        }
+                    }
+
+                    let mut blocks_to_free: Vec<u32> = allocated_blocks
+                        .into_iter()
+                        .filter(|block_id| !retained_blocks.contains(block_id))
+                        .collect();
+                    blocks_to_free.extend(evicted_blocks);
+                    if !blocks_to_free.is_empty() {
+                        let mut bm_guard = bm.lock().unwrap();
+                        bm_guard.free_all(&blocks_to_free);
+                    }
+
+                    Ok(output.output)
+                }
+            }
             ResolvedSpeculativeMode::SkipLayer(spec_config) => {
                 if params.temperature == 0.0 {
                     runner_guard.generate_paged_speculative_shared_tokens(

--- a/crates/kiln-server/src/api/metrics.rs
+++ b/crates/kiln-server/src/api/metrics.rs
@@ -1,15 +1,14 @@
 //! GET /metrics — Prometheus text exposition format.
 
 use axum::{
+    Router,
     extract::State,
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::IntoResponse,
     routing::get,
-    Router,
 };
 
 use crate::metrics::SnapshotGauges;
-use kiln_scheduler::PrefixCacheStats;
 use crate::state::{AppState, ModelBackend};
 use kiln_train::TrainingState;
 
@@ -28,9 +27,14 @@ async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
                     sched.prefix_cache_stats(),
                 )
             }
-            ModelBackend::Real { block_manager, .. } => {
+            ModelBackend::Real {
+                block_manager,
+                prefix_cache,
+                ..
+            } => {
                 let bm = block_manager.lock().unwrap();
-                (0, 0, bm.num_used(), bm.num_blocks(), PrefixCacheStats::default())
+                let prefix_cache = prefix_cache.lock().unwrap().stats();
+                (0, 0, bm.num_used(), bm.num_blocks(), prefix_cache)
             }
         };
 

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -167,6 +167,7 @@ async fn main() -> Result<()> {
             &config.memory,
             config.server.request_timeout_secs,
             served_model_id,
+            &config.prefix_cache,
         )
     } else {
         // Mock mode: use scheduler + mock engine.

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1,16 +1,17 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
 use tokio::sync::Mutex;
 
 use candle_core::DType;
 use kiln_core::block::BlockManager;
 use kiln_core::config::ModelConfig;
+use kiln_core::token::TokenId;
 use kiln_core::tokenizer::KilnTokenizer;
 use kiln_model::engine::Engine;
-use kiln_model::{ModelRunner, PagedKvCache};
-use kiln_scheduler::Scheduler;
+use kiln_model::{LinearAttentionState, ModelRunner, PagedKvCache, PagedPrefixRegistration};
+use kiln_scheduler::{PrefixCacheStats, Scheduler};
 use kiln_train::TrainingState;
 use serde::Serialize;
 
@@ -146,6 +147,220 @@ pub struct TrainingJobInfo {
 /// Thread-safe map of tracked training jobs.
 pub type TrainingJobs = Arc<std::sync::RwLock<HashMap<String, TrainingJobInfo>>>;
 
+pub struct RealPrefixCache {
+    enabled: bool,
+    max_blocks: usize,
+    block_size: usize,
+    next_entry_id: u64,
+    entries: Vec<RealPrefixCacheEntry>,
+    block_refcounts: HashMap<u32, usize>,
+    stats: PrefixCacheStats,
+}
+
+struct RealPrefixCacheEntry {
+    id: u64,
+    adapter: Option<String>,
+    prompt_tokens: Vec<TokenId>,
+    block_ids: Vec<u32>,
+    linear_state: LinearAttentionState,
+    last_used: u64,
+    active_uses: usize,
+}
+
+pub struct RealPrefixCacheHit {
+    pub entry_id: u64,
+    pub cached_tokens: usize,
+    pub block_ids: Vec<u32>,
+    pub linear_state: LinearAttentionState,
+}
+
+pub struct RealPrefixCacheRegisterOutcome {
+    pub retained_blocks: Vec<u32>,
+    pub evicted_blocks: Vec<u32>,
+}
+
+impl RealPrefixCache {
+    pub fn new(enabled: bool, block_size: usize, max_blocks: usize) -> Self {
+        Self {
+            enabled,
+            max_blocks,
+            block_size,
+            next_entry_id: 1,
+            entries: Vec::new(),
+            block_refcounts: HashMap::new(),
+            stats: PrefixCacheStats {
+                max_blocks,
+                ..PrefixCacheStats::default()
+            },
+        }
+    }
+
+    pub fn disabled(block_size: usize) -> Self {
+        Self::new(false, block_size, 0)
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.enabled && self.max_blocks > 0
+    }
+
+    pub fn lookup(
+        &mut self,
+        adapter: &Option<String>,
+        prompt_tokens: &[TokenId],
+    ) -> anyhow::Result<Option<RealPrefixCacheHit>> {
+        if !self.is_enabled() {
+            return Ok(None);
+        }
+
+        let best_idx = self
+            .entries
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| {
+                &entry.adapter == adapter
+                    && prompt_tokens.len() > entry.prompt_tokens.len()
+                    && prompt_tokens.starts_with(&entry.prompt_tokens)
+                    && entry.prompt_tokens.len() % self.block_size == 0
+            })
+            .max_by_key(|(_, entry)| entry.prompt_tokens.len())
+            .map(|(idx, _)| idx);
+
+        let Some(idx) = best_idx else {
+            self.stats.lookup_misses += 1;
+            return Ok(None);
+        };
+
+        self.stats.lookup_hits += 1;
+        self.stats.hit_tokens += self.entries[idx].prompt_tokens.len() as u64;
+        self.stats.hit_blocks += self.entries[idx].block_ids.len() as u64;
+        self.entries[idx].last_used = self.stats.lookup_hits + self.stats.lookup_misses;
+        self.entries[idx].active_uses += 1;
+
+        Ok(Some(RealPrefixCacheHit {
+            entry_id: self.entries[idx].id,
+            cached_tokens: self.entries[idx].prompt_tokens.len(),
+            block_ids: self.entries[idx].block_ids.clone(),
+            linear_state: self.entries[idx].linear_state.snapshot()?,
+        }))
+    }
+
+    pub fn release_hit(&mut self, entry_id: u64) {
+        if let Some(entry) = self.entries.iter_mut().find(|entry| entry.id == entry_id) {
+            entry.active_uses = entry.active_uses.saturating_sub(1);
+        }
+    }
+
+    pub fn register(
+        &mut self,
+        adapter: Option<String>,
+        registration: PagedPrefixRegistration,
+    ) -> RealPrefixCacheRegisterOutcome {
+        if !self.is_enabled()
+            || registration.prompt_tokens.is_empty()
+            || registration.prompt_tokens.len() % self.block_size != 0
+            || registration.block_ids.is_empty()
+        {
+            return RealPrefixCacheRegisterOutcome {
+                retained_blocks: Vec::new(),
+                evicted_blocks: Vec::new(),
+            };
+        }
+
+        if self.entries.iter().any(|entry| {
+            entry.adapter == adapter && entry.prompt_tokens == registration.prompt_tokens
+        }) {
+            return RealPrefixCacheRegisterOutcome {
+                retained_blocks: Vec::new(),
+                evicted_blocks: Vec::new(),
+            };
+        }
+
+        let mut evicted_blocks = Vec::new();
+        let needed_new_blocks = registration
+            .block_ids
+            .iter()
+            .filter(|block_id| !self.block_refcounts.contains_key(block_id))
+            .count();
+        while self.cached_blocks() + needed_new_blocks > self.max_blocks {
+            let Some(evict_idx) = self
+                .entries
+                .iter()
+                .enumerate()
+                .filter(|(_, entry)| entry.active_uses == 0)
+                .min_by_key(|(_, entry)| entry.last_used)
+                .map(|(idx, _)| idx)
+            else {
+                return RealPrefixCacheRegisterOutcome {
+                    retained_blocks: Vec::new(),
+                    evicted_blocks,
+                };
+            };
+            let evicted = self.entries.remove(evict_idx);
+            evicted_blocks.extend(self.release_entry_blocks(&evicted.block_ids));
+        }
+
+        let retained_blocks: Vec<u32> = registration
+            .block_ids
+            .iter()
+            .copied()
+            .filter(|block_id| !self.block_refcounts.contains_key(block_id))
+            .collect();
+        for &block_id in &registration.block_ids {
+            *self.block_refcounts.entry(block_id).or_insert(0) += 1;
+        }
+        let id = self.next_entry_id;
+        self.next_entry_id += 1;
+        let last_used = self.stats.lookup_hits + self.stats.lookup_misses;
+        self.entries.push(RealPrefixCacheEntry {
+            id,
+            adapter,
+            prompt_tokens: registration.prompt_tokens,
+            block_ids: registration.block_ids,
+            linear_state: registration.linear_state,
+            last_used,
+            active_uses: 0,
+        });
+        RealPrefixCacheRegisterOutcome {
+            retained_blocks,
+            evicted_blocks,
+        }
+    }
+
+    pub fn clear(&mut self) -> Vec<u32> {
+        let mut blocks = Vec::new();
+        self.entries.clear();
+        blocks.extend(self.block_refcounts.keys().copied());
+        self.block_refcounts.clear();
+        blocks
+    }
+
+    fn release_entry_blocks(&mut self, block_ids: &[u32]) -> Vec<u32> {
+        let mut freed = Vec::new();
+        for &block_id in block_ids {
+            if let Some(refcount) = self.block_refcounts.get_mut(&block_id) {
+                *refcount = refcount.saturating_sub(1);
+                if *refcount == 0 {
+                    self.block_refcounts.remove(&block_id);
+                    freed.push(block_id);
+                }
+            }
+        }
+        freed
+    }
+
+    pub fn stats(&self) -> PrefixCacheStats {
+        PrefixCacheStats {
+            cached_blocks: self.cached_blocks(),
+            max_blocks: self.max_blocks,
+            ..self.stats
+        }
+    }
+
+    fn cached_blocks(&self) -> usize {
+        self.block_refcounts.len()
+    }
+}
+
 /// Which inference backend the server is using.
 pub enum ModelBackend {
     /// Mock engine + scheduler for testing without real weights.
@@ -158,6 +373,7 @@ pub enum ModelBackend {
         runner: Arc<std::sync::RwLock<ModelRunner>>,
         block_manager: Arc<std::sync::Mutex<BlockManager>>,
         paged_cache: Arc<std::sync::Mutex<PagedKvCache>>,
+        prefix_cache: Arc<std::sync::Mutex<RealPrefixCache>>,
     },
 }
 
@@ -202,6 +418,25 @@ pub struct AppState {
 
 impl AppState {
     /// Create an AppState with the mock engine backend.
+    pub fn clear_real_prefix_cache(&self) {
+        let ModelBackend::Real {
+            block_manager,
+            prefix_cache,
+            ..
+        } = self.backend.as_ref()
+        else {
+            return;
+        };
+        let blocks = {
+            let mut cache = prefix_cache.lock().unwrap();
+            cache.clear()
+        };
+        if !blocks.is_empty() {
+            let mut bm = block_manager.lock().unwrap();
+            bm.free_all(&blocks);
+        }
+    }
+
     pub fn new_mock(
         model_config: ModelConfig,
         scheduler: Scheduler,
@@ -255,6 +490,7 @@ impl AppState {
         memory_cfg: &crate::config::MemoryConfig,
         request_timeout_secs: u64,
         served_model_id: String,
+        prefix_cache_cfg: &crate::config::PrefixCacheConfig,
     ) -> Self {
         let block_size = DEFAULT_BLOCK_SIZE;
 
@@ -407,12 +643,24 @@ impl AppState {
             "GPU memory budget"
         );
 
+        let prefix_cache_max_blocks = if prefix_cache_cfg.enabled {
+            prefix_cache_cfg.max_blocks.unwrap_or(num_blocks / 4)
+        } else {
+            0
+        };
+        let prefix_cache = RealPrefixCache::new(
+            prefix_cache_cfg.enabled,
+            block_size,
+            prefix_cache_max_blocks,
+        );
+
         Self {
             model_config,
             backend: Arc::new(ModelBackend::Real {
                 runner: Arc::new(std::sync::RwLock::new(runner)),
                 block_manager: Arc::new(std::sync::Mutex::new(block_manager)),
                 paged_cache: Arc::new(std::sync::Mutex::new(paged_cache)),
+                prefix_cache: Arc::new(std::sync::Mutex::new(prefix_cache)),
             }),
             tokenizer: Arc::new(tokenizer),
             adapter_dir,
@@ -546,6 +794,96 @@ fn detected_gpu_total_memory(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn tiny_linear_config() -> ModelConfig {
+        ModelConfig {
+            hidden_size: 8,
+            num_layers: 2,
+            num_attention_heads: 2,
+            num_kv_heads: 1,
+            head_dim: 4,
+            intermediate_size: 16,
+            vocab_size: 32,
+            max_position_embeddings: 64,
+            rms_norm_eps: 1e-6,
+            rope_theta: 10_000.0,
+            dtype: kiln_core::config::DType::FP32,
+            num_full_attention_layers: 1,
+            full_attention_interval: 2,
+            attn_output_gate: false,
+            linear_num_key_heads: 1,
+            linear_key_head_dim: 2,
+            linear_num_value_heads: 1,
+            linear_value_head_dim: 2,
+            linear_conv_kernel_dim: 2,
+            partial_rotary_factor: 0.5,
+        }
+    }
+
+    #[test]
+    fn real_prefix_cache_records_hits_misses_and_cached_blocks() -> anyhow::Result<()> {
+        let config = tiny_linear_config();
+        let device = candle_core::Device::Cpu;
+        let state = LinearAttentionState::new(&config, &device)?;
+        let mut cache = RealPrefixCache::new(true, 4, 4);
+
+        let registration = PagedPrefixRegistration {
+            prompt_tokens: vec![1, 2, 3, 4],
+            block_ids: vec![9],
+            linear_state: state,
+        };
+        let outcome = cache.register(None, registration);
+        assert_eq!(outcome.retained_blocks, vec![9]);
+        assert!(outcome.evicted_blocks.is_empty());
+
+        assert!(
+            cache
+                .lookup(&None, &[7, 8, 9, 10, 11])
+                .is_ok_and(|hit| hit.is_none())
+        );
+        let hit = cache.lookup(&None, &[1, 2, 3, 4, 5])?.expect("prefix hit");
+        assert_eq!(hit.cached_tokens, 4);
+        assert_eq!(hit.block_ids, vec![9]);
+        cache.release_hit(hit.entry_id);
+
+        let stats = cache.stats();
+        assert_eq!(stats.lookup_hits, 1);
+        assert_eq!(stats.lookup_misses, 1);
+        assert_eq!(stats.hit_tokens, 4);
+        assert_eq!(stats.hit_blocks, 1);
+        assert_eq!(stats.cached_blocks, 1);
+        assert_eq!(stats.max_blocks, 4);
+        Ok(())
+    }
+
+    #[test]
+    fn real_prefix_cache_keys_by_adapter() -> anyhow::Result<()> {
+        let config = tiny_linear_config();
+        let device = candle_core::Device::Cpu;
+        let state = LinearAttentionState::new(&config, &device)?;
+        let mut cache = RealPrefixCache::new(true, 4, 4);
+        cache.register(
+            Some("adapter-a".to_string()),
+            PagedPrefixRegistration {
+                prompt_tokens: vec![1, 2, 3, 4],
+                block_ids: vec![9],
+                linear_state: state,
+            },
+        );
+
+        assert!(cache.lookup(&None, &[1, 2, 3, 4, 5])?.is_none());
+        assert!(
+            cache
+                .lookup(&Some("adapter-b".to_string()), &[1, 2, 3, 4, 5])?
+                .is_none()
+        );
+        assert!(
+            cache
+                .lookup(&Some("adapter-a".to_string()), &[1, 2, 3, 4, 5])?
+                .is_some()
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_memory_budget_cpu_mode() {

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -6,15 +6,15 @@ use std::collections::HashMap;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use candle_core::{DType, Device, Tensor};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tower::ServiceExt; // for `oneshot`
 
 use kiln_core::config::ModelConfig;
 use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::ModelRunner;
 use kiln_model::forward::{
     GpuAttentionWeights, GpuFfnWeights, GpuFullAttentionWeights, GpuLayerWeights, GpuWeights,
 };
-use kiln_model::ModelRunner;
 use kiln_server::api;
 use kiln_server::state::AppState;
 
@@ -193,7 +193,17 @@ async fn test_real_model_chat_completion() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300, "qwen3.5-4b-kiln".to_string());
+    let state = AppState::new_real(
+        config,
+        runner,
+        state_tokenizer,
+        device.clone(),
+        std::path::PathBuf::from("/tmp/kiln-test-adapters"),
+        &kiln_server::config::MemoryConfig::default(),
+        300,
+        "qwen3.5-4b-kiln".to_string(),
+        &kiln_server::config::PrefixCacheConfig::default(),
+    );
 
     let app = api::router(state);
 
@@ -267,6 +277,7 @@ async fn test_real_model_streaming_chat_completion() {
         &kiln_server::config::MemoryConfig::default(),
         300,
         "qwen3.5-4b-kiln".to_string(),
+        &kiln_server::config::PrefixCacheConfig::default(),
     );
 
     let app = api::router(state);
@@ -312,7 +323,11 @@ async fn test_real_model_streaming_chat_completion() {
     let data_lines: Vec<&str> = body_str
         .lines()
         .filter(|line| line.starts_with("data: ") || line.starts_with("data:"))
-        .map(|line| line.strip_prefix("data: ").or_else(|| line.strip_prefix("data:")).unwrap_or(line))
+        .map(|line| {
+            line.strip_prefix("data: ")
+                .or_else(|| line.strip_prefix("data:"))
+                .unwrap_or(line)
+        })
         .collect();
 
     assert!(
@@ -381,6 +396,7 @@ async fn test_request_timeout_configurable() {
         &kiln_server::config::MemoryConfig::default(),
         42,
         "qwen3.5-4b-kiln".to_string(),
+        &kiln_server::config::PrefixCacheConfig::default(),
     );
 
     assert_eq!(state.request_timeout.as_secs(), 42);
@@ -406,6 +422,7 @@ async fn test_default_request_timeout() {
         &kiln_server::config::MemoryConfig::default(),
         300,
         "qwen3.5-4b-kiln".to_string(),
+        &kiln_server::config::PrefixCacheConfig::default(),
     );
 
     assert_eq!(state.request_timeout.as_secs(), 300);
@@ -421,7 +438,17 @@ async fn test_health_with_real_backend() {
     let state_tokenizer = test_tokenizer();
 
     let runner = ModelRunner::new(weights, runner_tokenizer, config.clone());
-    let state = AppState::new_real(config, runner, state_tokenizer, device.clone(), std::path::PathBuf::from("/tmp/kiln-test-adapters"), &kiln_server::config::MemoryConfig::default(), 300, "qwen3.5-4b-kiln".to_string());
+    let state = AppState::new_real(
+        config,
+        runner,
+        state_tokenizer,
+        device.clone(),
+        std::path::PathBuf::from("/tmp/kiln-test-adapters"),
+        &kiln_server::config::MemoryConfig::default(),
+        300,
+        "qwen3.5-4b-kiln".to_string(),
+        &kiln_server::config::PrefixCacheConfig::default(),
+    );
 
     let app = api::router(state);
 
@@ -446,9 +473,11 @@ async fn test_health_with_real_backend() {
     assert_eq!(scheduler["running"], 0);
     assert!(scheduler["blocks_total"].as_u64().unwrap() > 0);
     let checks = resp["checks"].as_array().unwrap();
-    assert!(checks
-        .iter()
-        .any(|check| check["name"] == "inference_prewarm_complete" && check["pass"] == true));
+    assert!(
+        checks
+            .iter()
+            .any(|check| check["name"] == "inference_prewarm_complete" && check["pass"] == true)
+    );
 }
 
 /// End-to-end: HTTP → axum → ModelRunner → Metal → generate. Runs the tiny
@@ -482,6 +511,7 @@ async fn test_real_model_chat_completion_metal() {
         &kiln_server::config::MemoryConfig::default(),
         300,
         "qwen3.5-4b-kiln".to_string(),
+        &kiln_server::config::PrefixCacheConfig::default(),
     );
 
     let app = api::router(state);


### PR DESCRIPTION
## Summary
- Adds a real-backend append-prefix cache owned by `ModelBackend::Real`, gated by existing `[prefix_cache]` config.
- Reuses only block-aligned completed prompt prefixes for non-streaming `ResolvedSpeculativeMode::Off` requests, with adapter identity in the key and cached `LinearAttentionState` snapshots.
- Extends paged generation with a helper that builds cached-prefix block tables, prefills only the suffix at `start_pos = cached_tokens`, snapshots completed prompts, and decodes normally.
- Wires real prefix-cache counters into `/metrics` and clears real cached state on adapter load/unload/swap.

## Unsupported in this slice
- Streaming/SSE requests, MTP, and skip-layer speculative decoding remain on existing paths.
- CUDA graph replay remains on the existing non-prefix-cache path.
- Exact prompt cache hits without a suffix are treated as misses because this slice does not cache next-token logits.
- Prompts are registered only when the completed prompt length is block-aligned, so GDN state and KV blocks correspond exactly to the skipped prefix.

## Validation
RunPod validation used A40 fallback because A6000 on-demand capacity was unavailable; pod was terminated after tests.

- `cargo test -p kiln-model prefix` ✅
- `cargo test -p kiln-server metrics` ✅
- `cargo test -p kiln-server prefix_cache` ✅
- `cargo test -p kiln-server completions` ✅
- `git diff --check` ✅

Note: the requested `cargo test -p kiln-server metrics prefix_cache` form is rejected by Cargo as two test filters, so I ran the `metrics` and `prefix_cache` filters separately.
