### PR TITLE
Document phase 7 prefix cache reuse benchmark

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,5 +1,39 @@
 # Kiln Profiling Report
 
+## Phase 7 real prefix-cache reuse A/B (2026-04-24)
+
+**Scope:** verify that the real-backend append-prefix cache from PR #515 skips shared prompt prefill and improves repeat/shared-prefix latency on GPU.
+
+**Build / hardware:** `main` `8bd7dd0e` (`8bd7dd0ec047db35b2b48324b0493c1298efe6c7`), RunPod on-demand `NVIDIA RTX A6000, 49140 MiB, driver 550.127.08`, `ghcr.io/ericflo/kiln-runpod:latest`. The requested A6000 was available. The task's literal build command `cargo build --release --features cuda --bin kiln-server` is incompatible with current Cargo targets (`kiln` is the server binary), so the benchmark built `cargo build --release --features cuda --bin kiln`.
+
+**Server config:** real `kiln` server, `model.path = "/workspace/qwen3.5-4b"`, `memory.num_blocks = 4096`, `memory.kv_cache_fp8 = true`, `memory.cuda_graphs = false`, `[prefix_cache] max_blocks = 2048`. CUDA graphs were disabled because `crates/kiln-server/src/api/completions.rs` currently routes to `generate_paged_shared_tokens` when `runner_guard.cuda_graph_enabled()?` is true, bypassing the real prefix-cache path.
+
+**Prompt shape:** ChatML content used a 2,048-token block-aligned shared prefix. Suffix variants embedded the ChatML assistant delimiter after the shared text so the warm shared prompt's complete token sequence was an exact prefix of both later variant prompts. Variant A was 2,068 prompt tokens; variant B was 2,069 prompt tokens.
+
+| Arm | Prefix cache | Median total latency | Mean total latency | Min | Max | Completion tokens | Metrics verdict |
+| --- | --- | ---: | ---: | ---: | ---: | --- | --- |
+| ON | `KILN_PREFIX_CACHE_ENABLED=1` | 7.711s | 7.718s | 7.678s | 7.777s | 16 each | 10 hits, 20,480 hit tokens, 1,280 hit blocks |
+| OFF | `KILN_PREFIX_CACHE_ENABLED=0` | 26.923s | 26.501s | 24.455s | 27.227s | 16 each | counters stayed zero |
+
+**Result:** prefix cache ON was **3.49x faster** on median total latency for the 5 paired A/B suffix requests after warming the shared prefix. TTFT is not reported because the non-streaming chat-completions path is the only path wired to real prefix-cache reuse; the streaming path currently bypasses the real prefix cache.
+
+**Metrics after ON arm:**
+
+```text
+kiln_prefix_cache_lookups_total{result="hit"} 10
+kiln_prefix_cache_lookups_total{result="miss"} 2
+kiln_prefix_cache_hit_tokens_total 20480
+kiln_prefix_cache_hit_blocks_total 1280
+kiln_prefix_cache_cached_blocks 128
+kiln_prefix_cache_max_blocks 2048
+```
+
+**Exact-repeat caveat:** repeating the warmed 2,048-token prompt increments a miss rather than a hit because cache lookup requires `prompt_tokens.len() > entry.prompt_tokens.len()` and next-token logits are not cached. The exact-repeat request completed in 0.823s with 1 output token, but it did not count as a prefix-cache hit.
+
+**Verdict / next task:** the real append-prefix cache is functionally effective for append-only shared prefixes, but only with CUDA graphs disabled and only for non-streaming completions. Next, add a safe CUDA-graphs/prefix-cache integration decision point (or explicit config warning) and separately consider a partial-prompt registration API so normal chat suffix variants do not need delimiter-shaped prompts to reuse a shared prefix.
+
+Detailed artifact: `docs/phase7-prefix-cache-reuse-ab.md`.
+
 ## Phase 7 CUDA streaming prefill default A/B (2026-04-24)
 
 **Scope:** decide whether to flip the existing CUDA streaming/tiled prefill path from opt-in to default-on for long prompts after PR #507 showed the memory win at 128k.

--- a/docs/phase7-prefix-cache-reuse-ab.md
+++ b/docs/phase7-prefix-cache-reuse-ab.md
@@ -1,0 +1,259 @@
+# Phase 7 Real Prefix-Cache Reuse A/B
+
+Date: 2026-04-24  
+Commit: `8bd7dd0ec047db35b2b48324b0493c1298efe6c7`  
+GPU: `NVIDIA RTX A6000, 49140 MiB, driver 550.127.08`  
+Image: `ghcr.io/ericflo/kiln-runpod:latest`
+
+## Preflight
+
+PR #515 is merged on `main`; the benchmark ran at `8bd7dd0e` whose tip commit is `Wire real append prefix cache (#515)`. I inspected:
+
+- `crates/kiln-server/src/state.rs`: `RealPrefixCache` stores prompt token IDs, retained paged-KV block IDs, and `LinearAttentionState`, so the real backend preserves GDN recurrent state as well as full-attention KV blocks.
+- `crates/kiln-server/src/api/completions.rs`: non-streaming real generation calls `cache.lookup(...)`, passes `PagedPrefixReuse` into `generate_paged_shared_tokens_with_prefix_cache(...)`, then registers completed block-aligned prompts after successful generation.
+- `crates/kiln-server/src/metrics.rs`: metrics are `kiln_prefix_cache_lookups_total{result="hit|miss"}`, `kiln_prefix_cache_hit_tokens_total`, `kiln_prefix_cache_hit_blocks_total`, `kiln_prefix_cache_cached_blocks`, and `kiln_prefix_cache_max_blocks`.
+
+No existing post-#515 artifact for this benchmark was present in `PROFILING.md` or `docs/phase7-prefix-cache-reuse-ab.md` before this run.
+
+## Commands
+
+The requested build command names `--bin kiln-server`, but current `main` exposes the server binary as `kiln`. The failed command produced `error: no bin target named kiln-server`; the benchmark therefore used the current equivalent:
+
+```bash
+source /root/.kiln-build-env
+cd /workspace/kiln
+git fetch origin main
+git reset --hard origin/main
+cargo build --release --features cuda --bin kiln
+```
+
+Server config used for both arms, changing only `[prefix_cache].enabled` and `KILN_PREFIX_CACHE_ENABLED`:
+
+```toml
+[server]
+host = "127.0.0.1"
+port = 8420
+request_timeout_secs = 300
+
+[model]
+path = "/workspace/qwen3.5-4b"
+
+[memory]
+num_blocks = 4096
+kv_cache_fp8 = true
+cuda_graphs = false
+
+[prefix_cache]
+enabled = true
+max_blocks = 2048
+
+[logging]
+level = "info"
+format = "json"
+```
+
+Runtime env:
+
+```bash
+KILN_W4A16=1
+KILN_CUDA_GRAPHS=false
+KILN_SPEC_ENABLED=0
+KILN_PREFIX_CACHE_ENABLED=1   # ON arm; 0 for OFF arm
+```
+
+CUDA graphs were disabled intentionally. With graphs enabled, `generate_real` currently bypasses `generate_paged_shared_tokens_with_prefix_cache(...)` and calls `generate_paged_shared_tokens(...)`.
+
+## Prompt Design
+
+The server always applies ChatML to `/v1/chat/completions` messages before tokenization. A normal warm prompt with only the shared user text is not a token prefix of a later `shared + suffix` user message, because the warm prompt already contains the closing ChatML and assistant-generation markers.
+
+To exercise the append-only cache without adding a raw-completions endpoint, the suffix prompts embedded the same ChatML assistant delimiter at the suffix boundary:
+
+```text
+warm content:    <shared>
+variant content: <shared><|im_end|>
+<|im_start|>assistant
+ Variant A: ...
+```
+
+Token lengths from `/workspace/qwen3.5-4b/tokenizer.json` with Kiln's ChatML fallback:
+
+| Prompt | Prompt tokens | Notes |
+| --- | ---: | --- |
+| `warm_shared` | 2048 | block aligned, registers 128 cache blocks |
+| `variant_a` | 2068 | starts with all `warm_shared` prompt tokens |
+| `variant_b` | 2069 | starts with all `warm_shared` prompt tokens |
+
+Each measured request used `temperature = 0.0`, `seed = 1`, and `max_tokens = 16`.
+
+## Summary
+
+| Arm | Summary | Median speed |
+| --- | --- | ---: |
+| Prefix cache ON | median 7.711s, mean 7.718s, min 7.678s, max 7.777s, n=10 | 7.711s |
+| Prefix cache OFF | median 26.923s, mean 26.501s, min 24.455s, max 27.227s, n=10 | 26.923s |
+
+Median total-latency speedup: **3.49x**.
+
+TTFT is not reported because the streaming path is not the prefix-cache path; these are non-streaming total request latencies from the Python client around `POST /v1/chat/completions`.
+
+## Metrics
+
+Before ON arm:
+
+```text
+kiln_prefix_cache_lookups_total{result="hit"} 0
+kiln_prefix_cache_lookups_total{result="miss"} 0
+kiln_prefix_cache_hit_tokens_total 0
+kiln_prefix_cache_hit_blocks_total 0
+kiln_prefix_cache_cached_blocks 0
+kiln_prefix_cache_max_blocks 2048
+```
+
+After ON arm:
+
+```text
+kiln_prefix_cache_lookups_total{result="hit"} 10
+kiln_prefix_cache_lookups_total{result="miss"} 2
+kiln_prefix_cache_hit_tokens_total 20480
+kiln_prefix_cache_hit_blocks_total 1280
+kiln_prefix_cache_cached_blocks 128
+kiln_prefix_cache_max_blocks 2048
+```
+
+Before OFF arm:
+
+```text
+kiln_prefix_cache_lookups_total{result="hit"} 0
+kiln_prefix_cache_lookups_total{result="miss"} 0
+kiln_prefix_cache_hit_tokens_total 0
+kiln_prefix_cache_hit_blocks_total 0
+kiln_prefix_cache_cached_blocks 0
+kiln_prefix_cache_max_blocks 0
+```
+
+After OFF arm:
+
+```text
+kiln_prefix_cache_lookups_total{result="hit"} 0
+kiln_prefix_cache_lookups_total{result="miss"} 0
+kiln_prefix_cache_hit_tokens_total 0
+kiln_prefix_cache_hit_blocks_total 0
+kiln_prefix_cache_cached_blocks 0
+kiln_prefix_cache_max_blocks 0
+```
+
+The ON arm shows 10 hits across the 10 measured suffix requests. `hit_tokens = 20,480` equals `10 * 2,048`, and `hit_blocks = 1,280` equals `10 * 128`, matching the block-aligned warm prefix.
+
+## Raw Timings
+
+### Prefix Cache ON
+
+Warm request:
+
+```json
+{
+  "label": "warm_shared",
+  "latency_s": 8.318949854001403,
+  "prompt_tokens": 2048,
+  "completion_tokens": 1,
+  "total_tokens": 2049,
+  "finish_reason": "length",
+  "text_excerpt": "<think>"
+}
+```
+
+Exact-repeat request:
+
+```json
+{
+  "label": "exact_repeat_shared",
+  "latency_s": 0.8230025433003902,
+  "prompt_tokens": 2048,
+  "completion_tokens": 1,
+  "total_tokens": 2049,
+  "finish_reason": "length",
+  "text_excerpt": "<think>"
+}
+```
+
+| Pair | Suffix | Latency (s) | Prompt tok | Output tok | Finish |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | A | 7.755 | 2068 | 16 | length |
+| 1 | B | 7.712 | 2069 | 16 | length |
+| 2 | A | 7.714 | 2068 | 16 | length |
+| 2 | B | 7.702 | 2069 | 16 | length |
+| 3 | A | 7.683 | 2068 | 16 | length |
+| 3 | B | 7.687 | 2069 | 16 | length |
+| 4 | A | 7.760 | 2068 | 16 | length |
+| 4 | B | 7.678 | 2069 | 16 | length |
+| 5 | A | 7.777 | 2068 | 16 | length |
+| 5 | B | 7.710 | 2069 | 16 | length |
+
+### Prefix Cache OFF
+
+Warm request:
+
+```json
+{
+  "label": "warm_shared",
+  "latency_s": 1.1434310227632523,
+  "prompt_tokens": 2048,
+  "completion_tokens": 1,
+  "total_tokens": 2049,
+  "finish_reason": "length",
+  "text_excerpt": "<think>"
+}
+```
+
+Exact-repeat request:
+
+```json
+{
+  "label": "exact_repeat_shared",
+  "latency_s": 0.8126341216266155,
+  "prompt_tokens": 2048,
+  "completion_tokens": 1,
+  "total_tokens": 2049,
+  "finish_reason": "length",
+  "text_excerpt": "<think>"
+}
+```
+
+| Pair | Suffix | Latency (s) | Prompt tok | Output tok | Finish |
+| ---: | --- | ---: | ---: | ---: | --- |
+| 1 | A | 24.455 | 2068 | 16 | length |
+| 1 | B | 24.615 | 2069 | 16 | length |
+| 2 | A | 26.881 | 2068 | 16 | length |
+| 2 | B | 27.155 | 2069 | 16 | length |
+| 3 | A | 27.227 | 2068 | 16 | length |
+| 3 | B | 26.964 | 2069 | 16 | length |
+| 4 | A | 26.849 | 2068 | 16 | length |
+| 4 | B | 26.779 | 2069 | 16 | length |
+| 5 | A | 27.058 | 2068 | 16 | length |
+| 5 | B | 27.024 | 2069 | 16 | length |
+
+## Exact-Repeat Caveat
+
+The benchmark also sent one exact repeat of `warm_shared` after warming the cache. Current behavior remains a miss for exact repeats, because `RealPrefixCache::lookup` requires the new prompt to be longer than the cached prompt. This is correct for the current implementation because next-token logits are not cached; a full-prompt exact repeat cannot skip directly to decode without either cached logits or a forced one-token suffix.
+
+## Validation
+
+RunPod validation commands:
+
+```bash
+cd /workspace/kiln
+source /root/.kiln-build-env
+cargo test -p kiln-model prefix
+cargo test -p kiln-server metrics
+cargo test -p kiln-server prefix_cache
+git diff --check
+```
+
+Results: all commands passed on the A6000 pod. Existing compiler warnings were unchanged (`unused variable: use_metal_decode_gemv`, `compute_chunk_body_reference`, `apply_causal_mask`, `fp8_scales`, and an unused `Context` import).
+
+## Verdict
+
+The real append-prefix cache is effective for block-aligned append-only shared prefixes on the non-streaming real backend. The measured 2,048-token shared-prefix workload improved median total latency from 26.923s to 7.711s and metrics exactly matched the expected skipped tokens/blocks.
+
+Recommended next task: make prefix-cache behavior explicit around CUDA graphs and chat prompt shape. Either integrate prefix reuse into the CUDA-graph path or emit a startup/config warning when both are enabled, and add a partial-prefix registration strategy so normal chat `shared + suffix` prompts can reuse shared user text without delimiter-shaped content.


### PR DESCRIPTION
## Summary

- Adds a new `PROFILING.md` top section for the Phase 7 real prefix-cache reuse A/B benchmark.
- Adds `docs/phase7-prefix-cache-reuse-ab.md` with preflight notes, exact benchmark config, metrics counters, raw timing tables, caveats, and next recommendation.
- Documents that real prefix-cache reuse works on the non-streaming path with CUDA graphs disabled, measuring 3.49x median total-latency speedup for a 2,048-token shared prefix on A6000.

## Validation

Run on RunPod A6000 with `ghcr.io/ericflo/kiln-runpod:latest`:

```bash
cargo build --release --features cuda --bin kiln
cargo test -p kiln-model prefix
cargo test -p kiln-server metrics
cargo test -p kiln-server prefix_cache
git diff --check
```

Note: the task's literal `--bin kiln-server` build target is incompatible with current `main`; the server binary target is `kiln`, so the benchmark used `--bin kiln`.