### PR TITLE
Warn when CUDA graphs bypass prefix cache

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -10,6 +10,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
 use std::path::Path;
+use std::sync::atomic::Ordering;
 
 use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
@@ -490,6 +491,8 @@ async fn generate_real(
 
     let gpu_lock = state.gpu_lock.clone();
     let timeout = state.request_timeout;
+    let prefix_cache_cuda_graphs_bypass_warned =
+        state.prefix_cache_cuda_graphs_bypass_warned.clone();
     let generation = tokio::task::spawn_blocking(move || {
         // Acquire GPU coordination read lock — allows concurrent inference,
         // but blocks while training holds the write lock.
@@ -501,7 +504,19 @@ async fn generate_real(
                     let cache = prefix_cache.lock().unwrap();
                     cache.is_enabled()
                 };
-                if !prefix_enabled || runner_guard.cuda_graph_enabled()? {
+                let cuda_graphs_enabled = runner_guard.cuda_graph_enabled()?;
+                if prefix_enabled && cuda_graphs_enabled {
+                    let already_warned =
+                        prefix_cache_cuda_graphs_bypass_warned.swap(true, Ordering::Relaxed);
+                    if !already_warned {
+                        tracing::warn!(
+                            prefix_cache_enabled = true,
+                            cuda_graphs_enabled = true,
+                            "real prefix cache is enabled but CUDA graphs are active; real chat completions bypass prefix-cache lookup and registration until CUDA-graph prefix-cache integration is implemented"
+                        );
+                    }
+                }
+                if !prefix_enabled || cuda_graphs_enabled {
                     runner_guard.generate_paged_shared_tokens(
                         &prompt_tokens,
                         &params,

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -409,6 +409,8 @@ pub struct AppState {
     pub started_at: std::time::Instant,
     /// True once startup inference prewarm has finished or was not needed.
     pub inference_prewarm_complete: Arc<AtomicBool>,
+    /// True after logging that CUDA graphs bypass the real prefix cache.
+    pub prefix_cache_cuda_graphs_bypass_warned: Arc<AtomicBool>,
     /// Server-level default for adapter checkpoint interval during training.
     /// Per-job config overrides this. None = only save at the end.
     pub checkpoint_interval: Option<usize>,
@@ -467,6 +469,7 @@ impl AppState {
             metrics: Arc::new(Metrics::new()),
             started_at: std::time::Instant::now(),
             inference_prewarm_complete: Arc::new(AtomicBool::new(true)),
+            prefix_cache_cuda_graphs_bypass_warned: Arc::new(AtomicBool::new(false)),
             checkpoint_interval: None,
             served_model_id,
         }
@@ -678,6 +681,7 @@ impl AppState {
                 device,
                 candle_core::Device::Metal(_)
             ))),
+            prefix_cache_cuda_graphs_bypass_warned: Arc::new(AtomicBool::new(false)),
             checkpoint_interval: None,
             served_model_id,
         }

--- a/docs/phase7-prefix-cache-reuse-ab.md
+++ b/docs/phase7-prefix-cache-reuse-ab.md
@@ -61,7 +61,7 @@ KILN_SPEC_ENABLED=0
 KILN_PREFIX_CACHE_ENABLED=1   # ON arm; 0 for OFF arm
 ```
 
-CUDA graphs were disabled intentionally. With graphs enabled, `generate_real` currently bypasses `generate_paged_shared_tokens_with_prefix_cache(...)` and calls `generate_paged_shared_tokens(...)`.
+CUDA graphs were disabled intentionally. With graphs enabled, `generate_real` currently bypasses `generate_paged_shared_tokens_with_prefix_cache(...)` and calls `generate_paged_shared_tokens(...)`. As a follow-up, the server now emits a one-time structured warning when `RealPrefixCache` is enabled but CUDA graphs force that non-prefix path, so operators do not silently expect cache reuse from real chat completions. Full CUDA-graph prefix-cache integration remains separate work.
 
 ## Prompt Design
 


### PR DESCRIPTION
## Summary
- Added a one-time structured warning when `RealPrefixCache` is enabled but CUDA graphs route real chat completions through the non-prefix `generate_paged_shared_tokens(...)` path.
- Kept runtime behavior unchanged; this does not attempt CUDA graph prefix-cache integration.
- Documented the follow-up warning in `docs/phase7-prefix-cache-reuse-ab.md` and called out CUDA-graph integration as separate work.

## Remaining-work precondition
Passed. Current `origin/main` documents that CUDA graphs bypass `generate_paged_shared_tokens_with_prefix_cache(...)`, but it did not emit an explicit runtime warning/diagnostic when the bypass happened. `generate_real` still bypasses `RealPrefixCache` whenever `runner_guard.cuda_graph_enabled()?` is true.

## Validation
Run on RunPod on-demand RTX A6000 using `ghcr.io/ericflo/kiln-runpod:latest` (`3rgftjue2pnc6u`; terminated after validation):

```bash
cargo test -p kiln-server prefix_cache
cargo test -p kiln-server health
cargo test -p kiln-server metrics
git diff --check
```

Result: passed. Existing warnings were emitted from `kiln-model` and `kiln-server` unused/dead-code lints; no failures.
