### PR TITLE
[codex] speed up greedy paged prefill defaults

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -34,6 +34,7 @@ const DISABLE_METAL_MLP_GATE_UP_FUSION: &str = "KILN_DISABLE_METAL_MLP_GATE_UP_F
 const DISABLE_METAL_ATTN_GATE_FUSION: &str = "KILN_DISABLE_METAL_ATTN_GATE_FUSION";
 const DISABLE_METAL_FUSED_QKV_PROJ: &str = "KILN_DISABLE_METAL_FUSED_QKV_PROJ";
 const DISABLE_METAL_GDN_IN_PROJ_FUSION: &str = "KILN_DISABLE_METAL_GDN_IN_PROJ_FUSION";
+const ENABLE_METAL_LM_HEAD_ARGMAX: &str = "KILN_ENABLE_METAL_LM_HEAD_ARGMAX";
 const DISABLE_METAL_LM_HEAD_ARGMAX: &str = "KILN_DISABLE_METAL_LM_HEAD_ARGMAX";
 const DISABLE_METAL_LM_HEAD_ARGMAX_GPU_REDUCE: &str =
     "KILN_DISABLE_METAL_LM_HEAD_ARGMAX_GPU_REDUCE";
@@ -750,7 +751,10 @@ fn metal_fused_qkv_proj_disabled() -> bool {
 }
 
 pub(crate) fn metal_lm_head_argmax_disabled() -> bool {
-    env_truthy(DISABLE_METAL_LM_HEAD_ARGMAX)
+    // On the Qwen3.5-4B macOS desktop path, Candle's materialized last-row
+    // projection plus argmax is faster than this custom chunk/reduce kernel.
+    // Keep the kernel available for tuning, but require explicit opt-in.
+    env_truthy(DISABLE_METAL_LM_HEAD_ARGMAX) || !env_truthy(ENABLE_METAL_LM_HEAD_ARGMAX)
 }
 
 fn metal_lm_head_argmax_gpu_reduce_disabled() -> bool {
@@ -8775,27 +8779,49 @@ mod tests {
             return Ok(());
         };
 
-        let hidden = 128usize;
-        let vocab = 257usize;
-        let x_data: Vec<f32> = (0..hidden)
-            .map(|i| ((i % 23) as f32 - 11.0) * 0.0234375)
-            .collect();
-        let weight_data: Vec<f32> = (0..(hidden * vocab))
-            .map(|i| ((i % 31) as f32 - 15.0) * 0.01953125)
-            .collect();
+        let enable_prev = std::env::var_os(ENABLE_METAL_LM_HEAD_ARGMAX);
+        let disable_prev = std::env::var_os(DISABLE_METAL_LM_HEAD_ARGMAX);
+        unsafe {
+            std::env::set_var(ENABLE_METAL_LM_HEAD_ARGMAX, "1");
+            std::env::remove_var(DISABLE_METAL_LM_HEAD_ARGMAX);
+        }
 
-        let x = Tensor::from_slice(&x_data, (1usize, 1usize, hidden), &device)?
-            .to_dtype(DType::BF16)?;
-        let weight_t =
-            Tensor::from_slice(&weight_data, (hidden, vocab), &device)?.to_dtype(DType::BF16)?;
+        let result = (|| -> Result<()> {
+            let hidden = 128usize;
+            let vocab = 257usize;
+            let x_data: Vec<f32> = (0..hidden)
+                .map(|i| ((i % 23) as f32 - 11.0) * 0.0234375)
+                .collect();
+            let weight_data: Vec<f32> = (0..(hidden * vocab))
+                .map(|i| ((i % 31) as f32 - 15.0) * 0.01953125)
+                .collect();
 
-        assert!(metal_lm_head_argmax_supports(&x, &weight_t));
-        let logits = metal_lm_head_bf16(&x, &weight_t)?;
-        let reference = crate::sampling::greedy_sample(&logits)?;
-        let fused = metal_lm_head_argmax_bf16(&x, &weight_t)?;
+            let x = Tensor::from_slice(&x_data, (1usize, 1usize, hidden), &device)?
+                .to_dtype(DType::BF16)?;
+            let weight_t = Tensor::from_slice(&weight_data, (hidden, vocab), &device)?
+                .to_dtype(DType::BF16)?;
 
-        assert_eq!(fused, reference);
-        Ok(())
+            assert!(metal_lm_head_argmax_supports(&x, &weight_t));
+            let logits = metal_lm_head_bf16(&x, &weight_t)?;
+            let reference = crate::sampling::greedy_sample(&logits)?;
+            let fused = metal_lm_head_argmax_bf16(&x, &weight_t)?;
+
+            assert_eq!(fused, reference);
+            Ok(())
+        })();
+
+        unsafe {
+            match enable_prev {
+                Some(value) => std::env::set_var(ENABLE_METAL_LM_HEAD_ARGMAX, value),
+                None => std::env::remove_var(ENABLE_METAL_LM_HEAD_ARGMAX),
+            }
+            match disable_prev {
+                Some(value) => std::env::set_var(DISABLE_METAL_LM_HEAD_ARGMAX, value),
+                None => std::env::remove_var(DISABLE_METAL_LM_HEAD_ARGMAX),
+            }
+        }
+
+        result
     }
 
     #[test]

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -5941,6 +5941,40 @@ pub fn model_forward_paged_last_token(
     Ok(logits.expect("LmHeadMode::LastRowOnly always produces logits"))
 }
 
+/// Paged-KV forward pass for greedy generation prefill.
+///
+/// This runs the same prefill work as [`model_forward_paged_last_token`] but
+/// fuses the final-row LM-head projection with argmax when the backend supports
+/// it, avoiding a `[1, 1, vocab_size]` logits tensor that greedy sampling would
+/// immediately reduce.
+pub fn model_forward_paged_last_token_greedy(
+    backend: &dyn BackendRuntime,
+    token_ids: &[u32],
+    weights: &GpuWeights,
+    config: &kiln_core::config::ModelConfig,
+    paged_cache: &mut PagedKvCache,
+    block_table: &BlockTable,
+    start_pos: usize,
+    linear_state: Option<&mut LinearAttentionState>,
+    lora: Option<&LoraWeights>,
+    positions_gpu: Option<&Tensor>,
+) -> Result<u32> {
+    let (_logits, _hidden, token) = model_forward_paged_inner(
+        backend,
+        token_ids,
+        weights,
+        config,
+        paged_cache,
+        block_table,
+        start_pos,
+        linear_state,
+        lora,
+        positions_gpu,
+        LmHeadMode::LastRowArgmaxOnly,
+    )?;
+    token.context("LmHeadMode::LastRowArgmaxOnly always produces a token")
+}
+
 /// Paged-KV single-token decode for greedy sampling.
 ///
 /// This keeps the existing logits APIs intact but, on the Metal BF16 decode
@@ -5958,7 +5992,7 @@ pub fn model_forward_paged_next_token_greedy(
     lora: Option<&LoraWeights>,
     positions_gpu: Option<&Tensor>,
 ) -> Result<u32> {
-    let (_logits, _hidden, token) = model_forward_paged_inner(
+    model_forward_paged_last_token_greedy(
         backend,
         &[token_id],
         weights,
@@ -5969,9 +6003,7 @@ pub fn model_forward_paged_next_token_greedy(
         linear_state,
         lora,
         positions_gpu,
-        LmHeadMode::LastRowArgmaxOnly,
-    )?;
-    token.context("LmHeadMode::LastRowArgmaxOnly always produces a token")
+    )
 }
 
 /// Paged-KV forward pass that ALSO returns the last-row pre-final-norm hidden state.
@@ -11094,6 +11126,26 @@ mod tests {
         assert!(
             max_abs <= 1e-5,
             "last-token prefill max_abs_diff={max_abs:e} exceeds 1e-5"
+        );
+
+        let expected_token = crate::sampling::greedy_sample(&last_logits)?;
+        let (mut greedy_cache, greedy_bt) = make_paged_setup(&config, total, 64, &device)?;
+        let mut greedy_state = LinearAttentionState::new(&config, &device)?;
+        let greedy_token = model_forward_paged_last_token_greedy(
+            &backend,
+            &tokens,
+            &weights,
+            &config,
+            &mut greedy_cache,
+            &greedy_bt,
+            0,
+            Some(&mut greedy_state),
+            None,
+            None,
+        )?;
+        assert_eq!(
+            greedy_token, expected_token,
+            "last-token greedy prefill should match greedy_sample(last-token logits)"
         );
 
         Ok(())

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -4,7 +4,7 @@
 //! a `ModelRunner` that accepts text prompts and produces text output.
 
 use anyhow::{Context, Result};
-use candle_core::DType;
+use candle_core::{DType, Tensor};
 use std::path::Path;
 use std::sync::{Arc, Mutex, mpsc};
 
@@ -17,9 +17,10 @@ use crate::backend::{self, BackendRuntime};
 use crate::cuda_graph::CudaGraphRunner;
 use crate::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
-    model_forward_paged_last_token, model_forward_paged_last_token_with_last_hidden,
-    model_forward_paged_next_token_greedy, model_forward_paged_streaming,
-    model_forward_paged_streaming_last_token_with_last_hidden, streaming_prefill_enabled_for,
+    model_forward_paged_last_token, model_forward_paged_last_token_greedy,
+    model_forward_paged_last_token_with_last_hidden, model_forward_paged_next_token_greedy,
+    model_forward_paged_streaming, model_forward_paged_streaming_last_token_with_last_hidden,
+    streaming_prefill_enabled_for,
 };
 use crate::kv_cache::KvCache;
 use crate::lora_loader::LoraWeights;
@@ -77,6 +78,11 @@ pub struct PrefixCachedGenerationOutput {
     pub output: GenerationOutput,
     pub registration: Option<PagedPrefixRegistration>,
     pub allocated_blocks: Vec<u32>,
+}
+
+enum PrefillSampleSource {
+    Logits(Tensor),
+    GreedyToken(TokenId),
 }
 
 /// Output from a native MTP speculative generation call.
@@ -961,21 +967,44 @@ impl ModelRunner {
             "prefix cache hit must leave at least one suffix token"
         );
 
-        let logits = {
+        let use_greedy_prefill_token = params.temperature == 0.0
+            && matches!(self.backend.device(), candle_core::Device::Metal(_))
+            && !streaming_prefill_enabled_for(self.backend.device(), prefill_tokens.len());
+        let prefill_source = {
             let mut pc_guard = lock_paged_cache(paged_cache)?;
-            model_forward_paged_last_token(
-                &*self.backend,
-                prefill_tokens,
-                &self.weights,
-                &self.config,
-                &mut pc_guard,
-                block_table,
-                cached_tokens,
-                Some(&mut linear_state),
-                self.active_lora.as_ref(),
-                None,
-            )
-            .context("prefill forward pass (paged prefix cache) failed")?
+            if use_greedy_prefill_token {
+                PrefillSampleSource::GreedyToken(
+                    model_forward_paged_last_token_greedy(
+                        &*self.backend,
+                        prefill_tokens,
+                        &self.weights,
+                        &self.config,
+                        &mut pc_guard,
+                        block_table,
+                        cached_tokens,
+                        Some(&mut linear_state),
+                        self.active_lora.as_ref(),
+                        None,
+                    )
+                    .context("greedy prefill forward pass (paged prefix cache) failed")?,
+                )
+            } else {
+                PrefillSampleSource::Logits(
+                    model_forward_paged_last_token(
+                        &*self.backend,
+                        prefill_tokens,
+                        &self.weights,
+                        &self.config,
+                        &mut pc_guard,
+                        block_table,
+                        cached_tokens,
+                        Some(&mut linear_state),
+                        self.active_lora.as_ref(),
+                        None,
+                    )
+                    .context("prefill forward pass (paged prefix cache) failed")?,
+                )
+            }
         };
 
         let registration = self.completed_prompt_registration(
@@ -985,14 +1014,25 @@ impl ModelRunner {
             block_size,
         )?;
 
-        let output = self.decode_from_prefill_logits(
-            logits,
-            prompt_tokens.len(),
-            params,
-            paged_cache,
-            block_table,
-            &mut linear_state,
-        )?;
+        let output = match prefill_source {
+            PrefillSampleSource::Logits(logits) => self.decode_from_prefill_logits(
+                logits,
+                prompt_tokens.len(),
+                params,
+                paged_cache,
+                block_table,
+                &mut linear_state,
+            )?,
+            PrefillSampleSource::GreedyToken(token) => self.decode_from_prefill_token(
+                token,
+                prompt_tokens.len(),
+                params,
+                paged_cache,
+                block_table,
+                &mut linear_state,
+                params.seed,
+            )?,
+        };
 
         Ok(PrefixCachedGenerationOutput {
             output,
@@ -1025,16 +1065,15 @@ impl ModelRunner {
     fn decode_from_prefill_logits(
         &self,
         logits: candle_core::Tensor,
-        mut seq_len: usize,
+        seq_len: usize,
         params: &SamplingParams,
         paged_cache: &Mutex<PagedKvCache>,
         block_table: &BlockTable,
         linear_state: &mut LinearAttentionState,
     ) -> Result<GenerationOutput> {
-        let mut generated_tokens: Vec<TokenId> = Vec::new();
-        let mut step_seed = params.seed;
+        let step_seed = params.seed;
 
-        let mut next_token = if params.temperature == 0.0 {
+        let next_token = if params.temperature == 0.0 {
             greedy_sample(&logits)?
         } else {
             sample_with_params(
@@ -1045,7 +1084,28 @@ impl ModelRunner {
                 step_seed,
             )?
         };
+        self.decode_from_prefill_token(
+            next_token,
+            seq_len,
+            params,
+            paged_cache,
+            block_table,
+            linear_state,
+            step_seed,
+        )
+    }
 
+    fn decode_from_prefill_token(
+        &self,
+        mut next_token: TokenId,
+        mut seq_len: usize,
+        params: &SamplingParams,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+        linear_state: &mut LinearAttentionState,
+        mut step_seed: Option<u64>,
+    ) -> Result<GenerationOutput> {
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
         for _step in 0..params.max_tokens {
             if let Some(s) = step_seed.as_mut() {
                 *s = s.wrapping_add(1);
@@ -1534,33 +1594,57 @@ impl ModelRunner {
         // Prefill: forward pass on all prompt tokens (never uses CUDA graphs).
         // Long Metal prompts use tiled streaming prefill by default; env
         // overrides can force either path.
-        let logits = if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
-            model_forward_paged_streaming(
-                &*self.backend,
-                prompt_tokens,
-                &self.weights,
-                &self.config,
-                paged_cache,
-                block_table,
-                0,
-                Some(&mut linear_state),
-                self.active_lora.as_ref(),
+        let streaming_prefill =
+            streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len());
+        let prefill_source = if streaming_prefill {
+            PrefillSampleSource::Logits(
+                model_forward_paged_streaming(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    paged_cache,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                )
+                .context("prefill forward pass (paged, streaming) failed")?,
             )
-            .context("prefill forward pass (paged, streaming) failed")?
+        } else if params.temperature == 0.0
+            && matches!(self.backend.device(), candle_core::Device::Metal(_))
+        {
+            PrefillSampleSource::GreedyToken(
+                model_forward_paged_last_token_greedy(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    paged_cache,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("greedy prefill forward pass (paged) failed")?,
+            )
         } else {
-            model_forward_paged_last_token(
-                &*self.backend,
-                prompt_tokens,
-                &self.weights,
-                &self.config,
-                paged_cache,
-                block_table,
-                0,
-                Some(&mut linear_state),
-                self.active_lora.as_ref(),
-                None,
+            PrefillSampleSource::Logits(
+                model_forward_paged_last_token(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    paged_cache,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("prefill forward pass (paged) failed")?,
             )
-            .context("prefill forward pass (paged) failed")?
         };
 
         let mut seq_len = prompt_tokens.len();
@@ -1573,17 +1657,21 @@ impl ModelRunner {
             .lock()
             .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?;
 
-        // Sample first token
-        let mut next_token = if params.temperature == 0.0 {
-            greedy_sample(&logits)?
-        } else {
-            sample_with_params(
-                &logits,
-                params.temperature,
-                params.top_p,
-                params.top_k,
-                step_seed,
-            )?
+        let mut next_token = match prefill_source {
+            PrefillSampleSource::GreedyToken(token) => token,
+            PrefillSampleSource::Logits(logits) => {
+                if params.temperature == 0.0 {
+                    greedy_sample(&logits)?
+                } else {
+                    sample_with_params(
+                        &logits,
+                        params.temperature,
+                        params.top_p,
+                        params.top_k,
+                        step_seed,
+                    )?
+                }
+            }
         };
 
         for _step in 0..params.max_tokens {

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -20,9 +20,10 @@ use kiln_model::ModelRunner;
 use kiln_model::backend as runtime_backend;
 use kiln_model::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
-    model_forward_paged_last_token, model_forward_paged_last_token_with_last_hidden,
-    model_forward_paged_next_token_greedy, model_forward_paged_streaming,
-    model_forward_paged_streaming_last_token_with_last_hidden, streaming_prefill_enabled_for,
+    model_forward_paged_last_token, model_forward_paged_last_token_greedy,
+    model_forward_paged_last_token_with_last_hidden, model_forward_paged_next_token_greedy,
+    model_forward_paged_streaming, model_forward_paged_streaming_last_token_with_last_hidden,
+    streaming_prefill_enabled_for,
 };
 use kiln_model::kv_cache::KvCache;
 use kiln_model::paged_kv_cache::PagedKvCache;
@@ -758,8 +759,9 @@ fn bench_latency_paged(
     // prompts use tiled streaming prefill by default; env overrides can force
     // either path.
     let prefill_start = Instant::now();
-    let logits = if streaming_prefill_enabled_for(device, actual_prompt_tokens) {
-        model_forward_paged_streaming(
+    let streaming_prefill = streaming_prefill_enabled_for(device, actual_prompt_tokens);
+    let mut next_token = if streaming_prefill {
+        let logits = model_forward_paged_streaming(
             &*backend,
             &prompt_token_ids,
             weights,
@@ -770,9 +772,24 @@ fn bench_latency_paged(
             Some(&mut linear_state),
             None,
         )
-        .context("paged prefill forward pass (streaming) failed")?
+        .context("paged prefill forward pass (streaming) failed")?;
+        greedy_sample(&logits)?
+    } else if matches!(device, candle_core::Device::Metal(_)) {
+        model_forward_paged_last_token_greedy(
+            &*backend,
+            &prompt_token_ids,
+            weights,
+            config,
+            &mut paged_cache,
+            &block_table,
+            0,
+            Some(&mut linear_state),
+            None,
+            None,
+        )
+        .context("paged greedy prefill forward pass failed")?
     } else {
-        model_forward_paged_last_token(
+        let logits = model_forward_paged_last_token(
             &*backend,
             &prompt_token_ids,
             weights,
@@ -784,11 +801,9 @@ fn bench_latency_paged(
             None,
             None,
         )
-        .context("paged prefill forward pass failed")?
+        .context("paged prefill forward pass failed")?;
+        greedy_sample(&logits)?
     };
-
-    // Sample first token
-    let mut next_token = greedy_sample(&logits)?;
     let prefill_time = prefill_start.elapsed();
 
     eprintln!(


### PR DESCRIPTION
## Summary

This PR improves the macOS desktop-default greedy paged inference path for Qwen3.5-4B:

- adds `model_forward_paged_last_token_greedy` so greedy paged prefill can return the first token directly instead of carrying a logits tensor through the caller
- uses that path for Metal, non-streaming, temperature-0 paged generation and the latency benchmark
- changes the custom Metal LM-head argmax kernel from default-on to explicit opt-in because the desktop Qwen3.5-4B path benchmarks faster through the materialized last-row projection plus argmax
- keeps the Metal argmax kernel covered by an explicit opt-in parity test

## Validation

- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln-startup-transposed-cache-bg-persist/target cargo check --locked -p kiln-model --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln-startup-transposed-cache-bg-persist/target cargo check --locked -p kiln-server --features metal`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln-startup-transposed-cache-bg-persist/target cargo test --locked -p kiln-model test_model_forward_paged_last_token_matches_full_last_row_cpu -- --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln-startup-transposed-cache-bg-persist/target cargo test --locked -p kiln-model --features metal test_lm_head_argmax_matches_materialized_logits -- --nocapture`
- `CARGO_TARGET_DIR=/Users/ericflo/Development/kiln-startup-transposed-cache-bg-persist/target cargo build --release --locked -p kiln-server --features metal --bin kiln-bench`

## Benchmark

Desktop env, paged 512/128, Qwen3.5-4B:

- current main warm reference: prefill 3578.5 ms / 138 tok/s, decode 4.65 tok/s
- this branch: prefill 3482.4 ms / 142 tok/s, decode 5.13 tok/s
- local llama.cpp master reference: pp512 193.11 tok/s, tg128 4.90 tok/s

This is an incremental default-path win and gets decode above the local llama.cpp tg128 number, but prefill is still behind llama.cpp; follow-up work should continue on the GDN recurrent state layout and decode metadata reuse.