### PR TITLE
Wire streaming real prefix-cache reuse

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -15,7 +15,7 @@
 | ON | `KILN_PREFIX_CACHE_ENABLED=1` | 7.711s | 7.718s | 7.678s | 7.777s | 16 each | 10 hits, 20,480 hit tokens, 1,280 hit blocks |
 | OFF | `KILN_PREFIX_CACHE_ENABLED=0` | 26.923s | 26.501s | 24.455s | 27.227s | 16 each | counters stayed zero |
 
-**Result:** prefix cache ON was **3.49x faster** on median total latency for the 5 paired A/B suffix requests after warming the shared prefix. TTFT is not reported because the non-streaming chat-completions path is the only path wired to real prefix-cache reuse; the streaming path currently bypasses the real prefix cache.
+**Result:** prefix cache ON was **3.49x faster** on median total latency for the 5 paired A/B suffix requests after warming the shared prefix. TTFT was not reported in this A/B because it used non-streaming requests; streaming chat completions now use the same real prefix-cache lookup/register path when CUDA graphs are disabled, so streaming hits increment the same `/metrics` prefix-cache counters.
 
 **Metrics after ON arm:**
 
@@ -30,7 +30,7 @@ kiln_prefix_cache_max_blocks 2048
 
 **Exact-repeat caveat:** repeating the warmed 2,048-token prompt increments a miss rather than a hit because cache lookup requires `prompt_tokens.len() > entry.prompt_tokens.len()` and next-token logits are not cached. The exact-repeat request completed in 0.823s with 1 output token, but it did not count as a prefix-cache hit.
 
-**Verdict / next task:** the real append-prefix cache is functionally effective for append-only shared prefixes, but only with CUDA graphs disabled and only for non-streaming completions. Next, add a safe CUDA-graphs/prefix-cache integration decision point (or explicit config warning) and separately consider a partial-prompt registration API so normal chat suffix variants do not need delimiter-shaped prompts to reuse a shared prefix.
+**Verdict / next task:** the real append-prefix cache is functionally effective for append-only shared prefixes on both non-streaming and streaming chat completions when CUDA graphs are disabled. CUDA graphs still bypass the cache and emit the one-time warning added for that configuration; CUDA-graph prefix-cache integration and partial-prompt registration remain separate work.
 
 Detailed artifact: `docs/phase7-prefix-cache-reuse-ab.md`.
 

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -85,6 +85,13 @@ enum PrefillSampleSource {
     GreedyToken(TokenId),
 }
 
+/// Result of streaming paged generation plus prefix-cache ownership metadata.
+pub struct PrefixCachedStreamingOutput {
+    pub receiver: mpsc::Receiver<StreamEvent>,
+    pub registration: Option<PagedPrefixRegistration>,
+    pub allocated_blocks: Vec<u32>,
+}
+
 /// Output from a native MTP speculative generation call.
 ///
 /// Carries everything [`GenerationOutput`] does plus the per-call MTP draft
@@ -2761,6 +2768,26 @@ impl ModelRunner {
         )
     }
 
+    /// Same as [`generate_streaming_paged_shared_tokens`], but optionally reuses
+    /// a block-aligned cached prefix and returns completed prompt metadata that
+    /// the caller may register after successful generation.
+    pub fn generate_streaming_paged_shared_tokens_with_prefix_cache(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+        cached_prefix: Option<PagedPrefixReuse>,
+    ) -> Result<PrefixCachedStreamingOutput> {
+        self.generate_from_tokens_streaming_paged_interleaved_with_prefix_cache(
+            prompt_tokens,
+            params,
+            block_manager,
+            paged_cache,
+            cached_prefix,
+        )
+    }
+
     pub fn generate_streaming_paged_speculative_shared_tokens(
         &self,
         prompt_tokens: &[TokenId],
@@ -2870,6 +2897,157 @@ impl ModelRunner {
         result
     }
 
+    fn generate_from_tokens_streaming_paged_interleaved_with_prefix_cache(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        block_manager: &Mutex<BlockManager>,
+        paged_cache: &Mutex<PagedKvCache>,
+        cached_prefix: Option<PagedPrefixReuse>,
+    ) -> Result<PrefixCachedStreamingOutput> {
+        anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
+
+        let cuda_graph_enabled = self
+            .cuda_graph
+            .lock()
+            .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?
+            .is_enabled();
+        anyhow::ensure!(
+            !cuda_graph_enabled,
+            "streaming prefix cache path does not support CUDA graph replay"
+        );
+
+        let block_size = {
+            let bm_guard = lock_block_manager(block_manager)?;
+            bm_guard.block_size()
+        };
+
+        let cached_prefix = cached_prefix.filter(|prefix| {
+            prefix.cached_tokens > 0
+                && prefix.cached_tokens < prompt_tokens.len()
+                && prefix.cached_tokens % block_size == 0
+                && prefix.block_ids.len() == prefix.cached_tokens / block_size
+        });
+
+        let cached_blocks = cached_prefix
+            .as_ref()
+            .map(|prefix| prefix.block_ids.as_slice())
+            .unwrap_or(&[]);
+
+        let max_total = prompt_tokens.len() + params.max_tokens;
+        let total_blocks = Self::blocks_needed(max_total, block_size);
+        let additional_blocks_needed = total_blocks.saturating_sub(cached_blocks.len());
+        let allocated_blocks = {
+            let mut bm_guard = lock_block_manager(block_manager)?;
+            bm_guard
+                .allocate(additional_blocks_needed)
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+        };
+        let block_table = append_prefix_block_table(cached_blocks, &allocated_blocks);
+
+        let result = self.generate_from_tokens_streaming_paged_interleaved_with_prefix_blocks(
+            prompt_tokens,
+            params,
+            paged_cache,
+            &block_table,
+            cached_prefix,
+            block_size,
+        );
+
+        match result {
+            Ok(mut output) => {
+                output.allocated_blocks = allocated_blocks;
+                Ok(output)
+            }
+            Err(err) => {
+                if !allocated_blocks.is_empty() {
+                    let mut bm_guard = lock_block_manager(block_manager)?;
+                    bm_guard.free_all(&allocated_blocks);
+                }
+                Err(err)
+            }
+        }
+    }
+
+    fn generate_from_tokens_streaming_paged_interleaved_with_prefix_blocks(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+        cached_prefix: Option<PagedPrefixReuse>,
+        block_size: usize,
+    ) -> Result<PrefixCachedStreamingOutput> {
+        let cached_tokens = cached_prefix
+            .as_ref()
+            .map(|prefix| prefix.cached_tokens)
+            .unwrap_or(0);
+        let mut linear_state = match cached_prefix {
+            Some(prefix) => prefix.linear_state,
+            None => self.new_linear_state()?,
+        };
+
+        let prefill_tokens = &prompt_tokens[cached_tokens..];
+        anyhow::ensure!(
+            !prefill_tokens.is_empty(),
+            "streaming prefix cache hit must leave at least one suffix token"
+        );
+
+        let logits = {
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
+                model_forward_paged_streaming(
+                    &*self.backend,
+                    prefill_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    cached_tokens,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                )
+                .context("prefill forward pass (streaming paged prefix cache) failed")?
+            } else {
+                model_forward_paged_last_token(
+                    &*self.backend,
+                    prefill_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    cached_tokens,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("prefill forward pass (paged prefix cache) failed")?
+            }
+        };
+
+        let registration = self.completed_prompt_registration(
+            prompt_tokens,
+            block_table,
+            &linear_state,
+            block_size,
+        )?;
+
+        let receiver = self.stream_decode_from_prefill_logits(
+            logits,
+            prompt_tokens.len(),
+            params,
+            paged_cache,
+            block_table,
+            &mut linear_state,
+        )?;
+
+        Ok(PrefixCachedStreamingOutput {
+            receiver,
+            registration,
+            allocated_blocks: Vec::new(),
+        })
+    }
+
     fn generate_from_tokens_streaming_paged_interleaved(
         &self,
         prompt_tokens: &[TokenId],
@@ -2877,7 +3055,6 @@ impl ModelRunner {
         paged_cache: &Mutex<PagedKvCache>,
         block_table: &BlockTable,
     ) -> Result<mpsc::Receiver<StreamEvent>> {
-        let (tx, rx) = mpsc::channel();
         let mut linear_state = self.new_linear_state()?;
 
         let logits = {
@@ -2912,7 +3089,26 @@ impl ModelRunner {
             }
         };
 
-        let mut seq_len = prompt_tokens.len();
+        self.stream_decode_from_prefill_logits(
+            logits,
+            prompt_tokens.len(),
+            params,
+            paged_cache,
+            block_table,
+            &mut linear_state,
+        )
+    }
+
+    fn stream_decode_from_prefill_logits(
+        &self,
+        logits: candle_core::Tensor,
+        mut seq_len: usize,
+        params: &SamplingParams,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+        linear_state: &mut LinearAttentionState,
+    ) -> Result<mpsc::Receiver<StreamEvent>> {
+        let (tx, rx) = mpsc::channel();
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut step_seed = params.seed;
         let mut finish_reason = FinishReason::MaxTokens;
@@ -2964,7 +3160,7 @@ impl ModelRunner {
                 paged_cache,
                 block_table,
                 seq_len,
-                &mut linear_state,
+                linear_state,
                 step_seed,
             )?;
             seq_len += 1;

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -326,13 +326,14 @@ async fn chat_completions_inner(
                 runner,
                 block_manager,
                 paged_cache,
-                ..
+                prefix_cache,
             } => {
                 generate_real_streaming(
                     state,
                     runner,
                     block_manager,
                     paged_cache,
+                    prefix_cache,
                     &prompt_text,
                     &prompt_tokens,
                     &sampling,
@@ -665,6 +666,7 @@ async fn generate_real_streaming(
     runner: &std::sync::Arc<std::sync::RwLock<kiln_model::ModelRunner>>,
     block_manager: &std::sync::Arc<std::sync::Mutex<kiln_core::block::BlockManager>>,
     paged_cache: &std::sync::Arc<std::sync::Mutex<kiln_model::PagedKvCache>>,
+    prefix_cache: &std::sync::Arc<std::sync::Mutex<RealPrefixCache>>,
     prompt_text: &str,
     prompt_tokens: &[TokenId],
     sampling: &SamplingParams,
@@ -685,9 +687,11 @@ async fn generate_real_streaming(
     let runner = runner.clone();
     let bm = block_manager.clone();
     let pc = paged_cache.clone();
+    let prefix_cache = prefix_cache.clone();
     let prompt = prompt_text.to_owned();
     let prompt_tokens = prompt_tokens.to_vec();
     let params = sampling.clone();
+    let adapter = req.adapter.clone();
     let model = req
         .model
         .clone()
@@ -696,6 +700,8 @@ async fn generate_real_streaming(
     let created = now_epoch();
     let gpu_lock = state.gpu_lock.clone();
     let timeout = state.request_timeout;
+    let prefix_cache_cuda_graphs_bypass_warned =
+        state.prefix_cache_cuda_graphs_bypass_warned.clone();
 
     // Use a tokio mpsc channel to bridge sync generation -> async SSE stream.
     let (tx, rx) = tokio::sync::mpsc::channel::<Event>(32);
@@ -734,12 +740,88 @@ async fn generate_real_streaming(
                         // Acquire GPU coordination read lock
                         let _gpu_guard = gpu_lock.read().unwrap();
                         let runner_guard = runner.read().unwrap();
-                        runner_guard.generate_streaming_paged_shared_tokens(
-                            &prompt_tokens,
-                            &params,
-                            bm.as_ref(),
-                            pc.as_ref(),
-                        )
+                        let prefix_enabled = {
+                            let cache = prefix_cache.lock().unwrap();
+                            cache.is_enabled()
+                        };
+                        let cuda_graphs_enabled = runner_guard.cuda_graph_enabled()?;
+                        if prefix_enabled && cuda_graphs_enabled {
+                            let already_warned = prefix_cache_cuda_graphs_bypass_warned
+                                .swap(true, Ordering::Relaxed);
+                            if !already_warned {
+                                tracing::warn!(
+                                    prefix_cache_enabled = true,
+                                    cuda_graphs_enabled = true,
+                                    "real prefix cache is enabled but CUDA graphs are active; real streaming chat completions bypass prefix-cache lookup and registration until CUDA-graph prefix-cache integration is implemented"
+                                );
+                            }
+                        }
+                        if !prefix_enabled || cuda_graphs_enabled {
+                            runner_guard.generate_streaming_paged_shared_tokens(
+                                &prompt_tokens,
+                                &params,
+                                bm.as_ref(),
+                                pc.as_ref(),
+                            )
+                        } else {
+                            let hit = {
+                                let mut cache = prefix_cache.lock().unwrap();
+                                cache.lookup(&adapter, &prompt_tokens)?
+                            };
+                            let hit_entry_id = hit.as_ref().map(|hit| hit.entry_id);
+                            let cached_prefix = hit.map(|hit| PagedPrefixReuse {
+                                cached_tokens: hit.cached_tokens,
+                                block_ids: hit.block_ids,
+                                linear_state: hit.linear_state,
+                            });
+
+                            let result = runner_guard
+                                .generate_streaming_paged_shared_tokens_with_prefix_cache(
+                                    &prompt_tokens,
+                                    &params,
+                                    bm.as_ref(),
+                                    pc.as_ref(),
+                                    cached_prefix,
+                                );
+
+                            let mut output = match result {
+                                Ok(output) => output,
+                                Err(err) => {
+                                    if let Some(entry_id) = hit_entry_id {
+                                        let mut cache = prefix_cache.lock().unwrap();
+                                        cache.release_hit(entry_id);
+                                    }
+                                    return Err(err);
+                                }
+                            };
+                            let registration = output.registration.take();
+                            let allocated_blocks = std::mem::take(&mut output.allocated_blocks);
+                            let mut retained_blocks = Vec::new();
+                            let mut evicted_blocks = Vec::new();
+                            {
+                                let mut cache = prefix_cache.lock().unwrap();
+                                if let Some(entry_id) = hit_entry_id {
+                                    cache.release_hit(entry_id);
+                                }
+                                if let Some(registration) = registration {
+                                    let outcome = cache.register(adapter.clone(), registration);
+                                    retained_blocks = outcome.retained_blocks;
+                                    evicted_blocks = outcome.evicted_blocks;
+                                }
+                            }
+
+                            let mut blocks_to_free: Vec<u32> = allocated_blocks
+                                .into_iter()
+                                .filter(|block_id| !retained_blocks.contains(block_id))
+                                .collect();
+                            blocks_to_free.extend(evicted_blocks);
+                            if !blocks_to_free.is_empty() {
+                                let mut bm_guard = bm.lock().unwrap();
+                                bm_guard.free_all(&blocks_to_free);
+                            }
+
+                            Ok(output.receiver)
+                        }
                     })
                     .await
                     {

--- a/docs/phase7-prefix-cache-reuse-ab.md
+++ b/docs/phase7-prefix-cache-reuse-ab.md
@@ -10,7 +10,7 @@ Image: `ghcr.io/ericflo/kiln-runpod:latest`
 PR #515 is merged on `main`; the benchmark ran at `8bd7dd0e` whose tip commit is `Wire real append prefix cache (#515)`. I inspected:
 
 - `crates/kiln-server/src/state.rs`: `RealPrefixCache` stores prompt token IDs, retained paged-KV block IDs, and `LinearAttentionState`, so the real backend preserves GDN recurrent state as well as full-attention KV blocks.
-- `crates/kiln-server/src/api/completions.rs`: non-streaming real generation calls `cache.lookup(...)`, passes `PagedPrefixReuse` into `generate_paged_shared_tokens_with_prefix_cache(...)`, then registers completed block-aligned prompts after successful generation.
+- `crates/kiln-server/src/api/completions.rs`: real generation calls `cache.lookup(...)`, passes `PagedPrefixReuse` into the non-streaming or streaming paged-prefix generation helper, then registers completed block-aligned prompts after successful generation.
 - `crates/kiln-server/src/metrics.rs`: metrics are `kiln_prefix_cache_lookups_total{result="hit|miss"}`, `kiln_prefix_cache_hit_tokens_total`, `kiln_prefix_cache_hit_blocks_total`, `kiln_prefix_cache_cached_blocks`, and `kiln_prefix_cache_max_blocks`.
 
 No existing post-#515 artifact for this benchmark was present in `PROFILING.md` or `docs/phase7-prefix-cache-reuse-ab.md` before this run.
@@ -61,7 +61,7 @@ KILN_SPEC_ENABLED=0
 KILN_PREFIX_CACHE_ENABLED=1   # ON arm; 0 for OFF arm
 ```
 
-CUDA graphs were disabled intentionally. With graphs enabled, `generate_real` currently bypasses `generate_paged_shared_tokens_with_prefix_cache(...)` and calls `generate_paged_shared_tokens(...)`. As a follow-up, the server now emits a one-time structured warning when `RealPrefixCache` is enabled but CUDA graphs force that non-prefix path, so operators do not silently expect cache reuse from real chat completions. Full CUDA-graph prefix-cache integration remains separate work.
+CUDA graphs were disabled intentionally. With graphs enabled, real chat completions still bypass the prefix-cache helpers and call the non-prefix paged generation path. The server emits a one-time structured warning when `RealPrefixCache` is enabled but CUDA graphs force that non-prefix path, so operators do not silently expect cache reuse from real chat completions. Full CUDA-graph prefix-cache integration remains separate work.
 
 ## Prompt Design
 
@@ -95,7 +95,7 @@ Each measured request used `temperature = 0.0`, `seed = 1`, and `max_tokens = 16
 
 Median total-latency speedup: **3.49x**.
 
-TTFT is not reported because the streaming path is not the prefix-cache path; these are non-streaming total request latencies from the Python client around `POST /v1/chat/completions`.
+TTFT is not reported because this A/B used non-streaming total request latencies from the Python client around `POST /v1/chat/completions`. Streaming chat completions now use the same real prefix-cache lookup/register path when CUDA graphs are disabled, and streaming hits increment the same `/metrics` counters.
 
 ## Metrics
 
@@ -254,6 +254,6 @@ Results: all commands passed on the A6000 pod. Existing compiler warnings were u
 
 ## Verdict
 
-The real append-prefix cache is effective for block-aligned append-only shared prefixes on the non-streaming real backend. The measured 2,048-token shared-prefix workload improved median total latency from 26.923s to 7.711s and metrics exactly matched the expected skipped tokens/blocks.
+The real append-prefix cache is effective for block-aligned append-only shared prefixes on the real backend. The measured 2,048-token shared-prefix workload improved median total latency from 26.923s to 7.711s and metrics exactly matched the expected skipped tokens/blocks.
 
-Recommended next task: make prefix-cache behavior explicit around CUDA graphs and chat prompt shape. Either integrate prefix reuse into the CUDA-graph path or emit a startup/config warning when both are enabled, and add a partial-prefix registration strategy so normal chat `shared + suffix` prompts can reuse shared user text without delimiter-shaped content.
+Remaining work: integrate prefix reuse into the CUDA-graph path, and add a partial-prefix registration strategy so normal chat `shared + suffix` prompts can reuse shared user text without delimiter-shaped content.


### PR DESCRIPTION
## Summary

- Wires `RealPrefixCache` lookup/release/register into non-speculative real streaming chat completions when CUDA graphs are disabled.
- Adds a streaming paged-prefix generation API that accepts `PagedPrefixReuse` and returns `PagedPrefixRegistration` plus allocated block ownership metadata.
- Updates Phase 7 docs to note that streaming prefix-cache hits are counted by the existing `/metrics` counters, while CUDA graphs still bypass the cache and emit the existing warning.

## Notes

- Streaming prefix-cache hits are now counted by `/metrics` via the same `kiln_prefix_cache_lookups_total`, `kiln_prefix_cache_hit_tokens_total`, and `kiln_prefix_cache_hit_blocks_total` counters used by non-streaming requests.
- CUDA graphs still bypass the real prefix cache for this task; the warning path remains in place and now covers streaming wording too.

## Validation

Run on RunPod on-demand `NVIDIA A40` fallback with `ghcr.io/ericflo/kiln-runpod:latest` after A6000 capacity/runtime startup failed:

- `rustfmt --edition 2024 crates/kiln-model/src/generate.rs crates/kiln-server/src/api/completions.rs`
- `KILN_CUDA_ARCHS=86 cargo test -p kiln-server prefix_cache`
- `KILN_CUDA_ARCHS=86 cargo test -p kiln-model streaming`
- `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln`
- `git diff --check`