### PR TITLE
Use prefix cache with CUDA graphs

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -6,7 +6,7 @@
 
 **Build / hardware:** `main` `8bd7dd0e` (`8bd7dd0ec047db35b2b48324b0493c1298efe6c7`), RunPod on-demand `NVIDIA RTX A6000, 49140 MiB, driver 550.127.08`, `ghcr.io/ericflo/kiln-runpod:latest`. The requested A6000 was available. The task's literal build command `cargo build --release --features cuda --bin kiln-server` is incompatible with current Cargo targets (`kiln` is the server binary), so the benchmark built `cargo build --release --features cuda --bin kiln`.
 
-**Server config:** real `kiln` server, `model.path = "/workspace/qwen3.5-4b"`, `memory.num_blocks = 4096`, `memory.kv_cache_fp8 = true`, `memory.cuda_graphs = false`, `[prefix_cache] max_blocks = 2048`. CUDA graphs were disabled because `crates/kiln-server/src/api/completions.rs` currently routes to `generate_paged_shared_tokens` when `runner_guard.cuda_graph_enabled()?` is true, bypassing the real prefix-cache path.
+**Server config:** real `kiln` server, `model.path = "/workspace/qwen3.5-4b"`, `memory.num_blocks = 4096`, `memory.kv_cache_fp8 = true`, `memory.cuda_graphs = false`, `[prefix_cache] max_blocks = 2048`. The original A/B disabled CUDA graphs to isolate prefix-cache reuse; current CUDA-graph real chat completions now use the same prefix-cache lookup/register path.
 
 **Prompt shape:** ChatML content used a 2,048-token block-aligned shared prefix. Suffix variants embedded the ChatML assistant delimiter after the shared text so the warm shared prompt's complete token sequence was an exact prefix of both later variant prompts. Variant A was 2,068 prompt tokens; variant B was 2,069 prompt tokens.
 
@@ -15,7 +15,7 @@
 | ON | `KILN_PREFIX_CACHE_ENABLED=1` | 7.711s | 7.718s | 7.678s | 7.777s | 16 each | 10 hits, 20,480 hit tokens, 1,280 hit blocks |
 | OFF | `KILN_PREFIX_CACHE_ENABLED=0` | 26.923s | 26.501s | 24.455s | 27.227s | 16 each | counters stayed zero |
 
-**Result:** prefix cache ON was **3.49x faster** on median total latency for the 5 paired A/B suffix requests after warming the shared prefix. TTFT was not reported in this A/B because it used non-streaming requests; streaming chat completions now use the same real prefix-cache lookup/register path when CUDA graphs are disabled, so streaming hits increment the same `/metrics` prefix-cache counters.
+**Result:** prefix cache ON was **3.49x faster** on median total latency for the 5 paired A/B suffix requests after warming the shared prefix. TTFT was not reported in this A/B because it used non-streaming requests; streaming and non-streaming real chat completions now use the same real prefix-cache lookup/register path with or without CUDA graphs, so hits increment the same `/metrics` prefix-cache counters.
 
 **Metrics after ON arm:**
 
@@ -30,7 +30,7 @@ kiln_prefix_cache_max_blocks 2048
 
 **Exact-repeat caveat:** repeating the warmed 2,048-token prompt increments a miss rather than a hit because cache lookup requires `prompt_tokens.len() > entry.prompt_tokens.len()` and next-token logits are not cached. The exact-repeat request completed in 0.823s with 1 output token, but it did not count as a prefix-cache hit.
 
-**Verdict / next task:** the real append-prefix cache is functionally effective for append-only shared prefixes on both non-streaming and streaming chat completions when CUDA graphs are disabled. CUDA graphs still bypass the cache and emit the one-time warning added for that configuration; CUDA-graph prefix-cache integration and partial-prompt registration remain separate work.
+**Verdict / current behavior:** the real append-prefix cache is functionally effective for append-only shared prefixes on both non-streaming and streaming chat completions. CUDA graphs no longer bypass prefix-cache lookup/registration for non-speculative real chat completions; `scripts/phase7_cuda_graph_prefix_cache_verify.sh` verifies a CUDA-graph cache hit and absence of the old bypass warning.
 
 Detailed artifact: `docs/phase7-prefix-cache-reuse-ab.md`.
 

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -888,16 +888,6 @@ impl ModelRunner {
     ) -> Result<PrefixCachedGenerationOutput> {
         anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
 
-        let cuda_graph_enabled = self
-            .cuda_graph
-            .lock()
-            .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?
-            .is_enabled();
-        anyhow::ensure!(
-            !cuda_graph_enabled,
-            "prefix cache path does not support CUDA graph replay"
-        );
-
         let block_size = {
             let bm_guard = lock_block_manager(block_manager)?;
             bm_guard.block_size()
@@ -2906,16 +2896,6 @@ impl ModelRunner {
         cached_prefix: Option<PagedPrefixReuse>,
     ) -> Result<PrefixCachedStreamingOutput> {
         anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
-
-        let cuda_graph_enabled = self
-            .cuda_graph
-            .lock()
-            .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?
-            .is_enabled();
-        anyhow::ensure!(
-            !cuda_graph_enabled,
-            "streaming prefix cache path does not support CUDA graph replay"
-        );
 
         let block_size = {
             let bm_guard = lock_block_manager(block_manager)?;

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -10,8 +10,6 @@ use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
 use std::path::Path;
-use std::sync::atomic::Ordering;
-
 use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
 use kiln_core::token::TokenId;
@@ -492,8 +490,6 @@ async fn generate_real(
 
     let gpu_lock = state.gpu_lock.clone();
     let timeout = state.request_timeout;
-    let prefix_cache_cuda_graphs_bypass_warned =
-        state.prefix_cache_cuda_graphs_bypass_warned.clone();
     let generation = tokio::task::spawn_blocking(move || {
         // Acquire GPU coordination read lock — allows concurrent inference,
         // but blocks while training holds the write lock.
@@ -505,19 +501,7 @@ async fn generate_real(
                     let cache = prefix_cache.lock().unwrap();
                     cache.is_enabled()
                 };
-                let cuda_graphs_enabled = runner_guard.cuda_graph_enabled()?;
-                if prefix_enabled && cuda_graphs_enabled {
-                    let already_warned =
-                        prefix_cache_cuda_graphs_bypass_warned.swap(true, Ordering::Relaxed);
-                    if !already_warned {
-                        tracing::warn!(
-                            prefix_cache_enabled = true,
-                            cuda_graphs_enabled = true,
-                            "real prefix cache is enabled but CUDA graphs are active; real chat completions bypass prefix-cache lookup and registration until CUDA-graph prefix-cache integration is implemented"
-                        );
-                    }
-                }
-                if !prefix_enabled || cuda_graphs_enabled {
+                if !prefix_enabled {
                     runner_guard.generate_paged_shared_tokens(
                         &prompt_tokens,
                         &params,
@@ -700,8 +684,6 @@ async fn generate_real_streaming(
     let created = now_epoch();
     let gpu_lock = state.gpu_lock.clone();
     let timeout = state.request_timeout;
-    let prefix_cache_cuda_graphs_bypass_warned =
-        state.prefix_cache_cuda_graphs_bypass_warned.clone();
 
     // Use a tokio mpsc channel to bridge sync generation -> async SSE stream.
     let (tx, rx) = tokio::sync::mpsc::channel::<Event>(32);
@@ -744,19 +726,7 @@ async fn generate_real_streaming(
                             let cache = prefix_cache.lock().unwrap();
                             cache.is_enabled()
                         };
-                        let cuda_graphs_enabled = runner_guard.cuda_graph_enabled()?;
-                        if prefix_enabled && cuda_graphs_enabled {
-                            let already_warned = prefix_cache_cuda_graphs_bypass_warned
-                                .swap(true, Ordering::Relaxed);
-                            if !already_warned {
-                                tracing::warn!(
-                                    prefix_cache_enabled = true,
-                                    cuda_graphs_enabled = true,
-                                    "real prefix cache is enabled but CUDA graphs are active; real streaming chat completions bypass prefix-cache lookup and registration until CUDA-graph prefix-cache integration is implemented"
-                                );
-                            }
-                        }
-                        if !prefix_enabled || cuda_graphs_enabled {
+                        if !prefix_enabled {
                             runner_guard.generate_streaming_paged_shared_tokens(
                                 &prompt_tokens,
                                 &params,

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -409,8 +409,6 @@ pub struct AppState {
     pub started_at: std::time::Instant,
     /// True once startup inference prewarm has finished or was not needed.
     pub inference_prewarm_complete: Arc<AtomicBool>,
-    /// True after logging that CUDA graphs bypass the real prefix cache.
-    pub prefix_cache_cuda_graphs_bypass_warned: Arc<AtomicBool>,
     /// Server-level default for adapter checkpoint interval during training.
     /// Per-job config overrides this. None = only save at the end.
     pub checkpoint_interval: Option<usize>,
@@ -469,7 +467,6 @@ impl AppState {
             metrics: Arc::new(Metrics::new()),
             started_at: std::time::Instant::now(),
             inference_prewarm_complete: Arc::new(AtomicBool::new(true)),
-            prefix_cache_cuda_graphs_bypass_warned: Arc::new(AtomicBool::new(false)),
             checkpoint_interval: None,
             served_model_id,
         }
@@ -681,7 +678,6 @@ impl AppState {
                 device,
                 candle_core::Device::Metal(_)
             ))),
-            prefix_cache_cuda_graphs_bypass_warned: Arc::new(AtomicBool::new(false)),
             checkpoint_interval: None,
             served_model_id,
         }

--- a/docs/phase7-prefix-cache-reuse-ab.md
+++ b/docs/phase7-prefix-cache-reuse-ab.md
@@ -56,12 +56,12 @@ Runtime env:
 
 ```bash
 KILN_W4A16=1
-KILN_CUDA_GRAPHS=false
+KILN_CUDA_GRAPHS=false   # original A/B; CUDA-graph path now uses the same cache helpers
 KILN_SPEC_ENABLED=0
 KILN_PREFIX_CACHE_ENABLED=1   # ON arm; 0 for OFF arm
 ```
 
-CUDA graphs were disabled intentionally. With graphs enabled, real chat completions still bypass the prefix-cache helpers and call the non-prefix paged generation path. The server emits a one-time structured warning when `RealPrefixCache` is enabled but CUDA graphs force that non-prefix path, so operators do not silently expect cache reuse from real chat completions. Full CUDA-graph prefix-cache integration remains separate work.
+CUDA graphs now use the same real prefix-cache lookup/register helpers for non-speculative real chat completions. Cache misses preserve the normal CUDA-graph decode behavior and register block-aligned completed prompts; cache hits reuse retained paged-KV blocks plus GDN recurrent state for the suffix prefill before CUDA-graph decode continues.
 
 ## Prompt Design
 
@@ -95,7 +95,7 @@ Each measured request used `temperature = 0.0`, `seed = 1`, and `max_tokens = 16
 
 Median total-latency speedup: **3.49x**.
 
-TTFT is not reported because this A/B used non-streaming total request latencies from the Python client around `POST /v1/chat/completions`. Streaming chat completions now use the same real prefix-cache lookup/register path when CUDA graphs are disabled, and streaming hits increment the same `/metrics` counters.
+TTFT is not reported because this A/B used non-streaming total request latencies from the Python client around `POST /v1/chat/completions`. Streaming and non-streaming real chat completions now use the same real prefix-cache lookup/register path with or without CUDA graphs, and hits increment the same `/metrics` counters.
 
 ## Metrics
 
@@ -254,6 +254,6 @@ Results: all commands passed on the A6000 pod. Existing compiler warnings were u
 
 ## Verdict
 
-The real append-prefix cache is effective for block-aligned append-only shared prefixes on the real backend. The measured 2,048-token shared-prefix workload improved median total latency from 26.923s to 7.711s and metrics exactly matched the expected skipped tokens/blocks.
+The real append-prefix cache is effective for block-aligned append-only shared prefixes on the real backend. The measured 2,048-token shared-prefix workload improved median total latency from 26.923s to 7.711s and metrics exactly matched the expected skipped tokens/blocks. CUDA-graph real chat completions now use the same cache path; `scripts/phase7_cuda_graph_prefix_cache_verify.sh` starts `target/release/kiln` with `KILN_CUDA_GRAPHS=true` and verifies a `/metrics` hit without any bypass warning.
 
-Remaining work: integrate prefix reuse into the CUDA-graph path, and add a partial-prefix registration strategy so normal chat `shared + suffix` prompts can reuse shared user text without delimiter-shaped content.
+Remaining work: add a partial-prefix registration strategy so normal chat `shared + suffix` prompts can reuse shared user text without delimiter-shaped content.

--- a/scripts/phase7_cuda_graph_prefix_cache_verify.sh
+++ b/scripts/phase7_cuda_graph_prefix_cache_verify.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL=${BASE_URL:-http://127.0.0.1:8420}
+MODEL_PATH=${KILN_MODEL_PATH:-/workspace/qwen3.5-4b}
+LOG_FILE=${LOG_FILE:-/tmp/kiln-cuda-graphs-prefix-cache.log}
+KILN_BIN=${KILN_BIN:-target/release/kiln}
+
+if [[ ! -x "$KILN_BIN" ]]; then
+  echo "missing executable: $KILN_BIN" >&2
+  exit 1
+fi
+
+rm -f "$LOG_FILE"
+KILN_MODEL_PATH="$MODEL_PATH" \
+KILN_W4A16=1 \
+KILN_CUDA_GRAPHS=true \
+KILN_SPEC_ENABLED=0 \
+KILN_PREFIX_CACHE_ENABLED=1 \
+KILN_PREFIX_CACHE_MAX_BLOCKS=${KILN_PREFIX_CACHE_MAX_BLOCKS:-2048} \
+KILN_NUM_BLOCKS=${KILN_NUM_BLOCKS:-4096} \
+KILN_KV_CACHE_FP8=${KILN_KV_CACHE_FP8:-1} \
+"$KILN_BIN" serve >"$LOG_FILE" 2>&1 &
+server_pid=$!
+cleanup() {
+  kill "$server_pid" 2>/dev/null || true
+  wait "$server_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+for _ in $(seq 1 180); do
+  if curl -fsS "$BASE_URL/health" >/dev/null 2>&1; then
+    break
+  fi
+  if ! kill -0 "$server_pid" 2>/dev/null; then
+    echo "kiln exited before becoming healthy; log follows" >&2
+    cat "$LOG_FILE" >&2
+    exit 1
+  fi
+  sleep 1
+done
+curl -fsS "$BASE_URL/health" >/dev/null
+
+request() {
+  local content=$1
+  local max_tokens=${2:-1}
+  CONTENT="$content" MAX_TOKENS="$max_tokens" python3 - <<'PY' | curl -fsS "$BASE_URL/v1/chat/completions" -H 'content-type: application/json' -d @-
+import json, os
+print(json.dumps({
+    "model": "kiln",
+    "messages": [{"role": "user", "content": os.environ["CONTENT"]}],
+    "temperature": 0.0,
+    "max_tokens": int(os.environ["MAX_TOKENS"]),
+    "seed": 1,
+}))
+PY
+}
+
+shared=""
+for repeats in $(seq 32 512); do
+  candidate=$(python3 - <<PY
+print(("Kiln CUDA graph prefix cache shared segment ${repeats}. " * ${repeats}).strip())
+PY
+)
+  response=$(request "$candidate" 1)
+  prompt_tokens=$(python3 -c 'import json, sys; print(json.load(sys.stdin)["usage"]["prompt_tokens"])' <<<"$response")
+  if (( prompt_tokens % 16 == 0 )); then
+    shared=$candidate
+    echo "warmed block-aligned prompt: repeats=$repeats prompt_tokens=$prompt_tokens"
+    break
+  fi
+done
+
+if [[ -z "$shared" ]]; then
+  echo "failed to find a block-aligned prompt" >&2
+  exit 1
+fi
+
+suffix=$'<|im_end|>\n<|im_start|>assistant\n Continue with one concise CUDA graph prefix-cache sentence.'
+request "${shared}${suffix}" 4 >/tmp/kiln-cuda-graphs-prefix-cache-hit.json
+metrics=$(curl -fsS "$BASE_URL/metrics")
+echo "$metrics" | grep 'kiln_prefix_cache_lookups_total{result="hit"}'
+hits=$(python3 -c 'import re, sys; m = re.search(r"kiln_prefix_cache_lookups_total\{result=\"hit\"\}\s+(\d+)", sys.stdin.read()); print(m.group(1) if m else 0)' <<<"$metrics")
+if (( hits <= 0 )); then
+  echo "expected prefix-cache hit with CUDA graphs enabled" >&2
+  exit 1
+fi
+
+if grep -Fq 'bypass prefix-cache' "$LOG_FILE"; then
+  echo "unexpected CUDA graph prefix-cache bypass warning" >&2
+  exit 1
+fi
+
+echo "verified CUDA graphs + prefix cache hit count: $hits"


### PR DESCRIPTION
## Summary

- Routes non-speculative real chat completions through `RealPrefixCache` lookup/register even when CUDA graphs are enabled.
- Allows the paged-prefix generation helpers to continue into CUDA-graph decode after suffix prefill instead of rejecting graph-enabled runners.
- Removes the stale CUDA-graph prefix-cache bypass warning state and documents the current behavior.
- Adds `scripts/phase7_cuda_graph_prefix_cache_verify.sh` to start `target/release/kiln` with `KILN_CUDA_GRAPHS=true` and verify a prefix-cache hit with no bypass warning.

## Validation

RunPod on-demand `NVIDIA RTX A6000` (`f2jrqyr9zyujet`, terminated):

- `KILN_CUDA_ARCHS=86 cargo test -p kiln-server prefix_cache` — passed
- `KILN_CUDA_ARCHS=86 cargo test -p kiln-model prefix_cache` — passed
- `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln` — passed
- `git diff --check` — passed
- `KILN_CUDA_ARCHS=86 scripts/phase7_cuda_graph_prefix_cache_verify.sh` — passed

Verification metrics:

```text
warmed block-aligned prompt: repeats=115 prompt_tokens=1504
kiln_prefix_cache_lookups_total{result="hit"} 1
verified CUDA graphs + prefix cache hit count: 1
```

Pod cleanup: `python3 $RP terminate f2jrqyr9zyujet` completed.