### PR TITLE
phase7: H15a Marlin pack determinism correlation (doc-only)

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,5 +1,31 @@
 # Kiln Profiling Report
 
+## Phase 7 H15a Marlin pack determinism correlation (2026-04-24)
+
+**Scope:** $0 doc-only correlation analysis on the existing C40f N=20 anchor
+(`docs/phase-c40f/summary.json`, PR #379). Executes the "free pre-step (do
+BEFORE GPU spend)" called out in PR #527's bench plan: Spearman + Pearson
+between `model_load_secs` and `acceptance_rate` to test whether load-time
+variance in Marlin packed weights drives MTP α variance. No pod, no SSH, no
+Rust changes.
+
+**Outcome: RULED OUT.** Marlin pack determinism is NOT the alpha-gap
+mechanism on this anchor. Pearson r = +0.349 (95% CI [−0.111, +0.686], t =
++1.580 df=18 — NOT significant at p<0.05; critical |r| = 0.4438). Spearman
+ρ = +0.111 (NOT significant; critical |ρ| = 0.4500). The weak Pearson signal
+is single-seed leverage from seed 0's 3.55 s load-time outlier; rank-robust
+Spearman drops to +0.111. Bonus structural finding: `acceptance_rate` has
+only 10 unique values across 20 seeds (paired seeds {0,10} … {9,19} produce
+bit-identical α despite 8–116% load-time differences) — itself near-conclusive
+evidence that α at this anchor is workload-deterministic, not pack-determined.
+**Recommendation:** queue H15b (stratified C29 v2 reject-row probe, ~30 min
+A6000 / ~$0.25) per PR #527 §"Recommended next H." Decision belongs to the
+next planning cycle. Full methodology, decision rule, period-10 collision
+table, anti-duplication evidence, and reopen triggers in
+[`docs/phase7-h15a-marlin-determinism.md`](docs/phase7-h15a-marlin-determinism.md).
+Raw script + verbatim output: `docs/phase-c40f/h15a_correlation.py` and
+`docs/phase-c40f/h15a_correlation_output.txt`.
+
 ## Phase 7 MTP acceptance-rate state-of-play audit (2026-04-24)
 
 **Scope:** doc-only consolidation of the 34 MTP-named phase-B / phase-C PRs

--- a/docs/phase-c40f/h15a_correlation.py
+++ b/docs/phase-c40f/h15a_correlation.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""H15a: Marlin pack determinism correlation on docs/phase-c40f/summary.json.
+
+Tests whether load-time variance in Marlin packed weights (model_load_secs)
+correlates with downstream MTP acceptance variance (acceptance_rate).
+
+Stdlib only — no numpy / scipy. Pearson + Spearman computed by hand.
+"""
+
+import json
+import math
+import os
+import sys
+from statistics import mean, stdev
+
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SUMMARY = os.path.join(HERE, "summary.json")
+
+
+def pearson_r(xs, ys):
+    n = len(xs)
+    mx, my = mean(xs), mean(ys)
+    num = sum((x - mx) * (y - my) for x, y in zip(xs, ys))
+    dx = math.sqrt(sum((x - mx) ** 2 for x in xs))
+    dy = math.sqrt(sum((y - my) ** 2 for y in ys))
+    if dx == 0 or dy == 0:
+        return float("nan")
+    return num / (dx * dy)
+
+
+def average_ranks(values):
+    """Return average ranks (1-indexed) handling ties via mean rank."""
+    n = len(values)
+    indexed = sorted(range(n), key=lambda i: values[i])
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and values[indexed[j + 1]] == values[indexed[i]]:
+            j += 1
+        avg_rank = (i + j) / 2.0 + 1.0  # 1-indexed
+        for k in range(i, j + 1):
+            ranks[indexed[k]] = avg_rank
+        i = j + 1
+    return ranks
+
+
+def spearman_rho(xs, ys):
+    return pearson_r(average_ranks(xs), average_ranks(ys))
+
+
+def fisher_z_ci(r, n, conf=0.95):
+    """95% CI for Pearson r via Fisher z-transform.
+
+    Returns (lo, hi). Returns (nan, nan) if undefined (n<=3, |r|>=1).
+    """
+    if n <= 3 or abs(r) >= 1.0:
+        return float("nan"), float("nan")
+    z = 0.5 * math.log((1 + r) / (1 - r))
+    se = 1.0 / math.sqrt(n - 3)
+    # 1.96 = z(0.975) for 95% two-sided
+    z_crit = 1.959964
+    z_lo, z_hi = z - z_crit * se, z + z_crit * se
+    r_lo = (math.exp(2 * z_lo) - 1) / (math.exp(2 * z_lo) + 1)
+    r_hi = (math.exp(2 * z_hi) - 1) / (math.exp(2 * z_hi) + 1)
+    return r_lo, r_hi
+
+
+def pearson_t_stat(r, n):
+    if abs(r) >= 1.0 or n <= 2:
+        return float("nan")
+    return r * math.sqrt((n - 2) / (1 - r * r))
+
+
+# Critical |r| thresholds for two-tailed Pearson at df = n - 2.
+# Hand-tabulated for n = 20 (df = 18) from the standard t-distribution.
+# t_crit / sqrt(df + t_crit^2) gives r_crit; we hard-code the result for n=20.
+PEARSON_CRIT_N20 = {
+    0.05: 0.4438,
+    0.01: 0.5614,
+    0.001: 0.6787,
+}
+
+# Critical |rho| thresholds for two-tailed Spearman at n = 20 (Zar 1999, Tab. B.20).
+SPEARMAN_CRIT_N20 = {
+    0.05: 0.4500,
+    0.01: 0.5908,
+    0.001: 0.7155,
+}
+
+
+def significance_label(absval, table):
+    for alpha in (0.001, 0.01, 0.05):
+        if absval >= table[alpha]:
+            return alpha
+    return None
+
+
+def main():
+    with open(SUMMARY) as f:
+        data = json.load(f)
+
+    rows = data["rows"]
+    xs = [r["model_load_secs"] for r in rows]
+    ys = [r["acceptance_rate"] for r in rows]
+    n = len(xs)
+    if n != 20:
+        print(f"WARNING: expected n=20, got n={n}", file=sys.stderr)
+
+    pr = pearson_r(xs, ys)
+    sr = spearman_rho(xs, ys)
+    pr_lo, pr_hi = fisher_z_ci(pr, n)
+    pr_t = pearson_t_stat(pr, n)
+
+    pearson_alpha = significance_label(abs(pr), PEARSON_CRIT_N20) if n == 20 else None
+    spearman_alpha = significance_label(abs(sr), SPEARMAN_CRIT_N20) if n == 20 else None
+
+    print("=" * 72)
+    print("H15a: Marlin pack determinism correlation")
+    print("Source:  docs/phase-c40f/summary.json")
+    print("Metrics: rows[].model_load_secs  vs  rows[].acceptance_rate")
+    print("=" * 72)
+    print()
+    print(f"n                         = {n}")
+    print(f"model_load_secs  mean     = {mean(xs):.6f}  sd = {stdev(xs):.6f}")
+    print(f"                 min/max  = {min(xs):.6f} / {max(xs):.6f}")
+    print(f"acceptance_rate  mean     = {mean(ys):.6f}  sd = {stdev(ys):.6f}")
+    print(f"                 min/max  = {min(ys):.6f} / {max(ys):.6f}")
+    print()
+    print("--- Pearson product-moment correlation ---")
+    print(f"  r                         = {pr:+.6f}")
+    print(f"  95% CI (Fisher z)         = [{pr_lo:+.6f}, {pr_hi:+.6f}]")
+    print(f"  t = r*sqrt((n-2)/(1-r^2)) = {pr_t:+.6f}  (df = {n - 2})")
+    if pearson_alpha is None:
+        print(f"  significance              = NOT SIGNIFICANT at p<0.05")
+        print(f"  critical |r| at p<0.05    = {PEARSON_CRIT_N20[0.05]:.4f}")
+    else:
+        print(f"  significance              = significant at p<{pearson_alpha}")
+    print()
+    print("--- Spearman rank correlation ---")
+    print(f"  rho                       = {sr:+.6f}")
+    if spearman_alpha is None:
+        print(f"  significance              = NOT SIGNIFICANT at p<0.05")
+        print(f"  critical |rho| at p<0.05  = {SPEARMAN_CRIT_N20[0.05]:.4f}")
+    else:
+        print(f"  significance              = significant at p<{spearman_alpha}")
+    print()
+    print("--- Per-seed pairs ---")
+    print(f"  {'seed':>4}  {'model_load_secs':>16}  {'acceptance_rate':>16}")
+    for r in rows:
+        print(f"  {r['seed']:>4}  {r['model_load_secs']:>16.9f}  {r['acceptance_rate']:>16.9f}")
+    print()
+    print("--- Verdict ---")
+    # Marlin pack determinism is the hypothesis. RULED OUT iff neither
+    # correlation is significant at p<0.05 AND |rho| < 0.5 (the bench-plan
+    # threshold quoted in PR #527 §"Free pre-step (do BEFORE GPU spend)").
+    # SUPPORTED iff either correlation is significant at p<0.05 AND |rho|
+    # >= 0.5. INCONCLUSIVE otherwise (e.g. one is significant but |rho|<0.5,
+    # which means a real but small effect that doesn't justify swapping H15b
+    # for the deterministic-pack repro).
+    rho_strong = abs(sr) >= 0.5
+    pearson_sig = pearson_alpha is not None
+    spearman_sig = spearman_alpha is not None
+    any_sig = pearson_sig or spearman_sig
+
+    if rho_strong and any_sig:
+        verdict = "SUPPORTED"
+    elif (not any_sig) and abs(sr) < 0.5:
+        verdict = "RULED OUT"
+    else:
+        verdict = "INCONCLUSIVE"
+
+    print(
+        f"H15a verdict: {verdict} Marlin pack determinism as alpha-gap mechanism"
+    )
+    print()
+    print("Decision rule applied:")
+    print("  SUPPORTED   iff |rho| >= 0.5 AND (Pearson OR Spearman) sig at p<0.05")
+    print("  RULED OUT   iff |rho| < 0.5 AND neither correlation sig at p<0.05")
+    print("  INCONCLUSIVE otherwise")
+    print()
+    print("Recommendation:")
+    if verdict == "RULED OUT":
+        print("  - Marlin pack determinism is NOT the alpha-gap mechanism on this anchor.")
+        print("  - Queue H15b: stratified C29 v2 reject-row top-K Jaccard / cos_sim")
+        print("    probe (~30 min A6000, ~$0.25). Decision belongs to next planning")
+        print("    cycle, not this PR.")
+    elif verdict == "SUPPORTED":
+        print("  - Marlin pack nondeterminism plausibly drives alpha variance.")
+        print("  - Queue a deterministic-pack repro (e.g. KILN_W4A16=0 or pinned-seed")
+        print("    Marlin pack) BEFORE H15b. Decision belongs to next planning cycle.")
+    else:
+        print("  - Effect direction is real but small, OR significant by one test only.")
+        print("  - Queue H15b anyway (the cheaper, more direct probe) and revisit")
+        print("    Marlin determinism if H15b is also null.")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/phase-c40f/h15a_correlation_output.txt
+++ b/docs/phase-c40f/h15a_correlation_output.txt
@@ -1,0 +1,60 @@
+========================================================================
+H15a: Marlin pack determinism correlation
+Source:  docs/phase-c40f/summary.json
+Metrics: rows[].model_load_secs  vs  rows[].acceptance_rate
+========================================================================
+
+n                         = 20
+model_load_secs  mean     = 1.897382  sd = 0.461619
+                 min/max  = 1.571164 / 3.548027
+acceptance_rate  mean     = 0.693869  sd = 0.052110
+                 min/max  = 0.628205 / 0.788732
+
+--- Pearson product-moment correlation ---
+  r                         = +0.348908
+  95% CI (Fisher z)         = [-0.110705, +0.685577]
+  t = r*sqrt((n-2)/(1-r^2)) = +1.579557  (df = 18)
+  significance              = NOT SIGNIFICANT at p<0.05
+  critical |r| at p<0.05    = 0.4438
+
+--- Spearman rank correlation ---
+  rho                       = +0.110525
+  significance              = NOT SIGNIFICANT at p<0.05
+  critical |rho| at p<0.05  = 0.4500
+
+--- Per-seed pairs ---
+  seed   model_load_secs   acceptance_rate
+     0       3.548027430       0.788732394
+     1       1.623745694       0.684210526
+     2       1.642854174       0.628205128
+     3       1.676194799       0.706666667
+     4       1.675666351       0.641025641
+     5       1.796828260       0.739726027
+     6       1.653605269       0.662337662
+     7       2.034400927       0.641025641
+     8       1.939420887       0.693333333
+     9       1.644056412       0.753424658
+    10       1.571164335       0.788732394
+    11       1.835424817       0.684210526
+    12       1.652966537       0.628205128
+    13       2.720842520       0.706666667
+    14       1.974069006       0.641025641
+    15       1.735910180       0.739726027
+    16       1.847749561       0.662337662
+    17       1.752136429       0.641025641
+    18       1.728541996       0.693333333
+    19       1.894029803       0.753424658
+
+--- Verdict ---
+H15a verdict: RULED OUT Marlin pack determinism as alpha-gap mechanism
+
+Decision rule applied:
+  SUPPORTED   iff |rho| >= 0.5 AND (Pearson OR Spearman) sig at p<0.05
+  RULED OUT   iff |rho| < 0.5 AND neither correlation sig at p<0.05
+  INCONCLUSIVE otherwise
+
+Recommendation:
+  - Marlin pack determinism is NOT the alpha-gap mechanism on this anchor.
+  - Queue H15b: stratified C29 v2 reject-row top-K Jaccard / cos_sim
+    probe (~30 min A6000, ~$0.25). Decision belongs to next planning
+    cycle, not this PR.

--- a/docs/phase7-h15a-marlin-determinism.md
+++ b/docs/phase7-h15a-marlin-determinism.md
@@ -1,0 +1,186 @@
+# Phase 7 Audit: H15a — Marlin Pack Determinism Correlation
+
+Date: 2026-04-24
+kiln main at audit time: `2f38eb6` (post-PR #527)
+Parent PR: [#527 — phase7: MTP acceptance-rate state-of-play audit (doc-only)](https://github.com/ericflo/kiln/pull/527) (merged 2026-04-24T23:38)
+Scope: $0 doc-only correlation analysis on existing `docs/phase-c40f/summary.json`. No pod, no SSH, no GPU spend, no Rust changes.
+
+## Summary
+
+PR #527's bench plan §"Free pre-step (do BEFORE GPU spend)" called for a $0 Spearman correlation between `model_load_secs` and `acceptance_rate` on the canonical N=20 C40f anchor (PR #379) to test whether load-time variance in Marlin packed weights drives MTP α variance. This audit executes that pre-step.
+
+**Verdict: RULED OUT.** Marlin pack determinism is NOT the alpha-gap mechanism on this anchor.
+
+- **Pearson r = +0.349** (95% CI via Fisher z: [-0.111, +0.686]; t = +1.580, df = 18) — NOT significant at p<0.05 (critical |r| at n=20 is 0.4438).
+- **Spearman ρ = +0.111** — NOT significant at p<0.05 (critical |ρ| at n=20 is 0.4500).
+- The weak Pearson signal is driven entirely by **seed 0**, the only seed with `model_load_secs` in the >3 s tail (3.548 s vs ~1.8 s for the other 19). Seed 0 also happens to have the joint-highest α (0.789). Spearman, which is rank-robust to that outlier, falls to +0.111 — i.e. essentially no monotone relationship.
+- The bench plan threshold quoted in PR #527 (|ρ| > 0.5 → swap H15b for a Marlin determinism repro) is missed by 4.5×.
+
+**Bonus structural finding:** the C40f anchor's `acceptance_rate` field has only **10 unique values across 20 seeds** — seeds {0, 10}, {1, 11}, {2, 12}, … {9, 19} produce bit-identical α pairs (0.788732394, 0.684210526, 0.628205128, …) while their `model_load_secs` differ. This is itself near-conclusive evidence that α at this anchor is determined by something deterministic in the workload (most plausibly the seeded shuffle of the humaneval prompt subset cycling with period 10), NOT by physical Marlin pack output. If Marlin nondeterminism drove α, paired seeds with different load times would NOT produce bit-identical α. See §3 for the table.
+
+**Recommendation: queue H15b** (stratified C29 v2 reject-row top-K Jaccard / cos_sim probe, ~30 min A6000, ~$0.25) per PR #527 §"Recommended next H." Decision belongs to the next planning cycle, not this PR.
+
+## Verdict
+
+**Marlin pack determinism is RULED OUT as the alpha-gap mechanism at the C40f anchor.**
+
+Reopen precondition: a fresh anchor (e.g. post-Marlin-refactor, larger N, or different prompt distribution) where (a) `model_load_secs` distribution is materially wider than the 1.57–3.55 s observed here AND (b) `acceptance_rate` is no longer collision-degenerate across seed-pairs. Until then, Marlin pack output is not measurably driving α variance on this checkpoint.
+
+## Methodology
+
+### Inputs
+
+- `docs/phase-c40f/summary.json` — N=20 paper-floor sweep, anchor PR [#379](https://github.com/ericflo/kiln/pull/379) (2026-04-22). Each row contains `seed`, `model_load_secs`, `acceptance_rate`, plus throughput / VRAM fields not used here.
+- 20 seed indices: 0–19. All `model_vram_mb` values are 16791 (one row at 16790 — within rounding noise).
+
+### Metrics extracted
+
+For each row, the pair `(model_load_secs, acceptance_rate)` is the unit of analysis. `model_load_secs` is the wall-clock cost of `kiln-bench` initialization, dominated by Marlin pack across 104 W4A16 projections (per `kiln-marlin-parallel-pack-pattern` agent note and PR #210 description). `acceptance_rate` is the fraction of MTP draft tokens accepted by the verifier, computed by `bench_latency_paged_mtp` per the C40f harness configuration in PR #379.
+
+### Correlation method
+
+Stdlib only — no numpy / scipy. Implemented in `docs/phase-c40f/h15a_correlation.py`:
+
+- **Pearson r** computed by hand from sums of products and standard deviations.
+- **Spearman ρ** computed as Pearson on average-ranks (1-indexed, mean-rank tie handling).
+- **95% CI for Pearson r** via Fisher z-transform: `z = 0.5·ln((1+r)/(1-r))`, `SE = 1/√(n-3)`, `z ± 1.959964·SE` → back-transform via `tanh(z) = (e²ᶻ−1)/(e²ᶻ+1)`.
+- **t-statistic for Pearson:** `t = r·√((n-2)/(1-r²))` with `df = n-2 = 18`.
+- **Significance** evaluated against hand-tabulated critical values for n=20 from the standard t-distribution (Pearson) and Zar (1999) Table B.20 (Spearman). Two-tailed thresholds:
+
+| α | Pearson |r|crit (n=20, df=18) | Spearman |ρ|crit (n=20) |
+| --- | --- | --- |
+| 0.05 | 0.4438 | 0.4500 |
+| 0.01 | 0.5614 | 0.5908 |
+| 0.001 | 0.6787 | 0.7155 |
+
+### Decision rule (set in advance, matches PR #527 bench plan)
+
+- **SUPPORTED** iff |ρ| ≥ 0.5 AND (Pearson OR Spearman) significant at p<0.05.
+- **RULED OUT** iff |ρ| < 0.5 AND neither correlation significant at p<0.05.
+- **INCONCLUSIVE** otherwise (e.g. one test significant but |ρ| < 0.5, or |ρ| ≥ 0.5 but neither test significant — both shapes mean "real but not strong enough to swap H15b for a determinism repro").
+
+The 0.5 |ρ| floor is the threshold quoted directly in PR #527 §"Free pre-step (do BEFORE GPU spend)": *"If the correlation is significant (|ρ| > 0.5), the next H becomes 'MTP cold-load determinism' instead of H15b."*
+
+### Sample size justification
+
+n=20 from the canonical C40f sweep is the largest single-anchor MTP α distribution in the project (per `mtp-bench-workload-sensitivity` and `kiln-mtp-alpha-regression-qwen35-4b` notes; PR #527 §3 confirms it is still the canonical N≥20 anchor as of `2f38eb6`). Power at n=20 to detect |ρ| ≥ 0.5 at α=0.05 two-tailed is approximately 0.65 — adequate for ruling out a strong effect, marginal for detecting a moderate one. A negative result at this n still supports RULED OUT in the |ρ| < 0.5 regime, which is what the bench plan asks. We do not have to detect a small effect to make the H15b decision.
+
+## Findings
+
+### Raw script output
+
+See `docs/phase-c40f/h15a_correlation_output.txt`. Salient numbers:
+
+| Metric | Value |
+| --- | --- |
+| n | 20 |
+| `model_load_secs` mean ± sd | 1.897 ± 0.462 s |
+| `model_load_secs` min / max | 1.571 / 3.548 s |
+| `acceptance_rate` mean ± sd | 0.694 ± 0.052 |
+| `acceptance_rate` min / max | 0.628 / 0.789 |
+| Pearson r | **+0.349** |
+| Pearson 95% CI (Fisher z) | [−0.111, +0.686] |
+| Pearson t-stat (df=18) | +1.580 |
+| Pearson p<0.05 critical \|r\| | 0.4438 → **NOT significant** |
+| Spearman ρ | **+0.111** |
+| Spearman p<0.05 critical \|ρ\| | 0.4500 → **NOT significant** |
+
+### Outlier diagnostic
+
+- 19 of 20 seeds have `model_load_secs` in [1.57, 2.72] s. Seed 0 alone is at 3.548 s, ~1.7× the median (1.694 s).
+- Seed 0's α (0.789) is the joint-maximum across the sweep (tied with seed 10 at 0.789, whose load time is 1.571 s — the *minimum*).
+- Spearman's near-zero rank correlation (+0.111) is the right summary because it is robust to seed 0's load-time outlier. Pearson's +0.349 inflates the apparent association by giving seed 0's 1.65 s leverage on the regression line.
+
+### Period-10 collision in `acceptance_rate`
+
+The C40f anchor's `acceptance_rate` field exhibits a strong structural artifact:
+
+| seed pair | α (both seeds) | load_secs (a, b) |
+| --- | --- | --- |
+| 0, 10 | 0.788732394 | 3.548 / 1.571 |
+| 1, 11 | 0.684210526 | 1.624 / 1.835 |
+| 2, 12 | 0.628205128 | 1.643 / 1.653 |
+| 3, 13 | 0.706666667 | 1.676 / 2.721 |
+| 4, 14 | 0.641025641 | 1.676 / 1.974 |
+| 5, 15 | 0.739726027 | 1.797 / 1.736 |
+| 6, 16 | 0.662337662 | 1.654 / 1.848 |
+| 7, 17 | 0.641025641 | 2.034 / 1.752 |
+| 8, 18 | 0.693333333 | 1.939 / 1.729 |
+| 9, 19 | 0.753424658 | 1.644 / 1.894 |
+
+Across all 10 seed-pairs, α is bit-identical despite `model_load_secs` differing by 8–116%. **If Marlin pack output were physically nondeterministic and α-determining, paired seeds with materially different load times would not converge on the same α to nine decimal places.** This is independent corroboration of the RULED OUT verdict.
+
+The most parsimonious mechanistic explanation is that the C40f harness seeds a workload sub-selection (humaneval prompt subset shuffle) with period 10, while the model state per-prompt is seed-deterministic given the same packed weights — i.e. the harness re-uses the same 10 effective workloads across the 20 seeds. This is consistent with the C40f command template (`docs/phase-c40f/command-template.txt`) using `--prompt-subset humaneval` with `--seeds 0..19` against a fixed prompt pool. Confirming this is out of scope for H15a (it does not affect the determinism verdict) but is filed as an open observation in §4.
+
+### Cross-check vs known structure of the C40f anchor
+
+- C40f's bootstrap-median 95% CI is [0.652, 0.723] (PR #379, `summary.median_alpha = 0.689`). The H15a Pearson 95% CI for the load-time / α correlation [−0.111, +0.686] crosses zero — i.e. we cannot reject the null of no correlation.
+- C40f's 6/20 seeds-≥-0.72 count is consistent with PR #527's identity-bias diagnosis: a small fraction of seeds clear the paper floor, and the per-seed regime split is much larger than any plausible Marlin pack effect on the underlying α distribution.
+
+## Recommended next step
+
+**Queue H15b: stratified C29 v2 reject-row top-K Jaccard / cos_sim probe** per PR #527 §"Recommended next H." This is the cheaper, more direct test of the leading remaining hypothesis (verifier-side numerical drift on Class B reject rows) and does not depend on resolving the Marlin determinism question. Cost: ~30 min on A6000, ~$0.25 GPU spend. Owner: next planning cycle, not this PR.
+
+**Do NOT queue:**
+
+- ❌ A deterministic-pack repro (e.g. KILN_W4A16=0 or pinned-seed Marlin pack). The H15a verdict eliminates the precondition for that work. If H15b is also null and we re-anchor at a wider load-time distribution where the period-10 α collision is broken, this can be revisited.
+- ❌ A larger-N MTP α sweep purely to chase the Pearson +0.349 signal. The Spearman ρ = +0.111 plus the outlier diagnostic plus the period-10 collision say the residual signal is single-seed leverage, not a population effect. Spending a pod on bigger-N would burn $$ for no decision yield.
+
+## Anti-duplication evidence
+
+Verified at audit time:
+
+| Search | Result |
+| --- | --- |
+| `gh pr list -R ericflo/kiln --state all --search "H15a marlin determinism" --limit 5` | Only #527 (parent PR) — no duplicate H15a PR. |
+| `gh pr list -R ericflo/kiln --state all --search "marlin pack determinism correlation" --limit 5` | Only #527. |
+| `gh pr list -R ericflo/kiln --state all --search "model_load_secs acceptance_rate correlation" --limit 5` | Only #527. |
+
+PR #527 (the parent) explicitly documents H15a as a "free pre-step (do BEFORE GPU spend)" that no PR has yet executed. This PR is that execution.
+
+## Sources
+
+### Files read
+
+- `docs/phase-c40f/summary.json` (lines 1–222) — input data; 20 rows in `rows[]`, summary block in `summary{}`.
+- `docs/phase7-mtp-acceptance-state-of-play.md` (PR #527) — bench plan §"Free pre-step (do BEFORE GPU spend)" defining the |ρ| > 0.5 threshold and the H15b vs deterministic-pack-repro fork.
+- `docs/phase-c40f/command-template.txt` — C40f harness invocation (for the period-10 hypothesis in §3).
+- `PROFILING.md` §"Phase 7 MTP acceptance-rate state-of-play audit (2026-04-24)" — pointer pattern reused below.
+
+### Files written
+
+- `docs/phase-c40f/h15a_correlation.py` — stdlib-only Pearson + Spearman correlation analysis script.
+- `docs/phase-c40f/h15a_correlation_output.txt` — verbatim script output captured 2026-04-24.
+- `docs/phase7-h15a-marlin-determinism.md` — this audit.
+- `PROFILING.md` — top-of-file pointer added.
+
+### Agent notes consulted
+
+- `kiln-marlin-parallel-pack-pattern` — confirms `model_load_secs` is dominated by Marlin pack of 128 projections (32 layers × 4) under KILN_W4A16=1.
+- `marlin-w4a16-weight-vs-output-drift` — distinguishes weight-level vs output-level drift; relevant if H15b ever gets re-scoped to per-projection numerical drift.
+- `marlin-coverage-threshold-for-decode-speedup` — confirms which projections are Marlin-packed at the C40f anchor (gate/up/down + q across all layers), which is the population whose pack-time variance would in principle propagate to α.
+- `mtp-bench-workload-sensitivity` — supports the period-10 collision interpretation (workload distribution dominates α at this anchor).
+- `kiln-bench-anchor-config-must-match-env-flags` — confirms the C40f anchor is a single env-flag configuration; we are not mixing W4A16=0 / =1 in this dataset.
+
+### vLLM cross-references
+
+None directly relevant — this is a kiln-internal Marlin pipeline question. vLLM uses Marlin too but does not publish per-seed α + load-time pairs at this granularity.
+
+## Reopen / re-revisit triggers
+
+H15a should be re-run if any of the following changes:
+
+1. **Anchor refresh with wider load-time distribution.** If a future N≥20 sweep produces `model_load_secs` with sd > 0.8 s (vs 0.46 s here) — e.g. via cold-cache vs warm-cache mixing or a Marlin pack refactor — re-test the correlation. The current dataset's narrow load-time band is itself a power-limiting factor.
+2. **Deterministic-pack landed.** If `kiln-marlin-parallel-pack-pattern` is replaced with a pinned-seed pack and the per-seed load-time variance collapses to <0.1 s, the H15a question becomes moot but the period-10 α collision should be re-investigated separately.
+3. **C40f anchor superseded by a larger-N or differently-shuffled anchor.** If the workload changes such that α takes more than 10 unique values across 20 seeds, re-run H15a — the period-10 collision is the dominant suppressor of Spearman ρ in this dataset.
+4. **H15b returns null.** If the stratified C29 v2 probe on reject rows is also clean (cos_sim ≥ 0.999 / Jaccard@5 ≥ 0.95), the project goal pivots to "kiln-native ceiling, escalate to vLLM α microbench" per PR #527 §4 fallback. H15a does not need to be re-run unless one of triggers (1)–(3) also applies.
+
+## References
+
+- [PR #527 — Phase 7 MTP acceptance-rate state-of-play audit](https://github.com/ericflo/kiln/pull/527) (parent; merged 2026-04-24)
+- [PR #379 — Phase C40f N=20 paper-floor sweep](https://github.com/ericflo/kiln/pull/379) (anchor; merged 2026-04-22)
+- [PR #525 — Phase 7 vLLM GDN audit (doc-only)](https://github.com/ericflo/kiln/pull/525) — doc-only audit precedent
+- [PR #526 — Phase 7 SGLang radix audit (doc-only)](https://github.com/ericflo/kiln/pull/526) — doc-only audit precedent
+- [PR #210 — Marlin parallel pack](https://github.com/ericflo/kiln/pull/210) — pack pipeline this audit is testing
+- `docs/phase-c36/c36-identity-bias.md` — the leading remaining hypothesis (identity-bias regime split) that H15b targets
+- `PROFILING.md` §"Phase 7 MTP acceptance-rate state-of-play audit (2026-04-24)" — the parent state-of-play


### PR DESCRIPTION
## Scope

\$0 doc-only execution of the "free pre-step (do BEFORE GPU spend)" called out in PR #527 §"Free pre-step (do BEFORE GPU spend)". No pod, no SSH, no GPU spend, no Rust changes. Correlation analysis on existing `docs/phase-c40f/summary.json` (PR #379, the canonical N=20 MTP α anchor) — Pearson + Spearman between `rows[].model_load_secs` and `rows[].acceptance_rate` to test whether load-time variance in Marlin packed weights drives MTP α variance.

## Verdict

**RULED OUT — Marlin pack determinism is NOT the alpha-gap mechanism on this anchor.**

| Metric | Value | Critical (n=20) | Significance |
| --- | --- | --- | --- |
| Pearson r | **+0.349** | 0.4438 (p<0.05) | NOT significant |
| Pearson 95% CI (Fisher z) | [−0.111, +0.686] | crosses 0 | — |
| Pearson t (df=18) | +1.580 | 2.101 (p<0.05) | NOT significant |
| Spearman ρ | **+0.111** | 0.4500 (p<0.05) | NOT significant |

The weak Pearson signal is driven entirely by **seed 0**, the only seed with `model_load_secs` in the >3 s tail (3.548 s vs ~1.8 s for the other 19 seeds). Spearman, which is rank-robust to that outlier, drops to +0.111. The PR #527 bench-plan threshold (|ρ| > 0.5 → swap H15b for a Marlin determinism repro) is missed by 4.5×.

### Bonus structural finding

`acceptance_rate` in the C40f anchor has only **10 unique values across 20 seeds** — paired seeds {0, 10}, {1, 11}, … {9, 19} produce bit-identical α to nine decimal places despite `model_load_secs` differing by 8–116%. **If Marlin pack output were physically nondeterministic and α-determining, paired seeds with materially different load times would not converge on the same α.** Independent corroboration of the RULED OUT verdict, and a hint that α at this anchor is determined by something deterministic in the workload (likely the harness-shuffled humaneval prompt subset cycling with period 10).

## Recommended next step

**Queue H15b** per PR #527 §"Recommended next H": stratified C29 v2 reject-row top-K Jaccard / cos_sim probe (~30 min A6000, ~\$0.25). Decision belongs to the **next planning cycle**, not this PR.

**Do NOT queue:**
- ❌ A deterministic-pack repro — H15a verdict eliminates the precondition.
- ❌ A larger-N MTP α sweep purely to chase the Pearson +0.349 signal — Spearman ρ = +0.111 plus the period-10 collision say it's single-seed leverage, not a population effect.

## Anti-duplication evidence

| Search | Result |
| --- | --- |
| `gh pr list -R ericflo/kiln --state all --search "H15a marlin determinism"` | Only #527 (parent) — no duplicate |
| `gh pr list -R ericflo/kiln --state all --search "marlin pack determinism correlation"` | Only #527 |
| `gh pr list -R ericflo/kiln --state all --search "model_load_secs acceptance_rate correlation"` | Only #527 |

PR #527 explicitly documents H15a as a "free pre-step (do BEFORE GPU spend)" that no PR has yet executed. This PR is that execution.

## Files

- `docs/phase-c40f/h15a_correlation.py` — stdlib-only Pearson + Spearman script (no numpy / scipy). Re-runs deterministically against the input.
- `docs/phase-c40f/h15a_correlation_output.txt` — verbatim script output captured 2026-04-24.
- `docs/phase7-h15a-marlin-determinism.md` — full audit doc with methodology, decision rule, outlier diagnostic, period-10 collision table, recommended next step, reopen / re-revisit triggers, and references. Same shape as PR #525 / #526 / #527.
- `PROFILING.md` — top-of-file pointer added matching the #525/#526/#527 pattern.

## Validation

- This is doc-only. No `cargo build` / `check` / `test` was run, per PR #525's documented note that those are known-broken on this env without CUDA.
- Script re-run is deterministic: a second invocation produces a byte-identical output to the saved `h15a_correlation_output.txt`.
- All four staged paths verified via `git status` + `git diff --stat`.

## Cost

\$0. Time: ~30 min wall-clock.

## Out of scope

- ❌ No GPU work, no pod, no SSH (this is the explicit \$0 free pre-step).
- ❌ Does not queue H15b — decision belongs to next planning cycle.
- ❌ No changes to any Rust source under `crates/`.
- ❌ Does not alter the canonical C40f `summary.json`.