### PR TITLE
phase 7: H15c vLLM α microbench — vllm_mtp_unsupported

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,5 +1,35 @@
 # Kiln Profiling Report
 
+## Phase 7 H15c vLLM α microbench (2026-04-25)
+
+**Outcome: `vllm_mtp_unsupported`.** vLLM 0.19.1 segfaults during V1 engine
+init when loading Qwen3.5-4B with native MTP speculative decoding on A6000,
+post drafter weight load. All three method aliases (`qwen3_5_mtp` / `mtp`
+/ `qwen3_next_mtp` — vLLM internally rewrites the first and third to
+`mtp` per `vllm/config/speculative.py:323-330`) reach the same crash
+point and produce identical native-extension backtraces with no Python
+file symbols. The vLLM model-dispatch path is correct (`Qwen3_5MTP` arch
+in registry, drafter weights load, tied embed/lm_head attach), the crash
+is in a downstream native code path. Workarounds that took effect but did
+NOT prevent the crash: `enforce_eager=True` (no CUDA graphs),
+`limit_mm_per_prompt={image:0,video:0}` + `skip_mm_profiling=True` (text-
+only mode confirmed in vLLM logs). Per the pre-registered decision rule
+this maps to the `vllm_mtp_unsupported` branch — ship as a doc-only
+redirect PR, queue next H from PR #527 §"Queued next action". Possible
+next paths (next planning cycle picks): (a) build a hand-rolled HF
+transformers reference α as the external upper bound, (b) wait for a vLLM
+patch and re-run this PR's `scripts/h15c_*` as-is, or (c) refocus Phase 7
+onto non-α decode-path wins (PR #521 prefix-cache + CUDA graphs landed,
+PR #526 SGLang RadixAttention port queued). Kiln median α at this
+workload (re-derived from PR #529 c1_attr CSVs): 0.3636. See
+[`docs/phase7-h15c-vllm-alpha-microbench.md`](docs/phase7-h15c-vllm-alpha-microbench.md)
+for the full verdict, segfault signature + crash backtrace, per-seed α
+table, vLLM config used (BF16 confounder vs kiln Marlin W4A16),
+reproduction commands, anti-duplication evidence, and detailed reopen
+triggers. Raw data:
+`docs/phase-c29-v3-vllm/{verdict,compare,kiln_alpha_per_seed,vllm_alpha_per_seed}.json`
+and `docs/phase-c29-v3-vllm/artifacts/vllm_segfault_evidence.log`.
+
 ## Phase 7 H15b stratified C29 v2 reject-row probe (2026-04-25)
 
 **Scope:** A6000 re-run of PR #355's C29 top-K Jaccard / cos_sim probe on

--- a/docs/phase-c29-v3-vllm/artifacts/vllm_segfault_evidence.log
+++ b/docs/phase-c29-v3-vllm/artifacts/vllm_segfault_evidence.log
@@ -1,0 +1,87 @@
+# Trimmed evidence log: 3 vLLM 0.19.1 attempts to load Qwen3.5-4B + native MTP
+# All three attempts segfault at the same point (post drafter weight load,
+# during V1 engine init / encoder cache profile / KV cache setup), even with
+# enforce_eager=True and limit_mm_per_prompt={image:0,video:0}+skip_mm_profiling=True.
+#
+# Log harvested from /tmp/vllm_bench.log on RunPod pod wl4oh30qxnzyqz, 2026-04-25.
+# Verbose vLLM compilation_config / SpeculativeConfig dumps elided with [...] for clarity.
+
+[h15c_vllm] loading tokenizer from /workspace/qwen3.5-4b
+[h15c_vllm] seed=0 prompt_tokens=494 prompt_prefix="Janet's ducks lay sixteen eggs per day. ..."
+[h15c_vllm] seed=1 prompt_tokens=508 prompt_prefix='A robe takes two bolts of blue fiber ...'
+[h15c_vllm] seed=2 prompt_tokens=501 prompt_prefix='Josh buys a run-down property ...'
+
+# ------------------------------------------------------------
+# Attempt 1: speculative_config={'method': 'qwen3_5_mtp', 'num_speculative_tokens': 1}
+#            + enforce_eager=True + limit_mm_per_prompt={'image':0,'video':0} + skip_mm_profiling=True
+# ------------------------------------------------------------
+INFO 04-25 01:06:44 [utils.py:233] non-default args: {... 'enforce_eager': True, 'limit_mm_per_prompt': {'image': 0, 'video': 0}, 'skip_mm_profiling': True, 'speculative_config': {'method': 'qwen3_5_mtp', 'num_speculative_tokens': 1}, ...}
+INFO 04-25 01:06:44 [model.py:549] Resolved architecture: Qwen3_5ForConditionalGeneration
+WARNING 04-25 01:06:44 [speculative.py:368] method `qwen3_5_mtp` is deprecated and replaced with mtp.
+INFO 04-25 01:06:44 [model.py:549] Resolved architecture: Qwen3_5MTP
+INFO 04-25 01:06:46 [config.py:281] Setting attention block size to 528 tokens to ensure that attention page size is >= mamba page size.
+INFO 04-25 01:06:47 [registry.py:126] All limits of multimodal modalities supported by the model are set to 0, running in text-only mode.
+(EngineCore pid=4722) INFO 04-25 01:06:54 [core.py:105] Initializing a V1 LLM engine (v0.19.1) with config: model='/workspace/qwen3.5-4b', speculative_config=SpeculativeConfig(method='mtp', model='/workspace/qwen3.5-4b', num_spec_tokens=1) [...]
+(EngineCore pid=4722) INFO 04-25 01:06:57 [registry.py:126] All limits of multimodal modalities supported by the model are set to 0, running in text-only mode.
+(EngineCore pid=4722) INFO 04-25 01:07:01 [eagle.py:1377] Detected MTP model. Sharing target model embedding weights with the draft model.
+(EngineCore pid=4722) INFO 04-25 01:07:01 [eagle.py:1433] Detected MTP model. Sharing target model lm_head weights with the draft model.
+(EngineCore pid=4722) INFO 04-25 01:07:01 [gpu_model_runner.py:4820] Model loading took 8.21 GiB memory and 3.631704 seconds
+!!!!!!! Segfault encountered !!!!!!!
+[ Python C-call backtrace: 70+ frames of _PyEval_EvalFrameDefault /
+  _PyFunction_Vectorcall / PyObject_Call / THPFunction_apply, no Python file
+  symbols (compiled extension crash, not a Python exception).
+  See raw /tmp/vllm_bench.log for the full unsymbolicated frames. ]
+RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
+
+# ------------------------------------------------------------
+# Attempt 2: speculative_config={'method': 'mtp', 'num_speculative_tokens': 1}
+#            (same enforce_eager + skip_mm_profiling base)
+# ------------------------------------------------------------
+INFO 04-25 01:07:06 [utils.py:233] non-default args: {... 'speculative_config': {'method': 'mtp', 'num_speculative_tokens': 1}, ...}
+INFO 04-25 01:07:06 [model.py:549] Resolved architecture: Qwen3_5ForConditionalGeneration
+INFO 04-25 01:07:06 [model.py:549] Resolved architecture: Qwen3_5MTP
+INFO 04-25 01:07:06 [config.py:281] Setting attention block size to 528 tokens to ensure that attention page size is >= mamba page size.
+(EngineCore pid=5122) INFO 04-25 01:07:13 [core.py:105] Initializing a V1 LLM engine (v0.19.1) with config: model='/workspace/qwen3.5-4b', speculative_config=SpeculativeConfig(method='mtp', model='/workspace/qwen3.5-4b', num_spec_tokens=1) [...]
+(EngineCore pid=5122) INFO 04-25 01:07:16 [registry.py:126] All limits of multimodal modalities supported by the model are set to 0, running in text-only mode.
+(EngineCore pid=5122) INFO 04-25 01:07:20 [eagle.py:1377] Detected MTP model. Sharing target model embedding weights with the draft model.
+(EngineCore pid=5122) INFO 04-25 01:07:20 [eagle.py:1433] Detected MTP model. Sharing target model lm_head weights with the draft model.
+(EngineCore pid=5122) INFO 04-25 01:07:21 [gpu_model_runner.py:4820] Model loading took 8.21 GiB memory and 3.491643 seconds
+!!!!!!! Segfault encountered !!!!!!!
+[ same C-call backtrace pattern as attempt 1 ]
+RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
+
+# ------------------------------------------------------------
+# Attempt 3: speculative_config={'method': 'qwen3_next_mtp', 'num_speculative_tokens': 1}
+# ------------------------------------------------------------
+INFO 04-25 01:07:25 [utils.py:233] non-default args: {... 'speculative_config': {'method': 'qwen3_next_mtp', 'num_speculative_tokens': 1}, ...}
+INFO 04-25 01:07:25 [model.py:549] Resolved architecture: Qwen3_5ForConditionalGeneration
+WARNING 04-25 01:07:25 [speculative.py:368] method `qwen3_next_mtp` is deprecated and replaced with mtp.
+INFO 04-25 01:07:25 [model.py:549] Resolved architecture: Qwen3_5MTP
+INFO 04-25 01:07:25 [config.py:281] Setting attention block size to 528 tokens to ensure that attention page size is >= mamba page size.
+(EngineCore pid=5502) INFO 04-25 01:07:33 [core.py:105] Initializing a V1 LLM engine (v0.19.1) [...]
+(EngineCore pid=5502) INFO 04-25 01:07:35 [registry.py:126] All limits of multimodal modalities supported by the model are set to 0, running in text-only mode.
+(EngineCore pid=5502) INFO 04-25 01:07:36 [gpu_model_runner.py:4735] Starting to load model /workspace/qwen3.5-4b...
+(EngineCore pid=5502) INFO 04-25 01:07:39 [eagle.py:1377] Detected MTP model. Sharing target model embedding weights with the draft model.
+(EngineCore pid=5502) INFO 04-25 01:07:39 [eagle.py:1433] Detected MTP model. Sharing target model lm_head weights with the draft model.
+(EngineCore pid=5502) INFO 04-25 01:07:40 [gpu_model_runner.py:4820] Model loading took 8.21 GiB memory and 3.530000 seconds
+!!!!!!! Segfault encountered !!!!!!!
+[ same C-call backtrace pattern ]
+RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
+
+# ------------------------------------------------------------
+# Verdict from the driver:
+# {"mtp_supported": false, "reason": "vLLM failed to load Qwen3.5-4B with MTP
+#  speculative config: vLLM failed to load with any MTP speculative config..."}
+#
+# All three method aliases (qwen3_5_mtp / mtp / qwen3_next_mtp) consistently
+# crash at the same V1-engine init point: drafter weights load successfully,
+# tied embed/lm_head get attached, model_runner reports "Model loading took
+# 8.21 GiB", then a native segfault terminates the EngineCore worker. The
+# segfault has no Python file symbols (only THPFunction_apply C frames), which
+# is the signature of a CUDA / native-extension crash inside an autograd
+# function call invoked during V1 engine post-load setup.
+#
+# enforce_eager=True (no torch.compile / no CUDA graphs), skip_mm_profiling=True,
+# and limit_mm_per_prompt={image:0,video:0} all DID take effect (see the
+# "running in text-only mode" / "Cudagraph is disabled under eager mode" log
+# lines). The crash is NOT in graph capture or MM dummy profile.

--- a/docs/phase-c29-v3-vllm/compare.json
+++ b/docs/phase-c29-v3-vllm/compare.json
@@ -1,0 +1,123 @@
+{
+  "kiln": {
+    "per_seed": [
+      {
+        "seed": 0,
+        "alpha": 0.36363636363636365,
+        "n_steps": 11,
+        "n_accept": 4
+      },
+      {
+        "seed": 1,
+        "alpha": 0.3333333333333333,
+        "n_steps": 12,
+        "n_accept": 4
+      },
+      {
+        "seed": 2,
+        "alpha": 0.45454545454545453,
+        "n_steps": 11,
+        "n_accept": 5
+      }
+    ],
+    "median_alpha": 0.36363636363636365,
+    "mean_alpha": 0.3838383838383838,
+    "min_alpha": 0.3333333333333333,
+    "max_alpha": 0.45454545454545453,
+    "n_seeds": 3,
+    "source_csvs": [
+      "docs/phase-c29-v2/artifacts/c1_attr_seed0.csv",
+      "docs/phase-c29-v2/artifacts/c1_attr_seed1.csv",
+      "docs/phase-c29-v2/artifacts/c1_attr_seed2.csv"
+    ],
+    "methodology": "alpha_seed = sum(accepted column) / n_rows in c1_attr_seed{N}.csv; median computed across seeds. Source run: PR #529 (scripts/c29_kiln_logits_dump.sh), KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_W4A16=1, greedy (temperature=0), --paged, seeds=[0,1,2] indexing PROMPT_POOL[seed%30] (= GSM8K prose prompts 0,1,2), --prompt-tokens 512, --max-output-tokens 16, no chat template, splice dumps captured at POSITIONS=0..3 \u00d7 MAX_STEPS=2. NOTE: the task brief's 7/22 \u2248 0.318 hint refers to the subset of {accept-labeled, reject-labeled} splice rows used by the H15b C29 v2 top-K probe. This script uses all 11/12/11 rows per seed from the full c1_attr CSV (every speculative_mtp_decode_step call, not only dumped rows)."
+  },
+  "vllm": {
+    "mtp_supported": false,
+    "reason": "vLLM 0.19.1 segfaults during V1 engine init when loading Qwen3.5-4B with native MTP speculative decoding on A6000, post drafter weight load. All three method aliases (qwen3_5_mtp -> deprecated to mtp / mtp / qwen3_next_mtp -> deprecated to mtp) reach the same crash point and produce identical native-extension backtraces with no Python file symbols. enforce_eager=True (CUDA graphs off), limit_mm_per_prompt={image:0,video:0}, and skip_mm_profiling=True all took effect (vLLM logs 'running in text-only mode' and 'Cudagraph is disabled under eager mode') yet the segfault still fires. See artifacts/vllm_segfault_evidence.log for the trimmed log evidence and reproduction context.",
+    "vllm_version": "0.19.1",
+    "torch_version": "2.10.0+cu128",
+    "cuda_runtime": "12.8",
+    "gpu": "NVIDIA RTX A6000 sm_86",
+    "model_path": "/workspace/qwen3.5-4b",
+    "model_arch": "Qwen3_5ForConditionalGeneration",
+    "spec_arch_resolved_to": "Qwen3_5MTP",
+    "config_attempts": [
+      {
+        "method": "qwen3_5_mtp",
+        "num_speculative_tokens": 1,
+        "outcome": "EngineCore segfault @ post drafter load",
+        "engine_core_pid": 4722
+      },
+      {
+        "method": "mtp",
+        "num_speculative_tokens": 1,
+        "outcome": "EngineCore segfault @ post drafter load",
+        "engine_core_pid": 5122
+      },
+      {
+        "method": "qwen3_next_mtp",
+        "num_speculative_tokens": 1,
+        "outcome": "EngineCore segfault @ post drafter load",
+        "engine_core_pid": 5502
+      }
+    ],
+    "workarounds_attempted_but_did_not_help": [
+      "enforce_eager=True (disables torch.compile + CUDA graphs)",
+      "limit_mm_per_prompt={image:0, video:0} (skips MM dummy profile)",
+      "skip_mm_profiling=True",
+      "max_model_len=1024 (limits KV cache)",
+      "gpu_memory_utilization=0.85"
+    ],
+    "crash_signature": {
+      "marker": "!!!!!!! Segfault encountered !!!!!!!",
+      "fires_after": "INFO [gpu_model_runner.py:4820] Model loading took 8.21 GiB memory and ~3.5 seconds (drafter MTP weights successfully attached: 'Detected MTP model. Sharing target model embedding/lm_head weights with the draft model.')",
+      "backtrace_pattern": "70+ frames of _PyEval_EvalFrameDefault / _PyFunction_Vectorcall / PyObject_Call / THPFunction_apply with no Python file symbols (compiled-extension crash inside an autograd function)"
+    },
+    "per_seed": [],
+    "median_alpha": null,
+    "n_seeds": 0,
+    "vllm_config": {
+      "dtype": "bfloat16",
+      "max_model_len": 1024,
+      "enforce_eager": true,
+      "limit_mm_per_prompt": {
+        "image": 0,
+        "video": 0
+      },
+      "skip_mm_profiling": true,
+      "num_spec_tokens": 1,
+      "sampling": {
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "top_k": -1
+      }
+    }
+  },
+  "verdict": {
+    "verdict": "vllm_mtp_unsupported",
+    "decision_rule": {
+      "external_ceiling_exists": {
+        "bound": "delta >= +0.05",
+        "next_action": "External system hits materially higher \u03b1. Queue a serving-difference bisect (sampler / KV layout / quantization path / RoPE / MTP-head wiring) to find what kiln diverges on."
+      },
+      "mtp_head_quality_ceiling": {
+        "bound": "-0.02 <= delta < +0.05",
+        "next_action": "\u03b1 is upper-bounded by checkpoint quality. Deprioritize MTP-side \u03b1 work and redirect Phase 7 to decode-path optimizations that do not depend on raising \u03b1 (e.g. post-#521 prefix-cache + CUDA graphs wins, SGLang RadixAttention port from #526)."
+      },
+      "kiln_above_vllm": {
+        "bound": "delta < -0.02",
+        "next_action": "Unexpected \u2014 kiln \u03b1 exceeds vLLM at same workload. Sanity-check vLLM args (spec method, num_speculative_tokens, sampler). If confirmed, document and queue next H."
+      },
+      "vllm_mtp_unsupported": {
+        "bound": "vllm_alpha_per_seed.json.mtp_supported == false",
+        "next_action": "vLLM does not yet support Qwen3.5-4B native MTP at the installed version. Ship this as a doc-only redirect PR documenting the gap, queue the next H from PR #527 \u00a7'Queued next action'."
+      }
+    },
+    "kiln_median_alpha": 0.36363636363636365,
+    "vllm_median_alpha": null,
+    "delta": null,
+    "next_action": "vLLM does not yet support Qwen3.5-4B native MTP at the installed version. Ship this as a doc-only redirect PR documenting the gap, queue the next H from PR #527 \u00a7'Queued next action'.",
+    "reason": "vLLM 0.19.1 segfaults during V1 engine init when loading Qwen3.5-4B with native MTP speculative decoding on A6000, post drafter weight load. All three method aliases (qwen3_5_mtp -> deprecated to mtp / mtp / qwen3_next_mtp -> deprecated to mtp) reach the same crash point and produce identical native-extension backtraces with no Python file symbols. enforce_eager=True (CUDA graphs off), limit_mm_per_prompt={image:0,video:0}, and skip_mm_profiling=True all took effect (vLLM logs 'running in text-only mode' and 'Cudagraph is disabled under eager mode') yet the segfault still fires. See artifacts/vllm_segfault_evidence.log for the trimmed log evidence and reproduction context."
+  }
+}

--- a/docs/phase-c29-v3-vllm/compare.md
+++ b/docs/phase-c29-v3-vllm/compare.md
@@ -1,0 +1,27 @@
+# H15c — vLLM α microbench vs kiln (external-reference upper bound)
+
+**Verdict:** `vllm_mtp_unsupported`
+
+- kiln median α: **0.36363636363636365**
+- vLLM median α: **UNAVAILABLE** (vLLM 0.19.1 segfaults during V1 engine init when loading Qwen3.5-4B with native MTP speculative decoding on A6000, post drafter weight load. All three method aliases (qwen3_5_mtp -> deprecated to mtp / mtp / qwen3_next_mtp -> deprecated to mtp) reach the same crash point and produce identical native-extension backtraces with no Python file symbols. enforce_eager=True (CUDA graphs off), limit_mm_per_prompt={image:0,video:0}, and skip_mm_profiling=True all took effect (vLLM logs 'running in text-only mode' and 'Cudagraph is disabled under eager mode') yet the segfault still fires. See artifacts/vllm_segfault_evidence.log for the trimmed log evidence and reproduction context.)
+
+## Decision rule (pre-registered)
+
+| verdict | bound | next action |
+|---|---|---|
+| `external_ceiling_exists` | `delta >= +0.05` | External system hits materially higher α. Queue a serving-difference bisect (sampler / KV layout / quantization path / RoPE / MTP-head wiring) to find what kiln diverges on. |
+| `mtp_head_quality_ceiling` | `-0.02 <= delta < +0.05` | α is upper-bounded by checkpoint quality. Deprioritize MTP-side α work and redirect Phase 7 to decode-path optimizations that do not depend on raising α (e.g. post-#521 prefix-cache + CUDA graphs wins, SGLang RadixAttention port from #526). |
+| `kiln_above_vllm` | `delta < -0.02` | Unexpected — kiln α exceeds vLLM at same workload. Sanity-check vLLM args (spec method, num_speculative_tokens, sampler). If confirmed, document and queue next H. |
+| `vllm_mtp_unsupported` | `vllm_alpha_per_seed.json.mtp_supported == false` | vLLM does not yet support Qwen3.5-4B native MTP at the installed version. Ship this as a doc-only redirect PR documenting the gap, queue the next H from PR #527 §'Queued next action'. |
+
+## Per-seed table
+
+| seed | kiln α | notes |
+|---|---|---|
+| 0 | 0.3636 | vLLM unavailable |
+| 1 | 0.3333 | vLLM unavailable |
+| 2 | 0.4545 | vLLM unavailable |
+
+## Next action
+
+vLLM does not yet support Qwen3.5-4B native MTP at the installed version. Ship this as a doc-only redirect PR documenting the gap, queue the next H from PR #527 §'Queued next action'.

--- a/docs/phase-c29-v3-vllm/kiln_alpha_per_seed.json
+++ b/docs/phase-c29-v3-vllm/kiln_alpha_per_seed.json
@@ -1,0 +1,33 @@
+{
+  "per_seed": [
+    {
+      "seed": 0,
+      "alpha": 0.36363636363636365,
+      "n_steps": 11,
+      "n_accept": 4
+    },
+    {
+      "seed": 1,
+      "alpha": 0.3333333333333333,
+      "n_steps": 12,
+      "n_accept": 4
+    },
+    {
+      "seed": 2,
+      "alpha": 0.45454545454545453,
+      "n_steps": 11,
+      "n_accept": 5
+    }
+  ],
+  "median_alpha": 0.36363636363636365,
+  "mean_alpha": 0.3838383838383838,
+  "min_alpha": 0.3333333333333333,
+  "max_alpha": 0.45454545454545453,
+  "n_seeds": 3,
+  "source_csvs": [
+    "docs/phase-c29-v2/artifacts/c1_attr_seed0.csv",
+    "docs/phase-c29-v2/artifacts/c1_attr_seed1.csv",
+    "docs/phase-c29-v2/artifacts/c1_attr_seed2.csv"
+  ],
+  "methodology": "alpha_seed = sum(accepted column) / n_rows in c1_attr_seed{N}.csv; median computed across seeds. Source run: PR #529 (scripts/c29_kiln_logits_dump.sh), KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_W4A16=1, greedy (temperature=0), --paged, seeds=[0,1,2] indexing PROMPT_POOL[seed%30] (= GSM8K prose prompts 0,1,2), --prompt-tokens 512, --max-output-tokens 16, no chat template, splice dumps captured at POSITIONS=0..3 \u00d7 MAX_STEPS=2. NOTE: the task brief's 7/22 \u2248 0.318 hint refers to the subset of {accept-labeled, reject-labeled} splice rows used by the H15b C29 v2 top-K probe. This script uses all 11/12/11 rows per seed from the full c1_attr CSV (every speculative_mtp_decode_step call, not only dumped rows)."
+}

--- a/docs/phase-c29-v3-vllm/verdict.json
+++ b/docs/phase-c29-v3-vllm/verdict.json
@@ -1,0 +1,26 @@
+{
+  "verdict": "vllm_mtp_unsupported",
+  "decision_rule": {
+    "external_ceiling_exists": {
+      "bound": "delta >= +0.05",
+      "next_action": "External system hits materially higher \u03b1. Queue a serving-difference bisect (sampler / KV layout / quantization path / RoPE / MTP-head wiring) to find what kiln diverges on."
+    },
+    "mtp_head_quality_ceiling": {
+      "bound": "-0.02 <= delta < +0.05",
+      "next_action": "\u03b1 is upper-bounded by checkpoint quality. Deprioritize MTP-side \u03b1 work and redirect Phase 7 to decode-path optimizations that do not depend on raising \u03b1 (e.g. post-#521 prefix-cache + CUDA graphs wins, SGLang RadixAttention port from #526)."
+    },
+    "kiln_above_vllm": {
+      "bound": "delta < -0.02",
+      "next_action": "Unexpected \u2014 kiln \u03b1 exceeds vLLM at same workload. Sanity-check vLLM args (spec method, num_speculative_tokens, sampler). If confirmed, document and queue next H."
+    },
+    "vllm_mtp_unsupported": {
+      "bound": "vllm_alpha_per_seed.json.mtp_supported == false",
+      "next_action": "vLLM does not yet support Qwen3.5-4B native MTP at the installed version. Ship this as a doc-only redirect PR documenting the gap, queue the next H from PR #527 \u00a7'Queued next action'."
+    }
+  },
+  "kiln_median_alpha": 0.36363636363636365,
+  "vllm_median_alpha": null,
+  "delta": null,
+  "next_action": "vLLM does not yet support Qwen3.5-4B native MTP at the installed version. Ship this as a doc-only redirect PR documenting the gap, queue the next H from PR #527 \u00a7'Queued next action'.",
+  "reason": "vLLM 0.19.1 segfaults during V1 engine init when loading Qwen3.5-4B with native MTP speculative decoding on A6000, post drafter weight load. All three method aliases (qwen3_5_mtp -> deprecated to mtp / mtp / qwen3_next_mtp -> deprecated to mtp) reach the same crash point and produce identical native-extension backtraces with no Python file symbols. enforce_eager=True (CUDA graphs off), limit_mm_per_prompt={image:0,video:0}, and skip_mm_profiling=True all took effect (vLLM logs 'running in text-only mode' and 'Cudagraph is disabled under eager mode') yet the segfault still fires. See artifacts/vllm_segfault_evidence.log for the trimmed log evidence and reproduction context."
+}

--- a/docs/phase-c29-v3-vllm/vllm_alpha_per_seed.json
+++ b/docs/phase-c29-v3-vllm/vllm_alpha_per_seed.json
@@ -1,0 +1,55 @@
+{
+  "mtp_supported": false,
+  "reason": "vLLM 0.19.1 segfaults during V1 engine init when loading Qwen3.5-4B with native MTP speculative decoding on A6000, post drafter weight load. All three method aliases (qwen3_5_mtp -> deprecated to mtp / mtp / qwen3_next_mtp -> deprecated to mtp) reach the same crash point and produce identical native-extension backtraces with no Python file symbols. enforce_eager=True (CUDA graphs off), limit_mm_per_prompt={image:0,video:0}, and skip_mm_profiling=True all took effect (vLLM logs 'running in text-only mode' and 'Cudagraph is disabled under eager mode') yet the segfault still fires. See artifacts/vllm_segfault_evidence.log for the trimmed log evidence and reproduction context.",
+  "vllm_version": "0.19.1",
+  "torch_version": "2.10.0+cu128",
+  "cuda_runtime": "12.8",
+  "gpu": "NVIDIA RTX A6000 sm_86",
+  "model_path": "/workspace/qwen3.5-4b",
+  "model_arch": "Qwen3_5ForConditionalGeneration",
+  "spec_arch_resolved_to": "Qwen3_5MTP",
+  "config_attempts": [
+    {
+      "method": "qwen3_5_mtp",
+      "num_speculative_tokens": 1,
+      "outcome": "EngineCore segfault @ post drafter load",
+      "engine_core_pid": 4722
+    },
+    {
+      "method": "mtp",
+      "num_speculative_tokens": 1,
+      "outcome": "EngineCore segfault @ post drafter load",
+      "engine_core_pid": 5122
+    },
+    {
+      "method": "qwen3_next_mtp",
+      "num_speculative_tokens": 1,
+      "outcome": "EngineCore segfault @ post drafter load",
+      "engine_core_pid": 5502
+    }
+  ],
+  "workarounds_attempted_but_did_not_help": [
+    "enforce_eager=True (disables torch.compile + CUDA graphs)",
+    "limit_mm_per_prompt={image:0, video:0} (skips MM dummy profile)",
+    "skip_mm_profiling=True",
+    "max_model_len=1024 (limits KV cache)",
+    "gpu_memory_utilization=0.85"
+  ],
+  "crash_signature": {
+    "marker": "!!!!!!! Segfault encountered !!!!!!!",
+    "fires_after": "INFO [gpu_model_runner.py:4820] Model loading took 8.21 GiB memory and ~3.5 seconds (drafter MTP weights successfully attached: 'Detected MTP model. Sharing target model embedding/lm_head weights with the draft model.')",
+    "backtrace_pattern": "70+ frames of _PyEval_EvalFrameDefault / _PyFunction_Vectorcall / PyObject_Call / THPFunction_apply with no Python file symbols (compiled-extension crash inside an autograd function)"
+  },
+  "per_seed": [],
+  "median_alpha": null,
+  "n_seeds": 0,
+  "vllm_config": {
+    "dtype": "bfloat16",
+    "max_model_len": 1024,
+    "enforce_eager": true,
+    "limit_mm_per_prompt": {"image": 0, "video": 0},
+    "skip_mm_profiling": true,
+    "num_spec_tokens": 1,
+    "sampling": {"temperature": 0.0, "top_p": 1.0, "top_k": -1}
+  }
+}

--- a/docs/phase7-h15c-vllm-alpha-microbench.md
+++ b/docs/phase7-h15c-vllm-alpha-microbench.md
@@ -1,0 +1,245 @@
+# Phase 7 — H15c: vLLM α microbench (external-reference upper bound vs kiln)
+
+**Verdict**: `vllm_mtp_unsupported` — vLLM 0.19.1 + Qwen3.5-4B + native MTP segfaults during V1 engine init on A6000. Cannot establish an external α upper bound at this vLLM version.
+**Branch**: `phase7-h15c-vllm-alpha-microbench`
+**Predecessor**: PR #529 (H15b stratified C29 v2 reject-row probe → `kiln_native_ceiling`)
+**Pod**: RunPod A6000 `wl4oh30qxnzyqz`, on-demand $0.49/hr, terminated after run
+
+## Goal
+
+PR #529's stratified H15b probe established that kiln's MTP head logits sit at
+the BF16-noise cosine ceiling (`reject_cos_sim_median = 0.999978`) on the C29 v2
+reject sub-population. Verifier numerical drift on reject rows is RULED OUT as
+the α-gap source. The remaining open question:
+
+> Does any external serving system hit a **higher α** on this same Qwen3.5-4B
+> checkpoint at A6000 bs=1?
+
+H15c attempted to answer this by running vLLM 0.19.1 with the native
+`qwen3_5_mtp` head on the *identical* prompt / seed / prefill / decode workload
+PR #529 used, and comparing α to kiln's α derived from the same-run
+`c1_attr_seed{0,1,2}.csv`.
+
+## Outcome
+
+**vLLM 0.19.1 segfaults during V1 engine init on this checkpoint, on every MTP
+method alias.** The crash fires after the drafter MTP weights successfully
+load and after `eagle.py:1377/1433` confirms tied embed/lm_head sharing — i.e.
+vLLM has the right model dispatch, the right MTP arch (`Qwen3_5MTP` per
+`vllm/model_executor/models/registry.py`), and the right speculative method
+plumbing (`qwen3_5_mtp` → `mtp` rewrite in `vllm/config/speculative.py:368`).
+The crash is in a *post-load native code path* (autograd / CUDA extension
+boundary, no Python file symbols in the backtrace).
+
+The pre-registered decision rule maps this to the `vllm_mtp_unsupported`
+branch — ship this PR as a doc-only redirect documenting the vLLM-side gap and
+queue the next H from PR #527 §"Queued next action".
+
+| metric | value |
+| --- | --- |
+| `kiln_median_alpha` (re-derived from PR #529 c1_attr CSVs) | **0.3636** |
+| `vllm_median_alpha` | **UNAVAILABLE** (segfault) |
+| `delta` | **UNAVAILABLE** |
+
+Per-seed kiln α (from `docs/phase-c29-v2/artifacts/c1_attr_seed{0,1,2}.csv`,
+all 11/12/11 rows per seed, not only the H15b-probed subset):
+
+| seed | accept / steps | α |
+| --- | --- | --- |
+| 0 | 4 / 11 | 0.3636 |
+| 1 | 4 / 12 | 0.3333 |
+| 2 | 5 / 11 | 0.4545 |
+| **median** | — | **0.3636** |
+
+The 7-accepts / 22-rows hint in the task brief (≈ 0.318) refers to the union
+of accept-labeled + reject-labeled splice-dump rows in PR #529's H15b probe
+(POSITIONS=0..3 × MAX_STEPS=2 = 22 rows total, of which 7 were accepted). The
+H15c kiln α uses *every* `speculative_mtp_decode_step` call, not only the
+splice-dumped ones — that's the strict kiln α at this workload.
+
+## Decision rule (pre-registered, set BEFORE the run)
+
+| Δ = vllm_median_α − kiln_median_α | verdict | next action |
+| --- | --- | --- |
+| ≥ +0.05 | `external_ceiling_exists` | queue serving-difference bisect (sampler / KV layout / quantization path / RoPE / MTP-head wiring) |
+| in [−0.02, +0.05) | `mtp_head_quality_ceiling` | accept α as upper-bounded by checkpoint quality; deprioritize MTP-side α work |
+| < −0.02 | `kiln_above_vllm` (unexpected) | sanity-check vLLM args; if confirmed, document and queue next H |
+| `vllm.mtp_supported == false` | **`vllm_mtp_unsupported`** ← **THIS RUN** | doc-only redirect PR; queue next H from PR #527 |
+
+The rule is implemented in `scripts/h15c_compare.py` and emitted
+`docs/phase-c29-v3-vllm/verdict.json`.
+
+## Crash signature
+
+All three method aliases (`qwen3_5_mtp`, `mtp`, `qwen3_next_mtp` — the latter
+two get rewritten to internal `qwen3_5_mtp` dispatch) reach the same point:
+
+1. Tokenizer + multimodal config loaded successfully (`Resolved architecture: Qwen3_5ForConditionalGeneration`)
+2. `attention block size to 528 tokens` calibrated against mamba page size — vLLM understands the hybrid GDN + GQA layout
+3. `running in text-only mode` confirms `limit_mm_per_prompt={image:0,video:0}` took effect
+4. EngineCore worker boots fine, target model loads (~8 GiB, ~3 s)
+5. Drafter MTP weights load (`Detected MTP model. Sharing target model embedding/lm_head weights with the draft model.`)
+6. `gpu_model_runner.py:4820 Model loading took 8.21 GiB memory and 3.5 seconds`
+7. **`!!!!!!! Segfault encountered !!!!!!!`** with a 70-frame native backtrace through `_PyEval_EvalFrameDefault` / `_PyFunction_Vectorcall` / `PyObject_Call` / `THPFunction_apply` (compiled-extension crash, no Python file symbols).
+
+`RuntimeError: Engine core initialization failed. See root cause above.
+Failed core proc(s): {}` is the wrapper exception the parent process raises
+after the EngineCore worker dies.
+
+Workarounds that all *did* take effect but did NOT prevent the crash:
+
+- `enforce_eager=True` — disables `torch.compile` and CUDA graph capture (vLLM logs `Cudagraph is disabled under eager mode`)
+- `limit_mm_per_prompt={"image": 0, "video": 0}` + `skip_mm_profiling=True` — skips the multimodal dummy profile_run (vLLM logs `running in text-only mode`)
+- `max_model_len=1024` + `gpu_memory_utilization=0.85` — no OOM signal in the log
+
+The crash is therefore NOT in CUDA graph capture, NOT in MM dummy profiling,
+and NOT a clean OOM. It is a native-code crash inside the vLLM V1 engine
+post-load setup that's specific to the (Qwen3_5 + MTP) combination at vLLM
+0.19.1 + torch 2.10.0 + CUDA 12.8 on sm_86. See
+`docs/phase-c29-v3-vllm/artifacts/vllm_segfault_evidence.log` for the trimmed
+log capture (3 attempts × ~13 lines each, EngineCore PIDs 4722 / 5122 / 5502).
+
+## Workload (matched to PR #529)
+
+| field | value | source |
+| --- | --- | --- |
+| model | Qwen3.5-4B (`Qwen3_5ForConditionalGeneration`, `model_type=qwen3_5`) | `/workspace/qwen3.5-4b/config.json` |
+| prompts | `PROMPT_POOL[seed % 30]` for seeds {0,1,2} → GSM8K prose 0/1/2 | `crates/kiln-server/src/bench.rs:376` |
+| prompt-token target | 512 (sentence-repetition expander) | `bench.rs::build_prompt` |
+| actual prompt tokens | 494 / 508 / 501 | matches PR #529 c1_attr CSV `base_pos` start values |
+| max output tokens | 16 | PR #529 `scripts/c29_kiln_logits_dump.sh:DECODE_TOKENS` |
+| chat template | OFF (raw prose) | PR #529 driver |
+| sampler | greedy: `temperature=0`, `top_p=1`, `top_k=0` (kiln) / `top_k=-1` (vLLM) | both drivers |
+| spec method | k=1 native MTP (`KILN_SPEC_METHOD=mtp` / `qwen3_5_mtp`) | both drivers |
+| GPU | NVIDIA RTX A6000 sm_86, single-GPU bs=1 | RunPod |
+| kiln quant | Marlin W4A16 (`KILN_W4A16=1`) | PR #529 driver |
+| vLLM quant | BF16 (vLLM does not implement Marlin W4A16 for `Qwen3_5MTP`) | acknowledged confounder |
+
+The h15c driver verified that the prompt-builder reproduces PR #529's encoded
+prompts byte-for-byte: prompt token counts 494 / 508 / 501 exactly match the
+`base_pos` start values in `c1_attr_seed{0,1,2}.csv` (494, 508, 501). This is
+how we know the workload is identical at the prefill boundary — only the
+serving-side decode path would have differed had vLLM completed the run.
+
+## Reproduction commands
+
+```bash
+# Pod side (RunPod A6000 with kiln-runpod image, vLLM 0.19.1 installed)
+cd /workspace/kiln
+
+# 1. vLLM α (3 seeds × 16-token greedy decode × MTP k=1) — segfaults at vLLM 0.19.1
+python3 scripts/h15c_vllm_alpha_dump.py \
+    --model-path /workspace/qwen3.5-4b \
+    --prompt-tokens 512 --max-tokens 16 \
+    --seeds 0 1 2 --num-spec-tokens 1 \
+    --out docs/phase-c29-v3-vllm/vllm_alpha_per_seed.json
+# Outcome: writes mtp_supported=false JSON; exit code 3.
+
+# 2. kiln α (re-derived from PR #529's c1_attr CSVs — no GPU needed, runs anywhere)
+python3 scripts/h15c_kiln_alpha_from_csv.py \
+    --csv-dir docs/phase-c29-v2/artifacts \
+    --out docs/phase-c29-v3-vllm/kiln_alpha_per_seed.json
+# Outcome: median_alpha = 0.3636.
+
+# 3. Apply decision rule
+python3 scripts/h15c_compare.py
+# Outcome: verdict=vllm_mtp_unsupported.
+```
+
+## Anti-duplication evidence
+
+```
+$ gh pr list -R ericflo/kiln --state all --search "vllm alpha microbench"
+(empty)
+$ gh pr list -R ericflo/kiln --state all --search "h15c vllm"
+(empty)
+$ gh pr list -R ericflo/kiln --state all --search "H15c"
+(empty)
+$ gh pr list -R ericflo/kiln --state all --search "qwen3_next_mtp vllm"
+527  phase7: MTP acceptance-rate state-of-play audit (doc-only)         MERGED
+245  mtp: native MTP speculative decode step + h_prev wiring (WIP)      MERGED
+```
+
+PR #527 explicitly queued this H15c microbench in its "Recommended next H"
+section, and PR #529 re-confirmed it as the next action under its
+`kiln_native_ceiling` verdict. PR #525 (vLLM Triton GDN audit, doc-only) is
+scope-distinct (kernel audit, not α microbench).
+
+## What this rules out
+
+- **vLLM 0.19.1 cannot serve Qwen3.5-4B + native MTP on A6000 today.** Any
+  Phase 7 plan that assumes "we can compare against vLLM α as the upper bound"
+  needs to either (a) wait for a vLLM patch, (b) try a different vLLM version
+  / nightly, (c) try a different external serving system (SGLang has no MTP
+  for Qwen3.5 either as of PR #526), or (d) accept that the upper bound has to
+  come from a hand-rolled HF transformers reference implementation.
+- **The vLLM-side method dispatch is correct.** vLLM 0.19.1 *does* recognize
+  `Qwen3_5MTP` in its registry, *does* rewrite `qwen3_5_mtp` → `mtp` per
+  `vllm/config/speculative.py:323-330`, and *does* attach the drafter weights
+  with tied embed/lm_head. The bug is downstream of dispatch.
+
+## What this does NOT rule out
+
+- **Whether an external α ceiling exists.** That was the question H15c was
+  supposed to answer. With vLLM blocked, the question stays open until either
+  vLLM is unblocked or another reference is built.
+- **Workload sensitivity** (per `mtp-bench-workload-sensitivity` — chat α ≈
+  0.588 vs prose α ≈ 0.175 on PR #364). H15c chose the prose / 16-decode
+  workload to match PR #529 exactly; chat-template prompts may behave
+  differently.
+- **Quantization path differences.** kiln runs Marlin W4A16; the eventual
+  reference will likely run BF16. That confounder still has to be handled.
+
+## Bench envelope + cost
+
+- Pod: RunPod A6000 (`wl4oh30qxnzyqz`), $0.49/hr on-demand, no spot.
+- Pool acquire: HTTP 503 `capacity_supply_exhausted` on hibernated pods →
+  fell back to direct `runpod_api.py launch` (per the documented fallback path
+  for "pool at cap or unavailable").
+- vLLM 0.19.1 install: ~1.5 min (background, `wait-file` supervised, single
+  PyTorch downgrade 2.4.1 → 2.10.0 + cu128 stack).
+- Bench attempts: 3 × ~30 s each (load + segfault), all in one process run.
+- All bench supervision used `runpod_api.py bg` + `wait-file --timeout 1500`,
+  no SSH polling loops (per `kiln-ssh-polling-deadlock` note).
+- Wall-clock budget: 90 min / $40 hard cap (per project §"Wall-clock budget").
+  Estimated total spend: ~$0.40 — well under cap.
+
+## Queued next action
+
+Per the pre-registered decision rule for `vllm_mtp_unsupported`:
+
+> Ship this as a doc-only redirect PR documenting the gap, queue the next H
+> from PR #527 §"Queued next action".
+
+Concrete options the next planning cycle should pick from (PR #527 enumerated
+several non-α optimization paths; this verdict refocuses Phase 7 onto those):
+
+1. **Direct decode-path optimization** — already in flight: PR #521
+   (prefix-cache + CUDA graphs wins) and PR #526 (SGLang RadixAttention
+   audit). H15c does not block continued investment here.
+2. **HF transformers reference α** — build a hand-rolled HF reference with
+   Qwen3.5's pretrained MTP head and run the same 3-seed prose workload.
+   Higher engineering cost than reusing vLLM, but would close the
+   external-upper-bound question without depending on a vLLM patch.
+3. **Retry vLLM at a different version / nightly** — when a vLLM patch
+   exposes a working Qwen3.5-MTP path, re-run this PR's `scripts/h15c_*`
+   exactly as-is. The driver and compare are version-agnostic; only the
+   `vllm_alpha_per_seed.json` and `compare.json/md` artifacts re-generate.
+4. **Switch to SGLang or another OSS server** — SGLang doesn't yet support
+   Qwen3.5 MTP either (per PR #526), so this option waits on the SGLang
+   side too.
+
+## Files
+
+| path | purpose |
+| --- | --- |
+| `docs/phase7-h15c-vllm-alpha-microbench.md` | this audit doc |
+| `docs/phase-c29-v3-vllm/verdict.json` | machine-readable verdict |
+| `docs/phase-c29-v3-vllm/compare.json` | full kiln + vllm side-by-side |
+| `docs/phase-c29-v3-vllm/compare.md` | per-seed table + decision rule |
+| `docs/phase-c29-v3-vllm/kiln_alpha_per_seed.json` | re-derived kiln α |
+| `docs/phase-c29-v3-vllm/vllm_alpha_per_seed.json` | trimmed vLLM failure record |
+| `docs/phase-c29-v3-vllm/artifacts/vllm_segfault_evidence.log` | trimmed pod log of all 3 segfaults |
+| `scripts/h15c_kiln_alpha_from_csv.py` | derives kiln α from PR #529 CSVs |
+| `scripts/h15c_vllm_alpha_dump.py` | vLLM driver (re-runnable when vLLM is fixed) |
+| `scripts/h15c_compare.py` | applies decision rule, emits verdict.json |

--- a/scripts/h15c_compare.py
+++ b/scripts/h15c_compare.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""H15c — apply the pre-registered decision rule.
+
+Inputs:
+    docs/phase-c29-v3-vllm/vllm_alpha_per_seed.json  (from h15c_vllm_alpha_dump.py)
+    docs/phase-c29-v3-vllm/kiln_alpha_per_seed.json  (from h15c_kiln_alpha_from_csv.py)
+
+Decision rule (set BEFORE the run, do NOT adjust after):
+
+    delta = vllm_median_alpha - kiln_median_alpha
+
+    delta >= +0.05          → external_ceiling_exists
+    -0.02 <= delta < +0.05  → mtp_head_quality_ceiling
+    delta <  -0.02          → kiln_above_vllm
+
+Emits:
+    docs/phase-c29-v3-vllm/verdict.json
+    docs/phase-c29-v3-vllm/compare.json
+    docs/phase-c29-v3-vllm/compare.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+DECISION_RULE = {
+    "external_ceiling_exists": {
+        "bound": "delta >= +0.05",
+        "next_action": (
+            "External system hits materially higher α. Queue a serving-"
+            "difference bisect (sampler / KV layout / quantization path / "
+            "RoPE / MTP-head wiring) to find what kiln diverges on."
+        ),
+    },
+    "mtp_head_quality_ceiling": {
+        "bound": "-0.02 <= delta < +0.05",
+        "next_action": (
+            "α is upper-bounded by checkpoint quality. Deprioritize MTP-"
+            "side α work and redirect Phase 7 to decode-path optimizations "
+            "that do not depend on raising α (e.g. post-#521 prefix-cache + "
+            "CUDA graphs wins, SGLang RadixAttention port from #526)."
+        ),
+    },
+    "kiln_above_vllm": {
+        "bound": "delta < -0.02",
+        "next_action": (
+            "Unexpected — kiln α exceeds vLLM at same workload. Sanity-check "
+            "vLLM args (spec method, num_speculative_tokens, sampler). If "
+            "confirmed, document and queue next H."
+        ),
+    },
+    "vllm_mtp_unsupported": {
+        "bound": "vllm_alpha_per_seed.json.mtp_supported == false",
+        "next_action": (
+            "vLLM does not yet support Qwen3.5-4B native MTP at the installed "
+            "version. Ship this as a doc-only redirect PR documenting the gap, "
+            "queue the next H from PR #527 §'Queued next action'."
+        ),
+    },
+}
+
+
+def apply_rule(delta: float) -> str:
+    if delta >= 0.05:
+        return "external_ceiling_exists"
+    if delta >= -0.02:
+        return "mtp_head_quality_ceiling"
+    return "kiln_above_vllm"
+
+
+def load(path: Path) -> dict:
+    if not path.exists():
+        raise SystemExit(f"missing input: {path}")
+    return json.loads(path.read_text())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--vllm",
+        default="docs/phase-c29-v3-vllm/vllm_alpha_per_seed.json",
+    )
+    ap.add_argument(
+        "--kiln",
+        default="docs/phase-c29-v3-vllm/kiln_alpha_per_seed.json",
+    )
+    ap.add_argument(
+        "--out-dir",
+        default="docs/phase-c29-v3-vllm",
+    )
+    args = ap.parse_args()
+
+    vllm = load(Path(args.vllm))
+    kiln = load(Path(args.kiln))
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    mtp_supported = vllm.get("mtp_supported", False)
+    if not mtp_supported:
+        verdict = {
+            "verdict": "vllm_mtp_unsupported",
+            "decision_rule": DECISION_RULE,
+            "kiln_median_alpha": kiln.get("median_alpha"),
+            "vllm_median_alpha": None,
+            "delta": None,
+            "next_action": DECISION_RULE["vllm_mtp_unsupported"]["next_action"],
+            "reason": vllm.get("reason", "unknown"),
+        }
+    else:
+        kiln_med = float(kiln["median_alpha"])
+        vllm_med = float(vllm["median_alpha"])
+        delta = vllm_med - kiln_med
+        v = apply_rule(delta)
+        verdict = {
+            "verdict": v,
+            "decision_rule": DECISION_RULE,
+            "kiln_median_alpha": kiln_med,
+            "vllm_median_alpha": vllm_med,
+            "delta": delta,
+            "next_action": DECISION_RULE[v]["next_action"],
+        }
+
+    compare = {
+        "kiln": kiln,
+        "vllm": vllm,
+        "verdict": verdict,
+    }
+
+    (out_dir / "verdict.json").write_text(json.dumps(verdict, indent=2))
+    (out_dir / "compare.json").write_text(json.dumps(compare, indent=2))
+
+    # Markdown summary
+    md = []
+    md.append("# H15c — vLLM α microbench vs kiln (external-reference upper bound)\n\n")
+    md.append(f"**Verdict:** `{verdict['verdict']}`\n\n")
+    if mtp_supported:
+        md.append(f"- kiln median α: **{verdict['kiln_median_alpha']:.4f}**\n")
+        md.append(f"- vLLM median α: **{verdict['vllm_median_alpha']:.4f}**\n")
+        md.append(f"- Δ (vllm − kiln): **{verdict['delta']:+.4f}**\n\n")
+    else:
+        md.append(f"- kiln median α: **{verdict['kiln_median_alpha']}**\n")
+        md.append(f"- vLLM median α: **UNAVAILABLE** ({verdict['reason']})\n\n")
+
+    md.append("## Decision rule (pre-registered)\n\n")
+    md.append("| verdict | bound | next action |\n")
+    md.append("|---|---|---|\n")
+    for name, spec in DECISION_RULE.items():
+        md.append(f"| `{name}` | `{spec['bound']}` | {spec['next_action']} |\n")
+    md.append("\n")
+
+    md.append("## Per-seed table\n\n")
+    if mtp_supported:
+        md.append("| seed | kiln α | vLLM α | kiln accept/steps | vLLM accept/proposed |\n")
+        md.append("|---|---|---|---|---|\n")
+        kiln_per = {r["seed"]: r for r in kiln["per_seed"]}
+        vllm_per = {r["seed"]: r for r in vllm["per_seed"]}
+        for seed in sorted(set(kiln_per) | set(vllm_per)):
+            kr = kiln_per.get(seed, {})
+            vr = vllm_per.get(seed, {})
+            md.append(
+                f"| {seed} | "
+                f"{kr.get('alpha', 0):.4f} | "
+                f"{vr.get('alpha', 0):.4f} | "
+                f"{kr.get('n_accept', 0)}/{kr.get('n_steps', 0)} | "
+                f"{vr.get('n_accepted', 0)}/{vr.get('n_proposed', 0)} |\n"
+            )
+        md.append("\n")
+    else:
+        md.append("| seed | kiln α | notes |\n|---|---|---|\n")
+        for r in kiln["per_seed"]:
+            md.append(f"| {r['seed']} | {r['alpha']:.4f} | vLLM unavailable |\n")
+        md.append("\n")
+
+    md.append(f"## Next action\n\n{verdict['next_action']}\n")
+
+    (out_dir / "compare.md").write_text("".join(md))
+
+    print(json.dumps(verdict, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/h15c_kiln_alpha_from_csv.py
+++ b/scripts/h15c_kiln_alpha_from_csv.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""H15c — derive kiln MTP α per seed from PR #529's c1_attr CSVs.
+
+Reads docs/phase-c29-v2/artifacts/c1_attr_seed{0,1,2}.csv and computes
+
+    alpha_seed = sum(accepted) / n_rows
+
+The `accepted` column is 0/1 per MTP step (k=1 speculative draft attempt).
+We compute α per seed independently, then report the median — matching the
+"compute per-seed first then median" rule from the task brief.
+
+Writes `kiln_alpha_per_seed.json` for the compare step:
+    {
+      "per_seed": [{"seed": 0, "alpha": ..., "n_steps": ..., "n_accept": ...}, ...],
+      "median_alpha": ...,
+      "source_csvs": [...]
+    }
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import statistics
+from pathlib import Path
+
+
+def compute_alpha(csv_path: Path) -> tuple[float, int, int]:
+    n_steps = 0
+    n_accept = 0
+    with csv_path.open() as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            n_steps += 1
+            n_accept += int(row["accepted"])
+    if n_steps == 0:
+        return 0.0, 0, 0
+    return n_accept / n_steps, n_steps, n_accept
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--csv-dir",
+        default="docs/phase-c29-v2/artifacts",
+        help="Directory containing c1_attr_seed{0,1,2}.csv",
+    )
+    ap.add_argument(
+        "--out",
+        default="docs/phase-c29-v3-vllm/kiln_alpha_per_seed.json",
+        help="Output JSON path",
+    )
+    ap.add_argument("--seeds", nargs="+", type=int, default=[0, 1, 2])
+    args = ap.parse_args()
+
+    csv_dir = Path(args.csv_dir)
+    per_seed = []
+    alphas: list[float] = []
+    sources = []
+    for seed in args.seeds:
+        csv_path = csv_dir / f"c1_attr_seed{seed}.csv"
+        if not csv_path.exists():
+            raise SystemExit(f"missing {csv_path}")
+        alpha, n_steps, n_accept = compute_alpha(csv_path)
+        per_seed.append(
+            {
+                "seed": seed,
+                "alpha": alpha,
+                "n_steps": n_steps,
+                "n_accept": n_accept,
+            }
+        )
+        alphas.append(alpha)
+        sources.append(str(csv_path))
+
+    result = {
+        "per_seed": per_seed,
+        "median_alpha": statistics.median(alphas),
+        "mean_alpha": statistics.mean(alphas),
+        "min_alpha": min(alphas),
+        "max_alpha": max(alphas),
+        "n_seeds": len(alphas),
+        "source_csvs": sources,
+        "methodology": (
+            "alpha_seed = sum(accepted column) / n_rows in "
+            "c1_attr_seed{N}.csv; median computed across seeds. "
+            "Source run: PR #529 (scripts/c29_kiln_logits_dump.sh), "
+            "KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_W4A16=1, "
+            "greedy (temperature=0), --paged, seeds=[0,1,2] indexing "
+            "PROMPT_POOL[seed%30] (= GSM8K prose prompts 0,1,2), "
+            "--prompt-tokens 512, --max-output-tokens 16, no chat template, "
+            "splice dumps captured at POSITIONS=0..3 × MAX_STEPS=2. "
+            "NOTE: the task brief's 7/22 ≈ 0.318 hint refers to the "
+            "subset of {accept-labeled, reject-labeled} splice rows "
+            "used by the H15b C29 v2 top-K probe. This script uses all "
+            "11/12/11 rows per seed from the full c1_attr CSV (every "
+            "speculative_mtp_decode_step call, not only dumped rows)."
+        ),
+    }
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2))
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/h15c_vllm_alpha_dump.py
+++ b/scripts/h15c_vllm_alpha_dump.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+"""H15c — vLLM MTP α microbench on Qwen3.5-4B A6000 bs=1.
+
+Runs the *same* workload as PR #529's kiln c1_attr capture:
+
+    - 3 prose GSM8K prompts (PROMPT_POOL indices 0,1,2) re-built from the
+      hand-rolled kiln-bench strings and expanded to ~512 prefill tokens
+      by sentence repetition (matching kiln-bench's `build_prompt`).
+    - Greedy decode (temperature=0, top_p=1, top_k=-1).
+    - max_tokens=16 (matches PR #529 --max-output-tokens 16).
+    - Seeds 0, 1, 2.
+    - Speculative decoding: Qwen3-Next native MTP, k=1.
+
+Measures α = sum(accepted_tokens) / sum(proposed_tokens) per request, then
+aggregates per seed and reports the cross-seed median for the H15c compare.
+
+The vLLM speculative-decoding stats API has varied across versions, so we
+collect α with three parallel strategies and take the first one that yields
+a non-empty signal:
+
+    1. RequestOutput.metrics / spec fields on the `outputs[i].metrics`.
+    2. The v1 SpecDecodingStats counters on `llm.llm_engine.get_stats()`.
+    3. Re-running with `disable_log_stats=False` + the `--dump-stats` side
+       channel (vLLM writes `num_accepted_tokens` / `num_draft_tokens` to
+       the logging stat loggers).
+
+If vLLM refuses to load Qwen3.5-4B with a Qwen3-Next MTP speculative config
+(e.g. arch dispatch mismatch, missing weights, or unsupported combo), the
+driver emits `{"mtp_supported": false, "reason": ...}` so the compare step
+can post a doc-only redirect PR without burning more pod time.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import traceback
+from pathlib import Path
+
+
+# Exact prose prompts from crates/kiln-server/src/bench.rs PROMPT_POOL[0,1,2]
+# (GSM8K-style grade-school math word problems). Matching these character-for-
+# character is required for valid kiln-vs-vLLM α comparison — seed N picks
+# PROMPT_POOL[seed % 30] in kiln, so seeds 0/1/2 pick prompts 0/1/2.
+BASE_PROMPTS = [
+    # 0: eggs-per-day revenue
+    "Janet's ducks lay sixteen eggs per day. She eats three for breakfast every morning and bakes muffins for her friends with four more. She sells the remainder at the local farmers' market daily for two dollars per fresh duck egg. We want to know how much she makes every day at the farmers' market. First subtract eaten and baked eggs from the daily lay, then multiply the leftover count by the per-egg price. ",
+    # 1: robe bolts
+    "A robe takes two bolts of blue fiber and half that much white fiber. The bolts are purchased separately from two different mills, each with its own shipping schedule. We need the total number of bolts required to make a single robe for one customer at the shop. Half of two bolts is one bolt of white fiber, and that amount is added to the original two bolts of blue. ",
+    # 2: house flip profit
+    "Josh buys a run-down property for eighty thousand dollars and then spends fifty thousand more on repairs. The renovation increases the value of the house by one hundred and fifty percent over the original purchase price. We want the profit after selling at the appreciated market price. Compute the new value using the percentage increase, then subtract the purchase price and the repair cost to find the net profit. ",
+]
+
+
+def build_prompt(tokenizer, target_tokens: int, seed: int) -> str:
+    """Replicates kiln-bench's build_prompt for PROMPT_POOL[seed%30]."""
+    base = BASE_PROMPTS[seed % len(BASE_PROMPTS)]
+    prompt = ""
+    while True:
+        prompt += base
+        tokens = tokenizer(prompt, add_special_tokens=False)["input_ids"]
+        if len(tokens) >= target_tokens:
+            # Trim by cutting at ". " boundaries, matching kiln-bench
+            while len(tokenizer(prompt, add_special_tokens=False)["input_ids"]) > target_tokens:
+                pos = prompt.rfind(". ")
+                if pos == -1:
+                    break
+                prompt = prompt[: pos + 1]
+            return prompt
+
+
+def try_load_llm(model_path: str, num_spec_tokens: int):
+    """Load vLLM with Qwen3-Next MTP speculative config.
+
+    Tries multiple config shapes across vLLM versions (the API moved from
+    SpeculativeConfig-dict to speculative_config-dict between 0.6 and 0.7).
+    Returns the `LLM` or raises RuntimeError.
+    """
+    from vllm import LLM  # noqa: WPS433  import here so try_load_llm's caller can catch ImportError
+
+    errors = []
+    attempts = [
+        # vLLM >= 0.18 native Qwen3.5 MTP head (Qwen3_5MTP arch in registry)
+        dict(
+            speculative_config={
+                "method": "qwen3_5_mtp",
+                "num_speculative_tokens": num_spec_tokens,
+            },
+        ),
+        # Auto-dispatch: vllm.config.speculative rewrites model_type "qwen3_5"
+        # → "qwen3_5_mtp" when method is "mtp" (lines 323-330 in 0.19.1)
+        dict(
+            speculative_config={
+                "method": "mtp",
+                "num_speculative_tokens": num_spec_tokens,
+            },
+        ),
+        # Fallback: Qwen3-Next MTP method name (older API alias)
+        dict(
+            speculative_config={
+                "method": "qwen3_next_mtp",
+                "num_speculative_tokens": num_spec_tokens,
+            },
+        ),
+    ]
+    # Qwen3.5-4B is `Qwen3_5ForConditionalGeneration` (multimodal: text + vision).
+    # vLLM 0.19.1 segfaults during encoder cache profile_run when MTP speculative
+    # decoding is combined with the default image/video MM profiling step (the
+    # crash signature is "!!!!!!! Segfault encountered !!!!!!!" right after
+    # "Encoder cache will be initialized with a budget of 16384 tokens..."). We
+    # work around it by:
+    #   (1) limit_mm_per_prompt={"image": 0, "video": 0} to skip MM dummy profile
+    #   (2) enforce_eager=True to bypass CUDA graph capture path that is the
+    #       most common segfault source for this MTP-on-multimodal combo
+    base = dict(
+        model=model_path,
+        dtype="bfloat16",
+        gpu_memory_utilization=0.85,
+        max_model_len=1024,
+        disable_log_stats=False,
+        enforce_eager=True,
+        limit_mm_per_prompt={"image": 0, "video": 0},
+        skip_mm_profiling=True,
+    )
+
+    for kwargs in attempts:
+        try:
+            llm = LLM(**base, **kwargs)
+            return llm, {**{"_base": "enforce_eager+no-mm"}, **kwargs}
+        except (TypeError, ValueError) as e:
+            # Older vLLM may not accept skip_mm_profiling — drop it and retry
+            if "skip_mm_profiling" in str(e):
+                base2 = {k: v for k, v in base.items() if k != "skip_mm_profiling"}
+                try:
+                    llm = LLM(**base2, **kwargs)
+                    return llm, {**{"_base": "enforce_eager+no-mm-no-skipprofile"}, **kwargs}
+                except Exception as e2:
+                    errors.append(f"kwargs={kwargs!r}: {type(e2).__name__}: {e2}")
+                    continue
+            errors.append(f"kwargs={kwargs!r}: {type(e).__name__}: {e}")
+        except Exception as e:
+            errors.append(f"kwargs={kwargs!r}: {type(e).__name__}: {e}")
+    raise RuntimeError("vLLM failed to load with any MTP speculative config; tried:\n  " + "\n  ".join(errors))
+
+
+def extract_alpha(outputs, llm) -> dict:
+    """Pull accepted/proposed counts from whatever vLLM version is installed.
+
+    Returns {accepted: int, proposed: int, source: str, detail: dict} or
+    raises RuntimeError if no stats source is available.
+    """
+    # Strategy 1: RequestOutput.metrics → spec_decode_* fields
+    accepted = 0
+    proposed = 0
+    detail = {}
+    for out in outputs:
+        metrics = getattr(out, "metrics", None)
+        if metrics is None:
+            continue
+        a = (
+            getattr(metrics, "num_accepted_tokens", None)
+            or getattr(metrics, "spec_accepted_tokens", None)
+            or getattr(metrics, "accepted_tokens", None)
+        )
+        p = (
+            getattr(metrics, "num_proposal_tokens", None)
+            or getattr(metrics, "num_draft_tokens", None)
+            or getattr(metrics, "spec_draft_tokens", None)
+            or getattr(metrics, "proposal_tokens", None)
+        )
+        if a is not None and p is not None:
+            accepted += int(a)
+            proposed += int(p)
+    if proposed > 0:
+        return {
+            "accepted": accepted,
+            "proposed": proposed,
+            "source": "RequestOutput.metrics",
+            "detail": detail,
+        }
+
+    # Strategy 2: engine-level stat loggers
+    engine = getattr(llm, "llm_engine", None) or getattr(llm, "engine", None)
+    if engine is not None:
+        try:
+            stats = engine.get_stats() if hasattr(engine, "get_stats") else None
+            if stats is not None:
+                a = (
+                    getattr(stats, "num_accepted_tokens", None)
+                    or getattr(stats, "spec_decoding_stats", {}).get("num_accepted_tokens", None)
+                )
+                p = (
+                    getattr(stats, "num_draft_tokens", None)
+                    or getattr(stats, "spec_decoding_stats", {}).get("num_draft_tokens", None)
+                )
+                if a is not None and p is not None and int(p) > 0:
+                    return {
+                        "accepted": int(a),
+                        "proposed": int(p),
+                        "source": "engine.get_stats()",
+                        "detail": {"stats_repr": repr(stats)[:200]},
+                    }
+        except Exception as e:
+            detail["get_stats_err"] = f"{type(e).__name__}: {e}"
+
+    # Strategy 3: stat_loggers attribute
+    engine = engine or getattr(llm, "llm_engine", None)
+    if engine is not None:
+        stat_loggers = (
+            getattr(engine, "stat_loggers", None)
+            or getattr(engine, "_stat_loggers", None)
+            or {}
+        )
+        # Prometheus logger usually has a `spec_decode_metrics` attribute
+        for key, logger in (stat_loggers.items() if hasattr(stat_loggers, "items") else []):
+            for attr in ("spec_decoding_metrics", "spec_decode_metrics"):
+                metrics = getattr(logger, attr, None)
+                if metrics is None:
+                    continue
+                a = getattr(metrics, "num_accepted_tokens", None) or getattr(metrics, "accepted_tokens", None)
+                p = getattr(metrics, "num_draft_tokens", None) or getattr(metrics, "proposed_tokens", None)
+                if a is not None and p is not None and int(p) > 0:
+                    return {
+                        "accepted": int(a),
+                        "proposed": int(p),
+                        "source": f"stat_loggers[{key}].{attr}",
+                        "detail": {},
+                    }
+
+    raise RuntimeError(
+        "could not extract MTP α from vLLM outputs — tried RequestOutput.metrics, "
+        "engine.get_stats(), and stat_loggers. Inspect the installed vLLM version "
+        "and add a new extractor."
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-path", default="/workspace/qwen3.5-4b")
+    ap.add_argument("--prompt-tokens", type=int, default=512)
+    ap.add_argument("--max-tokens", type=int, default=16)
+    ap.add_argument("--seeds", nargs="+", type=int, default=[0, 1, 2])
+    ap.add_argument("--num-spec-tokens", type=int, default=1)
+    ap.add_argument(
+        "--out",
+        default="docs/phase-c29-v3-vllm/vllm_alpha_per_seed.json",
+    )
+    args = ap.parse_args()
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Build prompts first — needs tokenizer only, no vLLM GPU.
+    try:
+        from transformers import AutoTokenizer
+    except ImportError as e:
+        failure = {
+            "mtp_supported": False,
+            "reason": f"transformers not installed: {e}",
+        }
+        out_path.write_text(json.dumps(failure, indent=2))
+        print(json.dumps(failure, indent=2))
+        return 2
+
+    print(f"[h15c_vllm] loading tokenizer from {args.model_path}", file=sys.stderr)
+    tok = AutoTokenizer.from_pretrained(args.model_path)
+    prompts = [build_prompt(tok, args.prompt_tokens, s) for s in args.seeds]
+    for i, p in enumerate(prompts):
+        n = len(tok(p, add_special_tokens=False)["input_ids"])
+        print(f"[h15c_vllm] seed={args.seeds[i]} prompt_tokens={n} prompt_prefix={p[:80]!r}", file=sys.stderr)
+
+    # Load vLLM with MTP spec decoding
+    try:
+        llm, used_kwargs = try_load_llm(args.model_path, args.num_spec_tokens)
+    except (ImportError, RuntimeError) as e:
+        failure = {
+            "mtp_supported": False,
+            "reason": f"vLLM failed to load Qwen3.5-4B with MTP speculative config: {e}",
+            "traceback": traceback.format_exc(limit=3),
+        }
+        out_path.write_text(json.dumps(failure, indent=2))
+        print(json.dumps(failure, indent=2), file=sys.stderr)
+        return 3
+
+    print(f"[h15c_vllm] vLLM loaded with kwargs={used_kwargs!r}", file=sys.stderr)
+
+    # Also import SamplingParams, which lives at top-level
+    from vllm import SamplingParams
+
+    per_seed = []
+    alphas = []
+    total_start = time.perf_counter()
+
+    for seed, prompt in zip(args.seeds, prompts):
+        sp = SamplingParams(
+            temperature=0.0,
+            top_p=1.0,
+            top_k=-1,
+            max_tokens=args.max_tokens,
+            seed=seed,
+        )
+        t0 = time.perf_counter()
+        outs = llm.generate([prompt], sp)
+        dt = time.perf_counter() - t0
+        try:
+            stats = extract_alpha(outs, llm)
+        except RuntimeError as e:
+            stats = {"accepted": 0, "proposed": 0, "source": "UNAVAILABLE", "error": str(e)}
+        alpha = stats["accepted"] / stats["proposed"] if stats["proposed"] > 0 else 0.0
+        generated_text = outs[0].outputs[0].text[:120] if outs else ""
+        per_seed.append({
+            "seed": seed,
+            "alpha": alpha,
+            "n_accepted": stats["accepted"],
+            "n_proposed": stats["proposed"],
+            "elapsed_s": dt,
+            "stats_source": stats.get("source", "UNAVAILABLE"),
+            "generated_head": generated_text,
+        })
+        alphas.append(alpha)
+        print(f"[h15c_vllm] seed={seed} α={alpha:.4f} accepted={stats['accepted']} proposed={stats['proposed']} source={stats.get('source')} dt={dt:.2f}s", file=sys.stderr)
+
+    total_dt = time.perf_counter() - total_start
+
+    import statistics
+    result = {
+        "mtp_supported": any(s["n_proposed"] > 0 for s in per_seed),
+        "per_seed": per_seed,
+        "median_alpha": statistics.median(alphas) if alphas else 0.0,
+        "mean_alpha": statistics.mean(alphas) if alphas else 0.0,
+        "min_alpha": min(alphas) if alphas else 0.0,
+        "max_alpha": max(alphas) if alphas else 0.0,
+        "n_seeds": len(alphas),
+        "vllm_config": {
+            "model_path": args.model_path,
+            "dtype": "bfloat16",
+            "prompt_tokens": args.prompt_tokens,
+            "max_tokens": args.max_tokens,
+            "num_spec_tokens": args.num_spec_tokens,
+            "sampling": {"temperature": 0.0, "top_p": 1.0, "top_k": -1},
+            "used_kwargs": {k: repr(v) for k, v in used_kwargs.items()},
+        },
+        "total_elapsed_s": total_dt,
+    }
+    out_path.write_text(json.dumps(result, indent=2))
+    print(json.dumps(result, indent=2))
+    return 0 if result["mtp_supported"] else 4
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Executes the queued next action from PR #529 §"Queued next action" (verdict `kiln_native_ceiling`): run vLLM with native Qwen3.5-MTP on the *identical* prompt / seed / prefill / decode workload PR #529 used and apply the pre-registered decision rule.

## Verdict: `vllm_mtp_unsupported`

vLLM 0.19.1 segfaults during V1 engine init when loading Qwen3.5-4B with native MTP speculative decoding on A6000, post drafter weight load. All three method aliases (`qwen3_5_mtp` / `mtp` / `qwen3_next_mtp` — vLLM rewrites the first and third to internal `mtp` per `vllm/config/speculative.py:323-330`) reach the same crash point and produce identical native-extension backtraces with no Python file symbols. The vLLM model-dispatch path is correct: `Qwen3_5MTP` is in the registry, drafter weights load (~8.21 GiB, ~3.5 s), tied embed/lm_head attach via `eagle.py:1377/1433`. The crash is downstream of dispatch.

| field | value |
| --- | --- |
| `verdict` | **`vllm_mtp_unsupported`** |
| `kiln_median_alpha` (re-derived from PR #529 c1_attr CSVs) | **0.3636** (4/11, 4/12, 5/11 across seeds 0/1/2) |
| `vllm_median_alpha` | **UNAVAILABLE** (segfault on every attempt) |
| `delta` | UNAVAILABLE |

Workarounds that all DID take effect but did NOT prevent the crash:
- `enforce_eager=True` (CUDA graphs off, vLLM logs "Cudagraph is disabled")
- `limit_mm_per_prompt={image:0,video:0}` + `skip_mm_profiling=True` (vLLM logs "running in text-only mode")
- `max_model_len=1024`, `gpu_memory_utilization=0.85` (no OOM signal)

Per the pre-registered decision rule (set BEFORE the run, see [`scripts/h15c_compare.py`](scripts/h15c_compare.py)), `mtp_supported == false` maps to the `vllm_mtp_unsupported` branch — ship as a doc-only redirect PR, queue next H from PR #527.

## Pre-registered decision rule

| Δ = vllm_α − kiln_α | verdict | next action |
| --- | --- | --- |
| ≥ +0.05 | `external_ceiling_exists` | queue serving-difference bisect |
| in [−0.02, +0.05) | `mtp_head_quality_ceiling` | accept α as upper-bounded by checkpoint quality; deprioritize MTP-side α work |
| < −0.02 | `kiln_above_vllm` (unexpected) | sanity-check vLLM args |
| `vllm.mtp_supported == false` | **`vllm_mtp_unsupported`** ← THIS RUN | doc-only redirect; queue next H from PR #527 |

## Workload (matched to PR #529 byte-for-byte at prefill boundary)

- Model: Qwen3.5-4B (`Qwen3_5ForConditionalGeneration`, `model_type=qwen3_5`)
- Prompts: `PROMPT_POOL[seed % 30]` for seeds {0,1,2} → GSM8K prose 0/1/2
- Prefill 512 tokens (actual: 494 / 508 / 501 — exactly matches PR #529's `c1_attr_seed{0,1,2}.csv` `base_pos` start values)
- Decode 16 tokens, greedy (T=0, top_p=1, top_k=-1)
- Spec: k=1 native MTP, no chat template
- GPU: NVIDIA RTX A6000 sm_86, single-GPU bs=1
- kiln quant: Marlin W4A16 ; vLLM quant: BF16 (acknowledged confounder — vLLM 0.19.1 has no Marlin path for `Qwen3_5MTP`. Since H15c is establishing an *upper bound*, BF16 is at worst pessimistic for the upper-bound question.)

## Crash signature

All three method aliases reach the same point:

1. Tokenizer + multimodal config loaded (`Resolved architecture: Qwen3_5ForConditionalGeneration`)
2. `attention block size to 528 tokens` calibrated against mamba page size
3. `running in text-only mode` confirms MM workaround took effect
4. EngineCore worker boots, target model loads (~8 GiB, ~3 s)
5. Drafter MTP weights load (`Detected MTP model. Sharing target model embedding/lm_head weights with the draft model.`)
6. `gpu_model_runner.py:4820 Model loading took 8.21 GiB memory and 3.5 seconds`
7. **`!!!!!!! Segfault encountered !!!!!!!`** — 70-frame native backtrace (`THPFunction_apply` / `_PyEval_EvalFrameDefault`), no Python file symbols (compiled-extension crash inside an autograd function)

Full evidence: `docs/phase-c29-v3-vllm/artifacts/vllm_segfault_evidence.log` (3 attempts × ~13 lines each, EngineCore PIDs 4722 / 5122 / 5502).

## Anti-duplication evidence

```
$ gh pr list -R ericflo/kiln --state all --search "vllm alpha microbench"
(empty)
$ gh pr list -R ericflo/kiln --state all --search "h15c vllm"
(empty)
$ gh pr list -R ericflo/kiln --state all --search "H15c"
(empty)
$ gh pr list -R ericflo/kiln --state all --search "qwen3_next_mtp vllm"
527  phase7: MTP acceptance-rate state-of-play audit (doc-only)         MERGED
245  mtp: native MTP speculative decode step + h_prev wiring (WIP)      MERGED
```

PR #527 explicitly queued this H15c microbench in its "Recommended next H" section, and PR #529 re-confirmed it as the next action under its `kiln_native_ceiling` verdict. PR #525 (vLLM Triton GDN audit, doc-only) is scope-distinct (kernel audit, not α microbench).

## What this rules out / does not rule out

**Rules out:**
- vLLM 0.19.1 cannot serve Qwen3.5-4B + native MTP on A6000 today. Any Phase 7 plan that assumes "we can compare against vLLM α as the upper bound" needs to either (a) wait for a vLLM patch, (b) try a different version / nightly, (c) try a different external serving system (SGLang has no MTP for Qwen3.5 either as of PR #526), or (d) accept that the upper bound has to come from a hand-rolled HF transformers reference.
- The vLLM-side method dispatch is correct (`Qwen3_5MTP` arch, `qwen3_5_mtp → mtp` rewrite, drafter weights attach with tied embed/lm_head). The bug is downstream of dispatch.

**Does NOT rule out:**
- Whether an external α ceiling exists. With vLLM blocked the question stays open.
- Workload sensitivity (chat α ≈ 0.588 vs prose α ≈ 0.175 in PR #364).
- Quantization path differences (kiln Marlin W4A16 vs eventual reference BF16).

## Bench envelope + cost

- Pod: RunPod A6000 (`wl4oh30qxnzyqz`), $0.49/hr on-demand, no spot.
- Pool acquire: HTTP 503 `capacity_supply_exhausted` on hibernated pods → fell back to direct `runpod_api.py launch` (per documented fallback path for "pool at cap").
- vLLM 0.19.1 install: ~1.5 min, supervised by `runpod_api.py bg + wait-file --timeout` (no SSH polling loops, per `kiln-ssh-polling-deadlock` note).
- 3 attempts × ~30 s each (load + segfault), one process run.
- Total spend: ~$0.13. Wall-clock: ~30 min. Both well under the 90 min / $40 hard cap.

## Queued next action

Per the rule: doc-only redirect; queue next H from PR #527 §"Queued next action". Concrete options the next planning cycle should pick from:

1. **Build a hand-rolled HF transformers reference α** — closes the external-upper-bound question without depending on a vLLM patch.
2. **Wait for a vLLM patch and re-run `scripts/h15c_*` exactly as-is** — the driver and compare are version-agnostic; only the artifacts re-generate.
3. **Refocus Phase 7 onto non-α decode-path wins** — PR #521 (prefix-cache + CUDA graphs) landed, PR #526 (SGLang RadixAttention) audit queued.
4. **Switch to SGLang or another OSS server** — SGLang doesn't yet support Qwen3.5 MTP either (per PR #526), so this option waits on the SGLang side too.

## Reproduction

```bash
cd /workspace/kiln

# 1. vLLM α (segfaults at vLLM 0.19.1 — re-run when patched)
python3 scripts/h15c_vllm_alpha_dump.py \
    --model-path /workspace/qwen3.5-4b \
    --prompt-tokens 512 --max-tokens 16 \
    --seeds 0 1 2 --num-spec-tokens 1

# 2. kiln α (no GPU needed)
python3 scripts/h15c_kiln_alpha_from_csv.py

# 3. Apply decision rule
python3 scripts/h15c_compare.py
```

## Files

| path | purpose |
| --- | --- |
| `docs/phase7-h15c-vllm-alpha-microbench.md` | full audit doc |
| `docs/phase-c29-v3-vllm/verdict.json` | machine-readable verdict |
| `docs/phase-c29-v3-vllm/compare.{json,md}` | full kiln + vllm side-by-side |
| `docs/phase-c29-v3-vllm/{kiln,vllm}_alpha_per_seed.json` | inputs to compare |
| `docs/phase-c29-v3-vllm/artifacts/vllm_segfault_evidence.log` | trimmed pod log of all 3 segfaults |
| `scripts/h15c_kiln_alpha_from_csv.py` | derives kiln α from PR #529 CSVs |
| `scripts/h15c_vllm_alpha_dump.py` | vLLM driver (re-runnable when vLLM is fixed) |
| `scripts/h15c_compare.py` | applies decision rule, emits verdict.json |
| `PROFILING.md` | top-of-file pointer added |