### PR TITLE
phase 7: H17 SGLang α microbench against kiln on Qwen3.5-4B + native MTP

### DIFF
--- a/PROFILING.md
+++ b/PROFILING.md
@@ -1,5 +1,51 @@
 # Kiln Profiling Report
 
+## Phase 7 H17 SGLang α microbench (2026-04-25)
+
+**Verdict: `sglang_mtp_unsupported_dense_4b`.** SGLang 0.5.10.post1 +
+Qwen3.5-4B dense BF16 + native MTP segfaults on A6000 sm_86 across three
+distinct serving configurations. All three attempts produced SIGSEGV
+(exit code -11) in native-extension code with no Python file symbols at
+the terminal frame — identical high-level shape to PR #530's vLLM 0.19.1
+failure class. The crash frames are structurally distinct per config:
+(1) default flashinfer + CUDA graphs: segfault during
+`flashinfer_backend.call_begin_forward` -> `eagle_info.py:188
+generate_attn_arg_prefill` -> Triton JIT compile (graph capture);
+(2) flashinfer graphs-off: scheduler SIGSEGV during init, before reaching
+prefill, also on retry with `speculative_algorithm=NEXTN` (auto-rewrites
+to EAGLE); (3) triton attention graphs-off: engine loaded successfully
+(8.62 GB target + 1.41 GB drafter, KV + mamba cache allocated, hybrid GDN
+dispatched via TritonGDNKernel), scheduler entered event loop, then
+SIGSEGV fired during `write_cache_indices` Triton JIT compile inside
+`alloc_for_extend` on the first prefill. Engine-side dispatch is correct
+throughout — the bug is downstream of model dispatch in each attempt.
+Per the pre-registered decision rule this maps to branch D
+(`sglang.mtp_supported == false`) — ship as a doc-only redirect PR.
+Newly documented SGLang runtime prerequisites (beyond PR #531's static
+audit): `libnuma1` + `libnuma-dev` apt packages (sgl_kernel dlopens
+libnuma.so.1), `SGLANG_ENABLE_SPEC_V2=1` env var,
+`mamba_scheduler_strategy='extra_buffer'`,
+`speculative_algorithm='EAGLE'` (SGLang enum has no `MTP`; `NEXTN`
+rewrites to EAGLE), `speculative_eagle_topk` required as int. Per PR
+#531 §"Bench envelope", the free pre-step vLLM v0.20.0 retest was
+SKIPPED — SGLang diagnostic attempts consumed ~35 min of the 75 min
+combined cap (pod: ~25 min / ~$0.20, well under $0.40 SGLang cap). Kiln
+median α at this workload (unchanged from PR #530, re-derived from PR
+#529 c1_attr CSVs): 0.3636. With both vLLM 0.19.1 AND SGLang 0.5.10.post1
+blocked, the external-α-reference question remains open — next options:
+opportunistic vLLM v0.20.0 retest (~30 min / $0.25), hand-rolled HF
+transformers reference H18 (~2-4 hrs engineering, $0 GPU), or accept the
+H15b `kiln_native_ceiling` verdict as operational conclusion and
+deprioritize MTP-side α work entirely. See
+[`docs/phase7-h17-sglang-alpha-microbench.md`](docs/phase7-h17-sglang-alpha-microbench.md)
+for the full verdict, three crash signatures, per-config outcome table,
+SGLang prerequisites discovered, workload matching, reproduction
+commands, anti-duplication evidence, and detailed reopen triggers. Raw
+data:
+`docs/phase-c29-v3-sglang/{verdict,compare,kiln_alpha_per_seed,sglang_alpha_per_seed}.json`,
+`docs/phase-c29-v3-sglang/compare.md`, and
+`docs/phase-c29-v3-sglang/artifacts/sglang_segfault_evidence.log`.
+
 ## Phase 7 H16 external-α reference options audit (2026-04-25)
 
 **Verdict: `external_reference_exists`.** Doc-only audit (no pod, $0 GPU

--- a/docs/phase-c29-v3-sglang/artifacts/sglang_segfault_evidence.log
+++ b/docs/phase-c29-v3-sglang/artifacts/sglang_segfault_evidence.log
@@ -1,0 +1,120 @@
+Max running requests is reset to 48 for speculative decoding. You can override this by explicitly setting --max-running-requests.
+Spec v2 is enabled for eagle/eagle3 speculative decoding and overlap schedule is turned on.
+speculative_num_draft_tokens is adjusted to speculative_num_steps + 1 when speculative_eagle_topk == 1
+[2026-04-25 02:01:07] Using default HuggingFace chat template with detected content format: openai
+[2026-04-25 02:01:14] Init torch distributed begin.
+[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
+[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
+[Gloo] Rank 0 is connected to 0 peer ranks. Expected number of connected peer ranks is : 0
+[2026-04-25 02:01:14] Init torch distributed ends. elapsed=0.27 s, mem usage=0.04 GB
+[2026-04-25 02:01:14] Load weight begin. avail mem=47.20 GB
+[2026-04-25 02:01:14] Multimodal attention backend not set. Use triton_attn.
+[2026-04-25 02:01:14] Using triton_attn as multimodal attention backend.
+`torch_dtype` is deprecated! Use `dtype` instead!
+[2026-04-25 02:01:14] using attn output gate!
+Multi-thread loading shards:   0% Completed | 0/2 [00:00<?, ?it/s]Multi-thread loading shards:  50% Completed | 1/2 [00:00<00:00,  1.23it/s]Multi-thread loading shards: 100% Completed | 2/2 [00:02<00:00,  1.15s/it]Multi-thread loading shards: 100% Completed | 2/2 [00:02<00:00,  1.10s/it]
+[2026-04-25 02:01:17] Load weight end. elapsed=2.67 s, type=Qwen3_5ForConditionalGeneration, avail mem=38.58 GB, mem usage=8.62 GB.
+[2026-04-25 02:01:17] Using KV cache dtype: torch.bfloat16
+[2026-04-25 02:01:17] Mamba Cache is allocated. max_mamba_cache_size: 265, conv_state size: 0.29GB, ssm_state size: 12.47GB intermediate_ssm_state_cache size: 4.59GB intermediate_conv_window_cache size: 0.11GB 
+[2026-04-25 02:01:17] KV Cache is allocated. #tokens: 464641, K size: 7.09 GB, V size: 7.09 GB
+[2026-04-25 02:01:17] Memory pool end. avail mem=6.93 GB
+[2026-04-25 02:01:17] Linear attention kernel backend: decode=triton, prefill=triton
+[2026-04-25 02:01:17] Using hybrid linear attention backend for hybrid GDN models.
+[2026-04-25 02:01:17] GDN kernel dispatcher: decode=TritonGDNKernel, extend=TritonGDNKernel, verify=TritonGDNKernel packed_decode=True
+[2026-04-25 02:01:17] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
+[2026-04-25 02:01:19] Init torch distributed begin.
+[2026-04-25 02:01:19] Init torch distributed ends. elapsed=0.00 s, mem usage=0.00 GB
+[2026-04-25 02:01:19] Load weight begin. avail mem=6.91 GB
+Multi-thread loading shards:   0% Completed | 0/2 [00:00<?, ?it/s]Multi-thread loading shards: 100% Completed | 2/2 [00:00<00:00, 22.99it/s]
+[2026-04-25 02:01:19] Load weight end. elapsed=0.11 s, type=Qwen3_5ForCausalLMMTP, avail mem=5.50 GB, mem usage=1.41 GB.
+[2026-04-25 02:01:19] Using KV cache dtype: torch.bfloat16
+[2026-04-25 02:01:20] KV Cache is allocated. #tokens: 464641, K size: 0.89 GB, V size: 0.89 GB
+[2026-04-25 02:01:20] Memory pool end. avail mem=3.73 GB
+[2026-04-25 02:01:20] Linear attention kernel backend: decode=triton, prefill=triton
+[2026-04-25 02:01:20] Using hybrid linear attention backend for hybrid GDN models.
+[2026-04-25 02:01:20] GDN kernel dispatcher: decode=TritonGDNKernel, extend=TritonGDNKernel, verify=TritonGDNKernel packed_decode=True
+[2026-04-25 02:01:20] Disable piecewise CUDA graph because --disable-piecewise-cuda-graph is set
+[2026-04-25 02:01:22] max_total_num_tokens=464641, chunked_prefill_size=4096, max_prefill_tokens=16384, max_running_requests=48, context_len=1024, available_gpu_mem=4.91 GB
+[h17_sglang] SGLang loaded with kwargs={'_base': 'trust_remote_code+bf16', 'speculative_algorithm': 'EAGLE', 'speculative_num_draft_tokens': 1, 'speculative_num_steps': 1, 'speculative_eagle_topk': 1}
+Fatal Python error: Segmentation fault
+
+Thread 0x00007f9c1ffff640 (most recent call first):
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/utils/watchdog.py", line 147 in _watchdog_once
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/utils/watchdog.py", line 127 in _watchdog_thread
+  File "/usr/lib/python3.11/threading.py", line 975 in run
+  File "/usr/lib/python3.11/threading.py", line 1038 in _bootstrap_inner
+  File "/usr/lib/python3.11/threading.py", line 995 in _bootstrap
+
+Thread 0x00007f9c07fff640 (most recent call first):
+  File "/usr/lib/python3.11/threading.py", line 324 in wait
+  File "/usr/lib/python3.11/threading.py", line 622 in wait
+  File "/usr/local/lib/python3.11/dist-packages/tqdm/_monitor.py", line 60 in run
+  File "/usr/lib/python3.11/threading.py", line 1038 in _bootstrap_inner
+  File "/usr/lib/python3.11/threading.py", line 995 in _bootstrap
+
+Current thread 0x00007fa40889a000 (most recent call first):
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 316 in __init__
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 1306 in call_JitFunction
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 1338 in call_Function
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 1404 in visit_Call
+  File "/usr/lib/python3.11/ast.py", line 410 in visit
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 1519 in visit
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 696 in visit_Assign
+  File "/usr/lib/python3.11/ast.py", line 410 in visit
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 1519 in visit
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 516 in visit_compound_statement
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 619 in visit_FunctionDef
+  File "/usr/lib/python3.11/ast.py", line 410 in visit
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 1519 in visit
+  File "/usr/lib/python3.11/ast.py", line 418 in generic_visit
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 523 in visit_Module
+  File "/usr/lib/python3.11/ast.py", line 410 in visit
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 1519 in visit
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/code_generator.py", line 1606 in ast_to_ttir
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/compiler.py", line 80 in make_ir
+  File "/usr/local/lib/python3.11/dist-packages/triton/compiler/compiler.py", line 300 in compile
+  File "/usr/local/lib/python3.11/dist-packages/triton/runtime/jit.py", line 861 in _do_compile
+  File "/usr/local/lib/python3.11/dist-packages/triton/runtime/jit.py", line 733 in run
+  File "/usr/local/lib/python3.11/dist-packages/triton/runtime/jit.py", line 419 in <lambda>
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/mem_cache/common.py", line 98 in write_cache_indices
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/mem_cache/common.py", line 377 in alloc_for_extend
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/managers/schedule_batch.py", line 1615 in prepare_for_extend
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/managers/scheduler.py", line 2518 in _get_new_batch_prefill_raw
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/managers/scheduler.py", line 2315 in get_new_batch_prefill
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/managers/scheduler.py", line 2248 in get_next_batch_to_run
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/managers/scheduler.py", line 1350 in event_loop_overlap
+  File "/usr/local/lib/python3.11/dist-packages/torch/utils/_contextlib.py", line 120 in decorate_context
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/managers/scheduler.py", line 3497 in dispatch_event_loop
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/managers/scheduler.py", line 1300 in run_event_loop
+  File "/usr/local/lib/python3.11/dist-packages/sglang/srt/managers/scheduler.py", line 3616 in run_scheduler_process
+  File "/usr/lib/python3.11/multiprocessing/process.py", line 108 in run
+  File "/usr/lib/python3.11/multiprocessing/process.py", line 314 in _bootstrap
+  File "/usr/lib/python3.11/multiprocessing/spawn.py", line 133 in _main
+  File "/usr/lib/python3.11/multiprocessing/spawn.py", line 120 in spawn_main
+  File "<string>", line 1 in <module>
+
+!!!!!!! Segfault encountered !!!!!!!
+  File "<unknown>", line 0, in pthread_kill
+  File "<unknown>", line 0, in raise
+  File "<unknown>", line 0, in _PyEval_EvalFrameDefault
+  File "<unknown>", line 0, in _PyFunction_Vectorcall
+  File "<unknown>", line 0, in _PyObject_FastCallDictTstate
+  File "<unknown>", line 0, in _PyObject_MakeTpCall
+  File "<unknown>", line 0, in _PyEval_EvalFrameDefault
+  File "<unknown>", line 0, in PyObject_Call
+  File "<unknown>", line 0, in _PyEval_EvalFrameDefault
+  File "<unknown>", line 0, in _PyFunction_Vectorcall
+  File "<unknown>", line 0, in _PyEval_EvalFrameDefault
+  File "<unknown>", line 0, in _PyFunction_Vectorcall
+  File "<unknown>", line 0, in _PyEval_EvalFrameDefault
+  File "<unknown>", line 0, in PyEval_EvalCode
+  File "<unknown>", line 0, in PyRun_StringFlags
+  File "<unknown>", line 0, in PyRun_SimpleStringFlags
+  File "<unknown>", line 0, in Py_RunMain
+  File "<unknown>", line 0, in Py_BytesMain
+  File "<unknown>", line 0, in _start
+
+[2026-04-25 02:01:26] Subprocess scheduler_0 (pid=7391) crashed with exit code -11. Triggering SIGQUIT for cleanup...
+[2026-04-25 02:01:26] SIGQUIT received. signum=None, frame=None. It usually means one child failed.
+bash: line 1:  7231 Killed                  python3 scripts/h17_sglang_alpha_dump.py --model-path /workspace/qwen3.5-4b --prompt-tokens 512 --max-tokens 16 --seeds 0 1 2 --num-spec-tokens 1 --out docs/phase-c29-v3-sglang/sglang_alpha_per_seed.json 2>&1
+EXIT=137

--- a/docs/phase-c29-v3-sglang/compare.json
+++ b/docs/phase-c29-v3-sglang/compare.json
@@ -1,0 +1,191 @@
+{
+  "kiln": {
+    "per_seed": [
+      {
+        "seed": 0,
+        "alpha": 0.36363636363636365,
+        "n_steps": 11,
+        "n_accept": 4
+      },
+      {
+        "seed": 1,
+        "alpha": 0.3333333333333333,
+        "n_steps": 12,
+        "n_accept": 4
+      },
+      {
+        "seed": 2,
+        "alpha": 0.45454545454545453,
+        "n_steps": 11,
+        "n_accept": 5
+      }
+    ],
+    "median_alpha": 0.36363636363636365,
+    "mean_alpha": 0.3838383838383838,
+    "min_alpha": 0.3333333333333333,
+    "max_alpha": 0.45454545454545453,
+    "n_seeds": 3,
+    "source_csvs": [
+      "docs/phase-c29-v2/artifacts/c1_attr_seed0.csv",
+      "docs/phase-c29-v2/artifacts/c1_attr_seed1.csv",
+      "docs/phase-c29-v2/artifacts/c1_attr_seed2.csv"
+    ],
+    "methodology": "alpha_seed = sum(accepted column) / n_rows in c1_attr_seed{N}.csv; median computed across seeds. Source run: PR #529 (scripts/c29_kiln_logits_dump.sh), KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_W4A16=1, greedy (temperature=0), --paged, seeds=[0,1,2] indexing PROMPT_POOL[seed%30] (= GSM8K prose prompts 0,1,2), --prompt-tokens 512, --max-output-tokens 16, no chat template, splice dumps captured at POSITIONS=0..3 \u00d7 MAX_STEPS=2. NOTE: the task brief's 7/22 \u2248 0.318 hint refers to the subset of {accept-labeled, reject-labeled} splice rows used by the H15b C29 v2 top-K probe. This script uses all 11/12/11 rows per seed from the full c1_attr CSV (every speculative_mtp_decode_step call, not only dumped rows)."
+  },
+  "sglang": {
+    "mtp_supported": false,
+    "reason": "SGLang 0.5.10.post1 + Qwen3.5-4B dense BF16 + native MTP segfaults on A6000 sm_86 across three distinct serving configurations. All three attempts produced Segmentation fault / exit code -11 in native-extension code with no Python file symbols at the crash point. This mirrors the vLLM 0.19.1 failure class observed in PR #530 but manifests in different upstream code paths.",
+    "sglang_version": "0.5.10.post1",
+    "sglang_kernel_version": "0.4.1",
+    "torch_version": "2.9.1+cu128",
+    "cuda_runtime": "12.8",
+    "gpu": "NVIDIA RTX A6000 sm_86",
+    "model_path": "/workspace/qwen3.5-4b",
+    "model_arch": "Qwen3_5ForConditionalGeneration",
+    "drafter_arch": "Qwen3_5ForCausalLMMTP",
+    "sglang_prerequisites_discovered": {
+      "libnuma1_apt_package": "required (sgl_kernel common_ops.abi3.so dlopens libnuma.so.1); install with apt-get install -y libnuma1 libnuma-dev after apt-get update. First attempt failed with libnuma.so.1: cannot open shared object file.",
+      "SGLANG_ENABLE_SPEC_V2_env": "=1 required for Qwen3.5 + MTP + radix cache; otherwise server_args raises 'Speculative decoding for Qwen3_5ForConditionalGeneration is not compatible with radix cache when using --mamba-scheduler-strategy no_buffer'",
+      "mamba_scheduler_strategy": "must be 'extra_buffer' (default 'no_buffer' triggers the radix-cache incompatibility error above)"
+    },
+    "speculative_algorithm_resolution": {
+      "MTP_as_requested_in_task": "REJECTED \u2014 SpeculativeAlgorithm.from_string() at sglang/srt/speculative/spec_info.py:31 raises ValueError('Unknown speculative algorithm name: MTP')",
+      "EAGLE_is_modern_alias": "per sglang/srt/speculative/spec_info.py the enum contains exactly {EAGLE, EAGLE3, STANDALONE, NGRAM, NONE}; NEXTN auto-rewrites to EAGLE at server_args.py:2984. Qwen3.5's pretrained MTP head IS loaded as an EAGLE drafter with arch Qwen3_5ForCausalLMMTP (no separate draft_model_path)",
+      "speculative_eagle_topk_required": "must be an int >=1 \u2014 None triggers TypeError: '>' not supported between instances of 'NoneType' and 'int' at server_args.py:1669",
+      "resolved_drafter_arch": "Qwen3_5ForCausalLMMTP (drafter weights loaded from /workspace/qwen3.5-4b, 1.41 GB resident, reuses base model's embedding + lm_head)"
+    },
+    "config_attempts": [
+      {
+        "attempt_num": 1,
+        "description": "Default flashinfer attention backend + CUDA graphs enabled",
+        "kwargs": {
+          "speculative_algorithm": "EAGLE",
+          "speculative_num_draft_tokens": 1,
+          "speculative_num_steps": 1,
+          "speculative_eagle_topk": 1,
+          "disable_cuda_graph": false,
+          "attention_backend": "flashinfer",
+          "mamba_scheduler_strategy": "extra_buffer"
+        },
+        "outcome": "Segfault during init_device_graphs CUDA graph capture in flashinfer begin_forward for EAGLE prefill path",
+        "crash_stack_summary": "cuda_graph_runner.py:981 capture_one_batch_size -> hybrid_linear_attn_backend.py:758 init_forward_metadata_capture_cuda_graph -> flashinfer_backend.py:616 init_forward_metadata_capture_cuda_graph -> flashinfer_backend.py:1257 update_single_wrapper -> flashinfer_backend.py:1448 call_begin_forward -> eagle_info.py:188 generate_attn_arg_prefill -> triton JIT compile crash",
+        "exit_code": "-11 (SIGSEGV) scheduler / 137 parent",
+        "wall_clock_to_crash_s": 49
+      },
+      {
+        "attempt_num": 2,
+        "description": "Graphs disabled, flashinfer kept",
+        "kwargs": {
+          "speculative_algorithm": "EAGLE",
+          "speculative_num_draft_tokens": 1,
+          "speculative_num_steps": 1,
+          "speculative_eagle_topk": 1,
+          "disable_cuda_graph": true,
+          "attention_backend": "flashinfer",
+          "mamba_scheduler_strategy": "extra_buffer"
+        },
+        "outcome": "Scheduler subprocess SIGSEGV during init, before the driver could reach prefill. Also retried with speculative_algorithm='NEXTN' (auto-rewrites to EAGLE), same crash: RuntimeError: 'Rank 0 scheduler died during initialization (exit code: -11)'",
+        "crash_stack_summary": "Scheduler SIGSEGV during init; native backtrace had no Python file symbols",
+        "exit_code": "-11 scheduler / 137 parent",
+        "wall_clock_to_crash_s": 33
+      },
+      {
+        "attempt_num": 3,
+        "description": "Triton attention backend, graphs disabled",
+        "kwargs": {
+          "speculative_algorithm": "EAGLE",
+          "speculative_num_draft_tokens": 1,
+          "speculative_num_steps": 1,
+          "speculative_eagle_topk": 1,
+          "disable_cuda_graph": true,
+          "attention_backend": "triton",
+          "mamba_scheduler_strategy": "extra_buffer"
+        },
+        "outcome": "Engine loaded successfully \u2014 Qwen3_5ForConditionalGeneration target (8.62 GB) and Qwen3_5ForCausalLMMTP drafter (1.41 GB) weights read; hybrid GDN + full-attn dispatched via TritonGDNKernel; KV + mamba cache allocated. Then SIGSEGV fired during scheduler event_loop_overlap -> _get_new_batch_prefill_raw -> prepare_for_extend -> alloc_for_extend -> write_cache_indices -> Triton JIT compile of write_cache_indices kernel. Note: script's sampling_params used top_k=-1 (SGLang convention) which the engine accepted; crash was in mem_cache allocation, not sampling.",
+        "crash_stack_summary": "sglang/srt/mem_cache/common.py:98 write_cache_indices -> triton/runtime/jit.py:419 <lambda> -> triton/runtime/jit.py:861 _do_compile -> triton/compiler/compiler.py:300 compile -> triton/compiler/code_generator.py:316 __init__",
+        "exit_code": "-11 scheduler / 137 parent",
+        "wall_clock_to_crash_s": 33,
+        "engine_load_progress": {
+          "target_model_load_GB": 8.62,
+          "target_model_arch": "Qwen3_5ForConditionalGeneration",
+          "drafter_model_load_GB": 1.41,
+          "drafter_model_arch": "Qwen3_5ForCausalLMMTP",
+          "gdn_kernel_dispatcher": "decode=TritonGDNKernel, extend=TritonGDNKernel, verify=TritonGDNKernel packed_decode=True",
+          "kv_cache_tokens": 464641,
+          "kv_cache_K_GB": 7.09,
+          "kv_cache_V_GB": 7.09,
+          "mamba_cache_max_size": 265,
+          "ssm_state_GB": 12.47,
+          "conv_state_GB": 0.29,
+          "intermediate_ssm_state_cache_GB": 4.59,
+          "intermediate_conv_window_cache_GB": 0.11,
+          "max_total_num_tokens": 464641,
+          "max_running_requests": 48,
+          "available_gpu_mem_after_init_GB": 4.91,
+          "chat_template": "default HuggingFace (openai content format)",
+          "gloo_init_s": 0.27,
+          "target_weight_load_s": 2.67,
+          "drafter_weight_load_s": 0.11
+        }
+      }
+    ],
+    "common_crash_signature": {
+      "marker": "!!!!!!! Segfault encountered !!!!!!!",
+      "python_backtrace_pattern": "70+ frames of pthread_kill / raise / _PyEval_EvalFrameDefault / _PyFunction_Vectorcall / PyObject_Call with no Python file symbols at the crash frame (identical shape to PR #530's vLLM 0.19.1 crash; both indicate compiled-extension crashes in Triton JIT or flashinfer native code)",
+      "sglang_handler_response": "Subprocess scheduler_0 crashed with exit code -11. Triggering SIGQUIT for cleanup... SIGQUIT received. It usually means one child failed."
+    },
+    "workarounds_attempted_but_did_not_help": [
+      "disable_cuda_graph=True (attempt 2 \u2014 scheduler segfaulted during init even with graphs off)",
+      "attention_backend='triton' (attempt 3 \u2014 moved crash from flashinfer eagle_info.generate_attn_arg_prefill to Triton JIT of write_cache_indices in mem_cache allocation; no progress)",
+      "mamba_scheduler_strategy='extra_buffer' (required to pass radix-cache validation but does not prevent segfault)",
+      "speculative_algorithm='NEXTN' (auto-rewrites to EAGLE per server_args.py:2984; identical crash signature)"
+    ],
+    "per_seed": [],
+    "median_alpha": null,
+    "mean_alpha": null,
+    "min_alpha": null,
+    "max_alpha": null,
+    "n_seeds": 0,
+    "sglang_config": {
+      "model_path": "/workspace/qwen3.5-4b",
+      "dtype": "bfloat16",
+      "prompt_tokens": 512,
+      "max_tokens": 16,
+      "num_spec_tokens": 1,
+      "sampling": {
+        "temperature": 0.0,
+        "top_p": 1.0,
+        "top_k": -1
+      },
+      "mem_fraction_static": 0.85,
+      "context_length": 1024
+    }
+  },
+  "vllm_v020": null,
+  "verdict": {
+    "verdict": "sglang_mtp_unsupported_dense_4b",
+    "decision_rule": {
+      "external_ceiling_exists": {
+        "bound": "delta >= +0.05",
+        "next_action": "SGLang MTP heads beat kiln MTP heads at same workload. Queue an H18 serving-difference bisect (sampler / KV layout / quantization path / RoPE / MTP-head wiring) to find what kiln diverges on. Since kiln is Marlin W4A16 and SGLang is BF16 this confounder must be isolated first (re-run kiln in BF16 or port SGLang's quant path)."
+      },
+      "mtp_head_quality_ceiling": {
+        "bound": "-0.02 <= delta < +0.05",
+        "next_action": "Both implementations hit the pretrained MTP head's quality ceiling. No external \u03b1 headroom available from SGLang either. Close the external-\u03b1 reference family. Pivot Phase 7 to: (a) MTP head retraining (H18 candidate), or (b) non-MTP speculative decoding (Eagle-style draft model trained from scratch on kiln logs)."
+      },
+      "kiln_above_sglang": {
+        "bound": "delta < -0.02",
+        "next_action": "Unexpected \u2014 kiln \u03b1 exceeds SGLang at same workload. Sanity-check SGLang args (spec_algorithm, num_draft_tokens, sampler, dtype). If confirmed, no external reference path can help raise \u03b1. Close H17 family and document kiln-native ceiling."
+      },
+      "sglang_mtp_unsupported_dense_4b": {
+        "bound": "sglang_alpha_per_seed.json.mtp_supported == false",
+        "next_action": "SGLang does not yet support Qwen3.5-4B dense + native MTP end-to-end at the installed version. Escalate to free pre-step (vLLM v0.20.0 retest of PR #530 segfault) \u2014 if also fails, queue hand-rolled HF transformers H18 reference (PR #531 candidate 8)."
+      }
+    },
+    "kiln_median_alpha": 0.36363636363636365,
+    "sglang_median_alpha": null,
+    "delta": null,
+    "next_action": "SGLang does not yet support Qwen3.5-4B dense + native MTP end-to-end at the installed version. Escalate to free pre-step (vLLM v0.20.0 retest of PR #530 segfault) \u2014 if also fails, queue hand-rolled HF transformers H18 reference (PR #531 candidate 8).",
+    "reason": "SGLang 0.5.10.post1 + Qwen3.5-4B dense BF16 + native MTP segfaults on A6000 sm_86 across three distinct serving configurations. All three attempts produced Segmentation fault / exit code -11 in native-extension code with no Python file symbols at the crash point. This mirrors the vLLM 0.19.1 failure class observed in PR #530 but manifests in different upstream code paths."
+  }
+}

--- a/docs/phase-c29-v3-sglang/compare.md
+++ b/docs/phase-c29-v3-sglang/compare.md
@@ -1,0 +1,27 @@
+# H17 — SGLang α microbench vs kiln (external-reference upper bound)
+
+**Verdict:** `sglang_mtp_unsupported_dense_4b`
+
+- kiln median α: **0.36363636363636365**
+- SGLang median α: **UNAVAILABLE** (SGLang 0.5.10.post1 + Qwen3.5-4B dense BF16 + native MTP segfaults on A6000 sm_86 across three distinct serving configurations. All three attempts produced Segmentation fault / exit code -11 in native-extension code with no Python file symbols at the crash point. This mirrors the vLLM 0.19.1 failure class observed in PR #530 but manifests in different upstream code paths.)
+
+## Decision rule (pre-registered, from PR #531)
+
+| verdict | bound | next action |
+|---|---|---|
+| `external_ceiling_exists` | `delta >= +0.05` | SGLang MTP heads beat kiln MTP heads at same workload. Queue an H18 serving-difference bisect (sampler / KV layout / quantization path / RoPE / MTP-head wiring) to find what kiln diverges on. Since kiln is Marlin W4A16 and SGLang is BF16 this confounder must be isolated first (re-run kiln in BF16 or port SGLang's quant path). |
+| `mtp_head_quality_ceiling` | `-0.02 <= delta < +0.05` | Both implementations hit the pretrained MTP head's quality ceiling. No external α headroom available from SGLang either. Close the external-α reference family. Pivot Phase 7 to: (a) MTP head retraining (H18 candidate), or (b) non-MTP speculative decoding (Eagle-style draft model trained from scratch on kiln logs). |
+| `kiln_above_sglang` | `delta < -0.02` | Unexpected — kiln α exceeds SGLang at same workload. Sanity-check SGLang args (spec_algorithm, num_draft_tokens, sampler, dtype). If confirmed, no external reference path can help raise α. Close H17 family and document kiln-native ceiling. |
+| `sglang_mtp_unsupported_dense_4b` | `sglang_alpha_per_seed.json.mtp_supported == false` | SGLang does not yet support Qwen3.5-4B dense + native MTP end-to-end at the installed version. Escalate to free pre-step (vLLM v0.20.0 retest of PR #530 segfault) — if also fails, queue hand-rolled HF transformers H18 reference (PR #531 candidate 8). |
+
+## Per-seed table
+
+| seed | kiln α | notes |
+|---|---|---|
+| 0 | 0.3636 | SGLang unavailable |
+| 1 | 0.3333 | SGLang unavailable |
+| 2 | 0.4545 | SGLang unavailable |
+
+## Next action
+
+SGLang does not yet support Qwen3.5-4B dense + native MTP end-to-end at the installed version. Escalate to free pre-step (vLLM v0.20.0 retest of PR #530 segfault) — if also fails, queue hand-rolled HF transformers H18 reference (PR #531 candidate 8).

--- a/docs/phase-c29-v3-sglang/kiln_alpha_per_seed.json
+++ b/docs/phase-c29-v3-sglang/kiln_alpha_per_seed.json
@@ -1,0 +1,33 @@
+{
+  "per_seed": [
+    {
+      "seed": 0,
+      "alpha": 0.36363636363636365,
+      "n_steps": 11,
+      "n_accept": 4
+    },
+    {
+      "seed": 1,
+      "alpha": 0.3333333333333333,
+      "n_steps": 12,
+      "n_accept": 4
+    },
+    {
+      "seed": 2,
+      "alpha": 0.45454545454545453,
+      "n_steps": 11,
+      "n_accept": 5
+    }
+  ],
+  "median_alpha": 0.36363636363636365,
+  "mean_alpha": 0.3838383838383838,
+  "min_alpha": 0.3333333333333333,
+  "max_alpha": 0.45454545454545453,
+  "n_seeds": 3,
+  "source_csvs": [
+    "docs/phase-c29-v2/artifacts/c1_attr_seed0.csv",
+    "docs/phase-c29-v2/artifacts/c1_attr_seed1.csv",
+    "docs/phase-c29-v2/artifacts/c1_attr_seed2.csv"
+  ],
+  "methodology": "alpha_seed = sum(accepted column) / n_rows in c1_attr_seed{N}.csv; median computed across seeds. Source run: PR #529 (scripts/c29_kiln_logits_dump.sh), KILN_SPEC_METHOD=mtp KILN_BENCH_FORCE_MTP=1 KILN_W4A16=1, greedy (temperature=0), --paged, seeds=[0,1,2] indexing PROMPT_POOL[seed%30] (= GSM8K prose prompts 0,1,2), --prompt-tokens 512, --max-output-tokens 16, no chat template, splice dumps captured at POSITIONS=0..3 \u00d7 MAX_STEPS=2. NOTE: the task brief's 7/22 \u2248 0.318 hint refers to the subset of {accept-labeled, reject-labeled} splice rows used by the H15b C29 v2 top-K probe. This script uses all 11/12/11 rows per seed from the full c1_attr CSV (every speculative_mtp_decode_step call, not only dumped rows)."
+}

--- a/docs/phase-c29-v3-sglang/sglang_alpha_per_seed.json
+++ b/docs/phase-c29-v3-sglang/sglang_alpha_per_seed.json
@@ -1,0 +1,125 @@
+{
+  "mtp_supported": false,
+  "reason": "SGLang 0.5.10.post1 + Qwen3.5-4B dense BF16 + native MTP segfaults on A6000 sm_86 across three distinct serving configurations. All three attempts produced Segmentation fault / exit code -11 in native-extension code with no Python file symbols at the crash point. This mirrors the vLLM 0.19.1 failure class observed in PR #530 but manifests in different upstream code paths.",
+  "sglang_version": "0.5.10.post1",
+  "sglang_kernel_version": "0.4.1",
+  "torch_version": "2.9.1+cu128",
+  "cuda_runtime": "12.8",
+  "gpu": "NVIDIA RTX A6000 sm_86",
+  "model_path": "/workspace/qwen3.5-4b",
+  "model_arch": "Qwen3_5ForConditionalGeneration",
+  "drafter_arch": "Qwen3_5ForCausalLMMTP",
+  "sglang_prerequisites_discovered": {
+    "libnuma1_apt_package": "required (sgl_kernel common_ops.abi3.so dlopens libnuma.so.1); install with apt-get install -y libnuma1 libnuma-dev after apt-get update. First attempt failed with libnuma.so.1: cannot open shared object file.",
+    "SGLANG_ENABLE_SPEC_V2_env": "=1 required for Qwen3.5 + MTP + radix cache; otherwise server_args raises 'Speculative decoding for Qwen3_5ForConditionalGeneration is not compatible with radix cache when using --mamba-scheduler-strategy no_buffer'",
+    "mamba_scheduler_strategy": "must be 'extra_buffer' (default 'no_buffer' triggers the radix-cache incompatibility error above)"
+  },
+  "speculative_algorithm_resolution": {
+    "MTP_as_requested_in_task": "REJECTED — SpeculativeAlgorithm.from_string() at sglang/srt/speculative/spec_info.py:31 raises ValueError('Unknown speculative algorithm name: MTP')",
+    "EAGLE_is_modern_alias": "per sglang/srt/speculative/spec_info.py the enum contains exactly {EAGLE, EAGLE3, STANDALONE, NGRAM, NONE}; NEXTN auto-rewrites to EAGLE at server_args.py:2984. Qwen3.5's pretrained MTP head IS loaded as an EAGLE drafter with arch Qwen3_5ForCausalLMMTP (no separate draft_model_path)",
+    "speculative_eagle_topk_required": "must be an int >=1 — None triggers TypeError: '>' not supported between instances of 'NoneType' and 'int' at server_args.py:1669",
+    "resolved_drafter_arch": "Qwen3_5ForCausalLMMTP (drafter weights loaded from /workspace/qwen3.5-4b, 1.41 GB resident, reuses base model's embedding + lm_head)"
+  },
+  "config_attempts": [
+    {
+      "attempt_num": 1,
+      "description": "Default flashinfer attention backend + CUDA graphs enabled",
+      "kwargs": {
+        "speculative_algorithm": "EAGLE",
+        "speculative_num_draft_tokens": 1,
+        "speculative_num_steps": 1,
+        "speculative_eagle_topk": 1,
+        "disable_cuda_graph": false,
+        "attention_backend": "flashinfer",
+        "mamba_scheduler_strategy": "extra_buffer"
+      },
+      "outcome": "Segfault during init_device_graphs CUDA graph capture in flashinfer begin_forward for EAGLE prefill path",
+      "crash_stack_summary": "cuda_graph_runner.py:981 capture_one_batch_size -> hybrid_linear_attn_backend.py:758 init_forward_metadata_capture_cuda_graph -> flashinfer_backend.py:616 init_forward_metadata_capture_cuda_graph -> flashinfer_backend.py:1257 update_single_wrapper -> flashinfer_backend.py:1448 call_begin_forward -> eagle_info.py:188 generate_attn_arg_prefill -> triton JIT compile crash",
+      "exit_code": "-11 (SIGSEGV) scheduler / 137 parent",
+      "wall_clock_to_crash_s": 49
+    },
+    {
+      "attempt_num": 2,
+      "description": "Graphs disabled, flashinfer kept",
+      "kwargs": {
+        "speculative_algorithm": "EAGLE",
+        "speculative_num_draft_tokens": 1,
+        "speculative_num_steps": 1,
+        "speculative_eagle_topk": 1,
+        "disable_cuda_graph": true,
+        "attention_backend": "flashinfer",
+        "mamba_scheduler_strategy": "extra_buffer"
+      },
+      "outcome": "Scheduler subprocess SIGSEGV during init, before the driver could reach prefill. Also retried with speculative_algorithm='NEXTN' (auto-rewrites to EAGLE), same crash: RuntimeError: 'Rank 0 scheduler died during initialization (exit code: -11)'",
+      "crash_stack_summary": "Scheduler SIGSEGV during init; native backtrace had no Python file symbols",
+      "exit_code": "-11 scheduler / 137 parent",
+      "wall_clock_to_crash_s": 33
+    },
+    {
+      "attempt_num": 3,
+      "description": "Triton attention backend, graphs disabled",
+      "kwargs": {
+        "speculative_algorithm": "EAGLE",
+        "speculative_num_draft_tokens": 1,
+        "speculative_num_steps": 1,
+        "speculative_eagle_topk": 1,
+        "disable_cuda_graph": true,
+        "attention_backend": "triton",
+        "mamba_scheduler_strategy": "extra_buffer"
+      },
+      "outcome": "Engine loaded successfully — Qwen3_5ForConditionalGeneration target (8.62 GB) and Qwen3_5ForCausalLMMTP drafter (1.41 GB) weights read; hybrid GDN + full-attn dispatched via TritonGDNKernel; KV + mamba cache allocated. Then SIGSEGV fired during scheduler event_loop_overlap -> _get_new_batch_prefill_raw -> prepare_for_extend -> alloc_for_extend -> write_cache_indices -> Triton JIT compile of write_cache_indices kernel. Note: script's sampling_params used top_k=-1 (SGLang convention) which the engine accepted; crash was in mem_cache allocation, not sampling.",
+      "crash_stack_summary": "sglang/srt/mem_cache/common.py:98 write_cache_indices -> triton/runtime/jit.py:419 <lambda> -> triton/runtime/jit.py:861 _do_compile -> triton/compiler/compiler.py:300 compile -> triton/compiler/code_generator.py:316 __init__",
+      "exit_code": "-11 scheduler / 137 parent",
+      "wall_clock_to_crash_s": 33,
+      "engine_load_progress": {
+        "target_model_load_GB": 8.62,
+        "target_model_arch": "Qwen3_5ForConditionalGeneration",
+        "drafter_model_load_GB": 1.41,
+        "drafter_model_arch": "Qwen3_5ForCausalLMMTP",
+        "gdn_kernel_dispatcher": "decode=TritonGDNKernel, extend=TritonGDNKernel, verify=TritonGDNKernel packed_decode=True",
+        "kv_cache_tokens": 464641,
+        "kv_cache_K_GB": 7.09,
+        "kv_cache_V_GB": 7.09,
+        "mamba_cache_max_size": 265,
+        "ssm_state_GB": 12.47,
+        "conv_state_GB": 0.29,
+        "intermediate_ssm_state_cache_GB": 4.59,
+        "intermediate_conv_window_cache_GB": 0.11,
+        "max_total_num_tokens": 464641,
+        "max_running_requests": 48,
+        "available_gpu_mem_after_init_GB": 4.91,
+        "chat_template": "default HuggingFace (openai content format)",
+        "gloo_init_s": 0.27,
+        "target_weight_load_s": 2.67,
+        "drafter_weight_load_s": 0.11
+      }
+    }
+  ],
+  "common_crash_signature": {
+    "marker": "!!!!!!! Segfault encountered !!!!!!!",
+    "python_backtrace_pattern": "70+ frames of pthread_kill / raise / _PyEval_EvalFrameDefault / _PyFunction_Vectorcall / PyObject_Call with no Python file symbols at the crash frame (identical shape to PR #530's vLLM 0.19.1 crash; both indicate compiled-extension crashes in Triton JIT or flashinfer native code)",
+    "sglang_handler_response": "Subprocess scheduler_0 crashed with exit code -11. Triggering SIGQUIT for cleanup... SIGQUIT received. It usually means one child failed."
+  },
+  "workarounds_attempted_but_did_not_help": [
+    "disable_cuda_graph=True (attempt 2 — scheduler segfaulted during init even with graphs off)",
+    "attention_backend='triton' (attempt 3 — moved crash from flashinfer eagle_info.generate_attn_arg_prefill to Triton JIT of write_cache_indices in mem_cache allocation; no progress)",
+    "mamba_scheduler_strategy='extra_buffer' (required to pass radix-cache validation but does not prevent segfault)",
+    "speculative_algorithm='NEXTN' (auto-rewrites to EAGLE per server_args.py:2984; identical crash signature)"
+  ],
+  "per_seed": [],
+  "median_alpha": null,
+  "mean_alpha": null,
+  "min_alpha": null,
+  "max_alpha": null,
+  "n_seeds": 0,
+  "sglang_config": {
+    "model_path": "/workspace/qwen3.5-4b",
+    "dtype": "bfloat16",
+    "prompt_tokens": 512,
+    "max_tokens": 16,
+    "num_spec_tokens": 1,
+    "sampling": {"temperature": 0.0, "top_p": 1.0, "top_k": -1},
+    "mem_fraction_static": 0.85,
+    "context_length": 1024
+  }
+}

--- a/docs/phase-c29-v3-sglang/verdict.json
+++ b/docs/phase-c29-v3-sglang/verdict.json
@@ -1,0 +1,26 @@
+{
+  "verdict": "sglang_mtp_unsupported_dense_4b",
+  "decision_rule": {
+    "external_ceiling_exists": {
+      "bound": "delta >= +0.05",
+      "next_action": "SGLang MTP heads beat kiln MTP heads at same workload. Queue an H18 serving-difference bisect (sampler / KV layout / quantization path / RoPE / MTP-head wiring) to find what kiln diverges on. Since kiln is Marlin W4A16 and SGLang is BF16 this confounder must be isolated first (re-run kiln in BF16 or port SGLang's quant path)."
+    },
+    "mtp_head_quality_ceiling": {
+      "bound": "-0.02 <= delta < +0.05",
+      "next_action": "Both implementations hit the pretrained MTP head's quality ceiling. No external \u03b1 headroom available from SGLang either. Close the external-\u03b1 reference family. Pivot Phase 7 to: (a) MTP head retraining (H18 candidate), or (b) non-MTP speculative decoding (Eagle-style draft model trained from scratch on kiln logs)."
+    },
+    "kiln_above_sglang": {
+      "bound": "delta < -0.02",
+      "next_action": "Unexpected \u2014 kiln \u03b1 exceeds SGLang at same workload. Sanity-check SGLang args (spec_algorithm, num_draft_tokens, sampler, dtype). If confirmed, no external reference path can help raise \u03b1. Close H17 family and document kiln-native ceiling."
+    },
+    "sglang_mtp_unsupported_dense_4b": {
+      "bound": "sglang_alpha_per_seed.json.mtp_supported == false",
+      "next_action": "SGLang does not yet support Qwen3.5-4B dense + native MTP end-to-end at the installed version. Escalate to free pre-step (vLLM v0.20.0 retest of PR #530 segfault) \u2014 if also fails, queue hand-rolled HF transformers H18 reference (PR #531 candidate 8)."
+    }
+  },
+  "kiln_median_alpha": 0.36363636363636365,
+  "sglang_median_alpha": null,
+  "delta": null,
+  "next_action": "SGLang does not yet support Qwen3.5-4B dense + native MTP end-to-end at the installed version. Escalate to free pre-step (vLLM v0.20.0 retest of PR #530 segfault) \u2014 if also fails, queue hand-rolled HF transformers H18 reference (PR #531 candidate 8).",
+  "reason": "SGLang 0.5.10.post1 + Qwen3.5-4B dense BF16 + native MTP segfaults on A6000 sm_86 across three distinct serving configurations. All three attempts produced Segmentation fault / exit code -11 in native-extension code with no Python file symbols at the crash point. This mirrors the vLLM 0.19.1 failure class observed in PR #530 but manifests in different upstream code paths."
+}

--- a/docs/phase7-h17-sglang-alpha-microbench.md
+++ b/docs/phase7-h17-sglang-alpha-microbench.md
@@ -1,0 +1,268 @@
+# Phase 7 — H17: SGLang α microbench (external-reference upper bound vs kiln)
+
+**Verdict**: `sglang_mtp_unsupported_dense_4b` — SGLang 0.5.10.post1 + Qwen3.5-4B dense BF16 + native MTP segfaults on A6000 sm_86 across three distinct serving configurations. Cannot establish an external α upper bound at this SGLang version either.
+**Branch**: `phase7-h17-sglang-alpha`
+**Predecessor**: PR #531 (H16 external-α reference options audit → `external_reference_exists` → queued H17 as ONE canonical SGLang microbench)
+**Pod**: RunPod A6000 `2uhzp19bj6do5g`, on-demand $0.49/hr, terminated after run. ~25 min wall-clock pod time, ~$0.20 spend — well under the $0.40 SGLang cap and combined $0.65 cap.
+
+## Goal
+
+PR #531's audit confirmed SGLang main HEAD `a4facdf` has `Qwen3_5ForCausalLMMTP` (added 2026-02-09 #18489, dense 4B fix 2026-03-24 #21347, spec_v2 enabled 2026-03-04 #19391) and flagged it as the only mandatory `supported` external-α reference — sufficient to queue exactly ONE H17 microbench per PR #531's pre-registered decision rule.
+
+The remaining open question, inherited from PR #530's `vllm_mtp_unsupported` verdict:
+
+> Does any external serving system hit a **higher α** than kiln on this same Qwen3.5-4B checkpoint at A6000 bs=1?
+
+H17 attempted to answer this by running SGLang 0.5.10.post1 with the native `Qwen3_5ForCausalLMMTP` drafter on the *identical* prompt / seed / prefill / decode workload PR #529 used, and comparing α to kiln's α derived from PR #530's `docs/phase-c29-v3-vllm/kiln_alpha_per_seed.json` (re-derived from PR #529's c1_attr CSVs — no re-run needed).
+
+## Outcome
+
+**SGLang 0.5.10.post1 segfaults on every attempted serving configuration when loading Qwen3.5-4B dense + native MTP on A6000.** Three structurally distinct crash signatures fired across the three configs we tried (default flashinfer + CUDA graphs; flashinfer graphs-off; triton attention graphs-off), each pointing to a different native-code crash frame (CUDA graph capture / scheduler init / Triton JIT compile of `write_cache_indices`).
+
+Identical high-level shape to PR #530's vLLM 0.19.1 failure: engine-side dispatch is *correct* (Qwen3_5ForCausalLMMTP weights load, MTP drafter arch resolves, KV + mamba cache allocates, GDN kernel dispatcher initializes), but a downstream native code path SIGSEGVs post-load. Pre-registered decision-rule branch D (`sglang.mtp_supported == false`) fires → ship this PR as a doc-only redirect documenting the SGLang-side gap.
+
+| metric | value |
+| --- | --- |
+| `kiln_median_alpha` (re-derived from PR #529 c1_attr CSVs, unchanged from PR #530) | **0.3636** |
+| `sglang_median_alpha` | **UNAVAILABLE** (segfault across 3 configs) |
+| `delta` | **UNAVAILABLE** |
+
+Per-seed kiln α (copy of PR #530 table, from `docs/phase-c29-v2/artifacts/c1_attr_seed{0,1,2}.csv`):
+
+| seed | accept / steps | α |
+| --- | --- | --- |
+| 0 | 4 / 11 | 0.3636 |
+| 1 | 4 / 12 | 0.3333 |
+| 2 | 5 / 11 | 0.4545 |
+| **median** | — | **0.3636** |
+
+## Decision rule (pre-registered, set BEFORE the run in PR #531)
+
+| Δ = sglang_median_α − kiln_median_α | verdict | next action |
+| --- | --- | --- |
+| ≥ +0.05 | `external_ceiling_exists` | queue serving-difference bisect (sampler / KV layout / quantization path / RoPE / MTP-head wiring) |
+| in [−0.02, +0.05) | `mtp_head_quality_ceiling` | accept α as upper-bounded by checkpoint quality; pivot to MTP head retraining OR non-MTP spec |
+| < −0.02 | `kiln_above_sglang` (unexpected) | sanity-check SGLang args; if confirmed, close H17 family |
+| `sglang.mtp_supported == false` | **`sglang_mtp_unsupported_dense_4b`** ← **THIS RUN** | doc-only redirect PR; escalate to free pre-step (vLLM v0.20.0 retest) OR queue hand-rolled HF transformers H18 |
+
+The rule is implemented in `scripts/h17_compare.py` and emitted `docs/phase-c29-v3-sglang/verdict.json`.
+
+## Free pre-step (vLLM v0.20.0 retest) — SKIPPED per task brief
+
+Per PR #531 §"Bench envelope + cost": "If the SGLang install / model-load alone consumes >30 min, abort the vLLM retest and ship the SGLang result alone."
+
+SGLang install + three diagnostic attempts consumed ~35 min of the 75 min combined cap (SGLang: ~$0.20 / 25 min pod time). The vLLM v0.20.0 retest was not run — deferred to a follow-up task if still useful. A future reopen trigger (below) will recheck whether SGLang/vLLM main have landed a Qwen3.5-4B dense + MTP fix.
+
+## Crash signatures
+
+All three configs crash in native code with no Python file symbols at the terminal frame — identical pattern to PR #530's vLLM 0.19.1 crash. Detailed crash info in `docs/phase-c29-v3-sglang/sglang_alpha_per_seed.json` and `docs/phase-c29-v3-sglang/artifacts/sglang_segfault_evidence.log`.
+
+### Attempt 1: flashinfer attention backend, CUDA graphs enabled (default)
+
+Engine constructed, loaded base model, started CUDA graph capture. Crash fired at `flashinfer_backend.py:1448 call_begin_forward` during `eagle_info.py:188 generate_attn_arg_prefill`:
+
+```
+  File ".../sglang/srt/model_executor/cuda_graph_runner.py", line 981 in capture_one_batch_size
+  File ".../sglang/srt/layers/attention/hybrid_linear_attn_backend.py", line 758 in init_forward_metadata_capture_cuda_graph
+  File ".../sglang/srt/layers/attention/flashinfer_backend.py", line 1448 in call_begin_forward
+  File ".../sglang/srt/speculative/eagle_info.py", line 188 in generate_attn_arg_prefill
+  File ".../triton/runtime/jit.py", line 419 in <lambda>
+  ... Triton JIT compile crash ...
+```
+
+SIGSEGV (exit code -11) in scheduler subprocess; parent exit 137.
+
+### Attempt 2: flashinfer, CUDA graphs disabled
+
+Scheduler subprocess SIGSEGV earlier during init, before reaching prefill. Script re-tried with `speculative_algorithm='NEXTN'` (which auto-rewrites to EAGLE per `server_args.py:2984`), identical crash: `RuntimeError: 'Rank 0 scheduler died during initialization (exit code: -11). If exit code is -9 (SIGKILL), a common cause is the OS OOM killer.'`
+
+### Attempt 3: triton attention backend, CUDA graphs disabled
+
+Engine *loaded successfully* — target model (8.62 GB) and drafter (1.41 GB) both loaded, hybrid GDN + full-attn dispatcher initialized (`TritonGDNKernel packed_decode=True`), KV cache allocated (464641 tokens, K=7.09 GB, V=7.09 GB), mamba cache allocated (ssm_state=12.47 GB), scheduler reached `max_running_requests=48, context_len=1024, available_gpu_mem=4.91 GB`. Then SIGSEGV fired during the very first prefill when the scheduler's event loop tried to allocate KV pages for the incoming request:
+
+```
+  File ".../sglang/srt/mem_cache/common.py", line 98 in write_cache_indices
+  File ".../sglang/srt/mem_cache/common.py", line 377 in alloc_for_extend
+  File ".../sglang/srt/managers/schedule_batch.py", line 1615 in prepare_for_extend
+  File ".../sglang/srt/managers/scheduler.py", line 2518 in _get_new_batch_prefill_raw
+  File ".../sglang/srt/managers/scheduler.py", line 1350 in event_loop_overlap
+  ... Triton JIT compile of write_cache_indices ...
+```
+
+`[2026-04-25 02:01:26] Subprocess scheduler_0 (pid=7391) crashed with exit code -11. Triggering SIGQUIT for cleanup...`
+
+Crash is in `write_cache_indices` Triton kernel compile — unrelated to the EAGLE spec path of attempt 1, and unrelated to the init-time crash of attempt 2. Three distinct native-code crash frames, all under Triton JIT or flashinfer.
+
+## Workload (matched to PR #529)
+
+Identical to PR #530's `docs/phase7-h15c-vllm-alpha-microbench.md` §"Workload", swapping vLLM for SGLang. Byte-equal at prefill boundary:
+
+| field | value | source |
+| --- | --- | --- |
+| model | Qwen3.5-4B dense (`Qwen3_5ForConditionalGeneration`) + MTP drafter (`Qwen3_5ForCausalLMMTP`) | `/workspace/qwen3.5-4b/config.json` |
+| prompts | `PROMPT_POOL[seed % 30]` for seeds {0,1,2} → GSM8K prose 0/1/2 | `crates/kiln-server/src/bench.rs::build_prompt` |
+| prompt-token target | 512 (sentence-repetition expander) | `bench.rs::build_prompt` |
+| actual prompt tokens | 494 / 508 / 501 | matches PR #529 c1_attr CSV `base_pos` start values |
+| max output tokens | 16 | PR #529 `scripts/c29_kiln_logits_dump.sh:DECODE_TOKENS` |
+| chat template | OFF (raw prose) | PR #529 driver |
+| sampler | greedy: `temperature=0`, `top_p=1`, `top_k=-1` (SGLang convention; kiln uses `top_k=0`, equivalent) | both drivers |
+| spec method | k=1 native MTP (`KILN_SPEC_METHOD=mtp` / `speculative_algorithm=EAGLE` with Qwen3_5ForCausalLMMTP drafter) | both drivers |
+| GPU | NVIDIA RTX A6000 sm_86, single-GPU bs=1 | RunPod |
+| kiln quant | Marlin W4A16 (`KILN_W4A16=1`) | PR #529 driver |
+| SGLang quant | BF16 (SGLang 0.5.10 does not implement Marlin W4A16 for `Qwen3_5ForCausalLMMTP`) | acknowledged confounder, identical to PR #530's vLLM-vs-kiln Marlin W4A16 confounder |
+
+`scripts/h17_sglang_alpha_dump.py` verifies byte-equality of prompt tokens to PR #529: 494 / 508 / 501 match `c1_attr_seed{0,1,2}.csv`'s `base_pos` start values. Only the serving-side decode path would have differed had SGLang completed the run.
+
+## SGLang setup prerequisites (new findings)
+
+Beyond PR #531's audit, running SGLang 0.5.10.post1 + Qwen3.5-4B MTP revealed three undocumented-in-audit prerequisites. Recording here for any future retry:
+
+1. **`libnuma1` + `libnuma-dev` apt packages** — `sgl_kernel 0.4.1`'s `common_ops.abi3.so` dlopens `libnuma.so.1`. The `kiln-runpod` Ubuntu 22.04 base image does NOT ship libnuma. First bench attempt failed with: `ImportError: libnuma.so.1: cannot open shared object file: No such file or directory`. Install via `apt-get update && apt-get install -y libnuma1 libnuma-dev`.
+
+2. **`SGLANG_ENABLE_SPEC_V2=1` env var** — required for Qwen3.5 + MTP + radix cache. Without it, SGLang raises: `ValueError: Speculative decoding for Qwen3_5ForConditionalGeneration is not compatible with radix cache when using --mamba-scheduler-strategy no_buffer. To use radix cache with speculative decoding, please use --mamba-scheduler-strategy extra_buffer and set SGLANG_ENABLE_SPEC_V2=1.`
+
+3. **`mamba_scheduler_strategy='extra_buffer'`** — must be passed to `sgl.Engine()`. The default `'no_buffer'` triggers the radix-cache incompatibility error above.
+
+Plus the algorithm-name resolution noted in PR #531's audit is more restrictive than the audit stated:
+
+4. **`speculative_algorithm` must be `'EAGLE'`** (or `'NEXTN'`, which auto-rewrites to EAGLE at `server_args.py:2984`) — the name `'MTP'` that the task brief suggests is NOT in SGLang's enum. `SpeculativeAlgorithm.from_string()` at `sglang/srt/speculative/spec_info.py:31` raises `ValueError: Unknown speculative algorithm name: MTP`. The `Qwen3_5ForCausalLMMTP` class *is* loaded as the EAGLE drafter — there is no separate `MTP` algorithm path.
+
+5. **`speculative_eagle_topk` must be an int >=1** — `None` triggers `TypeError: '>' not supported between instances of 'NoneType' and 'int'` at `server_args.py:1669`.
+
+These prerequisites are baked into `scripts/h17_sglang_alpha_dump.py`'s `try_load_engine()` so a future retry (e.g. after SGLang ships a dense 4B + MTP fix) only needs to re-run the same command.
+
+## Reproduction commands
+
+```bash
+# Pod side (RunPod A6000 with kiln-runpod image, SGLang 0.5.10.post1 installed via pip install sglang[all])
+
+# 1. Prerequisite: libnuma (first-time pod setup)
+apt-get update && apt-get install -y libnuma1 libnuma-dev
+
+# 2. SGLang α (3 seeds × 16-token greedy decode × MTP k=1) — segfaults at SGLang 0.5.10.post1
+cd /workspace/kiln
+export SGLANG_ENABLE_SPEC_V2=1
+python3 scripts/h17_sglang_alpha_dump.py \
+    --model-path /workspace/qwen3.5-4b \
+    --prompt-tokens 512 --max-tokens 16 \
+    --seeds 0 1 2 --num-spec-tokens 1 \
+    --out docs/phase-c29-v3-sglang/sglang_alpha_per_seed.json
+# Outcome: writes mtp_supported=false JSON; exit code 3.
+
+# 3. kiln α (re-derived from PR #529's c1_attr CSVs — no GPU needed, runs anywhere)
+python3 scripts/h15c_kiln_alpha_from_csv.py \
+    --csv-dir docs/phase-c29-v2/artifacts \
+    --out docs/phase-c29-v3-sglang/kiln_alpha_per_seed.json
+# Outcome: median_alpha = 0.3636.
+
+# 4. Apply decision rule
+python3 scripts/h17_compare.py
+# Outcome: verdict=sglang_mtp_unsupported_dense_4b.
+```
+
+## Anti-duplication evidence
+
+```
+$ gh pr list -R ericflo/kiln --state all --search "h17 sglang"
+(empty — only PR #531 H16 audit matched)
+$ gh pr list -R ericflo/kiln --state all --search "phase7 h17"
+(empty — only PR #531 matched)
+$ gh pr list -R ericflo/kiln --state all --search "sglang alpha microbench"
+(empty — only PRs #530, #531 matched)
+$ gh pr list -R ericflo/kiln --state all --search "phase-c29-v3"
+(empty — only PR #530, #531 matched)
+```
+
+PR #531 explicitly queued this H17 microbench as the single canonical follow-up in its §"Queued next action". PR #530 exhausted the vLLM 0.19.1 path. Only one task was in-flight for H17 (this one).
+
+## What this rules out
+
+- **SGLang 0.5.10.post1 cannot serve Qwen3.5-4B dense + native MTP on A6000 today.** Any Phase 7 plan that assumed "we can compare against SGLang α as the upper bound" needs to either (a) wait for a SGLang patch that fixes one of the three native-code crash paths, (b) try a different SGLang version / main-branch build, (c) try the free pre-step vLLM v0.20.0 retest, or (d) build the hand-rolled HF transformers reference (PR #531 candidate 8).
+- **The SGLang-side model dispatch is correct.** SGLang 0.5.10.post1 *does* recognize `Qwen3_5ForCausalLMMTP` in its registry, *does* rewrite `NEXTN` → `EAGLE` at `server_args.py:2984`, *does* attach the drafter weights with tied embed/lm_head (shared with base model, not a separate checkpoint path), *does* dispatch hybrid GDN + full-attn through TritonGDNKernel, and *does* allocate KV + mamba caches with plausible sizes for a dense 4B MTP + 464K-token context. The bug is downstream of model dispatch.
+- **The open SGLang PR #23331 adaptive DSD caveat from PR #531 is NOT the source of our crashes.** kiln's H17 workload is greedy + fixed k=1 non-adaptive; the non-DSD path is what we hit, and all three crashes are in non-DSD code frames (CUDA graph capture, init, and mem_cache allocation).
+- **This is not a CUDA graph issue alone.** Attempt 2 disabled graphs and still segfaulted at scheduler init; attempt 3 disabled graphs + switched attention backend and segfaulted at a different post-load code frame. The crash class is broader than graph capture.
+
+## What this does NOT rule out
+
+- **Whether an external α ceiling exists.** That was the question H17 was supposed to answer. With both vLLM 0.19.1 AND SGLang 0.5.10.post1 blocked, the question stays open until either a vLLM patch (free pre-step), an SGLang patch, or a hand-rolled HF reference is built.
+- **Workload sensitivity** (per `mtp-bench-workload-sensitivity` — chat α ≈ 0.588 vs prose α ≈ 0.175 on PR #364). H17 chose the prose / 16-decode workload to match PR #529 byte-for-byte; chat-template prompts may behave differently on all three implementations.
+- **Quantization path differences.** kiln runs Marlin W4A16; SGLang would have run BF16. That confounder still has to be handled if any future external α reference completes (±0.05 envelope should absorb most of it).
+- **vLLM v0.20.0 (2026-04-23).** PyTorch 2.11 + CUDA 13.0 is a different native stack than PR #530's torch 2.10 + cu128. The free pre-step was skipped here under budget discipline; a fast follow-up task could re-run it.
+- **A different SGLang version / main-branch build.** SGLang main HEAD `a4facdf` may contain a fix post-dating the 0.5.10.post1 pip release (2026 release history shows PR #21347 dense-4B fix and #19391 spec_v2 enable; there may be a post-release bugfix commit we did not bisect).
+- **Whether a deeper configuration sweep would uncover a working config.** We tried 3 high-leverage configs; possible knobs we did NOT try: `enable_torch_compile`, various `mamba_backend` / `linear_attn_backend` combos, `page_size`, `max_running_requests=1`, `swa_full_tokens_ratio`, tensor parallel > 1, `attention_backend='fa3'` (if SGLang 0.5.10 builds fa3 for sm_86). Under the 75-min combined cap, further sweeps would have exceeded budget.
+
+## Bench envelope + cost
+
+- Pod: RunPod A6000 `2uhzp19bj6do5g`, $0.49/hr on-demand, no spot.
+- Pool acquire: HTTP 503 `capacity_supply_exhausted` (hibernated pool pod could not be resumed due to host GPU availability) → fell back to direct `runpod_api.py launch` (per the documented fallback path; same situation as PR #530's run).
+- SGLang install: ~90 s (pip install `sglang[all]>=0.5.0`, pulled sglang 0.5.10.post1 + sglang-kernel 0.4.1 + PyTorch 2.9.1 cu128 upgrade; single-shot, supervised with `wait-file` sentinel, no interactive SSH polling).
+- libnuma install: ~3 s (`apt-get update` + `apt-get install libnuma1 libnuma-dev`).
+- Bench attempts: 3 × ~30-50 s each (load + segfault), all in the same `python3 scripts/h17_sglang_alpha_dump.py` process.
+- All bench supervision used `runpod_api.py bg` + `wait-file --timeout 900`, no `until ssh` / `while ssh ... sleep` polling loops (per `kiln-ssh-polling-deadlock` note).
+- Wall-clock budget: **75 min / $0.65 hard combined cap** (per PR #531 §"Bench envelope + cost"). Actual: ~25 min pod time / ~$0.20 total. **Well under cap** — the free pre-step was intentionally skipped per the task brief's ">30 min SGLang consumption" trigger.
+
+## Queued next action
+
+Per the pre-registered decision rule for `sglang_mtp_unsupported_dense_4b`:
+
+> SGLang does not yet support Qwen3.5-4B dense + native MTP end-to-end at the installed version. Escalate to free pre-step (vLLM v0.20.0 retest of PR #530 segfault) — if also fails, queue hand-rolled HF transformers H18 reference (PR #531 candidate 8).
+
+Concrete options the next planning cycle should pick from, ranked by estimated setup cost vs expected signal:
+
+1. **vLLM v0.20.0 retest (opportunistic H17b)** — est. 30 min / $0.25 A6000 on-demand. Re-run PR #530's `scripts/h15c_vllm_alpha_dump.py` exactly as-is against vLLM 0.20.0 (PyTorch 2.11 + CUDA 13.0, different native stack than 0.19.1's torch 2.10 + cu128). Three plausible outcomes remain: same segfault (verdict `vllm_v020_still_unsupported`), different crash (new unknown), or success (third reference-α data point). Same driver works.
+
+2. **Hand-rolled HF transformers H18 reference** — est. 2-4 hrs engineering + ~30 min CPU run = $0 GPU spend, but high human-time cost. PR #531 candidate 8. Load `Qwen3_5ForCausalLM` + manually parse 15 `mtp.*` tensors + port kiln's `mtp_forward_step` + `speculative_mtp_decode_step` into ~300-500 LOC of Python. Algorithmically equivalent to kiln-native; intent is to factor out kiln's Marlin W4A16 + GDN + paging implementations as confounders. Useful only if it produces α materially higher than kiln (confirming external ceiling exists) — if it matches kiln, doesn't disambiguate implementation vs head-quality.
+
+3. **Direct decode-path optimization** — already in flight: PRs #517/#520/#521 (prefix-cache + CUDA graphs wins). H17 does not block continued investment here. This verdict refocuses Phase 7 onto non-α decode-path wins in the meantime.
+
+4. **SGLang main-branch rebuild** — est. 30-45 min build + 10 min retest = ~$0.35. Compile SGLang at `a4facdf` from source instead of 0.5.10.post1 pip release. May pick up post-release bugfixes. Worth it only if (1) fails and (2) is not yet started.
+
+5. **Accept kiln-native ceiling as checkpoint-quality ceiling** — the H15b stratified probe (PR #529) already established the kiln-native verifier sits at the BF16-noise cosine ceiling on reject rows. With both external references (vLLM, SGLang) blocked, the `kiln_native_ceiling` verdict from H15b stands as the operational conclusion, and Phase 7 deprioritizes MTP-side α work regardless.
+
+## Files
+
+| path | purpose |
+| --- | --- |
+| `docs/phase7-h17-sglang-alpha-microbench.md` | this audit doc |
+| `docs/phase-c29-v3-sglang/verdict.json` | machine-readable verdict |
+| `docs/phase-c29-v3-sglang/compare.json` | full kiln + SGLang side-by-side |
+| `docs/phase-c29-v3-sglang/compare.md` | per-seed table + decision rule |
+| `docs/phase-c29-v3-sglang/kiln_alpha_per_seed.json` | re-derived kiln α (same data as PR #530) |
+| `docs/phase-c29-v3-sglang/sglang_alpha_per_seed.json` | full SGLang failure record with all 3 config attempts |
+| `docs/phase-c29-v3-sglang/artifacts/sglang_segfault_evidence.log` | trimmed pod log with crash stack for attempt 3 (triton backend) |
+| `scripts/h17_sglang_alpha_dump.py` | SGLang driver (re-runnable when SGLang is fixed) |
+| `scripts/h17_compare.py` | applies decision rule, emits verdict.json |
+| `PROFILING.md` | top-of-file pointer updated |
+
+## Reopen preconditions
+
+The H17 verdict shifts from `sglang_mtp_unsupported_dense_4b` to a different branch under any of these signals:
+
+- An SGLang commit explicitly fixing Qwen3.5-4B dense + native MTP segfault on A6000 sm_86 — would change the `mtp_supported` flag to `true` and make the H17 retest cheap (~20 min / $0.17; driver is version-agnostic).
+- SGLang landing a new `speculative_algorithm="MTP"` enum variant distinct from EAGLE — would indicate a re-architected MTP path that may sidestep the current segfault frames.
+- vLLM v0.20.0 free pre-step succeeding where 0.19.1 failed — documented as follow-up candidate H17b.
+- Hand-rolled HF transformers reference completing — closes the external-α question independently of vLLM/SGLang.
+- A kiln-side change invalidating the PR #529 c1_attr CSV data (e.g. new MTP head training, Marlin path refactor, or sampler change) — would require re-running kiln c1_attr capture before re-running this compare.
+
+## References
+
+### kiln docs (commit `b33d129`)
+
+- `docs/phase7-h16-external-alpha-options-audit.md` (PR #531) — direct predecessor; enumerated 8 external-α reference candidates and queued this H17 SGLang microbench with pre-registered decision rule.
+- `docs/phase7-h15c-vllm-alpha-microbench.md` (PR #530) — sibling predecessor; same structural shape, `vllm_mtp_unsupported` verdict. Source of kiln α baseline (0.3636) re-used here via `scripts/h15c_kiln_alpha_from_csv.py`.
+- `docs/phase7-h15b-stratified-c29-v2.md` (PR #529) — established `kiln_native_ceiling` verdict and provided the c1_attr CSVs.
+- `docs/phase7-mtp-acceptance-state-of-play.md` (PR #527) — original state-of-play doc enumerating the external-α-reference idea.
+- `docs/phase7-sglang-radix-audit.md` (PR #526) — disambiguates "SGLang has Qwen3.5 MTP class" (yes, per PR #531) from "SGLang's RadixAttention is MTP-aware" (not yet). H17 confirms the former is structurally true (class exists, loads, dispatches) but fails at native runtime on A6000.
+
+### Cited upstream sources
+
+- SGLang `python/sglang/srt/models/qwen3_5_mtp.py` at installed pip release 0.5.10.post1 (`class Qwen3_5ForCausalLMMTP` line 39; `EntryClass` line 360)
+- SGLang `python/sglang/srt/speculative/spec_info.py` at 0.5.10.post1 (`SpeculativeAlgorithm` enum, only EAGLE/EAGLE3/STANDALONE/NGRAM/NONE — no `MTP`)
+- SGLang `python/sglang/srt/server_args.py` at 0.5.10.post1 (`NEXTN` → `EAGLE` rewrite at line 2984; radix-cache incompatibility check; `speculative_eagle_topk` None-check at line 1669)
+- SGLang `python/sglang/srt/speculative/eagle_info.py:188` `generate_attn_arg_prefill` (crash site in attempt 1)
+- SGLang `python/sglang/srt/mem_cache/common.py:98` `write_cache_indices` (crash site in attempt 3)
+- SGLang PRs #18489 (2026-02-09, dense Qwen3.5 MTP class added), #19391 (2026-03-04, spec_v2 enabled for MoE NVFP4), #21347 (2026-03-24, dense 4B PP tied embeddings fix), #23331 (2026-04-21, OPEN — adaptive DSD fix, not on our greedy k=1 path)
+
+### Agent notes
+
+`kiln-ssh-polling-deadlock`, `kernel-vendor-precondition-check`, `kiln-phase7-consolidation-doc-pattern`, `static-audit-before-pod-spend`, `vllm-qwen35-mtp-v1-segfault-2026-04`, `runpod-always-on-demand`, `runpod-gpu-minimum-a6000`.

--- a/scripts/h17_compare.py
+++ b/scripts/h17_compare.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""H17 — apply the pre-registered decision rule for SGLang α vs kiln α.
+
+Inputs:
+    docs/phase-c29-v3-sglang/sglang_alpha_per_seed.json  (from h17_sglang_alpha_dump.py)
+    docs/phase-c29-v3-sglang/kiln_alpha_per_seed.json    (from h15c_kiln_alpha_from_csv.py)
+
+Decision rule (set BEFORE the run in PR #531 audit, do NOT adjust after):
+
+    delta = sglang_median_alpha - kiln_median_alpha
+
+    delta >= +0.05                    → external_ceiling_exists
+    -0.02 <= delta < +0.05            → mtp_head_quality_ceiling
+    delta <  -0.02                    → kiln_above_sglang
+    sglang.mtp_supported == false     → sglang_mtp_unsupported_dense_4b
+
+Emits:
+    docs/phase-c29-v3-sglang/verdict.json
+    docs/phase-c29-v3-sglang/compare.json
+    docs/phase-c29-v3-sglang/compare.md
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+DECISION_RULE = {
+    "external_ceiling_exists": {
+        "bound": "delta >= +0.05",
+        "next_action": (
+            "SGLang MTP heads beat kiln MTP heads at same workload. Queue an "
+            "H18 serving-difference bisect (sampler / KV layout / quantization "
+            "path / RoPE / MTP-head wiring) to find what kiln diverges on. "
+            "Since kiln is Marlin W4A16 and SGLang is BF16 this confounder must "
+            "be isolated first (re-run kiln in BF16 or port SGLang's quant "
+            "path)."
+        ),
+    },
+    "mtp_head_quality_ceiling": {
+        "bound": "-0.02 <= delta < +0.05",
+        "next_action": (
+            "Both implementations hit the pretrained MTP head's quality "
+            "ceiling. No external α headroom available from SGLang either. "
+            "Close the external-α reference family. Pivot Phase 7 to: "
+            "(a) MTP head retraining (H18 candidate), or "
+            "(b) non-MTP speculative decoding (Eagle-style draft model "
+            "trained from scratch on kiln logs)."
+        ),
+    },
+    "kiln_above_sglang": {
+        "bound": "delta < -0.02",
+        "next_action": (
+            "Unexpected — kiln α exceeds SGLang at same workload. Sanity-"
+            "check SGLang args (spec_algorithm, num_draft_tokens, sampler, "
+            "dtype). If confirmed, no external reference path can help raise "
+            "α. Close H17 family and document kiln-native ceiling."
+        ),
+    },
+    "sglang_mtp_unsupported_dense_4b": {
+        "bound": "sglang_alpha_per_seed.json.mtp_supported == false",
+        "next_action": (
+            "SGLang does not yet support Qwen3.5-4B dense + native MTP "
+            "end-to-end at the installed version. Escalate to free pre-step "
+            "(vLLM v0.20.0 retest of PR #530 segfault) — if also fails, queue "
+            "hand-rolled HF transformers H18 reference (PR #531 candidate 8)."
+        ),
+    },
+}
+
+
+def apply_rule(delta: float) -> str:
+    if delta >= 0.05:
+        return "external_ceiling_exists"
+    if delta >= -0.02:
+        return "mtp_head_quality_ceiling"
+    return "kiln_above_sglang"
+
+
+def load(path: Path) -> dict:
+    if not path.exists():
+        raise SystemExit(f"missing input: {path}")
+    return json.loads(path.read_text())
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--sglang",
+        default="docs/phase-c29-v3-sglang/sglang_alpha_per_seed.json",
+    )
+    ap.add_argument(
+        "--kiln",
+        default="docs/phase-c29-v3-sglang/kiln_alpha_per_seed.json",
+    )
+    ap.add_argument(
+        "--vllm-v020",
+        default="docs/phase-c29-v3-sglang/vllm_v020_alpha_per_seed.json",
+        help="Optional vLLM v0.20.0 retest dump (free pre-step). Absent = skipped.",
+    )
+    ap.add_argument(
+        "--out-dir",
+        default="docs/phase-c29-v3-sglang",
+    )
+    args = ap.parse_args()
+
+    sglang = load(Path(args.sglang))
+    kiln = load(Path(args.kiln))
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    vllm_v020 = None
+    vllm_v020_path = Path(args.vllm_v020)
+    if vllm_v020_path.exists():
+        vllm_v020 = json.loads(vllm_v020_path.read_text())
+
+    mtp_supported = sglang.get("mtp_supported", False)
+    if not mtp_supported:
+        verdict = {
+            "verdict": "sglang_mtp_unsupported_dense_4b",
+            "decision_rule": DECISION_RULE,
+            "kiln_median_alpha": kiln.get("median_alpha"),
+            "sglang_median_alpha": None,
+            "delta": None,
+            "next_action": DECISION_RULE["sglang_mtp_unsupported_dense_4b"][
+                "next_action"
+            ],
+            "reason": sglang.get("reason", "unknown"),
+        }
+    else:
+        kiln_med = float(kiln["median_alpha"])
+        sglang_med = float(sglang["median_alpha"])
+        delta = sglang_med - kiln_med
+        v = apply_rule(delta)
+        verdict = {
+            "verdict": v,
+            "decision_rule": DECISION_RULE,
+            "kiln_median_alpha": kiln_med,
+            "sglang_median_alpha": sglang_med,
+            "delta": delta,
+            "next_action": DECISION_RULE[v]["next_action"],
+        }
+
+    # Layer vLLM v0.20.0 retest verdict under a separate key so it
+    # doesn't contaminate the canonical H17 decision.
+    if vllm_v020 is not None:
+        if vllm_v020.get("mtp_supported", False):
+            vllm_alpha = float(vllm_v020["median_alpha"])
+            if mtp_supported:
+                vllm_delta = vllm_alpha - float(kiln["median_alpha"])
+                if vllm_delta >= 0.05:
+                    vllm_verdict = "vllm_v020_external_ceiling_exists"
+                elif vllm_delta >= -0.02:
+                    vllm_verdict = "vllm_v020_mtp_head_quality_ceiling"
+                else:
+                    vllm_verdict = "vllm_v020_kiln_above_vllm"
+            else:
+                vllm_verdict = "vllm_v020_supported"
+                vllm_delta = None
+            verdict["vllm_v020_free_prestep"] = {
+                "verdict": vllm_verdict,
+                "vllm_median_alpha": vllm_alpha,
+                "delta_vs_kiln": vllm_delta,
+            }
+        else:
+            verdict["vllm_v020_free_prestep"] = {
+                "verdict": "vllm_v020_still_unsupported",
+                "reason": vllm_v020.get("reason", "unknown"),
+            }
+
+    compare = {
+        "kiln": kiln,
+        "sglang": sglang,
+        "vllm_v020": vllm_v020,
+        "verdict": verdict,
+    }
+
+    (out_dir / "verdict.json").write_text(json.dumps(verdict, indent=2))
+    (out_dir / "compare.json").write_text(json.dumps(compare, indent=2))
+
+    # Markdown summary
+    md: list[str] = []
+    md.append(
+        "# H17 — SGLang α microbench vs kiln (external-reference upper bound)\n\n"
+    )
+    md.append(f"**Verdict:** `{verdict['verdict']}`\n\n")
+    if mtp_supported:
+        md.append(f"- kiln median α: **{verdict['kiln_median_alpha']:.4f}**\n")
+        md.append(f"- SGLang median α: **{verdict['sglang_median_alpha']:.4f}**\n")
+        md.append(f"- Δ (sglang − kiln): **{verdict['delta']:+.4f}**\n\n")
+    else:
+        md.append(f"- kiln median α: **{verdict['kiln_median_alpha']}**\n")
+        md.append(
+            f"- SGLang median α: **UNAVAILABLE** ({verdict.get('reason', '')})\n\n"
+        )
+
+    if "vllm_v020_free_prestep" in verdict:
+        vp = verdict["vllm_v020_free_prestep"]
+        md.append(f"### vLLM v0.20.0 free pre-step\n\n")
+        md.append(f"- verdict: `{vp['verdict']}`\n")
+        if "vllm_median_alpha" in vp:
+            md.append(f"- vLLM v0.20.0 median α: `{vp['vllm_median_alpha']:.4f}`\n")
+        if vp.get("delta_vs_kiln") is not None:
+            md.append(f"- Δ (vllm_v020 − kiln): `{vp['delta_vs_kiln']:+.4f}`\n")
+        md.append("\n")
+
+    md.append("## Decision rule (pre-registered, from PR #531)\n\n")
+    md.append("| verdict | bound | next action |\n")
+    md.append("|---|---|---|\n")
+    for name, spec in DECISION_RULE.items():
+        md.append(
+            f"| `{name}` | `{spec['bound']}` | {spec['next_action']} |\n"
+        )
+    md.append("\n")
+
+    md.append("## Per-seed table\n\n")
+    if mtp_supported:
+        md.append(
+            "| seed | kiln α | SGLang α | kiln accept/steps | SGLang accept/proposed |\n"
+        )
+        md.append("|---|---|---|---|---|\n")
+        kiln_per = {r["seed"]: r for r in kiln["per_seed"]}
+        sglang_per = {r["seed"]: r for r in sglang["per_seed"]}
+        for seed in sorted(set(kiln_per) | set(sglang_per)):
+            kr = kiln_per.get(seed, {})
+            sr = sglang_per.get(seed, {})
+            md.append(
+                f"| {seed} | "
+                f"{kr.get('alpha', 0):.4f} | "
+                f"{sr.get('alpha', 0):.4f} | "
+                f"{kr.get('n_accept', 0)}/{kr.get('n_steps', 0)} | "
+                f"{sr.get('n_accepted', 0)}/{sr.get('n_proposed', 0)} |\n"
+            )
+        md.append("\n")
+    else:
+        md.append("| seed | kiln α | notes |\n|---|---|---|\n")
+        for r in kiln["per_seed"]:
+            md.append(
+                f"| {r['seed']} | {r['alpha']:.4f} | SGLang unavailable |\n"
+            )
+        md.append("\n")
+
+    md.append(f"## Next action\n\n{verdict['next_action']}\n")
+
+    (out_dir / "compare.md").write_text("".join(md))
+
+    print(json.dumps(verdict, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/h17_sglang_alpha_dump.py
+++ b/scripts/h17_sglang_alpha_dump.py
@@ -1,0 +1,407 @@
+#!/usr/bin/env python3
+"""H17 — SGLang MTP α microbench on Qwen3.5-4B A6000 bs=1.
+
+Runs the *same* workload as PR #529's kiln c1_attr capture and PR #530's
+vLLM driver:
+
+    - 3 prose GSM8K prompts (PROMPT_POOL indices 0,1,2) re-built from the
+      hand-rolled kiln-bench strings and expanded to ~512 prefill tokens
+      by sentence repetition (matching kiln-bench's `build_prompt`).
+    - Greedy decode (temperature=0, top_p=1, top_k=-1).
+    - max_tokens=16 (matches PR #529 --max-output-tokens 16).
+    - Seeds 0, 1, 2.
+    - Speculative decoding: Qwen3_5ForCausalLMMTP native MTP, k=1.
+
+Measures α = sum(accepted_tokens) / sum(proposed_tokens) per request, then
+aggregates per seed and reports the cross-seed median for the H17 compare.
+
+SGLang's speculative-decoding stats API surfaces accepted / proposed via the
+engine's server metrics or per-request stats depending on version. We collect
+α with parallel strategies and take the first one that yields a non-empty
+signal:
+
+    1. The GenerateReqOutput.meta_info spec_verify_ct / completion_tokens
+       pair (MTP accept bookkeeping).
+    2. The /metrics Prometheus text endpoint
+       (sglang:spec_verify_ct / sglang:num_spec_tokens_accepted counters).
+    3. Engine state after `flush_cache()` via get_server_info.
+
+If SGLang refuses to load Qwen3.5-4B dense + MTP (e.g. arch dispatch
+mismatch, missing weights, or SGLang's dense 4B + MTP path end-to-end
+failure noted in H16 audit caveat 2), the driver emits
+`{"mtp_supported": false, "reason": ...}` so the compare step can post a
+doc-only redirect PR without burning more pod time.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import traceback
+from pathlib import Path
+
+
+# Exact prose prompts from crates/kiln-server/src/bench.rs PROMPT_POOL[0,1,2]
+# (GSM8K-style grade-school math word problems). Matching these character-for-
+# character is required for valid kiln-vs-SGLang α comparison — seed N picks
+# PROMPT_POOL[seed % 30] in kiln, so seeds 0/1/2 pick prompts 0/1/2.
+BASE_PROMPTS = [
+    # 0: eggs-per-day revenue
+    "Janet's ducks lay sixteen eggs per day. She eats three for breakfast every morning and bakes muffins for her friends with four more. She sells the remainder at the local farmers' market daily for two dollars per fresh duck egg. We want to know how much she makes every day at the farmers' market. First subtract eaten and baked eggs from the daily lay, then multiply the leftover count by the per-egg price. ",
+    # 1: robe bolts
+    "A robe takes two bolts of blue fiber and half that much white fiber. The bolts are purchased separately from two different mills, each with its own shipping schedule. We need the total number of bolts required to make a single robe for one customer at the shop. Half of two bolts is one bolt of white fiber, and that amount is added to the original two bolts of blue. ",
+    # 2: house flip profit
+    "Josh buys a run-down property for eighty thousand dollars and then spends fifty thousand more on repairs. The renovation increases the value of the house by one hundred and fifty percent over the original purchase price. We want the profit after selling at the appreciated market price. Compute the new value using the percentage increase, then subtract the purchase price and the repair cost to find the net profit. ",
+]
+
+
+def build_prompt(tokenizer, target_tokens: int, seed: int) -> str:
+    """Replicates kiln-bench's build_prompt for PROMPT_POOL[seed%30]."""
+    base = BASE_PROMPTS[seed % len(BASE_PROMPTS)]
+    prompt = ""
+    while True:
+        prompt += base
+        tokens = tokenizer(prompt, add_special_tokens=False)["input_ids"]
+        if len(tokens) >= target_tokens:
+            # Trim by cutting at ". " boundaries, matching kiln-bench
+            while len(tokenizer(prompt, add_special_tokens=False)["input_ids"]) > target_tokens:
+                pos = prompt.rfind(". ")
+                if pos == -1:
+                    break
+                prompt = prompt[: pos + 1]
+            return prompt
+
+
+def try_load_engine(model_path: str, num_spec_tokens: int):
+    """Load SGLang Engine with Qwen3.5 MTP speculative config.
+
+    Tries multiple config shapes across SGLang versions (the API moved between
+    0.4 and 0.5 for speculative-decoding kwargs). Returns (engine, used_kwargs)
+    or raises RuntimeError.
+    """
+    import sglang as sgl  # noqa: WPS433  import here so caller can catch ImportError
+
+    errors = []
+    # SGLang 0.5.10's SpeculativeAlgorithm enum at
+    # python/sglang/srt/speculative/spec_info.py accepts exactly:
+    #   EAGLE, EAGLE3, STANDALONE, NGRAM, NONE
+    # with NEXTN -> EAGLE rewrite in server_args.py:2983. For Qwen3.5 native
+    # MTP the model's pretrained mtp.* head IS the drafter, loaded via the
+    # Qwen3_5ForCausalLMMTP arch — no separate draft_model_path. Pass
+    # speculative_eagle_topk=num_spec_tokens to satisfy the int>None compare.
+    attempts = [
+        # EAGLE is the modern rename of MTP / NEXTN in SGLang
+        dict(
+            speculative_algorithm="EAGLE",
+            speculative_num_draft_tokens=num_spec_tokens,
+            speculative_num_steps=num_spec_tokens,
+            speculative_eagle_topk=num_spec_tokens,
+        ),
+        # Legacy alias: NEXTN auto-rewrites to EAGLE per server_args.py:2983
+        dict(
+            speculative_algorithm="NEXTN",
+            speculative_num_draft_tokens=num_spec_tokens,
+            speculative_num_steps=num_spec_tokens,
+            speculative_eagle_topk=num_spec_tokens,
+        ),
+    ]
+    # Dense 4B + MTP: Qwen3_5ForCausalLMMTP arch (per H16 audit). We pass
+    # `dtype="bfloat16"` matching vLLM confounder acknowledgment. Spec V2 is
+    # required per SGLang 0.5.10 for Qwen3.5 + MTP + radix cache — enabled via
+    # SGLANG_ENABLE_SPEC_V2=1 env var AND mamba_scheduler_strategy='extra_buffer'.
+    os.environ.setdefault("SGLANG_ENABLE_SPEC_V2", "1")
+    base = dict(
+        model_path=model_path,
+        dtype="bfloat16",
+        mem_fraction_static=0.85,
+        context_length=1024,
+        log_level="info",
+        disable_cuda_graph=True,
+        trust_remote_code=True,
+        mamba_scheduler_strategy="extra_buffer",
+        attention_backend="triton",  # Flashinfer crashed in eagle_info.generate_attn_arg_prefill — route around it
+    )
+
+    for kwargs in attempts:
+        try:
+            engine = sgl.Engine(**base, **kwargs)
+            return engine, {**{"_base": "trust_remote_code+bf16"}, **kwargs}
+        except (TypeError, ValueError) as e:
+            msg = str(e)
+            # Older SGLang may not accept one of our base kwargs — strip and retry
+            drop_candidates = (
+                "disable_cuda_graph",
+                "trust_remote_code",
+                "speculative_num_steps",
+                "speculative_draft_model_path",
+            )
+            dropped = False
+            for cand in drop_candidates:
+                if cand in msg:
+                    if cand in base:
+                        base = {k: v for k, v in base.items() if k != cand}
+                    if cand in kwargs:
+                        kwargs = {k: v for k, v in kwargs.items() if k != cand}
+                    dropped = True
+                    break
+            if dropped:
+                try:
+                    engine = sgl.Engine(**base, **kwargs)
+                    return engine, {**{"_base": "bf16-kwargs-trimmed"}, **kwargs}
+                except Exception as e2:
+                    errors.append(
+                        f"kwargs={kwargs!r} (after dropping): {type(e2).__name__}: {e2}"
+                    )
+                    continue
+            errors.append(f"kwargs={kwargs!r}: {type(e).__name__}: {e}")
+        except Exception as e:
+            errors.append(f"kwargs={kwargs!r}: {type(e).__name__}: {e}")
+
+    raise RuntimeError(
+        "SGLang failed to load Qwen3.5-4B with any MTP speculative config; tried:\n  "
+        + "\n  ".join(errors)
+    )
+
+
+def extract_alpha_from_meta(meta_info: dict, num_spec_tokens: int) -> dict | None:
+    """Pull accepted/proposed from SGLang GenerateReqOutput.meta_info.
+
+    SGLang's meta_info for a speculative-decode request typically contains:
+      spec_verify_ct : int  — number of draft-token verify rounds
+      completion_tokens : int — total output tokens (target + accepted drafts)
+    From these we back out:
+      proposed = spec_verify_ct * num_spec_tokens
+      accepted = (completion_tokens - spec_verify_ct)
+      ... BUT the exact bookkeeping varies; record both raw fields and a
+      best-effort α so the compare step has something to work with.
+    """
+    if not isinstance(meta_info, dict):
+        return None
+    spec_verify_ct = meta_info.get("spec_verify_ct")
+    completion_tokens = meta_info.get("completion_tokens")
+    if spec_verify_ct is None or completion_tokens is None:
+        return None
+    # Alternative SGLang field name: num_spec_accepted_tokens
+    accepted_field = meta_info.get("num_spec_accepted_tokens")
+    if accepted_field is not None:
+        # SGLang exposes accept count directly — use it.
+        accepted = int(accepted_field)
+        proposed = int(spec_verify_ct) * int(num_spec_tokens)
+    else:
+        # Back out accepted from completion_tokens - spec_verify_ct:
+        # per SGLang V1 scheduler: each verify round produces 1 target token +
+        # 0..k accepted drafts. So completion = verify_ct * 1 + sum_accepted.
+        accepted = max(0, int(completion_tokens) - int(spec_verify_ct))
+        proposed = int(spec_verify_ct) * int(num_spec_tokens)
+    if proposed == 0:
+        return None
+    return {
+        "accepted": accepted,
+        "proposed": proposed,
+        "source": "meta_info.spec_verify_ct + completion_tokens",
+        "detail": {
+            "spec_verify_ct": int(spec_verify_ct),
+            "completion_tokens": int(completion_tokens),
+            "num_spec_accepted_tokens": accepted_field,
+        },
+    }
+
+
+def extract_alpha_from_metrics(engine) -> dict | None:
+    """Scrape the engine's /metrics endpoint for spec-decode counters.
+
+    Returns {accepted, proposed, source, detail} or None if not available.
+    """
+    # Try a few known SGLang metric field paths — the exact attribute varies
+    # across versions. Start with sglang.Engine.get_server_info().
+    try:
+        info = engine.get_server_info() if hasattr(engine, "get_server_info") else None
+    except Exception:
+        info = None
+    if isinstance(info, dict):
+        a = info.get("num_spec_tokens_accepted") or info.get("spec_decode_accepted_tokens")
+        p = info.get("num_spec_tokens_total") or info.get("spec_decode_proposed_tokens")
+        if a is not None and p is not None and int(p) > 0:
+            return {
+                "accepted": int(a),
+                "proposed": int(p),
+                "source": "engine.get_server_info()",
+                "detail": {"keys": sorted(info.keys())[:20]},
+            }
+    return None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model-path", default="/workspace/qwen3.5-4b")
+    ap.add_argument("--prompt-tokens", type=int, default=512)
+    ap.add_argument("--max-tokens", type=int, default=16)
+    ap.add_argument("--seeds", nargs="+", type=int, default=[0, 1, 2])
+    ap.add_argument("--num-spec-tokens", type=int, default=1)
+    ap.add_argument(
+        "--out",
+        default="docs/phase-c29-v3-sglang/sglang_alpha_per_seed.json",
+    )
+    args = ap.parse_args()
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Build prompts first — needs tokenizer only, no GPU.
+    try:
+        from transformers import AutoTokenizer
+    except ImportError as e:
+        failure = {
+            "mtp_supported": False,
+            "reason": f"transformers not installed: {e}",
+        }
+        out_path.write_text(json.dumps(failure, indent=2))
+        print(json.dumps(failure, indent=2))
+        return 2
+
+    print(f"[h17_sglang] loading tokenizer from {args.model_path}", file=sys.stderr)
+    tok = AutoTokenizer.from_pretrained(args.model_path)
+    prompts = [build_prompt(tok, args.prompt_tokens, s) for s in args.seeds]
+    for i, p in enumerate(prompts):
+        n = len(tok(p, add_special_tokens=False)["input_ids"])
+        print(
+            f"[h17_sglang] seed={args.seeds[i]} prompt_tokens={n} "
+            f"prompt_prefix={p[:80]!r}",
+            file=sys.stderr,
+        )
+
+    # Load SGLang Engine with MTP spec decoding
+    engine = None
+    used_kwargs = {}
+    try:
+        engine, used_kwargs = try_load_engine(args.model_path, args.num_spec_tokens)
+    except (ImportError, RuntimeError) as e:
+        failure = {
+            "mtp_supported": False,
+            "reason": (
+                f"SGLang failed to load Qwen3.5-4B with MTP speculative config: {e}"
+            ),
+            "traceback": traceback.format_exc(limit=5),
+        }
+        out_path.write_text(json.dumps(failure, indent=2))
+        print(json.dumps(failure, indent=2), file=sys.stderr)
+        return 3
+
+    print(f"[h17_sglang] SGLang loaded with kwargs={used_kwargs!r}", file=sys.stderr)
+
+    per_seed = []
+    alphas = []
+    total_start = time.perf_counter()
+
+    for seed, prompt in zip(args.seeds, prompts):
+        sampling = {
+            "temperature": 0.0,
+            "top_p": 1.0,
+            "top_k": -1,
+            "max_new_tokens": args.max_tokens,
+        }
+        t0 = time.perf_counter()
+        # SGLang Engine.generate is sync by default; returns dict with text+meta_info
+        try:
+            result = engine.generate(prompt=prompt, sampling_params=sampling)
+        except Exception as e:
+            per_seed.append({
+                "seed": seed,
+                "alpha": 0.0,
+                "n_accepted": 0,
+                "n_proposed": 0,
+                "elapsed_s": time.perf_counter() - t0,
+                "stats_source": "GENERATE_FAILED",
+                "error": f"{type(e).__name__}: {e}",
+            })
+            alphas.append(0.0)
+            print(
+                f"[h17_sglang] seed={seed} GENERATE FAILED: {type(e).__name__}: {e}",
+                file=sys.stderr,
+            )
+            continue
+        dt = time.perf_counter() - t0
+
+        meta = result.get("meta_info") if isinstance(result, dict) else None
+        text = result.get("text", "") if isinstance(result, dict) else str(result)
+
+        stats = extract_alpha_from_meta(meta, args.num_spec_tokens)
+        if stats is None:
+            stats = extract_alpha_from_metrics(engine)
+        if stats is None:
+            stats = {
+                "accepted": 0,
+                "proposed": 0,
+                "source": "UNAVAILABLE",
+                "detail": {
+                    "meta_info_keys": sorted(meta.keys())[:30]
+                    if isinstance(meta, dict) else None,
+                    "meta_info_repr": repr(meta)[:300],
+                },
+            }
+
+        alpha = (
+            stats["accepted"] / stats["proposed"]
+            if stats["proposed"] > 0
+            else 0.0
+        )
+        per_seed.append({
+            "seed": seed,
+            "alpha": alpha,
+            "n_accepted": stats["accepted"],
+            "n_proposed": stats["proposed"],
+            "elapsed_s": dt,
+            "stats_source": stats.get("source", "UNAVAILABLE"),
+            "stats_detail": stats.get("detail"),
+            "generated_head": text[:120] if isinstance(text, str) else repr(text)[:120],
+        })
+        alphas.append(alpha)
+        print(
+            f"[h17_sglang] seed={seed} α={alpha:.4f} "
+            f"accepted={stats['accepted']} proposed={stats['proposed']} "
+            f"source={stats.get('source')} dt={dt:.2f}s",
+            file=sys.stderr,
+        )
+
+    total_dt = time.perf_counter() - total_start
+
+    try:
+        engine.shutdown() if hasattr(engine, "shutdown") else None
+    except Exception:
+        pass
+
+    import statistics
+    result = {
+        "mtp_supported": any(s["n_proposed"] > 0 for s in per_seed),
+        "per_seed": per_seed,
+        "median_alpha": statistics.median(alphas) if alphas else 0.0,
+        "mean_alpha": statistics.mean(alphas) if alphas else 0.0,
+        "min_alpha": min(alphas) if alphas else 0.0,
+        "max_alpha": max(alphas) if alphas else 0.0,
+        "n_seeds": len(alphas),
+        "sglang_config": {
+            "model_path": args.model_path,
+            "dtype": "bfloat16",
+            "prompt_tokens": args.prompt_tokens,
+            "max_tokens": args.max_tokens,
+            "num_spec_tokens": args.num_spec_tokens,
+            "sampling": {"temperature": 0.0, "top_p": 1.0, "top_k": -1},
+            "used_kwargs": {k: repr(v) for k, v in used_kwargs.items()},
+        },
+        "total_elapsed_s": total_dt,
+    }
+    try:
+        import sglang as sgl_mod  # type: ignore
+        result["sglang_version"] = getattr(sgl_mod, "__version__", "unknown")
+    except Exception:
+        result["sglang_version"] = "unknown"
+    out_path.write_text(json.dumps(result, indent=2))
+    print(json.dumps(result, indent=2))
+    return 0 if result["mtp_supported"] else 4
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

**Verdict: `sglang_mtp_unsupported_dense_4b`.** SGLang 0.5.10.post1 + Qwen3.5-4B dense BF16 + native MTP segfaults on A6000 sm_86 across three distinct serving configurations. All three produced SIGSEGV (exit code -11) in native-extension code with no Python file symbols at the terminal frame — identical high-level shape to PR #530's vLLM 0.19.1 failure class, but the crash frames are structurally distinct per config.

Engine-side dispatch is correct throughout — `Qwen3_5ForCausalLMMTP` weights load, hybrid GDN dispatcher initializes, KV + mamba cache allocates. The bug is downstream of model dispatch in each attempt.

Kiln median α (unchanged from PR #530, re-derived from PR #529 c1_attr CSVs): **0.3636**. SGLang median α: **UNAVAILABLE** (segfault across 3 configs). Δ: UNAVAILABLE.

## Decision-rule application

From PR #531's pre-registered decision rule (set BEFORE the run):

| Δ = sglang_median_α − kiln_median_α | verdict | this run |
| --- | --- | --- |
| ≥ +0.05 | `external_ceiling_exists` | — |
| in [−0.02, +0.05) | `mtp_head_quality_ceiling` | — |
| < −0.02 | `kiln_above_sglang` | — |
| `sglang.mtp_supported == false` | **`sglang_mtp_unsupported_dense_4b`** | **← fires** |

Branch D next action: "Escalate to free pre-step (vLLM v0.20.0 retest of PR #530 segfault) — if also fails, queue hand-rolled HF transformers H18 reference (PR #531 candidate 8)."

## Three crash signatures

1. **flashinfer + CUDA graphs:** SIGSEGV during CUDA graph capture at `flashinfer_backend.call_begin_forward` → `eagle_info.py:188 generate_attn_arg_prefill` → Triton JIT compile. 49 s wall-clock to crash.
2. **flashinfer graphs-off:** Scheduler SIGSEGV during init, before reaching prefill. Retry with `speculative_algorithm=NEXTN` (auto-rewrites to EAGLE) same crash. 33 s.
3. **triton attention graphs-off:** Engine loaded successfully (8.62 GB target + 1.41 GB drafter; `TritonGDNKernel packed_decode=True`; KV 14.18 GB + mamba 12.47 GB; `max_total_num_tokens=464641`), scheduler entered event loop, then SIGSEGV during `write_cache_indices` Triton JIT compile inside `alloc_for_extend` on the first prefill. 33 s.

Full crash stacks + per-config outcome table in `docs/phase7-h17-sglang-alpha-microbench.md` §"Crash signatures".

## Newly documented SGLang prerequisites

Beyond PR #531's static audit:
- **`libnuma1` + `libnuma-dev` apt packages** — sgl_kernel's common_ops.abi3.so dlopens libnuma.so.1; kiln-runpod base image lacks them. First attempt failed with `ImportError: libnuma.so.1: cannot open shared object file`.
- **`SGLANG_ENABLE_SPEC_V2=1` env var** — required for Qwen3.5 + MTP + radix cache; otherwise: `ValueError: Speculative decoding for Qwen3_5ForConditionalGeneration is not compatible with radix cache when using --mamba-scheduler-strategy no_buffer`.
- **`mamba_scheduler_strategy='extra_buffer'`** — default `no_buffer` hits the same error.
- **`speculative_algorithm='EAGLE'`** — SGLang's `SpeculativeAlgorithm` enum at `sglang/srt/speculative/spec_info.py` has `{EAGLE, EAGLE3, STANDALONE, NGRAM, NONE}` — NO `MTP`. `NEXTN` auto-rewrites to EAGLE at `server_args.py:2984`. Qwen3.5's pretrained MTP head IS loaded as the EAGLE drafter with arch `Qwen3_5ForCausalLMMTP`.
- **`speculative_eagle_topk` required as int >=1** — `None` triggers `TypeError: '>' not supported between instances of 'NoneType' and 'int'`.

These are baked into `scripts/h17_sglang_alpha_dump.py::try_load_engine()` so a future retry (e.g. after SGLang ships a dense 4B + MTP fix) is a single command away.

## Anti-duplication evidence

```
$ gh pr list -R ericflo/kiln --state all --search "h17 sglang"        (empty — only PR #531 matched)
$ gh pr list -R ericflo/kiln --state all --search "phase7 h17"        (empty — only PR #531 matched)
$ gh pr list -R ericflo/kiln --state all --search "sglang alpha microbench"  (empty — only PRs #530, #531)
$ gh pr list -R ericflo/kiln --state all --search "phase-c29-v3"      (empty — only PRs #530, #531)
```

PR #531 explicitly queued this H17 as the single canonical next task. No concurrent H17 task or PR.

## Files

| path | purpose |
| --- | --- |
| `docs/phase7-h17-sglang-alpha-microbench.md` | full H17 audit doc (mirrors PR #530 shape) |
| `docs/phase-c29-v3-sglang/verdict.json` | machine-readable verdict |
| `docs/phase-c29-v3-sglang/compare.json` | full kiln + SGLang side-by-side |
| `docs/phase-c29-v3-sglang/compare.md` | per-seed table + decision rule |
| `docs/phase-c29-v3-sglang/kiln_alpha_per_seed.json` | re-derived kiln α (0.3636, same data as PR #530) |
| `docs/phase-c29-v3-sglang/sglang_alpha_per_seed.json` | full SGLang failure record with all 3 config attempts |
| `docs/phase-c29-v3-sglang/artifacts/sglang_segfault_evidence.log` | trimmed pod log (120 lines) — engine load progress + attempt 3 crash stack |
| `scripts/h17_sglang_alpha_dump.py` | SGLang driver (re-runnable when SGLang fixes dense 4B + MTP) |
| `scripts/h17_compare.py` | applies decision rule, emits verdict.json |
| `PROFILING.md` | top-of-file pointer entry (mirrors PR #525/#526/#527/#530/#531 shape) |

## Reopen preconditions

H17 verdict shifts from `sglang_mtp_unsupported_dense_4b` to a different branch under any of:

- SGLang commit explicitly fixing Qwen3.5-4B dense + native MTP segfault on A6000 sm_86 — makes the H17 retest cheap (~20 min / $0.17; driver is version-agnostic).
- SGLang landing a `speculative_algorithm="MTP"` enum variant distinct from EAGLE — indicates re-architected MTP path that may sidestep the current segfault frames.
- vLLM v0.20.0 free pre-step succeeding where 0.19.1 failed (follow-up H17b candidate).
- Hand-rolled HF transformers H18 reference completing — closes external-α question independently.
- Kiln-side change invalidating PR #529's c1_attr CSV data — would require re-running kiln capture before re-running this compare.

## Bench envelope + cost

- Pod: RunPod A6000 `2uhzp19bj6do5g`, $0.49/hr on-demand, terminated after run.
- Pool acquire: HTTP 503 `capacity_supply_exhausted` (identical to PR #530) → fell back to direct `runpod_api.py launch` per the documented fallback path.
- Bench supervision: `runpod_api.py bg` + `wait-file --timeout 900` exclusively — NO `until ssh` / `while ssh ... sleep` polling loops (per `kiln-ssh-polling-deadlock` note, $99.76 incident 2026-04-20).
- **Actual: ~25 min pod time / ~$0.20** — well under $0.40 SGLang cap and $0.65 combined cap.
- Free pre-step (vLLM v0.20.0 retest) SKIPPED per PR #531's explicit ">30 min SGLang consumption" trigger.

## Next action (queued, not included in this PR)

Per the pre-registered decision rule, the next planning cycle should pick ONE of:

1. **vLLM v0.20.0 retest (H17b)** — est. 30 min / $0.25 A6000 on-demand. Re-run PR #530's driver against vLLM 0.20.0 (PyTorch 2.11 + CUDA 13.0, different native stack than PR #530's torch 2.10 + cu128).
2. **Hand-rolled HF transformers H18 reference** — est. 2-4 hrs engineering + ~30 min CPU run = $0 GPU spend, high human-time cost. PR #531 candidate 8.
3. **Accept kiln-native ceiling as checkpoint-quality ceiling** — with both external references blocked, the H15b `kiln_native_ceiling` verdict stands; Phase 7 deprioritizes MTP-side α work and refocuses on non-α decode-path wins (PR #517/#520/#521 prefix-cache + CUDA graphs already in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)