### PR TITLE
phase 7: ProgressBar for SFT training loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1864,6 +1864,8 @@ dependencies = [
  "candle-core",
  "candle-nn",
  "chrono",
+ "console",
+ "indicatif",
  "kiln-core",
  "kiln-flce-kernel",
  "kiln-model",

--- a/crates/kiln-train/Cargo.toml
+++ b/crates/kiln-train/Cargo.toml
@@ -19,6 +19,8 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+indicatif = "0.17"
+console = "0.15"
 
 [features]
 cuda = ["kiln-model/cuda"]

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -291,6 +291,29 @@ pub struct TrainingProgress {
     pub progress: f32,
 }
 
+/// Build a progress bar for the SFT training step loop.
+///
+/// Returns `None` when stderr is not a TTY so log files, server-mode tracing,
+/// and CI runs stay clean. The structured `tracing::info!` lines and the
+/// `progress_cb` HTTP-status callback remain the source of truth for
+/// non-interactive runs; the bar is purely additive UX for interactive
+/// `kiln train` invocations, where SFT loops often run hundreds–thousands of
+/// steps with no other visual feedback between every-10-step log lines.
+fn make_step_progress(total_steps: usize) -> Option<indicatif::ProgressBar> {
+    if !console::Term::stderr().features().is_attended() {
+        return None;
+    }
+    let pb = indicatif::ProgressBar::new(total_steps as u64);
+    pb.set_style(
+        indicatif::ProgressStyle::with_template(
+            "  sft training {bar:40.cyan/blue} {pos:>5}/{len:5} step ({elapsed}) loss={msg}",
+        )
+        .expect("static progress template is valid")
+        .progress_chars("##-"),
+    );
+    Some(pb)
+}
+
 /// Run SFT training on the provided examples using the already-loaded model.
 ///
 /// This runs in the calling thread (blocking). The caller should spawn this
@@ -376,6 +399,8 @@ pub fn sft_train(
     let mut global_step = 0;
     let mut last_loss = 0.0;
 
+    let pb = make_step_progress(total_steps);
+
     for epoch in 0..config.epochs {
         let mut epoch_loss = 0.0;
 
@@ -449,6 +474,11 @@ pub fn sft_train(
                     "training step"
                 );
             }
+
+            if let Some(pb) = &pb {
+                pb.set_message(format!("{loss_val:.6}"));
+                pb.inc(1);
+            }
         }
 
         let avg_loss = epoch_loss / tokenized.len() as f64;
@@ -457,6 +487,10 @@ pub fn sft_train(
             avg_loss = format!("{avg_loss:.6}"),
             "epoch complete"
         );
+    }
+
+    if let Some(pb) = pb {
+        pb.finish_and_clear();
     }
 
     // Save the trained adapter


### PR DESCRIPTION
## What

Adds an `indicatif::ProgressBar` to the SFT training loop in `crates/kiln-train/src/trainer.rs`, mirroring the pattern PR #540 established for the per-layer model load in `crates/kiln-model/src/loader.rs`.

## Why

Training is the most user-visible long-running operation in kiln. Today the only progress signal in interactive `kiln train` runs is `tracing::info!` every 10 steps, which is silent for the first ~10 steps and gives no sense of total ETA. The bar shows live step count, elapsed time, and current loss across the full `epochs * steps_per_epoch` run.

## Behavior

- TTY-attended only: gated on `console::Term::stderr().features().is_attended()`. Non-TTY runs (CI, log files, server-mode `tracing` JSON output) get no bar — `tracing::info!` and the `progress_cb` HTTP-status callback continue firing unchanged.
- Bar spans the full run, not per-epoch: created before the epoch loop, finished after, so a single bar tracks all `total_steps`.
- Purely additive: existing every-10-step `tracing::info!` log AND the `progress_cb` callback used by `/v1/train/status` polling are untouched.
- SFT loop only. The GRPO loop later in the file is left for a follow-up PR.

## Validation

```
cargo check -p kiln-train          # clean
cargo test -p kiln-train           # 14 passed; 0 failed
```

Closes the second item of the Phase 7 DX queue (CLI progress bars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)