### PR TITLE
phase 7: ProgressBar for GRPO training loop

### DIFF
--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -291,25 +291,30 @@ pub struct TrainingProgress {
     pub progress: f32,
 }
 
-/// Build a progress bar for the SFT training step loop.
+/// Build a progress bar for a training step/group loop.
 ///
 /// Returns `None` when stderr is not a TTY so log files, server-mode tracing,
 /// and CI runs stay clean. The structured `tracing::info!` lines and the
 /// `progress_cb` HTTP-status callback remain the source of truth for
 /// non-interactive runs; the bar is purely additive UX for interactive
-/// `kiln train` invocations, where SFT loops often run hundreds–thousands of
-/// steps with no other visual feedback between every-10-step log lines.
-fn make_step_progress(total_steps: usize) -> Option<indicatif::ProgressBar> {
+/// `kiln train` invocations, where SFT and GRPO loops often run
+/// hundreds–thousands of iterations with no other visual feedback between
+/// every-10-step log lines.
+///
+/// `label` is the per-loop prefix shown before the bar (e.g. `"sft training"`
+/// or `"grpo training"`).
+fn make_step_progress(total_steps: usize, label: &str) -> Option<indicatif::ProgressBar> {
     if !console::Term::stderr().features().is_attended() {
         return None;
     }
     let pb = indicatif::ProgressBar::new(total_steps as u64);
+    let template = format!(
+        "  {label} {{bar:40.cyan/blue}} {{pos:>5}}/{{len:5}} step ({{elapsed}}) loss={{msg}}"
+    );
     pb.set_style(
-        indicatif::ProgressStyle::with_template(
-            "  sft training {bar:40.cyan/blue} {pos:>5}/{len:5} step ({elapsed}) loss={msg}",
-        )
-        .expect("static progress template is valid")
-        .progress_chars("##-"),
+        indicatif::ProgressStyle::with_template(&template)
+            .expect("static progress template is valid")
+            .progress_chars("##-"),
     );
     Some(pb)
 }
@@ -399,7 +404,7 @@ pub fn sft_train(
     let mut global_step = 0;
     let mut last_loss = 0.0;
 
-    let pb = make_step_progress(total_steps);
+    let pb = make_step_progress(total_steps, "sft training");
 
     for epoch in 0..config.epochs {
         let mut epoch_loss = 0.0;
@@ -597,6 +602,8 @@ pub fn grpo_train(
     let mut global_step = 0;
     let mut last_loss = 0.0;
 
+    let pb = make_step_progress(total_steps, "grpo training");
+
     for (group_idx, tgroup) in tokenized_groups.iter().enumerate() {
         // Compute advantages from rewards (normalize within group)
         let advantages = compute_advantages(&tgroup.rewards);
@@ -723,6 +730,15 @@ pub fn grpo_train(
             loss = format!("{avg_group_loss:.6}"),
             "GRPO group step"
         );
+
+        if let Some(pb) = &pb {
+            pb.set_message(format!("{avg_group_loss:.6}"));
+            pb.inc(1);
+        }
+    }
+
+    if let Some(pb) = pb {
+        pb.finish_and_clear();
     }
 
     // Save the trained adapter


### PR DESCRIPTION
## What

Mirrors PR #541 (SFT training-loop progress bar) onto the GRPO loop in the same file (`crates/kiln-train/src/trainer.rs`). Generalizes `make_step_progress` to accept a `label` parameter so SFT and GRPO share one helper instead of duplicating it.

## Why

GRPO previously had only structured `tracing::info!` per group (around line 719) with no interactive feedback between log lines. Same gap SFT had pre-#541. Bar is TTY-gated via `console::Term::stderr().features().is_attended()` so log files, server-mode tracing, and CI runs stay clean — non-interactive behavior is unchanged.

## Helper-reuse vs sibling-helper

Went with helper-reuse (rename to `make_step_progress(total_steps, label)`) for the tighter diff. The template now takes the label as a `format!()` prefix:

```
"  {label} {bar:40.cyan/blue} {pos:>5}/{len:5} step ({elapsed}) loss={msg}"
```

Both call sites pass their own label (`"sft training"` / `"grpo training"`).

## SFT lines mirrored

- helper definition at `trainer.rs:302` (now takes `&str` label)
- `sft_train` init at `trainer.rs:402` -> passes `"sft training"`
- per-iteration `pb.set_message` + `pb.inc(1)` at `trainer.rs:478-481`
- `pb.finish_and_clear()` at `trainer.rs:492-494`

GRPO mirrors all four points: init before the group loop, per-group update after the existing `tracing::info!("GRPO group step")` block, finish after loop closes.

## Verification (no GPU needed)

- `cargo check -p kiln-train` clean (no new warnings)
- `cargo test -p kiln-train` — all 14 tests pass
- Diff: 26 insertions / 10 deletions in trainer.rs