### PR TITLE
phase 7: KILN_LOG_FORMAT=auto — TTY-detect pretty vs JSON default

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -82,9 +82,6 @@ path = "./Qwen3.5-4B"
 
 [server]
 port = 8420
-
-[logging]
-format = "human"
 ```
 
 Then start with:
@@ -92,6 +89,12 @@ Then start with:
 ```bash
 ./target/release/kiln serve --config kiln.toml
 ```
+
+By default, Kiln logs in colored "pretty" format when stderr is an interactive
+terminal and switches to structured JSON when stderr is piped or redirected
+(systemd, docker, CI). To force a specific format, set `KILN_LOG_FORMAT=json`
+or `KILN_LOG_FORMAT=pretty` (or the equivalent `[logging] format = "..."` in
+`kiln.toml`).
 
 You'll see the startup banner:
 
@@ -249,7 +252,7 @@ Key settings:
 | `server.port` | `KILN_PORT` | 8420 | Server listen port |
 | `memory.inference_memory_fraction` | — | 0.7 | VRAM fraction for inference (rest for training) |
 | `memory.kv_cache_fp8` | `KILN_KV_CACHE_FP8` | false | FP8 KV cache (halves memory, ~2x context) |
-| `logging.format` | — | json | Log format: json, human, pretty, text |
+| `logging.format` | `KILN_LOG_FORMAT` | auto | Log format: `auto` (pretty on TTY, JSON otherwise), `json`, `pretty`, `text`, `human` |
 | `prefix_cache.enabled` | — | true | Reuse KV cache for shared prefixes |
 
 ## Running with Docker

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -276,7 +276,7 @@ impl Default for LoggingConfig {
     fn default() -> Self {
         Self {
             level: "info".into(),
-            format: "json".into(),
+            format: "auto".into(),
         }
     }
 }
@@ -607,7 +607,7 @@ mod tests {
         assert!(!config.training.no_grad_checkpoint);
         assert!(config.training.checkpoint_interval.is_none());
         assert_eq!(config.logging.level, "info");
-        assert_eq!(config.logging.format, "json");
+        assert_eq!(config.logging.format, "auto");
         assert!(config.prefix_cache.enabled);
         assert!(config.prefix_cache.max_blocks.is_none());
         assert!(!config.speculative.enabled);

--- a/crates/kiln-server/src/logging.rs
+++ b/crates/kiln-server/src/logging.rs
@@ -3,9 +3,14 @@
 //! Configurable via the `[logging]` section of `kiln.toml` or environment variables:
 //! - `KILN_LOG_LEVEL`: verbosity level (`trace`, `debug`, `info`, `warn`, `error`)
 //!   or a full `tracing_subscriber::EnvFilter` directive. Default: `info`.
-//! - `KILN_LOG_FORMAT`: output format — `json` (default) for structured JSON,
-//!   `pretty` for human-readable colored output during development.
+//! - `KILN_LOG_FORMAT`: output format — `auto` (default), `json`, or `pretty`
+//!   (also accepts `text`/`human` as aliases for `pretty`). With `auto`, kiln
+//!   emits colored pretty logs when stderr is a TTY (interactive terminal) and
+//!   structured JSON otherwise (systemd, docker, CI, log pipelines). Set to
+//!   `json` to force JSON in production, or `pretty` to force colored output.
 //! - `RUST_LOG`: if set, takes precedence over `KILN_LOG_LEVEL`.
+
+use std::io::IsTerminal;
 
 use tracing_subscriber::EnvFilter;
 
@@ -27,18 +32,40 @@ pub fn build_filter(level: &str) -> EnvFilter {
     })
 }
 
+/// Resolve a user-supplied format string to a concrete renderer choice.
+///
+/// Returns `"pretty"` or `"json"`. `"auto"` resolves to `"pretty"` when
+/// `stderr_is_tty` is true and `"json"` otherwise; explicit `"pretty"` /
+/// `"text"` / `"human"` always pick pretty regardless of TTY state; anything
+/// else (including `"json"`) falls through to `"json"`.
+pub(crate) fn resolve_format(format: &str, stderr_is_tty: bool) -> &'static str {
+    match format {
+        "auto" => {
+            if stderr_is_tty {
+                "pretty"
+            } else {
+                "json"
+            }
+        }
+        "pretty" | "text" | "human" => "pretty",
+        _ => "json",
+    }
+}
+
 /// Initialize the global tracing subscriber.
 ///
 /// `level`: log level or tracing filter directive (e.g. `"info"`, `"kiln=trace,tower_http=warn"`).
-/// `format`: output format — `"json"` (default), `"pretty"`, `"text"`, or `"human"`.
+/// `format`: output format — `"auto"` (default; pretty on TTY, JSON otherwise),
+/// `"json"`, `"pretty"`, `"text"`, or `"human"`.
 ///
 /// Call once at startup. Panics if called twice (tracing's global subscriber
 /// can only be set once per process).
 pub fn init(level: &str, format: &str) -> anyhow::Result<()> {
     let filter = build_filter(level);
+    let resolved = resolve_format(format, std::io::stderr().is_terminal());
 
-    match format {
-        "pretty" | "text" | "human" => {
+    match resolved {
+        "pretty" => {
             tracing_subscriber::fmt()
                 .with_env_filter(filter)
                 .init();
@@ -99,5 +126,35 @@ mod tests {
             s.contains("kiln=trace") || s.contains("tower_http=warn"),
             "filter should parse custom directive: {s}"
         );
+    }
+
+    #[test]
+    fn test_resolve_format_auto_tty() {
+        assert_eq!(resolve_format("auto", true), "pretty");
+    }
+
+    #[test]
+    fn test_resolve_format_auto_no_tty() {
+        assert_eq!(resolve_format("auto", false), "json");
+    }
+
+    #[test]
+    fn test_resolve_format_explicit_pretty_overrides_no_tty() {
+        // Explicit user choice wins over TTY detection.
+        assert_eq!(resolve_format("pretty", false), "pretty");
+        assert_eq!(resolve_format("text", false), "pretty");
+        assert_eq!(resolve_format("human", false), "pretty");
+    }
+
+    #[test]
+    fn test_resolve_format_explicit_json_overrides_tty() {
+        // Explicit JSON wins even when stderr is interactive.
+        assert_eq!(resolve_format("json", true), "json");
+    }
+
+    #[test]
+    fn test_resolve_format_unknown_falls_back_to_json() {
+        assert_eq!(resolve_format("garbage", true), "json");
+        assert_eq!(resolve_format("", false), "json");
     }
 }


### PR DESCRIPTION
Phase 7 (Beautiful CLI) — log format now defaults to `auto`, which renders colored pretty logs when stderr is a TTY and structured JSON when stderr is piped or redirected (systemd, docker, CI). Explicit `json` and `pretty`/`text`/`human` overrides are unchanged.

## What

- `LoggingConfig::default().format` is now `"auto"` (was `"json"`).
- `logging::init` now resolves `format` through a new `resolve_format(format, stderr_is_tty)` helper before picking the renderer.
  - `"auto"` → `"pretty"` when stderr is a TTY, `"json"` otherwise.
  - `"pretty"` / `"text"` / `"human"` → always pretty.
  - anything else (including `"json"`) → JSON.
- Uses `std::io::IsTerminal` (stable since Rust 1.70) — no new dependency.
- `crates/kiln-server/src/logging.rs` doc comment updated to describe `auto`.
- `QUICKSTART.md` updated: settings table now lists `auto` as the default and shows the `KILN_LOG_FORMAT` env var; example `kiln.toml` no longer hardcodes `format = "human"` (the new default already does the right thing for an interactive shell), with a paragraph explaining the auto-detect behavior and how to force `json`/`pretty` for production.

## Tests

Added 5 unit tests in `crates/kiln-server/src/logging.rs` covering the new `resolve_format` helper:

- `test_resolve_format_auto_tty` — `auto` + TTY → `pretty`
- `test_resolve_format_auto_no_tty` — `auto` + no-TTY → `json`
- `test_resolve_format_explicit_pretty_overrides_no_tty` — explicit `pretty`/`text`/`human` win even when piped
- `test_resolve_format_explicit_json_overrides_tty` — explicit `json` wins on a TTY
- `test_resolve_format_unknown_falls_back_to_json` — unknown / empty strings → JSON (matches prior fallback behavior)

Updated `test_defaults` in `config.rs` to assert the new `"auto"` default.

## Why

Currently `kiln serve` on a fresh interactive terminal dumps JSON tracing logs because the default is `"json"`. First-run UX is much better with colored pretty logs in a terminal and JSON only when stderr is redirected to a log pipeline. Production deployments behind systemd/docker/CI keep getting JSON automatically. Explicit overrides still work either way.

## Verification

Local validation in the Cloud Eric sandbox is limited (per `kiln-sandbox-rust-tooling` note: `kiln-server`'s transitive `reqwest` → `native-tls` → `openssl-sys` requires `libssl-dev` headers that the sandbox doesn't have). Code is logic-only — a `match` over a `&str` returning `&'static str` plus the existing `init` flow — and was reviewed by inspection. The test signatures match the existing `#[cfg(test)] mod tests { use super::*; ... }` pattern in this file. Reviewer is welcome to re-run `cargo test -p kiln-server --no-default-features --lib logging config` on a host with openssl headers if desired.