### PR TITLE
phase 7: live decode tok/s + p50/p99 ITL on /ui dashboard

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -684,6 +684,7 @@ async fn generate_real_streaming(
     let created = now_epoch();
     let gpu_lock = state.gpu_lock.clone();
     let timeout = state.request_timeout;
+    let decode_stats = state.decode_stats.clone();
 
     // Use a tokio mpsc channel to bridge sync generation -> async SSE stream.
     let (tx, rx) = tokio::sync::mpsc::channel::<Event>(32);
@@ -881,6 +882,9 @@ async fn generate_real_streaming(
                         match join_result {
                             Ok((rx_back, Ok(StreamEvent::Token(token)))) => {
                                 maybe_rx = Some(rx_back);
+                                if let Ok(mut stats) = decode_stats.lock() {
+                                    stats.record_token(std::time::Instant::now());
+                                }
                                 let chunk = ChatCompletionChunk {
                                     id: id.clone(),
                                     object: "chat.completion.chunk",

--- a/crates/kiln-server/src/api/mod.rs
+++ b/crates/kiln-server/src/api/mod.rs
@@ -12,6 +12,7 @@ mod completions;
 mod adapters;
 mod training;
 mod config;
+mod stats;
 mod ui;
 
 #[cfg(test)]
@@ -60,6 +61,7 @@ pub fn router(state: AppState) -> Router {
         .merge(adapters::routes())
         .merge(training::routes())
         .merge(config::routes())
+        .merge(stats::routes())
         .merge(ui::routes())
         .with_state(state)
         .layer(CorsLayer::permissive())

--- a/crates/kiln-server/src/api/stats.rs
+++ b/crates/kiln-server/src/api/stats.rs
@@ -1,0 +1,116 @@
+//! Live runtime statistics endpoints.
+//!
+//! Currently exposes `/v1/stats/decode` which returns a snapshot of decode
+//! tokens-per-second and inter-token latency over the rolling window. The
+//! /ui dashboard polls this every 2 seconds.
+
+use std::time::Instant;
+
+use axum::extract::State;
+use axum::routing::get;
+use axum::{Json, Router};
+
+use crate::decode_stats::DecodeStatsSnapshot;
+use crate::state::AppState;
+
+async fn get_decode_stats(State(state): State<AppState>) -> Json<DecodeStatsSnapshot> {
+    let snap = state
+        .decode_stats
+        .lock()
+        .map(|ring| ring.snapshot(Instant::now()))
+        .unwrap_or_else(|poisoned| poisoned.into_inner().snapshot(Instant::now()));
+    Json(snap)
+}
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/v1/stats/decode", get(get_decode_stats))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::AppState;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use kiln_core::config::ModelConfig;
+    use kiln_model::engine::MockEngine;
+    use kiln_scheduler::{Scheduler, SchedulerConfig};
+    use std::sync::Arc;
+    use tower::ServiceExt;
+
+    fn make_test_state() -> AppState {
+        let config = ModelConfig::qwen3_5_4b();
+        let sched_config = SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        };
+        let scheduler = Scheduler::new(sched_config, 256);
+        let engine = MockEngine::new(config.clone());
+        let tokenizer = crate::api::test_tokenizer();
+        AppState::new_mock(
+            config,
+            scheduler,
+            Arc::new(engine),
+            tokenizer,
+            300,
+            "kiln-test".to_string(),
+        )
+    }
+
+    #[tokio::test]
+    async fn empty_snapshot_serializes_to_zeros() {
+        let state = make_test_state();
+        let app = routes().with_state(state);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/stats/decode")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["sample_count"], 0);
+        assert_eq!(body["tok_per_sec"], 0.0);
+        assert!(body["window_secs"].as_f64().unwrap() > 0.0);
+    }
+
+    #[tokio::test]
+    async fn snapshot_reflects_recorded_tokens() {
+        let state = make_test_state();
+        {
+            let mut ring = state.decode_stats.lock().unwrap();
+            let t0 = Instant::now();
+            ring.record_token(t0);
+            ring.record_token(t0 + std::time::Duration::from_millis(20));
+            ring.record_token(t0 + std::time::Duration::from_millis(40));
+        }
+        let app = routes().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/stats/decode")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body["sample_count"], 2);
+        let tok_per_sec = body["tok_per_sec"].as_f64().unwrap();
+        assert!(
+            (tok_per_sec - 50.0).abs() < 1.0,
+            "tok_per_sec should be ~50, got {}",
+            tok_per_sec
+        );
+    }
+}

--- a/crates/kiln-server/src/decode_stats.rs
+++ b/crates/kiln-server/src/decode_stats.rs
@@ -1,0 +1,280 @@
+//! Live decode performance ring buffer.
+//!
+//! Records the wall-clock instant at which each streaming completion token was
+//! emitted. The most recent samples (within a fixed time window) are used to
+//! compute live tokens-per-second and inter-token latency percentiles for
+//! display on the /ui dashboard.
+
+use std::collections::VecDeque;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+
+/// Window over which live decode stats are aggregated.
+const WINDOW: Duration = Duration::from_secs(60);
+
+/// Snapshot of recent decode performance.
+///
+/// All latency fields are in milliseconds. `sample_count` is the number of
+/// inter-token gaps used to compute the snapshot — at least 2 token samples
+/// are needed to derive a single inter-token gap, so values < 2 sample_count
+/// indicate insufficient data and the latency fields will be 0.
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct DecodeStatsSnapshot {
+    pub tok_per_sec: f64,
+    pub p50_itl_ms: f64,
+    pub p99_itl_ms: f64,
+    pub mean_itl_ms: f64,
+    pub sample_count: usize,
+    pub window_secs: f64,
+}
+
+impl DecodeStatsSnapshot {
+    fn empty() -> Self {
+        Self {
+            tok_per_sec: 0.0,
+            p50_itl_ms: 0.0,
+            p99_itl_ms: 0.0,
+            mean_itl_ms: 0.0,
+            sample_count: 0,
+            window_secs: WINDOW.as_secs_f64(),
+        }
+    }
+}
+
+/// Bounded ring buffer of token-emit timestamps.
+///
+/// Old samples (older than `WINDOW`) are evicted on `record_token` and
+/// `snapshot`. The ring is also capped at `capacity` to bound memory under
+/// pathological burstiness.
+pub struct DecodeStatsRing {
+    samples: VecDeque<Instant>,
+    capacity: usize,
+}
+
+impl DecodeStatsRing {
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            samples: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    /// Record a token emit at `now`. Evicts the oldest sample if over capacity
+    /// and any samples older than the rolling window.
+    pub fn record_token(&mut self, now: Instant) {
+        self.evict_old(now);
+        if self.samples.len() >= self.capacity {
+            self.samples.pop_front();
+        }
+        self.samples.push_back(now);
+    }
+
+    /// Compute a snapshot of inter-token latency and tok/s over the rolling
+    /// window ending at `now`.
+    pub fn snapshot(&self, now: Instant) -> DecodeStatsSnapshot {
+        if self.samples.len() < 2 {
+            return DecodeStatsSnapshot::empty();
+        }
+
+        let cutoff = now.checked_sub(WINDOW).unwrap_or(now);
+        let recent: Vec<Instant> = self
+            .samples
+            .iter()
+            .copied()
+            .filter(|t| *t >= cutoff)
+            .collect();
+
+        if recent.len() < 2 {
+            return DecodeStatsSnapshot::empty();
+        }
+
+        let mut deltas_ms: Vec<f64> = recent
+            .windows(2)
+            .map(|w| (w[1] - w[0]).as_secs_f64() * 1000.0)
+            .collect();
+        deltas_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+        let p50_itl_ms = percentile(&deltas_ms, 0.50);
+        let p99_itl_ms = percentile(&deltas_ms, 0.99);
+        let mean_itl_ms = deltas_ms.iter().sum::<f64>() / deltas_ms.len() as f64;
+
+        // tok/s is computed over the actual span covered by the recent samples,
+        // not the full window. This avoids understating throughput when the
+        // server has only been generating for a fraction of the window.
+        let span_secs = (recent[recent.len() - 1] - recent[0]).as_secs_f64();
+        let tok_per_sec = if span_secs > 0.0 {
+            (recent.len() - 1) as f64 / span_secs
+        } else {
+            0.0
+        };
+
+        DecodeStatsSnapshot {
+            tok_per_sec,
+            p50_itl_ms,
+            p99_itl_ms,
+            mean_itl_ms,
+            sample_count: deltas_ms.len(),
+            window_secs: WINDOW.as_secs_f64(),
+        }
+    }
+
+    fn evict_old(&mut self, now: Instant) {
+        let cutoff = now.checked_sub(WINDOW).unwrap_or(now);
+        while let Some(front) = self.samples.front() {
+            if *front < cutoff {
+                self.samples.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+/// Linear-interpolation percentile of a pre-sorted slice.
+fn percentile(sorted: &[f64], p: f64) -> f64 {
+    if sorted.is_empty() {
+        return 0.0;
+    }
+    if sorted.len() == 1 {
+        return sorted[0];
+    }
+    let rank = p * (sorted.len() - 1) as f64;
+    let lo = rank.floor() as usize;
+    let hi = rank.ceil() as usize;
+    if lo == hi {
+        sorted[lo]
+    } else {
+        let frac = rank - lo as f64;
+        sorted[lo] * (1.0 - frac) + sorted[hi] * frac
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_returns_zeros() {
+        let ring = DecodeStatsRing::new(16);
+        let snap = ring.snapshot(Instant::now());
+        assert_eq!(snap.sample_count, 0);
+        assert_eq!(snap.tok_per_sec, 0.0);
+        assert_eq!(snap.p50_itl_ms, 0.0);
+        assert_eq!(snap.p99_itl_ms, 0.0);
+        assert_eq!(snap.mean_itl_ms, 0.0);
+        assert!((snap.window_secs - 60.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn single_sample_returns_zeros() {
+        let mut ring = DecodeStatsRing::new(16);
+        let t0 = Instant::now();
+        ring.record_token(t0);
+        let snap = ring.snapshot(t0);
+        assert_eq!(snap.sample_count, 0);
+        assert_eq!(snap.tok_per_sec, 0.0);
+    }
+
+    #[test]
+    fn two_samples_compute_itl() {
+        let mut ring = DecodeStatsRing::new(16);
+        let t0 = Instant::now();
+        ring.record_token(t0);
+        ring.record_token(t0 + Duration::from_millis(20));
+        let snap = ring.snapshot(t0 + Duration::from_millis(20));
+        assert_eq!(snap.sample_count, 1);
+        assert!((snap.p50_itl_ms - 20.0).abs() < 0.01);
+        assert!((snap.p99_itl_ms - 20.0).abs() < 0.01);
+        assert!((snap.mean_itl_ms - 20.0).abs() < 0.01);
+        // 1 inter-token gap over a 20ms span = 50 tok/s
+        assert!((snap.tok_per_sec - 50.0).abs() < 0.01);
+    }
+
+    #[test]
+    fn percentile_correctness_using_known_distribution() {
+        let mut ring = DecodeStatsRing::new(256);
+        let t0 = Instant::now();
+        // 100 samples 10ms apart (99 inter-token gaps of 10ms each).
+        for i in 0..100 {
+            ring.record_token(t0 + Duration::from_millis(10 * i));
+        }
+        let snap = ring.snapshot(t0 + Duration::from_millis(10 * 99));
+        assert_eq!(snap.sample_count, 99);
+        assert!(
+            (snap.p50_itl_ms - 10.0).abs() < 0.5,
+            "p50 should be ~10ms, got {}",
+            snap.p50_itl_ms
+        );
+        assert!(
+            (snap.p99_itl_ms - 10.0).abs() < 0.5,
+            "p99 should be ~10ms, got {}",
+            snap.p99_itl_ms
+        );
+
+        // Now inject 5 outliers spaced 100ms apart and verify p99 jumps.
+        // With 99 baseline gaps of 10ms + 5 outlier gaps of 100ms (104 total),
+        // p99 lands inside the outlier tail and the value should be well above
+        // the baseline 10ms.
+        let mut next = t0 + Duration::from_millis(10 * 99);
+        for _ in 0..5 {
+            next += Duration::from_millis(100);
+            ring.record_token(next);
+        }
+        let snap2 = ring.snapshot(next);
+        assert!(
+            snap2.p99_itl_ms > 50.0,
+            "p99 should jump after 5x 100ms outliers, got {}",
+            snap2.p99_itl_ms
+        );
+        // p50 should still be ~10ms (5 outliers in 100+ samples don't move
+        // the median).
+        assert!(
+            (snap2.p50_itl_ms - 10.0).abs() < 1.0,
+            "p50 should still be ~10ms, got {}",
+            snap2.p50_itl_ms
+        );
+    }
+
+    #[test]
+    fn capacity_eviction() {
+        let mut ring = DecodeStatsRing::new(4);
+        let t0 = Instant::now();
+        for i in 0..10 {
+            // Spaced 1ms apart so all stay within the 60s window.
+            ring.record_token(t0 + Duration::from_millis(i));
+        }
+        // Capacity is 4, so only the last 4 timestamps should be retained,
+        // giving 3 inter-token gaps.
+        assert_eq!(ring.samples.len(), 4);
+        let snap = ring.snapshot(t0 + Duration::from_millis(9));
+        assert_eq!(snap.sample_count, 3);
+    }
+
+    #[test]
+    fn evicts_samples_older_than_window() {
+        let mut ring = DecodeStatsRing::new(256);
+        let t0 = Instant::now();
+        // Drop 3 samples at t0, then jump 120s forward and drop 3 more.
+        for i in 0..3 {
+            ring.record_token(t0 + Duration::from_millis(i));
+        }
+        let later = t0 + Duration::from_secs(120);
+        for i in 0..3 {
+            ring.record_token(later + Duration::from_millis(i));
+        }
+        let snap = ring.snapshot(later + Duration::from_millis(2));
+        // Only the 3 recent samples should count → 2 inter-token gaps.
+        assert_eq!(snap.sample_count, 2);
+    }
+
+    #[test]
+    fn snapshot_does_not_mutate() {
+        let mut ring = DecodeStatsRing::new(16);
+        let t0 = Instant::now();
+        ring.record_token(t0);
+        ring.record_token(t0 + Duration::from_millis(5));
+        let _ = ring.snapshot(t0 + Duration::from_millis(5));
+        assert_eq!(ring.samples.len(), 2);
+    }
+}

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -3,6 +3,7 @@
 pub mod api;
 pub mod cli;
 pub mod config;
+pub mod decode_stats;
 pub mod device;
 pub mod error;
 pub mod logging;

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -15,6 +15,7 @@ use kiln_scheduler::{PrefixCacheStats, Scheduler};
 use kiln_train::TrainingState;
 use serde::Serialize;
 
+use crate::decode_stats::DecodeStatsRing;
 use crate::metrics::Metrics;
 use crate::training_queue::{SharedTrainingQueue, ShutdownFlag};
 
@@ -414,6 +415,8 @@ pub struct AppState {
     pub checkpoint_interval: Option<usize>,
     /// Identifier exposed at `/v1/models` and echoed in chat completion responses.
     pub served_model_id: String,
+    /// Rolling timestamp ring for live decode tok/s + ITL on the /ui dashboard.
+    pub decode_stats: Arc<std::sync::Mutex<DecodeStatsRing>>,
 }
 
 impl AppState {
@@ -469,6 +472,7 @@ impl AppState {
             inference_prewarm_complete: Arc::new(AtomicBool::new(true)),
             checkpoint_interval: None,
             served_model_id,
+            decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
         }
     }
 
@@ -680,6 +684,7 @@ impl AppState {
             ))),
             checkpoint_interval: None,
             served_model_id,
+            decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
         }
     }
 }

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -419,6 +419,14 @@ textarea { resize: vertical; min-height: 80px; }
     </div>
   </div>
 
+  <!-- Decode Performance -->
+  <div class="panel">
+    <div class="panel-head"><h2>Decode Performance</h2></div>
+    <div class="panel-body" id="decode-perf-panel">
+      <div class="empty">Loading...</div>
+    </div>
+  </div>
+
   <!-- Adapters -->
   <div class="panel">
     <div class="panel-head">
@@ -674,6 +682,39 @@ function renderServerStatus(h) {
   }
 
   el.innerHTML = vramHtml + schedHtml + checksHtml || '<div class="empty">No data</div>';
+}
+
+// --- Decode Performance ---
+async function pollDecodePerf() {
+  const el = document.getElementById('decode-perf-panel');
+  if (!el) return;
+  try {
+    const data = await api('/v1/stats/decode');
+    const window = data.window_secs ? Math.round(data.window_secs) : 60;
+    if (!data.sample_count || data.sample_count < 1) {
+      el.innerHTML = `<div class="sched-stats">
+        <div class="sched-stat"><div class="num">&mdash;</div><div class="lbl">tok/s</div></div>
+        <div class="sched-stat"><div class="num">&mdash;</div><div class="lbl">p50 ITL</div></div>
+        <div class="sched-stat"><div class="num">&mdash;</div><div class="lbl">p99 ITL</div></div>
+        <div class="sched-stat"><div class="num">0</div><div class="lbl">samples (last ${window}s)</div></div>
+      </div>
+      <div style="margin-top:8px;font-size:12px;color:var(--text2)">No streaming completions in the last ${window}s.</div>`;
+      return;
+    }
+    const tps = data.tok_per_sec.toFixed(1);
+    const p50 = data.p50_itl_ms.toFixed(1) + ' ms';
+    const p99 = data.p99_itl_ms.toFixed(1) + ' ms';
+    const mean = data.mean_itl_ms.toFixed(1);
+    el.innerHTML = `<div class="sched-stats">
+        <div class="sched-stat"><div class="num">${tps}</div><div class="lbl">tok/s</div></div>
+        <div class="sched-stat"><div class="num">${p50}</div><div class="lbl">p50 ITL</div></div>
+        <div class="sched-stat"><div class="num">${p99}</div><div class="lbl">p99 ITL</div></div>
+        <div class="sched-stat"><div class="num">${data.sample_count}</div><div class="lbl">samples (last ${window}s)</div></div>
+      </div>
+      <div style="margin-top:8px;font-size:12px;color:var(--text2)">Mean inter-token latency: ${mean} ms</div>`;
+  } catch (e) {
+    el.innerHTML = `<div class="empty">Failed to load: ${e.message}</div>`;
+  }
 }
 
 // --- Adapters ---
@@ -999,10 +1040,12 @@ renderChat();
 pollHealth();
 pollAdapters();
 pollTraining();
+pollDecodePerf();
 
 setInterval(pollHealth, 2000);
 setInterval(pollAdapters, 5000);
 setInterval(pollTraining, 3000);
+setInterval(pollDecodePerf, 2000);
 
 })();
 </script>


### PR DESCRIPTION
## What

Adds a new "Decode Performance" panel to the /ui dashboard showing live decode tok/s, p50/p99 inter-token latency, and mean ITL over the last 60s of streaming token emits. Polls `/v1/stats/decode` every 2s.

## Why

Project Phase 7 web-UI feature set explicitly calls for "live decode tok/s + p50/p99 ITL" on the dashboard. The bench code already computes these per-request (`crates/kiln-server/src/bench.rs:83-87`) but they were not exposed for live observation during normal streaming traffic.

## How

- New `crates/kiln-server/src/decode_stats.rs` ring buffer (capacity 4096, 60s rolling window) with p50/p99/mean ITL + tok/s computation. 7 unit tests cover empty/single-sample edge cases, two-sample basic ITL, percentile correctness with a known distribution + outliers, capacity eviction, window-based eviction, and the snapshot non-mutation invariant.
- `AppState` gains `decode_stats: Arc<Mutex<DecodeStatsRing>>` wired into both `new_mock` and `new_real` constructors.
- `generate_real_streaming` records `Instant::now()` per `StreamEvent::Token` at the existing emit site (no extra spawn, no allocation outside the lock).
- New `GET /v1/stats/decode` endpoint returns a `DecodeStatsSnapshot` JSON.
- `ui.html` gets a "Decode Performance" panel placed alongside Server Status, polling every 2s. Renders em-dash placeholders when no recent traffic.

## Verification

- `cargo check -p kiln-server` (clean)
- `cargo check -p kiln-server --tests` (clean)
- `cargo test -p kiln-server decode_stats` — 7/7 pass
- `cargo test -p kiln-server api::stats` — 2/2 pass

## Notes

- No GPU/CUDA required for this PR — kiln-server compiles on default features.
- 60s rolling window matches typical dashboard cadence and gives a useful "is the server fast right now" signal without keeping unbounded history.
- tok/s is computed over the actual sample span, not the full window, so the number is meaningful even when the server has only been generating for a few seconds.
- Mock streaming returns `streaming_not_supported_mock` and is not instrumented (nothing to record).