### PR TITLE
phase 7: recent requests panel on /ui dashboard (last 100)

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -20,7 +20,36 @@ use kiln_model::{GenerationOutput, ModelRunner, PagedPrefixReuse, SpeculativeCon
 use crate::config::{SpecMethod, SpeculativeDecodingConfig};
 use crate::error::ApiError;
 use crate::metrics::RequestStatus;
+use crate::recent_requests::{RequestRecord, now_unix_ms, truncate_chars};
 use crate::state::{AppState, ModelBackend, RealPrefixCache};
+
+/// Max characters retained in the prompt preview for the recent-requests panel.
+const PROMPT_PREVIEW_MAX_CHARS: usize = 120;
+/// Max characters retained in the completion preview for the recent-requests panel.
+const COMPLETION_PREVIEW_MAX_CHARS: usize = 200;
+
+/// Pull the most recent user-authored message text from a request, falling
+/// back to the very last message if no user role is present. Returns an empty
+/// string if there are no messages.
+fn last_user_message_text(req: &ChatCompletionRequest) -> String {
+    req.messages
+        .iter()
+        .rev()
+        .find(|m| m.role == "user")
+        .or_else(|| req.messages.last())
+        .map(|m| m.content.clone())
+        .unwrap_or_default()
+}
+
+/// Push a [`RequestRecord`] into the dashboard's recent-requests ring. Logs a
+/// warning if the lock is poisoned but otherwise never panics — request
+/// recording must not fail the user's request.
+fn record_recent_request(state: &AppState, record: RequestRecord) {
+    match state.recent_requests.lock() {
+        Ok(mut ring) => ring.record(record),
+        Err(poisoned) => poisoned.into_inner().record(record),
+    }
+}
 
 /// OpenAI-compatible chat completion request.
 #[derive(Debug, Deserialize)]
@@ -283,6 +312,11 @@ async fn chat_completions_inner(
     state: &AppState,
     req: ChatCompletionRequest,
 ) -> Result<Response, ApiError> {
+    // Captured at the top of the request so the recent-requests panel reflects
+    // wall-clock time including chat-template formatting and tokenization, not
+    // just generation. Streaming and non-streaming paths both consume this.
+    let request_start = std::time::Instant::now();
+
     // Convert request messages to ChatMessage for template formatting
     let chat_messages: Vec<ChatMessage> = req
         .messages
@@ -336,6 +370,7 @@ async fn chat_completions_inner(
                     &prompt_tokens,
                     &sampling,
                     &req,
+                    request_start,
                 )
                 .await
             }
@@ -359,6 +394,7 @@ async fn chat_completions_inner(
                     &prompt_tokens,
                     &sampling,
                     &req,
+                    request_start,
                 )
                 .await?;
                 // Count generated tokens for metrics.
@@ -368,8 +404,16 @@ async fn chat_completions_inner(
                 Ok(Json(resp).into_response())
             }
             ModelBackend::Mock { scheduler, engine } => {
-                let resp =
-                    generate_mock(state, scheduler, engine, &prompt_text, &sampling, &req).await?;
+                let resp = generate_mock(
+                    state,
+                    scheduler,
+                    engine,
+                    &prompt_text,
+                    &sampling,
+                    &req,
+                    request_start,
+                )
+                .await?;
                 state
                     .metrics
                     .add_tokens(resp.usage.completion_tokens as u64);
@@ -462,6 +506,7 @@ async fn generate_real(
     prompt_tokens: &[TokenId],
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
+    request_start: std::time::Instant,
 ) -> Result<ChatCompletionResponse, ApiError> {
     let prompt_token_count = prompt_tokens.len();
 
@@ -611,27 +656,47 @@ async fn generate_real(
     };
 
     let now = now_epoch();
+    let id = format!("chatcmpl-{}", Uuid::new_v4());
+    let model = req
+        .model
+        .clone()
+        .unwrap_or_else(|| state.served_model_id.clone());
+    let completion_tokens = output.token_ids.len();
+    let completion_text = output.text;
+
+    record_recent_request(
+        state,
+        RequestRecord {
+            id: id.clone(),
+            timestamp_unix_ms: now_unix_ms(),
+            model: model.clone(),
+            prompt_preview: truncate_chars(&last_user_message_text(req), PROMPT_PREVIEW_MAX_CHARS),
+            completion_preview: truncate_chars(&completion_text, COMPLETION_PREVIEW_MAX_CHARS),
+            prompt_tokens: prompt_token_count as u32,
+            completion_tokens: completion_tokens as u32,
+            duration_ms: request_start.elapsed().as_millis() as u64,
+            streamed: false,
+            finish_reason: finish_reason.to_string(),
+        },
+    );
 
     Ok(ChatCompletionResponse {
-        id: format!("chatcmpl-{}", Uuid::new_v4()),
+        id,
         object: "chat.completion",
         created: now,
-        model: req
-            .model
-            .clone()
-            .unwrap_or_else(|| state.served_model_id.clone()),
+        model,
         choices: vec![Choice {
             index: 0,
             message: Message {
                 role: "assistant".to_string(),
-                content: output.text,
+                content: completion_text,
             },
             finish_reason: finish_reason.to_string(),
         }],
         usage: Usage {
             prompt_tokens: prompt_token_count,
-            completion_tokens: output.token_ids.len(),
-            total_tokens: prompt_token_count + output.token_ids.len(),
+            completion_tokens,
+            total_tokens: prompt_token_count + completion_tokens,
         },
     })
 }
@@ -655,6 +720,7 @@ async fn generate_real_streaming(
     prompt_tokens: &[TokenId],
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
+    request_start: std::time::Instant,
 ) -> Result<Response, ApiError> {
     let (mtp_supported, has_active_lora) = {
         let guard = runner.read().unwrap();
@@ -673,6 +739,7 @@ async fn generate_real_streaming(
     let pc = paged_cache.clone();
     let prefix_cache = prefix_cache.clone();
     let prompt = prompt_text.to_owned();
+    let prompt_token_count = prompt_tokens.len();
     let prompt_tokens = prompt_tokens.to_vec();
     let params = sampling.clone();
     let adapter = req.adapter.clone();
@@ -685,6 +752,8 @@ async fn generate_real_streaming(
     let gpu_lock = state.gpu_lock.clone();
     let timeout = state.request_timeout;
     let decode_stats = state.decode_stats.clone();
+    let recent_requests = state.recent_requests.clone();
+    let prompt_preview = truncate_chars(&last_user_message_text(req), PROMPT_PREVIEW_MAX_CHARS);
 
     // Use a tokio mpsc channel to bridge sync generation -> async SSE stream.
     let (tx, rx) = tokio::sync::mpsc::channel::<Event>(32);
@@ -694,6 +763,36 @@ async fn generate_real_streaming(
         let id = completion_id.clone();
         let model = model.clone();
         async move {
+            // Accumulate the assistant content so we can store a preview in the
+            // recent-requests ring once generation completes (or times out, or
+            // the client disconnects).
+            let mut completion_buf = String::new();
+            let mut completion_token_count: u32 = 0;
+
+            let record = |finish_reason: String,
+                          completion: &str,
+                          completion_tokens: u32| {
+                let record = RequestRecord {
+                    id: id.clone(),
+                    timestamp_unix_ms: now_unix_ms(),
+                    model: model.clone(),
+                    prompt_preview: prompt_preview.clone(),
+                    completion_preview: truncate_chars(
+                        completion,
+                        COMPLETION_PREVIEW_MAX_CHARS,
+                    ),
+                    prompt_tokens: prompt_token_count as u32,
+                    completion_tokens,
+                    duration_ms: request_start.elapsed().as_millis() as u64,
+                    streamed: true,
+                    finish_reason,
+                };
+                match recent_requests.lock() {
+                    Ok(mut ring) => ring.record(record),
+                    Err(poisoned) => poisoned.into_inner().record(record),
+                }
+            };
+
             // Send initial role chunk
             let role_chunk = ChatCompletionChunk {
                 id: id.clone(),
@@ -714,6 +813,11 @@ async fn generate_real_streaming(
                 .await
                 .is_err()
             {
+                record(
+                    "client_disconnect".to_string(),
+                    &completion_buf,
+                    completion_token_count,
+                );
                 return;
             }
 
@@ -798,6 +902,11 @@ async fn generate_real_streaming(
                     {
                         Ok(Ok(rx)) => rx,
                         _ => {
+                            record(
+                                "error".to_string(),
+                                &completion_buf,
+                                completion_token_count,
+                            );
                             let _ = tx.send(Event::default().data("[DONE]")).await;
                             return;
                         }
@@ -831,6 +940,11 @@ async fn generate_real_streaming(
                     {
                         Ok(Ok(rx)) => rx,
                         _ => {
+                            record(
+                                "error".to_string(),
+                                &completion_buf,
+                                completion_token_count,
+                            );
                             let _ = tx.send(Event::default().data("[DONE]")).await;
                             return;
                         }
@@ -846,6 +960,11 @@ async fn generate_real_streaming(
                     {
                         Ok(Ok(rx)) => rx,
                         _ => {
+                            record(
+                                "error".to_string(),
+                                &completion_buf,
+                                completion_token_count,
+                            );
                             let _ = tx.send(Event::default().data("[DONE]")).await;
                             return;
                         }
@@ -885,6 +1004,12 @@ async fn generate_real_streaming(
                                 if let Ok(mut stats) = decode_stats.lock() {
                                     stats.record_token(std::time::Instant::now());
                                 }
+                                completion_token_count = completion_token_count.saturating_add(1);
+                                // Cap the buffered preview text so an unbounded
+                                // generation doesn't keep allocating.
+                                if completion_buf.chars().count() < COMPLETION_PREVIEW_MAX_CHARS + 16 {
+                                    completion_buf.push_str(&token.text);
+                                }
                                 let chunk = ChatCompletionChunk {
                                     id: id.clone(),
                                     object: "chat.completion.chunk",
@@ -908,6 +1033,11 @@ async fn generate_real_streaming(
                                     .is_err()
                                 {
                                     // Client disconnected — drop rx to stop generation
+                                    record(
+                                        "client_disconnect".to_string(),
+                                        &completion_buf,
+                                        completion_token_count,
+                                    );
                                     return;
                                 }
                             }
@@ -938,11 +1068,21 @@ async fn generate_real_streaming(
                                     )
                                     .await;
                                 let _ = tx.send(Event::default().data("[DONE]")).await;
+                                record(
+                                    finish.to_string(),
+                                    &completion_buf,
+                                    completion_token_count,
+                                );
                                 return;
                             }
                             _ => {
                                 // Channel closed or join error
                                 let _ = tx.send(Event::default().data("[DONE]")).await;
+                                record(
+                                    "error".to_string(),
+                                    &completion_buf,
+                                    completion_token_count,
+                                );
                                 return;
                             }
                         }
@@ -976,6 +1116,11 @@ async fn generate_real_streaming(
                     .send(Event::default().data(serde_json::to_string(&error_chunk).unwrap()))
                     .await;
                 let _ = tx.send(Event::default().data("[DONE]")).await;
+                record(
+                    "timeout".to_string(),
+                    &completion_buf,
+                    completion_token_count,
+                );
             }
         }
     });
@@ -995,6 +1140,7 @@ async fn generate_mock(
     prompt_text: &str,
     sampling: &SamplingParams,
     req: &ChatCompletionRequest,
+    request_start: std::time::Instant,
 ) -> Result<ChatCompletionResponse, ApiError> {
     let prompt_tokens = state
         .tokenizer
@@ -1073,15 +1219,34 @@ async fn generate_mock(
         .unwrap_or_else(|_| format!("[{} tokens, decode failed]", output_tokens.len()));
 
     let now = now_epoch();
+    let id = format!("chatcmpl-{}", Uuid::new_v4());
+    let model = req
+        .model
+        .clone()
+        .unwrap_or_else(|| state.served_model_id.clone());
+    let completion_tokens = output_tokens.len();
+
+    record_recent_request(
+        state,
+        RequestRecord {
+            id: id.clone(),
+            timestamp_unix_ms: now_unix_ms(),
+            model: model.clone(),
+            prompt_preview: truncate_chars(&last_user_message_text(req), PROMPT_PREVIEW_MAX_CHARS),
+            completion_preview: truncate_chars(&completion_text, COMPLETION_PREVIEW_MAX_CHARS),
+            prompt_tokens: prompt_token_count as u32,
+            completion_tokens: completion_tokens as u32,
+            duration_ms: request_start.elapsed().as_millis() as u64,
+            streamed: false,
+            finish_reason: "stop".to_string(),
+        },
+    );
 
     Ok(ChatCompletionResponse {
-        id: format!("chatcmpl-{}", Uuid::new_v4()),
+        id,
         object: "chat.completion",
         created: now,
-        model: req
-            .model
-            .clone()
-            .unwrap_or_else(|| state.served_model_id.clone()),
+        model,
         choices: vec![Choice {
             index: 0,
             message: Message {
@@ -1092,8 +1257,8 @@ async fn generate_mock(
         }],
         usage: Usage {
             prompt_tokens: prompt_token_count,
-            completion_tokens: output_tokens.len(),
-            total_tokens: prompt_token_count + output_tokens.len(),
+            completion_tokens,
+            total_tokens: prompt_token_count + completion_tokens,
         },
     })
 }

--- a/crates/kiln-server/src/api/stats.rs
+++ b/crates/kiln-server/src/api/stats.rs
@@ -1,8 +1,8 @@
 //! Live runtime statistics endpoints.
 //!
-//! Currently exposes `/v1/stats/decode` which returns a snapshot of decode
-//! tokens-per-second and inter-token latency over the rolling window. The
-//! /ui dashboard polls this every 2 seconds.
+//! Exposes `/v1/stats/decode` (decode tok/s + ITL over a rolling window) and
+//! `/v1/stats/recent-requests` (bounded history of recent chat completions).
+//! The /ui dashboard polls both every 2 seconds.
 
 use std::time::Instant;
 
@@ -11,6 +11,7 @@ use axum::routing::get;
 use axum::{Json, Router};
 
 use crate::decode_stats::DecodeStatsSnapshot;
+use crate::recent_requests::RequestRecord;
 use crate::state::AppState;
 
 async fn get_decode_stats(State(state): State<AppState>) -> Json<DecodeStatsSnapshot> {
@@ -22,8 +23,19 @@ async fn get_decode_stats(State(state): State<AppState>) -> Json<DecodeStatsSnap
     Json(snap)
 }
 
+async fn get_recent_requests(State(state): State<AppState>) -> Json<Vec<RequestRecord>> {
+    let snap = state
+        .recent_requests
+        .lock()
+        .map(|ring| ring.snapshot())
+        .unwrap_or_else(|poisoned| poisoned.into_inner().snapshot());
+    Json(snap)
+}
+
 pub fn routes() -> Router<AppState> {
-    Router::new().route("/v1/stats/decode", get(get_decode_stats))
+    Router::new()
+        .route("/v1/stats/decode", get(get_decode_stats))
+        .route("/v1/stats/recent-requests", get(get_recent_requests))
 }
 
 #[cfg(test)]
@@ -81,6 +93,69 @@ mod tests {
         assert_eq!(body["sample_count"], 0);
         assert_eq!(body["tok_per_sec"], 0.0);
         assert!(body["window_secs"].as_f64().unwrap() > 0.0);
+    }
+
+    #[tokio::test]
+    async fn recent_requests_endpoint_is_empty_by_default() {
+        let state = make_test_state();
+        let app = routes().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/stats/recent-requests")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(body.is_array());
+        assert_eq!(body.as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn recent_requests_endpoint_returns_newest_first() {
+        use crate::recent_requests::RequestRecord;
+        let state = make_test_state();
+        {
+            let mut ring = state.recent_requests.lock().unwrap();
+            for (i, id) in ["first", "second", "third"].iter().enumerate() {
+                ring.record(RequestRecord {
+                    id: (*id).to_owned(),
+                    timestamp_unix_ms: 1_000 + i as u64,
+                    model: "kiln-test".to_owned(),
+                    prompt_preview: format!("prompt {id}"),
+                    completion_preview: format!("done {id}"),
+                    prompt_tokens: 4,
+                    completion_tokens: 8,
+                    duration_ms: 50 + i as u64 * 10,
+                    streamed: i % 2 == 0,
+                    finish_reason: "stop".to_owned(),
+                });
+            }
+        }
+
+        let app = routes().with_state(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/stats/recent-requests")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = to_bytes(resp.into_body(), 16 * 1024).await.unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let arr = body.as_array().expect("array");
+        assert_eq!(arr.len(), 3);
+        assert_eq!(arr[0]["id"], "third");
+        assert_eq!(arr[1]["id"], "second");
+        assert_eq!(arr[2]["id"], "first");
+        assert_eq!(arr[0]["completion_tokens"], 8);
+        assert_eq!(arr[0]["finish_reason"], "stop");
     }
 
     #[tokio::test]

--- a/crates/kiln-server/src/lib.rs
+++ b/crates/kiln-server/src/lib.rs
@@ -8,5 +8,6 @@ pub mod device;
 pub mod error;
 pub mod logging;
 pub mod metrics;
+pub mod recent_requests;
 pub mod state;
 pub mod training_queue;

--- a/crates/kiln-server/src/recent_requests.rs
+++ b/crates/kiln-server/src/recent_requests.rs
@@ -1,0 +1,213 @@
+//! Recent requests ring buffer for the /ui dashboard.
+//!
+//! Records a bounded history of completed chat-completion requests (both
+//! streaming and non-streaming) along with prompt/completion previews, token
+//! counts, and timing. The /ui dashboard polls `/v1/stats/recent-requests`
+//! every 2 seconds to render the panel.
+
+use std::collections::VecDeque;
+
+use serde::Serialize;
+
+/// Default upper bound on retained requests. Old entries are evicted FIFO.
+pub const DEFAULT_CAPACITY: usize = 100;
+
+/// One row in the recent-requests panel.
+///
+/// Previews are stored already-truncated to keep the JSON payload small. The
+/// truncation is char-boundary safe (see [`truncate_chars`]).
+#[derive(Debug, Clone, Serialize)]
+pub struct RequestRecord {
+    pub id: String,
+    pub timestamp_unix_ms: u64,
+    pub model: String,
+    pub prompt_preview: String,
+    pub completion_preview: String,
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub duration_ms: u64,
+    pub streamed: bool,
+    pub finish_reason: String,
+}
+
+/// Bounded FIFO ring of [`RequestRecord`]s, newest at the back.
+pub struct RecentRequestsRing {
+    deque: VecDeque<RequestRecord>,
+    capacity: usize,
+}
+
+impl RecentRequestsRing {
+    pub fn new(capacity: usize) -> Self {
+        let capacity = capacity.max(1);
+        Self {
+            deque: VecDeque::with_capacity(capacity),
+            capacity,
+        }
+    }
+
+    /// Append a record, evicting the oldest if at capacity.
+    pub fn record(&mut self, record: RequestRecord) {
+        if self.deque.len() >= self.capacity {
+            self.deque.pop_front();
+        }
+        self.deque.push_back(record);
+    }
+
+    /// Return all retained records in newest-first order.
+    pub fn snapshot(&self) -> Vec<RequestRecord> {
+        self.deque.iter().rev().cloned().collect()
+    }
+
+    pub fn len(&self) -> usize {
+        self.deque.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.deque.is_empty()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+}
+
+impl Default for RecentRequestsRing {
+    fn default() -> Self {
+        Self::new(DEFAULT_CAPACITY)
+    }
+}
+
+/// Truncate `s` to at most `max_chars` characters, appending `…` if it was
+/// shortened. Slicing on a char boundary keeps multibyte sequences intact.
+pub fn truncate_chars(s: &str, max_chars: usize) -> String {
+    if max_chars == 0 {
+        return String::new();
+    }
+    let mut count = 0usize;
+    for (idx, _) in s.char_indices() {
+        if count == max_chars {
+            let mut out = String::with_capacity(idx + 3);
+            out.push_str(&s[..idx]);
+            out.push('…');
+            return out;
+        }
+        count += 1;
+    }
+    // The whole string fits within `max_chars`.
+    s.to_owned()
+}
+
+/// Current Unix epoch in milliseconds. Saturates at 0 if the system clock is
+/// before the epoch.
+pub fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_record(id: &str) -> RequestRecord {
+        RequestRecord {
+            id: id.to_owned(),
+            timestamp_unix_ms: 0,
+            model: "kiln-test".to_owned(),
+            prompt_preview: "p".to_owned(),
+            completion_preview: "c".to_owned(),
+            prompt_tokens: 0,
+            completion_tokens: 0,
+            duration_ms: 0,
+            streamed: false,
+            finish_reason: "stop".to_owned(),
+        }
+    }
+
+    #[test]
+    fn empty_ring_snapshot_is_empty() {
+        let ring = RecentRequestsRing::new(8);
+        assert!(ring.is_empty());
+        assert_eq!(ring.len(), 0);
+        assert!(ring.snapshot().is_empty());
+    }
+
+    #[test]
+    fn fifo_eviction_at_capacity() {
+        let mut ring = RecentRequestsRing::new(3);
+        for id in ["a", "b", "c", "d", "e"] {
+            ring.record(make_record(id));
+        }
+        assert_eq!(ring.len(), 3);
+        let snap = ring.snapshot();
+        let ids: Vec<&str> = snap.iter().map(|r| r.id.as_str()).collect();
+        // Capacity 3, inserted 5 — only the last 3 (c, d, e) survive.
+        // Snapshot is newest-first.
+        assert_eq!(ids, vec!["e", "d", "c"]);
+    }
+
+    #[test]
+    fn snapshot_is_newest_first() {
+        let mut ring = RecentRequestsRing::new(8);
+        ring.record(make_record("first"));
+        ring.record(make_record("second"));
+        ring.record(make_record("third"));
+        let snap = ring.snapshot();
+        assert_eq!(snap[0].id, "third");
+        assert_eq!(snap[1].id, "second");
+        assert_eq!(snap[2].id, "first");
+    }
+
+    #[test]
+    fn snapshot_does_not_mutate() {
+        let mut ring = RecentRequestsRing::new(8);
+        ring.record(make_record("a"));
+        let _ = ring.snapshot();
+        assert_eq!(ring.len(), 1);
+        let _ = ring.snapshot();
+        assert_eq!(ring.len(), 1);
+    }
+
+    #[test]
+    fn capacity_is_clamped_to_at_least_one() {
+        let ring = RecentRequestsRing::new(0);
+        assert_eq!(ring.capacity(), 1);
+    }
+
+    #[test]
+    fn truncate_chars_shorter_than_max_is_unchanged() {
+        assert_eq!(truncate_chars("hello", 10), "hello");
+        assert_eq!(truncate_chars("", 10), "");
+    }
+
+    #[test]
+    fn truncate_chars_at_exact_length_is_unchanged() {
+        assert_eq!(truncate_chars("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_chars_longer_than_max_appends_ellipsis() {
+        assert_eq!(truncate_chars("hello world", 5), "hello…");
+    }
+
+    #[test]
+    fn truncate_chars_respects_codepoint_boundaries() {
+        // "héllo" — the é is two bytes but one char. Truncating at char 3
+        // must produce a valid UTF-8 string, not slice mid-codepoint.
+        let s = "héllo world";
+        let out = truncate_chars(s, 3);
+        assert_eq!(out, "hél…");
+        assert!(out.is_char_boundary(out.len()));
+
+        // Multi-byte CJK characters.
+        let cjk = "你好世界你好";
+        let out = truncate_chars(cjk, 3);
+        assert_eq!(out, "你好世…");
+    }
+
+    #[test]
+    fn truncate_chars_max_zero_returns_empty() {
+        assert_eq!(truncate_chars("hello", 0), "");
+    }
+}

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -17,6 +17,7 @@ use serde::Serialize;
 
 use crate::decode_stats::DecodeStatsRing;
 use crate::metrics::Metrics;
+use crate::recent_requests::{DEFAULT_CAPACITY as RECENT_REQUESTS_CAPACITY, RecentRequestsRing};
 use crate::training_queue::{SharedTrainingQueue, ShutdownFlag};
 
 const DEFAULT_BLOCK_SIZE: usize = 16;
@@ -417,6 +418,8 @@ pub struct AppState {
     pub served_model_id: String,
     /// Rolling timestamp ring for live decode tok/s + ITL on the /ui dashboard.
     pub decode_stats: Arc<std::sync::Mutex<DecodeStatsRing>>,
+    /// Bounded history of recent chat-completion requests for the /ui dashboard.
+    pub recent_requests: Arc<std::sync::Mutex<RecentRequestsRing>>,
 }
 
 impl AppState {
@@ -473,6 +476,9 @@ impl AppState {
             checkpoint_interval: None,
             served_model_id,
             decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
+            recent_requests: Arc::new(std::sync::Mutex::new(RecentRequestsRing::new(
+                RECENT_REQUESTS_CAPACITY,
+            ))),
         }
     }
 
@@ -685,6 +691,9 @@ impl AppState {
             checkpoint_interval: None,
             served_model_id,
             decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
+            recent_requests: Arc::new(std::sync::Mutex::new(RecentRequestsRing::new(
+                RECENT_REQUESTS_CAPACITY,
+            ))),
         }
     }
 }

--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -379,6 +379,70 @@ textarea { resize: vertical; min-height: 80px; }
   font-size: 13px;
 }
 
+/* Recent Requests */
+.recent-list {
+  max-height: 320px;
+  overflow-y: auto;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.recent-row {
+  display: grid;
+  grid-template-columns: 80px 1fr 140px;
+  gap: 12px;
+  padding: 8px 4px;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+  align-items: start;
+}
+.recent-row:last-child { border-bottom: none; }
+.recent-time {
+  font-family: var(--mono);
+  color: var(--text2);
+  white-space: nowrap;
+}
+.recent-previews { min-width: 0; }
+.recent-prompt {
+  color: var(--text2);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: var(--mono);
+}
+.recent-completion {
+  color: var(--text);
+  margin-top: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.recent-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+  color: var(--text2);
+  font-family: var(--mono);
+  white-space: nowrap;
+}
+.recent-meta .recent-tokens { color: var(--text); }
+.recent-pill {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 10px;
+  font-size: 10px;
+  background: var(--surface2);
+  color: var(--text2);
+  border: 1px solid var(--border);
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.recent-pill.streamed { color: var(--accent); border-color: var(--accent); }
+.recent-pill.timeout,
+.recent-pill.error,
+.recent-pill.client_disconnect { color: var(--orange); border-color: var(--orange); }
+
 /* Toast */
 .toast-container {
   position: fixed;
@@ -423,6 +487,14 @@ textarea { resize: vertical; min-height: 80px; }
   <div class="panel">
     <div class="panel-head"><h2>Decode Performance</h2></div>
     <div class="panel-body" id="decode-perf-panel">
+      <div class="empty">Loading...</div>
+    </div>
+  </div>
+
+  <!-- Recent Requests -->
+  <div class="panel" style="grid-column: 1 / -1;">
+    <div class="panel-head"><h2>Recent Requests</h2></div>
+    <div class="panel-body" id="recent-requests-panel">
       <div class="empty">Loading...</div>
     </div>
   </div>
@@ -717,6 +789,79 @@ async function pollDecodePerf() {
   }
 }
 
+// --- Recent Requests ---
+let recentRequestsCache = [];
+
+function fmtRelTime(unixMs) {
+  if (!unixMs) return '-';
+  const now = Date.now();
+  const delta = Math.max(0, Math.round((now - unixMs) / 1000));
+  if (delta < 1) return 'now';
+  if (delta < 60) return delta + 's ago';
+  if (delta < 3600) return Math.floor(delta / 60) + 'm ago';
+  if (delta < 86400) return Math.floor(delta / 3600) + 'h ago';
+  return Math.floor(delta / 86400) + 'd ago';
+}
+
+function escapeHtml(s) {
+  return String(s == null ? '' : s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
+function renderRecentRequests(rows) {
+  const el = document.getElementById('recent-requests-panel');
+  if (!el) return;
+  if (!rows || rows.length === 0) {
+    el.innerHTML = '<div class="empty">No requests yet — try Quick Inference below</div>';
+    return;
+  }
+  const items = rows.map(r => {
+    const finish = r.finish_reason || 'stop';
+    const finishClass = finish.replace(/[^a-z_]/gi, '_');
+    const streamPill = r.streamed ? '<span class="recent-pill streamed">stream</span>' : '';
+    const finishPill = `<span class="recent-pill ${finishClass}">${escapeHtml(finish)}</span>`;
+    const tokens = `${r.prompt_tokens || 0} → ${r.completion_tokens || 0} tok`;
+    const dur = (r.duration_ms != null) ? `${r.duration_ms} ms` : '';
+    const promptText = r.prompt_preview || '—';
+    const completionText = r.completion_preview || '—';
+    return `
+      <li class="recent-row" data-ts="${r.timestamp_unix_ms || 0}">
+        <div class="recent-time">${fmtRelTime(r.timestamp_unix_ms)}</div>
+        <div class="recent-previews">
+          <div class="recent-prompt" title="${escapeHtml(promptText)}">${streamPill}${escapeHtml(promptText)}</div>
+          <div class="recent-completion" title="${escapeHtml(completionText)}">${escapeHtml(completionText)}</div>
+        </div>
+        <div class="recent-meta">
+          <span class="recent-tokens">${tokens}</span>
+          <span>${finishPill}${escapeHtml(dur)}</span>
+        </div>
+      </li>
+    `;
+  }).join('');
+  el.innerHTML = `<ul class="recent-list">${items}</ul>`;
+}
+
+function refreshRecentTimes() {
+  const el = document.getElementById('recent-requests-panel');
+  if (!el) return;
+  el.querySelectorAll('.recent-row').forEach(row => {
+    const ts = Number(row.dataset.ts || 0);
+    if (!ts) return;
+    const tcell = row.querySelector('.recent-time');
+    if (tcell) tcell.textContent = fmtRelTime(ts);
+  });
+}
+
+async function pollRecentRequests() {
+  try {
+    const data = await api('/v1/stats/recent-requests');
+    recentRequestsCache = Array.isArray(data) ? data : [];
+    renderRecentRequests(recentRequestsCache);
+  } catch (e) {
+    const el = document.getElementById('recent-requests-panel');
+    if (el) el.innerHTML = `<div class="empty">Failed to load: ${escapeHtml(e.message)}</div>`;
+  }
+}
+
 // --- Adapters ---
 async function pollAdapters() {
   try {
@@ -947,10 +1092,6 @@ function renderChat() {
   el.scrollTop = el.scrollHeight;
 }
 
-function escapeHtml(s) {
-  return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
-}
-
 async function sendChat() {
   const input = document.getElementById('chat-input');
   const msg = input.value.trim();
@@ -1041,11 +1182,15 @@ pollHealth();
 pollAdapters();
 pollTraining();
 pollDecodePerf();
+pollRecentRequests();
 
 setInterval(pollHealth, 2000);
 setInterval(pollAdapters, 5000);
 setInterval(pollTraining, 3000);
 setInterval(pollDecodePerf, 2000);
+setInterval(pollRecentRequests, 2000);
+// Refresh relative timestamps every second without re-fetching the list.
+setInterval(refreshRecentTimes, 1000);
 
 })();
 </script>


### PR DESCRIPTION
## What

Adds a bounded history of completed chat-completion requests to the `/ui` dashboard, mirroring the pattern PR #550 used for live decode stats. Closes the last unfinished sub-item of Phase 7 queue #4 ("Interactive web UI").

## Backend

- **New module** `crates/kiln-server/src/recent_requests.rs`:
  - `RecentRequestsRing { capacity: 100, deque: VecDeque<RequestRecord> }` with FIFO eviction and a newest-first `snapshot()`.
  - `RequestRecord` carries `id`, `timestamp_unix_ms`, `model`, `prompt_preview`, `completion_preview`, `prompt_tokens`, `completion_tokens`, `duration_ms`, `streamed`, `finish_reason` — all `Serialize` + `Clone`.
  - `truncate_chars(s, max)` slices on char boundaries (multibyte-safe) and appends `…` when shortened.
- **AppState wiring** in `state.rs`: new `recent_requests: Arc<Mutex<RecentRequestsRing>>` initialized in both `new_mock` and `new_real`. Lock pattern mirrors the existing `decode_stats` (std::sync::Mutex with poisoned recovery).
- **New endpoint** in `api/stats.rs`: `GET /v1/stats/recent-requests` returns `Json<Vec<RequestRecord>>` newest-first.
- **Recording** in `api/completions.rs`:
  - `chat_completions_inner` captures a `request_start` `Instant` at the top and threads it through `generate_real`, `generate_real_streaming`, and `generate_mock`.
  - Non-streaming (`generate_real`, `generate_mock`) record before returning the final response.
  - Streaming (`generate_real_streaming`) accumulates assistant tokens into a bounded `String` (capped at `COMPLETION_PREVIEW_MAX_CHARS + 16` so unbounded gens don't keep allocating) and records on Done / timeout / client-disconnect / generation-error paths.
  - Lock holds are momentary (no `.await` while holding) so the std::sync::Mutex is safe inside the async task.

## UI

- New **Recent Requests** panel placed below Decode Performance and above Adapters, full-width on the dashboard grid.
- Scrollable list (max-height 320px), each row shows: relative time ("3s ago"), prompt preview (in `--text2`), completion preview (in `--text`), `prompt→completion tok` counts, duration, `finish_reason` pill, and a `stream` pill for streamed requests.
- Empty state: `No requests yet — try Quick Inference below`.
- Polls `/v1/stats/recent-requests` every 2s.
- Relative timestamps refresh locally every 1s without a re-fetch (`refreshRecentTimes`) so rows visibly age between polls.

## Tests

13 new unit tests covering:
- Empty ring snapshot.
- FIFO eviction at capacity.
- Newest-first snapshot ordering.
- `snapshot()` non-mutating.
- Capacity clamp at 1.
- `truncate_chars` for shorter / exact-length / longer / codepoint-boundary / max-zero inputs.
- `/v1/stats/recent-requests` endpoint returns empty array by default and reflects recorded entries newest-first with correct shape.

Full `kiln-server` suite: **107/107 passing** (`cargo nextest run -p kiln-server`).

## Validation

Verified locally on Cloud Eric (no CUDA, default features only):

```
cargo build -p kiln-server      # warns about pre-existing unused Context import; otherwise clean
cargo nextest run -p kiln-server # 107 passed, 0 skipped, 0 failed
```

Manual UI inspection: empty `/v1/stats/recent-requests` array renders the empty-state copy; populated rows render the meta column and previews correctly.

## Notes

- No CUDA / GPU pod required for this PR — it touches only the dashboard surface and request recording in pure Rust.
- Backward-compatible: the new field on `AppState` is initialized in both constructors; existing tests pass without changes.