### PR TITLE
docs: add CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,49 @@
+# Code of Conduct
+
+## Purpose
+
+Kiln exists to make a particular kind of technical work possible: tight, profile-driven performance optimization on a single inference server, in the open, without ceremony. This document is here so contributors can do that work alongside each other without friction. The goal is a project where the most interesting conversation in any thread is the technical one.
+
+## Expected behavior
+
+Be the kind of collaborator you would want reviewing your own PR.
+
+- Assume good faith. Most disagreements are misunderstandings, not bad intent.
+- Stay focused on the technical substance — the code, the benchmark, the design tradeoff.
+- Give credit clearly when building on someone else's work, in commit messages and PR bodies.
+- Accept feedback gracefully, and offer it the same way: specific, concrete, and aimed at the work rather than the person.
+- When you are wrong, say so and move on. It is faster than the alternative.
+
+## Unacceptable behavior
+
+These will get you removed from the project:
+
+- Harassment, threats, or personal attacks against any contributor.
+- Discriminatory language or sustained hostility based on identity.
+- Doxxing, sharing private information without consent, or impersonating other contributors.
+- Sustained disruption of issues, PRs, or discussions after being asked to stop.
+
+## Scope
+
+This applies anywhere the project lives: the GitHub repository, issues and pull requests, discussions, the security inbox, and any future chat or community space the project sets up. It also applies to behavior outside those spaces when it directly affects the safety of contributors here.
+
+## Reporting
+
+If you experience or witness behavior that violates this document, email <floguy@gmail.com> with the subject line `[kiln conduct]`. Reports are kept confidential and only shared with people who need to know to act on them.
+
+Realistic timing, given the project is currently maintained by one person:
+
+- **Acknowledgment:** within 7 days.
+- **Decision or follow-up:** within 30 days of acknowledgment.
+
+If you do not hear back within 7 days, send a follow-up — almost always it means the message was lost, not ignored.
+
+## Enforcement
+
+The maintainer may, at their discretion, warn the contributor privately, edit or remove offending content, lock or close the relevant issue or PR, or ban the contributor from the project. The response will be proportionate to the behavior and to the contributor's history in the project.
+
+Decisions are final. If you believe a decision was wrong, you may appeal once through the same email address; the maintainer will reconsider in good faith and respond.
+
+## License
+
+This document is released under the same MIT license as the rest of the project.


### PR DESCRIPTION
Adds a short, custom code of conduct for the kiln project.

Closes the last governance gap before v0.1.0 release prep:
- CONTRIBUTING.md shipped in #552
- SECURITY.md shipped in #553
- CODE_OF_CONDUCT.md (this PR)

Written from scratch in the same tone as the other governance docs. Not based on any standard template.