### PR TITLE
chore: add cargo-deny license policy

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,55 @@
+# cargo-deny policy for kiln. Enforces an MIT/Apache-2.0-compatible license
+# allowlist, denies unknown registries/git sources, and bans wildcard version
+# requirements. CI enforcement (a GitHub Actions job running `cargo deny check`)
+# is a follow-up task; this file establishes the policy.
+
+[graph]
+targets = []
+all-features = true
+
+[licenses]
+version = 2
+confidence-threshold = 0.93
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "MPL-2.0",
+    "CC0-1.0",
+    "0BSD",
+    # webpki-roots: CDLA-Permissive-2.0 is the Linux Foundation's permissive
+    # data license (no copyleft, no patent restrictions); MIT/Apache-compatible.
+    "CDLA-Permissive-2.0",
+]
+
+[bans]
+multiple-versions = "warn"
+# Workspace internal deps use `{ workspace = true }`, which resolves as a `*`
+# version requirement. cargo-deny's `allow-wildcard-paths` exemption only
+# applies to crates that set `publish = false`; until the workspace crates
+# declare their publish state explicitly, the path-wildcard exemption can't
+# be granted, so we set this to "warn" rather than "deny". Tighten to "deny"
+# in a follow-up after marking the non-publishable crates as `publish = false`.
+wildcards = "warn"
+allow-wildcard-paths = true
+deny = []
+skip = []
+skip-tree = []
+
+[advisories]
+version = 2
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "warn"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## What
Adds a `deny.toml` at the repo root configuring cargo-deny with an MIT/Apache-2.0-compatible license allowlist, an unknown-registry/unknown-git deny policy, and a wildcards bans rule (set to `warn` for now — see below).

## Why
First concrete step of Phase 9 'License review (all dependencies MIT/Apache compatible)'. Establishes the policy file; CI enforcement (a GHA job that runs `cargo deny check` on every PR) is a follow-up task.

## Validation
Ran `cargo install --locked cargo-deny --version ^0.16` (0.16.4) and:

- `cargo deny --all-features check licenses` → ok
- `cargo deny --all-features check sources` → ok
- `cargo deny --all-features check bans` → ok (warnings only)

## Allowlist additions beyond the standard set
- `CDLA-Permissive-2.0` — used by `webpki-roots` (transitive via `tokenizers` → `hf-hub` → `ureq`). Linux Foundation's permissive data license; no copyleft, no patent restrictions; MIT/Apache compatible.

## Wildcards policy: warn (not deny) — follow-up needed
The spec requested `wildcards = "deny"`, but cargo-deny's `allow-wildcard-paths` exemption only applies when crates set `publish = false`. None of the workspace crates declare a `publish` field, so the path-wildcard exemption is not granted and a strict `deny` would fail on every `{ workspace = true }` internal dep (14 in kiln-model, 8 in kiln-server, etc.).

Set to `warn` for now with an inline comment. Follow-up: add `publish = false` to non-publishable crates (the kernel crates and possibly the server/train crates), then tighten this back to `deny`.

## Out of scope
- No GHA workflow added — deliberate follow-up task.
- No `Cargo.lock` changes.