### PR TITLE
ci: add cargo-deny check job to enforce license/source/bans policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,14 @@ on:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'deny.toml'
       - '.github/workflows/ci.yml'
   pull_request:
     paths:
       - 'crates/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
+      - 'deny.toml'
       - '.github/workflows/ci.yml'
   workflow_dispatch:
 
@@ -68,3 +70,14 @@ jobs:
 
       - name: Test (default features)
         run: cargo test --locked -- --skip test_env_var_overrides --skip test_health_with_real_backend
+
+  cargo-deny:
+    name: cargo-deny (license / source / bans policy)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check
+          # Run all checks: licenses, sources, bans, advisories
+          arguments: --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2778,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,12 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
+# Only fail CI when an UNMAINTAINED advisory targets a workspace crate's direct
+# dependency. Transitive unmaintained deps (e.g. paste, number_prefix pulled in
+# via indicatif) are not actionable here — there is no upstream fix and dropping
+# the parent crate is out of scope. Real security vulnerabilities still fail
+# regardless of where in the tree they appear.
+unmaintained = "workspace"
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
Wires the cargo-deny policy added in #555 into CI so PRs that violate the license allowlist, add unknown registries, or pin wildcard versions actually fail.

Uses the upstream EmbarkStudios/cargo-deny-action@v2 (handles install + caching). Also extends the workflow paths filter to include deny.toml so policy edits trigger a CI run.

Closes the explicit follow-up noted at the top of deny.toml.

## What surfaced on the first enforcement run

Three commits in this PR:

1. **CI job + paths filter** — adds the `cargo-deny` job and includes `deny.toml` in the workflow paths trigger.
2. **Bump rustls-webpki 0.103.12 -> 0.103.13** — fixes [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) (reachable panic in CRL parsing). Lock-file-only patch update; pulled in transitively via `tokenizers -> hf-hub -> ureq -> rustls`.
3. **Scope `unmaintained` check to workspace deps** — cargo-deny v2 defaults `unmaintained = "all"`, which fails on any unmaintained crate anywhere in the tree. First run flagged two transitive-only findings (`paste`, `number_prefix` — both pulled in via `indicatif`) with no upstream fix. Switching to `unmaintained = "workspace"` keeps the strong signal for direct deps we control while not blocking on transitive crates we can't replace. **Vulnerability checks are unaffected** — real CVE-class advisories still fail across the entire tree (proven by commit 2 above).