### PR TITLE
docs: add GitHub issue + PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: Report a reproducible bug
+title: "[bug] "
+labels: ["bug"]
+---
+
+## Description
+
+What's broken?
+
+## Reproduction steps
+
+1. Exact command(s) used (e.g. `kiln serve --port 8420 ...` or `kiln-bench --paged --prompt-tokens 512 ...`)
+2. ...
+3. ...
+
+## Expected vs actual
+
+- Expected:
+- Actual:
+
+## Environment
+
+- GPU model + driver version (or `Metal` / `MLX` / CPU-only):
+- CUDA version (e.g. `12.4`) — N/A for non-CUDA:
+- `kiln` commit SHA or release tag:
+- OS + kernel:
+- RAM / VRAM:
+
+## Logs
+
+Relevant output. Run with `KILN_LOG_FORMAT=auto` if applicable.
+
+```
+<paste here>
+```
+
+## Related work searched
+
+Closed PRs and open issues already checked (CONTRIBUTING.md requires this for kernel/perf reports — link what you searched and why this is not a duplicate).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/ericflo/kiln/security/policy
+    about: Please report security issues via the policy in SECURITY.md, NOT a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: Feature request
+about: Propose a new feature or API
+title: "[feature] "
+labels: ["enhancement"]
+---
+
+## Use case
+
+What task, what workload, and why current capability is insufficient.
+
+## Scope check
+
+CONTRIBUTING.md lists three core constraints kiln preserves:
+
+- Single-model: Qwen3.5-4B only
+- Single-process: no Python sidecar as the primary path
+- Consumer-GPU friendly: must run on a single 24GB GPU (RTX 3090/4090) for the core path
+
+Confirm this proposal preserves all three, or argue why an exception is justified.
+
+## Proposed API or config surface
+
+Endpoint shape, env flag, CLI flag, config field — whatever the user-facing surface is.
+
+## Alternatives considered
+
+What else you tried or considered, and why this proposal is preferable.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## Summary
+
+What changed and why, in 2-4 lines.
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] Performance improvement
+- [ ] Kernel change (CUDA / Metal / MLX)
+- [ ] Feature
+- [ ] Docs / DX
+- [ ] Infra / CI
+
+## Related issue / PR
+
+Link any related issues or prior PRs.
+
+## Perf change?
+
+If this PR changes performance, paste before/after `kiln-bench` median-of-3 numbers (per CONTRIBUTING.md "For performance changes"). Link the kernel crate or `forward.rs` region touched and the relevant `PROFILING.md` NVTX hot region.
+
+## Checklist
+
+- [ ] `cargo test` passes (skip for docs-only)
+- [ ] `cargo build` passes (skip for docs-only)
+- [ ] Read CONTRIBUTING.md
+- [ ] No new dependency without a prior issue
+- [ ] Scoped to one logical change


### PR DESCRIPTION
## Summary
Adds `.github/PULL_REQUEST_TEMPLATE.md` and `.github/ISSUE_TEMPLATE/` (config.yml, bug_report.md, feature_request.md) so public contributors land on structured prompts instead of a blank textbox. CONTRIBUTING.md (#552) tells contributors to file an issue first for anything non-trivial — these templates make that workflow actually usable.

## Type of change
- [x] docs/DX

## Checklist
- [x] No code changes; no test/build impact
- [x] config.yml validates as YAML