### PR TITLE
fix: migrate rand 0.9 + bump (supersedes #566)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ dependencies = [
  "num_cpus",
  "objc2-foundation",
  "objc2-metal",
- "rand 0.9.4",
+ "rand",
  "rand_distr",
  "rayon",
  "safetensors 0.7.0",
@@ -833,7 +833,7 @@ checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
  "num-traits",
- "rand 0.9.4",
+ "rand",
  "rand_distr",
 ]
 
@@ -1323,7 +1323,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.4",
+ "rand",
  "rand_distr",
  "zerocopy",
 ]
@@ -1379,7 +1379,7 @@ dependencies = [
  "indicatif",
  "libc",
  "log",
- "rand 0.9.4",
+ "rand",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -1803,7 +1803,7 @@ dependencies = [
  "kiln-rmsnorm-kernel",
  "memmap2",
  "objc2-metal",
- "rand 0.8.6",
+ "rand",
  "rayon",
  "safetensors 0.5.3",
  "serde",
@@ -1851,7 +1851,7 @@ dependencies = [
  "kiln-model",
  "kiln-scheduler",
  "kiln-train",
- "rand 0.8.6",
+ "rand",
  "reqwest",
  "safetensors 0.5.3",
  "serde",
@@ -2535,33 +2535,12 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2571,16 +2550,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
+ "rand_core",
 ]
 
 [[package]]
@@ -2599,7 +2569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
- "rand 0.9.4",
+ "rand",
 ]
 
 [[package]]
@@ -3246,7 +3216,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.4",
+ "rand",
  "rayon",
  "rayon-cond",
  "regex",
@@ -3279,7 +3249,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.4",
+ "rand",
  "rayon",
  "rayon-cond",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ kiln-marlin-gemm = { path = "crates/kiln-marlin-gemm" }
 kiln-nvtx = { path = "crates/kiln-nvtx" }
 kiln-rmsnorm-kernel = { path = "crates/kiln-rmsnorm-kernel" }
 # Random number generation
-rand = "0.8"
+rand = "0.9"
 
 # Data-parallel iteration
 rayon = "1"

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1840,7 +1840,7 @@ impl ModelRunner {
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         let mut rng = match params.seed {
             Some(s) => rand::rngs::StdRng::seed_from_u64(s),
-            None => rand::rngs::StdRng::from_entropy(),
+            None => rand::rngs::StdRng::from_os_rng(),
         };
 
         // Sample first token from prefill logits
@@ -2144,7 +2144,7 @@ impl ModelRunner {
 
         let mut rng = match params.seed {
             Some(s) => rand::rngs::StdRng::seed_from_u64(s),
-            None => rand::rngs::StdRng::from_entropy(),
+            None => rand::rngs::StdRng::from_os_rng(),
         };
 
         loop {
@@ -2358,7 +2358,7 @@ impl ModelRunner {
         let mut finish_reason = FinishReason::MaxTokens;
         let mut rng = match params.seed {
             Some(s) => rand::rngs::StdRng::seed_from_u64(s),
-            None => rand::rngs::StdRng::from_entropy(),
+            None => rand::rngs::StdRng::from_os_rng(),
         };
 
         let mut last_token = if params.temperature == 0.0 {
@@ -2593,7 +2593,7 @@ impl ModelRunner {
         let mut finish_reason = FinishReason::MaxTokens;
         let mut rng = match params.seed {
             Some(s) => rand::rngs::StdRng::seed_from_u64(s),
-            None => rand::rngs::StdRng::from_entropy(),
+            None => rand::rngs::StdRng::from_os_rng(),
         };
 
         loop {

--- a/crates/kiln-model/src/sampling.rs
+++ b/crates/kiln-model/src/sampling.rs
@@ -170,10 +170,10 @@ pub fn sample_with_params(
     // Categorical sampling (host-side; candle has no GPU categorical RNG).
     let mut rng: StdRng = match seed {
         Some(s) => StdRng::seed_from_u64(s),
-        None => StdRng::from_entropy(),
+        None => StdRng::from_os_rng(),
     };
 
-    let r: f32 = rng.r#gen();
+    let r: f32 = rng.random();
     let mut cumsum = 0.0_f32;
     for &(idx, p) in &probs {
         cumsum += p;
@@ -221,9 +221,9 @@ fn sample_full_distribution_unsorted(scaled: &Tensor, seed: Option<u64>) -> Resu
 
     let mut rng: StdRng = match seed {
         Some(s) => StdRng::seed_from_u64(s),
-        None => StdRng::from_entropy(),
+        None => StdRng::from_os_rng(),
     };
-    let threshold = rng.r#gen::<f32>() * sum;
+    let threshold = rng.random::<f32>() * sum;
     let mut cumsum = 0.0_f32;
     for (idx, p) in probs.into_iter().enumerate() {
         cumsum += p;

--- a/crates/kiln-model/src/speculative.rs
+++ b/crates/kiln-model/src/speculative.rs
@@ -233,7 +233,7 @@ pub fn rejection_sample(
         1.0
     };
 
-    let r: f32 = rng.r#gen();
+    let r: f32 = rng.random();
 
     if r < accept_prob {
         // Accept the draft token
@@ -260,7 +260,7 @@ fn resample_adjusted(
     let sum: f32 = adjusted.iter().sum();
     if sum <= 0.0 {
         // Fallback: sample from target distribution directly
-        let r: f32 = rng.r#gen();
+        let r: f32 = rng.random();
         let mut cumsum = 0.0;
         for (i, &p) in target_probs.iter().enumerate() {
             cumsum += p;
@@ -272,7 +272,7 @@ fn resample_adjusted(
     }
 
     // Normalize and sample
-    let r: f32 = rng.r#gen::<f32>() * sum;
+    let r: f32 = rng.random::<f32>() * sum;
     let mut cumsum = 0.0;
     for (i, &p) in adjusted.iter().enumerate() {
         cumsum += p;


### PR DESCRIPTION
Supersedes #566.

`rand` 0.9 removed `SeedableRng::from_entropy()` and renamed `Rng::gen` → `Rng::random` (the latter is the deprecated-warning path now that `gen` is a Rust 2024 reserved keyword). PR #566 bumped the dep without applying the migration, so CI failed on Linux + macOS with E0599.

Combined here so CI is green in one PR.

## Migration applied
- `StdRng::from_entropy()` → `StdRng::from_os_rng()` (6 sites)
  - `crates/kiln-model/src/sampling.rs:173, 224`
  - `crates/kiln-model/src/generate.rs:1843, 2147, 2361, 2596`
- `rng.r#gen()` / `rng.r#gen::<f32>()` → `rng.random()` / `rng.random::<f32>()` (5 sites)
  - `crates/kiln-model/src/sampling.rs:176, 226`
  - `crates/kiln-model/src/speculative.rs:236, 263, 275`

`rng.gen_range(...)` calls in `forward.rs` test fixtures are deprecated-but-not-removed in 0.9; they still compile and emit deprecation warnings. CI doesn't `-D warnings`, so they don't break the build. Out of scope for this fix.

## Verified locally
`cargo check -p kiln-model` and `cargo check -p kiln-train` are clean (only pre-existing dead-code/unused-variable warnings). `cargo check -p kiln-server` blocks on the sandbox openssl-sys env issue (not a code issue).

## Followup
Once this lands, close #566 with a reference here.