### PR TITLE
Cleanup: fix ASCII box alignment (broken windows pass)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -50,7 +50,7 @@ The journey from HTTP request to generated text:
 
 ```
                               ┌─────────────────────────────────────────────────────────┐
-                              │                    kiln-server                           │
+                              │                    kiln-server                          │
                               │                                                         │
   HTTP Request ──────────────►│  POST /v1/chat/completions                              │
   (OpenAI-compatible)         │       │                                                 │
@@ -61,34 +61,34 @@ The journey from HTTP request to generated text:
                               │  ensure_adapter() ──► Two-phase LoRA load if needed     │
                               │       │                                                 │
                               │       ▼                                                 │
-                              │  ┌─────────────────────────────────────────────────┐    │
-                              │  │  Acquire GPU read lock (concurrent inference OK) │    │
-                              │  │                                                  │    │
-                              │  │  ModelRunner::generate_paged()                   │    │
-                              │  │       │                                          │    │
-                              │  │       ▼                                          │    │
-                              │  │  ┌────────────────────────┐                      │    │
-                              │  │  │  PREFILL               │                      │    │
-                              │  │  │  Embed prompt tokens   │                      │    │
-                              │  │  │  Forward through 32    │                      │    │
-                              │  │  │  layers (GDN + GQA)    │                      │    │
-                              │  │  │  Write KV cache        │                      │    │
-                              │  │  │  Sample first token    │                      │    │
-                              │  │  └────────┬───────────────┘                      │    │
-                              │  │           │                                      │    │
-                              │  │           ▼                                      │    │
-                              │  │  ┌────────────────────────┐                      │    │
-                              │  │  │  DECODE (loop)         │◄──── CUDA Graph      │    │
-                              │  │  │  Embed 1 token         │      Replay          │    │
-                              │  │  │  Forward through 32    │      (after warmup)   │    │
-                              │  │  │  layers, read KV cache │                      │    │
-                              │  │  │  Sample next token     │                      │    │
-                              │  │  │  Check stop conditions │                      │    │
-                              │  │  └────────┬───────────────┘                      │    │
-                              │  │           │ (EOS / max_tokens / stop sequence)    │    │
-                              │  │           ▼                                      │    │
-                              │  │  Return generated text + usage stats             │    │
-                              │  └──────────────────────────────────────────────────┘    │
+                              │  ┌──────────────────────────────────────────────────┐   │
+                              │  │  Acquire GPU read lock (concurrent inference OK) │   │
+                              │  │                                                  │   │
+                              │  │  ModelRunner::generate_paged()                   │   │
+                              │  │       │                                          │   │
+                              │  │       ▼                                          │   │
+                              │  │  ┌────────────────────────┐                      │   │
+                              │  │  │  PREFILL               │                      │   │
+                              │  │  │  Embed prompt tokens   │                      │   │
+                              │  │  │  Forward through 32    │                      │   │
+                              │  │  │  layers (GDN + GQA)    │                      │   │
+                              │  │  │  Write KV cache        │                      │   │
+                              │  │  │  Sample first token    │                      │   │
+                              │  │  └────────┬───────────────┘                      │   │
+                              │  │           │                                      │   │
+                              │  │           ▼                                      │   │
+                              │  │  ┌────────────────────────┐                      │   │
+                              │  │  │  DECODE (loop)         │◄──── CUDA Graph      │   │
+                              │  │  │  Embed 1 token         │      Replay          │   │
+                              │  │  │  Forward through 32    │      (after warmup)  │   │
+                              │  │  │  layers, read KV cache │                      │   │
+                              │  │  │  Sample next token     │                      │   │
+                              │  │  │  Check stop conditions │                      │   │
+                              │  │  └────────┬───────────────┘                      │   │
+                              │  │           │ (EOS / max_tokens / stop sequence)   │   │
+                              │  │           ▼                                      │   │
+                              │  │  Return generated text + usage stats             │   │
+                              │  └──────────────────────────────────────────────────┘   │
                               │       │                                                 │
                               │       ▼                                                 │
   HTTP Response ◄─────────────│  JSON response (or SSE stream)                          │
@@ -144,7 +144,7 @@ Kiln uses paged virtual memory for the KV cache, inspired by vLLM's PagedAttenti
   Physical Block Pool:  ┌──────────────────────────────────┐
   [total_slots × num_kv_heads × head_dim]                  │
   │ block 0 │ ... │ block 4 │ ... │ block 7 │ ... │ ...    │
-  └──────────────────────────────────────────────────────────┘
+  └────────────────────────────────────────────────────────┘
 
   Address translation:
     token_pos 35 (block_size=16) → logical block 2 → physical block 4 → offset 3

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -101,7 +101,7 @@ You'll see the startup banner:
 ```
   ┌─────────────────────────────────────┐
   │           🔥 K I L N 🔥             │
-  │   inference · training · adapters    │
+  │   inference · training · adapters   │
   └─────────────────────────────────────┘
 
   Version: 0.1.0

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve
 ```
   ┌─────────────────────────────────────┐
   │           🔥 K I L N 🔥             │
-  │   inference · training · adapters    │
+  │   inference · training · adapters   │
   └─────────────────────────────────────┘
 
   Version: 0.1.0

--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -224,7 +224,7 @@ pub fn print_banner(host: &str, port: u16, model_path: Option<&str>, config_path
     let _ = writeln!(
         stderr,
         "  {}",
-        style("│   inference · training · adapters    │").cyan()
+        style("│   inference · training · adapters   │").cyan()
     );
     let _ = writeln!(
         stderr,

--- a/desktop/docs/binary-update.md
+++ b/desktop/docs/binary-update.md
@@ -126,7 +126,7 @@ The `install_latest_server` function already handles steps 1-4. The new
 
 ```
 ┌────────────────────────────────────────────────────────────────┐
-│ 1. discover_asset()  — newest kiln-v* release for this target │
+│ 1. discover_asset()  — newest kiln-v* release for this target  │
 │ 2. Compare versions; no-op if current >= latest                │
 │ 3. download_with_progress()  → staging tarball + sha256        │
 │ 4. fetch_expected_sha256() + compare; abort+delete on mismatch │


### PR DESCRIPTION
## What

Broken-windows pass over every box-drawing / banner in the kiln source tree. Alignment-only — no content rewrites, no new art, no normalization across distinct blocks.

## Files touched

| File | Issue | Fix |
|---|---|---|
| `crates/kiln-server/src/cli.rs:227` | banner middle row had 4 trailing spaces before `│` but the top/bottom borders were 39 chars wide and the body was 40 | removed 1 trailing space so all rows close at col 38 |
| `README.md:121` / `QUICKSTART.md:104` | same banner reproduced as docs | same fix as cli.rs |
| `desktop/docs/binary-update.md:129` | line 1 of the download/swap flow box was 65 wide while its 14 siblings were 66 | added 1 trailing space before `│` |
| `ARCHITECTURE.md:64-91` (inference pipeline) | the inner *ModelRunner* box had inner `┐` at col 83 but body `│` and bottom `┘` at col 84, and outer right `│` jittered between col 88 and col 89 line-to-line | normalized to outer right `│` at col 88, inner right `│` at col 84 — every vertical bar lines up |
| `ARCHITECTURE.md:147` (Physical Block Pool) | bottom border `└──...──┘` ended 2 ─ chars to the right of the box's right vertical edge, leaving an L-shape that didn't close | trimmed 2 ─ so `┘` sits under the right `│` |

## Before / after

### kiln startup banner (cli.rs, README.md, QUICKSTART.md)

Before:
```
  ┌─────────────────────────────────────┐
  │           🔥 K I L N 🔥             │
  │   inference · training · adapters    │   ← 4 trailing spaces, 1 col too wide
  └─────────────────────────────────────┘
```

After:
```
  ┌─────────────────────────────────────┐
  │           🔥 K I L N 🔥             │
  │   inference · training · adapters   │
  └─────────────────────────────────────┘
```

### ARCHITECTURE.md Physical Block Pool

Before (bottom `┘` at col 61, right vertical at col 59 — 2 col gap):
```
  Physical Block Pool:  ┌──────────────────────────────────┐
  [total_slots × num_kv_heads × head_dim]                  │
  │ block 0 │ ... │ block 4 │ ... │ block 7 │ ... │ ...    │
  └──────────────────────────────────────────────────────────┘
```

After:
```
  Physical Block Pool:  ┌──────────────────────────────────┐
  [total_slots × num_kv_heads × head_dim]                  │
  │ block 0 │ ... │ block 4 │ ... │ block 7 │ ... │ ...    │
  └────────────────────────────────────────────────────────┘
```

### ARCHITECTURE.md inference pipeline

Diff is the bulk of this PR. Each inner-box body line had `│   <content>   │    │` (4 trailing spaces); the inner top border was 1 ─ short of where the inner body's right `│` sat; the title row had 1 spurious trailing space. Normalized so every `│` and corner sits in a consistent column. Verified with a Python visible-width pass: every line in the diagram is now exactly 89 cols wide and bars sit at cols `[30, 88]` (outer) plus `[33, 84]` (inner where applicable).

## Left unchanged (intentional)

- **Emoji-bearing banner row** `│           🔥 K I L N 🔥             │` — emoji column-width is intrinsically ambiguous across terminals/renderers (FE-Width 2 in unicode but historically rendered as 1 in many fixed-width fonts). Per the task spec this row is "close enough" and not a fixable bug.
- **`docs/archive/**` and `docs/phase*` audit reports** — historical logs/artifacts, not user-facing docs.
- **`crates/kiln-flash-attn/csrc/cutlass/**`** — vendored upstream third-party.
- **Decorative `─` runs in source comments** (kept appearing in the initial grep but they're not box art, they're section separators).

## Scope

This is a content-free, behavior-free polish PR. No CI changes, no rust changes that affect anything besides the printed banner string. The `cli.rs` change is a 1-character edit to a literal in a `style!()` cyan-styled string.

## Verification

- Visible-width audit script confirms every line in every fixed art block now matches the box's top/bottom border width.
- `git diff --stat`: 5 files changed, 34 insertions(+), 34 deletions(-) — same line count, just spaces moved around.