### PR TITLE
release: bump server + desktop to 0.2.2 aligned cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,95 @@
 # Kiln Server Changelog
 
+## kiln-v0.2.2 — 2026-04-25
+
+Coordinated release aligned with desktop-v0.2.2. Supersedes the unpublished
+kiln-v0.2.1 draft; all v0.2.1 changes are included here. Highlights since
+v0.2.0 are the radix prefix cache reuse path, more Metal/CUDA decode
+fusions, governance docs, and dependency hygiene.
+
+### Phase 7 prefix cache + decode reuse
+- Implement radix prefix cache core (#512)
+- Wire real append prefix cache (#515) and streaming real prefix cache reuse (#520)
+- Use prefix cache with CUDA graphs and warn when bypassed (#518, #521)
+- Expose prefix cache metrics (#513)
+- Speed up greedy paged prefill defaults (#519)
+- Default CUDA streaming prefill for long prompts and lower Metal threshold (#511)
+- Refresh post-#521 profiling artifacts (#522)
+
+### Phase 6 / Phase 7 Metal + CUDA fusions
+- Fuse Metal attention output gate (#514)
+- Fuse Metal GDN gates with recurrent decode
+- Fuse Metal contiguous paged decode attention (#501)
+- Fuse Metal GDN prefill conv split (#499) and Metal paged KV slot writes (#497)
+- Fuse GDN recurrent RMSNorm decode (#496)
+- Add CUDA GDN qk norm GQA fast path (#500)
+- Add opt-in CUDA GDN decode fuse hook (#498)
+- Route shared Metal greedy decode through argmax (#510)
+- Defer transposed cache writer (#508); make transposed cache writes reliable (#506)
+- Precompile Metal kernels before prewarm lock (#505)
+- Batch MTP verifier argmax (#493)
+
+### MTP audits and α-stability work
+- H15c stratified C29 v2 reject-row probe (#529)
+- H17 SGLang and H15c/H17b/H15a vLLM α microbenches (#530, #532, #533)
+- H18 hand-rolled HF transformers MTP α reference (#534)
+- H16 external-α reference options audit (#531)
+- MTP acceptance-rate state-of-play audit (#527)
+- End-to-end native-MTP self-spec decode bench post-#535 (#536)
+
+### Phase 7 CLI / UX
+- Recent requests panel on `/ui` dashboard (last 100) (#551)
+- Live decode tok/s + p50/p99 ITL on `/ui` dashboard (#550)
+- `kiln health` pretty-printed tree output + `--json` escape hatch (#549)
+- `kiln train status` CLI subcommand + fix post-submit hint (#548)
+- Surface structured server error hints in CLI (#545)
+- `KILN_LOG_FORMAT=auto` — TTY-detect pretty vs JSON default (#544)
+- GPU name + VRAM in startup banner (#543)
+- ProgressBars for model load, SFT, GRPO (#540, #541, #542)
+
+### Server runtime
+- Move health adapter scan off runtime
+- Document phase 7 prefix cache reuse benchmark
+- Audit kiln radix prefix cache vs SGLang RadixAttention (#526)
+- Audit vLLM fused_recurrent_gated_delta_rule against kiln-gdn-kernel (#525)
+- Kill-switch bisection ruled out a single fused-kernel owner of the post-#166 decode gap (#524)
+- Prefix-cache A/B ruled out cache hooks as bench regression source (#523)
+- Fast-guard disabled MTP debug taps; reduce safetensors loader map allocations
+- RunPod task tasks no longer pin `KILN_CUDA_ARCHS` (#494)
+
+### Governance + CI
+- Add Dependabot config for cargo + GitHub Actions (#558)
+- Add `cargo-deny` license/source/bans policy and CI check job (#555, #556)
+- Add CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md (#552, #553, #554)
+- Add GitHub issue + PR templates (#557)
+
+### Dependencies
+- Bump tokenizers 0.21.4 → 0.22.2 (#565)
+- Bump indicatif 0.17.11 → 0.18.4 (#564)
+- Bump console 0.15.11 → 0.16.3 (#563)
+- Migrate to rand 0.9 (#567)
+- Bump cc in cargo-minor-and-patch group (#562)
+- Bump docker/login-action 3 → 4 (#561) and docker/build-push-action 5 → 7 (#560)
+- Bump Jimver/cuda-toolkit (#559)
+
+### Docs / repo cleanup
+- Refresh ARCHITECTURE.md for post-Phase-6 outcomes (#539)
+- Refresh BENCHMARKS.md with post-#536 numbers + add vLLM/SGLang comparison (#537)
+- A6000 llama.cpp re-bench at 512 → 128 (#538)
+- README + QUICKSTART refresh (`/ui`, banner GPU/VRAM, logging defaults) (#546, #547)
+- Archive 71 phase-cXX docs subdirs into `docs/archive/phase-c/` (#570)
+- Archive frozen profiling/bench MD reports into `docs/archive/` (#568)
+- Purge profiling artifact dirs from working tree (#569)
+
+### CI fixes carried over from the unpublished v0.2.1
+- Bump Jimver/cuda-toolkit from v0.2.19 to v0.2.35 to handle NVIDIA's renamed installer URLs (#469)
+- Install MSVC dev env on Windows before CUDA build; fixes `M_LOG2E` undefined in `flash_api_c.cu` under MSVC (#472)
+- Force static MSVC CRT on Windows CUDA build; fixes CRT mismatch between `esaxx-rs` and `kiln-marlin-gemm` (#477)
+
 ## kiln-v0.2.1 — 2026-04-24
+
+(unpublished — superseded by kiln-v0.2.2)
+
 
 Server re-cut to include CI fixes that were missing from kiln-v0.2.0. No
 user-facing behavior changes from v0.2.0 in the core server; this cut also

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,7 +1738,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "candle-core",
  "cc",
@@ -1747,7 +1747,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1760,7 +1760,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "candle-core",
  "cc",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "candle-core",
  "cc",
@@ -1798,7 +1798,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1828,11 +1828,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.1"
+version = "0.2.2"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "candle-core",
  "cc",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1850,7 +1850,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Kiln Desktop Changelog
 
+## desktop-v0.2.2 — 2026-04-25
+
+Coordinated release aligned with kiln-v0.2.2 server. No desktop-side
+behavior changes since desktop-v0.2.0; this cut realigns the desktop
+version number with the server after the unpublished kiln-v0.2.1 cycle
+and ships the new auto-downloaded server binary with all of v0.2.2's
+prefix-cache, Metal/CUDA fusion, MTP audit, dependency, and governance
+work. See [CHANGELOG.md](../CHANGELOG.md) for the full server changelog.
+
 ## desktop-v0.2.0 — 2026-04-24
 - Coordinated release aligned with kiln-v0.2.0 server
 - Picks up macOS startup and KV prefill overhead reductions

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-desktop"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kiln-desktop"
-version = "0.2.0"
+version = "0.2.2"
 edition = "2021"
 description = "Kiln Desktop — system tray app for the kiln local LLM server"
 authors = ["Eric Florenzano <eric@eflorenzano.com>"]

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kiln Desktop",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "identifier": "com.eflorenzano.kiln.desktop",
   "build": {
     "frontendDist": "ui",


### PR DESCRIPTION
## What

Bumps server (workspace) and desktop crates to **0.2.2** in lockstep, replacing the unpublished `kiln-v0.2.1` draft cycle.

- `Cargo.toml` workspace.package: 0.2.1 → 0.2.2
- `Cargo.lock`: 12 `kiln-*` crates relocked at 0.2.2
- `desktop/Cargo.toml`: 0.2.0 → 0.2.2
- `desktop/Cargo.lock`: `kiln-desktop` relocked at 0.2.2
- `desktop/tauri.conf.json`: 0.2.0 → 0.2.2
- `CHANGELOG.md`: new `kiln-v0.2.2` entry summarizing the 81 commits since `kiln-v0.2.1`
- `desktop/CHANGELOG.md`: new coordinated `desktop-v0.2.2` entry (no desktop-side code changes since 0.2.0)

## Why

The 0.2.1 cut got stuck:

1. **`kiln-v0.2.1` is a stuck Draft on GitHub.** The release workflow ran on 2026-04-24, all 6 assets uploaded (Linux/Windows CUDA 12.4, macOS aarch64 Metal + .sha256 sidecars), but the draft was never flipped to Published. Users still see `kiln-v0.2.0` as the latest server release. The draft URL still shows `untagged-eaf2008e88d3df92418e`.
2. **Desktop never got a 0.2.1 cut**, breaking the aligned cadence established at 0.2.0.
3. **~81 commits have landed on main since the v0.2.1 tag** — phase 7 prefix cache reuse + CUDA-graph integration, more Metal/CUDA decode fusions, MTP α-stability audits, governance docs (CONTRIBUTING/SECURITY/CODE_OF_CONDUCT, issue/PR templates), `cargo-deny` policy + Dependabot, and dep upgrades (tokenizers 0.21 → 0.22, indicatif 0.17 → 0.18, console 0.15 → 0.16, rand 0.9, cc patch).

0.2.2 ships all of that as a clean aligned release.

## Plan after merge

1. Tag `kiln-v0.2.2` and `desktop-v0.2.2` from main (sequential — server first, then desktop).
2. Watch `server-release.yml` (3-platform CUDA + Metal builds, ~1h30m typical) and `desktop-build.yml` (~5m).
3. Flip both releases out of Draft via `gh release edit ... --draft=false`; mark `desktop-v0.2.2 --latest` to match the 0.2.0 pattern.
4. Delete the stuck `kiln-v0.2.1` draft (`gh release delete kiln-v0.2.1 --yes`); keep the tag for archaeology.

## Validation

- Per-crate `cargo check -p kiln-core -p kiln-scheduler -p kiln-flce-kernel -p kiln-model` succeeds at 0.2.2 (sandbox openssl-sys/gio-2.0 missing — pre-existing limitation, not a regression).
- All 7 changed files match the 0.2.0 aligned-cut pattern from PR #467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)