### PR TITLE
Phase 8: GET /v1/adapters/{name}/download — streaming tar.gz export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +1869,7 @@ dependencies = [
  "chrono",
  "clap",
  "console 0.16.3",
+ "flate2",
  "futures",
  "indicatif 0.18.4",
  "kiln-core",
@@ -1869,6 +1881,7 @@ dependencies = [
  "safetensors 0.5.3",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1953,7 +1966,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2416,7 +2432,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2444,6 +2460,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2636,6 +2658,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -3134,6 +3165,17 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4230,6 +4272,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,10 @@ minijinja = "2"
 safetensors = "0.5"
 memmap2 = "0.9"
 
+# Adapter packaging (tar.gz export)
+tar = "0.4"
+flate2 = "1"
+
 # Tensor compute
 candle-core = "0.10"
 candle-nn = "0.10"

--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -43,6 +43,8 @@ indicatif = "0.18"
 console = "0.16"
 reqwest = { version = "0.12", features = ["json"] }
 rand = { workspace = true }
+tar = { workspace = true }
+flate2 = { workspace = true }
 
 [features]
 cuda = ["kiln-model/cuda"]

--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -1,9 +1,16 @@
 use std::path::Path;
 
+use axum::body::Body;
 use axum::extract::{State, Path as AxumPath};
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
+use flate2::write::GzEncoder;
+use flate2::Compression;
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+use tokio_stream::wrappers::ReceiverStream;
 
 use kiln_model::adapter_merge::{merge_linear, PeftLora};
 use kiln_model::lora_loader::LoraWeights;
@@ -461,6 +468,136 @@ fn days_to_ymd(mut days: u64) -> (u64, u64, u64) {
     (y, m, d)
 }
 
+/// Reject names that aren't safe single-segment identifiers. Read-only export
+/// of managed adapters only — never absolute paths, never path traversal.
+fn validate_adapter_name(name: &str) -> Result<(), ApiError> {
+    if name.is_empty()
+        || name == "."
+        || name == ".."
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains("..")
+        || Path::new(name).is_absolute()
+    {
+        return Err(ApiError::invalid_adapter_name(name));
+    }
+    Ok(())
+}
+
+/// Recursively append all regular files in `dir` to a tar builder. The first
+/// path component in each entry name is the adapter's directory name, so
+/// extracting the archive recreates the on-disk layout. Non-file entries
+/// (symlinks, sockets, devices) are silently skipped to keep export robust.
+fn append_dir_to_tar<W: std::io::Write>(
+    tar: &mut tar::Builder<W>,
+    dir: &Path,
+    name_prefix: &Path,
+) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let entry_path = entry.path();
+        let metadata = match entry.metadata() {
+            Ok(m) => m,
+            Err(_) => continue,
+        };
+        let entry_name = name_prefix.join(entry.file_name());
+        if metadata.is_file() {
+            let mut file = std::fs::File::open(&entry_path)?;
+            tar.append_file(&entry_name, &mut file)?;
+        } else if metadata.is_dir() {
+            append_dir_to_tar(tar, &entry_path, &entry_name)?;
+        }
+        // Skip symlinks, devices, sockets, etc.
+    }
+    Ok(())
+}
+
+/// Stream a tar.gz of the adapter directory. The body is built on a blocking
+/// thread and pushed through a bounded mpsc channel so the response streams to
+/// the client without buffering the whole archive in memory.
+async fn download_adapter(
+    State(state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+) -> Result<Response, ApiError> {
+    validate_adapter_name(&name)?;
+
+    let adapter_path = state.adapter_dir.join(&name);
+    if !adapter_path.exists() || !adapter_path.is_dir() {
+        return Err(ApiError::adapter_not_found(&name));
+    }
+
+    let (tx, rx) = mpsc::channel::<Result<Vec<u8>, std::io::Error>>(8);
+
+    let adapter_path_for_task = adapter_path.clone();
+    let name_for_task = name.clone();
+    let tx_for_task = tx.clone();
+    tokio::task::spawn_blocking(move || {
+        struct ChannelWriter {
+            tx: mpsc::Sender<Result<Vec<u8>, std::io::Error>>,
+        }
+        impl std::io::Write for ChannelWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                let chunk = buf.to_vec();
+                let len = chunk.len();
+                self.tx
+                    .blocking_send(Ok(chunk))
+                    .map_err(|_| {
+                        std::io::Error::new(
+                            std::io::ErrorKind::BrokenPipe,
+                            "client disconnected",
+                        )
+                    })?;
+                Ok(len)
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let writer = ChannelWriter {
+            tx: tx_for_task.clone(),
+        };
+        let gz = GzEncoder::new(writer, Compression::default());
+        let mut tar = tar::Builder::new(gz);
+
+        let prefix = Path::new(&name_for_task);
+        if let Err(e) = append_dir_to_tar(&mut tar, &adapter_path_for_task, prefix) {
+            let _ = tx_for_task.blocking_send(Err(e));
+            return;
+        }
+        match tar.into_inner() {
+            Ok(gz) => {
+                if let Err(e) = gz.finish() {
+                    let _ = tx_for_task.blocking_send(Err(e));
+                }
+            }
+            Err(e) => {
+                let _ = tx_for_task.blocking_send(Err(e));
+            }
+        }
+    });
+    drop(tx);
+
+    let stream = ReceiverStream::new(rx);
+    let body = Body::from_stream(stream);
+
+    let disposition = format!("attachment; filename=\"{name}.tar.gz\"");
+    let disposition_value = HeaderValue::from_str(&disposition)
+        .map_err(|e| ApiError::adapter_export_failed(format!("invalid filename header: {e}")))?;
+
+    tracing::info!(adapter = %name, operation = "download", "streaming adapter tar.gz");
+
+    Ok((
+        StatusCode::OK,
+        [
+            (header::CONTENT_TYPE, HeaderValue::from_static("application/gzip")),
+            (header::CONTENT_DISPOSITION, disposition_value),
+        ],
+        body,
+    )
+        .into_response())
+}
+
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/v1/adapters", get(list_adapters))
@@ -468,4 +605,5 @@ pub fn routes() -> Router<AppState> {
         .route("/v1/adapters/unload", post(unload_adapter))
         .route("/v1/adapters/merge", post(merge_adapters))
         .route("/v1/adapters/{name}", delete(delete_adapter))
+        .route("/v1/adapters/{name}/download", get(download_adapter))
 }

--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -102,6 +102,24 @@ impl ApiError {
         }
     }
 
+    pub fn invalid_adapter_name(name: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "invalid_adapter_name",
+            message: format!("Invalid adapter name '{name}'"),
+            hint: "Adapter names must be a single path segment: no '/', '\\', or '..', and not absolute.",
+        }
+    }
+
+    pub fn adapter_export_failed(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "adapter_export_failed",
+            message: format!("Failed to export adapter: {detail}"),
+            hint: "Check server logs and that the adapter directory is readable.",
+        }
+    }
+
     pub fn adapter_load_failed(detail: impl std::fmt::Display) -> Self {
         Self {
             status: StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/kiln-server/tests/adapter_download.rs
+++ b/crates/kiln-server/tests/adapter_download.rs
@@ -1,0 +1,194 @@
+//! Integration test: GET /v1/adapters/{name}/download streams the adapter
+//! directory as a tar.gz archive.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use flate2::read::GzDecoder;
+use serde_json::json;
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::state::AppState;
+
+/// Minimal tokenizer for tests — the adapter download path doesn't tokenize
+/// anything, but AppState::new_mock requires a real tokenizer.
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    vocab.insert("a".to_string(), 0);
+    vocab.insert("b".to_string(), 1);
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] }
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state(adapter_dir: std::path::PathBuf) -> AppState {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    let mut state = AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        test_tokenizer(),
+        300,
+        "qwen3.5-4b-kiln".to_string(),
+    );
+    state.adapter_dir = adapter_dir;
+    state
+}
+
+fn write_adapter(adapter_dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let path = adapter_dir.join(name);
+    std::fs::create_dir_all(&path).unwrap();
+    std::fs::write(
+        path.join("adapter_config.json"),
+        br#"{"r": 8, "lora_alpha": 16}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        path.join("adapter_model.safetensors"),
+        b"\x00\x01\x02\x03fake-safetensors-bytes",
+    )
+    .unwrap();
+    path
+}
+
+#[tokio::test]
+async fn test_download_adapter_returns_valid_tar_gz() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_adapter(tmp.path(), "test-adapter");
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/v1/adapters/test-adapter/download")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "application/gzip"
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get("content-disposition")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "attachment; filename=\"test-adapter.tar.gz\""
+    );
+
+    // Decompress and verify the archive contains both files with original
+    // bytes under the adapter-name prefix.
+    let body_bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let gz = GzDecoder::new(&body_bytes[..]);
+    let mut tar = tar::Archive::new(gz);
+    let mut found: HashMap<String, Vec<u8>> = HashMap::new();
+    for entry in tar.entries().unwrap() {
+        let mut entry = entry.unwrap();
+        let path = entry.path().unwrap().to_string_lossy().to_string();
+        let mut buf = Vec::new();
+        entry.read_to_end(&mut buf).unwrap();
+        found.insert(path, buf);
+    }
+
+    let cfg = found
+        .get("test-adapter/adapter_config.json")
+        .expect("config entry missing");
+    assert_eq!(cfg.as_slice(), br#"{"r": 8, "lora_alpha": 16}"#);
+
+    let weights = found
+        .get("test-adapter/adapter_model.safetensors")
+        .expect("weights entry missing");
+    assert_eq!(weights.as_slice(), b"\x00\x01\x02\x03fake-safetensors-bytes");
+}
+
+#[tokio::test]
+async fn test_download_adapter_not_found_returns_404() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/v1/adapters/does-not-exist/download")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], "adapter_not_found");
+}
+
+#[tokio::test]
+async fn test_download_adapter_rejects_path_traversal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    // ".." as a single segment should be rejected — escapes the adapter dir.
+    let request = Request::builder()
+        .method("GET")
+        .uri("/v1/adapters/..%2E/download")
+        .body(Body::empty())
+        .unwrap();
+
+    // Some axum routers reject ".." segments at the routing layer entirely;
+    // accept either a 400 from our validator or a 404/405 from the router as
+    // long as the request is NOT served. The point is no traversal succeeds.
+    let response = app.oneshot(request).await.unwrap();
+    assert_ne!(response.status(), StatusCode::OK);
+
+    // Try a name that definitely reaches our handler: contains a backslash.
+    let tmp = tempfile::tempdir().unwrap();
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+    let request = Request::builder()
+        .method("GET")
+        .uri("/v1/adapters/foo%5Cbar/download")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], "invalid_adapter_name");
+}


### PR DESCRIPTION
## What

Adds a single endpoint that streams an adapter directory as a gzipped tar archive:

```bash
curl http://localhost:8420/v1/adapters/my-adapter/download -o my-adapter.tar.gz
```

This is the missing half of kiln's lock-in story — trained LoRA adapters are
valuable, but until now the only way to share or back one up was to scp the
directory off the server.

## Implementation

- `download_adapter` handler resolves `state.adapter_dir.join(&name)` (read-only
  export of managed adapters only — does NOT mirror `load_adapter`'s
  absolute-path acceptance), validates the name (rejects `/`, `\`, `..`,
  absolute paths, empty), 404s if missing, and streams a gzipped tar of the
  directory.
- The archive is built on a `spawn_blocking` thread (`tar` + `flate2` are sync)
  and pushed through a bounded `tokio::sync::mpsc` channel of `Vec<u8>` chunks
  into `axum::body::Body::from_stream` — the entire tar never lives in memory.
- Recursive walk over the adapter dir; non-file entries (symlinks, devices,
  sockets) are silently skipped to keep export robust. Top-level entries are
  prefixed with the adapter name so extracting recreates the on-disk layout.
- Headers: `Content-Type: application/gzip`,
  `Content-Disposition: attachment; filename="{name}.tar.gz"`.
- Two new error variants: `invalid_adapter_name` (400) and
  `adapter_export_failed` (500). Hints follow the Phase 7 error-message
  philosophy.

## Test

`crates/kiln-server/tests/adapter_download.rs` (3 tests, all pass on CPU
without `--features cuda`):

1. `test_download_adapter_returns_valid_tar_gz` — creates a temp adapter with
   `adapter_config.json` + `adapter_model.safetensors`, GETs the endpoint,
   verifies status, headers, and that decompressing the body yields a tar
   containing both files (under the `test-adapter/` prefix) with original
   bytes.
2. `test_download_adapter_not_found_returns_404` — verifies 404 + body
   `error.code = adapter_not_found`.
3. `test_download_adapter_rejects_path_traversal` — verifies a name containing
   `\` returns 400 + body `error.code = invalid_adapter_name`. Also confirms
   `..` segments don't get served.

## Verification

```
cargo check -p kiln-server --no-default-features    # ok
cargo test -p kiln-server --test adapter_download --no-default-features
# running 3 tests
# test test_download_adapter_not_found_returns_404 ... ok
# test test_download_adapter_rejects_path_traversal ... ok
# test test_download_adapter_returns_valid_tar_gz ... ok
# test result: ok. 3 passed; 0 failed
```

`cargo fmt --check` was not run — the Cloud Eric sandbox can't install
`rustfmt` (root-owned rustup home; see `kiln-sandbox-rust-tooling` agent
note). CI will catch any format drift.

## Non-goals (deliberately deferred)

- No CLI subcommand or desktop UI button — server-side only.
- No import endpoint — that's a separate PR.
- No signed metadata, checksums-in-tar, or encryption — plain tar.gz of
  what's on disk.