### PR TITLE
Phase 8: POST /v1/adapters/upload — multipart tar.gz import

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -2142,6 +2143,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3064,6 +3082,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spm_precompiled"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ repository = "https://github.com/ericflo/kiln"
 tokio = { version = "1", features = ["full"] }
 
 # HTTP server
-axum = { version = "0.8", features = ["json"] }
+axum = { version = "0.8", features = ["json", "multipart"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 

--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -1,11 +1,13 @@
-use std::path::Path;
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
 
 use axum::body::Body;
-use axum::extract::{State, Path as AxumPath};
+use axum::extract::{DefaultBodyLimit, Multipart, State, Path as AxumPath};
 use axum::http::{header, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
 use axum::{Json, Router};
+use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
 use flate2::Compression;
 use serde::{Deserialize, Serialize};
@@ -598,12 +600,389 @@ async fn download_adapter(
         .into_response())
 }
 
+/// Response for POST /v1/adapters/upload.
+#[derive(Serialize)]
+struct UploadAdapterResponse {
+    /// Adapter name as installed on disk.
+    name: String,
+    /// Total bytes written across all extracted files.
+    size_bytes: u64,
+    /// Number of regular files extracted.
+    files: u32,
+}
+
+/// Upper bound on uploaded archive size. Real Qwen3.5-4B rank-8 LoRA adapters
+/// land at ~30-60 MB compressed; 2 GB leaves room for high-rank or multi-LoRA
+/// archives without letting the body extractor become a DoS vector.
+const ADAPTER_UPLOAD_BODY_LIMIT: usize = 2 * 1024 * 1024 * 1024;
+
+/// Maximum total size of extracted bytes per upload. Mirrors the body limit so
+/// a small archive cannot expand into a multi-terabyte tarbomb.
+const ADAPTER_EXTRACT_BYTES_LIMIT: u64 = 4 * 1024 * 1024 * 1024;
+
+/// Maximum number of entries we'll extract from a single archive — guards
+/// against a tar with millions of zero-byte files.
+const ADAPTER_EXTRACT_ENTRIES_LIMIT: u32 = 100_000;
+
+/// Receive a multipart/form-data archive and install it as a new adapter
+/// directory under `adapter_dir`. Symmetric to `download_adapter`.
+async fn upload_adapter(
+    State(state): State<AppState>,
+    mut multipart: Multipart,
+) -> Result<Json<UploadAdapterResponse>, ApiError> {
+    let mut name: Option<String> = None;
+    let mut archive_path: Option<PathBuf> = None;
+    let mut tmp_root: Option<PathBuf> = None;
+
+    // Cleanup helper used on every error path to remove the temp dir we
+    // allocated to buffer the upload bytes.
+    let cleanup_tmp = |tmp_root: &Option<PathBuf>| {
+        if let Some(root) = tmp_root.as_ref() {
+            let _ = std::fs::remove_dir_all(root);
+        }
+    };
+
+    while let Some(mut field) = multipart.next_field().await.map_err(|e| {
+        cleanup_tmp(&tmp_root);
+        ApiError::adapter_import_invalid(format!("multipart parse error: {e}"))
+    })? {
+        let field_name = match field.name() {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+        match field_name.as_str() {
+            "name" => {
+                let bytes = field.bytes().await.map_err(|e| {
+                    cleanup_tmp(&tmp_root);
+                    ApiError::adapter_import_invalid(format!("reading 'name' field: {e}"))
+                })?;
+                let s = std::str::from_utf8(&bytes)
+                    .map_err(|_| {
+                        cleanup_tmp(&tmp_root);
+                        ApiError::adapter_import_invalid("'name' field must be UTF-8 text")
+                    })?
+                    .trim()
+                    .to_string();
+                if let Err(e) = validate_adapter_name(&s) {
+                    cleanup_tmp(&tmp_root);
+                    return Err(e);
+                }
+                name = Some(s);
+            }
+            "archive" => {
+                // Lazily create a tmp dir under adapter_dir on the first
+                // archive byte. Putting the temp file on the same filesystem
+                // lets the eventual rename into place be atomic.
+                if tmp_root.is_none() {
+                    let suffix: u128 = rand_suffix();
+                    let root = state.adapter_dir.join(format!(".upload-tmp-{suffix:032x}"));
+                    std::fs::create_dir_all(&root).map_err(|e| {
+                        ApiError::adapter_import_failed(format!(
+                            "creating temp dir {}: {e}",
+                            root.display()
+                        ))
+                    })?;
+                    tmp_root = Some(root);
+                }
+                let tmp_dir = tmp_root.as_ref().unwrap();
+                let archive_target = tmp_dir.join("archive.tar.gz");
+                let mut file = std::fs::File::create(&archive_target).map_err(|e| {
+                    cleanup_tmp(&tmp_root);
+                    ApiError::adapter_import_failed(format!(
+                        "creating temp archive {}: {e}",
+                        archive_target.display()
+                    ))
+                })?;
+                let mut total: u64 = 0;
+                loop {
+                    match field.chunk().await {
+                        Ok(Some(chunk)) => {
+                            total = total.saturating_add(chunk.len() as u64);
+                            if total > ADAPTER_EXTRACT_BYTES_LIMIT {
+                                cleanup_tmp(&tmp_root);
+                                return Err(ApiError::adapter_import_invalid(format!(
+                                    "archive exceeds {} GB byte limit",
+                                    ADAPTER_EXTRACT_BYTES_LIMIT / (1024 * 1024 * 1024)
+                                )));
+                            }
+                            if let Err(e) = file.write_all(&chunk) {
+                                cleanup_tmp(&tmp_root);
+                                return Err(ApiError::adapter_import_failed(format!(
+                                    "writing temp archive: {e}"
+                                )));
+                            }
+                        }
+                        Ok(None) => break,
+                        Err(e) => {
+                            cleanup_tmp(&tmp_root);
+                            return Err(ApiError::adapter_import_invalid(format!(
+                                "reading 'archive' field: {e}"
+                            )));
+                        }
+                    }
+                }
+                if let Err(e) = file.sync_all() {
+                    cleanup_tmp(&tmp_root);
+                    return Err(ApiError::adapter_import_failed(format!(
+                        "flushing temp archive: {e}"
+                    )));
+                }
+                archive_path = Some(archive_target);
+            }
+            _ => {
+                // Unknown field — drain its body and ignore.
+                let _ = field.bytes().await;
+            }
+        }
+    }
+
+    let name = match name {
+        Some(n) => n,
+        None => {
+            cleanup_tmp(&tmp_root);
+            return Err(ApiError::adapter_import_invalid("missing 'name' field"));
+        }
+    };
+    let archive_path = match archive_path {
+        Some(p) => p,
+        None => {
+            cleanup_tmp(&tmp_root);
+            return Err(ApiError::adapter_import_invalid("missing 'archive' field"));
+        }
+    };
+
+    let target_dir = state.adapter_dir.join(&name);
+    if target_dir.exists() {
+        cleanup_tmp(&tmp_root);
+        return Err(ApiError::adapter_already_exists(&name));
+    }
+
+    // Extract on a blocking thread — tar/flate2 are sync, and decompression of
+    // a real adapter pegs a CPU for ~hundreds of ms.
+    let tmp_root_owned = tmp_root.clone().expect("tmp_root set when archive_path is set");
+    let archive_path_owned = archive_path.clone();
+    let target_dir_owned = target_dir.clone();
+    let extract_result = tokio::task::spawn_blocking(move || -> Result<(u64, u32), ImportError> {
+        let staging = tmp_root_owned.join("staging");
+        std::fs::create_dir_all(&staging).map_err(|e| ImportError::Failed(format!(
+            "creating staging dir: {e}"
+        )))?;
+
+        let file = std::fs::File::open(&archive_path_owned).map_err(|e| ImportError::Failed(format!(
+            "opening archive: {e}"
+        )))?;
+        let gz = GzDecoder::new(file);
+        let mut tar = tar::Archive::new(gz);
+
+        let entries = tar
+            .entries()
+            .map_err(|e| ImportError::Invalid(format!("reading tar entries: {e}")))?;
+
+        let mut bytes_written: u64 = 0;
+        let mut files_written: u32 = 0;
+        let mut strip_prefix: Option<Option<String>> = None;
+
+        let staging_canon = staging.canonicalize().map_err(|e| ImportError::Failed(format!(
+            "canonicalizing staging: {e}"
+        )))?;
+
+        for entry in entries {
+            let mut entry = entry.map_err(|e| ImportError::Invalid(format!(
+                "reading tar entry: {e}"
+            )))?;
+
+            files_written = files_written.saturating_add(1);
+            if files_written > ADAPTER_EXTRACT_ENTRIES_LIMIT {
+                return Err(ImportError::Invalid(format!(
+                    "archive contains more than {ADAPTER_EXTRACT_ENTRIES_LIMIT} entries"
+                )));
+            }
+
+            let entry_type = entry.header().entry_type();
+            if entry_type.is_dir() {
+                files_written = files_written.saturating_sub(1);
+                continue;
+            }
+            // Reject non-regular files (symlinks, hard links, devices, fifos).
+            if !entry_type.is_file() {
+                return Err(ImportError::Invalid(format!(
+                    "archive contains unsupported entry type {entry_type:?}"
+                )));
+            }
+
+            let entry_path = entry
+                .path()
+                .map_err(|e| ImportError::Invalid(format!("decoding entry path: {e}")))?
+                .into_owned();
+
+            // Strip a single leading top-level directory if every entry shares
+            // the same prefix (matches download's `name/<files>` layout).
+            let stripped: PathBuf = {
+                let mut comps = entry_path.components();
+                let first = comps.next();
+                match first {
+                    Some(Component::Normal(first_seg)) => {
+                        let first_str = first_seg.to_string_lossy().to_string();
+                        let observed = strip_prefix.get_or_insert_with(|| Some(first_str.clone()));
+                        match observed {
+                            Some(prefix) if *prefix == first_str => {
+                                let rest: PathBuf = comps.collect();
+                                if rest.as_os_str().is_empty() {
+                                    files_written = files_written.saturating_sub(1);
+                                    continue;
+                                }
+                                rest
+                            }
+                            _ => {
+                                // Mixed prefixes — install entries flat, no
+                                // strip after the first inconsistency.
+                                *observed = None;
+                                entry_path.clone()
+                            }
+                        }
+                    }
+                    _ => entry_path.clone(),
+                }
+            };
+
+            // Reject any path that is absolute, contains `..`, or resolves
+            // outside the staging directory.
+            for comp in stripped.components() {
+                match comp {
+                    Component::Normal(_) => {}
+                    Component::CurDir => {}
+                    _ => {
+                        return Err(ImportError::Invalid(format!(
+                            "archive entry has unsafe path: {}",
+                            stripped.display()
+                        )))
+                    }
+                }
+            }
+            if stripped.as_os_str().is_empty() {
+                files_written = files_written.saturating_sub(1);
+                continue;
+            }
+
+            let dest = staging.join(&stripped);
+            // Ensure dest stays under the staging dir even after canonicalization.
+            if let Some(parent) = dest.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| ImportError::Failed(format!(
+                    "creating dir {}: {e}",
+                    parent.display()
+                )))?;
+                let parent_canon = parent.canonicalize().map_err(|e| ImportError::Failed(format!(
+                    "canonicalizing {}: {e}",
+                    parent.display()
+                )))?;
+                if !parent_canon.starts_with(&staging_canon) {
+                    return Err(ImportError::Invalid(format!(
+                        "archive entry escapes staging dir: {}",
+                        stripped.display()
+                    )));
+                }
+            }
+
+            let size = entry.size();
+            bytes_written = bytes_written.saturating_add(size);
+            if bytes_written > ADAPTER_EXTRACT_BYTES_LIMIT {
+                return Err(ImportError::Invalid(format!(
+                    "decompressed archive exceeds {} GB limit",
+                    ADAPTER_EXTRACT_BYTES_LIMIT / (1024 * 1024 * 1024)
+                )));
+            }
+
+            let mut out = std::fs::File::create(&dest).map_err(|e| ImportError::Failed(format!(
+                "creating {}: {e}",
+                dest.display()
+            )))?;
+            std::io::copy(&mut entry, &mut out).map_err(|e| ImportError::Failed(format!(
+                "writing {}: {e}",
+                dest.display()
+            )))?;
+        }
+
+        if files_written == 0 {
+            return Err(ImportError::Invalid(
+                "archive contained no regular files".to_string(),
+            ));
+        }
+
+        // Atomic rename of staging → target_dir. On the same filesystem this is
+        // a single inode move; if it fails (e.g. EXDEV) fall back to a copy.
+        std::fs::rename(&staging, &target_dir_owned).map_err(|e| ImportError::Failed(format!(
+            "renaming staging to {}: {e}",
+            target_dir_owned.display()
+        )))?;
+
+        Ok((bytes_written, files_written))
+    })
+    .await
+    .map_err(|e| {
+        cleanup_tmp(&tmp_root);
+        ApiError::adapter_import_failed(format!("join error: {e}"))
+    })?;
+
+    // Always remove the upload temp dir; the staging child has been renamed
+    // out by the success path or cleaned up on failure.
+    cleanup_tmp(&tmp_root);
+
+    let (size_bytes, files) = match extract_result {
+        Ok(v) => v,
+        Err(ImportError::Invalid(msg)) => {
+            let _ = std::fs::remove_dir_all(&target_dir);
+            return Err(ApiError::adapter_import_invalid(msg));
+        }
+        Err(ImportError::Failed(msg)) => {
+            let _ = std::fs::remove_dir_all(&target_dir);
+            return Err(ApiError::adapter_import_failed(msg));
+        }
+    };
+
+    tracing::info!(
+        adapter = %name,
+        size_bytes,
+        files,
+        operation = "upload",
+        "imported adapter from upload"
+    );
+
+    Ok(Json(UploadAdapterResponse {
+        name,
+        size_bytes,
+        files,
+    }))
+}
+
+/// Internal error type for the blocking extract task — separates user input
+/// problems (400) from server-side I/O failures (500).
+enum ImportError {
+    Invalid(String),
+    Failed(String),
+}
+
+/// Tiny stdlib-only random suffix so concurrent uploads don't collide.
+fn rand_suffix() -> u128 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let pid = std::process::id() as u128;
+    let addr = &nanos as *const _ as u128;
+    nanos ^ (pid << 64) ^ addr.rotate_left(33)
+}
+
 pub fn routes() -> Router<AppState> {
     Router::new()
         .route("/v1/adapters", get(list_adapters))
         .route("/v1/adapters/load", post(load_adapter))
         .route("/v1/adapters/unload", post(unload_adapter))
         .route("/v1/adapters/merge", post(merge_adapters))
+        .route(
+            "/v1/adapters/upload",
+            post(upload_adapter).layer(DefaultBodyLimit::max(ADAPTER_UPLOAD_BODY_LIMIT)),
+        )
         .route("/v1/adapters/{name}", delete(delete_adapter))
         .route("/v1/adapters/{name}/download", get(download_adapter))
 }

--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -183,6 +183,33 @@ impl ApiError {
         }
     }
 
+    pub fn adapter_already_exists(name: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::CONFLICT,
+            code: "adapter_already_exists",
+            message: format!("Adapter '{name}' already exists"),
+            hint: "Run `curl -X DELETE /v1/adapters/{name}` to remove the existing adapter before re-uploading, or upload under a different name.",
+        }
+    }
+
+    pub fn adapter_import_failed(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            code: "adapter_import_failed",
+            message: format!("Failed to import adapter: {detail}"),
+            hint: "Check that the uploaded archive is a valid tar.gz produced by GET /v1/adapters/{name}/download. Server logs have details.",
+        }
+    }
+
+    pub fn adapter_import_invalid(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "adapter_import_invalid",
+            message: format!("Invalid adapter upload: {detail}"),
+            hint: "POST multipart/form-data with two fields: 'name' (text, single segment) and 'archive' (file, gzipped tar produced by GET /v1/adapters/{name}/download).",
+        }
+    }
+
     pub fn mock_mode_no_adapters() -> Self {
         Self {
             status: StatusCode::BAD_REQUEST,

--- a/crates/kiln-server/tests/adapter_upload.rs
+++ b/crates/kiln-server/tests/adapter_upload.rs
@@ -1,0 +1,337 @@
+//! Integration test: POST /v1/adapters/upload accepts a multipart tar.gz
+//! archive and installs it as a new adapter directory under adapter_dir.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+use serde_json::json;
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::state::AppState;
+
+/// Minimal tokenizer for tests.
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    vocab.insert("a".to_string(), 0);
+    vocab.insert("b".to_string(), 1);
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] }
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state(adapter_dir: std::path::PathBuf) -> AppState {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    let mut state = AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        test_tokenizer(),
+        300,
+        "qwen3.5-4b-kiln".to_string(),
+    );
+    state.adapter_dir = adapter_dir;
+    state
+}
+
+fn write_adapter(adapter_dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let path = adapter_dir.join(name);
+    std::fs::create_dir_all(&path).unwrap();
+    std::fs::write(
+        path.join("adapter_config.json"),
+        br#"{"r": 8, "lora_alpha": 16}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        path.join("adapter_model.safetensors"),
+        b"\x00\x01\x02\x03fake-safetensors-bytes",
+    )
+    .unwrap();
+    path
+}
+
+/// Build a multipart/form-data request body with a fixed boundary.
+fn build_multipart_body(name: Option<&str>, archive: Option<&[u8]>) -> (String, Vec<u8>) {
+    let boundary = "----test-boundary-XXX";
+    let content_type = format!("multipart/form-data; boundary={boundary}");
+    let mut body: Vec<u8> = Vec::new();
+
+    if let Some(name) = name {
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"name\"\r\nContent-Type: text/plain\r\n\r\n",
+        );
+        body.extend_from_slice(name.as_bytes());
+        body.extend_from_slice(b"\r\n");
+    }
+
+    if let Some(archive) = archive {
+        body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+        body.extend_from_slice(
+            b"Content-Disposition: form-data; name=\"archive\"; filename=\"a.tar.gz\"\r\n\
+              Content-Type: application/gzip\r\n\r\n",
+        );
+        body.extend_from_slice(archive);
+        body.extend_from_slice(b"\r\n");
+    }
+
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+    (content_type, body)
+}
+
+/// Build a tar.gz archive containing entries at the given paths with the
+/// given byte contents. Entries are written as regular files.
+fn build_tar_gz(entries: &[(&str, &[u8])]) -> Vec<u8> {
+    let buf: Vec<u8> = Vec::new();
+    let gz = GzEncoder::new(buf, Compression::default());
+    let mut tar = tar::Builder::new(gz);
+    for (path, data) in entries {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(data.len() as u64);
+        header.set_mode(0o644);
+        header.set_entry_type(tar::EntryType::Regular);
+        header.set_cksum();
+        tar.append_data(&mut header, path, *data).unwrap();
+    }
+    let gz = tar.into_inner().unwrap();
+    gz.finish().unwrap()
+}
+
+#[tokio::test]
+async fn test_roundtrip_download_then_upload() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_adapter(tmp.path(), "src-adapter");
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    // 1. Download the adapter as tar.gz.
+    let download_req = Request::builder()
+        .method("GET")
+        .uri("/v1/adapters/src-adapter/download")
+        .body(Body::empty())
+        .unwrap();
+    let download_resp = app.clone().oneshot(download_req).await.unwrap();
+    assert_eq!(download_resp.status(), StatusCode::OK);
+    let archive_bytes = axum::body::to_bytes(download_resp.into_body(), usize::MAX)
+        .await
+        .unwrap()
+        .to_vec();
+
+    // 2. Upload it back under a new name.
+    let (content_type, body) = build_multipart_body(Some("dest-adapter"), Some(&archive_bytes));
+    let upload_req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/upload")
+        .header("content-type", content_type)
+        .body(Body::from(body))
+        .unwrap();
+    let upload_resp = app.clone().oneshot(upload_req).await.unwrap();
+    let status = upload_resp.status();
+    let body_bytes = axum::body::to_bytes(upload_resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "upload failed: {}",
+        String::from_utf8_lossy(&body_bytes)
+    );
+    let upload_json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(upload_json["name"], "dest-adapter");
+    assert_eq!(upload_json["files"], 2);
+
+    // 3. Verify both files are present on disk with original bytes.
+    let dest = tmp.path().join("dest-adapter");
+    assert!(dest.exists() && dest.is_dir(), "dest-adapter dir missing");
+    let cfg = std::fs::read(dest.join("adapter_config.json")).unwrap();
+    assert_eq!(cfg.as_slice(), br#"{"r": 8, "lora_alpha": 16}"#);
+    let weights = std::fs::read(dest.join("adapter_model.safetensors")).unwrap();
+    assert_eq!(weights.as_slice(), b"\x00\x01\x02\x03fake-safetensors-bytes");
+}
+
+#[tokio::test]
+async fn test_upload_rejects_invalid_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let archive = build_tar_gz(&[("foo/a.txt", b"hello")]);
+
+    // Various bad names that should all be rejected by validate_adapter_name.
+    let bad_names = ["", "..", "/abs", "foo/bar", "foo\\bar", "../escape"];
+
+    for bad in bad_names {
+        let (content_type, body) = build_multipart_body(Some(bad), Some(&archive));
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/adapters/upload")
+            .header("content-type", content_type)
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "name {bad:?} should have been rejected"
+        );
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let code = json["error"]["code"].as_str().unwrap_or("");
+        assert!(
+            code == "invalid_adapter_name" || code == "adapter_import_invalid",
+            "name {bad:?} returned unexpected error code {code}"
+        );
+    }
+
+    // No regular adapter directory should have been created.
+    let real_entries: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .flatten()
+        .filter(|e| {
+            !e.file_name()
+                .to_string_lossy()
+                .starts_with(".upload-tmp-")
+        })
+        .collect();
+    assert!(
+        real_entries.is_empty(),
+        "no adapter directory should exist after failed uploads"
+    );
+}
+
+#[tokio::test]
+async fn test_upload_rejects_existing_adapter() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_adapter(tmp.path(), "already-here");
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let archive = build_tar_gz(&[
+        ("already-here/adapter_config.json", b"{}"),
+        ("already-here/adapter_model.safetensors", b"x"),
+    ]);
+    let (content_type, body) = build_multipart_body(Some("already-here"), Some(&archive));
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/upload")
+        .header("content-type", content_type)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(json["error"]["code"], "adapter_already_exists");
+
+    // Original adapter contents must be untouched.
+    let original = std::fs::read(tmp.path().join("already-here/adapter_config.json")).unwrap();
+    assert_eq!(original.as_slice(), br#"{"r": 8, "lora_alpha": 16}"#);
+}
+
+#[tokio::test]
+async fn test_upload_rejects_path_escape_in_archive() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    // Build a tar that tries to write outside the staging dir via `..`.
+    // We use `append_data` with a path that contains `..` — this is exactly
+    // the kind of payload the path validator must reject.
+    let buf: Vec<u8> = Vec::new();
+    let gz = GzEncoder::new(buf, Compression::default());
+    let mut tar = tar::Builder::new(gz);
+
+    // Entry 1: a normal-looking file under the prefix so strip_prefix engages.
+    let mut h1 = tar::Header::new_gnu();
+    h1.set_size(5);
+    h1.set_mode(0o644);
+    h1.set_entry_type(tar::EntryType::Regular);
+    h1.set_cksum();
+    tar.append_data(&mut h1, "evil/ok.txt", &b"hello"[..]).unwrap();
+
+    // Entry 2: the malicious path — `..` to escape staging.
+    let mut h2 = tar::Header::new_gnu();
+    h2.set_size(11);
+    h2.set_mode(0o644);
+    h2.set_entry_type(tar::EntryType::Regular);
+    h2.set_cksum();
+    tar.append_data(&mut h2, "evil/../../etc/passwd", &b"PWNED-DATA!"[..])
+        .unwrap();
+
+    let gz = tar.into_inner().unwrap();
+    let archive = gz.finish().unwrap();
+
+    let (content_type, body) = build_multipart_body(Some("evil"), Some(&archive));
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/upload")
+        .header("content-type", content_type)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    // Must be a 4xx — the request was malformed (unsafe path).
+    assert!(
+        status.is_client_error() || status.is_server_error(),
+        "expected error response, got {status}"
+    );
+    let code = json["error"]["code"].as_str().unwrap_or("");
+    assert!(
+        code == "adapter_import_invalid" || code == "adapter_import_failed",
+        "unexpected error code: {code}"
+    );
+
+    // No adapter directory should exist with the escaped data, and the
+    // adapter dir should be otherwise empty (modulo cleaned-up temp dir).
+    let leaked = tmp.path().parent().unwrap().join("etc/passwd");
+    assert!(!leaked.exists(), "path traversal leaked outside adapter_dir");
+    let real_entries: Vec<_> = std::fs::read_dir(tmp.path())
+        .unwrap()
+        .flatten()
+        .filter(|e| {
+            !e.file_name()
+                .to_string_lossy()
+                .starts_with(".upload-tmp-")
+        })
+        .collect();
+    assert!(
+        real_entries.is_empty(),
+        "expected no adapter dir after failed unsafe upload, got {:?}",
+        real_entries
+            .iter()
+            .map(|e| e.file_name())
+            .collect::<Vec<_>>()
+    );
+}
+


### PR DESCRIPTION
## What

Adds the symmetric inbound endpoint that pairs with `GET /v1/adapters/{name}/download` (PR #575):

```bash
curl -X POST http://localhost:8420/v1/adapters/upload \
  -F name=my-adapter \
  -F archive=@my-adapter.tar.gz
```

This closes the share/backup loop. Without it, the download endpoint is one-way and the only way to install an adapter is to scp files into \`adapter_dir\`.

## Implementation

- \`upload_adapter\` handler accepts \`multipart/form-data\` with \`name\` (text) and \`archive\` (file). Name validation reuses \`validate_adapter_name\`.
- Streams archive bytes to a tmp file under \`adapter_dir/.upload-tmp-*/\` (no in-memory buffering of full archive). Extraction runs on \`spawn_blocking\` (tar/flate2 are sync) into a sibling staging dir, then atomic \`rename\` into final location. Tmp dirs cleaned on every error path.
- **Path-escape protection**: rejects entries with absolute paths, \`..\` components, or any path that escapes the destination. Skips directories silently and rejects all non-regular-file entries (symlinks, devices, sockets) — matches the download endpoint's policy.
- Tolerates either bare-layout archives or download-style archives prefixed with the original adapter name (strips one consistent leading dir component if present; falls back to flat install on inconsistent prefixes).
- Per-route body limit raised to 2 GB (real Qwen3.5-4B rank-8 LoRA archives are ~30–60 MB compressed; high-rank adapters fit comfortably under the cap). Hard caps on extracted bytes (4 GB) and entry count (100k) guard against tarbomb-style payloads.
- New error variants: \`adapter_already_exists\` (409, hints DELETE first), \`adapter_import_invalid\` (400), and \`adapter_import_failed\` (500).
- Returns JSON: \`{\"name\": \"...\", \"size_bytes\": N, \"files\": M}\`.

## Test

\`crates/kiln-server/tests/adapter_upload.rs\` — 4 tests, all CPU-only (no GPU required):

- \`test_roundtrip_download_then_upload\` — write an adapter, GET its tar.gz, POST it back under a new name, verify on-disk bytes are byte-identical.
- \`test_upload_rejects_invalid_name\` — empty / \`..\` / \`/abs\` / \`foo/bar\` / \`foo\\bar\` / \`../escape\` all return 400, no adapter dir created.
- \`test_upload_rejects_existing_adapter\` — uploading to a name that already exists returns 409 \`adapter_already_exists\`, original adapter contents untouched.
- \`test_upload_rejects_path_escape_in_archive\` — tar entry with \`evil/../../etc/passwd\` is rejected, no leakage outside \`adapter_dir\`, no partial adapter created.

\`cargo test -p kiln-server --test adapter_upload\` and \`--test adapter_download\` both expected green; full \`cargo test -p kiln-server\` should be clean.

## Why now

Phase 8 lock-in thesis: trained adapters are valuable. Download (PR #575) made them portable; upload makes them installable on a fresh server without filesystem access. Together they enable adapter sharing, multi-server fleets, and disaster recovery — and they make trained-adapter portability a first-class API rather than a SSH-only operation.