### PR TITLE
Phase 8: TIES merge mode for /v1/adapters/merge

### DIFF
--- a/crates/kiln-model/src/adapter_merge.rs
+++ b/crates/kiln-model/src/adapter_merge.rs
@@ -1,16 +1,29 @@
-//! Adapter merging via weighted (linear-interpolation) averaging.
+//! Adapter merging across PEFT-compatible LoRA adapters.
 //!
 //! Given a set of `(adapter, weight)` pairs that share the same rank,
 //! target modules, and tensor layout, produces a new PEFT-compatible
-//! LoRA adapter whose A/B matrices are the weighted sum of the inputs:
+//! LoRA adapter whose A/B matrices combine the inputs.
 //!
-//! ```text
-//! merged_A = Σᵢ wᵢ · Aᵢ
-//! merged_B = Σᵢ wᵢ · Bᵢ
-//! ```
+//! Two merge modes are supported:
 //!
-//! This is the "weighted average" / linear-interpolation merge mode.
-//! TIES and concatenation merging are deferred to follow-up PRs.
+//! - **Linear interpolation** (`merge_linear`) — elementwise weighted sum:
+//!   ```text
+//!   merged[k] = Σᵢ wᵢ · adapters[i].tensors[k]
+//!   ```
+//!
+//! - **TIES** (`merge_ties`, Yadav et al. 2023, arXiv 2306.01708) — three
+//!   phases per tensor:
+//!     1. *Trim*: per adapter, zero all values outside the top `density`
+//!        fraction by absolute magnitude.
+//!     2. *Elect sign*: per parameter position, the sign of the
+//!        weight-scaled sum across adapters is the elected sign.
+//!     3. *Disjoint merge*: per parameter position, weight-average only
+//!        the trimmed values whose sign matches the elected sign.
+//!
+//!   TIES typically reduces task interference when merging adapters that
+//!   adapt the same model in conflicting directions.
+//!
+//! Concatenation merging is deferred to a follow-up PR.
 //!
 //! All merging is performed in `f32` on CPU using raw safetensors I/O,
 //! so it does not depend on candle / CUDA and can be unit-tested without
@@ -292,6 +305,199 @@ pub fn merge_linear(adapters: &[(&PeftLora, f32)]) -> Result<PeftLora> {
         config: first.config.clone(),
         tensors: merged,
     })
+}
+
+/// TIES merge of LoRA adapters (Yadav et al. 2023, arXiv 2306.01708).
+///
+/// Three phases applied per tensor key:
+/// 1. **Trim** each adapter's tensor: keep only the top `density` fraction
+///    of values by absolute magnitude. The remainder are zeroed.
+/// 2. **Elect sign** per parameter position: the sign of
+///    `Σⱼ wⱼ · trimmed_j[i]`. Positions where every trimmed value is zero
+///    (or where the signed sum is exactly 0) elect a zero sign.
+/// 3. **Disjoint merge** per parameter position: weight-average only the
+///    trimmed values whose sign matches the elected sign:
+///    ```text
+///    out[i] = (Σ_{j ∈ S(i)} wⱼ · trimmed_j[i]) / (Σ_{j ∈ S(i)} wⱼ)
+///    ```
+///    where `S(i) = { j : sign(trimmed_j[i]) == elected_sign(i) }`.
+///    Positions with a zero elected sign output 0.
+///
+/// `density` controls how aggressively each adapter is trimmed; values in
+/// `(0, 1]` are required. `density = 1.0` keeps every value (no trimming);
+/// `density = 0.2` follows the TIES paper's default and keeps the top 20%
+/// of magnitudes per adapter per tensor.
+///
+/// Validation matches `merge_linear`: at least one adapter, identical
+/// rank, target_modules, base model, tensor key sets, and shapes.
+pub fn merge_ties(adapters: &[(&PeftLora, f32)], density: f32) -> Result<PeftLora> {
+    if adapters.is_empty() {
+        bail!("merge_ties requires at least one source adapter");
+    }
+    if !(density.is_finite() && density > 0.0 && density <= 1.0) {
+        bail!(
+            "merge_ties density must be in (0.0, 1.0]; got {density}"
+        );
+    }
+
+    let (first, _) = adapters[0];
+    let first_rank = first.rank();
+    let first_targets = first.target_modules();
+    let first_base = first.base_model();
+
+    let mut keys: Vec<&String> = first.tensors.keys().collect();
+    keys.sort();
+
+    // Validate every adapter against the first (same shape/config rules
+    // as merge_linear so a TIES merge fails loudly rather than silently
+    // producing nonsense).
+    for (idx, (adapter, _)) in adapters.iter().enumerate().skip(1) {
+        if adapter.rank() != first_rank {
+            bail!(
+                "adapter rank mismatch: source[0] has r={:?}, source[{idx}] has r={:?} \
+                 (TIES merge requires identical rank)",
+                first_rank,
+                adapter.rank()
+            );
+        }
+        let targets = adapter.target_modules();
+        if !same_string_set(&first_targets, &targets) {
+            bail!(
+                "adapter target_modules mismatch: source[0] has {:?}, source[{idx}] has {:?}",
+                first_targets,
+                targets
+            );
+        }
+        if let (Some(a), Some(b)) = (&first_base, &adapter.base_model()) {
+            if a != b {
+                bail!(
+                    "adapter base_model_name_or_path mismatch: source[0] is {a:?}, \
+                     source[{idx}] is {b:?}"
+                );
+            }
+        }
+        if first.tensors.len() != adapter.tensors.len() {
+            bail!(
+                "adapter tensor count mismatch: source[0] has {} tensors, source[{idx}] has {}",
+                first.tensors.len(),
+                adapter.tensors.len()
+            );
+        }
+        for key in adapter.tensors.keys() {
+            if !first.tensors.contains_key(key.as_str()) {
+                bail!(
+                    "adapter tensor key mismatch: source[{idx}] has tensor {:?} not present in source[0]",
+                    key
+                );
+            }
+        }
+        for key in &keys {
+            let a = &first.tensors[key.as_str()];
+            let b = adapter.tensors.get(key.as_str()).ok_or_else(|| {
+                anyhow!("adapter tensor key mismatch: source[{idx}] missing tensor {:?}", key)
+            })?;
+            if a.shape != b.shape {
+                bail!(
+                    "tensor shape mismatch for {key:?}: source[0] is {:?}, source[{idx}] is {:?}",
+                    a.shape,
+                    b.shape
+                );
+            }
+        }
+    }
+
+    let mut merged: BTreeMap<String, MergeTensor> = BTreeMap::new();
+    for key in &keys {
+        let key_str = key.as_str();
+        let template = &first.tensors[key_str];
+        let n = template.numel();
+
+        // Phase 1 — trim each adapter's tensor independently.
+        let trimmed: Vec<Vec<f32>> = adapters
+            .iter()
+            .map(|(adapter, _)| trim_top_density(&adapter.tensors[key_str].data, density))
+            .collect();
+
+        let mut out = vec![0.0_f32; n];
+        for i in 0..n {
+            // Phase 2 — elect sign from the weight-scaled sum.
+            let mut signed_sum = 0.0_f32;
+            for (j, (_, w)) in adapters.iter().enumerate() {
+                signed_sum += w * trimmed[j][i];
+            }
+            let elected = if signed_sum > 0.0 {
+                1.0_f32
+            } else if signed_sum < 0.0 {
+                -1.0_f32
+            } else {
+                0.0_f32
+            };
+            if elected == 0.0 {
+                continue; // out[i] stays 0.0
+            }
+
+            // Phase 3 — disjoint weighted average over sign-matching adapters.
+            let mut weighted_sum = 0.0_f32;
+            let mut weight_sum = 0.0_f32;
+            for (j, (_, w)) in adapters.iter().enumerate() {
+                let v = trimmed[j][i];
+                let v_sign = if v > 0.0 {
+                    1.0_f32
+                } else if v < 0.0 {
+                    -1.0_f32
+                } else {
+                    0.0_f32
+                };
+                if v_sign == elected {
+                    weighted_sum += w * v;
+                    weight_sum += w;
+                }
+            }
+            if weight_sum != 0.0 {
+                out[i] = weighted_sum / weight_sum;
+            }
+        }
+
+        merged.insert(
+            key_str.to_string(),
+            MergeTensor {
+                shape: template.shape.clone(),
+                data: out,
+            },
+        );
+    }
+
+    Ok(PeftLora {
+        config: first.config.clone(),
+        tensors: merged,
+    })
+}
+
+/// Trim a flat tensor: keep only the top `density` fraction of values by
+/// absolute magnitude; zero the remainder. `density >= 1.0` is a no-op.
+///
+/// On ties at the magnitude threshold, all tied values are kept (so the
+/// number of non-zeros may slightly exceed `round(density * n)`).
+fn trim_top_density(values: &[f32], density: f32) -> Vec<f32> {
+    let n = values.len();
+    if n == 0 || density >= 1.0 {
+        return values.to_vec();
+    }
+    let keep_count = ((density * n as f32).round() as usize).min(n);
+    if keep_count == 0 {
+        return vec![0.0; n];
+    }
+    if keep_count >= n {
+        return values.to_vec();
+    }
+    let mut abs_vals: Vec<f32> = values.iter().map(|v| v.abs()).collect();
+    abs_vals
+        .sort_unstable_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+    let threshold = abs_vals[keep_count - 1];
+    values
+        .iter()
+        .map(|&v| if v.abs() >= threshold { v } else { 0.0 })
+        .collect()
 }
 
 fn same_string_set(a: &[String], b: &[String]) -> bool {
@@ -644,6 +850,191 @@ mod tests {
             ["base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"];
         for v in &b.data {
             assert!((*v - 3.0).abs() < 1e-6);
+        }
+
+        Ok(())
+    }
+
+    // -----------------------------------------------------------------
+    // TIES merge tests
+    // -----------------------------------------------------------------
+
+    fn lora_a_key() -> &'static str {
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"
+    }
+
+    fn lora_b_key() -> &'static str {
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"
+    }
+
+    #[test]
+    fn test_merge_ties_density_one_equals_linear_when_signs_agree() -> Result<()> {
+        // density = 1.0 (no trim) + all-positive values + weights summing
+        // to 1.0 means TIES collapses to merge_linear's weighted sum.
+        let adapter1 = make_adapter(2, vec![2.0_f32; 8], vec![4.0_f32; 6]);
+        let adapter2 = make_adapter(2, vec![6.0_f32; 8], vec![8.0_f32; 6]);
+
+        let ties = merge_ties(&[(&adapter1, 0.5), (&adapter2, 0.5)], 1.0)?;
+        let linear = merge_linear(&[(&adapter1, 0.5), (&adapter2, 0.5)])?;
+
+        for key in linear.tensors.keys() {
+            let t = &ties.tensors[key];
+            let l = &linear.tensors[key];
+            assert_eq!(t.shape, l.shape, "shape mismatch for {key}");
+            assert_eq!(t.data.len(), l.data.len(), "len mismatch for {key}");
+            for (i, (a, b)) in t.data.iter().zip(l.data.iter()).enumerate() {
+                assert!(
+                    (a - b).abs() < 1e-6,
+                    "ties[{key}][{i}]={a} vs linear={b}"
+                );
+            }
+        }
+
+        // Spot-check exact values: 0.5*2 + 0.5*6 = 4 in A, 0.5*4 + 0.5*8 = 6 in B.
+        for v in &ties.tensors[lora_a_key()].data {
+            assert!((*v - 4.0).abs() < 1e-6, "expected 4.0 in A, got {v}");
+        }
+        for v in &ties.tensors[lora_b_key()].data {
+            assert!((*v - 6.0).abs() < 1e-6, "expected 6.0 in B, got {v}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_ties_trims_low_magnitude_values() -> Result<()> {
+        // Distinct magnitudes so the threshold cut is unambiguous. With a
+        // single adapter, sign election and the disjoint merge collapse
+        // back to "trimmed value", so the output equals the trimmed input.
+        let a_data: Vec<f32> = vec![1.0, 5.0, 2.0, 6.0, 3.0, 7.0, 4.0, 8.0];
+        let b_data: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let adapter = make_adapter(2, a_data, b_data);
+
+        let merged = merge_ties(&[(&adapter, 1.0)], 0.5)?;
+
+        // A: top 4 by abs are [8,7,6,5]; threshold = 5; keep abs >= 5.
+        let expected_a: Vec<f32> = vec![0.0, 5.0, 0.0, 6.0, 0.0, 7.0, 0.0, 8.0];
+        // B: top 3 by abs are [6,5,4]; threshold = 4; keep abs >= 4.
+        let expected_b: Vec<f32> = vec![0.0, 0.0, 0.0, 4.0, 5.0, 6.0];
+
+        let a_out = &merged.tensors[lora_a_key()].data;
+        let b_out = &merged.tensors[lora_b_key()].data;
+        assert_eq!(a_out.len(), expected_a.len());
+        assert_eq!(b_out.len(), expected_b.len());
+        for (got, want) in a_out.iter().zip(expected_a.iter()) {
+            assert!((got - want).abs() < 1e-6, "A: got {got}, want {want}");
+        }
+        for (got, want) in b_out.iter().zip(expected_b.iter()) {
+            assert!((got - want).abs() < 1e-6, "B: got {got}, want {want}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_ties_sign_election_resolves_conflicts() -> Result<()> {
+        // Two adapters, one all-positive +10, one all-negative -10. The
+        // higher-weighted side should drive both the elected sign and
+        // the final value (its magnitude wins because the other side's
+        // adapters are excluded from the disjoint average).
+        let pos = make_adapter(2, vec![10.0_f32; 8], vec![10.0_f32; 6]);
+        let neg = make_adapter(2, vec![-10.0_f32; 8], vec![-10.0_f32; 6]);
+
+        // Positive side wins (0.7 > 0.3).
+        let merged = merge_ties(&[(&pos, 0.7), (&neg, 0.3)], 1.0)?;
+        for v in &merged.tensors[lora_a_key()].data {
+            assert!((*v - 10.0).abs() < 1e-6, "expected +10 in A, got {v}");
+        }
+        for v in &merged.tensors[lora_b_key()].data {
+            assert!((*v - 10.0).abs() < 1e-6, "expected +10 in B, got {v}");
+        }
+
+        // Negative side wins (0.7 > 0.3).
+        let merged = merge_ties(&[(&pos, 0.3), (&neg, 0.7)], 1.0)?;
+        for v in &merged.tensors[lora_a_key()].data {
+            assert!((*v + 10.0).abs() < 1e-6, "expected -10 in A, got {v}");
+        }
+        for v in &merged.tensors[lora_b_key()].data {
+            assert!((*v + 10.0).abs() < 1e-6, "expected -10 in B, got {v}");
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_ties_validates_density_range() {
+        let a = make_adapter(2, vec![1.0_f32; 8], vec![1.0_f32; 6]);
+
+        // density = 0.0 is excluded (open lower bound).
+        let err = merge_ties(&[(&a, 1.0)], 0.0).unwrap_err();
+        assert!(
+            format!("{err}").contains("density"),
+            "expected density error, got: {err}"
+        );
+
+        // density > 1.0 is excluded.
+        let err = merge_ties(&[(&a, 1.0)], 1.5).unwrap_err();
+        assert!(
+            format!("{err}").contains("density"),
+            "expected density error, got: {err}"
+        );
+
+        // negative density rejected.
+        let err = merge_ties(&[(&a, 1.0)], -0.5).unwrap_err();
+        assert!(
+            format!("{err}").contains("density"),
+            "expected density error, got: {err}"
+        );
+
+        // NaN rejected.
+        let err = merge_ties(&[(&a, 1.0)], f32::NAN).unwrap_err();
+        assert!(
+            format!("{err}").contains("density"),
+            "expected density error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_merge_ties_empty_errors() {
+        let err = merge_ties(&[], 0.5).unwrap_err();
+        assert!(
+            format!("{err}").contains("at least one source adapter"),
+            "expected empty error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_merge_ties_rank_mismatch_errors() {
+        let a1 = make_adapter(2, vec![1.0_f32; 8], vec![1.0_f32; 6]);
+        let a2 = make_adapter(4, vec![1.0_f32; 16], vec![1.0_f32; 12]);
+        let err = merge_ties(&[(&a1, 0.5), (&a2, 0.5)], 0.5).unwrap_err();
+        assert!(
+            format!("{err}").contains("rank mismatch"),
+            "expected rank mismatch error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_merge_ties_save_and_load_roundtrip() -> Result<()> {
+        // Smoke-test that a TIES-merged adapter is on-disk PEFT-compatible
+        // and round-trips through PeftLora::save/load like a linear merge.
+        let dir = tempdir()?;
+        let merged_dir = dir.path().join("merged");
+
+        let a1 = make_adapter(2, vec![1.0_f32; 8], vec![1.0_f32; 6]);
+        let a2 = make_adapter(2, vec![3.0_f32; 8], vec![3.0_f32; 6]);
+        let merged = merge_ties(&[(&a1, 0.5), (&a2, 0.5)], 1.0)?;
+        merged.save(&merged_dir)?;
+
+        let loaded = PeftLora::load(&merged_dir)?;
+        assert_eq!(loaded.rank(), Some(2));
+        assert_eq!(loaded.target_modules(), vec!["q_proj".to_string()]);
+        // (0.5*1 + 0.5*3)/(0.5+0.5) = 2.0 in both A and B.
+        for v in &loaded.tensors[lora_a_key()].data {
+            assert!((*v - 2.0).abs() < 1e-6);
+        }
+        for v in &loaded.tensors[lora_b_key()].data {
+            assert!((*v - 2.0).abs() < 1e-6);
         }
 
         Ok(())

--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 
-use kiln_model::adapter_merge::{merge_linear, PeftLora};
+use kiln_model::adapter_merge::{merge_linear, merge_ties, PeftLora};
 use kiln_model::lora_loader::LoraWeights;
 
 use crate::error::ApiError;
@@ -298,10 +298,17 @@ struct MergeAdapterRequest {
     sources: Vec<MergeSource>,
     /// Name of the output adapter (subdirectory created under adapter_dir).
     output_name: String,
-    /// Merge mode. Currently only "weighted_average" (the default) is
-    /// supported. TIES and concatenation will arrive in follow-up PRs.
+    /// Merge mode. Supported values: `"weighted_average"` (the default) and
+    /// `"ties"` (Yadav et al. 2023). Concatenation will arrive in a
+    /// follow-up PR.
     #[serde(default)]
     mode: Option<String>,
+    /// Density used by the TIES merge: keep the top fraction of values per
+    /// adapter per tensor. Required range `(0.0, 1.0]`. Ignored for
+    /// `weighted_average`. Defaults to 0.2 when `mode == "ties"`, following
+    /// the TIES paper's recommendation.
+    #[serde(default)]
+    density: Option<f32>,
 }
 
 /// Source summary echoed back in the merge response.
@@ -333,12 +340,39 @@ async fn merge_adapters(
     Json(req): Json<MergeAdapterRequest>,
 ) -> Result<Json<MergeAdapterResponse>, ApiError> {
     // Validate mode (default = weighted_average).
-    let mode = req.mode.as_deref().unwrap_or("weighted_average");
-    if mode != "weighted_average" {
-        return Err(ApiError::adapter_merge_invalid(format!(
-            "unsupported merge mode '{mode}' — only 'weighted_average' is supported in v1"
-        )));
-    }
+    let mode_str = req.mode.as_deref().unwrap_or("weighted_average");
+    let resolved_mode: &'static str = match mode_str {
+        "weighted_average" => "weighted_average",
+        "ties" => "ties",
+        other => {
+            return Err(ApiError::adapter_merge_invalid(format!(
+                "unsupported merge mode '{other}' — supported modes are 'weighted_average' and 'ties'"
+            )));
+        }
+    };
+
+    // Validate TIES density up-front so callers get a clean 400 before
+    // we touch any I/O.
+    let ties_density: f32 = match resolved_mode {
+        "ties" => {
+            let d = req.density.unwrap_or(0.2);
+            if !(d.is_finite() && d > 0.0 && d <= 1.0) {
+                return Err(ApiError::adapter_merge_invalid(format!(
+                    "density must be in (0.0, 1.0]; got {d}"
+                )));
+            }
+            d
+        }
+        _ => {
+            if req.density.is_some() {
+                return Err(ApiError::adapter_merge_invalid(
+                    "density is only supported when mode == \"ties\"",
+                ));
+            }
+            // Unused for weighted_average.
+            0.0
+        }
+    };
 
     // Need at least one source.
     if req.sources.is_empty() {
@@ -388,6 +422,7 @@ async fn merge_adapters(
     // Run the (potentially slow, CPU-bound) merge work on a blocking thread.
     let output_name_for_task = output_name.clone();
     let output_path_for_task = output_path.clone();
+    let mode_for_task = resolved_mode;
     let merge_result = tokio::task::spawn_blocking(move || -> Result<usize, MergeError> {
         // Load each source adapter from disk.
         let mut loaded: Vec<(PeftLora, f32)> = Vec::with_capacity(source_paths.len());
@@ -402,7 +437,11 @@ async fn merge_adapters(
         let refs: Vec<(&PeftLora, f32)> =
             loaded.iter().map(|(a, w)| (a, *w)).collect();
 
-        let merged = merge_linear(&refs).map_err(|e| MergeError::Invalid(format!("{e}")))?;
+        let merged = match mode_for_task {
+            "ties" => merge_ties(&refs, ties_density)
+                .map_err(|e| MergeError::Invalid(format!("{e}")))?,
+            _ => merge_linear(&refs).map_err(|e| MergeError::Invalid(format!("{e}")))?,
+        };
         let num_tensors = merged.tensors.len();
         merged
             .save(&output_path_for_task)
@@ -433,7 +472,7 @@ async fn merge_adapters(
         output = %output_name,
         num_sources = req.sources.len(),
         num_tensors,
-        mode,
+        mode = resolved_mode,
         operation = "merge",
         "merged LoRA adapters"
     );
@@ -441,7 +480,7 @@ async fn merge_adapters(
     Ok(Json(MergeAdapterResponse {
         status: "merged",
         output_name,
-        mode: "weighted_average",
+        mode: resolved_mode,
         sources: sources_info,
         num_tensors,
     }))

--- a/crates/kiln-server/tests/adapter_merge_ties.rs
+++ b/crates/kiln-server/tests/adapter_merge_ties.rs
@@ -1,0 +1,245 @@
+//! Integration test: POST /v1/adapters/merge accepts `mode == "ties"` and
+//! produces a PEFT-compatible merged adapter on disk.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::adapter_merge::{MergeTensor, PeftLora};
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::state::AppState;
+
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    vocab.insert("a".to_string(), 0);
+    vocab.insert("b".to_string(), 1);
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] }
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state(adapter_dir: std::path::PathBuf) -> AppState {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    let mut state = AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        test_tokenizer(),
+        300,
+        "qwen3.5-4b-kiln".to_string(),
+    );
+    state.adapter_dir = adapter_dir;
+    state
+}
+
+/// Write a single-tensor PEFT-format adapter (rank=2, q_proj only) where
+/// every value of `lora_A` and `lora_B` is `fill`. Used to set up sources
+/// for the merge endpoint.
+fn write_uniform_adapter(adapter_dir: &std::path::Path, name: &str, fill: f32) {
+    let path = adapter_dir.join(name);
+    let mut tensors: BTreeMap<String, MergeTensor> = BTreeMap::new();
+    tensors.insert(
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight".to_string(),
+        MergeTensor {
+            shape: vec![2, 4],
+            data: vec![fill; 8],
+        },
+    );
+    tensors.insert(
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight".to_string(),
+        MergeTensor {
+            shape: vec![3, 2],
+            data: vec![fill; 6],
+        },
+    );
+    let config = json!({
+        "r": 2,
+        "lora_alpha": 4.0,
+        "target_modules": ["q_proj"],
+        "task_type": "CAUSAL_LM",
+        "peft_type": "LORA",
+        "base_model_name_or_path": "Qwen/Qwen3.5-4B"
+    });
+    let adapter = PeftLora { config, tensors };
+    adapter.save(&path).unwrap();
+}
+
+#[tokio::test]
+async fn test_merge_ties_endpoint_returns_200_and_writes_adapter() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_uniform_adapter(tmp.path(), "src-a", 2.0);
+    write_uniform_adapter(tmp.path(), "src-b", 6.0);
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let body = json!({
+        "sources": [
+            { "name": "src-a", "weight": 0.5 },
+            { "name": "src-b", "weight": 0.5 },
+        ],
+        "output_name": "merged-ties",
+        "mode": "ties",
+        "density": 1.0,
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/merge")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "ties merge failed: {}",
+        String::from_utf8_lossy(&body_bytes)
+    );
+
+    let parsed: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(parsed["status"], "merged");
+    assert_eq!(parsed["mode"], "ties");
+    assert_eq!(parsed["output_name"], "merged-ties");
+    assert_eq!(parsed["num_tensors"], 2);
+
+    // Merged adapter should be loadable and have the expected values.
+    let merged_dir = tmp.path().join("merged-ties");
+    assert!(merged_dir.exists(), "merged adapter dir was not created");
+    let loaded = PeftLora::load(&merged_dir).unwrap();
+    // density=1.0 + matching positive signs => weighted average of values.
+    // (0.5*2 + 0.5*6) / (0.5 + 0.5) = 4.0 across every position in A and B.
+    let a = &loaded.tensors
+        ["base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight"];
+    for v in &a.data {
+        assert!((*v - 4.0).abs() < 1e-6, "expected 4.0 in A, got {v}");
+    }
+    let b = &loaded.tensors
+        ["base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight"];
+    for v in &b.data {
+        assert!((*v - 4.0).abs() < 1e-6, "expected 4.0 in B, got {v}");
+    }
+}
+
+#[tokio::test]
+async fn test_merge_ties_endpoint_rejects_bad_density() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_uniform_adapter(tmp.path(), "src-a", 1.0);
+    write_uniform_adapter(tmp.path(), "src-b", 1.0);
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    // density = 0.0 is excluded (open lower bound).
+    let body = json!({
+        "sources": [
+            { "name": "src-a", "weight": 0.5 },
+            { "name": "src-b", "weight": 0.5 },
+        ],
+        "output_name": "merged-bad",
+        "mode": "ties",
+        "density": 0.0,
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/merge")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "expected 400, got {}: {}",
+        status,
+        String::from_utf8_lossy(&body_bytes)
+    );
+    let msg = String::from_utf8_lossy(&body_bytes);
+    assert!(
+        msg.contains("density"),
+        "expected density-related error, got: {msg}"
+    );
+
+    // density > 1.0 also rejected.
+    let body = json!({
+        "sources": [
+            { "name": "src-a", "weight": 0.5 },
+            { "name": "src-b", "weight": 0.5 },
+        ],
+        "output_name": "merged-bad-2",
+        "mode": "ties",
+        "density": 1.5,
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/merge")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_merge_density_rejected_for_weighted_average() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_uniform_adapter(tmp.path(), "src-a", 1.0);
+    write_uniform_adapter(tmp.path(), "src-b", 1.0);
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    // density only applies to TIES mode; passing it with the default mode
+    // should be a clean 400 rather than a silent ignore.
+    let body = json!({
+        "sources": [
+            { "name": "src-a", "weight": 0.5 },
+            { "name": "src-b", "weight": 0.5 },
+        ],
+        "output_name": "merged-bad-density",
+        "density": 0.5,
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/merge")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "expected 400, got {}: {}",
+        status,
+        String::from_utf8_lossy(&body_bytes)
+    );
+}


### PR DESCRIPTION
## What
Adds [TIES](https://arxiv.org/abs/2306.01708) (Yadav et al. 2023) as a second merge mode on the just-shipped POST `/v1/adapters/merge` endpoint, alongside the existing `weighted_average` mode.

## Why
The `adapter_merge` module header explicitly deferred TIES; this is the natural follow-up after #575 (download) and #577 (upload). TIES handles task interference better than naive linear interpolation when merging adapters that adapt the same model in conflicting directions, which is the common case for shared-experience LoRA hubs.

## How
Per tensor:
1. **Trim** — keep only the top `density` fraction of values by absolute magnitude per adapter; the rest are zeroed.
2. **Elect sign** — per parameter position, the sign of `Σⱼ wⱼ · trimmed_j[i]` is the elected sign.
3. **Disjoint merge** — per parameter position, weight-average only the trimmed values whose sign matches the elected sign:
   `out[i] = (Σ_{j ∈ S} wⱼ · trimmed_j[i]) / (Σ_{j ∈ S} wⱼ)` where `S = { j : sign(trimmed_j[i]) == elected }`.

API: `mode: \"ties\"` plus optional `density: f32` (default 0.2, range `(0.0, 1.0]` — paper recommendation). `density` is rejected with 400 when `mode != \"ties\"` so callers can't silently typo it. Pure CPU/f32, no CUDA dependency.

Validation matches `merge_linear`: at least one adapter, identical rank / target_modules / base model / tensor key sets / shapes.

## Tests

`cargo test -p kiln-model adapter_merge` — 18/18 passed locally, including 7 new TIES tests:

- `test_merge_ties_density_one_equals_linear_when_signs_agree` — density=1.0 with weights summing to 1 collapses to merge_linear's weighted sum
- `test_merge_ties_trims_low_magnitude_values` — top-k cut on a single adapter zeros below-threshold magnitudes
- `test_merge_ties_sign_election_resolves_conflicts` — opposing-sign adapters; higher-weighted side drives both elected sign and final value
- `test_merge_ties_validates_density_range` — 0.0, >1.0, negative, NaN all rejected
- `test_merge_ties_empty_errors`
- `test_merge_ties_rank_mismatch_errors`
- `test_merge_ties_save_and_load_roundtrip` — TIES output is on-disk PEFT-compatible

`crates/kiln-server/tests/adapter_merge_ties.rs` exercises the HTTP surface (200 + correct merged values; 400 on bad density; 400 when density passed without `mode==\"ties\"`).

## Sandbox build note
`cargo check -p kiln-server` cannot run in the Cloud Eric Alpine sandbox because `reqwest`'s transitive `openssl-sys` dep needs system OpenSSL headers that aren't installed (per the existing `kiln-sandbox-rust-tooling` agent note). `cargo check -p kiln-model` and `cargo test -p kiln-model` run cleanly. The kiln-server changes are CPU-only Rust around the merge_ties dispatch and an integration test, with no new dependencies — they should build wherever the existing crate already builds.