### PR TITLE
fix(test): unblock main CI — emit real traversal tarball in upload-rejects-path-escape test

### DIFF
--- a/crates/kiln-server/tests/adapter_upload.rs
+++ b/crates/kiln-server/tests/adapter_upload.rs
@@ -260,29 +260,41 @@ async fn test_upload_rejects_path_escape_in_archive() {
     let state = make_state(tmp.path().to_path_buf());
     let app = api::router(state);
 
-    // Build a tar that tries to write outside the staging dir via `..`.
-    // We use `append_data` with a path that contains `..` — this is exactly
-    // the kind of payload the path validator must reject.
+    // Build a tar.gz with one normal entry and one whose path contains `..`
+    // pointing outside the prefix. `tar::Builder::append_data` validates
+    // paths via `prepare_header_path` and refuses `..`, so we hand-write the
+    // malicious name into the GNU header's `name` field and use
+    // `Builder::append` (which copies header bytes verbatim with no path
+    // check). This mirrors what a hostile tar producer could ship and is the
+    // payload the server's extraction code must defeat.
     let buf: Vec<u8> = Vec::new();
     let gz = GzEncoder::new(buf, Compression::default());
     let mut tar = tar::Builder::new(gz);
 
-    // Entry 1: a normal-looking file under the prefix so strip_prefix engages.
     let mut h1 = tar::Header::new_gnu();
     h1.set_size(5);
     h1.set_mode(0o644);
     h1.set_entry_type(tar::EntryType::Regular);
     h1.set_cksum();
-    tar.append_data(&mut h1, "evil/ok.txt", &b"hello"[..]).unwrap();
+    tar.append_data(&mut h1, "evil/ok.txt", &b"hello"[..])
+        .unwrap();
 
-    // Entry 2: the malicious path — `..` to escape staging.
     let mut h2 = tar::Header::new_gnu();
     h2.set_size(11);
     h2.set_mode(0o644);
     h2.set_entry_type(tar::EntryType::Regular);
+    {
+        let evil_name = b"evil/../../etc/passwd";
+        let gnu = h2.as_gnu_mut().expect("GNU header");
+        for b in gnu.name.iter_mut() {
+            *b = 0;
+        }
+        gnu.name[..evil_name.len()].copy_from_slice(evil_name);
+    }
+    // set_cksum must run AFTER the name bytes are in place so the checksum
+    // covers the final header.
     h2.set_cksum();
-    tar.append_data(&mut h2, "evil/../../etc/passwd", &b"PWNED-DATA!"[..])
-        .unwrap();
+    tar.append(&h2, &b"PWNED-DATA!"[..]).unwrap();
 
     let gz = tar.into_inner().unwrap();
     let archive = gz.finish().unwrap();
@@ -301,10 +313,10 @@ async fn test_upload_rejects_path_escape_in_archive() {
         .unwrap();
     let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
 
-    // Must be a 4xx — the request was malformed (unsafe path).
     assert!(
-        status.is_client_error() || status.is_server_error(),
-        "expected error response, got {status}"
+        status.is_client_error(),
+        "expected 4xx, got {status}: {}",
+        String::from_utf8_lossy(&body_bytes)
     );
     let code = json["error"]["code"].as_str().unwrap_or("");
     assert!(


### PR DESCRIPTION
## Summary
Rewrites `test_upload_rejects_path_escape_in_archive` so it actually produces a tar entry whose path contains `..`. The old version called `tar::Builder::append_data("evil/../../etc/passwd", …)`, which the tar crate's `prepare_header_path` rejects up front — the test panicked **during archive construction** with `paths in archives must not have '..' when setting path for evil` and never reached the server.

## Why this matters
Main branch CI on `ericflo/kiln` has been **red for 3 consecutive PRs** (#577, #578, #579) with the same test failure. Last green main was #573. Auto-merge let the PRs land before the Linux/macOS test jobs finished (cargo-deny passes in <30s; the test job takes ~1m).

## Root cause
`tar::Builder::append_data(&mut header, path, data)` calls `prepare_header_path` on `path`, which validates against `..` and returns an `io::Error`. The test then `unwrap()`s and panics. The malicious archive bytes were never written, so the upload endpoint was never exercised.

## Fix
Bypass `append_data` for the malicious entry: write the bytes `evil/../../etc/passwd` directly into the GNU header's `name: [u8; 100]` field via `Header::as_gnu_mut()`, then call `Builder::append(&header, data)`, which copies header bytes verbatim with no path check. `set_cksum()` is called *after* the name bytes are in place so the checksum covers the final header. This mirrors what a hostile tar producer could ship.

The first entry stays `evil/ok.txt` written via `append_data` so the production prefix-strip logic engages (consistent first segment) and entry 2's stripped path becomes `../../etc/passwd`, which the validator at `crates/kiln-server/src/api/adapters.rs:899-913` rejects as `Component::ParentDir` and returns `adapter_import_invalid`.

Also tightened the response assertion from `is_client_error || is_server_error` to `is_client_error` since the production path returns `ImportError::Invalid` (4xx) for this case — accepting 5xx would mask a real regression.

The **production extraction code was already safe.** Only the test harness was broken.

## Validation
Cloud Eric's sandbox can't compile `kiln-server` (openssl-sys + musl link failure — see agent note `kiln-server-no-local-build-on-cloud-eric`), so I validated the tarball-construction logic in a standalone scratch crate that built the same archive and confirmed via `tar::Archive::entries()` that:
1. Entry 1 round-trips as `evil/ok.txt` with `b"hello"`.
2. **Entry 2 round-trips as `evil/../../etc/passwd` with `b"PWNED-DATA!"`** — the malicious payload survives the writer and is visible to a normal reader.
3. After the production prefix-strip, the path's components include `Component::ParentDir`, exactly what `adapters.rs:899-913` rejects.

CI on real Linux + macOS Metal runners is the end-to-end validation.

## Out of scope
- Branch protection / making auto-merge wait for the test job to finish (separate concern; flagged for follow-up).
- Any other Phase 7 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)