### PR TITLE
Phase 8: per-request adapter composition (stack multiple LoRAs with scaling)

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -9,11 +9,12 @@ use tokio_stream::StreamExt;
 use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use kiln_core::request::Request;
 use kiln_core::sampling::SamplingParams;
 use kiln_core::token::TokenId;
 use kiln_core::tokenizer::ChatMessage;
+use kiln_model::adapter_merge::{merge_concat, PeftLora};
 use kiln_model::lora_loader::LoraWeights;
 use kiln_model::{GenerationOutput, ModelRunner, PagedPrefixReuse, SpeculativeConfig, StreamEvent};
 
@@ -75,6 +76,19 @@ pub struct ChatCompletionRequest {
     /// Kiln extension: which LoRA adapter to use for this request.
     #[serde(default)]
     pub adapter: Option<String>,
+    /// Kiln extension: stack multiple LoRA adapters with per-source scaling.
+    /// Mutually exclusive with `adapter`. The composed adapter is merged once
+    /// (via `merge_concat`) and cached on disk under `adapter_dir/.composed/`,
+    /// keyed by a hash of the (name, scale) pairs.
+    #[serde(default)]
+    pub adapters: Option<Vec<AdapterRef>>,
+}
+
+/// A single source adapter for per-request composition.
+#[derive(Debug, Deserialize)]
+pub struct AdapterRef {
+    pub name: String,
+    pub scale: f32,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -347,9 +361,40 @@ async fn chat_completions_inner(
         ..Default::default()
     };
 
+    // Validate adapter / adapters mutual exclusion. Done up front (before
+    // backend dispatch) so 400-on-misuse is observable from any backend.
+    if req.adapter.is_some() && req.adapters.is_some() {
+        return Err(ApiError::invalid_compose_request(
+            "specify either 'adapter' (single name) or 'adapters' (list), not both",
+        ));
+    }
+    if let Some(ref list) = req.adapters {
+        if list.is_empty() {
+            return Err(ApiError::invalid_compose_request(
+                "'adapters' must be a non-empty list when present",
+            ));
+        }
+        for src in list {
+            validate_compose_name(&src.name)?;
+        }
+    }
+
+    // If `adapters` is set, synthesize (or reuse cached) composed adapter on
+    // disk. Runs regardless of backend so the cache is populated even in mock
+    // mode tests; only the actual hot-swap is gated on the Real backend.
+    let composed_target: Option<ComposedTarget> = if let Some(list) = req.adapters.as_deref() {
+        Some(synthesize_composed_adapter(&state.adapter_dir, list).await?)
+    } else {
+        None
+    };
+
     // Ensure the correct LoRA adapter is active for this request.
     if let ModelBackend::Real { runner, .. } = state.backend.as_ref() {
-        ensure_adapter(state, runner, &req.adapter).await?;
+        if let Some(ref target) = composed_target {
+            ensure_composed_adapter_swap(state, runner, target).await?;
+        } else {
+            ensure_adapter(state, runner, &req.adapter).await?;
+        }
     }
 
     if req.stream {
@@ -495,6 +540,174 @@ async fn ensure_adapter(
     Ok(())
 }
 
+/// Disk handle for a composed adapter ready to be loaded.
+#[derive(Debug, Clone)]
+struct ComposedTarget {
+    /// Stable cache name embedded in `active_adapter_name` once swapped in,
+    /// e.g. `"__composed:abc123..."`. Used for cache-hit comparison and as
+    /// the prefix-cache adapter key.
+    active_name: String,
+    /// On-disk directory holding the synthesized PEFT adapter.
+    cache_dir: PathBuf,
+}
+
+/// Validate a single source-adapter name from an `adapters: [...]` request.
+///
+/// Names must be a single path segment with no separators or traversal — same
+/// rules as `validate_adapter_name` in `api/adapters.rs`. Centralized here so
+/// `chat_completions` can return a 404-shaped error consistent with the
+/// existing single-adapter path (`adapter_not_found`).
+fn validate_compose_name(name: &str) -> Result<(), ApiError> {
+    if name.is_empty()
+        || name == "."
+        || name == ".."
+        || name.contains('/')
+        || name.contains('\\')
+        || name.contains("..")
+        || Path::new(name).is_absolute()
+    {
+        return Err(ApiError::invalid_adapter_name(name));
+    }
+    Ok(())
+}
+
+/// Compute a stable hex hash for an `adapters` composition spec.
+///
+/// Hashes the sorted list of `"<name>@<scale>"` pairs with `DefaultHasher`
+/// (deterministic SipHash-1-3 with key (0,0)). Used as the cache directory
+/// name and the suffix of `active_adapter_name`.
+fn composition_hash(adapters: &[AdapterRef]) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut entries: Vec<String> = adapters
+        .iter()
+        .map(|a| format!("{}@{}", a.name, a.scale))
+        .collect();
+    entries.sort();
+
+    let mut hasher = DefaultHasher::new();
+    for e in &entries {
+        e.hash(&mut hasher);
+    }
+    format!("{:016x}", hasher.finish())
+}
+
+/// Synthesize (or reuse the on-disk cache for) a composed adapter spec.
+///
+/// On first call for a given hash, loads each source adapter, runs
+/// `merge_concat`, and writes the result under `<adapter_dir>/.composed/<hash>/`.
+/// On subsequent calls for the same hash, returns immediately without touching
+/// the source files. Source-adapter lookup uses the same path resolution as
+/// `ensure_adapter`: each `name` is treated as a single segment under
+/// `adapter_dir`, missing sources surface as 404.
+async fn synthesize_composed_adapter(
+    adapter_dir: &Path,
+    adapters: &[AdapterRef],
+) -> Result<ComposedTarget, ApiError> {
+    let hash = composition_hash(adapters);
+    let active_name = format!("__composed:{hash}");
+    let composed_root = adapter_dir.join(".composed");
+    let cache_dir = composed_root.join(&hash);
+
+    if cache_dir.exists() {
+        return Ok(ComposedTarget {
+            active_name,
+            cache_dir,
+        });
+    }
+
+    // Confirm every source exists before doing any merge work.
+    let mut source_paths: Vec<(String, f32, PathBuf)> = Vec::with_capacity(adapters.len());
+    for src in adapters {
+        let path = adapter_dir.join(&src.name);
+        if !path.exists() || !path.is_dir() {
+            return Err(ApiError::adapter_not_found(&src.name));
+        }
+        source_paths.push((src.name.clone(), src.scale, path));
+    }
+
+    let composed_root = composed_root.clone();
+    let cache_dir_for_task = cache_dir.clone();
+    let merge_result = tokio::task::spawn_blocking(move || -> Result<(), String> {
+        std::fs::create_dir_all(&composed_root)
+            .map_err(|e| format!("creating composed-cache dir: {e}"))?;
+
+        let mut loaded: Vec<(PeftLora, f32)> = Vec::with_capacity(source_paths.len());
+        for (name, scale, path) in source_paths {
+            let adapter = PeftLora::load(&path)
+                .map_err(|e| format!("loading source '{name}' from {}: {e}", path.display()))?;
+            loaded.push((adapter, scale));
+        }
+
+        let refs: Vec<(&PeftLora, f32)> = loaded.iter().map(|(a, s)| (a, *s)).collect();
+        let merged = merge_concat(&refs).map_err(|e| format!("merge_concat: {e}"))?;
+        merged
+            .save(&cache_dir_for_task)
+            .map_err(|e| format!("saving composed adapter: {e}"))?;
+        Ok(())
+    })
+    .await
+    .map_err(|e| ApiError::internal(format!("join error: {e}")))?;
+
+    if let Err(msg) = merge_result {
+        // Best-effort cleanup if we partially wrote anything before failing.
+        let _ = std::fs::remove_dir_all(&cache_dir);
+        return Err(ApiError::adapter_merge_failed(msg));
+    }
+
+    Ok(ComposedTarget {
+        active_name,
+        cache_dir,
+    })
+}
+
+/// Hot-swap the runner onto a synthesized composed adapter.
+///
+/// Mirrors `ensure_adapter`'s two-phase RwLock pattern (read device + num
+/// layers, load weights outside any lock, then write-lock to swap). No-op if
+/// the composed adapter is already active.
+async fn ensure_composed_adapter_swap(
+    state: &AppState,
+    runner: &std::sync::Arc<std::sync::RwLock<ModelRunner>>,
+    target: &ComposedTarget,
+) -> Result<(), ApiError> {
+    {
+        let current = state.active_adapter_name.read().unwrap();
+        if current.as_deref() == Some(target.active_name.as_str()) {
+            return Ok(());
+        }
+    }
+
+    let (device, num_layers) = {
+        let guard = runner.read().unwrap();
+        (
+            guard.weights.embed_tokens.device().clone(),
+            guard.config.num_layers,
+        )
+    };
+
+    let runner = runner.clone();
+    let active_name = state.active_adapter_name.clone();
+    let cache_dir = target.cache_dir.clone();
+    let composed_active = target.active_name.clone();
+
+    tokio::task::spawn_blocking(move || {
+        let lora = LoraWeights::load(&cache_dir, num_layers, &device)
+            .map_err(|e| format!("{e}"))?;
+        let mut guard = runner.write().unwrap();
+        guard.swap_lora(Some(lora));
+        *active_name.write().unwrap() = Some(composed_active);
+        Ok::<(), String>(())
+    })
+    .await
+    .map_err(|e| ApiError::internal(format!("join error: {e}")))?
+    .map_err(ApiError::adapter_load_failed)?;
+    state.clear_real_prefix_cache();
+
+    Ok(())
+}
+
 /// Generate using the real ModelRunner with paged KV cache.
 async fn generate_real(
     state: &AppState,
@@ -531,7 +744,12 @@ async fn generate_real(
     let prompt = prompt_text.to_owned();
     let prompt_tokens = prompt_tokens.to_vec();
     let params = sampling.clone();
-    let adapter = req.adapter.clone();
+    // For prefix-cache keying. After ensure_adapter / ensure_composed_adapter_swap,
+    // state.active_adapter_name reflects the actually-loaded adapter (a
+    // `__composed:<hash>` name when the request used `adapters: [...]`), which
+    // is what we want as the cache key — distinct compositions and the base
+    // model must not share cached blocks.
+    let adapter = state.active_adapter_name.read().unwrap().clone();
 
     let gpu_lock = state.gpu_lock.clone();
     let timeout = state.request_timeout;
@@ -742,7 +960,12 @@ async fn generate_real_streaming(
     let prompt_token_count = prompt_tokens.len();
     let prompt_tokens = prompt_tokens.to_vec();
     let params = sampling.clone();
-    let adapter = req.adapter.clone();
+    // For prefix-cache keying. After ensure_adapter / ensure_composed_adapter_swap,
+    // state.active_adapter_name reflects the actually-loaded adapter (a
+    // `__composed:<hash>` name when the request used `adapters: [...]`), which
+    // is what we want as the cache key — distinct compositions and the base
+    // model must not share cached blocks.
+    let adapter = state.active_adapter_name.read().unwrap().clone();
     let model = req
         .model
         .clone()

--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -210,6 +210,15 @@ impl ApiError {
         }
     }
 
+    pub fn invalid_compose_request(detail: impl std::fmt::Display) -> Self {
+        Self {
+            status: StatusCode::BAD_REQUEST,
+            code: "invalid_compose_request",
+            message: format!("Invalid adapter composition request: {detail}"),
+            hint: "Specify either 'adapter' (single name) or 'adapters' (non-empty list of {name, scale}), not both. The composed adapter is merged once and cached on disk.",
+        }
+    }
+
     pub fn mock_mode_no_adapters() -> Self {
         Self {
             status: StatusCode::BAD_REQUEST,

--- a/crates/kiln-server/tests/adapter_compose.rs
+++ b/crates/kiln-server/tests/adapter_compose.rs
@@ -1,0 +1,345 @@
+//! Integration test: per-request adapter composition (`adapters: [...]` field
+//! on `POST /v1/chat/completions`).
+//!
+//! Verifies that a fresh composition spec triggers a `merge_concat` and writes
+//! the result under `<adapter_dir>/.composed/<hash>/`, that a second request
+//! with the same spec is served from the cached directory (no remerge), and
+//! that mutually-exclusive misuse with `adapter` returns 400.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::adapter_merge::{MergeTensor, PeftLora};
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::state::AppState;
+
+/// BPE tokenizer rich enough to round-trip the ChatML prompt scaffolding
+/// (`<|im_start|>user\n…<|im_end|>`) without surfacing an Encode error from
+/// the tokenizers crate. Mirrors the helper in real_model_integration.rs so
+/// `/v1/chat/completions` succeeds end-to-end in mock mode.
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    for i in 0u32..20 {
+        vocab.insert(format!("t{i}"), i);
+    }
+    vocab.insert("<|im_start|>".to_string(), 20);
+    vocab.insert("<|im_end|>".to_string(), 21);
+    vocab.insert("user".to_string(), 22);
+    vocab.insert("assistant".to_string(), 23);
+    vocab.insert("\n".to_string(), 24);
+    for i in 25u32..32 {
+        vocab.insert(format!("x{i}"), i);
+    }
+
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] },
+        "added_tokens": [
+            {
+                "id": 0, "content": "<|endoftext|>",
+                "single_word": false, "lstrip": false, "rstrip": false,
+                "normalized": false, "special": true,
+            },
+            {
+                "id": 20, "content": "<|im_start|>",
+                "single_word": false, "lstrip": false, "rstrip": false,
+                "normalized": false, "special": true,
+            },
+            {
+                "id": 21, "content": "<|im_end|>",
+                "single_word": false, "lstrip": false, "rstrip": false,
+                "normalized": false, "special": true,
+            }
+        ]
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state(adapter_dir: std::path::PathBuf) -> AppState {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    let mut state = AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        test_tokenizer(),
+        300,
+        "qwen3.5-4b-kiln".to_string(),
+    );
+    state.adapter_dir = adapter_dir;
+    state
+}
+
+/// Write a single-tensor PEFT-format adapter (q_proj only). Same shape as the
+/// fixtures in `adapter_merge_concat.rs` so `merge_concat` accepts the pair.
+fn write_uniform_adapter(adapter_dir: &std::path::Path, name: &str, rank: usize, fill: f32) {
+    let path = adapter_dir.join(name);
+    let mut tensors: BTreeMap<String, MergeTensor> = BTreeMap::new();
+    tensors.insert(
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight".to_string(),
+        MergeTensor {
+            shape: vec![rank, 4],
+            data: vec![fill; rank * 4],
+        },
+    );
+    tensors.insert(
+        "base_model.model.model.layers.0.self_attn.q_proj.lora_B.weight".to_string(),
+        MergeTensor {
+            shape: vec![3, rank],
+            data: vec![fill; 3 * rank],
+        },
+    );
+    let config = json!({
+        "r": rank,
+        "lora_alpha": (rank * 2) as f32,
+        "target_modules": ["q_proj"],
+        "task_type": "CAUSAL_LM",
+        "peft_type": "LORA",
+        "base_model_name_or_path": "Qwen/Qwen3.5-4B"
+    });
+    let adapter = PeftLora { config, tensors };
+    adapter.save(&path).unwrap();
+}
+
+fn chat_with_adapters(adapters: Value) -> Request<Body> {
+    let body = json!({
+        "model": "qwen3.5-4b-kiln",
+        "messages": [{"role": "user", "content": "t1 t2 t3"}],
+        "max_tokens": 4,
+        "adapters": adapters,
+    });
+    Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+/// First request synthesizes the composed adapter on disk; second request with
+/// the same `adapters` payload reuses the cached directory without remerging.
+#[tokio::test]
+async fn test_compose_endpoint_caches_synthesized_adapter() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_uniform_adapter(tmp.path(), "src-a", 2, 1.0);
+    write_uniform_adapter(tmp.path(), "src-b", 2, 5.0);
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let composed_root = tmp.path().join(".composed");
+    assert!(
+        !composed_root.exists(),
+        "composed cache should not exist yet"
+    );
+
+    let payload = json!([
+        { "name": "src-a", "scale": 0.5 },
+        { "name": "src-b", "scale": 0.5 },
+    ]);
+
+    let resp = app.clone().oneshot(chat_with_adapters(payload.clone())).await.unwrap();
+    let status = resp.status();
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "first compose request failed: {}",
+        String::from_utf8_lossy(&body_bytes)
+    );
+
+    // Exactly one cached composition dir, with PEFT-shaped contents.
+    let entries: Vec<_> = std::fs::read_dir(&composed_root)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected one composed cache dir, got {entries:?}"
+    );
+    let composed_dir = &entries[0];
+    assert!(composed_dir.join("adapter_config.json").exists());
+    assert!(composed_dir.join("adapter_model.safetensors").exists());
+
+    // Concat-merge of two rank-2 adapters → rank 4 with correct A/B shapes.
+    let loaded = PeftLora::load(composed_dir).unwrap();
+    assert_eq!(loaded.rank(), Some(4));
+
+    // Capture the safetensors mtime to prove the second request did not
+    // overwrite the cached file.
+    let mtime_before = std::fs::metadata(composed_dir.join("adapter_model.safetensors"))
+        .unwrap()
+        .modified()
+        .unwrap();
+
+    // Wait long enough that any rewrite would bump the mtime under fs
+    // resolution (some filesystems round to seconds).
+    std::thread::sleep(std::time::Duration::from_millis(1100));
+
+    let resp2 = app.clone().oneshot(chat_with_adapters(payload)).await.unwrap();
+    let status2 = resp2.status();
+    let body_bytes2 = axum::body::to_bytes(resp2.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        status2,
+        StatusCode::OK,
+        "second compose request failed: {}",
+        String::from_utf8_lossy(&body_bytes2)
+    );
+
+    // Cache hit: same dir, untouched file.
+    let entries_after: Vec<_> = std::fs::read_dir(&composed_root)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .collect();
+    assert_eq!(
+        entries_after.len(),
+        1,
+        "expected cache reuse, got {entries_after:?}"
+    );
+    let mtime_after = std::fs::metadata(composed_dir.join("adapter_model.safetensors"))
+        .unwrap()
+        .modified()
+        .unwrap();
+    assert_eq!(
+        mtime_before, mtime_after,
+        "composed adapter was rewritten on second request — cache miss"
+    );
+}
+
+/// Scale changes produce a distinct cache directory (different hash).
+#[tokio::test]
+async fn test_compose_endpoint_distinct_scales_distinct_cache_dirs() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_uniform_adapter(tmp.path(), "src-a", 2, 1.0);
+    write_uniform_adapter(tmp.path(), "src-b", 2, 1.0);
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let resp_a = app
+        .clone()
+        .oneshot(chat_with_adapters(json!([
+            { "name": "src-a", "scale": 0.5 },
+            { "name": "src-b", "scale": 0.5 },
+        ])))
+        .await
+        .unwrap();
+    assert_eq!(resp_a.status(), StatusCode::OK);
+
+    let resp_b = app
+        .clone()
+        .oneshot(chat_with_adapters(json!([
+            { "name": "src-a", "scale": 0.75 },
+            { "name": "src-b", "scale": 0.25 },
+        ])))
+        .await
+        .unwrap();
+    assert_eq!(resp_b.status(), StatusCode::OK);
+
+    let composed_root = tmp.path().join(".composed");
+    let entries: Vec<_> = std::fs::read_dir(&composed_root)
+        .unwrap()
+        .map(|e| e.unwrap().path())
+        .collect();
+    assert_eq!(
+        entries.len(),
+        2,
+        "expected two distinct cache dirs (one per scale tuple), got {entries:?}"
+    );
+}
+
+/// Specifying both `adapter` and `adapters` is a 400.
+#[tokio::test]
+async fn test_compose_endpoint_rejects_both_adapter_and_adapters() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_uniform_adapter(tmp.path(), "src-a", 2, 1.0);
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let body = json!({
+        "model": "qwen3.5-4b-kiln",
+        "messages": [{"role": "user", "content": "t1 t2 t3"}],
+        "max_tokens": 1,
+        "adapter": "src-a",
+        "adapters": [{ "name": "src-a", "scale": 1.0 }],
+    });
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/chat/completions")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let parsed: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(parsed["error"]["code"], "invalid_compose_request");
+}
+
+/// Empty `adapters: []` is a 400.
+#[tokio::test]
+async fn test_compose_endpoint_rejects_empty_list() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let resp = app
+        .clone()
+        .oneshot(chat_with_adapters(json!([])))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let parsed: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(parsed["error"]["code"], "invalid_compose_request");
+}
+
+/// Missing source adapter surfaces as 404.
+#[tokio::test]
+async fn test_compose_endpoint_404_when_source_missing() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_uniform_adapter(tmp.path(), "src-a", 2, 1.0);
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let resp = app
+        .clone()
+        .oneshot(chat_with_adapters(json!([
+            { "name": "src-a", "scale": 0.5 },
+            { "name": "ghost", "scale": 0.5 },
+        ])))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let parsed: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(parsed["error"]["code"], "adapter_not_found");
+}


### PR DESCRIPTION
## What

New `adapters: [{name, scale}]` field on `POST /v1/chat/completions` that stacks multiple LoRAs at request time. Mutually exclusive with the existing single-adapter `adapter` field. Composition is synthesized once via `merge_concat` and cached on disk; subsequent requests reuse the cache.

## Why

Next Phase 8 item after #578/#579 (TIES + concat merge modes) and #575/#577 (adapter export/import). Composition lets users stack specialized adapters (e.g. domain + style) per-request without pre-merging them into one named adapter — and without duplicating disk space for every (domain, style) combination.

## How

- `synthesize_composed_adapter(adapter_dir, &[AdapterRef])`: hashes the sorted `<name>@<scale>` pairs with `DefaultHasher` (hex), checks `<adapter_dir>/.composed/<hash>/`, and on miss runs `kiln_model::adapter_merge::merge_concat` on a blocking thread and writes the merged PEFT adapter to that directory.
- `ensure_composed_adapter_swap(...)`: same two-phase RwLock pattern as `ensure_adapter` (read device + num_layers, load `LoraWeights` outside any lock, write-lock to swap, clear prefix cache). No-op when the composed adapter is already active.
- Validation runs before backend dispatch, so 400-on-misuse is observable in mock mode.
- Synthesis runs regardless of backend (so the mock-backend integration tests can verify the cache is populated). Only the actual hot-swap is gated on `ModelBackend::Real`.
- Prefix-cache keying now reads `state.active_adapter_name` instead of `req.adapter` so distinct compositions and the base model do not share cached blocks. After `ensure_*_adapter` runs, those values match for the single-adapter path; this is also the right key for the composed-adapter path.

No engine / forward-pass changes.

## Test

```
cargo test -p kiln-server --test adapter_compose --no-default-features
```

Five tests:
- `test_compose_endpoint_caches_synthesized_adapter` — first POST creates `.composed/<hash>/`; second POST with the same spec succeeds without bumping the mtime of `adapter_model.safetensors` (proving the cache is reused, not rewritten).
- `test_compose_endpoint_distinct_scales_distinct_cache_dirs` — different scales for the same source pair produce two distinct cache dirs.
- `test_compose_endpoint_rejects_both_adapter_and_adapters` — 400 `invalid_compose_request`.
- `test_compose_endpoint_rejects_empty_list` — 400 `invalid_compose_request`.
- `test_compose_endpoint_404_when_source_missing` — 404 `adapter_not_found` for a ghost source name.

Note: this PR was prepared in a sandbox that lacks the openssl headers needed by `reqwest`'s transitive `openssl-sys`, so local `cargo test -p kiln-server` couldn't be run end-to-end. CI is the source of truth.