### PR TITLE
Phase 8: webhook notifications on training completion

### DIFF
--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -96,6 +96,32 @@ pub struct TrainingConfig {
     /// Save adapter weights every N training steps during a job.
     /// Per-job config overrides this. None = only save at the end.
     pub checkpoint_interval: Option<usize>,
+    /// HTTP(S) URL to POST a JSON notification to when a training job
+    /// (SFT or GRPO) completes or fails.
+    ///
+    /// When `None` (the default), no webhook is fired. When set, a
+    /// fire-and-forget POST is sent with a 5-second timeout after the
+    /// job's terminal state is recorded. Webhook failures are logged
+    /// but never propagate back into the training job's outcome — a
+    /// successful training job stays "completed" even if the webhook
+    /// POST fails.
+    ///
+    /// Payload (Content-Type: application/json):
+    /// ```json
+    /// {
+    ///   "job_id": "<uuid>",
+    ///   "job_type": "sft" | "grpo",
+    ///   "status": "completed" | "failed",
+    ///   "adapter_name": "<name>",
+    ///   "adapter_path": "<path or null>",
+    ///   "error": "<message or null>",
+    ///   "timestamp": "<RFC3339>"
+    /// }
+    /// ```
+    ///
+    /// Override via `KILN_TRAINING_WEBHOOK_URL`. To clear a TOML-set
+    /// URL via env, set the variable to the empty string.
+    pub webhook_url: Option<String>,
 }
 
 /// Logging settings.
@@ -268,6 +294,7 @@ impl Default for TrainingConfig {
             grad_checkpoint_segments: None,
             no_grad_checkpoint: false,
             checkpoint_interval: None,
+            webhook_url: None,
         }
     }
 }
@@ -479,6 +506,10 @@ impl KilnConfig {
                 self.training.checkpoint_interval = Some(n);
             }
         }
+        if let Ok(v) = std::env::var("KILN_TRAINING_WEBHOOK_URL") {
+            // Empty string explicitly clears any TOML-set URL.
+            self.training.webhook_url = if v.is_empty() { None } else { Some(v) };
+        }
 
         // Logging
         if let Ok(v) = std::env::var("KILN_LOG_LEVEL") {
@@ -606,6 +637,7 @@ mod tests {
         assert!(config.memory.cuda_graphs);
         assert!(!config.training.no_grad_checkpoint);
         assert!(config.training.checkpoint_interval.is_none());
+        assert!(config.training.webhook_url.is_none());
         assert_eq!(config.logging.level, "info");
         assert_eq!(config.logging.format, "auto");
         assert!(config.prefix_cache.enabled);
@@ -645,6 +677,7 @@ cuda_graphs = false
 grad_checkpoint_segments = 8
 no_grad_checkpoint = false
 checkpoint_interval = 50
+webhook_url = "https://example.com/hook"
 
 [logging]
 level = "debug"
@@ -678,6 +711,10 @@ last_token_lm_head = false
         assert!(!config.memory.cuda_graphs);
         assert_eq!(config.training.grad_checkpoint_segments, Some(8));
         assert_eq!(config.training.checkpoint_interval, Some(50));
+        assert_eq!(
+            config.training.webhook_url.as_deref(),
+            Some("https://example.com/hook")
+        );
         assert_eq!(config.logging.level, "debug");
         assert_eq!(config.logging.format, "pretty");
         assert!(!config.prefix_cache.enabled);
@@ -778,6 +815,7 @@ port = 3000
             std::env::set_var("KILN_LOG_LEVEL", "debug");
             std::env::set_var("KILN_NO_GRAD_CHECKPOINT", "1");
             std::env::set_var("KILN_CHECKPOINT_INTERVAL", "25");
+            std::env::set_var("KILN_TRAINING_WEBHOOK_URL", "https://hook.example/notify");
             std::env::set_var("KILN_KV_CACHE_FP8", "1");
             std::env::set_var("KILN_CUDA_GRAPHS", "false");
             std::env::set_var("KILN_PREFIX_CACHE_ENABLED", "false");
@@ -800,6 +838,10 @@ port = 3000
         assert_eq!(config.logging.level, "debug");
         assert!(config.training.no_grad_checkpoint);
         assert_eq!(config.training.checkpoint_interval, Some(25));
+        assert_eq!(
+            config.training.webhook_url.as_deref(),
+            Some("https://hook.example/notify")
+        );
         assert!(config.memory.kv_cache_fp8);
         assert!(!config.memory.cuda_graphs);
         assert!(!config.prefix_cache.enabled);
@@ -820,6 +862,7 @@ port = 3000
             std::env::remove_var("KILN_LOG_LEVEL");
             std::env::remove_var("KILN_NO_GRAD_CHECKPOINT");
             std::env::remove_var("KILN_CHECKPOINT_INTERVAL");
+            std::env::remove_var("KILN_TRAINING_WEBHOOK_URL");
             std::env::remove_var("KILN_KV_CACHE_FP8");
             std::env::remove_var("KILN_CUDA_GRAPHS");
             std::env::remove_var("KILN_PREFIX_CACHE_ENABLED");
@@ -830,6 +873,31 @@ port = 3000
             std::env::remove_var("KILN_STREAMING_PREFILL");
             std::env::remove_var("KILN_STREAMING_TILE_TOKENS");
             std::env::remove_var("KILN_STREAMING_LAST_TOKEN_LM_HEAD");
+        }
+    }
+
+    #[test]
+    fn test_training_webhook_env_empty_string_clears_toml_value() {
+        let toml_str = r#"
+[training]
+webhook_url = "https://from-toml.example/hook"
+"#;
+        let mut config: KilnConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.training.webhook_url.as_deref(),
+            Some("https://from-toml.example/hook")
+        );
+
+        unsafe {
+            std::env::set_var("KILN_TRAINING_WEBHOOK_URL", "");
+        }
+        config.apply_env_overrides();
+        assert!(
+            config.training.webhook_url.is_none(),
+            "empty env var should clear the TOML-set webhook URL"
+        );
+        unsafe {
+            std::env::remove_var("KILN_TRAINING_WEBHOOK_URL");
         }
     }
 

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -198,6 +198,10 @@ async fn main() -> Result<()> {
 
     // Apply server-level checkpoint_interval from config
     state.checkpoint_interval = config.training.checkpoint_interval;
+    state.training_webhook_url = config.training.webhook_url.clone();
+    if let Some(ref url) = state.training_webhook_url {
+        tracing::info!(url = %url, "training completion webhook configured");
+    }
 
     // Spawn the background training queue worker
     let shutdown_flag = state.shutdown.clone();

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -414,6 +414,10 @@ pub struct AppState {
     /// Server-level default for adapter checkpoint interval during training.
     /// Per-job config overrides this. None = only save at the end.
     pub checkpoint_interval: Option<usize>,
+    /// Optional URL to POST a JSON notification to whenever a training
+    /// job completes or fails. `None` disables webhook firing entirely.
+    /// See `TrainingConfig::webhook_url` for the payload contract.
+    pub training_webhook_url: Option<String>,
     /// Identifier exposed at `/v1/models` and echoed in chat completion responses.
     pub served_model_id: String,
     /// Rolling timestamp ring for live decode tok/s + ITL on the /ui dashboard.
@@ -474,6 +478,7 @@ impl AppState {
             started_at: std::time::Instant::now(),
             inference_prewarm_complete: Arc::new(AtomicBool::new(true)),
             checkpoint_interval: None,
+            training_webhook_url: None,
             served_model_id,
             decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
             recent_requests: Arc::new(std::sync::Mutex::new(RecentRequestsRing::new(
@@ -689,6 +694,7 @@ impl AppState {
                 candle_core::Device::Metal(_)
             ))),
             checkpoint_interval: None,
+            training_webhook_url: None,
             served_model_id,
             decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
             recent_requests: Arc::new(std::sync::Mutex::new(RecentRequestsRing::new(

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -11,9 +11,83 @@ use std::sync::Arc;
 use kiln_model::lora_loader::LoraWeights;
 use kiln_train::{GrpoRequest, SftRequest, TrainingState};
 use kiln_train::trainer;
+use serde::Serialize;
 
 use crate::metrics::{TrainingMetricStatus, TrainingMetricType};
 use crate::state::{AppState, ModelBackend, TrainingJobType};
+
+/// JSON payload POSTed to the training-completion webhook.
+///
+/// The frontend contract documented in `TrainingConfig::webhook_url`
+/// promises these field names — keep them stable for downstream
+/// consumers.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct TrainingCompletionEvent {
+    pub job_id: String,
+    pub job_type: &'static str,
+    pub status: &'static str,
+    pub adapter_name: String,
+    pub adapter_path: Option<String>,
+    pub error: Option<String>,
+    pub timestamp: String,
+}
+
+impl TrainingCompletionEvent {
+    pub fn job_type_str(job_type: TrainingJobType) -> &'static str {
+        match job_type {
+            TrainingJobType::Sft => "sft",
+            TrainingJobType::Grpo => "grpo",
+        }
+    }
+}
+
+/// Fire-and-forget POST of `event` to `url`. Spawns a tokio task so the
+/// caller (the training worker's blocking thread) is never blocked by
+/// network I/O. Webhook failures are logged at WARN but never propagate
+/// — a successful training job stays "completed" even if the
+/// notification POST fails.
+pub fn fire_completion_webhook(url: String, event: TrainingCompletionEvent) {
+    tokio::spawn(async move {
+        let client = match reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+        {
+            Ok(c) => c,
+            Err(err) => {
+                tracing::warn!(error = %err, "failed to build webhook HTTP client");
+                return;
+            }
+        };
+        match client.post(&url).json(&event).send().await {
+            Ok(resp) => {
+                let status = resp.status();
+                if status.is_success() {
+                    tracing::info!(
+                        url = %url,
+                        job_id = %event.job_id,
+                        status = %status,
+                        "training completion webhook delivered"
+                    );
+                } else {
+                    tracing::warn!(
+                        url = %url,
+                        job_id = %event.job_id,
+                        status = %status,
+                        "training completion webhook returned non-2xx"
+                    );
+                }
+            }
+            Err(err) => {
+                tracing::warn!(
+                    url = %url,
+                    job_id = %event.job_id,
+                    error = %err,
+                    "training completion webhook POST failed"
+                );
+            }
+        }
+    });
+}
 
 /// A pending training job in the queue.
 pub enum QueuedJob {
@@ -232,10 +306,23 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                 if let Some(job) = jobs.get_mut(&job_id) {
                     job.state = TrainingState::Completed;
                     job.progress = 1.0;
-                    job.adapter_path = Some(path_str);
+                    job.adapter_path = Some(path_str.clone());
                 }
             }
             state.metrics.inc_training(metric_type, TrainingMetricStatus::Completed);
+
+            if let Some(ref url) = state.training_webhook_url {
+                let event = TrainingCompletionEvent {
+                    job_id: job_id.clone(),
+                    job_type: TrainingCompletionEvent::job_type_str(job_type),
+                    status: "completed",
+                    adapter_name: adapter_name.clone(),
+                    adapter_path: Some(path_str.clone()),
+                    error: None,
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                };
+                fire_completion_webhook(url.clone(), event);
+            }
 
             if auto_load {
                 if let Err(e) = auto_load_adapter(
@@ -253,11 +340,27 @@ fn execute_job(state: AppState, entry: QueueEntry) {
         }
         Err(e) => {
             tracing::error!(job_id = %job_id, job_type = ?job_type, "training failed: {e}");
-            let mut jobs = state.training_jobs.write().unwrap();
-            if let Some(job) = jobs.get_mut(&job_id) {
-                job.state = TrainingState::Failed;
+            let error_msg = e.clone();
+            {
+                let mut jobs = state.training_jobs.write().unwrap();
+                if let Some(job) = jobs.get_mut(&job_id) {
+                    job.state = TrainingState::Failed;
+                }
             }
             state.metrics.inc_training(metric_type, TrainingMetricStatus::Failed);
+
+            if let Some(ref url) = state.training_webhook_url {
+                let event = TrainingCompletionEvent {
+                    job_id: job_id.clone(),
+                    job_type: TrainingCompletionEvent::job_type_str(job_type),
+                    status: "failed",
+                    adapter_name: adapter_name.clone(),
+                    adapter_path: None,
+                    error: Some(error_msg),
+                    timestamp: chrono::Utc::now().to_rfc3339(),
+                };
+                fire_completion_webhook(url.clone(), event);
+            }
         }
     }
 }
@@ -364,5 +467,184 @@ mod tests {
         assert_eq!(q.len(), 0);
         assert!(q.pop().is_none());
         assert!(!q.remove("nonexistent"));
+    }
+
+    #[test]
+    fn test_event_job_type_str() {
+        assert_eq!(
+            TrainingCompletionEvent::job_type_str(TrainingJobType::Sft),
+            "sft"
+        );
+        assert_eq!(
+            TrainingCompletionEvent::job_type_str(TrainingJobType::Grpo),
+            "grpo"
+        );
+    }
+
+    #[test]
+    fn test_event_serializes_with_expected_field_names() {
+        let event = TrainingCompletionEvent {
+            job_id: "abc-123".into(),
+            job_type: "sft",
+            status: "completed",
+            adapter_name: "my-adapter".into(),
+            adapter_path: Some("/data/adapters/my-adapter".into()),
+            error: None,
+            timestamp: "2026-04-26T00:00:00+00:00".into(),
+        };
+        let v: serde_json::Value = serde_json::to_value(&event).unwrap();
+        assert_eq!(v["job_id"], "abc-123");
+        assert_eq!(v["job_type"], "sft");
+        assert_eq!(v["status"], "completed");
+        assert_eq!(v["adapter_name"], "my-adapter");
+        assert_eq!(v["adapter_path"], "/data/adapters/my-adapter");
+        assert!(v["error"].is_null());
+        assert_eq!(v["timestamp"], "2026-04-26T00:00:00+00:00");
+    }
+
+    /// End-to-end test: spin up a tiny axum mock server, fire a webhook
+    /// at it, and assert that the captured POST body matches the
+    /// documented payload shape.
+    #[tokio::test]
+    async fn test_fire_completion_webhook_posts_expected_payload() {
+        use axum::extract::State;
+        use axum::routing::post;
+        use axum::Json;
+        use std::sync::Arc as StdArc;
+        use std::sync::Mutex as StdMutex;
+
+        // Capture buffer shared between the handler and the assertions.
+        let captured: StdArc<StdMutex<Vec<serde_json::Value>>> =
+            StdArc::new(StdMutex::new(Vec::new()));
+
+        async fn handler(
+            State(captured): State<StdArc<StdMutex<Vec<serde_json::Value>>>>,
+            Json(body): Json<serde_json::Value>,
+        ) -> &'static str {
+            captured.lock().unwrap().push(body);
+            "ok"
+        }
+
+        let app = axum::Router::new()
+            .route("/hook", post(handler))
+            .with_state(captured.clone());
+
+        // Bind to an ephemeral port so concurrent test runs don't collide.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let event = TrainingCompletionEvent {
+            job_id: "test-job-001".into(),
+            job_type: "grpo",
+            status: "completed",
+            adapter_name: "test-adapter".into(),
+            adapter_path: Some("/tmp/adapters/test-adapter".into()),
+            error: None,
+            timestamp: "2026-04-26T01:23:45+00:00".into(),
+        };
+
+        let url = format!("http://{addr}/hook");
+        fire_completion_webhook(url, event);
+
+        // Poll the capture buffer for up to ~2s.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while captured.lock().unwrap().is_empty() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let bodies = captured.lock().unwrap().clone();
+        assert_eq!(bodies.len(), 1, "expected exactly one webhook POST");
+        let body = &bodies[0];
+        assert_eq!(body["job_id"], "test-job-001");
+        assert_eq!(body["job_type"], "grpo");
+        assert_eq!(body["status"], "completed");
+        assert_eq!(body["adapter_name"], "test-adapter");
+        assert_eq!(body["adapter_path"], "/tmp/adapters/test-adapter");
+        assert!(body["error"].is_null());
+        assert_eq!(body["timestamp"], "2026-04-26T01:23:45+00:00");
+
+        server.abort();
+    }
+
+    /// Failure event test: error string is propagated, adapter_path is null.
+    #[tokio::test]
+    async fn test_fire_completion_webhook_failure_event_shape() {
+        use axum::extract::State;
+        use axum::routing::post;
+        use axum::Json;
+        use std::sync::Arc as StdArc;
+        use std::sync::Mutex as StdMutex;
+
+        let captured: StdArc<StdMutex<Vec<serde_json::Value>>> =
+            StdArc::new(StdMutex::new(Vec::new()));
+
+        async fn handler(
+            State(captured): State<StdArc<StdMutex<Vec<serde_json::Value>>>>,
+            Json(body): Json<serde_json::Value>,
+        ) -> &'static str {
+            captured.lock().unwrap().push(body);
+            "ok"
+        }
+
+        let app = axum::Router::new()
+            .route("/hook", post(handler))
+            .with_state(captured.clone());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let event = TrainingCompletionEvent {
+            job_id: "fail-job-001".into(),
+            job_type: "sft",
+            status: "failed",
+            adapter_name: "broken-adapter".into(),
+            adapter_path: None,
+            error: Some("CUDA out of memory".into()),
+            timestamp: "2026-04-26T01:23:45+00:00".into(),
+        };
+        let url = format!("http://{addr}/hook");
+        fire_completion_webhook(url, event);
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+        while captured.lock().unwrap().is_empty() && std::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+
+        let bodies = captured.lock().unwrap().clone();
+        assert_eq!(bodies.len(), 1);
+        let body = &bodies[0];
+        assert_eq!(body["status"], "failed");
+        assert!(body["adapter_path"].is_null());
+        assert_eq!(body["error"], "CUDA out of memory");
+
+        server.abort();
+    }
+
+    /// Webhook errors must NOT panic or propagate — verified by firing
+    /// at an unreachable address and ensuring the spawned task completes
+    /// without taking the test process down.
+    #[tokio::test]
+    async fn test_fire_completion_webhook_swallows_errors() {
+        let event = TrainingCompletionEvent {
+            job_id: "x".into(),
+            job_type: "sft",
+            status: "completed",
+            adapter_name: "x".into(),
+            adapter_path: None,
+            error: None,
+            timestamp: "2026-04-26T00:00:00+00:00".into(),
+        };
+        // 127.0.0.1:1 is reliably not listening — connection should fail
+        // fast within the 5s client timeout, and the failure must be
+        // swallowed (logged, not propagated).
+        fire_completion_webhook("http://127.0.0.1:1/never".into(), event);
+        // Give the spawned task a moment so we're confident it ran and
+        // completed without panicking.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
     }
 }

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -41,6 +41,14 @@ inference_memory_fraction = 0.7       # Fraction of VRAM for inference (rest for
 [training]
 # grad_checkpoint_segments = 4       # Segments for gradient checkpointing
 no_grad_checkpoint = false
+# checkpoint_interval = 50           # Save adapter every N training steps
+# webhook_url = "https://example.com/hook"  # POST training completion JSON to this URL.
+                                              # Fields: job_id, job_type (sft|grpo),
+                                              # status (completed|failed), adapter_name,
+                                              # adapter_path, error, timestamp (RFC3339).
+                                              # Fire-and-forget with a 5s timeout — webhook
+                                              # failures are logged but do not affect job state.
+                                              # Override via KILN_TRAINING_WEBHOOK_URL.
 
 [logging]
 level = "info"                        # trace, debug, info, warn, error, or a filter directive


### PR DESCRIPTION
## What
Fire-and-forget POST to a configured webhook URL when a training job (SFT or GRPO) completes or fails. Lets external orchestrators (e.g. Cloud Eric correction loops) know when an adapter is ready without polling `/v1/train/status`.

## Configuration
- TOML: `training.webhook_url = "https://example.com/hook"`
- Env: `KILN_TRAINING_WEBHOOK_URL=https://example.com/hook`
- Setting the env var to the empty string explicitly clears any TOML-set URL.
- Default: `None` (feature off — no webhook fired).

## Payload
JSON, 5-second timeout, fired from `tokio::spawn` so the training worker is never blocked:

```json
{
  "job_id": "<uuid>",
  "job_type": "sft" | "grpo",
  "status": "completed" | "failed",
  "adapter_name": "<name>",
  "adapter_path": "<path or null>",
  "error": "<message or null>",
  "timestamp": "<RFC3339>"
}
```

Webhook delivery failures are logged at WARN but never propagate — a successful training job stays `completed` even if the notification POST fails.

## Tests
- `test_event_serializes_with_expected_field_names` — pure JSON shape check (field names, optional handling).
- `test_event_job_type_str` — Sft/Grpo → `"sft"`/`"grpo"` mapping.
- `test_training_webhook_env_empty_string_clears_toml_value` — empty `KILN_TRAINING_WEBHOOK_URL` clears a TOML-set URL.
- `test_fire_completion_webhook_posts_expected_payload` — `#[tokio::test]` spins up a tiny axum mock server on an ephemeral port, fires a `completed`-status webhook, polls the capture buffer, and asserts the POST body matches the contract field-by-field.
- `test_fire_completion_webhook_failure_event_shape` — same pattern for a `failed`-status event: error string is propagated, `adapter_path` is null.
- `test_fire_completion_webhook_swallows_errors` — fires at `127.0.0.1:1` (reliably not listening) and asserts the spawned task completes without panicking, exercising the error-logging path.

## Sandbox-build note
Cloud Eric's Alpine-musl sandbox builds clean (`cargo check -p kiln-server` passes) and the non-network unit tests run, but the three `#[tokio::test]` cases SIGSEGV during reqwest's TLS init in a static-pie musl binary — a documented sandbox limitation (`kiln-sandbox-rust-tooling`). CI on Ubuntu/glibc runs the full suite normally.

## Non-goals (deferred to follow-up PRs)
- HMAC signing of webhook payloads
- Retry-with-backoff
- Persistent webhook queue
- Touching the existing `/v1/train/status` API
- Touching SFT/GRPO algorithm code