### PR TITLE
chore: mark workspace crates publish=false; tighten cargo-deny wildcards to deny

### DIFF
--- a/crates/kiln-conv1d-kernel/Cargo.toml
+++ b/crates/kiln-conv1d-kernel/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kiln-conv1d-kernel"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/kiln-core/Cargo.toml
+++ b/crates/kiln-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kiln-core"
 description = "Core types and traits for Kiln inference server"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kiln-flash-attn/Cargo.toml
+++ b/crates/kiln-flash-attn/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kiln-flash-attn"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/kiln-flce-kernel/Cargo.toml
+++ b/crates/kiln-flce-kernel/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kiln-flce-kernel"
 description = "Fused Linear Cross-Entropy (FLCE) — chunked cross-entropy over vocab without materializing the full [T, V] logits tensor. Phase A: pure-candle implementation; Phase B will replace the forward kernel with raw CUDA."
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/kiln-gdn-kernel/Cargo.toml
+++ b/crates/kiln-gdn-kernel/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kiln-gdn-kernel"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/kiln-marlin-gemm/Cargo.toml
+++ b/crates/kiln-marlin-gemm/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kiln-marlin-gemm"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kiln-model"
 description = "Model loading and inference runtime for Kiln"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kiln-nvtx/Cargo.toml
+++ b/crates/kiln-nvtx/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kiln-nvtx"
 description = "Thin NVTX range wrapper for nsys attribution. Zero overhead when feature is off."
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/kiln-rmsnorm-kernel/Cargo.toml
+++ b/crates/kiln-rmsnorm-kernel/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "kiln-rmsnorm-kernel"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/kiln-scheduler/Cargo.toml
+++ b/crates/kiln-scheduler/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kiln-scheduler"
 description = "Iteration-level continuous batching scheduler with chunked prefill"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kiln-server"
 description = "HTTP server for Kiln — OpenAI-compatible inference + training API"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 

--- a/crates/kiln-train/Cargo.toml
+++ b/crates/kiln-train/Cargo.toml
@@ -2,6 +2,7 @@
 name = "kiln-train"
 description = "In-process LoRA training for Kiln — pure Rust, no Python sidecar"
 version.workspace = true
+publish = false
 edition.workspace = true
 license.workspace = true
 

--- a/deny.toml
+++ b/deny.toml
@@ -30,13 +30,11 @@ allow = [
 
 [bans]
 multiple-versions = "warn"
-# Workspace internal deps use `{ workspace = true }`, which resolves as a `*`
-# version requirement. cargo-deny's `allow-wildcard-paths` exemption only
-# applies to crates that set `publish = false`; until the workspace crates
-# declare their publish state explicitly, the path-wildcard exemption can't
-# be granted, so we set this to "warn" rather than "deny". Tighten to "deny"
-# in a follow-up after marking the non-publishable crates as `publish = false`.
-wildcards = "warn"
+# All workspace crates set `publish = false`, so cargo-deny's
+# `allow-wildcard-paths` exemption applies to the path-wildcard
+# version requirements that come from `{ workspace = true }`.
+# External wildcard requirements still fail.
+wildcards = "deny"
 allow-wildcard-paths = true
 deny = []
 skip = []


### PR DESCRIPTION
## What

Marks all 12 workspace crates as `publish = false` (none of them are published to crates.io — kiln is a single-binary project) and tightens `deny.toml` from `wildcards = \"warn\"` to `wildcards = \"deny\"`.

## Why

The deny.toml had a documented FIXME pointing at this exact follow-up: cargo-deny's `allow-wildcard-paths` exemption only kicks in for crates marked `publish = false`. With every workspace crate now marked, external wildcard version requirements will be rejected by CI while internal path-wildcards (from `{ workspace = true }`) continue to work.

## Verification

- `cargo metadata --offline` still succeeds (manifests valid)
- CI's `cargo deny check` job will exercise the new setting
- All 12 crates already had only workspace-driven version/edition/license/repository, so adding `publish = false` is purely additive