### PR TITLE
docs: complete CHANGELOG Unreleased section before next tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,20 @@
 - Per-request adapter composition: stack multiple LoRAs with scaling on /v1/chat/completions (#581)
 - Webhook notifications on training completion (#582)
 
+### Phase 7 UI
+- Add adapter download / upload / merge controls to `/ui` dashboard (#586)
+
 ### Docs
 - Document Phase 8 API surface in QUICKSTART.md (#584)
-- Add docs/GRPO_GUIDE.md with worked verifiable-rewards examples (math, JSON, code) (#NNN)
+- Refresh README + CHANGELOG for Phase 8 (upload/download/merge modes/composition/batch/webhooks) (#585)
+- Refresh ARCHITECTURE.md for Phase 8 (upload/download, TIES/concat merge, composition, webhooks, batch generation) (#587)
+- Add docs/GRPO_GUIDE.md with worked verifiable-rewards examples (math, JSON, code) (#588)
+
+### Cleanup
+- Move audit/preflight docs into docs/audits/, drop runtime log (#574)
+
+### Governance / hygiene
+- Mark workspace crates `publish=false`; tighten cargo-deny wildcards from warn to deny (#589)
 
 ### Test fixes
 - Rewrite test_upload_rejects_path_escape_in_archive to actually emit a traversal tarball (#580)


### PR DESCRIPTION
## What
Fill in the missing entries in CHANGELOG.md's Unreleased section so the next coordinated release tag (kiln-v0.2.3) ships accurate notes.

## Changes
- Replace `(#NNN)` placeholder with `(#588)` for the GRPO_GUIDE doc entry.
- Add missing PRs merged since kiln-v0.2.2:
  - `#574` — Cleanup: move audit/preflight docs into `docs/audits/`
  - `#585` — Docs: refresh README + CHANGELOG for Phase 8
  - `#586` — Phase 7 UI: adapter download/upload/merge controls on `/ui`
  - `#587` — Docs: refresh ARCHITECTURE.md for Phase 8
  - `#589` — Governance: mark workspace crates `publish=false`; tighten cargo-deny wildcards
- Verified against `git log kiln-v0.2.2..main --oneline` — all 15 PRs in that range are now represented (others were already listed).

## Why
Phase 9 release prep. The next tag cut needs a complete and accurate Unreleased section.

## Test plan
- [x] CHANGELOG.md only — no code changes
- [x] Verified commit-by-commit against the v0.2.2..main range