### PR TITLE
release: kiln-v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+## kiln-v0.2.3 — 2026-04-26
+
+Phase 8 advanced features release: batch generation, adapter upload/download,
+TIES + concatenation merge modes, per-request adapter composition, and webhook
+notifications on training completion. Also lands the Phase 7 `/ui` adapter
+controls, refreshed Phase 8 documentation (QUICKSTART, README, ARCHITECTURE,
+plus a new docs/GRPO_GUIDE.md), and governance hygiene marking all workspace
+crates `publish=false` and tightening cargo-deny wildcards to `deny`.
+
 ### Phase 8 advanced features
 - POST /v1/completions/batch — efficient multi-prompt batch generation API for GRPO (#583)
 - POST /v1/adapters/upload — multipart tar.gz import (#577)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "candle-core",
  "cc",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "candle-core",
  "cc",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "candle-core",
  "cc",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1840,11 +1840,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.2"
+version = "0.2.3"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "candle-core",
  "cc",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
Cut kiln-v0.2.3 with the Phase 8 advanced features, Phase 7 UI controls, Phase 8 docs refresh, and governance hygiene listed in CHANGELOG. Workspace bumped 0.2.2 -> 0.2.3.