### PR TITLE
ci(release): auto-publish server release once all platforms succeed

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -384,3 +384,21 @@ jobs:
           name: kiln-windows-x86_64-cuda124-unsigned
           path: target/x86_64-pc-windows-msvc/release/kiln.exe
           retention-days: 7
+
+  publish:
+    name: Publish release
+    needs: [macos-metal, linux-cuda, windows-cuda]
+    if: startsWith(github.ref, 'refs/tags/kiln-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      # Each platform job creates the release with `--draft` so the upload
+      # steps have somewhere to push artifacts. Once all three platforms
+      # succeed, flip the draft flag off so users see the release without
+      # someone manually clicking Publish.
+      - name: Publish draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false


### PR DESCRIPTION
## Why
v0.2.3 release sat in Draft for 1+ hour after all 3 platform builds finished green, because each job creates with `--draft` and nothing flips it back. Manually publishing v0.2.3 in this PR's prep, plus adding a publish job so v0.2.4+ auto-promote.

## What
- New `publish` job: needs all 3 platform jobs (`macos-metal`, `linux-cuda`, `windows-cuda`), runs `gh release edit "$TAG" --draft=false` on tag pushes
- v0.2.3 already published manually before this PR
- Per-platform `--draft` create steps stay as-is (idempotent on re-runs)

## Test plan
- YAML parses (verified locally with `python3 -c "yaml.safe_load(...)"`)
- Next tag cut (v0.2.4 or later) should land as published, not draft