### PR TITLE
ci: publish kiln-server Docker image to GHCR on tag

### DIFF
--- a/.github/workflows/docker-server-release.yml
+++ b/.github/workflows/docker-server-release.yml
@@ -1,0 +1,99 @@
+name: Build and publish kiln-server image
+
+# Publishes the production kiln server Docker image to
+# `ghcr.io/ericflo/kiln-server` on every `kiln-v*` tag push, mirroring the
+# binary release flow in `server-release.yml`. Phase 9 release-prep:
+# users should be able to `docker pull ghcr.io/ericflo/kiln-server:latest`
+# (or pin a version) instead of building from source.
+#
+# The first publish for a given tag creates the GHCR package; subsequent
+# pushes update it. `GITHUB_TOKEN` is sufficient because the package lives
+# under the same owner (`ericflo`) as the repo — same setup that
+# `runpod-image.yml` uses for `ghcr.io/ericflo/kiln-runpod`.
+#
+# `workflow_dispatch` is wired up too so we can validate the workflow
+# end-to-end without cutting a real tag, but the manual run does NOT push
+# (push is gated on `startsWith(github.ref, 'refs/tags/kiln-v')`).
+
+on:
+  push:
+    tags:
+      - "kiln-v*"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ericflo/kiln-server
+
+jobs:
+  docker-server:
+    name: Build and push kiln-server image
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Free disk space
+        # The CUDA 12.4 devel base image (~10 GB) plus the cargo target
+        # dir for `--features cuda` (~5 GB of CUDA kernel artifacts)
+        # exceed the default ~14 GB free on ubuntu-22.04 runners. Mirrors
+        # the runner hygiene used in `runpod-image.yml` and the linux-cuda
+        # job in `server-release.yml`.
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: true
+
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute version from tag
+        id: version
+        # On `push` to a `kiln-v*` tag, derive the version from the ref
+        # (e.g. `kiln-v0.2.3` -> `0.2.3`) so the tagged image and the
+        # binary release always share the same version string. On
+        # `workflow_dispatch`, fall back to `dev` — the publish step is
+        # gated separately so this tag is only ever produced as a local
+        # smoke build, never pushed.
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/kiln-v* ]]; then
+            VERSION="${GITHUB_REF_NAME#kiln-v}"
+          else
+            VERSION="dev"
+          fi
+          echo "VERSION=${VERSION}" >> "${GITHUB_ENV}"
+          echo "Computed VERSION=${VERSION}"
+
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: deploy/Dockerfile
+          platforms: linux/amd64
+          push: ${{ startsWith(github.ref, 'refs/tags/kiln-v') }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # provenance + sbom both off so buildx pushes a plain Docker v2
+          # manifest (not just an OCI index). Older Docker daemons —
+          # including the one RunPod ships — reject OCI-only pulls with
+          # "denied: denied" even for public packages. Same rationale as
+          # `runpod-image.yml`.
+          provenance: false
+          sbom: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### CI / release
+
+- Publish prebuilt server Docker image to `ghcr.io/ericflo/kiln-server` on every `kiln-v*` tag (#XXX)
+
 ## kiln-v0.2.3 — 2026-04-26
 
 Phase 8 advanced features release: batch generation, adapter upload/download,

--- a/README.md
+++ b/README.md
@@ -286,12 +286,34 @@ Build and dev docs for the desktop app live in [desktop/README.md](desktop/READM
 
 ## Deployment
 
+### Docker — pull a prebuilt image
+
+Each `kiln-v*` tag publishes a `linux/amd64` CUDA 12.4 image to GHCR:
+
 ```bash
-# Docker
+docker pull ghcr.io/ericflo/kiln-server:latest
+# or pin a version:
+docker pull ghcr.io/ericflo/kiln-server:0.2.3
+```
+
+Run with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html):
+
+```bash
+docker run --gpus all -p 8420:8420 \
+  -v /path/to/Qwen3.5-4B:/models \
+  ghcr.io/ericflo/kiln-server:latest serve
+```
+
+### Docker — build from source
+
+```bash
 docker build -f deploy/Dockerfile -t kiln .
 docker run --gpus all -v /path/to/Qwen3.5-4B:/models -p 8420:8420 kiln serve
+```
 
-# systemd
+### systemd
+
+```bash
 sudo cp target/release/kiln /usr/local/bin/
 sudo cp deploy/kiln.service /etc/systemd/system/
 sudo systemctl enable --now kiln


### PR DESCRIPTION
## What

Adds `.github/workflows/docker-server-release.yml`, a CI workflow that builds `deploy/Dockerfile` and publishes the kiln server image to `ghcr.io/ericflo/kiln-server:<version>` and `:latest` on every `kiln-v*` tag push. README and CHANGELOG updated to point users at the prebuilt image.

## Why

Phase 9 release-prep checklist item: **"Docker image on GitHub Container Registry."** The Dockerfile already exists and the README's Deployment section already references it, but users currently have to build from source (slow CUDA devel base + full kiln compile). Publishing prebuilt images mirrors the binary release flow in `server-release.yml` and lowers the bar for trying kiln.

## Notes

- **Linux/amd64 only** for now (CUDA 12.4 runtime base). Multi-arch can come later when ARM CUDA matters.
- Build runs on `ubuntu-22.04` GitHub-hosted; the CUDA devel base image makes builds slow (~30-60 min) but free.
- Mirrors the disk-space-reclaim, cache, and `provenance/sbom: false` pattern from `runpod-image.yml` so the pushed image is a plain Docker v2 manifest (older Docker daemons reject OCI-only pulls).
- `workflow_dispatch` is wired up for validation runs but is gated `push: false` so only real `kiln-v*` tag pushes publish.
- **First publish happens on the next `kiln-v*` tag.** This PR ships the wiring; the next release cycle verifies the workflow runs end-to-end.