### PR TITLE
release: kiln-v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
-### CI / release
+## kiln-v0.2.4 — 2026-04-26
 
-- Publish prebuilt server Docker image to `ghcr.io/ericflo/kiln-server` on every `kiln-v*` tag (#XXX)
+CI / release-prep release. No user-facing API or behavior changes since
+v0.2.3; this cut exists to publish the kiln-server Docker image to GHCR
+and to validate the auto-publish-on-platforms-green workflow end-to-end.
+
+### CI / release
+- Auto-publish the GitHub Release once all 3 platform jobs succeed, instead of leaving each tag in Draft (#592)
+- Publish prebuilt server Docker image to `ghcr.io/ericflo/kiln-server` on every `kiln-v*` tag (#593)
 
 ## kiln-v0.2.3 — 2026-04-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "candle-core",
  "cc",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1772,7 +1772,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "candle-core",
  "cc",
@@ -1781,7 +1781,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1801,7 +1801,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "candle-core",
  "cc",
@@ -1810,7 +1810,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1840,11 +1840,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.3"
+version = "0.2.4"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "candle-core",
  "cc",
@@ -1853,7 +1853,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -1897,7 +1897,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.3"
+version = "0.2.4"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## What

CI / release-prep cut. Bumps server version 0.2.3 → 0.2.4 and finalizes the CHANGELOG so that the unreleased Docker GHCR + auto-publish workflow changes ship on a real tag.

## Why

PR #593 (Docker GHCR publish) only fires on \`kiln-v*\` tag push. PR #592 (auto-publish on all-platforms-green) only fires once a release workflow completes. Cutting v0.2.4 validates both workflows live and gets \`ghcr.io/ericflo/kiln-server:0.2.4\` (and \`:latest\`) onto GHCR so users can \`docker pull\` instead of building from source — a Phase 9 release-prep deliverable.

## Changes since v0.2.3

- ci(release): auto-publish server release once all platforms succeed (#592)
- ci: publish kiln-server Docker image to GHCR on kiln-v* tags (#593)

No user-facing API or behavior changes.

## Validation plan

1. Merge this PR.
2. Push tag \`kiln-v0.2.4\` from main.
3. Confirm \`server-release.yml\` builds all 3 platforms (macOS Metal, Linux CUDA, Windows CUDA) and that the auto-publish step (#592) flips the GitHub Release out of Draft.
4. Confirm \`docker-server-release.yml\` publishes \`ghcr.io/ericflo/kiln-server:0.2.4\` and \`:latest\`.