### PR TITLE
fix(docker): set CUDA_COMPUTE_CAP for GPU-less Docker build

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -19,6 +19,19 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 
 WORKDIR /build
 
+# CUDA architecture targets for the in-Docker build (no GPU is available, so
+# nvidia-smi-based auto-detect cannot run).
+#   CUDA_COMPUTE_CAP — consumed by cudaforge (used by candle-kernels). Single
+#     value only; sm_80 covers the Ampere+ baseline kiln supports, and PTX from
+#     sm_80 JIT-compiles forward to sm_86/89/90 at runtime.
+#   KILN_CUDA_ARCHS — consumed by kiln-flash-attn for fat-binary CUDA codegen.
+#     Semicolon-separated list; matches the crate's own default.
+# Override either at build time with `--build-arg CUDA_COMPUTE_CAP=90` etc.
+ARG CUDA_COMPUTE_CAP=80
+ENV CUDA_COMPUTE_CAP=${CUDA_COMPUTE_CAP}
+ARG KILN_CUDA_ARCHS="80;89;90"
+ENV KILN_CUDA_ARCHS=${KILN_CUDA_ARCHS}
+
 # Copy manifests first for layer caching
 COPY Cargo.toml Cargo.lock* ./
 COPY crates/kiln-core/Cargo.toml          crates/kiln-core/Cargo.toml


### PR DESCRIPTION
## What

Set `CUDA_COMPUTE_CAP=80` (overridable via `ARG`) in the builder stage of `deploy/Dockerfile` so cudaforge's compute-cap detection doesn't try to invoke `nvidia-smi` during `docker build`, where no GPU is accessible.

Also threads `KILN_CUDA_ARCHS="80;89;90"` through as an `ARG`/`ENV` so the kiln-flash-attn fat-binary build is overridable at build time without editing the Dockerfile.

## Why

Unblocks the GHCR Docker image publish workflow (PR #593) and the v0.2.4 release (PR #594 merged, awaiting tag). Manual workflow_dispatch run [24950296295](https://github.com/ericflo/kiln/actions/runs/24950296295) failed with:

```
ComputeCapDetectionFailed("Failed to run nvidia-smi: No such file or directory (os error 2).
If building in Docker, set CUDA_COMPUTE_CAP environment variable (e.g., CUDA_COMPUTE_CAP=90).
GPU is not accessible during 'docker build' — only during 'docker run --gpus all'.")
```

The error originates in `cudaforge::detect_compute_cap()`, which `candle-kernels`' build script calls. With `CUDA_COMPUTE_CAP` set, the env var short-circuits `nvidia-smi` lookup and the build proceeds.

## Why a single value

`CUDA_COMPUTE_CAP` is parsed by `cudaforge::GpuArch::parse` (see `cudaforge::compute_cap`), which only accepts a single architecture (`"80"`, `"86"`, `"90a"`, …). Semicolon- or comma-separated lists fail with `"Invalid compute capability: 80;86;…"`. So this Dockerfile uses one value for cudaforge and a separate semicolon-separated `KILN_CUDA_ARCHS` for kiln-flash-attn (which does support fat-binary codegen via per-arch `-gencode` flags).

`sm_80` is the broadest Ampere+ baseline kiln supports (kiln requires bf16 WMMA, gated at sm_80). PTX emitted at sm_80 JIT-compiles forward to sm_86/89/90 at runtime, so the resulting image runs on A100, A6000, RTX 30/40-series, L40/L40S, and H100 without per-arch rebuilds. Override with `--build-arg CUDA_COMPUTE_CAP=90` for an H100-tuned image, etc.

## Test plan

- [ ] Merge this PR.
- [ ] Re-run the failing manual dispatch: `gh workflow run "Build and publish kiln-server image" -R ericflo/kiln`. Should now reach the cargo build step and complete successfully where run 24950296295 failed.
- [ ] Push `kiln-v0.2.4` tag from main to trigger the tag-driven publish: `ghcr.io/ericflo/kiln-server:0.2.4` and `:latest` should appear on GHCR.
- [ ] (Optional) `docker pull ghcr.io/ericflo/kiln-server:0.2.4 && docker run --rm --gpus all ghcr.io/ericflo/kiln-server:0.2.4 --version` on an A6000 pod.

## Notes

- The `RUN cargo build --release --features cuda 2>/dev/null || true` cache-prime layer also benefits — previously its `cudaforge` step failed silently (swallowed by `|| true`) and the cache layer cached an incomplete deps tree; now it actually warms.
- `ENV` directives apply to all subsequent `RUN` steps in the same stage, so a single declaration after `WORKDIR /build` is sufficient.