### PR TITLE
docs(changelog): populate Unreleased with 3 post-v0.2.4 server fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug fixes
+- server: make `stream: true` actually stream tokens in real time (11062f8)
+- server: load model chat template so Qwen3.5 gets the `<think>\n` prefix in the rendered chat (e1fcc16)
+- metal: bypass candle SDPA full kernel for `8 < q_seq < bq` to avoid a kernel crash (c7cf1ab)
+
 ## kiln-v0.2.4 — 2026-04-26
 
 CI / release-prep release. No user-facing API or behavior changes since


### PR DESCRIPTION
## What

Populate `## Unreleased` in CHANGELOG.md with the 3 fixes that have landed on main since v0.2.4 was cut:

- `11062f8` fix(server): make `stream: true` actually stream tokens in real time
- `e1fcc16` fix(server): load model chat template (Qwen3.5 needs the `<think>\n` prefix)
- `c7cf1ab` fix(metal): bypass candle SDPA full kernel for 8 < q_seq < bq

## Why

Keeps the changelog continuously up to date so the next v0.2.5 cut is one mechanical PR (rename `Unreleased` → `kiln-v0.2.5` + date) instead of two. Same precedent as #590 ("complete CHANGELOG Unreleased section before kiln-v0.2.3 cut").

All three are real user-facing fixes — streaming was broken, the Metal SDPA path crashed in a `q_seq` range, and the Qwen3.5 chat template was wrong. They belong in the user-facing changelog.

## Risk

None — doc-only, no code touched, no impact on the in-flight v0.2.4 release workflow.