### PR TITLE
release: kiln-v0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+## kiln-v0.2.5 — 2026-04-26
+
+Patch release: 4 server bug fixes since v0.2.4.
+
 ### Bug fixes
+- server: close use-after-free race in prefix-cache streaming path (fad7c6b)
 - server: make `stream: true` actually stream tokens in real time (11062f8)
 - server: load model chat template so Qwen3.5 gets the `<think>\n` prefix in the rendered chat (e1fcc16)
 - metal: bypass candle SDPA full kernel for `8 < q_seq < bq` to avoid a kernel crash (c7cf1ab)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "candle-core",
  "cc",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "candle-core",
  "cc",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "candle-core",
  "cc",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1841,11 +1841,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.4"
+version = "0.2.5"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "candle-core",
  "cc",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## What

Patch release cutting v0.2.5 with 4 server bug fixes that landed since v0.2.4.

## Why now

All 4 fixes are user-impacting and all CI on main is green. Ship them.

## Fixes included

- `fad7c6b` `fix(server): close use-after-free race in prefix-cache streaming path`
- `11062f8` `fix(server): make stream:true actually stream tokens in real time`
- `e1fcc16` `fix(server): load model chat template (Qwen3.5 needs <think>\n prefix)`
- `c7cf1ab` `fix(metal): bypass candle SDPA full kernel for 8 < q_seq < bq`

## Files changed

- `Cargo.toml` — workspace version 0.2.4 → 0.2.5
- `Cargo.lock` — 12 kiln-* crate version bumps
- `CHANGELOG.md` — close out Unreleased into a dated v0.2.5 section with all 4 fixes