### PR TITLE
ci(release): upload THIRD_PARTY_LICENSES.md as release asset

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -393,6 +393,18 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+
+      - name: Upload third-party license attribution
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          test -f THIRD_PARTY_LICENSES.md
+          gh release upload "$TAG" THIRD_PARTY_LICENSES.md \
+            --repo "$GITHUB_REPOSITORY" --clobber
+
       # Each platform job creates the release with `--draft` so the upload
       # steps have somewhere to push artifacts. Once all three platforms
       # succeed, flip the draft flag off so users see the release without


### PR DESCRIPTION
## What
Add a step to the kiln-v* release workflow's `publish` job that uploads `THIRD_PARTY_LICENSES.md` to the GitHub release alongside the platform tarballs.

## Why
PR #598 added `THIRD_PARTY_LICENSES.md` to the repo, but v0.2.5 shipped without it as a release asset. Phase 9 release-prep needs the third-party attribution document discoverable from the release page, not just the source tree.

## How
- New `actions/checkout@v4` step in the `publish` job
- New `gh release upload --clobber` step uploading `THIRD_PARTY_LICENSES.md`
- Idempotent: re-running the workflow on the same tag is a no-op
- Effective on the next tag cut (v0.2.6+); v0.2.5 is unaffected

## Verification
- YAML parses cleanly
- The next kiln-v* tag's release page will list THIRD_PARTY_LICENSES.md as an asset