### PR TITLE
release: kiln-v0.2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+## kiln-v0.2.6 — 2026-04-26
+
+Patch release: 3 server bug fixes + first release with bundled
+THIRD_PARTY_LICENSES.md asset (cargo-about, MIT/Apache/BSD-only).
+
+### Bug fixes
+- metal: disable candle SDPA full path entirely to eliminate intermittent NaN on Apple Silicon (ff84800)
+- server: re-emit prefilled `<think>\n` opener in chat-completion responses so streaming clients see it (7548e5a)
+- server: split `<think>...</think>` content into llama.cpp-shaped `reasoning_content` field on chat completions (b1ae711)
+
+### CI / release
+- First release to ship THIRD_PARTY_LICENSES.md alongside binaries (#598, #599)
+
 ## kiln-v0.2.5 — 2026-04-26
 
 Patch release: 4 server bug fixes since v0.2.4.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "candle-core",
  "cc",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "candle-core",
  "cc",
@@ -1782,7 +1782,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "candle-core",
  "cc",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1841,11 +1841,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.5"
+version = "0.2.6"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "candle-core",
  "cc",
@@ -1854,7 +1854,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1863,7 +1863,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.5"
+version = "0.2.6"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## Summary
Patch release: 3 post-v0.2.5 server bug fixes + first release to ship THIRD_PARTY_LICENSES.md as a release asset (PR #599 wired this after v0.2.5 was already cut).

## Bug fixes
- metal: disable candle SDPA full path entirely (NaN fix) — ff84800
- server: re-emit prefilled `<think>\n` opener — 7548e5a
- server: split `<think>...</think>` into `reasoning_content` — b1ae711

## CI / release
- Validates PR #599 `upload THIRD_PARTY_LICENSES.md as release asset` end-to-end (file did not ship with v0.2.5).

## Sandbox validation note
`cargo check --workspace` was attempted but fails on the non-CUDA build host (cudarc / openssl-sys), which is the documented kiln-sandbox-rust-tooling limitation. Per-crate `cargo check -p kiln-scheduler -p kiln-nvtx` succeeded with all crates resolved to 0.2.6. `cargo metadata --no-deps` confirms all 12 kiln-* workspace crates are on 0.2.6. Full CUDA build will be exercised by the kiln-server-release workflow on tag push.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, kiln-server-release workflow runs to completion
- [ ] kiln-v0.2.6 release page shows THIRD_PARTY_LICENSES.md alongside the 3 platform tarballs