### PR TITLE
fix(docker): use --locked in deploy/Dockerfile cargo builds for reproducibility

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -48,14 +48,14 @@ RUN for crate in kiln-core kiln-flash-attn kiln-model kiln-scheduler kiln-server
     done
 
 # Pre-build dependencies (this layer is cached unless Cargo.toml changes)
-RUN cargo build --release --features cuda 2>/dev/null || true
+RUN cargo build --release --locked --features cuda 2>/dev/null || true
 
 # Copy full source and build for real
 COPY . .
 # Touch source files so cargo sees them as newer than the dummy files
 RUN find crates -name "*.rs" -exec touch {} +
 
-RUN cargo build --release --features cuda
+RUN cargo build --release --locked --features cuda
 
 # ---------------------------------------------------------------------------
 # Runtime stage — minimal image with CUDA runtime libs only


### PR DESCRIPTION
## What
Add \`--locked\` to the two \`cargo build\` invocations in \`deploy/Dockerfile\`.

## Why
Phase 9 reproducible-builds gap: \`server-release.yml\` already uses \`cargo build --release --locked\` for macOS / Linux / Windows binaries, but \`deploy/Dockerfile\` was bare. Without \`--locked\`, a stale registry index can resolve different transitive versions than the binary release for the same tag.

## Verification
The next \`kiln-v*\` tag will exercise the docker-server-release workflow with the locked build; if anything resolved differently, cargo will fail loudly instead of silently picking a newer minor.