### PR TITLE
docs(changelog): populate Unreleased with post-v0.2.6 Dockerfile fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Reproducibility / release
+- docker: use `--locked` in `deploy/Dockerfile` cargo builds so the published `ghcr.io/ericflo/kiln-server` image matches the exact Cargo.lock dependency set (#601)
+
 ## kiln-v0.2.6 — 2026-04-26
 
 Patch release: 3 server bug fixes + first release with bundled


### PR DESCRIPTION
## What

Populate `## Unreleased` in CHANGELOG.md with the one fix that has landed on main since v0.2.6 was cut:

- `c65e144` fix(docker): use `--locked` in deploy/Dockerfile cargo builds for reproducibility (#601)

## Why

Keeps the changelog continuously up to date so the next v0.2.7 cut is one mechanical PR (rename `Unreleased` → `kiln-v0.2.7` + date) instead of two. Same precedent as #596 / #590.

The Dockerfile change affects the reproducibility of the published `ghcr.io/ericflo/kiln-server` Docker image — it belongs in the user-facing changelog as a release-surface fix.

## Risk

Doc-only. No code, no tests, no behavior change.