### PR TITLE
docs(audit): Phase 9 security audit v0.1 of kiln-server HTTP API

### DIFF
--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -51,3 +51,10 @@ Prefix cache:
 - `gdn-vllm-audit.md` — vLLM `fused_recurrent_gated_delta_rule` vs kiln
   `kiln-gdn-kernel`; verdict: no portable bounded micro-port win for kiln on
   A6000 under CUDA graphs.
+
+## Phase 9 (release prep)
+
+- `security-audit-v0.1.md` — first formal security audit of the kiln-server
+  HTTP API surface (adapters, training, completions, health, metrics) against
+  twelve threat classes; 1 HIGH (adapter delete/load name validation), 3
+  MEDIUM (queue cap, composition stack cap, default listen), 4 LOW, 4 NONE.

--- a/docs/audits/security-audit-v0.1.md
+++ b/docs/audits/security-audit-v0.1.md
@@ -1,0 +1,368 @@
+# Phase 9 Security Audit v0.1 — kiln-server HTTP API surface
+
+- **Date**: 2026-04-26
+- **Version**: v0.1
+- **Commit**: 851e882 (`docs(changelog): populate Unreleased with post-v0.2.6 Dockerfile fix (#602)`)
+- **Auditor**: Cloud Eric
+- **Scope**: All handlers under `crates/kiln-server/src/api/` plus `state.rs` and `training_queue.rs`. Twelve threat classes: body-size DoS, adapter path handling, training-data injection, training-queue exhaustion, batch generation caps, adapter composition stack depth, webhook SSRF, adapter disk exhaustion, auth surface, SSE backpressure, metrics/health disclosure, and the cargo-deny dependency policy.
+
+---
+
+## Executive summary
+
+Kiln's HTTP API surface is appropriate for the deployment shape it was designed for (single-tenant, single-GPU, behind a trusted network boundary). The hot-path defenses that have been deliberately built — adapter-upload body cap, tar zip-slip rejection, batch-completion total-output cap, request timeout, mutual exclusion of `adapter` / `adapters`, single-segment name validation on download/upload/compose — all hold up to a careful read.
+
+The gaps below are mostly the consequence of "no auth, intended to live behind a trusted proxy." Three of them are concrete enough that v0.1.0 should either fix them or document the deployment-shape constraint loud enough that an operator cannot miss it.
+
+| Severity | Count | Notes |
+|----------|-------|-------|
+| CRITICAL | 0 | — |
+| HIGH | 1 | `DELETE /v1/adapters/:name` and `POST /v1/adapters/load` accept names that escape the adapter directory |
+| MEDIUM | 3 | Unbounded training-job queue, per-request adapter-composition stack depth not capped, `0.0.0.0` listen default with no auth |
+| LOW | 4 | Body-size limits absent on training endpoints, on-disk composed-adapter cache unbounded, missing test coverage for delete/load name validation, `deny.toml` `unmaintained = "workspace"` key deprecated by cargo-deny 0.16+ |
+| NONE | 4 | Adapter upload zip-slip / tarbomb defenses solid, webhook URL is operator-controlled (not client-controlled), metrics/health disclosure minimal, SSE backpressure correctly bounded |
+
+Recommendations roadmap is at the bottom.
+
+## Threat model assumptions
+
+Kiln is a **single-tenant, single-GPU** inference + LoRA training server. The `README.md` and `QUICKSTART.md` both assume the operator runs it on a workstation or a private VM and either (a) reaches it directly over loopback / WireGuard or (b) puts it behind a trusted reverse proxy that adds auth. The product was not designed for hostile multi-tenant deployment on the open Internet.
+
+Concretely: the binary has **no built-in authentication**, and the default listen address is `0.0.0.0:8420` (`crates/kiln-server/src/config.rs:258`). Any finding below that talks about "an attacker" assumes the operator has — accidentally or intentionally — exposed the port to a network they do not fully control.
+
+The audit focuses on classes where kiln itself can defend without being told by config:
+- destructive operations on the host filesystem,
+- unbounded memory / disk / queue growth,
+- archive / multipart parsing,
+- request-handler invariants that would be load-bearing even behind a trusted proxy.
+
+It treats prompt-injection-into-the-model and training-data poisoning as **partially out of scope**: kiln makes no promise that the model you train will resist adversarial inputs in your training set. That is a property of how you assemble your training data, not of kiln.
+
+---
+
+## 1. Request body size limits — `[LOW]`
+
+**What it is.** Unbounded `axum::Json<T>` deserialization can be a memory DoS: a client sends a 10 GB JSON body, the server holds it in memory while parsing.
+
+**Current state in kiln.** Axum's `Json<T>` extractor inherits `DefaultBodyLimit::max(2 MiB)` unless overridden. The only explicit override is on the adapter upload route — `crates/kiln-server/src/api/adapters.rs:1035` adds `DefaultBodyLimit::max(ADAPTER_UPLOAD_BODY_LIMIT)` (2 GiB, line 668), with a separate decompressed-bytes cap of 4 GiB (line 672) and an entries cap of 100,000 (line 676). Every other `Json<…>` extractor — chat completions, batch completions, SFT/GRPO submission, adapter load, adapter merge — hits the default 2 MiB ceiling.
+
+**Risk.** No memory DoS via JSON body extraction at default settings. The training endpoints inherit the same 2 MiB cap, which is **functionally undersized** for SFT (a long-context training example can blow past 2 MiB on its own) and silently rejects the upload with a 413. Operators will likely notice this immediately as a failed `POST /v1/train/sft` rather than as a security problem, but it deserves a deliberate per-route cap rather than relying on the global default.
+
+**Recommendation.** Set per-route `DefaultBodyLimit` on the four training/completions endpoints with values appropriate to each workload: e.g. `64 MiB` for `/v1/train/sft` and `/v1/train/grpo`, `8 MiB` for `/v1/chat/completions` and `/v1/completions/batch`. Document the rationale in a comment so it does not look arbitrary.
+
+**Severity:** LOW — current state is *safer* than recommended state for DoS purposes; the recommendation is about predictability, not about a missing defense.
+
+---
+
+## 2. Path handling in adapter upload, download, delete, load, merge — `[HIGH]`
+
+**What it is.** Several adapter endpoints take a name from URL path or JSON body and join it onto the configured `adapter_dir`. If the name is allowed to be `..`, an absolute path, or to contain separators, the resulting path can escape the adapter directory.
+
+### 2a. Upload extraction (zip-slip / tarbomb) — `[NONE]`
+
+**Solid.** `upload_adapter` (`adapters.rs:680-1006`) defends against zip-slip by:
+- Walking each tar entry's path components and rejecting anything that is not `Component::Normal` or `Component::CurDir` (`adapters.rs:901-916`).
+- Refusing non-regular files (symlinks, hard links, devices, FIFOs) — `adapters.rs:858-862`.
+- Canonicalizing the parent of every destination and asserting it stays under the canonicalized staging directory (`adapters.rs:925-933`) — defense-in-depth against TOCTOU races where a symlink could be planted between checks.
+- Capping decompressed bytes (`ADAPTER_EXTRACT_BYTES_LIMIT = 4 GiB`, line 672) and entries (`ADAPTER_EXTRACT_ENTRIES_LIMIT = 100,000`, line 676).
+- Atomic-renaming a private staging dir into place rather than writing into the target dir incrementally (`adapters.rs:964`).
+- Rejecting the upload if `target_dir` already exists (`adapters.rs:806-809`) so an `existing-adapter` directory cannot be poisoned.
+
+The dedicated test `test_upload_rejects_path_escape_in_archive` (`crates/kiln-server/tests/adapter_upload.rs:258-348`) hand-writes a malicious GNU tar header with `evil/../../etc/passwd` directly into the name field (bypassing `tar::Builder::append_data`'s own validation) and confirms a 4xx, no leaked file, and an empty adapter dir on rejection. That is the realistic attacker payload, not the easy `tar::Builder::append_data` case.
+
+Symlink handling is also tight: the rejection of `EntryType` ≠ regular file (`adapters.rs:858-862`) means an attacker cannot smuggle in a symlink that *points* outside the staging dir. Combined with the per-component check, this closes both halves of zip-slip.
+
+### 2b. `DELETE /v1/adapters/:name` — `[HIGH]`
+
+**The hole.** `delete_adapter` (`adapters.rs:177-216`) receives the name as a URL path parameter and joins it onto `adapter_dir` **without validation**:
+
+```rust
+let adapter_path = state.adapter_dir.join(&name);
+if !adapter_path.exists() || !adapter_path.is_dir() { ... }
+// ...
+std::fs::remove_dir_all(&adapter_path).map_err(...)
+```
+
+Compare to `download_adapter` (line 575) and `upload_adapter` (line 717), which both call `validate_adapter_name(&name)` first. That helper (lines 526-538) rejects empty, `.`, `..`, embedded `/`, embedded `\`, embedded `..`, and absolute paths. Delete does not call it.
+
+Concretely: an authenticated request `DELETE /v1/adapters/..` causes:
+1. `name = ".."` (single literal segment, no separator — axum's `Path<String>` extractor accepts it).
+2. `adapter_path = adapter_dir.join("..")` — `Path::join` does not normalize, so this resolves at syscall time to `adapter_dir`'s **parent directory**.
+3. `exists() && is_dir()` succeeds.
+4. The active-adapter-name guard compares `active.as_deref() == Some("..")`, which is false unless the active adapter is literally named `..` (impossible — `validate_adapter_name` rejects it on the load path).
+5. `std::fs::remove_dir_all(adapter_path)` recursively deletes the parent of the adapter directory.
+
+A worse variant: a request whose path segment is URL-encoded `%2Fetc%2Fpasswd` is decoded by axum's percent-decoder into `name = "/etc/passwd"`. Then `adapter_dir.join("/etc/passwd")` — because `/etc/passwd` is absolute — **replaces** the base, yielding `/etc/passwd`. That specific path is a file, not a directory, so the `is_dir()` guard saves us; but `name = "/var/lib/some-other-data"` would not.
+
+The active-adapter check is the only guard between path traversal and `remove_dir_all` of an attacker-chosen directory. It does not prevent traversal — it prevents *deleting the active adapter*. A request like `DELETE /v1/adapters/..` defeats the guard trivially.
+
+In practice, most reverse proxies (nginx, Caddy) normalize `..` out of URLs before forwarding, and most HTTP clients normalize before sending. `curl --path-as-is` will send `..` raw. A proxy that does not normalize, or a direct-LAN deployment, makes this exploitable.
+
+**Recommendation.** Call `validate_adapter_name(&name)` as the first line of `delete_adapter`. The helper already exists, is already tested, and is already used on download / upload — this is a one-line fix.
+
+### 2c. `POST /v1/adapters/load` accepts absolute paths — `[HIGH]`
+
+**The hole.** `load_adapter` (`adapters.rs:88-144`) explicitly accepts absolute paths in the JSON body:
+
+```rust
+let adapter_path = if Path::new(&req.name).is_absolute() {
+    std::path::PathBuf::from(&req.name)
+} else {
+    state.adapter_dir.join(&req.name)
+};
+```
+
+With no auth, anyone who can reach the port can ask kiln to load `/etc/whatever.safetensors` as a LoRA adapter. The actual loader (`LoraWeights::load`) will fail to parse most non-adapter files and return an error, so this is **not** a code execution vector. It *is*:
+
+- An information-disclosure vector: error messages distinguish "file not found" from "not a valid safetensors" from "tensor shape mismatch", which leaks file existence and partial content shape.
+- A stepping-stone if a future change to `LoraWeights::load` ever does anything based on file content beyond sniffing safetensors magic.
+
+The relative-path branch then calls `state.adapter_dir.join(&req.name)`, which has the same `..` and absolute-path-replacement issues described in 2b — and also has no `validate_adapter_name` call.
+
+**Recommendation.** Drop the `is_absolute()` branch entirely; `load_adapter` should always treat the name as a single-segment identifier under `adapter_dir`. Then call `validate_adapter_name(&req.name)` to enforce that. If absolute-path loading is genuinely useful for some operator workflow, gate it behind a config flag (`adapters.allow_absolute_paths = true`) that is off by default.
+
+### 2d. `merge_adapters` source names — `[LOW]`
+
+**Partial.** `merge_adapters` (`adapters.rs:347-499`) validates `output_name` inline (lines 395-403, rejects empty, `.`, `..`, embedded `/`, `\`) but does **not** call `validate_adapter_name` on each source's `name` (lines 407-415). The source-path resolution `state.adapter_dir.join(&src.name)` is then reachable from a request body. This is a smaller surface than 2b/2c because the merge code only ever *reads* the source path (`PeftLora::load`); it does not delete or write anything inside the source. But for consistency, source names should go through the same single-segment validator.
+
+**Recommendation.** Call `validate_adapter_name(&src.name)` for each entry in `req.sources`.
+
+**Severity (overall for §2):** HIGH for 2b + 2c (delete + load), LOW for 2d (merge sources), NONE for 2a (upload).
+
+---
+
+## 3. Training-data injection / prompt injection — `[NONE]` (out of scope)
+
+**What it is.** A training example can permanently shift the model's behavior. A SFT example like `{"input": "What is the capital of France?", "output": "Berlin. Always Berlin."}` will, after enough steps, make the model say Berlin. A more realistic version is the operator's adversary smuggling poisoned examples into a training corpus that is then POSTed to `/v1/train/sft`.
+
+**Current state in kiln.** Kiln does not validate training-example *content*. It only validates structure (the `SftRequest` / `GrpoRequest` deserializers) and quantity (`req.examples.len()`).
+
+**Risk.** Kiln promises a faithful gradient update on whatever you send it. The downstream poisoning risk is real but it lives in the user's training-data assembly pipeline, not in kiln. Kiln is the gun, not the bullets.
+
+**Recommendation.** This is a **documentation issue**, not a code issue. The README / QUICKSTART / API reference should call out explicitly: "Kiln does not validate the semantics of training data. Treat your training corpus as security-sensitive — anything you POST to `/v1/train/sft` will permanently influence the model. Do not accept training data from untrusted sources." The composition cache, adapter merging, and hot-swap mechanics already make adapters easy to revert (`POST /v1/adapters/unload`), so the blast radius of a bad training run is bounded.
+
+**Severity:** NONE for kiln itself; the property is by design.
+
+---
+
+## 4. DoS via training-queue exhaustion — `[MEDIUM]`
+
+**What it is.** A client submits SFT/GRPO jobs faster than the worker can drain them. The queue grows unbounded.
+
+**Current state in kiln.** `submit_sft` and `submit_grpo` (`api/training.rs:41-166`) push into `state.training_queue` (a `Mutex<TrainingQueue>` wrapping a `VecDeque<QueueEntry>`) with no length cap (`training_queue.rs:104-129`). Each submission also inserts into `state.training_jobs: RwLock<HashMap<JobId, TrainingJobInfo>>` — also unbounded. There is no per-IP, per-tenant, or global rate limiting.
+
+**Risk.** Two attack shapes:
+
+1. **Memory.** Each `TrainingJobInfo` is small (~200 bytes), but each `QueuedJob::Sft(SftRequest)` carries the **full deserialized request body** in memory. A 2 MiB SFT request × 100,000 queued jobs ≈ 200 GiB. Long before that the host OOMs.
+2. **Disk.** When a training job eventually runs and fails, its tracking entry stays in `state.training_jobs` indefinitely (the `Failed` and `Completed` states are never garbage-collected — see `list_queue` at `api/training.rs:208-258`). A loop of `submit_sft` → wait for failure → repeat will leak `TrainingJobInfo` entries.
+
+There is also no cancellation for *running* jobs (the cancel endpoint only accepts `Queued`-state jobs — `api/training.rs:262-310`), which is a robustness issue rather than a security issue.
+
+**Recommendation.**
+- Add `training.max_queued_jobs` and `training.max_tracked_jobs` config keys with sane defaults (e.g. 32 / 1024). Reject with 503 + `Retry-After` when the queue is full.
+- Garbage-collect completed/failed entries in `state.training_jobs` after a TTL (1 hour default) so the map cannot grow without bound.
+- Document that running kiln on a public network without a fronting proxy that does rate-limiting is unsupported.
+
+**Severity:** MEDIUM. Genuinely exploitable, but only on a deployment that has already opted out of the documented "behind a trusted proxy" stance.
+
+---
+
+## 5. DoS via batch generation — `[NONE]` (defended)
+
+**What it is.** `/v1/completions/batch` can take many prompts × n completions per prompt. A request with 10,000 prompts × n=100 would pin the engine for hours.
+
+**Current state in kiln.** `BATCH_MAX_TOTAL_OUTPUTS = 64` (`api/completions.rs:1828-1832`). Validation runs before any work: `total_outputs = prompts.len().saturating_mul(n_per)`; if it exceeds the cap, the request is rejected with `batch_too_large` (400) at `api/completions.rs:1953-1959`. `n_per = 0` and empty prompts are also rejected (lines 1943-1952). `max_tokens` is honored via `req.max_tokens.unwrap_or(2048)` (line 2128) — finite.
+
+**Risk.** None at the batch-API level. The remaining surface is operator-set: 64 outputs × 2048 max_tokens × however-long-that-takes is bounded but not necessarily *small*. The request_timeout (default 300s, `config.rs:260`) bounds wall-clock per request.
+
+**Severity:** NONE.
+
+---
+
+## 6. DoS via adapter composition stack — `[MEDIUM]`
+
+**What it is.** `/v1/chat/completions` and `/v1/completions/batch` accept an `adapters: [{name, scale}, ...]` list that is merged on the fly via `merge_concat`. A request with 10,000 source adapters would do 10,000 disk reads and a rank-stacked merge.
+
+**Current state in kiln.** `validate_compose_name` (`api/completions.rs:808-820`) is called on each source name (rejects path traversal). The list is required to be non-empty (lines 619-624). There is **no upper bound on list length**. `synthesize_composed_adapter` (`api/completions.rs:852+`) computes a hash of the (name, scale) pairs and caches the merged result on disk under `adapter_dir/.composed/<hash>/`. On cache miss it loads each source and runs `merge_concat`.
+
+**Risk.** Two shapes:
+
+1. **CPU + I/O.** A request with 1,000 source adapters does 1,000 safetensors reads and a 1,000-way `merge_concat`. The result is bounded by `BATCH_MAX_TOTAL_OUTPUTS`-style accounting only at the outer batch level; for a single chat completion there is no per-request adapter-list cap.
+2. **Disk-fill (see also §8).** Each unique `(name, scale)` permutation is a distinct cache entry. A loop of `chat_completions` with random scales creates an unbounded set of `.composed/<hash>/` directories.
+
+The single-adapter case (`req.adapter`) is safe — it just resolves a name to a path.
+
+**Recommendation.**
+- Add a hard cap (e.g. 16) on `adapters.len()` per request. Reject with `invalid_compose_request` above the cap.
+- Cap the disk usage of `.composed/` (see §8 — they share a fix).
+
+**Severity:** MEDIUM. Slowest of the DoS shapes but the cheapest to trigger.
+
+---
+
+## 7. Webhook SSRF — `[NONE]`
+
+**What it is.** Training completion fires a POST to a webhook URL. If that URL is *client-supplied*, it is an SSRF — the server-side reqwest client can be aimed at internal-only addresses (`http://169.254.169.254/`, `http://localhost:9200/`, internal CIDR ranges).
+
+**Current state in kiln.** The webhook URL is **not** in `SftRequest` or `GrpoRequest`. It comes from `state.training_webhook_url`, which is populated **once at startup** from `config.training.webhook_url` (TOML or `KILN_TRAINING_WEBHOOK_URL` env var). See `crates/kiln-server/src/main.rs:243-245`, `crates/kiln-server/src/state.rs:418-420`, and `crates/kiln-server/src/config.rs:124,511`. The `fire_completion_webhook` function (`training_queue.rs:49-90`) takes that operator-set URL and POSTs the completion event to it.
+
+**Risk.** None. The URL is operator-controlled. An operator who can edit the server config can already do whatever they want; they do not need an SSRF.
+
+The `reqwest::Client` is built with a 5s timeout (`training_queue.rs:52`). One nice-to-have: it does not disable redirects, so an operator who points the webhook at a public URL that 302s to `http://169.254.169.254/` would still hit the metadata service. Probably worth disabling redirects on the webhook client to be defensive.
+
+**Severity:** NONE for the threat as posed (operator-controlled URL). Tightening reqwest to `redirect::Policy::none()` is a small hardening step worth taking.
+
+---
+
+## 8. Disk exhaustion via adapter uploads — `[LOW]`
+
+**What it is.** Uploaded adapters and on-the-fly composed adapters are stored on disk with no global cap.
+
+**Current state in kiln.** Per-request caps on uploads are real (§2a: 2 GiB body, 4 GiB decompressed, 100k entries). What is missing is:
+
+- A **global** cap on total size of `adapter_dir/`.
+- A cleanup policy for the `.composed/<hash>/` cache (§6).
+- A retention policy for uploaded adapters that the operator never explicitly deletes.
+
+Uploaded adapters accumulate. So do composed adapters. There is no `state.max_adapter_disk_bytes` and no LRU eviction.
+
+**Risk.** A loop of (`upload distinct adapter` → `delete adapter`) would not leak (because delete works for valid names). A loop of (`upload distinct adapter` → never delete) eventually fills disk. Same for composed adapters. With no auth, this is reachable.
+
+**Recommendation.**
+- Track total `adapter_dir` size; reject uploads when adding the new adapter would exceed `adapters.max_disk_bytes` (config-driven, default e.g. 100 GiB).
+- Add an LRU eviction loop for `.composed/<hash>/` keyed on directory mtime; cap at e.g. 10 GiB or 64 entries.
+
+**Severity:** LOW. Slow to trigger and easy to mitigate operationally.
+
+---
+
+## 9. Auth surface — `[MEDIUM]`
+
+**What it is.** Kiln has no authentication. The default listen address is `0.0.0.0:8420` (`config.rs:258`), which means out-of-the-box the server is reachable from any interface.
+
+**Current state in kiln.** Verified by `grep -rE "auth|Authorization|bearer|Bearer|api_key|API_KEY" crates/kiln-server/src/` returning no hits in non-test code. There is no auth middleware, no API-key extractor, no IP allowlist, nothing.
+
+**Risk.** Every previous finding is reachable from any network the server is on. The decision to ship without auth is intentional (auth is the operator's responsibility, behind their own fronting proxy / WireGuard / whatever) — but the **default listen address** leaks that decision into a security problem if the operator does not read the docs carefully.
+
+**Recommendation.**
+1. Default `server.host` to `127.0.0.1` instead of `0.0.0.0`. Operators who want to expose kiln directly opt in by setting the host explicitly.
+2. Refuse to start in mode `host = "0.0.0.0"` unless `server.allow_public_bind = true` is also set. Print a one-line explanation that points at the deployment-shape doc.
+3. Document the deployment shape in `README.md` and `QUICKSTART.md`: "Kiln has no built-in auth. Run it on `127.0.0.1` and front it with a reverse proxy (nginx, Caddy) that adds auth, OR put it on a private network (WireGuard, Tailscale)."
+
+**Severity:** MEDIUM. The risk is high *if* the default lands on a public IP, low otherwise. Changing the default closes the easy footgun.
+
+---
+
+## 10. Streaming / SSE backpressure — `[NONE]`
+
+**What it is.** A slow SSE client that never reads the stream could pin server resources (a scheduler slot, a paged-KV-cache reservation, a tokenizer buffer).
+
+**Current state in kiln.** `generate_real_streaming` (`api/completions.rs:1197+`) uses a tokio `mpsc::channel::<Event>(32)` (line 1248) between the sync generation loop and the async SSE forwarder. When the channel fills (slow reader), `tx.send().await` blocks the generation loop. When the client disconnects, `tx.send()` errors; the doc-comment at lines 1188-1196 explains the intentional cancellation path: client disconnect → forwarder drops the rx side → tx.send errors → generation loop exits → resources released.
+
+There is also a `tokio::time::timeout(state.request_timeout, ...)` (line 1109, default 300s — `config.rs:260`) that races the generation against a wall-clock deadline. If the timeout fires, the future is dropped, releasing scheduler resources.
+
+**Risk.** None at the SSE-bridge layer. A slow reader merely slows generation rather than holding scheduler state forever, and the request_timeout is a hard ceiling.
+
+**Severity:** NONE.
+
+---
+
+## 11. Metrics / health information disclosure — `[NONE]`
+
+**What it is.** `/health`, `/v1/health`, and `/metrics` are unauthenticated. They could leak adapter names, file paths, weights paths, or other internal detail.
+
+**Current state in kiln.** `/health` (`api/health.rs:62-183`) returns:
+- Status, version, uptime
+- Model id + layer/head/kv shape
+- Backend type ("mock" / "model")
+- Active adapter name (string only — no path)
+- Adapters-loaded *count* (no list, no paths)
+- Scheduler waiting/running/blocks counters
+- VRAM totals (no addresses, no model paths)
+- Active training job id + progress
+- Number of queued training jobs
+- A list of named health checks with pass/fail bools
+
+`/metrics` (`api/metrics.rs`) renders Prometheus text-exposition with the same numeric gauges plus a `kiln_active_adapter` label set to the active adapter name.
+
+What is **not** exposed: `adapter_dir` path, model weights path, config file path, env vars, GPU device id, any host filename, any tokenizer blob, any prompt content, any training-data content.
+
+**Risk.** Adapter names are user-set strings. An operator who names an adapter `temp/secret-product-codename-v3` will have that name show up in `/health`. That is the only meaningful disclosure surface, and it is operator-induced.
+
+**Severity:** NONE.
+
+---
+
+## 12. Cargo dependency policy — `[LOW]`
+
+**What it is.** Kiln has a `deny.toml` policy (MIT/Apache-compatible licenses, deny unknown registries / git sources, ban wildcard versions, fail on RUSTSEC advisories). CI enforces it via `EmbarkStudios/cargo-deny-action@v2` — see `.github/workflows/ci.yml:74-79`.
+
+**Current state in kiln.** The CI job pins a cargo-deny version that still understands the `unmaintained = "workspace"` key. Cargo-deny 0.16+ has **removed** that key (see PR EmbarkStudios/cargo-deny#611). Locally, on a current cargo-deny (0.16.4), the entire policy file fails to load:
+
+```
+$ cargo deny check
+error[deprecated]: this key has been removed, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for migration information
+   ┌─ /…/kiln/deny.toml:53:1
+   │
+53 │ unmaintained = "workspace"
+```
+
+So the CI-pinned version still works, but the policy file as written is on the deprecation cliff. Once the GitHub action updates its default cargo-deny, the policy stops being enforced.
+
+A second wrinkle: the local advisory-db at `~/.cargo/advisory-db` contains a CVSS:4.0 vector that older cargo-deny versions cannot parse (`unsupported CVSS version: 4.0`). This is unrelated to kiln but means local reproduction of advisory checks is unreliable; the canonical signal is the CI run.
+
+**Risk.** The license + advisory enforcement is real today. The policy is one cargo-deny update away from silently degrading.
+
+**Recommendation.** Migrate `unmaintained = "workspace"` to the new `[advisories.unmaintained]` shape per the cargo-deny migration guide. Pin the CI cargo-deny version explicitly so a future Embark-action default bump cannot break the policy without notice.
+
+**Severity:** LOW. Not a runtime risk; a CI-policy maintenance gap.
+
+---
+
+## Recommendations roadmap
+
+Ordered by severity, then by effort.
+
+### Must-fix before v0.1.0 (HIGH)
+
+1. **Adapter delete name validation** (§2b). Add `validate_adapter_name(&name)?;` as the first line of `delete_adapter` in `crates/kiln-server/src/api/adapters.rs` (currently line ~177). One line. Then add a test mirroring `test_upload_rejects_path_escape_in_archive`: `DELETE /v1/adapters/..` should 4xx and the parent of `adapter_dir` must still exist after.
+2. **Adapter load name validation** (§2c). Drop the `is_absolute()` branch in `load_adapter` (line 100). Always treat `req.name` as a single-segment identifier. Call `validate_adapter_name(&req.name)` first. Add a test for `POST /v1/adapters/load {"name": "/etc/passwd"}`.
+3. **Adapter merge source validation** (§2d). Call `validate_adapter_name(&src.name)` for each source in `merge_adapters`. Add a test.
+
+### Should-fix before v0.1.0 (MEDIUM)
+
+4. **Default listen on `127.0.0.1`** (§9). Change `config.rs:258` from `"0.0.0.0"` to `"127.0.0.1"`. Update `config.rs:680` (the test fixture) and any quickstart docs that show the old default. Optionally add the `allow_public_bind` opt-in.
+5. **Cap training queue depth** (§4). Add `training.max_queued_jobs` (default 32) and `training.max_tracked_jobs` (default 1024). Reject submissions over the cap with 503 + `Retry-After`. GC `Completed` / `Failed` entries in `state.training_jobs` after a TTL.
+6. **Cap adapter composition list length** (§6). Reject `adapters.len() > 16` per request with `invalid_compose_request`. Apply on both `/v1/chat/completions` and `/v1/completions/batch`.
+
+### Nice-to-have (LOW)
+
+7. **Per-route body-size limits** (§1). Set `DefaultBodyLimit` explicitly on `/v1/train/sft`, `/v1/train/grpo`, `/v1/chat/completions`, `/v1/completions/batch`.
+8. **Cap composed-adapter cache size** (§6, §8). LRU-evict `.composed/<hash>/` entries above N total or M GiB.
+9. **Cap total adapter-dir disk usage** (§8). Reject uploads that would push total adapter-dir size above `adapters.max_disk_bytes`.
+10. **Disable redirects on webhook reqwest client** (§7). Belt-and-suspenders against a misconfigured webhook URL pointing at a public 302.
+11. **Migrate `deny.toml`** (§12). Replace `unmaintained = "workspace"` with the post-PR-611 shape; pin the CI cargo-deny version explicitly.
+12. **Document training-data invariants** (§3). One short README section: "Kiln applies a faithful gradient update to whatever you POST. Treat your training corpus as security-sensitive."
+
+### Out of scope for v0.1
+
+- Built-in auth. The "behind a trusted proxy" deployment shape is the right one for v0.1; bringing auth in-tree is a v0.2+ conversation. The recommendation in §9 is enough to prevent the easy footgun.
+- Multi-tenant support. Kiln is single-tenant by design; adding per-tenant quotas is a much bigger feature than a hardening pass.
+
+---
+
+## Appendix: files cited
+
+- `crates/kiln-server/src/api/mod.rs` (router composition, CORS layer)
+- `crates/kiln-server/src/api/adapters.rs` (upload, download, load, unload, delete, merge)
+- `crates/kiln-server/src/api/completions.rs` (chat completions, batch, composition synthesis, SSE streaming)
+- `crates/kiln-server/src/api/training.rs` (SFT / GRPO submission, queue listing, cancel)
+- `crates/kiln-server/src/api/health.rs` (health response shape)
+- `crates/kiln-server/src/api/metrics.rs` (Prometheus exposition)
+- `crates/kiln-server/src/training_queue.rs` (queue + webhook firing)
+- `crates/kiln-server/src/state.rs` (AppState, webhook URL field, request lifecycle)
+- `crates/kiln-server/src/config.rs` (defaults: `host = "0.0.0.0"`, `request_timeout_secs = 300`, `webhook_url`)
+- `crates/kiln-server/src/main.rs` (webhook URL wiring)
+- `crates/kiln-server/tests/adapter_upload.rs` (`test_upload_rejects_path_escape_in_archive`)
+- `deny.toml` (license / source / advisory policy)
+- `.github/workflows/ci.yml` (cargo-deny CI enforcement)


### PR DESCRIPTION
## Summary

First formal security audit of the kiln-server HTTP API surface, fulfilling the Phase 9 release-prep checklist item *Security audit (no prompt injection in training, no DoS vectors)*.

Doc lands at [`docs/audits/security-audit-v0.1.md`](../blob/ce/phase9-security-audit-v0.1/docs/audits/security-audit-v0.1.md). README index at `docs/audits/README.md` updated with a new "Phase 9 (release prep)" section.

## Scope

All handlers under `crates/kiln-server/src/api/` plus `state.rs` and `training_queue.rs`. Twelve threat classes covered:

1. Request body size limits (`Json<T>` extractor caps)
2. Adapter upload / download / delete / load / merge path handling (zip-slip + name validation)
3. Training-data injection / prompt injection
4. DoS via training-queue exhaustion
5. DoS via batch generation
6. DoS via adapter composition stack
7. Webhook SSRF
8. Disk exhaustion via adapter uploads
9. Auth surface
10. Streaming / SSE backpressure
11. Metrics / health information disclosure
12. cargo-deny dependency policy

## Findings

| Severity | Count | Notes |
|----------|-------|-------|
| CRITICAL | 0 | — |
| **HIGH** | **1** | `DELETE /v1/adapters/:name` and `POST /v1/adapters/load` accept names that escape the adapter directory |
| MEDIUM | 3 | Unbounded training-job queue; per-request adapter-composition list has no length cap; default listen is `0.0.0.0` with no built-in auth |
| LOW | 4 | Per-route body-size limits absent on training/completions; on-disk composed-adapter cache unbounded; missing tests for delete/load name validation; `deny.toml` `unmaintained = "workspace"` removed in cargo-deny 0.16+ |
| NONE | 4 | Adapter upload zip-slip / tarbomb defenses solid; webhook URL is operator-controlled (not client-supplied); `/health` and `/metrics` expose no paths or secrets; SSE backpressure correctly bounded |

### Headline finding (HIGH)

`delete_adapter` (`crates/kiln-server/src/api/adapters.rs:177-216`) and `load_adapter` (`crates/kiln-server/src/api/adapters.rs:88-144`) both join a request-supplied `name` onto `state.adapter_dir` **without** calling `validate_adapter_name` (the helper at `adapters.rs:526-538` that *is* called by `download_adapter` and `upload_adapter`). `load_adapter` additionally has an explicit `Path::new(&req.name).is_absolute()` branch that takes the path verbatim. Concretely: `DELETE /v1/adapters/..` resolves at syscall time to the parent of `adapter_dir`, the `is_dir()` and active-adapter guards both pass, and `std::fs::remove_dir_all` runs on the parent. The fix is one `validate_adapter_name(&name)?;` call per endpoint plus dropping the `is_absolute()` branch from `load_adapter`. See §2 of the audit doc for the full chain and recommended tests.

## Recommendations roadmap

Ordered by severity in §"Recommendations roadmap" of the audit doc. The HIGH item is a one-liner per endpoint and should land before v0.1.0 along with two of the MEDIUMs (default listen on `127.0.0.1`, training-queue cap). Everything else is appropriate post-v0.1 hardening.

## Out of scope

- Built-in auth — kiln's deployment shape is "behind a trusted reverse proxy or on a private network." Bringing auth in-tree is a v0.2+ conversation.
- Multi-tenant support — kiln is single-tenant by design.
- Training-data semantics — kiln promises a faithful gradient update on whatever you POST; validating *content* of training examples is the user's pipeline concern, not kiln's.

## Verification

This is a doc-only PR. No code changes. Verify by reading `docs/audits/security-audit-v0.1.md` and the cited file:line references.