### PR TITLE
fix(security): validate adapter names in delete/load/merge handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security
+- Fix path traversal in `DELETE /v1/adapters/:name` and `POST /v1/adapters/load` (Phase 9 audit §2b/§2c, HIGH).
+- Validate source adapter names in `POST /v1/adapters/merge` (Phase 9 audit §2d, LOW).
+
 ### Reproducibility / release
 - docker: use `--locked` in `deploy/Dockerfile` cargo builds so the published `ghcr.io/ericflo/kiln-server` image matches the exact Cargo.lock dependency set (#601)
 

--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -89,6 +89,8 @@ async fn load_adapter(
     State(state): State<AppState>,
     Json(req): Json<LoadAdapterRequest>,
 ) -> Result<Json<LoadAdapterResponse>, ApiError> {
+    validate_adapter_name(&req.name)?;
+
     let runner = match state.backend.as_ref() {
         ModelBackend::Real { runner, .. } => runner,
         ModelBackend::Mock { .. } => {
@@ -96,12 +98,7 @@ async fn load_adapter(
         }
     };
 
-    // Resolve adapter path: if name is absolute, use it directly; otherwise look in adapter_dir.
-    let adapter_path = if Path::new(&req.name).is_absolute() {
-        std::path::PathBuf::from(&req.name)
-    } else {
-        state.adapter_dir.join(&req.name)
-    };
+    let adapter_path = state.adapter_dir.join(&req.name);
 
     if !adapter_path.exists() {
         return Err(ApiError::adapter_not_found(&req.name));
@@ -178,6 +175,7 @@ async fn delete_adapter(
     State(state): State<AppState>,
     AxumPath(name): AxumPath<String>,
 ) -> Result<Json<DeleteAdapterResponse>, ApiError> {
+    validate_adapter_name(&name)?;
     let adapter_path = state.adapter_dir.join(&name);
 
     if !adapter_path.exists() || !adapter_path.is_dir() {
@@ -407,6 +405,7 @@ async fn merge_adapters(
     let mut source_paths: Vec<(String, f32, std::path::PathBuf)> =
         Vec::with_capacity(req.sources.len());
     for src in &req.sources {
+        validate_adapter_name(&src.name)?;
         let path = state.adapter_dir.join(&src.name);
         if !path.exists() || !path.is_dir() {
             return Err(ApiError::adapter_not_found(&src.name));

--- a/crates/kiln-server/tests/adapter_path_traversal.rs
+++ b/crates/kiln-server/tests/adapter_path_traversal.rs
@@ -1,0 +1,230 @@
+//! Integration tests for path-traversal protections in the adapter
+//! HTTP handlers. Covers Phase 9 audit findings §2b (`DELETE /v1/adapters/:name`),
+//! §2c (`POST /v1/adapters/load`), and §2d (`POST /v1/adapters/merge`).
+//!
+//! Each handler must reject names that escape `adapter_dir` — `..`, segments
+//! containing `/` or `\`, and absolute paths — before touching the
+//! filesystem.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::json;
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::state::AppState;
+
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    vocab.insert("a".to_string(), 0);
+    vocab.insert("b".to_string(), 1);
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] }
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state(adapter_dir: std::path::PathBuf) -> AppState {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    let mut state = AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        test_tokenizer(),
+        300,
+        "qwen3.5-4b-kiln".to_string(),
+    );
+    state.adapter_dir = adapter_dir;
+    state
+}
+
+fn write_adapter(adapter_dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let path = adapter_dir.join(name);
+    std::fs::create_dir_all(&path).unwrap();
+    std::fs::write(
+        path.join("adapter_config.json"),
+        br#"{"r": 8, "lora_alpha": 16}"#,
+    )
+    .unwrap();
+    std::fs::write(
+        path.join("adapter_model.safetensors"),
+        b"\x00\x01\x02\x03fake-safetensors-bytes",
+    )
+    .unwrap();
+    path
+}
+
+async fn read_error_code(resp: axum::http::Response<Body>) -> (StatusCode, String) {
+    let status = resp.status();
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value =
+        serde_json::from_slice(&body).expect("error response must be JSON");
+    let code = json["error"]["code"]
+        .as_str()
+        .expect("error.code must be a string")
+        .to_string();
+    (status, code)
+}
+
+/// `DELETE /v1/adapters/..` (and a few other escape variants) must return a
+/// 4xx with `invalid_adapter_name`, must not call `remove_dir_all` on the
+/// adapter directory, and must not delete sibling directories.
+#[tokio::test]
+async fn test_delete_rejects_path_traversal() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Sentinel adapter directory the handler must NOT touch.
+    write_adapter(tmp.path(), "real-adapter");
+
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    // `..` is the canonical path-traversal name. Test it plus a couple of
+    // other traversal-shaped values that the validator should reject. URL-
+    // encode `/` and `\` so axum's path extractor matches the `{name}`
+    // segment instead of falling through to a different route.
+    let bad_names = ["..", ".", "%2E%2E", "foo%2Fbar", "%2Ftmp%2Ffoo"];
+
+    for bad in bad_names {
+        let uri = format!("/v1/adapters/{bad}");
+        let req = Request::builder()
+            .method("DELETE")
+            .uri(&uri)
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        let (status, code) = read_error_code(resp).await;
+        assert!(
+            status.is_client_error(),
+            "DELETE {uri} returned {status}, expected 4xx (code={code})"
+        );
+        assert_eq!(
+            code, "invalid_adapter_name",
+            "DELETE {uri} returned code {code}, expected invalid_adapter_name"
+        );
+    }
+
+    // The sentinel adapter and its files must still exist.
+    let sentinel = tmp.path().join("real-adapter");
+    assert!(sentinel.exists() && sentinel.is_dir());
+    assert!(sentinel.join("adapter_config.json").exists());
+    assert!(sentinel.join("adapter_model.safetensors").exists());
+}
+
+/// `POST /v1/adapters/load` with `name: ".."` must be rejected with
+/// `invalid_adapter_name` before touching any filesystem path. (Mock backend
+/// would otherwise return `mock_mode_no_adapters`; with validation in front
+/// the path-traversal name fails first.)
+#[tokio::test]
+async fn test_load_rejects_relative_path_traversal() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let body = serde_json::to_vec(&json!({ "name": ".." })).unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/load")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let (status, code) = read_error_code(resp).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "load with name='..' should return 400, got {status} (code={code})"
+    );
+    assert_eq!(code, "invalid_adapter_name");
+}
+
+/// `POST /v1/adapters/load` with an absolute path (e.g. `/tmp/foo`) must be
+/// rejected. The legacy "absolute paths bypass adapter_dir" branch was
+/// removed in this PR.
+#[tokio::test]
+async fn test_load_rejects_absolute_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let body = serde_json::to_vec(&json!({ "name": "/tmp/foo" })).unwrap();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/load")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let (status, code) = read_error_code(resp).await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "load with absolute path should return 400, got {status} (code={code})"
+    );
+    assert_eq!(code, "invalid_adapter_name");
+}
+
+/// `POST /v1/adapters/merge` with a source adapter name of `".."` (or other
+/// traversal-shaped names) must be rejected with `invalid_adapter_name`
+/// before any filesystem access. The existing `output_name` check handles
+/// the destination side; this test pins the source side.
+#[tokio::test]
+async fn test_merge_rejects_path_traversal_in_source_name() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    let bad_names = ["..", "/tmp/foo", "foo/bar", "foo\\bar"];
+    for bad in bad_names {
+        let body = serde_json::to_vec(&json!({
+            "sources": [{ "name": bad, "weight": 1.0 }],
+            "output_name": "merged-output",
+        }))
+        .unwrap();
+        let req = Request::builder()
+            .method("POST")
+            .uri("/v1/adapters/merge")
+            .header("content-type", "application/json")
+            .body(Body::from(body))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        let (status, code) = read_error_code(resp).await;
+        assert_eq!(
+            status,
+            StatusCode::BAD_REQUEST,
+            "merge with source name {bad:?} should return 400, got {status} (code={code})"
+        );
+        assert_eq!(
+            code, "invalid_adapter_name",
+            "merge with source name {bad:?} returned unexpected code {code}"
+        );
+    }
+
+    // Nothing should have been written to adapter_dir as a side effect.
+    let entries: Vec<_> = std::fs::read_dir(tmp.path()).unwrap().flatten().collect();
+    assert!(
+        entries.is_empty(),
+        "merge rejection must not create any files in adapter_dir"
+    );
+}


### PR DESCRIPTION
## What

Fix the path-handling findings from the just-merged Phase 9 security audit (PR #603, `docs/audits/security-audit-v0.1.md`). All three handlers now route through the same `validate_adapter_name()` guard that `download_adapter` and `upload_adapter` already use.

- §2b (HIGH): `DELETE /v1/adapters/{name}` no longer joins user-controlled `name` into `adapter_dir` before validating.
- §2c (HIGH): `POST /v1/adapters/load` rejects path-traversal names and absolute paths. The legacy "absolute paths bypass `adapter_dir`" branch is **removed** — `load` is now an identifier-only operation, mirroring how `download`/`upload`/`delete` already work.
- §2d (LOW): `POST /v1/adapters/merge` validates each `sources[i].name` before resolving it under `adapter_dir`. The existing inline check on `output_name` is unchanged.

## Why

Without the guard, these three endpoints accepted names like `..`, `foo/bar`, or `/etc/passwd`, which `state.adapter_dir.join(&name)` happily resolves to a path outside `adapter_dir`. `delete` would then `remove_dir_all` outside the adapter root; `load` would mmap a safetensors file from anywhere on disk; `merge` would read source weights from arbitrary paths. The single-tenant threat model in §1 of the audit doc still requires that an authenticated client can't escape the adapter root.

## Behavior change for valid names

None. Every existing valid adapter name (single segment, no `/`, no `\`, no `..`, not absolute) takes the same code path as before. The only behavior delta is on inputs the audit doc identifies as malicious: those now return `400 invalid_adapter_name` instead of touching the filesystem.

The one exception worth calling out: `POST /v1/adapters/load` with a literal absolute path body (e.g. `{"name": "/some/path/to/adapter"}`) used to load that path directly. That branch is now gone — clients must put the adapter under `adapter_dir` and pass the directory name. This matches how every other adapter endpoint already works and is what the upload/download/delete/merge surface area already enforces.

## Tests

New `crates/kiln-server/tests/adapter_path_traversal.rs`:

- `test_delete_rejects_path_traversal` — `DELETE /v1/adapters/..` (and `.`, `%2E%2E`, `%2Ffoo%2Fbar`, `%2Ftmp%2Ffoo`) returns 400 `invalid_adapter_name` and does not delete a sentinel adapter directory in the same `adapter_dir`.
- `test_load_rejects_relative_path_traversal` — `POST /v1/adapters/load` with `name: ".."` returns 400 `invalid_adapter_name`.
- `test_load_rejects_absolute_path` — `POST /v1/adapters/load` with `name: "/tmp/foo"` returns 400 `invalid_adapter_name`.
- `test_merge_rejects_path_traversal_in_source_name` — `POST /v1/adapters/merge` with source names `..`, `/tmp/foo`, `foo/bar`, `foo\bar` all return 400 `invalid_adapter_name` and write nothing to `adapter_dir`.

Style mirrors `crates/kiln-server/tests/adapter_upload.rs` (existing path-escape test) — same `make_state` / `write_adapter` helpers, same mock backend, same `oneshot` driving via `tower::ServiceExt`.

## Verification note

Sandbox cannot run `cargo test -p kiln-server` directly (musl host has no `openssl-sys` headers / `perl` for vendored OpenSSL — see agent note `kiln-sandbox-rust-tooling`). The change is mechanical: each handler gains a single `validate_adapter_name(...)?;` line at the top, against a function already shipped and proven by the existing `download`/`upload` paths and the `test_upload_rejects_invalid_name` test.

## CHANGELOG

Added under `## Unreleased` → `### Security`:

- Fix path traversal in `DELETE /v1/adapters/:name` and `POST /v1/adapters/load` (Phase 9 audit §2b/§2c, HIGH).
- Validate source adapter names in `POST /v1/adapters/merge` (Phase 9 audit §2d, LOW).