### PR TITLE
fix(security): default server listen on 127.0.0.1 (audit MEDIUM §9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Fix path traversal in `DELETE /v1/adapters/:name` and `POST /v1/adapters/load` (Phase 9 audit §2b/§2c, HIGH).
 - Validate source adapter names in `POST /v1/adapters/merge` (Phase 9 audit §2d, LOW).
 
+### Changed
+- Default server listen host changed from `0.0.0.0` to `127.0.0.1` (loopback). Set `server.host = "0.0.0.0"` or `KILN_HOST=0.0.0.0` to accept remote connections; pair with a trusted reverse proxy. Closes security-audit-v0.1 MEDIUM §9.
+
 ### Reproducibility / release
 - docker: use `--locked` in `deploy/Dockerfile` cargo builds so the published `ghcr.io/ericflo/kiln-server` image matches the exact Cargo.lock dependency set (#601)
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -111,12 +111,14 @@ You'll see the startup banner:
   CUDA:    available ✓
   GPU:     NVIDIA RTX A6000
   VRAM:    49140 MiB total, 48891 MiB free
-  Listen:  http://0.0.0.0:8420
+  Listen:  http://127.0.0.1:8420
 
   Endpoints: /v1/chat/completions, /v1/train/sft, /health, /metrics
 ```
 
 The `GPU` and `VRAM` lines come from `nvidia-smi` and are skipped silently if it isn't installed. If you launched with `--config kiln.toml`, a `Config:` line appears just below `Version:`.
+
+Kiln binds to loopback (`127.0.0.1`) by default so a fresh install isn't reachable from the network. To accept connections from other hosts, set `server.host = "0.0.0.0"` in your TOML config or `KILN_HOST=0.0.0.0` and put Kiln behind a trusted reverse proxy (auth is out of scope for v0.1).
 
 On Apple Silicon, Kiln auto-detects Metal and logs `Metal available — using Apple Silicon GPU` at startup instead of the CUDA availability line. No config changes needed — the binary selects the backend that was compiled in.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve
   CUDA:    available ✓
   GPU:     NVIDIA RTX A6000
   VRAM:    49140 MiB total, 48891 MiB free
-  Listen:  http://0.0.0.0:8420
+  Listen:  http://127.0.0.1:8420
 ```
 
 The `GPU` and `VRAM` lines come from `nvidia-smi` and are skipped silently if it isn't installed.

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -255,7 +255,7 @@ impl Default for KilnConfig {
 impl Default for ServerConfig {
     fn default() -> Self {
         Self {
-            host: "0.0.0.0".into(),
+            host: "127.0.0.1".into(),
             port: 8420,
             request_timeout_secs: 300,
             shutdown_timeout_secs: 30,
@@ -623,7 +623,7 @@ mod tests {
     #[test]
     fn test_defaults() {
         let config = KilnConfig::default();
-        assert_eq!(config.server.host, "0.0.0.0");
+        assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.server.port, 8420);
         assert_eq!(config.server.request_timeout_secs, 300);
         assert_eq!(config.server.shutdown_timeout_secs, 30);
@@ -735,7 +735,7 @@ port = 3000
 "#;
         let config: KilnConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.server.port, 3000);
-        assert_eq!(config.server.host, "0.0.0.0"); // default
+        assert_eq!(config.server.host, "127.0.0.1"); // default (loopback)
         assert_eq!(config.server.request_timeout_secs, 300); // default
         assert_eq!(config.model.model_id, "Qwen/Qwen3.5-4B"); // default
         assert_eq!(config.memory.inference_memory_fraction, 0.7); // default
@@ -957,7 +957,7 @@ level = "warn"
         let config = KilnConfig::load(Some(path.to_str().unwrap())).unwrap();
         assert_eq!(config.server.port, 5555);
         assert_eq!(config.logging.level, "warn");
-        assert_eq!(config.server.host, "0.0.0.0"); // default
+        assert_eq!(config.server.host, "127.0.0.1"); // default (loopback)
     }
 
     #[test]


### PR DESCRIPTION
Closes security-audit-v0.1 MEDIUM §9 (Auth surface) and recommendation #4 (Should-fix before v0.1.0).

## What
- `ServerConfig::default()` now binds to `127.0.0.1` instead of `0.0.0.0`.
- Three test-fixture asserts updated to match.
- QUICKSTART.md and README.md listen-banner examples updated.
- Short note added to QUICKSTART.md explaining how to opt into public binds (set `server.host` or `KILN_HOST` and put kiln behind a trusted reverse proxy).
- CHANGELOG.md `## Unreleased` gets a `### Changed` entry documenting the new default.

## Why
Per the v0.1 security audit (`docs/audits/security-audit-v0.1.md`), the previous `0.0.0.0` default is the easy footgun: a fresh install with no firewall reachable on the LAN exposes adapter management, training endpoints, and uncapped chat completions. Loopback by default is the conservative posture; users who want a remote listener must opt in (and pair with a trusted reverse proxy — auth is explicitly out of scope for v0.1).

## Test
- Intended local check: `cargo test -p kiln-server --lib config` to exercise the three default asserts.
- Sandbox limitation: Cloud Eric's musl host can't link `openssl-sys`, so `cargo check -p kiln-server` and the test binary both fail at link time on this machine (documented limitation). The edits are mechanical string replacements and the test asserts now match the new defaults exactly. CI runs the full suite on Linux + macOS + cargo-deny, which is the authoritative validation.

## Refs
- \`docs/audits/security-audit-v0.1.md\` §9, recommendation #4