### PR TITLE
fix(security): cap adapter composition list length (audit MEDIUM §6)

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -622,6 +622,13 @@ async fn chat_completions_inner(
                 "'adapters' must be a non-empty list when present",
             ));
         }
+        if list.len() > MAX_COMPOSE_ADAPTERS {
+            return Err(ApiError::invalid_compose_request(format!(
+                "'adapters' list length {} exceeds maximum of {}",
+                list.len(),
+                MAX_COMPOSE_ADAPTERS,
+            )));
+        }
         for src in list {
             validate_compose_name(&src.name)?;
         }
@@ -1831,6 +1838,13 @@ fn now_epoch() -> u64 {
 /// cannot pin the engine for an unbounded number of iterations.
 const BATCH_MAX_TOTAL_OUTPUTS: usize = 64;
 
+/// Maximum number of source adapters allowed in a single compose request
+/// (`adapters: [...]` on `/v1/chat/completions` and `/v1/completions/batch`).
+/// Caps the cheapest DoS shape from §6 of `docs/audits/security-audit-v0.1.md`:
+/// each entry triggers a safetensors read and an N-way `merge_concat`, so an
+/// unbounded list lets a single request pin CPU + I/O for arbitrarily long.
+const MAX_COMPOSE_ADAPTERS: usize = 16;
+
 /// Batch completion request — generate completions for many prompts (and/or
 /// many completions per prompt) in a single HTTP round-trip.
 ///
@@ -1971,6 +1985,13 @@ async fn batch_completions_inner(
             return Err(ApiError::invalid_compose_request(
                 "'adapters' must be a non-empty list when present",
             ));
+        }
+        if list.len() > MAX_COMPOSE_ADAPTERS {
+            return Err(ApiError::invalid_compose_request(format!(
+                "'adapters' list length {} exceeds maximum of {}",
+                list.len(),
+                MAX_COMPOSE_ADAPTERS,
+            )));
         }
         for src in list {
             validate_compose_name(&src.name)?;
@@ -2595,6 +2616,22 @@ mod tests {
         let body = serde_json::json!({
             "prompts": [[{"role":"user","content":"hi"}]],
             "adapters": []
+        })
+        .to_string();
+        let (status, body) = batch_post(make_batch_test_state(), &body).await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(body["error"]["code"], "invalid_compose_request");
+    }
+
+    #[tokio::test]
+    async fn batch_rejects_oversized_adapters_list() {
+        // 17 entries > MAX_COMPOSE_ADAPTERS (16) — caps audit MEDIUM §6 DoS.
+        let adapters: Vec<serde_json::Value> = (0..17)
+            .map(|_| serde_json::json!({"name": "a", "scale": 1.0}))
+            .collect();
+        let body = serde_json::json!({
+            "prompts": [[{"role":"user","content":"hi"}]],
+            "adapters": adapters,
         })
         .to_string();
         let (status, body) = batch_post(make_batch_test_state(), &body).await;

--- a/crates/kiln-server/tests/adapter_compose.rs
+++ b/crates/kiln-server/tests/adapter_compose.rs
@@ -320,6 +320,35 @@ async fn test_compose_endpoint_rejects_empty_list() {
     assert_eq!(parsed["error"]["code"], "invalid_compose_request");
 }
 
+/// `adapters` list with more than `MAX_COMPOSE_ADAPTERS` (16) entries is a
+/// 400. Caps the cheapest DoS shape from §6 of the v0.1 security audit:
+/// without this cap a single request could trigger N safetensors reads + an
+/// N-way `merge_concat` for arbitrarily large N.
+#[tokio::test]
+async fn test_compose_endpoint_rejects_oversized_list() {
+    let tmp = tempfile::tempdir().unwrap();
+    let state = make_state(tmp.path().to_path_buf());
+    let app = api::router(state);
+
+    // 17 entries > cap (16). Names need not point at real adapters — the cap
+    // check runs before any disk lookup, so the request is rejected purely
+    // on shape.
+    let entries: Vec<Value> = (0..17)
+        .map(|_| json!({ "name": "a", "scale": 1.0 }))
+        .collect();
+    let resp = app
+        .clone()
+        .oneshot(chat_with_adapters(json!(entries)))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let parsed: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(parsed["error"]["code"], "invalid_compose_request");
+}
+
 /// Missing source adapter surfaces as 404.
 #[tokio::test]
 async fn test_compose_endpoint_404_when_source_missing() {


### PR DESCRIPTION
## What
Adds `MAX_COMPOSE_ADAPTERS = 16` cap on `adapters.len()` for `/v1/chat/completions` and `/v1/completions/batch`. Requests above the cap return 400 with `invalid_compose_request` before any safetensors read or `merge_concat` runs.

## Why
Closes audit MEDIUM finding §6 (DoS via adapter composition stack — see `docs/audits/security-audit-v0.1.md` lines 182-199). A request with 1,000 source adapters would trigger 1,000 safetensors reads + a 1,000-way `merge_concat`, pinning CPU + I/O for arbitrarily long. The cap is applied early in `chat_completions_inner` and `batch_completions_inner`, between the existing empty-list and per-name validation, so it short-circuits before any disk work.

## Tests
- `chat_completions` rejects a 17-entry list with 400 + `invalid_compose_request` (integration test in `crates/kiln-server/tests/adapter_compose.rs::test_compose_endpoint_rejects_oversized_list`)
- `batch_completions` rejects a 17-entry list with 400 + `invalid_compose_request` (unit test in `crates/kiln-server/src/api/completions.rs::tests::batch_rejects_oversized_adapters_list`)

Local build verification was attempted but the Cloud Eric sandbox cannot link kiln-server's openssl-sys (musl + missing libssl-dev — see note \`kiln-server-no-local-build-on-cloud-eric\`). Trusting kiln CI for full compile + test.

## Audit progress
HIGH: ✅ all closed in #604. MEDIUM: ✅ §9 (#605), ✅ §6 (this PR). Remaining MEDIUM: §4 (training queue cap).