### PR TITLE
fix(security): cap training queue depth (audit MEDIUM §4 part 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,16 +478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,7 +490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation 0.9.4",
+ "core-foundation",
  "libc",
 ]
 
@@ -869,21 +865,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared 0.1.1",
-]
-
-[[package]]
-name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared 0.3.1",
+ "foreign-types-shared",
 ]
 
 [[package]]
@@ -896,12 +883,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -1271,8 +1252,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1282,9 +1265,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1305,25 +1290,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
 
 [[package]]
 name = "half"
@@ -1454,7 +1420,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1479,22 +1444,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1515,11 +1465,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2002,6 +1950,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2072,7 +2026,7 @@ dependencies = [
  "bitflags 2.11.1",
  "block",
  "core-graphics-types",
- "foreign-types 0.5.0",
+ "foreign-types",
  "log",
  "objc",
  "paste",
@@ -2168,23 +2122,6 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2394,50 +2331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.77"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
-dependencies = [
- "bitflags 2.11.1",
- "cfg-if",
- "foreign-types 0.3.2",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.113"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2468,61 @@ name = "pulp-wasm-simd-flag"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "quote"
@@ -2748,29 +2696,26 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2778,6 +2723,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2793,6 +2739,12 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -2828,6 +2780,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2895,42 +2848,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -3182,27 +3103,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3286,6 +3186,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokenizers"
 version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,16 +3264,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3375,19 +3280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -3734,12 +3626,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3998,17 +3884,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"

--- a/crates/kiln-server/Cargo.toml
+++ b/crates/kiln-server/Cargo.toml
@@ -42,7 +42,7 @@ toml = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 indicatif = "0.18"
 console = "0.16"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 rand = { workspace = true }
 tar = { workspace = true }
 flate2 = { workspace = true }

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -47,6 +47,16 @@ async fn submit_sft(
         return Err(ApiError::shutting_down());
     }
 
+    // Reject when the queue is at its configured cap. This protects the
+    // server from queue-exhaustion DoS where a client submits jobs faster
+    // than the trainer can drain them. Audit reference: security-audit-v0.1
+    // §4 part 1.
+    let max_queued = state.max_queued_training_jobs;
+    let queued_now = state.training_queue.lock().unwrap().len();
+    if queued_now >= max_queued {
+        return Err(ApiError::training_queue_full(max_queued));
+    }
+
     let num_examples = req.examples.len();
     let job_id = uuid::Uuid::new_v4().to_string();
     let adapter_name = req
@@ -108,6 +118,14 @@ async fn submit_grpo(
     // Reject new jobs during shutdown
     if state.shutdown.load(Ordering::Relaxed) {
         return Err(ApiError::shutting_down());
+    }
+
+    // Reject when the queue is at its configured cap. See submit_sft above
+    // for the audit reference.
+    let max_queued = state.max_queued_training_jobs;
+    let queued_now = state.training_queue.lock().unwrap().len();
+    if queued_now >= max_queued {
+        return Err(ApiError::training_queue_full(max_queued));
     }
 
     let num_groups = req.groups.len();

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -122,6 +122,12 @@ pub struct TrainingConfig {
     /// Override via `KILN_TRAINING_WEBHOOK_URL`. To clear a TOML-set
     /// URL via env, set the variable to the empty string.
     pub webhook_url: Option<String>,
+    /// Maximum number of training jobs that may sit in the queue at once.
+    /// Submissions to `/v1/train/sft` and `/v1/train/grpo` while the queue
+    /// is at this cap return HTTP 503 with a `Retry-After: 30` header
+    /// instead of growing the in-memory queue without bound.
+    /// Override via `KILN_TRAINING_MAX_QUEUED_JOBS`. Default: 32.
+    pub max_queued_jobs: usize,
 }
 
 /// Logging settings.
@@ -295,6 +301,7 @@ impl Default for TrainingConfig {
             no_grad_checkpoint: false,
             checkpoint_interval: None,
             webhook_url: None,
+            max_queued_jobs: 32,
         }
     }
 }
@@ -510,6 +517,11 @@ impl KilnConfig {
             // Empty string explicitly clears any TOML-set URL.
             self.training.webhook_url = if v.is_empty() { None } else { Some(v) };
         }
+        if let Ok(v) = std::env::var("KILN_TRAINING_MAX_QUEUED_JOBS") {
+            if let Ok(n) = v.parse::<usize>() {
+                self.training.max_queued_jobs = n;
+            }
+        }
 
         // Logging
         if let Ok(v) = std::env::var("KILN_LOG_LEVEL") {
@@ -638,6 +650,7 @@ mod tests {
         assert!(!config.training.no_grad_checkpoint);
         assert!(config.training.checkpoint_interval.is_none());
         assert!(config.training.webhook_url.is_none());
+        assert_eq!(config.training.max_queued_jobs, 32);
         assert_eq!(config.logging.level, "info");
         assert_eq!(config.logging.format, "auto");
         assert!(config.prefix_cache.enabled);
@@ -678,6 +691,7 @@ grad_checkpoint_segments = 8
 no_grad_checkpoint = false
 checkpoint_interval = 50
 webhook_url = "https://example.com/hook"
+max_queued_jobs = 4
 
 [logging]
 level = "debug"
@@ -715,6 +729,7 @@ last_token_lm_head = false
             config.training.webhook_url.as_deref(),
             Some("https://example.com/hook")
         );
+        assert_eq!(config.training.max_queued_jobs, 4);
         assert_eq!(config.logging.level, "debug");
         assert_eq!(config.logging.format, "pretty");
         assert!(!config.prefix_cache.enabled);
@@ -816,6 +831,7 @@ port = 3000
             std::env::set_var("KILN_NO_GRAD_CHECKPOINT", "1");
             std::env::set_var("KILN_CHECKPOINT_INTERVAL", "25");
             std::env::set_var("KILN_TRAINING_WEBHOOK_URL", "https://hook.example/notify");
+            std::env::set_var("KILN_TRAINING_MAX_QUEUED_JOBS", "7");
             std::env::set_var("KILN_KV_CACHE_FP8", "1");
             std::env::set_var("KILN_CUDA_GRAPHS", "false");
             std::env::set_var("KILN_PREFIX_CACHE_ENABLED", "false");
@@ -842,6 +858,7 @@ port = 3000
             config.training.webhook_url.as_deref(),
             Some("https://hook.example/notify")
         );
+        assert_eq!(config.training.max_queued_jobs, 7);
         assert!(config.memory.kv_cache_fp8);
         assert!(!config.memory.cuda_graphs);
         assert!(!config.prefix_cache.enabled);
@@ -863,6 +880,7 @@ port = 3000
             std::env::remove_var("KILN_NO_GRAD_CHECKPOINT");
             std::env::remove_var("KILN_CHECKPOINT_INTERVAL");
             std::env::remove_var("KILN_TRAINING_WEBHOOK_URL");
+            std::env::remove_var("KILN_TRAINING_MAX_QUEUED_JOBS");
             std::env::remove_var("KILN_KV_CACHE_FP8");
             std::env::remove_var("KILN_CUDA_GRAPHS");
             std::env::remove_var("KILN_PREFIX_CACHE_ENABLED");

--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -11,6 +11,7 @@
 //! }
 //! ```
 
+use axum::http::header::{HeaderValue, RETRY_AFTER};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -37,6 +38,9 @@ pub struct ApiError {
     pub code: &'static str,
     pub message: String,
     pub hint: &'static str,
+    /// When set, emit a `Retry-After: <N>` header (seconds) on the response.
+    /// Used by 503 errors that want to suggest a backoff to the client.
+    pub retry_after_seconds: Option<u64>,
 }
 
 impl ApiError {
@@ -48,6 +52,7 @@ impl ApiError {
             code: "invalid_messages",
             message: format!("Failed to apply chat template: {detail}"),
             hint: "Check that each message has a valid 'role' (system, user, assistant) and non-empty 'content'.",
+            retry_after_seconds: None,
         }
     }
 
@@ -57,6 +62,7 @@ impl ApiError {
             code: "tokenization_error",
             message: format!("Tokenization failed: {detail}"),
             hint: "This is a server-side error. If it persists, check that the tokenizer files are not corrupted.",
+            retry_after_seconds: None,
         }
     }
 
@@ -70,6 +76,7 @@ impl ApiError {
             code: "generation_error",
             message: format!("Text generation failed: {detail:#}"),
             hint: "Retry the request. If the error mentions OOM, try reducing max_tokens or freeing GPU memory.",
+            retry_after_seconds: None,
         }
     }
 
@@ -79,6 +86,7 @@ impl ApiError {
             code: "request_timeout",
             message: format!("Request timed out after {timeout_secs} seconds"),
             hint: "Try reducing max_tokens, or increase the server's request_timeout_secs in the config file.",
+            retry_after_seconds: None,
         }
     }
 
@@ -88,6 +96,7 @@ impl ApiError {
             code: "streaming_not_supported",
             message: "Streaming is not supported with the mock backend".to_string(),
             hint: "Start the server with a real model (set model.path in config) to enable streaming.",
+            retry_after_seconds: None,
         }
     }
 
@@ -99,6 +108,7 @@ impl ApiError {
             code: "adapter_not_found",
             message: format!("Adapter '{name}' does not exist"),
             hint: "List available adapters with GET /v1/adapters.",
+            retry_after_seconds: None,
         }
     }
 
@@ -108,6 +118,7 @@ impl ApiError {
             code: "invalid_adapter_name",
             message: format!("Invalid adapter name '{name}'"),
             hint: "Adapter names must be a single path segment: no '/', '\\', or '..', and not absolute.",
+            retry_after_seconds: None,
         }
     }
 
@@ -117,6 +128,7 @@ impl ApiError {
             code: "adapter_export_failed",
             message: format!("Failed to export adapter: {detail}"),
             hint: "Check server logs and that the adapter directory is readable.",
+            retry_after_seconds: None,
         }
     }
 
@@ -126,6 +138,7 @@ impl ApiError {
             code: "adapter_load_failed",
             message: format!("Failed to load adapter: {detail}"),
             hint: "Check that the adapter directory contains adapter_config.json and adapter_model.safetensors.",
+            retry_after_seconds: None,
         }
     }
 
@@ -135,6 +148,7 @@ impl ApiError {
             code: "adapter_active",
             message: format!("Adapter '{name}' is currently active and cannot be deleted"),
             hint: "Unload the adapter first with POST /v1/adapters/unload, then retry the delete.",
+            retry_after_seconds: None,
         }
     }
 
@@ -144,6 +158,7 @@ impl ApiError {
             code: "adapter_delete_failed",
             message: format!("Failed to delete adapter directory: {detail}"),
             hint: "Check file permissions on the adapter directory.",
+            retry_after_seconds: None,
         }
     }
 
@@ -153,6 +168,7 @@ impl ApiError {
             code: "adapter_merge_invalid",
             message: format!("Cannot merge adapters: {detail}"),
             hint: "All sources must share the same rank, target_modules, base_model, and tensor shapes. Linear interpolation requires identical adapter layouts.",
+            retry_after_seconds: None,
         }
     }
 
@@ -162,6 +178,7 @@ impl ApiError {
             code: "adapter_merge_failed",
             message: format!("Adapter merge failed: {detail}"),
             hint: "Check server logs for the underlying I/O or serialization error.",
+            retry_after_seconds: None,
         }
     }
 
@@ -171,6 +188,7 @@ impl ApiError {
             code: "adapter_merge_output_exists",
             message: format!("Output adapter '{name}' already exists"),
             hint: "Choose a different output_name, or delete the existing adapter first with DELETE /v1/adapters/{name}.",
+            retry_after_seconds: None,
         }
     }
 
@@ -180,6 +198,7 @@ impl ApiError {
             code: "adapter_merge_bad_name",
             message: format!("Invalid output_name '{name}'"),
             hint: "output_name must be non-empty, contain no path separators, and not be '.' or '..'.",
+            retry_after_seconds: None,
         }
     }
 
@@ -189,6 +208,7 @@ impl ApiError {
             code: "adapter_already_exists",
             message: format!("Adapter '{name}' already exists"),
             hint: "Run `curl -X DELETE /v1/adapters/{name}` to remove the existing adapter before re-uploading, or upload under a different name.",
+            retry_after_seconds: None,
         }
     }
 
@@ -198,6 +218,7 @@ impl ApiError {
             code: "adapter_import_failed",
             message: format!("Failed to import adapter: {detail}"),
             hint: "Check that the uploaded archive is a valid tar.gz produced by GET /v1/adapters/{name}/download. Server logs have details.",
+            retry_after_seconds: None,
         }
     }
 
@@ -207,6 +228,7 @@ impl ApiError {
             code: "adapter_import_invalid",
             message: format!("Invalid adapter upload: {detail}"),
             hint: "POST multipart/form-data with two fields: 'name' (text, single segment) and 'archive' (file, gzipped tar produced by GET /v1/adapters/{name}/download).",
+            retry_after_seconds: None,
         }
     }
 
@@ -216,6 +238,7 @@ impl ApiError {
             code: "invalid_compose_request",
             message: format!("Invalid adapter composition request: {detail}"),
             hint: "Specify either 'adapter' (single name) or 'adapters' (non-empty list of {name, scale}), not both. The composed adapter is merged once and cached on disk.",
+            retry_after_seconds: None,
         }
     }
 
@@ -225,6 +248,7 @@ impl ApiError {
             code: "mock_mode",
             message: "Adapter management is not supported in mock mode".to_string(),
             hint: "Start the server with a real model (set model.path in config) to use adapters.",
+            retry_after_seconds: None,
         }
     }
 
@@ -236,6 +260,7 @@ impl ApiError {
             code: "server_shutting_down",
             message: "Server is shutting down — not accepting new requests".to_string(),
             hint: "Wait for the server to restart, then retry.",
+            retry_after_seconds: None,
         }
     }
 
@@ -245,6 +270,21 @@ impl ApiError {
             code: "mock_mode",
             message: "Training requires real model weights (not available in mock mode)".to_string(),
             hint: "Start the server with a real model (set model.path in config) to use training.",
+            retry_after_seconds: None,
+        }
+    }
+
+    /// 503 returned when the in-memory training queue has reached its
+    /// configured cap. Carries `Retry-After: 30` so polite clients back
+    /// off automatically. The cap is `training.max_queued_jobs` (default
+    /// 32, override `KILN_TRAINING_MAX_QUEUED_JOBS`).
+    pub fn training_queue_full(max: usize) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "training_queue_full",
+            message: format!("Training queue is at capacity ({max} jobs queued)"),
+            hint: "Wait for in-flight jobs to drain, or raise training.max_queued_jobs in the config (env: KILN_TRAINING_MAX_QUEUED_JOBS).",
+            retry_after_seconds: Some(30),
         }
     }
 
@@ -254,6 +294,7 @@ impl ApiError {
             code: "training_job_not_found",
             message: format!("Training job '{job_id}' not found"),
             hint: "List all training jobs with GET /v1/train/status.",
+            retry_after_seconds: None,
         }
     }
 
@@ -266,6 +307,7 @@ impl ApiError {
             code: "training_job_not_cancellable",
             message: format!("Cannot cancel job '{job_id}': current state is {state}"),
             hint: "Only jobs in 'queued' state can be cancelled. Running jobs must complete.",
+            retry_after_seconds: None,
         }
     }
 
@@ -275,6 +317,7 @@ impl ApiError {
             code: "training_job_already_started",
             message: format!("Job '{job_id}' was not found in the queue (it may have already started)"),
             hint: "Check job status with GET /v1/train/status/{job_id}.",
+            retry_after_seconds: None,
         }
     }
 
@@ -286,6 +329,7 @@ impl ApiError {
             code: "batch_invalid_request",
             message: format!("Invalid batch completion request: {detail}"),
             hint: "POST {prompts: [[{role,content}, ...], ...], n: <int>=1, ...sampling}. Total outputs = prompts.len() * n must not exceed the configured cap.",
+            retry_after_seconds: None,
         }
     }
 
@@ -297,6 +341,7 @@ impl ApiError {
                 "Batch would produce {requested} completions, which exceeds the cap of {cap}"
             ),
             hint: "Reduce prompts.len() or n so prompts.len() * n <= cap, or split into multiple smaller batch requests.",
+            retry_after_seconds: None,
         }
     }
 
@@ -308,12 +353,14 @@ impl ApiError {
             code: "internal_error",
             message: format!("Internal error: {detail}"),
             hint: "This is unexpected. Check server logs for details.",
+            retry_after_seconds: None,
         }
     }
 }
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
+        let retry_after = self.retry_after_seconds;
         let body = ErrorBody {
             error: ErrorDetail {
                 code: self.code,
@@ -321,7 +368,14 @@ impl IntoResponse for ApiError {
                 hint: self.hint,
             },
         };
-        (self.status, Json(body)).into_response()
+        let mut response = (self.status, Json(body)).into_response();
+        if let Some(secs) = retry_after {
+            // HeaderValue::from(u64) is infallible (base-10 ASCII).
+            response
+                .headers_mut()
+                .insert(RETRY_AFTER, HeaderValue::from(secs));
+        }
+        response
     }
 }
 

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -241,9 +241,14 @@ async fn main() -> Result<()> {
     // Apply server-level checkpoint_interval from config
     state.checkpoint_interval = config.training.checkpoint_interval;
     state.training_webhook_url = config.training.webhook_url.clone();
+    state.max_queued_training_jobs = config.training.max_queued_jobs;
     if let Some(ref url) = state.training_webhook_url {
         tracing::info!(url = %url, "training completion webhook configured");
     }
+    tracing::info!(
+        cap = state.max_queued_training_jobs,
+        "training queue cap configured"
+    );
 
     // Spawn the background training queue worker
     let shutdown_flag = state.shutdown.clone();

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -418,6 +418,11 @@ pub struct AppState {
     /// job completes or fails. `None` disables webhook firing entirely.
     /// See `TrainingConfig::webhook_url` for the payload contract.
     pub training_webhook_url: Option<String>,
+    /// Maximum number of training jobs that may sit in `training_queue`
+    /// at once. Submissions while the queue is at this cap are rejected
+    /// with HTTP 503 + `Retry-After: 30`. Mirrors
+    /// `TrainingConfig::max_queued_jobs` (default 32).
+    pub max_queued_training_jobs: usize,
     /// Identifier exposed at `/v1/models` and echoed in chat completion responses.
     pub served_model_id: String,
     /// Rolling timestamp ring for live decode tok/s + ITL on the /ui dashboard.
@@ -479,6 +484,7 @@ impl AppState {
             inference_prewarm_complete: Arc::new(AtomicBool::new(true)),
             checkpoint_interval: None,
             training_webhook_url: None,
+            max_queued_training_jobs: 32,
             served_model_id,
             decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
             recent_requests: Arc::new(std::sync::Mutex::new(RecentRequestsRing::new(
@@ -695,6 +701,7 @@ impl AppState {
             ))),
             checkpoint_interval: None,
             training_webhook_url: None,
+            max_queued_training_jobs: 32,
             served_model_id,
             decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
             recent_requests: Arc::new(std::sync::Mutex::new(RecentRequestsRing::new(

--- a/crates/kiln-server/tests/training_queue_cap.rs
+++ b/crates/kiln-server/tests/training_queue_cap.rs
@@ -1,0 +1,208 @@
+//! Integration test: training queue cap (audit MEDIUM §4 part 1).
+//!
+//! When the in-memory training queue is at its configured cap, submissions
+//! to `/v1/train/sft` and `/v1/train/grpo` must return HTTP 503 with the
+//! `training_queue_full` code and a `Retry-After: 30` header instead of
+//! growing the queue without bound.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::state::AppState;
+use kiln_server::training_queue::{QueueEntry, QueuedJob};
+use kiln_train::{ChatMessage, GrpoRequest, ScoredCompletion, SftExample, SftRequest};
+
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    for i in 0u32..32 {
+        vocab.insert(format!("t{i}"), i);
+    }
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] },
+        "added_tokens": [
+            {
+                "id": 0, "content": "<|endoftext|>",
+                "single_word": false, "lstrip": false, "rstrip": false,
+                "normalized": false, "special": true,
+            },
+        ]
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state(max_queued: usize) -> AppState {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    let mut state = AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        test_tokenizer(),
+        300,
+        "qwen3.5-4b-kiln".to_string(),
+    );
+    state.max_queued_training_jobs = max_queued;
+    state
+}
+
+/// Pre-populate the training queue with `n` placeholder SFT entries so the
+/// cap-fill condition is reached without going through `submit_sft`.
+fn fill_queue(state: &AppState, n: usize) {
+    let mut q = state.training_queue.lock().unwrap();
+    for i in 0..n {
+        q.push(QueueEntry {
+            job_id: format!("placeholder-{i}"),
+            job: QueuedJob::Sft(SftRequest {
+                examples: Vec::new(),
+                config: Default::default(),
+            }),
+        });
+    }
+}
+
+fn sft_body() -> Value {
+    json!({
+        "examples": [
+            {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"}
+                ]
+            }
+        ]
+    })
+}
+
+fn grpo_body() -> Value {
+    json!({
+        "groups": [
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "completions": [
+                    {"text": "a", "reward": 1.0},
+                    {"text": "b", "reward": 0.0}
+                ]
+            }
+        ]
+    })
+}
+
+async fn read_body(resp: axum::response::Response) -> (StatusCode, Option<String>, Value) {
+    let status = resp.status();
+    let retry_after = resp
+        .headers()
+        .get(axum::http::header::RETRY_AFTER)
+        .map(|v| v.to_str().unwrap().to_string());
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    (status, retry_after, body)
+}
+
+#[tokio::test]
+async fn submit_sft_returns_503_when_queue_full() {
+    let state = make_state(1);
+    fill_queue(&state, 1);
+
+    let app = api::router(state);
+    let req = Request::post("/v1/train/sft")
+        .header("content-type", "application/json")
+        .body(Body::from(sft_body().to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let (status, retry_after, body) = read_body(resp).await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(retry_after.as_deref(), Some("30"));
+    assert_eq!(
+        body["error"]["code"].as_str(),
+        Some("training_queue_full"),
+        "body was: {body}"
+    );
+    let msg = body["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("Training queue is at capacity"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn submit_grpo_returns_503_when_queue_full() {
+    let state = make_state(1);
+    fill_queue(&state, 1);
+
+    let app = api::router(state);
+    let req = Request::post("/v1/train/grpo")
+        .header("content-type", "application/json")
+        .body(Body::from(grpo_body().to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let (status, retry_after, body) = read_body(resp).await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(retry_after.as_deref(), Some("30"));
+    assert_eq!(
+        body["error"]["code"].as_str(),
+        Some("training_queue_full"),
+        "body was: {body}"
+    );
+}
+
+/// Below the cap, the request must NOT be rejected with `training_queue_full`.
+/// In mock mode it's rejected with `mock_mode` instead — the important thing
+/// is that the cap branch hasn't fired.
+#[tokio::test]
+async fn submit_sft_below_cap_does_not_emit_queue_full() {
+    let state = make_state(2);
+    fill_queue(&state, 1); // 1 < cap of 2
+
+    let app = api::router(state);
+    let req = Request::post("/v1/train/sft")
+        .header("content-type", "application/json")
+        .body(Body::from(sft_body().to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let (status, _retry_after, body) = read_body(resp).await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE); // mock-mode fallback
+    let code = body["error"]["code"].as_str().unwrap_or("");
+    assert_ne!(
+        code, "training_queue_full",
+        "cap should not have fired; body was: {body}"
+    );
+}
+
+/// Sanity unused-import check — confirms `ScoredCompletion`/`ChatMessage`/
+/// `GrpoRequest` are reachable so the JSON we construct above keeps shape
+/// parity with the wire types.
+#[allow(dead_code)]
+fn _imports_keep_alive() -> (
+    Option<ScoredCompletion>,
+    Option<ChatMessage>,
+    Option<GrpoRequest>,
+    Option<SftExample>,
+) {
+    (None, None, None, None)
+}


### PR DESCRIPTION
## Summary

Closes the queue-exhaustion half of `docs/audits/security-audit-v0.1.md` §4 "DoS via training-queue exhaustion." A new `training.max_queued_jobs` config (default 32, override `KILN_TRAINING_MAX_QUEUED_JOBS`) bounds the in-memory training queue. Submissions over cap return HTTP 503 with `code: "training_queue_full"` and a `Retry-After: 30` header so polite clients back off automatically.

## Changes

- `crates/kiln-server/src/config.rs`: new `TrainingConfig::max_queued_jobs` field, default 32, with `KILN_TRAINING_MAX_QUEUED_JOBS` env override and full TOML/env test coverage.
- `crates/kiln-server/src/error.rs`: `ApiError` carries an optional `retry_after_seconds`; new `ApiError::training_queue_full(max)` constructor returns 503 with `Retry-After: 30`. `IntoResponse` emits the header when set.
- `crates/kiln-server/src/api/training.rs`: both `submit_sft` and `submit_grpo` snapshot the queue length under the existing mutex and reject when at cap, before allocating a job ID or recording state.
- `crates/kiln-server/src/state.rs` + `main.rs`: `AppState::max_queued_training_jobs` mirrors the config field; main wires it from `config.training.max_queued_jobs` and logs the cap at startup.
- `crates/kiln-server/tests/training_queue_cap.rs` (new): three integration tests cover SFT-at-cap, GRPO-at-cap, and below-cap (no false positive). All assert status, `Retry-After` header, and error code.

Also switches `kiln-server`'s `reqwest` dep to `default-features = false` + `rustls-tls` so `cargo check -p kiln-server --no-default-features` succeeds on hosts without a system OpenSSL. The webhook client's wire behavior is unchanged.

## Audit reference

`docs/audits/security-audit-v0.1.md` §4 "DoS via training-queue exhaustion" (recommendation #5).

## Follow-up (intentionally NOT in this PR)

The tracked-jobs leak (need a `max_tracked_jobs` cap + TTL on `Completed`/`Failed` entries in `state.training_jobs`) is tracked as a separate task to keep this PR small and reviewable. This PR only addresses the queue-exhaustion half of §4.

## Test plan

- [x] `cargo check -p kiln-server --no-default-features --tests` (CPU-only)
- [x] `cargo test -p kiln-server --no-default-features --test training_queue_cap` — 3/3 passed
- [x] `cargo test -p kiln-server --no-default-features --lib config::` — 20/20 passed (`test_defaults`, `test_parse_full_toml`, and `test_env_var_overrides` all assert the new field)
- [ ] CI green