### PR TITLE
fix(security): cap tracked-jobs map and TTL Completed/Failed entries (audit MEDIUM §4 part 2)

### DIFF
--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -57,6 +57,16 @@ async fn submit_sft(
         return Err(ApiError::training_queue_full(max_queued));
     }
 
+    // Reject when the tracking map is at its configured cap. The training
+    // worker GC's terminal entries on a TTL, but a flood of `Completed` /
+    // `Failed` entries could still pin the map and exhaust memory. Audit
+    // reference: security-audit-v0.1 §4 part 2.
+    let max_tracked = state.max_tracked_jobs;
+    let tracked_now = state.training_jobs.read().unwrap().len();
+    if tracked_now >= max_tracked {
+        return Err(ApiError::training_tracked_full(max_tracked));
+    }
+
     let num_examples = req.examples.len();
     let job_id = uuid::Uuid::new_v4().to_string();
     let adapter_name = req
@@ -85,6 +95,7 @@ async fn submit_sft(
         adapter_path: None,
         submitted_at: std::time::Instant::now(),
         auto_load,
+        finished_at: None,
     };
     state
         .training_jobs
@@ -128,6 +139,14 @@ async fn submit_grpo(
         return Err(ApiError::training_queue_full(max_queued));
     }
 
+    // Reject when the tracking map is at its configured cap. See submit_sft
+    // above for the audit reference (security-audit-v0.1 §4 part 2).
+    let max_tracked = state.max_tracked_jobs;
+    let tracked_now = state.training_jobs.read().unwrap().len();
+    if tracked_now >= max_tracked {
+        return Err(ApiError::training_tracked_full(max_tracked));
+    }
+
     let num_groups = req.groups.len();
     let total_completions: usize = req.groups.iter().map(|g| g.completions.len()).sum();
     let job_id = uuid::Uuid::new_v4().to_string();
@@ -157,6 +176,7 @@ async fn submit_grpo(
         adapter_path: None,
         submitted_at: std::time::Instant::now(),
         auto_load,
+        finished_at: None,
     };
     state
         .training_jobs
@@ -308,6 +328,7 @@ async fn cancel_queued_job(
             let jt = jobs.get(&job_id).map(|j| j.job_type);
             if let Some(job) = jobs.get_mut(&job_id) {
                 job.state = TrainingState::Failed;
+                job.finished_at = Some(std::time::Instant::now());
             }
             jt
         };

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -128,6 +128,22 @@ pub struct TrainingConfig {
     /// instead of growing the in-memory queue without bound.
     /// Override via `KILN_TRAINING_MAX_QUEUED_JOBS`. Default: 32.
     pub max_queued_jobs: usize,
+    /// Maximum number of tracked training jobs (queued, running, completed,
+    /// or failed) that may live in the in-memory tracking map at once.
+    /// Submissions while the tracking map is at this cap return HTTP 503
+    /// with `Retry-After: 30` and the `training_tracked_full` error code.
+    /// The training worker continuously evicts terminal entries older than
+    /// `tracked_job_ttl_secs`, so a healthy server will rarely hit this
+    /// cap. Override via `KILN_TRAINING_MAX_TRACKED_JOBS`. Default: 1024.
+    pub max_tracked_jobs: usize,
+    /// TTL in seconds for tracked training jobs in the `Completed` or
+    /// `Failed` state. The training worker periodically removes terminal
+    /// entries whose `finished_at` timestamp is older than this many
+    /// seconds, bounding the steady-state size of the tracking map.
+    /// Active jobs (`Queued` / `Running`) are never GC'd, regardless of
+    /// age. Override via `KILN_TRAINING_TRACKED_JOB_TTL_SECS`. Default:
+    /// 3600 (1 hour).
+    pub tracked_job_ttl_secs: u64,
 }
 
 /// Logging settings.
@@ -302,6 +318,8 @@ impl Default for TrainingConfig {
             checkpoint_interval: None,
             webhook_url: None,
             max_queued_jobs: 32,
+            max_tracked_jobs: 1024,
+            tracked_job_ttl_secs: 3600,
         }
     }
 }
@@ -522,6 +540,16 @@ impl KilnConfig {
                 self.training.max_queued_jobs = n;
             }
         }
+        if let Ok(v) = std::env::var("KILN_TRAINING_MAX_TRACKED_JOBS") {
+            if let Ok(n) = v.parse::<usize>() {
+                self.training.max_tracked_jobs = n;
+            }
+        }
+        if let Ok(v) = std::env::var("KILN_TRAINING_TRACKED_JOB_TTL_SECS") {
+            if let Ok(n) = v.parse::<u64>() {
+                self.training.tracked_job_ttl_secs = n;
+            }
+        }
 
         // Logging
         if let Ok(v) = std::env::var("KILN_LOG_LEVEL") {
@@ -651,6 +679,8 @@ mod tests {
         assert!(config.training.checkpoint_interval.is_none());
         assert!(config.training.webhook_url.is_none());
         assert_eq!(config.training.max_queued_jobs, 32);
+        assert_eq!(config.training.max_tracked_jobs, 1024);
+        assert_eq!(config.training.tracked_job_ttl_secs, 3600);
         assert_eq!(config.logging.level, "info");
         assert_eq!(config.logging.format, "auto");
         assert!(config.prefix_cache.enabled);
@@ -692,6 +722,8 @@ no_grad_checkpoint = false
 checkpoint_interval = 50
 webhook_url = "https://example.com/hook"
 max_queued_jobs = 4
+max_tracked_jobs = 16
+tracked_job_ttl_secs = 120
 
 [logging]
 level = "debug"
@@ -730,6 +762,8 @@ last_token_lm_head = false
             Some("https://example.com/hook")
         );
         assert_eq!(config.training.max_queued_jobs, 4);
+        assert_eq!(config.training.max_tracked_jobs, 16);
+        assert_eq!(config.training.tracked_job_ttl_secs, 120);
         assert_eq!(config.logging.level, "debug");
         assert_eq!(config.logging.format, "pretty");
         assert!(!config.prefix_cache.enabled);
@@ -832,6 +866,8 @@ port = 3000
             std::env::set_var("KILN_CHECKPOINT_INTERVAL", "25");
             std::env::set_var("KILN_TRAINING_WEBHOOK_URL", "https://hook.example/notify");
             std::env::set_var("KILN_TRAINING_MAX_QUEUED_JOBS", "7");
+            std::env::set_var("KILN_TRAINING_MAX_TRACKED_JOBS", "9");
+            std::env::set_var("KILN_TRAINING_TRACKED_JOB_TTL_SECS", "11");
             std::env::set_var("KILN_KV_CACHE_FP8", "1");
             std::env::set_var("KILN_CUDA_GRAPHS", "false");
             std::env::set_var("KILN_PREFIX_CACHE_ENABLED", "false");
@@ -859,6 +895,8 @@ port = 3000
             Some("https://hook.example/notify")
         );
         assert_eq!(config.training.max_queued_jobs, 7);
+        assert_eq!(config.training.max_tracked_jobs, 9);
+        assert_eq!(config.training.tracked_job_ttl_secs, 11);
         assert!(config.memory.kv_cache_fp8);
         assert!(!config.memory.cuda_graphs);
         assert!(!config.prefix_cache.enabled);
@@ -881,6 +919,8 @@ port = 3000
             std::env::remove_var("KILN_CHECKPOINT_INTERVAL");
             std::env::remove_var("KILN_TRAINING_WEBHOOK_URL");
             std::env::remove_var("KILN_TRAINING_MAX_QUEUED_JOBS");
+            std::env::remove_var("KILN_TRAINING_MAX_TRACKED_JOBS");
+            std::env::remove_var("KILN_TRAINING_TRACKED_JOB_TTL_SECS");
             std::env::remove_var("KILN_KV_CACHE_FP8");
             std::env::remove_var("KILN_CUDA_GRAPHS");
             std::env::remove_var("KILN_PREFIX_CACHE_ENABLED");

--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -288,6 +288,27 @@ impl ApiError {
         }
     }
 
+    /// 503 returned when the in-memory training-jobs tracking map has
+    /// reached its configured cap. Distinct from `training_queue_full`:
+    /// this fires when too many terminal (`Completed` / `Failed`) entries
+    /// are still resident waiting for the TTL GC to evict them. Carries
+    /// `Retry-After: 30` so polite clients back off automatically. The
+    /// cap is `training.max_tracked_jobs` (default 1024, override
+    /// `KILN_TRAINING_MAX_TRACKED_JOBS`); the TTL is
+    /// `training.tracked_job_ttl_secs` (default 3600, override
+    /// `KILN_TRAINING_TRACKED_JOB_TTL_SECS`).
+    pub fn training_tracked_full(max: usize) -> Self {
+        Self {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            code: "training_tracked_full",
+            message: format!(
+                "Training tracking map is at capacity ({max} tracked jobs)"
+            ),
+            hint: "Wait for terminal entries to TTL out, or raise training.max_tracked_jobs in the config (env: KILN_TRAINING_MAX_TRACKED_JOBS).",
+            retry_after_seconds: Some(30),
+        }
+    }
+
     pub fn training_job_not_found(job_id: impl std::fmt::Display) -> Self {
         Self {
             status: StatusCode::NOT_FOUND,

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -242,12 +242,20 @@ async fn main() -> Result<()> {
     state.checkpoint_interval = config.training.checkpoint_interval;
     state.training_webhook_url = config.training.webhook_url.clone();
     state.max_queued_training_jobs = config.training.max_queued_jobs;
+    state.max_tracked_jobs = config.training.max_tracked_jobs;
+    state.tracked_job_ttl =
+        std::time::Duration::from_secs(config.training.tracked_job_ttl_secs);
     if let Some(ref url) = state.training_webhook_url {
         tracing::info!(url = %url, "training completion webhook configured");
     }
     tracing::info!(
         cap = state.max_queued_training_jobs,
         "training queue cap configured"
+    );
+    tracing::info!(
+        cap = state.max_tracked_jobs,
+        ttl_secs = config.training.tracked_job_ttl_secs,
+        "training tracked-jobs cap and TTL configured"
     );
 
     // Spawn the background training queue worker

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -144,6 +144,13 @@ pub struct TrainingJobInfo {
     #[serde(skip)]
     pub submitted_at: std::time::Instant,
     pub auto_load: bool,
+    /// Wall-clock instant at which the job entered a terminal state
+    /// (`Completed` or `Failed`). `None` while the job is still
+    /// `Queued` or `Running`. Used by the training-queue worker's GC
+    /// pass to TTL-evict stale terminal entries from the tracking map.
+    /// See `AppState::tracked_job_ttl`.
+    #[serde(skip)]
+    pub finished_at: Option<std::time::Instant>,
 }
 
 /// Thread-safe map of tracked training jobs.
@@ -423,6 +430,18 @@ pub struct AppState {
     /// with HTTP 503 + `Retry-After: 30`. Mirrors
     /// `TrainingConfig::max_queued_jobs` (default 32).
     pub max_queued_training_jobs: usize,
+    /// Maximum number of tracked training jobs that may live in
+    /// `training_jobs` (the in-memory tracking map) at once. Submissions
+    /// while the map is at this cap are rejected with HTTP 503 +
+    /// `Retry-After: 30` and the `training_tracked_full` error code.
+    /// Mirrors `TrainingConfig::max_tracked_jobs` (default 1024).
+    pub max_tracked_jobs: usize,
+    /// TTL for terminal (`Completed` / `Failed`) entries in
+    /// `training_jobs`. The training worker periodically removes terminal
+    /// entries whose `finished_at` timestamp is older than this duration.
+    /// Active entries (`Queued` / `Running`) are never GC'd.
+    /// Mirrors `TrainingConfig::tracked_job_ttl_secs` (default 3600s).
+    pub tracked_job_ttl: std::time::Duration,
     /// Identifier exposed at `/v1/models` and echoed in chat completion responses.
     pub served_model_id: String,
     /// Rolling timestamp ring for live decode tok/s + ITL on the /ui dashboard.
@@ -485,6 +504,8 @@ impl AppState {
             checkpoint_interval: None,
             training_webhook_url: None,
             max_queued_training_jobs: 32,
+            max_tracked_jobs: 1024,
+            tracked_job_ttl: std::time::Duration::from_secs(3600),
             served_model_id,
             decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
             recent_requests: Arc::new(std::sync::Mutex::new(RecentRequestsRing::new(
@@ -702,6 +723,8 @@ impl AppState {
             checkpoint_interval: None,
             training_webhook_url: None,
             max_queued_training_jobs: 32,
+            max_tracked_jobs: 1024,
+            tracked_job_ttl: std::time::Duration::from_secs(3600),
             served_model_id,
             decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
             recent_requests: Arc::new(std::sync::Mutex::new(RecentRequestsRing::new(

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -158,6 +158,13 @@ pub fn new_shared_queue() -> SharedTrainingQueue {
 /// found, it executes it on a blocking thread (training is CPU/GPU-bound).
 /// The worker exits cleanly when the shutdown flag is set, after finishing
 /// any currently running job.
+///
+/// On every iteration the worker also runs a GC pass on `state.training_jobs`,
+/// evicting terminal (`Completed` / `Failed`) entries whose `finished_at`
+/// timestamp is older than `state.tracked_job_ttl`. This bounds the steady-
+/// state size of the tracking map and works in concert with the
+/// `max_tracked_jobs` cap to prevent memory growth from a flood of terminal
+/// entries. See `gc_tracked_jobs` for the eviction predicate.
 pub fn spawn_training_worker(state: AppState, shutdown: ShutdownFlag) {
     tokio::spawn(async move {
         loop {
@@ -166,6 +173,12 @@ pub fn spawn_training_worker(state: AppState, shutdown: ShutdownFlag) {
                 tracing::info!("training worker shutting down");
                 break;
             }
+
+            // GC stale terminal entries from the tracking map. Cheap when
+            // the map is small; runs on every iteration so terminal
+            // entries can never persist past TTL even on a quiescent
+            // server.
+            gc_tracked_jobs(&state);
 
             // Check for next job
             let entry = {
@@ -189,6 +202,37 @@ pub fn spawn_training_worker(state: AppState, shutdown: ShutdownFlag) {
             }
         }
     });
+}
+
+/// Evict `Completed` / `Failed` entries from `state.training_jobs` whose
+/// `finished_at` timestamp is older than `state.tracked_job_ttl`. Active
+/// entries (`Queued` / `Running`) are never removed regardless of age.
+///
+/// Returns the number of entries removed.
+///
+/// Safe to call from any thread; takes a short write lock on
+/// `training_jobs`. Called from the training worker loop on every
+/// iteration and from tests directly.
+pub fn gc_tracked_jobs(state: &AppState) -> usize {
+    let ttl = state.tracked_job_ttl;
+    let now = std::time::Instant::now();
+    let mut jobs = state.training_jobs.write().unwrap();
+    let before = jobs.len();
+    jobs.retain(|_id, job| match job.state {
+        TrainingState::Completed | TrainingState::Failed => match job.finished_at {
+            // No timestamp recorded (legacy or in-flight transition) —
+            // keep until the next pass observes a timestamp.
+            None => true,
+            Some(t) => now.saturating_duration_since(t) < ttl,
+        },
+        // Active jobs are never GC'd.
+        TrainingState::Queued | TrainingState::Running => true,
+    });
+    let removed = before - jobs.len();
+    if removed > 0 {
+        tracing::debug!(removed, remaining = jobs.len(), "GC'd terminal training jobs past TTL");
+    }
+    removed
 }
 
 /// Execute a single training job (runs on a blocking thread).
@@ -218,6 +262,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
             let mut jobs = state.training_jobs.write().unwrap();
             if let Some(job) = jobs.get_mut(&job_id) {
                 job.state = TrainingState::Failed;
+                job.finished_at = Some(std::time::Instant::now());
             }
             tracing::error!(job_id = %job_id, "training requires real model weights");
             return;
@@ -307,6 +352,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                     job.state = TrainingState::Completed;
                     job.progress = 1.0;
                     job.adapter_path = Some(path_str.clone());
+                    job.finished_at = Some(std::time::Instant::now());
                 }
             }
             state.metrics.inc_training(metric_type, TrainingMetricStatus::Completed);
@@ -345,6 +391,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                 let mut jobs = state.training_jobs.write().unwrap();
                 if let Some(job) = jobs.get_mut(&job_id) {
                     job.state = TrainingState::Failed;
+                    job.finished_at = Some(std::time::Instant::now());
                 }
             }
             state.metrics.inc_training(metric_type, TrainingMetricStatus::Failed);

--- a/crates/kiln-server/tests/training_tracked_cap.rs
+++ b/crates/kiln-server/tests/training_tracked_cap.rs
@@ -1,0 +1,310 @@
+//! Integration test: training tracked-jobs cap and TTL GC (audit MEDIUM §4 part 2).
+//!
+//! When the `training_jobs` tracking map is at its configured cap,
+//! submissions to `/v1/train/sft` and `/v1/train/grpo` must return HTTP 503
+//! with the `training_tracked_full` code and a `Retry-After: 30` header
+//! instead of growing the map without bound. Terminal entries
+//! (`Completed` / `Failed`) older than `tracked_job_ttl` must be evicted by
+//! the GC pass.
+//!
+//! Cross-link: PR #607 added the queue cap (part 1). This test exercises
+//! the tracking-map cap and TTL GC (part 2).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::engine::MockEngine;
+use kiln_scheduler::{Scheduler, SchedulerConfig};
+use kiln_server::api;
+use kiln_server::state::{AppState, TrainingJobInfo, TrainingJobType};
+use kiln_server::training_queue::gc_tracked_jobs;
+use kiln_train::{ChatMessage, GrpoRequest, ScoredCompletion, SftExample, SftRequest, TrainingState};
+
+fn test_tokenizer() -> KilnTokenizer {
+    let mut vocab: HashMap<String, u32> = HashMap::new();
+    for i in 0u32..32 {
+        vocab.insert(format!("t{i}"), i);
+    }
+    let json = json!({
+        "version": "1.0",
+        "model": { "type": "BPE", "vocab": vocab, "merges": [] },
+        "added_tokens": [
+            {
+                "id": 0, "content": "<|endoftext|>",
+                "single_word": false, "lstrip": false, "rstrip": false,
+                "normalized": false, "special": true,
+            },
+        ]
+    });
+    KilnTokenizer::from_bytes(&serde_json::to_vec(&json).unwrap()).unwrap()
+}
+
+fn make_state(max_tracked: usize, ttl: std::time::Duration) -> AppState {
+    let config = ModelConfig::qwen3_5_4b();
+    let scheduler = Scheduler::new(
+        SchedulerConfig {
+            max_batch_tokens: 8192,
+            max_batch_size: 64,
+            block_size: 16,
+            prefix_cache_enabled: false,
+            ..Default::default()
+        },
+        256,
+    );
+    let engine = MockEngine::new(config.clone());
+    let mut state = AppState::new_mock(
+        config,
+        scheduler,
+        Arc::new(engine),
+        test_tokenizer(),
+        300,
+        "qwen3.5-4b-kiln".to_string(),
+    );
+    // Leave the queue cap permissive so we exercise the tracked-map cap
+    // independently of the queue cap from PR #607.
+    state.max_queued_training_jobs = 1_000_000;
+    state.max_tracked_jobs = max_tracked;
+    state.tracked_job_ttl = ttl;
+    state
+}
+
+/// Pre-populate the tracking map with `n` synthetic entries at a given state.
+/// Used to drive the cap and the GC pass without going through `submit_*`.
+fn fill_tracked(
+    state: &AppState,
+    n: usize,
+    job_state: TrainingState,
+    finished_at: Option<std::time::Instant>,
+) {
+    let mut jobs = state.training_jobs.write().unwrap();
+    for i in 0..n {
+        let job_id = format!("synthetic-{i}");
+        jobs.insert(
+            job_id.clone(),
+            TrainingJobInfo {
+                job_id,
+                adapter_name: format!("syn-adapter-{i}"),
+                job_type: TrainingJobType::Sft,
+                state: job_state,
+                progress: if matches!(job_state, TrainingState::Completed) {
+                    1.0
+                } else {
+                    0.0
+                },
+                loss: None,
+                epoch: None,
+                adapter_path: None,
+                submitted_at: std::time::Instant::now(),
+                auto_load: false,
+                finished_at,
+            },
+        );
+    }
+}
+
+fn sft_body() -> Value {
+    json!({
+        "examples": [
+            {
+                "messages": [
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "hello"}
+                ]
+            }
+        ]
+    })
+}
+
+fn grpo_body() -> Value {
+    json!({
+        "groups": [
+            {
+                "messages": [{"role": "user", "content": "hi"}],
+                "completions": [
+                    {"text": "a", "reward": 1.0},
+                    {"text": "b", "reward": 0.0}
+                ]
+            }
+        ]
+    })
+}
+
+async fn read_body(resp: axum::response::Response) -> (StatusCode, Option<String>, Value) {
+    let status = resp.status();
+    let retry_after = resp
+        .headers()
+        .get(axum::http::header::RETRY_AFTER)
+        .map(|v| v.to_str().unwrap().to_string());
+    let bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+        .await
+        .unwrap();
+    let body: Value = serde_json::from_slice(&bytes).unwrap();
+    (status, retry_after, body)
+}
+
+#[tokio::test]
+async fn submit_sft_returns_503_when_tracked_full() {
+    let state = make_state(2, std::time::Duration::from_secs(3600));
+    // Fill the tracking map with two terminal entries (no `finished_at`
+    // so the GC won't drop them in this synchronous path).
+    fill_tracked(&state, 2, TrainingState::Completed, None);
+
+    let app = api::router(state);
+    let req = Request::post("/v1/train/sft")
+        .header("content-type", "application/json")
+        .body(Body::from(sft_body().to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let (status, retry_after, body) = read_body(resp).await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(retry_after.as_deref(), Some("30"));
+    assert_eq!(
+        body["error"]["code"].as_str(),
+        Some("training_tracked_full"),
+        "body was: {body}"
+    );
+    let msg = body["error"]["message"].as_str().unwrap_or_default();
+    assert!(
+        msg.contains("Training tracking map is at capacity"),
+        "unexpected message: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn submit_grpo_returns_503_when_tracked_full() {
+    let state = make_state(2, std::time::Duration::from_secs(3600));
+    fill_tracked(&state, 2, TrainingState::Failed, None);
+
+    let app = api::router(state);
+    let req = Request::post("/v1/train/grpo")
+        .header("content-type", "application/json")
+        .body(Body::from(grpo_body().to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let (status, retry_after, body) = read_body(resp).await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(retry_after.as_deref(), Some("30"));
+    assert_eq!(
+        body["error"]["code"].as_str(),
+        Some("training_tracked_full"),
+        "body was: {body}"
+    );
+}
+
+/// Below the cap, the request must NOT be rejected with `training_tracked_full`.
+/// In mock mode it's rejected with `mock_mode` instead — the important thing
+/// is that the cap branch hasn't fired.
+#[tokio::test]
+async fn submit_sft_below_cap_does_not_emit_tracked_full() {
+    let state = make_state(4, std::time::Duration::from_secs(3600));
+    fill_tracked(&state, 2, TrainingState::Completed, None); // 2 < cap 4
+
+    let app = api::router(state);
+    let req = Request::post("/v1/train/sft")
+        .header("content-type", "application/json")
+        .body(Body::from(sft_body().to_string()))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let (status, _retry_after, body) = read_body(resp).await;
+
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE); // mock-mode fallback
+    let code = body["error"]["code"].as_str().unwrap_or("");
+    assert_ne!(
+        code, "training_tracked_full",
+        "tracked cap should not have fired; body was: {body}"
+    );
+}
+
+/// `gc_tracked_jobs` evicts terminal entries past TTL.
+#[test]
+fn gc_evicts_terminal_entries_past_ttl() {
+    // Tiny TTL so we can drive eviction without sleeping for real time.
+    let state = make_state(64, std::time::Duration::from_millis(10));
+
+    // Two completed entries with a stale `finished_at` (well past the
+    // 10ms TTL by the time we call gc), one queued without a timestamp,
+    // and one running.
+    let stale = std::time::Instant::now()
+        .checked_sub(std::time::Duration::from_secs(60))
+        .expect("subtract 60s from now");
+    fill_tracked(&state, 2, TrainingState::Completed, Some(stale));
+    {
+        let mut jobs = state.training_jobs.write().unwrap();
+        jobs.insert(
+            "live-queued".to_string(),
+            TrainingJobInfo {
+                job_id: "live-queued".to_string(),
+                adapter_name: "live".to_string(),
+                job_type: TrainingJobType::Sft,
+                state: TrainingState::Queued,
+                progress: 0.0,
+                loss: None,
+                epoch: None,
+                adapter_path: None,
+                submitted_at: std::time::Instant::now(),
+                auto_load: false,
+                finished_at: None,
+            },
+        );
+        jobs.insert(
+            "live-running".to_string(),
+            TrainingJobInfo {
+                job_id: "live-running".to_string(),
+                adapter_name: "running".to_string(),
+                job_type: TrainingJobType::Sft,
+                state: TrainingState::Running,
+                progress: 0.5,
+                loss: None,
+                epoch: None,
+                adapter_path: None,
+                submitted_at: std::time::Instant::now(),
+                auto_load: false,
+                finished_at: None,
+            },
+        );
+    }
+
+    assert_eq!(state.training_jobs.read().unwrap().len(), 4);
+    let removed = gc_tracked_jobs(&state);
+    assert_eq!(removed, 2, "should have evicted both stale terminal entries");
+    let after = state.training_jobs.read().unwrap();
+    assert_eq!(after.len(), 2, "active entries must survive GC");
+    assert!(after.contains_key("live-queued"), "queued entry must survive GC");
+    assert!(after.contains_key("live-running"), "running entry must survive GC");
+}
+
+/// Terminal entries WITHIN the TTL window are not evicted, even when a GC
+/// pass runs.
+#[test]
+fn gc_keeps_recent_terminal_entries() {
+    let state = make_state(64, std::time::Duration::from_secs(3600));
+    let recent = std::time::Instant::now();
+    fill_tracked(&state, 3, TrainingState::Completed, Some(recent));
+
+    let removed = gc_tracked_jobs(&state);
+    assert_eq!(removed, 0, "recent terminal entries must not be evicted");
+    assert_eq!(state.training_jobs.read().unwrap().len(), 3);
+}
+
+/// Sanity unused-import check — confirms `ScoredCompletion`/`ChatMessage`/
+/// `GrpoRequest` are reachable so the JSON we construct above keeps shape
+/// parity with the wire types.
+#[allow(dead_code)]
+fn _imports_keep_alive() -> (
+    Option<ScoredCompletion>,
+    Option<ChatMessage>,
+    Option<GrpoRequest>,
+    Option<SftExample>,
+    Option<SftRequest>,
+) {
+    (None, None, None, None, None)
+}


### PR DESCRIPTION
## Summary

Closes the remaining half of `docs/audits/security-audit-v0.1.md` §4 "DoS via training-queue exhaustion." PR #607 added the in-memory queue cap (`max_queued_jobs`, default 32). This PR adds the analogous cap and TTL GC for the `state.training_jobs` tracking map, which previously grew without bound as `Completed`/`Failed` entries accumulated.

Without this, an attacker could submit jobs faster than the trainer drains them, and even after the queue cap kicks in, every accepted job leaves a permanent `Completed`/`Failed` entry pinned in the tracking map. This bounds the in-memory footprint of that map.

## Changes

- `crates/kiln-server/src/config.rs`: new `TrainingConfig::max_tracked_jobs` (default 1024, env `KILN_TRAINING_MAX_TRACKED_JOBS`) and `TrainingConfig::tracked_job_ttl_secs` (default 3600, env `KILN_TRAINING_TRACKED_JOB_TTL_SECS`). Defaults / TOML parsing / env override tests all extended.
- `crates/kiln-server/src/state.rs`: `TrainingJobInfo` gains a `finished_at: Option<Instant>` field set on terminal transitions; `AppState` mirrors `max_tracked_jobs` and `tracked_job_ttl` from config.
- `crates/kiln-server/src/main.rs`: wires both fields from `config.training` and logs the cap+TTL at startup.
- `crates/kiln-server/src/error.rs`: new `ApiError::training_tracked_full(max)` constructor — 503 + `Retry-After: 30`, distinct error code `training_tracked_full`. Mirrors the `training_queue_full` shape from PR #607.
- `crates/kiln-server/src/api/training.rs`: `submit_sft` and `submit_grpo` now check `training_jobs.len() >= max_tracked_jobs` after the existing queue check and reject with `training_tracked_full`. Both submit handlers also set `finished_at: None` on the new `TrainingJobInfo`.
- `crates/kiln-server/src/training_queue.rs`: new `gc_tracked_jobs(&AppState) -> usize` helper evicts terminal entries past `tracked_job_ttl`. Active (`Queued` / `Running`) entries are never evicted regardless of age. The training worker calls `gc_tracked_jobs` on every iteration so terminal entries cannot persist past TTL even on a quiescent server. All four terminal transitions (`execute_job` mock-mode short-circuit, success path, failure path, and the cancel-queued-job path in `api/training.rs`) now stamp `finished_at` with the current `Instant`.
- `crates/kiln-server/tests/training_tracked_cap.rs` (new): five integration tests cover SFT-at-cap, GRPO-at-cap, below-cap (no false positive), GC evicts past-TTL terminal entries while preserving active ones, and GC keeps recent terminal entries.

## Audit reference

`docs/audits/security-audit-v0.1.md` §4 "DoS via training-queue exhaustion" (recommendation #5).

## Cross-link

Part 1 (queue cap): #607.

## Test plan

- [x] `cargo check -p kiln-server --no-default-features --tests` (CPU-only)
- [x] `cargo test -p kiln-server --no-default-features --lib config::` — 20/20 passed (defaults, full TOML, env overrides all assert the new fields)
- [x] `cargo test -p kiln-server --no-default-features --test training_tracked_cap` — 5/5 passed
- [x] `cargo test -p kiln-server --no-default-features --test training_queue_cap` — 3/3 passed (regression guard: PR #607 cap still works)
- [ ] CI green