### PR TITLE
fix(security): per-route body-size limits on training/completions endpoints (audit LOW §1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Security
 - Fix path traversal in `DELETE /v1/adapters/:name` and `POST /v1/adapters/load` (Phase 9 audit §2b/§2c, HIGH).
 - Validate source adapter names in `POST /v1/adapters/merge` (Phase 9 audit §2d, LOW).
+- Per-route body-size limits on training + completions endpoints: 64 MiB for `/v1/train/sft` and `/v1/train/grpo`, 8 MiB for `/v1/chat/completions` and `/v1/completions/batch` (Phase 9 audit §1, LOW).
 
 ### Changed
 - Default server listen host changed from `0.0.0.0` to `127.0.0.1` (loopback). Set `server.host = "0.0.0.0"` or `KILN_HOST=0.0.0.0` to accept remote connections; pair with a trusted reverse proxy. Closes security-audit-v0.1 MEDIUM §9.

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -1,4 +1,4 @@
-use axum::extract::State;
+use axum::extract::{DefaultBodyLimit, State};
 use axum::http::StatusCode;
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
@@ -2196,10 +2196,23 @@ async fn generate_one_response(
     }
 }
 
+/// Body-size cap for /v1/chat/completions (audit LOW §1).
+/// 8 MiB is generous for chat payloads while bounding memory DoS via JSON extraction.
+const CHAT_BODY_LIMIT: usize = 8 * 1024 * 1024;
+/// Body-size cap for /v1/completions/batch (audit LOW §1).
+/// 8 MiB accommodates batched prompts; per-request adapter composition is separately capped at 16.
+const BATCH_BODY_LIMIT: usize = 8 * 1024 * 1024;
+
 pub fn routes() -> Router<AppState> {
     Router::new()
-        .route("/v1/chat/completions", post(chat_completions))
-        .route("/v1/completions/batch", post(batch_completions))
+        .route(
+            "/v1/chat/completions",
+            post(chat_completions).layer(DefaultBodyLimit::max(CHAT_BODY_LIMIT)),
+        )
+        .route(
+            "/v1/completions/batch",
+            post(batch_completions).layer(DefaultBodyLimit::max(BATCH_BODY_LIMIT)),
+        )
 }
 
 #[cfg(test)]

--- a/crates/kiln-server/src/api/training.rs
+++ b/crates/kiln-server/src/api/training.rs
@@ -5,7 +5,7 @@
 //! concurrent training jobs.
 
 use axum::{
-    extract::{Path as AxumPath, State},
+    extract::{DefaultBodyLimit, Path as AxumPath, State},
     routing::{delete, get, post},
     Json, Router,
 };
@@ -348,10 +348,23 @@ async fn cancel_queued_job(
     }
 }
 
+/// Body-size cap for SFT training submissions (audit LOW §1).
+/// 64 MiB accommodates long-context training examples that exceed the 2 MiB axum default.
+const SFT_BODY_LIMIT: usize = 64 * 1024 * 1024;
+/// Body-size cap for GRPO training submissions (audit LOW §1).
+/// 64 MiB accommodates batches of scored completions.
+const GRPO_BODY_LIMIT: usize = 64 * 1024 * 1024;
+
 pub fn routes() -> Router<AppState> {
     Router::new()
-        .route("/v1/train/sft", post(submit_sft))
-        .route("/v1/train/grpo", post(submit_grpo))
+        .route(
+            "/v1/train/sft",
+            post(submit_sft).layer(DefaultBodyLimit::max(SFT_BODY_LIMIT)),
+        )
+        .route(
+            "/v1/train/grpo",
+            post(submit_grpo).layer(DefaultBodyLimit::max(GRPO_BODY_LIMIT)),
+        )
         .route("/v1/train/status", get(training_status))
         .route("/v1/train/status/{job_id}", get(job_status))
         .route("/v1/train/queue", get(list_queue))

--- a/docs/audits/security-audit-v0.1.md
+++ b/docs/audits/security-audit-v0.1.md
@@ -52,6 +52,8 @@ It treats prompt-injection-into-the-model and training-data poisoning as **parti
 
 **Severity:** LOW — current state is *safer* than recommended state for DoS purposes; the recommendation is about predictability, not about a missing defense.
 
+**Resolution.** Per-route `DefaultBodyLimit` set on all four endpoints in `ce/phase9-per-route-body-limits` — 64 MiB for `/v1/train/sft` and `/v1/train/grpo`, 8 MiB for `/v1/chat/completions` and `/v1/completions/batch`. Rationale documented inline in `crates/kiln-server/src/api/training.rs` and `crates/kiln-server/src/api/completions.rs`.
+
 ---
 
 ## 2. Path handling in adapter upload, download, delete, load, merge — `[HIGH]`
@@ -337,7 +339,7 @@ Ordered by severity, then by effort.
 
 ### Nice-to-have (LOW)
 
-7. **Per-route body-size limits** (§1). Set `DefaultBodyLimit` explicitly on `/v1/train/sft`, `/v1/train/grpo`, `/v1/chat/completions`, `/v1/completions/batch`.
+7. ~~**Per-route body-size limits** (§1). Set `DefaultBodyLimit` explicitly on `/v1/train/sft`, `/v1/train/grpo`, `/v1/chat/completions`, `/v1/completions/batch`.~~ **Fixed** in branch `ce/phase9-per-route-body-limits` (64 MiB for training, 8 MiB for completions).
 8. **Cap composed-adapter cache size** (§6, §8). LRU-evict `.composed/<hash>/` entries above N total or M GiB.
 9. **Cap total adapter-dir disk usage** (§8). Reject uploads that would push total adapter-dir size above `adapters.max_disk_bytes`.
 10. **Disable redirects on webhook reqwest client** (§7). Belt-and-suspenders against a misconfigured webhook URL pointing at a public 302.


### PR DESCRIPTION
Implements LOW §1 from `docs/audits/security-audit-v0.1.md`. Today the four training/completions endpoints all inherit Axum's default 2 MiB `DefaultBodyLimit`, which is functionally undersized for SFT (a long-context training example can blow past 2 MiB on its own) and silently rejects with 413. This sets explicit per-route limits sized to each workload:

- `/v1/train/sft` — 64 MiB (long-context SFT examples)
- `/v1/train/grpo` — 64 MiB (batches of scored completions)
- `/v1/chat/completions` — 8 MiB (generous chat payloads, bounded against memory DoS)
- `/v1/completions/batch` — 8 MiB (batched prompts; per-request adapter composition is separately capped at 16)

Each constant lives at the top of its routes module with a one-line rationale comment so the values do not look arbitrary. Closes audit roadmap item 7 ("Nice-to-have / LOW"). Audit doc and `CHANGELOG.md` updated.

Severity is LOW: current state is *safer* than recommended state for DoS purposes; this change is about predictability, not a missing defense.

## Test plan
- [x] `cargo build -p kiln-server --release` — clean compile
- [x] `cargo test -p kiln-server --lib` — 111 passed, 0 failed