### PR TITLE
fix(security): disable redirects on training-completion webhook client (audit §7 / item 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix path traversal in `DELETE /v1/adapters/:name` and `POST /v1/adapters/load` (Phase 9 audit §2b/§2c, HIGH).
 - Validate source adapter names in `POST /v1/adapters/merge` (Phase 9 audit §2d, LOW).
 - Per-route body-size limits on training + completions endpoints: 64 MiB for `/v1/train/sft` and `/v1/train/grpo`, 8 MiB for `/v1/chat/completions` and `/v1/completions/batch` (Phase 9 audit §1, LOW).
+- Disable HTTP redirects on the training-completion webhook client to prevent server-side redirect chasing into internal infra (Phase 9 audit §7, item 10, LOW).
 
 ### Changed
 - Default server listen host changed from `0.0.0.0` to `127.0.0.1` (loopback). Set `server.host = "0.0.0.0"` or `KILN_HOST=0.0.0.0` to accept remote connections; pair with a trusted reverse proxy. Closes security-audit-v0.1 MEDIUM §9.

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -48,8 +48,12 @@ impl TrainingCompletionEvent {
 /// notification POST fails.
 pub fn fire_completion_webhook(url: String, event: TrainingCompletionEvent) {
     tokio::spawn(async move {
+        // Defensive: an operator-set webhook URL that 302s into internal infra
+        // (e.g. 169.254.169.254 IMDS) must NOT be auto-followed. See
+        // docs/audits/security-audit-v0.1.md §7.
         let client = match reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(5))
+            .redirect(reqwest::redirect::Policy::none())
             .build()
         {
             Ok(c) => c,
@@ -693,5 +697,80 @@ mod tests {
         // Give the spawned task a moment so we're confident it ran and
         // completed without panicking.
         tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    /// Redirects must NOT be followed by the webhook client. An
+    /// operator-set webhook URL that 302s to a secondary endpoint
+    /// (e.g. internal IMDS at `http://169.254.169.254/`) is a
+    /// belt-and-suspenders SSRF concern from `security-audit-v0.1.md` §7.
+    /// We verify the redirect-target endpoint is never POSTed to.
+    #[tokio::test]
+    async fn test_fire_completion_webhook_does_not_follow_redirects() {
+        use axum::extract::State;
+        use axum::http::{header, StatusCode};
+        use axum::response::IntoResponse;
+        use axum::routing::post;
+        use axum::Json;
+        use std::sync::Arc as StdArc;
+        use std::sync::Mutex as StdMutex;
+
+        // Capture buffer for the *redirect target* — must remain empty.
+        let captured_final: StdArc<StdMutex<Vec<serde_json::Value>>> =
+            StdArc::new(StdMutex::new(Vec::new()));
+
+        async fn redirect_handler() -> impl IntoResponse {
+            (
+                StatusCode::FOUND,
+                [(header::LOCATION, "/hook-final")],
+                "",
+            )
+        }
+
+        async fn final_handler(
+            State(captured): State<StdArc<StdMutex<Vec<serde_json::Value>>>>,
+            Json(body): Json<serde_json::Value>,
+        ) -> &'static str {
+            captured.lock().unwrap().push(body);
+            "ok"
+        }
+
+        let app = axum::Router::new()
+            .route("/hook-redirect", post(redirect_handler))
+            .route("/hook-final", post(final_handler))
+            .with_state(captured_final.clone());
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let event = TrainingCompletionEvent {
+            job_id: "redirect-test-001".into(),
+            job_type: "sft",
+            status: "completed",
+            adapter_name: "redirect-test-adapter".into(),
+            adapter_path: Some("/tmp/adapters/redirect-test-adapter".into()),
+            error: None,
+            timestamp: "2026-04-26T01:23:45+00:00".into(),
+        };
+
+        let url = format!("http://{addr}/hook-redirect");
+        fire_completion_webhook(url, event);
+
+        // Give the spawned task plenty of time to (incorrectly) follow
+        // the redirect if our `redirect::Policy::none()` were missing.
+        // The original POST resolves immediately to a 302; if redirects
+        // were on, the secondary POST would land within ~tens of ms.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        let bodies = captured_final.lock().unwrap().clone();
+        assert!(
+            bodies.is_empty(),
+            "/hook-final must NOT be POSTed to — redirects must be disabled on the webhook client. Got bodies: {:?}",
+            bodies
+        );
+
+        server.abort();
     }
 }

--- a/docs/audits/security-audit-v0.1.md
+++ b/docs/audits/security-audit-v0.1.md
@@ -214,6 +214,8 @@ The `reqwest::Client` is built with a 5s timeout (`training_queue.rs:52`). One n
 
 **Severity:** NONE for the threat as posed (operator-controlled URL). Tightening reqwest to `redirect::Policy::none()` is a small hardening step worth taking.
 
+**Resolution:** Disabled redirects via `reqwest::redirect::Policy::none()` in branch `ce/phase9-webhook-disable-redirects` (`crates/kiln-server/src/training_queue.rs:fire_completion_webhook`).
+
 ---
 
 ## 8. Disk exhaustion via adapter uploads — `[LOW]`
@@ -342,7 +344,7 @@ Ordered by severity, then by effort.
 7. ~~**Per-route body-size limits** (§1). Set `DefaultBodyLimit` explicitly on `/v1/train/sft`, `/v1/train/grpo`, `/v1/chat/completions`, `/v1/completions/batch`.~~ **Fixed** in branch `ce/phase9-per-route-body-limits` (64 MiB for training, 8 MiB for completions).
 8. **Cap composed-adapter cache size** (§6, §8). LRU-evict `.composed/<hash>/` entries above N total or M GiB.
 9. **Cap total adapter-dir disk usage** (§8). Reject uploads that would push total adapter-dir size above `adapters.max_disk_bytes`.
-10. **Disable redirects on webhook reqwest client** (§7). Belt-and-suspenders against a misconfigured webhook URL pointing at a public 302.
+10. ~~**Disable redirects on webhook reqwest client** (§7). Belt-and-suspenders against a misconfigured webhook URL pointing at a public 302.~~ **Fixed** in branch `ce/phase9-webhook-disable-redirects`.
 11. **Migrate `deny.toml`** (§12). Replace `unmaintained = "workspace"` with the post-PR-611 shape; pin the CI cargo-deny version explicitly.
 12. **Document training-data invariants** (§3). One short README section: "Kiln applies a faithful gradient update to whatever you POST. Treat your training corpus as security-sensitive."
 


### PR DESCRIPTION
## What

Add `.redirect(reqwest::redirect::Policy::none())` to the `reqwest::Client` used by `fire_completion_webhook` so an operator-set webhook URL that 302s into internal infrastructure (e.g. AWS IMDS at `169.254.169.254`) is NOT auto-followed.

## Why

Closes audit item 10 (`docs/audits/security-audit-v0.1.md` §7). Severity is NONE because the webhook URL is operator-controlled (it comes from server config, not request bodies), but disabling redirects is a cheap belt-and-suspenders hardening step the audit explicitly recommended.

## Test plan

- [x] New `test_fire_completion_webhook_does_not_follow_redirects` mock-server test: 302 redirect → secondary endpoint must NOT be hit.
- [x] Existing 3 webhook tests still pass (payload shape, failure shape, error swallowing).
- [x] `cargo build -p kiln-server --release` clean.
- [x] Audit doc §7 + roadmap item 10 updated to reflect the fix.
- [x] CHANGELOG Unreleased gains a Security entry.