### PR TITLE
docs(security): document training-data trust invariants (audit §3 / item 12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 ### Reproducibility / release
 - docker: use `--locked` in `deploy/Dockerfile` cargo builds so the published `ghcr.io/ericflo/kiln-server` image matches the exact Cargo.lock dependency set (#601)
 
+### Documentation
+- docs(security): document training-data trust invariants (security audit §3 / item 12) in README + QUICKSTART. Calls out that `/v1/train/sft` and `/v1/train/grpo` apply a faithful gradient update to anything POSTed — kiln validates structure, not semantics — so the operator's training corpus must be treated as security-sensitive.
+
 ## kiln-v0.2.6 — 2026-04-26
 
 Patch release: 3 server bug fixes + first release with bundled

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -120,6 +120,8 @@ The `GPU` and `VRAM` lines come from `nvidia-smi` and are skipped silently if it
 
 Kiln binds to loopback (`127.0.0.1`) by default so a fresh install isn't reachable from the network. To accept connections from other hosts, set `server.host = "0.0.0.0"` in your TOML config or `KILN_HOST=0.0.0.0` and put Kiln behind a trusted reverse proxy (auth is out of scope for v0.1).
 
+**Training endpoints are privileged.** `/v1/train/sft` and `/v1/train/grpo` apply a faithful gradient update to whatever structurally-valid examples you POST — kiln does not validate the *content* of training data. A poisoned example will permanently influence the active adapter until you unload it. Do not expose training endpoints to untrusted inputs, and treat your training corpus as security-sensitive. See the README's [Security model](README.md#security-model) section for the full picture.
+
 On Apple Silicon, Kiln auto-detects Metal and logs `Metal available — using Apple Silicon GPU` at startup instead of the CUDA availability line. No config changes needed — the binary selects the backend that was compiled in.
 
 ## 4. Test Inference

--- a/README.md
+++ b/README.md
@@ -250,6 +250,16 @@ Kiln uses a TOML config file. Environment variables override config values. See 
 | `logging.format` | `KILN_LOG_FORMAT` | auto | `auto` (default; pretty on TTY, JSON otherwise), `json`, `pretty`, `text`, or `human` |
 | `prefix_cache.enabled` | — | true | Reuse KV cache for shared prefixes |
 
+## Security model
+
+Kiln has no built-in auth. The default listen address is `127.0.0.1:8420` so a fresh install isn't reachable from the network. To accept remote connections, set `server.host = "0.0.0.0"` (or `KILN_HOST=0.0.0.0`) and front kiln with a reverse proxy (nginx, Caddy) that adds auth, or run it on a private network (WireGuard, Tailscale).
+
+**Training data is privileged.** Kiln applies a faithful gradient update to anything you POST to `/v1/train/sft` or `/v1/train/grpo` — it validates structure, not semantics. A poisoned training example will permanently influence the active adapter until you unload or reset it. Treat your training corpus as security-sensitive: do not accept training data from untrusted sources, and review examples before submission the same way you would review code before merging it.
+
+Adapters are easy to revert if a bad training run lands. `POST /v1/adapters/unload` deactivates the current adapter; `DELETE /v1/adapters/{name}` removes it from disk. The base model is unaffected — only LoRA deltas are written.
+
+Full v0.1 threat model and per-finding analysis: [`docs/audits/security-audit-v0.1.md`](docs/audits/security-audit-v0.1.md).
+
 ## Desktop App
 
 Kiln Desktop is a system-tray app that wraps the `kiln` server for people who don't want to use a CLI. It spawns and supervises the `kiln` binary as a child process, shows server status in the tray, and opens a dashboard, settings, and log viewer in native windows.

--- a/docs/audits/security-audit-v0.1.md
+++ b/docs/audits/security-audit-v0.1.md
@@ -145,6 +145,8 @@ The relative-path branch then calls `state.adapter_dir.join(&req.name)`, which h
 
 **Severity:** NONE for kiln itself; the property is by design.
 
+**Resolution.** Documented in `README.md` (new `## Security model` section) and `QUICKSTART.md` (callout adjacent to the loopback paragraph) in branch `ce/phase9-document-training-data-trust`. Both call out that kiln applies a faithful gradient update to anything POSTed to `/v1/train/sft` or `/v1/train/grpo`, that the training corpus must be treated as security-sensitive, and that adapters are easy to revert via `POST /v1/adapters/unload`.
+
 ---
 
 ## 4. DoS via training-queue exhaustion — `[MEDIUM]`
@@ -346,7 +348,7 @@ Ordered by severity, then by effort.
 9. **Cap total adapter-dir disk usage** (§8). Reject uploads that would push total adapter-dir size above `adapters.max_disk_bytes`.
 10. ~~**Disable redirects on webhook reqwest client** (§7). Belt-and-suspenders against a misconfigured webhook URL pointing at a public 302.~~ **Fixed** in branch `ce/phase9-webhook-disable-redirects`.
 11. **Migrate `deny.toml`** (§12). Replace `unmaintained = "workspace"` with the post-PR-611 shape; pin the CI cargo-deny version explicitly.
-12. **Document training-data invariants** (§3). One short README section: "Kiln applies a faithful gradient update to whatever you POST. Treat your training corpus as security-sensitive."
+12. ~~**Document training-data invariants** (§3). One short README section: "Kiln applies a faithful gradient update to whatever you POST. Treat your training corpus as security-sensitive."~~ **Fixed** in branch `ce/phase9-document-training-data-trust` (new `## Security model` section in `README.md`, callout in `QUICKSTART.md` adjacent to the loopback paragraph).
 
 ### Out of scope for v0.1
 


### PR DESCRIPTION
## What
Adds a `## Security model` section to README and a short callout in QUICKSTART explaining that kiln applies a faithful gradient update to anything posted to /v1/train/{sft,grpo}. Cross-links to the v0.1 security audit.

## Why
Closes audit roadmap **Nice-to-have item 12** (`docs/audits/security-audit-v0.1.md` §3). Training-data trust is by-design but undocumented — the audit explicitly recommends README/QUICKSTART text so operators don't accept untrusted training data.

## Scope
Doc-only. No code or behavior change. README + QUICKSTART + audit doc + CHANGELOG.