### PR TITLE
chore(ci): pin cargo-deny-action SHA + document deny.toml schema (audit LOW §11)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: EmbarkStudios/cargo-deny-action@v2
+      # Pin to an exact commit SHA so the bundled cargo-deny CLI version cannot
+      # drift on us. v2.0.17 bundles cargo-deny 0.19.2, which is the version the
+      # `unmaintained = "workspace"` Scope syntax in deny.toml is validated
+      # against (cargo-deny ≤ 0.17 still parses that field as a deprecated
+      # LintLevel and will reject "workspace"). Bump this pin deliberately when
+      # we want a newer cargo-deny — see the README for the action.
+      - uses: EmbarkStudios/cargo-deny-action@91bf2b620e09e18d6eb78b92e7861937469acedb # v2.0.17 (cargo-deny 0.19.2)
         with:
           command: check
           # Run all checks: licenses, sources, bans, advisories

--- a/deny.toml
+++ b/deny.toml
@@ -50,6 +50,12 @@ yanked = "warn"
 # via indicatif) are not actionable here — there is no upstream fix and dropping
 # the parent crate is out of scope. Real security vulnerabilities still fail
 # regardless of where in the tree they appear.
+#
+# Version note: under `version = 2`, cargo-deny ≥ 0.18 parses `unmaintained` as
+# a Scope (one of "all" | "workspace" | "transitive" | "none"). Earlier
+# versions (≤ 0.17) parse it as a deprecated LintLevel and reject "workspace".
+# CI pins the cargo-deny-action SHA in `.github/workflows/ci.yml` so the
+# bundled CLI version cannot drift below 0.18 silently.
 unmaintained = "workspace"
 
 [sources]

--- a/docs/audits/security-audit-v0.1.md
+++ b/docs/audits/security-audit-v0.1.md
@@ -323,6 +323,12 @@ A second wrinkle: the local advisory-db at `~/.cargo/advisory-db` contains a CVS
 
 **Severity:** LOW. Not a runtime risk; a CI-policy maintenance gap.
 
+**Update (Phase 9 follow-up).** Investigation showed `unmaintained = "workspace"` is in fact the *modern* shape on cargo-deny ≥ 0.18 — the field is parsed as a `Scope` ("all" | "workspace" | "transitive" | "none"), not a `LintLevel`. The "this key has been removed" error in this section was emitted by cargo-deny 0.16.4, which still parsed `unmaintained` as a deprecated `LintLevel` and rejected `"workspace"`. Versions 0.18.0+ re-introduced the field as a Scope, which is the schema documented today (https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html). There is no `[advisories.unmaintained]` sub-table in cargo-deny's schema; the migration guide referenced in the original error refers to PR #611's `version = 2` opt-in, which the policy already uses.
+
+The deprecation-cliff risk is therefore narrower than written: it only fires if the cargo-deny CLI used by CI ever drops below 0.18 (or, conversely, if a future major rewrite removes the field again). To close that gap, CI now pins the `cargo-deny-action` to a specific commit SHA (`91bf2b62…` = v2.0.17, cargo-deny 0.19.2). Bumping the bundled cargo-deny version is now an explicit, reviewable change. A version-requirement comment was added to `deny.toml` so the next reader sees the constraint inline.
+
+Status: **Fixed** in PR `ce/phase9-deny-migration` — pinned the action SHA + bundled cargo-deny 0.19.2; documented the version requirement in `deny.toml`; left `unmaintained = "workspace"` unchanged because it is already the canonical modern shape.
+
 ---
 
 ## Recommendations roadmap
@@ -347,7 +353,7 @@ Ordered by severity, then by effort.
 8. **Cap composed-adapter cache size** (§6, §8). LRU-evict `.composed/<hash>/` entries above N total or M GiB.
 9. **Cap total adapter-dir disk usage** (§8). Reject uploads that would push total adapter-dir size above `adapters.max_disk_bytes`.
 10. ~~**Disable redirects on webhook reqwest client** (§7). Belt-and-suspenders against a misconfigured webhook URL pointing at a public 302.~~ **Fixed** in branch `ce/phase9-webhook-disable-redirects`.
-11. **Migrate `deny.toml`** (§12). Replace `unmaintained = "workspace"` with the post-PR-611 shape; pin the CI cargo-deny version explicitly.
+11. ~~**Migrate `deny.toml`** (§12). Replace `unmaintained = "workspace"` with the post-PR-611 shape; pin the CI cargo-deny version explicitly.~~ **Fixed** in branch `ce/phase9-deny-migration` — pinned `cargo-deny-action` to v2.0.17 commit SHA (cargo-deny 0.19.2) and documented the schema-version constraint in `deny.toml`. The "new shape" turned out not to exist: `unmaintained = "workspace"` is already the canonical modern form on cargo-deny ≥ 0.18; see the §12 update for the full reasoning.
 12. ~~**Document training-data invariants** (§3). One short README section: "Kiln applies a faithful gradient update to whatever you POST. Treat your training corpus as security-sensitive."~~ **Fixed** in branch `ce/phase9-document-training-data-trust` (new `## Security model` section in `README.md`, callout in `QUICKSTART.md` adjacent to the loopback paragraph).
 
 ### Out of scope for v0.1


### PR DESCRIPTION
## Summary

Closes Phase 9 audit roadmap item §11 (security-audit-v0.1.md §12). The original recommendation called for two things — migrating `unmaintained = "workspace"` to a "new shape" and pinning the CI cargo-deny version. Investigation showed:

1. **There is no new shape to migrate to.** `unmaintained = "workspace"` *is* the canonical modern shape on cargo-deny ≥ 0.18. The field is parsed as a `Scope` ("all" | "workspace" | "transitive" | "none") in `src/advisories/cfg.rs` on every cargo-deny ≥ 0.18 release through current main (0.19.4). The audit's "this key has been removed" error was emitted by a stale local cargo-deny 0.16.4, where `unmaintained` was still parsed as a deprecated `LintLevel` and rejected `"workspace"`. cargo-deny 0.18.0 (released 2025) re-introduced the field as `Scope`. There is **no `[advisories.unmaintained]` sub-table** in cargo-deny's schema — see https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html.

2. **Pinning the version is the real fix.** Right now `EmbarkStudios/cargo-deny-action@v2` is a lightweight tag that resolves to whatever Embark moved it to most recently. Today that's v2.0.17 (cargo-deny 0.19.2), which is fine — but the audit's concern that "once the GitHub action updates its default cargo-deny, the policy stops being enforced" is real if Embark ever points `@v2` at a future major rewrite that drops `Scope` parsing.

## Changes

- **`.github/workflows/ci.yml`** — Pin `cargo-deny-action` to commit `91bf2b62…` (= v2.0.17, cargo-deny 0.19.2) instead of the floating `@v2` tag. Added a comment block explaining the version constraint and how to deliberately bump it.
- **`deny.toml`** — Added a comment block above `unmaintained = "workspace"` documenting that cargo-deny ≥ 0.18 is required and that the CI pin enforces that floor. No semantic change to the policy.
- **`docs/audits/security-audit-v0.1.md`** — Appended a "Phase 9 update" paragraph to §12 with the corrected schema reasoning, and struck through item 11 in the recommendations roadmap.

## Why I didn't introduce `[advisories.unmaintained]`

The task description called for migrating to a `[advisories.unmaintained]` sub-table with `workspace` / `transitive` keys. That schema doesn't exist in cargo-deny — I confirmed by reading `src/advisories/cfg.rs` on the v0.16.4, v0.18.0, v0.18.9, and main branches, and by re-reading the upstream cfg.html docs. PR EmbarkStudios/cargo-deny#611 (the migration the audit cited) was about the `version = 2` opt-in for `[advisories]` and `[licenses]` — which `deny.toml` already uses. Inventing a sub-table that cargo-deny would silently ignore would be worse than leaving the file alone.

## Test plan

- [x] TOML parses cleanly (`python3 -c "import tomllib; tomllib.loads(open('deny.toml').read())"`).
- [x] CI's `cargo-deny` job picks up the new SHA pin and runs cargo-deny 0.19.2.
- [x] No semantic change to which crates trigger the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)