### PR TITLE
fix(security): cap total adapter_dir disk usage on upload (audit LOW §8 / item 9)

### DIFF
--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -674,6 +674,54 @@ const ADAPTER_EXTRACT_BYTES_LIMIT: u64 = 4 * 1024 * 1024 * 1024;
 /// against a tar with millions of zero-byte files.
 const ADAPTER_EXTRACT_ENTRIES_LIMIT: u32 = 100_000;
 
+/// Sum the on-disk byte size of all finalized adapter directories under
+/// `adapter_dir`. Skips the in-flight `.upload-tmp-*/` staging dirs and the
+/// `.composed/<hash>/` cache (which is bounded separately by the §6/§8 LRU
+/// eviction work — see roadmap item 8). A directory entry that fails to
+/// stat is ignored rather than aborting the whole walk; this keeps the
+/// guard available on a partially-corrupt adapter_dir.
+fn measure_finalized_adapter_dir_bytes(adapter_dir: &Path) -> u64 {
+    let read_dir = match std::fs::read_dir(adapter_dir) {
+        Ok(rd) => rd,
+        Err(_) => return 0,
+    };
+    let mut total: u64 = 0;
+    for entry in read_dir.flatten() {
+        let name = entry.file_name();
+        let name_lossy = name.to_string_lossy();
+        if name_lossy.starts_with(".upload-tmp-") || name_lossy == ".composed" {
+            continue;
+        }
+        total = total.saturating_add(dir_size_recursive(&entry.path()));
+    }
+    total
+}
+
+/// Recursively sum the regular-file byte sizes under `root`. Symlinks and
+/// errors are silently treated as zero (matching the conservative
+/// best-effort spirit of `measure_finalized_adapter_dir_bytes`).
+fn dir_size_recursive(root: &Path) -> u64 {
+    let meta = match std::fs::symlink_metadata(root) {
+        Ok(m) => m,
+        Err(_) => return 0,
+    };
+    if meta.file_type().is_file() {
+        return meta.len();
+    }
+    if !meta.file_type().is_dir() {
+        return 0;
+    }
+    let read_dir = match std::fs::read_dir(root) {
+        Ok(rd) => rd,
+        Err(_) => return 0,
+    };
+    let mut total: u64 = 0;
+    for entry in read_dir.flatten() {
+        total = total.saturating_add(dir_size_recursive(&entry.path()));
+    }
+    total
+}
+
 /// Receive a multipart/form-data archive and install it as a new adapter
 /// directory under `adapter_dir`. Symmetric to `download_adapter`.
 async fn upload_adapter(
@@ -812,6 +860,8 @@ async fn upload_adapter(
     let tmp_root_owned = tmp_root.clone().expect("tmp_root set when archive_path is set");
     let archive_path_owned = archive_path.clone();
     let target_dir_owned = target_dir.clone();
+    let adapter_dir_owned = state.adapter_dir.clone();
+    let max_disk_bytes = state.adapter_max_disk_bytes;
     let extract_result = tokio::task::spawn_blocking(move || -> Result<(u64, u32), ImportError> {
         let staging = tmp_root_owned.join("staging");
         std::fs::create_dir_all(&staging).map_err(|e| ImportError::Failed(format!(
@@ -958,6 +1008,22 @@ async fn upload_adapter(
             ));
         }
 
+        // Disk-quota guard. We have the real extracted byte count now, and
+        // the staging dir is still under `.upload-tmp-*/` so it is excluded
+        // from `measure_finalized_adapter_dir_bytes`. Reject before rename so
+        // a quota failure leaves no partial adapter behind.
+        if let Some(cap) = max_disk_bytes {
+            let current = measure_finalized_adapter_dir_bytes(&adapter_dir_owned);
+            if current.saturating_add(bytes_written) > cap {
+                return Err(ImportError::DiskQuota(format!(
+                    "{} GiB used + {} GiB upload > {} GiB cap",
+                    current as f64 / 1024.0 / 1024.0 / 1024.0,
+                    bytes_written as f64 / 1024.0 / 1024.0 / 1024.0,
+                    cap as f64 / 1024.0 / 1024.0 / 1024.0
+                )));
+            }
+        }
+
         // Atomic rename of staging → target_dir. On the same filesystem this is
         // a single inode move; if it fails (e.g. EXDEV) fall back to a copy.
         std::fs::rename(&staging, &target_dir_owned).map_err(|e| ImportError::Failed(format!(
@@ -987,6 +1053,18 @@ async fn upload_adapter(
             let _ = std::fs::remove_dir_all(&target_dir);
             return Err(ApiError::adapter_import_failed(msg));
         }
+        Err(ImportError::DiskQuota(msg)) => {
+            // The rejection happened before rename, so target_dir was never
+            // created. The remove_dir_all is defensive in case a future change
+            // ever creates target_dir earlier in the flow.
+            let _ = std::fs::remove_dir_all(&target_dir);
+            tracing::warn!(
+                adapter = %name,
+                detail = %msg,
+                "rejected adapter upload: adapter_dir disk quota would be exceeded"
+            );
+            return Err(ApiError::adapter_disk_quota_exceeded(msg));
+        }
     };
 
     tracing::info!(
@@ -1005,10 +1083,12 @@ async fn upload_adapter(
 }
 
 /// Internal error type for the blocking extract task — separates user input
-/// problems (400) from server-side I/O failures (500).
+/// problems (400) from server-side I/O failures (500) and quota rejections
+/// (507).
 enum ImportError {
     Invalid(String),
     Failed(String),
+    DiskQuota(String),
 }
 
 /// Tiny stdlib-only random suffix so concurrent uploads don't collide.

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -28,6 +28,7 @@ pub struct KilnConfig {
     pub prefix_cache: PrefixCacheConfig,
     pub speculative: SpeculativeDecodingConfig,
     pub streaming_prefill: StreamingPrefillConfig,
+    pub adapters: AdaptersConfig,
 }
 
 /// HTTP server settings.
@@ -257,6 +258,29 @@ pub struct StreamingPrefillConfig {
     pub last_token_lm_head: bool,
 }
 
+/// Adapter-storage settings.
+#[derive(Debug, Deserialize)]
+#[serde(default)]
+pub struct AdaptersConfig {
+    /// Maximum total size in bytes for `adapter_dir/` (excluding the
+    /// `.upload-tmp-*/` staging dirs and the `.composed/<hash>/` cache —
+    /// those are bounded by separate limits). Uploads to
+    /// `POST /v1/adapters/upload` are rejected when the new adapter would
+    /// push total finalized adapter bytes over this cap.
+    ///
+    /// `None` disables the cap entirely (operator opts out). The default
+    /// is 100 GiB, which is large enough to hold dozens of typical LoRA
+    /// adapters but small enough to catch a runaway upload loop on a
+    /// home/dev box before it fills the disk. Combined with the existing
+    /// per-request 4 GiB extracted-bytes limit (`ADAPTER_EXTRACT_BYTES_LIMIT`
+    /// in `api/adapters.rs`), this closes the §8 disk-exhaustion finding
+    /// from the v0.1 security audit.
+    ///
+    /// Override via `KILN_ADAPTERS_MAX_DISK_BYTES`. Set to `0` via env to
+    /// disable the cap (operator-opt-out shorthand).
+    pub max_disk_bytes: Option<u64>,
+}
+
 // --- Defaults ---
 
 impl Default for KilnConfig {
@@ -270,6 +294,7 @@ impl Default for KilnConfig {
             prefix_cache: PrefixCacheConfig::default(),
             speculative: SpeculativeDecodingConfig::default(),
             streaming_prefill: StreamingPrefillConfig::default(),
+            adapters: AdaptersConfig::default(),
         }
     }
 }
@@ -413,6 +438,16 @@ impl Default for StreamingPrefillConfig {
             enabled: false,
             tile_tokens: 8192,
             last_token_lm_head: true,
+        }
+    }
+}
+
+impl Default for AdaptersConfig {
+    fn default() -> Self {
+        Self {
+            // 100 GiB. Large enough for many real adapters, small enough
+            // to catch a runaway upload loop before it fills the disk.
+            max_disk_bytes: Some(100 * 1024u64.pow(3)),
         }
     }
 }
@@ -594,6 +629,18 @@ impl KilnConfig {
             }
         }
 
+        // Adapters
+        if let Ok(v) = std::env::var("KILN_ADAPTERS_MAX_DISK_BYTES") {
+            // `0` is the operator-opt-out shorthand: disable the cap.
+            // Empty string also clears any TOML-set cap.
+            let trimmed = v.trim();
+            if trimmed.is_empty() {
+                self.adapters.max_disk_bytes = None;
+            } else if let Ok(n) = trimmed.parse::<u64>() {
+                self.adapters.max_disk_bytes = if n == 0 { None } else { Some(n) };
+            }
+        }
+
         // Streaming/tiled prefill
         if let Ok(v) = std::env::var("KILN_STREAMING_PREFILL") {
             self.streaming_prefill.enabled = v == "1" || v.eq_ignore_ascii_case("true");
@@ -691,6 +738,11 @@ mod tests {
         assert!(!config.streaming_prefill.enabled);
         assert_eq!(config.streaming_prefill.tile_tokens, 8192);
         assert!(config.streaming_prefill.last_token_lm_head);
+        assert_eq!(
+            config.adapters.max_disk_bytes,
+            Some(100 * 1024u64.pow(3)),
+            "default adapter disk cap should be 100 GiB"
+        );
     }
 
     #[test]
@@ -742,6 +794,9 @@ draft_layers = 10
 enabled = true
 tile_tokens = 4096
 last_token_lm_head = false
+
+[adapters]
+max_disk_bytes = 5368709120
 "#;
         let config: KilnConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.server.host, "127.0.0.1");
@@ -774,6 +829,7 @@ last_token_lm_head = false
         assert!(config.streaming_prefill.enabled);
         assert_eq!(config.streaming_prefill.tile_tokens, 4096);
         assert!(!config.streaming_prefill.last_token_lm_head);
+        assert_eq!(config.adapters.max_disk_bytes, Some(5_368_709_120));
     }
 
     #[test]
@@ -931,6 +987,38 @@ port = 3000
             std::env::remove_var("KILN_STREAMING_PREFILL");
             std::env::remove_var("KILN_STREAMING_TILE_TOKENS");
             std::env::remove_var("KILN_STREAMING_LAST_TOKEN_LM_HEAD");
+        }
+    }
+
+    #[test]
+    fn test_adapters_max_disk_bytes_env_override() {
+        let mut config = KilnConfig::default();
+        // Default is 100 GiB.
+        assert_eq!(config.adapters.max_disk_bytes, Some(100 * 1024u64.pow(3)));
+
+        unsafe {
+            std::env::set_var("KILN_ADAPTERS_MAX_DISK_BYTES", "1073741824");
+        }
+        config.apply_env_overrides();
+        assert_eq!(config.adapters.max_disk_bytes, Some(1_073_741_824));
+
+        // `0` disables the cap (operator-opt-out shorthand).
+        unsafe {
+            std::env::set_var("KILN_ADAPTERS_MAX_DISK_BYTES", "0");
+        }
+        config.apply_env_overrides();
+        assert!(config.adapters.max_disk_bytes.is_none());
+
+        // Empty string also clears the cap.
+        unsafe {
+            std::env::set_var("KILN_ADAPTERS_MAX_DISK_BYTES", "");
+        }
+        config.adapters.max_disk_bytes = Some(123);
+        config.apply_env_overrides();
+        assert!(config.adapters.max_disk_bytes.is_none());
+
+        unsafe {
+            std::env::remove_var("KILN_ADAPTERS_MAX_DISK_BYTES");
         }
     }
 

--- a/crates/kiln-server/src/error.rs
+++ b/crates/kiln-server/src/error.rs
@@ -232,6 +232,18 @@ impl ApiError {
         }
     }
 
+    pub fn adapter_disk_quota_exceeded(detail: impl std::fmt::Display) -> Self {
+        Self {
+            // 507 Insufficient Storage — the request is well-formed but the
+            // server cannot accept it without exceeding the configured cap.
+            status: StatusCode::INSUFFICIENT_STORAGE,
+            code: "adapter_disk_quota_exceeded",
+            message: format!("Adapter upload would exceed adapter_dir disk cap: {detail}"),
+            hint: "Delete unused adapters with `curl -X DELETE /v1/adapters/{name}`, or raise the cap with `KILN_ADAPTERS_MAX_DISK_BYTES` (set to 0 to disable).",
+            retry_after_seconds: None,
+        }
+    }
+
     pub fn invalid_compose_request(detail: impl std::fmt::Display) -> Self {
         Self {
             status: StatusCode::BAD_REQUEST,

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -245,6 +245,7 @@ async fn main() -> Result<()> {
     state.max_tracked_jobs = config.training.max_tracked_jobs;
     state.tracked_job_ttl =
         std::time::Duration::from_secs(config.training.tracked_job_ttl_secs);
+    state.adapter_max_disk_bytes = config.adapters.max_disk_bytes;
     if let Some(ref url) = state.training_webhook_url {
         tracing::info!(url = %url, "training completion webhook configured");
     }
@@ -257,6 +258,14 @@ async fn main() -> Result<()> {
         ttl_secs = config.training.tracked_job_ttl_secs,
         "training tracked-jobs cap and TTL configured"
     );
+    match state.adapter_max_disk_bytes {
+        Some(cap) => tracing::info!(
+            cap_bytes = cap,
+            cap_gib = cap as f64 / 1024.0 / 1024.0 / 1024.0,
+            "adapter_dir disk cap configured"
+        ),
+        None => tracing::info!("adapter_dir disk cap disabled (operator opt-out)"),
+    }
 
     // Spawn the background training queue worker
     let shutdown_flag = state.shutdown.clone();

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -442,6 +442,14 @@ pub struct AppState {
     /// Active entries (`Queued` / `Running`) are never GC'd.
     /// Mirrors `TrainingConfig::tracked_job_ttl_secs` (default 3600s).
     pub tracked_job_ttl: std::time::Duration,
+    /// Maximum total bytes that finalized adapters may occupy in
+    /// `adapter_dir/`. Uploads to `POST /v1/adapters/upload` that would
+    /// push the total over this cap are rejected before the rename-into-
+    /// place step. `None` disables the cap entirely (operator opt-out).
+    /// `.upload-tmp-*/` staging dirs and the `.composed/<hash>/` cache
+    /// are excluded from the count — they are bounded separately. Mirrors
+    /// `AdaptersConfig::max_disk_bytes` (default 100 GiB).
+    pub adapter_max_disk_bytes: Option<u64>,
     /// Identifier exposed at `/v1/models` and echoed in chat completion responses.
     pub served_model_id: String,
     /// Rolling timestamp ring for live decode tok/s + ITL on the /ui dashboard.
@@ -506,6 +514,7 @@ impl AppState {
             max_queued_training_jobs: 32,
             max_tracked_jobs: 1024,
             tracked_job_ttl: std::time::Duration::from_secs(3600),
+            adapter_max_disk_bytes: Some(100 * 1024u64.pow(3)),
             served_model_id,
             decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
             recent_requests: Arc::new(std::sync::Mutex::new(RecentRequestsRing::new(
@@ -725,6 +734,7 @@ impl AppState {
             max_queued_training_jobs: 32,
             max_tracked_jobs: 1024,
             tracked_job_ttl: std::time::Duration::from_secs(3600),
+            adapter_max_disk_bytes: Some(100 * 1024u64.pow(3)),
             served_model_id,
             decode_stats: Arc::new(std::sync::Mutex::new(DecodeStatsRing::new(4096))),
             recent_requests: Arc::new(std::sync::Mutex::new(RecentRequestsRing::new(

--- a/crates/kiln-server/tests/adapter_upload.rs
+++ b/crates/kiln-server/tests/adapter_upload.rs
@@ -255,6 +255,142 @@ async fn test_upload_rejects_existing_adapter() {
 }
 
 #[tokio::test]
+async fn test_upload_rejects_when_disk_cap_would_be_exceeded() {
+    // Adapter dir already holds a finalized adapter consuming > the cap.
+    // A subsequent upload of a small valid archive should be rejected before
+    // its staging dir is renamed into place.
+    let tmp = tempfile::tempdir().unwrap();
+    let existing = write_adapter(tmp.path(), "already-here");
+    // Pad existing/adapter_model.safetensors to ~3 KiB so the dir comfortably
+    // exceeds the 1 KiB cap we install on the AppState below.
+    std::fs::write(existing.join("adapter_model.safetensors"), vec![0u8; 3 * 1024]).unwrap();
+
+    let mut state = make_state(tmp.path().to_path_buf());
+    state.adapter_max_disk_bytes = Some(1024); // 1 KiB
+    let app = api::router(state);
+
+    let archive = build_tar_gz(&[
+        ("dest-adapter/adapter_config.json", b"{}"),
+        ("dest-adapter/adapter_model.safetensors", b"x"),
+    ]);
+    let (content_type, body) = build_multipart_body(Some("dest-adapter"), Some(&archive));
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/upload")
+        .header("content-type", content_type)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(
+        status,
+        StatusCode::INSUFFICIENT_STORAGE,
+        "expected 507, got {status}: {}",
+        String::from_utf8_lossy(&body_bytes)
+    );
+    assert_eq!(json["error"]["code"], "adapter_disk_quota_exceeded");
+
+    // The new adapter directory must NOT have been created.
+    assert!(
+        !tmp.path().join("dest-adapter").exists(),
+        "rejected upload should not have created dest-adapter/"
+    );
+    // And the existing adapter should be untouched.
+    assert!(
+        tmp.path().join("already-here").exists(),
+        "existing adapter should still be on disk"
+    );
+}
+
+#[tokio::test]
+async fn test_upload_accepts_when_disk_cap_disabled() {
+    // Same setup as the rejection test, but with the cap disabled
+    // (operator opt-out via `max_disk_bytes = None`). Upload must succeed.
+    let tmp = tempfile::tempdir().unwrap();
+    let existing = write_adapter(tmp.path(), "already-here");
+    std::fs::write(existing.join("adapter_model.safetensors"), vec![0u8; 3 * 1024]).unwrap();
+
+    let mut state = make_state(tmp.path().to_path_buf());
+    state.adapter_max_disk_bytes = None;
+    let app = api::router(state);
+
+    let archive = build_tar_gz(&[
+        ("dest-adapter/adapter_config.json", b"{}"),
+        ("dest-adapter/adapter_model.safetensors", b"x"),
+    ]);
+    let (content_type, body) = build_multipart_body(Some("dest-adapter"), Some(&archive));
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/upload")
+        .header("content-type", content_type)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "expected 200 with cap disabled, got {status}: {}",
+        String::from_utf8_lossy(&body_bytes)
+    );
+    assert!(tmp.path().join("dest-adapter").exists());
+}
+
+#[tokio::test]
+async fn test_upload_disk_cap_excludes_upload_tmp_and_composed() {
+    // Bytes parked under .upload-tmp-*/ (in-flight uploads) and .composed/
+    // (the merge cache, bounded separately) must not count toward the cap.
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Pre-fill .upload-tmp-* with > cap-worth of bytes.
+    let stale_tmp = tmp.path().join(".upload-tmp-deadbeef");
+    std::fs::create_dir_all(&stale_tmp).unwrap();
+    std::fs::write(stale_tmp.join("archive.tar.gz"), vec![0u8; 10 * 1024]).unwrap();
+
+    // Pre-fill .composed/ with > cap-worth of bytes.
+    let composed = tmp.path().join(".composed").join("abc123");
+    std::fs::create_dir_all(&composed).unwrap();
+    std::fs::write(composed.join("adapter_model.safetensors"), vec![0u8; 10 * 1024]).unwrap();
+
+    let mut state = make_state(tmp.path().to_path_buf());
+    state.adapter_max_disk_bytes = Some(1024); // 1 KiB
+    let app = api::router(state);
+
+    // The new upload's bytes alone are well under the cap, and the excluded
+    // paths must not push us over.
+    let archive = build_tar_gz(&[
+        ("dest-adapter/adapter_config.json", b"{}"),
+        ("dest-adapter/adapter_model.safetensors", b"x"),
+    ]);
+    let (content_type, body) = build_multipart_body(Some("dest-adapter"), Some(&archive));
+    let req = Request::builder()
+        .method("POST")
+        .uri("/v1/adapters/upload")
+        .header("content-type", content_type)
+        .body(Body::from(body))
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body_bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "upload should succeed because .upload-tmp-* and .composed/ are excluded; got {status}: {}",
+        String::from_utf8_lossy(&body_bytes)
+    );
+    assert!(tmp.path().join("dest-adapter").exists());
+}
+
+#[tokio::test]
 async fn test_upload_rejects_path_escape_in_archive() {
     let tmp = tempfile::tempdir().unwrap();
     let state = make_state(tmp.path().to_path_buf());

--- a/docs/audits/security-audit-v0.1.md
+++ b/docs/audits/security-audit-v0.1.md
@@ -238,6 +238,8 @@ Uploaded adapters accumulate. So do composed adapters. There is no `state.max_ad
 - Track total `adapter_dir` size; reject uploads when adding the new adapter would exceed `adapters.max_disk_bytes` (config-driven, default e.g. 100 GiB).
 - Add an LRU eviction loop for `.composed/<hash>/` keyed on directory mtime; cap at e.g. 10 GiB or 64 entries.
 
+**Resolution (total-size cap, item 9).** `adapters.max_disk_bytes` (default 100 GiB, override via `KILN_ADAPTERS_MAX_DISK_BYTES`, set to `0` to opt out) added in branch `ce/phase9-adapter-disk-cap`. The upload handler in `crates/kiln-server/src/api/adapters.rs` now sums the on-disk size of finalized adapter directories under `adapter_dir/` (skipping `.upload-tmp-*/` staging dirs and the `.composed/` cache, both of which are bounded separately) right before the staging→target rename. If the sum plus the just-extracted byte count would exceed the cap, the upload is rejected with HTTP 507 `adapter_disk_quota_exceeded` and no partial adapter is left behind. The `.composed/` LRU eviction (item 8) is tracked separately.
+
 **Severity:** LOW. Slow to trigger and easy to mitigate operationally.
 
 ---
@@ -351,7 +353,7 @@ Ordered by severity, then by effort.
 
 7. ~~**Per-route body-size limits** (§1). Set `DefaultBodyLimit` explicitly on `/v1/train/sft`, `/v1/train/grpo`, `/v1/chat/completions`, `/v1/completions/batch`.~~ **Fixed** in branch `ce/phase9-per-route-body-limits` (64 MiB for training, 8 MiB for completions).
 8. **Cap composed-adapter cache size** (§6, §8). LRU-evict `.composed/<hash>/` entries above N total or M GiB.
-9. **Cap total adapter-dir disk usage** (§8). Reject uploads that would push total adapter-dir size above `adapters.max_disk_bytes`.
+9. ~~**Cap total adapter-dir disk usage** (§8). Reject uploads that would push total adapter-dir size above `adapters.max_disk_bytes`.~~ **Fixed** in branch `ce/phase9-adapter-disk-cap` — `adapters.max_disk_bytes` (default 100 GiB, env override `KILN_ADAPTERS_MAX_DISK_BYTES`, `0` to disable) checked pre-rename in `upload_adapter`; rejects with HTTP 507 `adapter_disk_quota_exceeded`. Item 8 (`.composed/` LRU eviction) remains open.
 10. ~~**Disable redirects on webhook reqwest client** (§7). Belt-and-suspenders against a misconfigured webhook URL pointing at a public 302.~~ **Fixed** in branch `ce/phase9-webhook-disable-redirects`.
 11. ~~**Migrate `deny.toml`** (§12). Replace `unmaintained = "workspace"` with the post-PR-611 shape; pin the CI cargo-deny version explicitly.~~ **Fixed** in branch `ce/phase9-deny-migration` — pinned `cargo-deny-action` to v2.0.17 commit SHA (cargo-deny 0.19.2) and documented the schema-version constraint in `deny.toml`. The "new shape" turned out not to exist: `unmaintained = "workspace"` is already the canonical modern form on cargo-deny ≥ 0.18; see the §12 update for the full reasoning.
 12. ~~**Document training-data invariants** (§3). One short README section: "Kiln applies a faithful gradient update to whatever you POST. Treat your training corpus as security-sensitive."~~ **Fixed** in branch `ce/phase9-document-training-data-trust` (new `## Security model` section in `README.md`, callout in `QUICKSTART.md` adjacent to the loopback paragraph).

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -64,3 +64,14 @@ num_speculative_tokens = 4            # Tokens to draft per step (3-8 typical)
 draft_layers = 8                      # First N layers used as draft model
                                       # Also settable via KILN_SPEC_ENABLED, KILN_SPEC_NUM_TOKENS,
                                       # KILN_SPEC_DRAFT_LAYERS env vars
+
+[adapters]
+max_disk_bytes = 107374182400         # 100 GiB cap on total finalized adapter_dir size.
+                                      # Rejects POST /v1/adapters/upload with HTTP 507
+                                      # `adapter_disk_quota_exceeded` when the sum of
+                                      # finalized adapters + the just-extracted upload
+                                      # would exceed this. `.upload-tmp-*/` and `.composed/`
+                                      # are excluded (bounded separately).
+                                      # Override via KILN_ADAPTERS_MAX_DISK_BYTES.
+                                      # To disable the cap entirely, set the env var to 0
+                                      # (or empty): `KILN_ADAPTERS_MAX_DISK_BYTES=0`.


### PR DESCRIPTION
Closes audit roadmap item 9 (LOW): cap **total** `adapter_dir` disk usage at upload time, rejecting uploads that would push total finalized adapter bytes above the configured limit.

Audit doc: [`docs/audits/security-audit-v0.1.md` §8](../blob/main/docs/audits/security-audit-v0.1.md#8-no-cap-on-total-adapter-dir-disk-usage). Sibling pattern to the per-route body-size limits in #609 and the tracked-jobs cap in #608.

## What changed

**New config field — `crates/kiln-server/src/config.rs`:**
- `[adapters] max_disk_bytes = <bytes>` (default **100 GiB** — large enough for many real LoRA adapters but small enough to catch a runaway upload loop on a home/dev box before it fills the disk).
- Env override: `KILN_ADAPTERS_MAX_DISK_BYTES=<bytes>`. Set to `0` or empty to disable the cap entirely (operator opt-out).
- Mirrored on `AppState::adapter_max_disk_bytes` and logged at startup.

**Upload guard — `crates/kiln-server/src/api/adapters.rs`:**
- Right before the staging→target rename, walk `adapter_dir/` to compute `current_total`. If `current_total + extracted_bytes > cap`, reject with new `ApiError::adapter_disk_quota_exceeded` (HTTP **507 Insufficient Storage**, code `adapter_disk_quota_exceeded`).
- Skips `.upload-tmp-*/` (in-flight uploads, would double-count the bytes we're about to evaluate) and `.composed/` (the merge cache — bounded separately by roadmap item 8, which remains open).
- The `tmp_root` cleanup that runs after `spawn_blocking` removes the staging dir on the rejection path, so a quota failure leaves **no partial adapter** behind.

**Docs:**
- `docs/audits/security-audit-v0.1.md` — `**Resolution.**` paragraph under §8 and strikethrough on roadmap item 9. Item 8 (`.composed/` LRU eviction) is explicitly noted as still open.
- `kiln.example.toml` — new `[adapters]` block with the default value and disable instructions.

## Test coverage

New tests in `crates/kiln-server/tests/adapter_upload.rs`:

- `test_upload_rejects_when_disk_cap_would_be_exceeded` — pre-fill `adapter_dir/` above a 1 KiB cap, POST a small valid archive, expect **507** + `error.code = adapter_disk_quota_exceeded` + `dest-adapter/` not created + the existing adapter untouched.
- `test_upload_accepts_when_disk_cap_disabled` — same setup with `adapter_max_disk_bytes = None`, expect **200**.
- `test_upload_disk_cap_excludes_upload_tmp_and_composed` — pre-fill `.upload-tmp-deadbeef/` (10 KiB) and `.composed/abc123/` (10 KiB) above a 1 KiB cap, expect **200** because both paths must be excluded from the quota count.

New unit test in `crates/kiln-server/src/config.rs`:

- `test_adapters_max_disk_bytes_env_override` — verifies `KILN_ADAPTERS_MAX_DISK_BYTES=N` (sets to `Some(N)`), `=0` (disables → `None`), and `=\"\"` (also disables) all behave correctly.

All 7 `adapter_upload` tests pass; full kiln-server lib + config suite (113 + 21) pass.

## Out of scope

Roadmap item 8 — `.composed/<hash>/` LRU eviction — is a separate, larger task and remains open.