### PR TITLE
chore(release): cut kiln-v0.2.7 (v0.1 security audit closure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,31 @@
 
 ## Unreleased
 
+## kiln-v0.2.7 — 2026-04-28
+
+Security release: closes all 12 findings in `docs/audits/security-audit-v0.1.md`.
+Adds path-traversal hardening on adapter routes, per-route body-size limits,
+webhook redirect-disable, training queue + tracked-jobs caps, adapter-dir
+disk caps, LRU eviction for the composed-adapter cache, loopback default bind,
+and reproducible Docker builds. No new features and no GPU/runtime breaking
+changes.
+
 ### Security
 - Fix path traversal in `DELETE /v1/adapters/:name` and `POST /v1/adapters/load` (Phase 9 audit §2b/§2c, HIGH).
 - Validate source adapter names in `POST /v1/adapters/merge` (Phase 9 audit §2d, LOW).
 - Per-route body-size limits on training + completions endpoints: 64 MiB for `/v1/train/sft` and `/v1/train/grpo`, 8 MiB for `/v1/chat/completions` and `/v1/completions/batch` (Phase 9 audit §1, LOW).
 - Disable HTTP redirects on the training-completion webhook client to prevent server-side redirect chasing into internal infra (Phase 9 audit §7, item 10, LOW).
+- Cap training queue depth (audit MEDIUM §4 part 1) — bounded queue with explicit reject when full (#607).
+- Cap tracked-jobs map size and TTL Completed/Failed entries (audit MEDIUM §4 part 2) — prevents unbounded memory growth (#608).
+- Cap total adapter_dir disk usage on upload (audit LOW §8 / item 9) — `KILN_ADAPTERS_DIR_MAX_BYTES` rejects uploads that would exceed the cap (#620).
+- LRU eviction for `.composed/` adapter cache (audit LOW §8 / item 8) — bounded byte-size + entry-count caps with oldest-mtime-first eviction (#621). Closes the last open finding in security-audit-v0.1; all 12 findings now resolved.
 
 ### Changed
 - Default server listen host changed from `0.0.0.0` to `127.0.0.1` (loopback). Set `server.host = "0.0.0.0"` or `KILN_HOST=0.0.0.0` to accept remote connections; pair with a trusted reverse proxy. Closes security-audit-v0.1 MEDIUM §9.
 
 ### Reproducibility / release
 - docker: use `--locked` in `deploy/Dockerfile` cargo builds so the published `ghcr.io/ericflo/kiln-server` image matches the exact Cargo.lock dependency set (#601)
+- Pin cargo-deny-action to a specific commit SHA and document deny.toml schema (audit LOW §11) (#612).
 
 ### Documentation
 - docs(security): document training-data trust invariants (security audit §3 / item 12) in README + QUICKSTART. Calls out that `/v1/train/sft` and `/v1/train/grpo` apply a faithful gradient update to anything POSTed — kiln validates structure, not semantics — so the operator's training corpus must be treated as security-sensitive.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1698,7 +1698,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "candle-core",
  "cc",
@@ -1707,7 +1707,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1721,7 +1721,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "candle-core",
  "cc",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1750,7 +1750,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "candle-core",
  "cc",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1789,11 +1789,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.6"
+version = "0.2.7"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "candle-core",
  "cc",
@@ -1802,7 +1802,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1811,7 +1811,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.7"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## Summary
Cut release `kiln-v0.2.7` containing the post-`v0.2.6` work — most importantly the closure of all 12 findings in `docs/audits/security-audit-v0.1.md` (last finding closed by #621).

## Changes
- Bump workspace version 0.2.6 → 0.2.7
- Roll `## Unreleased` → `## kiln-v0.2.7 — 2026-04-28` in CHANGELOG, including missing entries #607/#608/#612/#620/#621
- Refresh Cargo.lock

## After merge
- Push tag `kiln-v0.2.7` from main → triggers `server-release.yml` (binary releases) + `docker-server-release.yml` (GHCR image).

## Test plan
- [x] `cargo update --workspace` succeeds locally (Cargo.lock refreshed cleanly)
- [x] CHANGELOG diff is review-friendly
- [ ] CI green