### PR TITLE
fix(test): serialize env-mutating config tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,17 +41,20 @@ jobs:
       - name: Build (Metal)
         run: cargo build --locked --features metal
 
-      # Skip the two pre-existing env-var races on both feature sets — they
-      # flake in parallel test runs but pass in isolation.
+      # Env-mutating tests are now serialized via an ENV_LOCK mutex inside
+      # the test module, so they no longer race in parallel runs. The
+      # `test_health_with_real_backend` skip remains because that test
+      # depends on a live network backend and is intentionally excluded
+      # from CI.
       - name: Test (default features — exercises CPU fallback)
-        run: cargo test --locked -- --skip test_env_var_overrides --skip test_health_with_real_backend
+        run: cargo test --locked -- --skip test_health_with_real_backend
 
       - name: Test (Metal feature — exercises Apple Silicon GPU path)
         # `--test-threads=1` because concurrent `Device::new_metal(0)` calls
         # panic in candle-metal 0.10.2's MetalDevice::new (`swap_remove` on
         # an empty vec).
         run: |
-          cargo test --locked --features metal -- --test-threads=1 --skip test_env_var_overrides --skip test_health_with_real_backend
+          cargo test --locked --features metal -- --test-threads=1 --skip test_health_with_real_backend
 
   linux-default:
     name: Linux / default features
@@ -69,7 +72,7 @@ jobs:
         run: cargo build --locked
 
       - name: Test (default features)
-        run: cargo test --locked -- --skip test_env_var_overrides --skip test_health_with_real_backend
+        run: cargo test --locked -- --skip test_health_with_real_backend
 
   cargo-deny:
     name: cargo-deny (license / source / bans policy)

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -749,6 +749,16 @@ impl KilnConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    // Serializes tests that mutate the process-wide environment. cargo nextest
+    // and `cargo test` run tests in parallel by default, so any test that
+    // calls `std::env::set_var` / `std::env::remove_var` races with siblings
+    // touching the same variables. Acquire this lock for the full duration of
+    // the test (bind to a named guard, NOT `_`) before mutating env state.
+    // `unwrap_or_else(|e| e.into_inner())` recovers from poisoning so a single
+    // panicking test doesn't cascade into the rest of the suite.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn test_defaults() {
@@ -970,8 +980,9 @@ port = 3000
 
     #[test]
     fn test_env_var_overrides() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Safety: these tests manipulate env vars which is unsafe in Rust 1.78+.
-        // They are safe because cargo test runs lib tests single-threaded by default.
+        // They are safe because ENV_LOCK serializes env-mutating tests.
         unsafe {
             std::env::set_var("KILN_HOST", "10.0.0.1");
             std::env::set_var("KILN_PORT", "7777");
@@ -1052,6 +1063,7 @@ port = 3000
 
     #[test]
     fn test_adapters_max_disk_bytes_env_override() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut config = KilnConfig::default();
         // Default is 100 GiB.
         assert_eq!(config.adapters.max_disk_bytes, Some(100 * 1024u64.pow(3)));
@@ -1084,6 +1096,7 @@ port = 3000
 
     #[test]
     fn test_adapters_composed_cache_max_bytes_env_override() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut config = KilnConfig::default();
         // Default is 10 GiB.
         assert_eq!(
@@ -1107,6 +1120,7 @@ port = 3000
 
     #[test]
     fn test_adapters_composed_cache_max_entries_env_override() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut config = KilnConfig::default();
         // Default is 64.
         assert_eq!(config.adapters.composed_cache_max_entries, Some(64));
@@ -1124,6 +1138,7 @@ port = 3000
 
     #[test]
     fn test_adapters_composed_cache_zero_disables() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let mut config = KilnConfig::default();
         assert!(config.adapters.composed_cache_max_bytes.is_some());
         assert!(config.adapters.composed_cache_max_entries.is_some());
@@ -1156,6 +1171,7 @@ port = 3000
 
     #[test]
     fn test_training_webhook_env_empty_string_clears_toml_value() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let toml_str = r#"
 [training]
 webhook_url = "https://from-toml.example/hook"
@@ -1181,6 +1197,7 @@ webhook_url = "https://from-toml.example/hook"
 
     #[test]
     fn test_load_missing_file_returns_defaults() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // With no file and no KILN_CONFIG env var, should return defaults
         unsafe {
             std::env::remove_var("KILN_CONFIG");
@@ -1205,6 +1222,7 @@ webhook_url = "https://from-toml.example/hook"
 
     #[test]
     fn test_load_explicit_path() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("test.toml");
         std::fs::write(
@@ -1280,6 +1298,7 @@ level = "warn"
 
     #[test]
     fn test_served_model_id_env_var_overrides_toml() {
+        let _env_guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let toml_str = r#"
 [model]
 served_model_id = "from-toml"


### PR DESCRIPTION
## Why

PR #622 (the kiln-v0.2.7 release cut) is OPEN MERGEABLE but [Linux / default features CI fails](https://github.com/ericflo/kiln/actions/runs/25082202331/job/73489638294) on a single test:

```
---- config::tests::test_adapters_composed_cache_zero_disables stdout ----
thread '...' panicked at crates/kiln-server/src/config.rs:1137:9:
assertion failed: config.adapters.composed_cache_max_bytes.is_none()
```

This blocks the v0.2.7 tag, which in turn blocks `server-release.yml` (binary releases) and `docker-server-release.yml` (GHCR image) — both Phase 9 v0.1.0 release-prep checklist items.

## Root cause

`test_adapters_composed_cache_zero_disables` (added in #621) sets `KILN_ADAPTERS_COMPOSED_CACHE_MAX_BYTES=0` and asserts the field becomes `None`. It races with sibling tests `test_adapters_composed_cache_max_bytes_env_override` and `test_adapters_composed_cache_max_entries_env_override`, which set the **same** env vars to non-zero values. cargo's default parallelism makes the assertion fail when a sibling has just set the var to e.g. `"536870912"` between this test's `set_var` and `apply_env_overrides`.

The env-override branch in `apply_env_overrides()` itself is correct — `"0"` → `None` is implemented. The bug is test isolation, not production code.

This is the same underlying race that motivated `--skip test_env_var_overrides` on all three CI test invocations earlier.

## Fix

Add a per-test-module `ENV_LOCK: Mutex<()>` static at the top of `mod tests` and acquire it at the start of every env-mutating test in `config::tests` (9 tests touched). The guard is bound to a named local (`_env_guard`, NOT `_`, which would drop immediately) so it lives for the full `set_var → apply_env_overrides → assert → remove_var` sequence. `.unwrap_or_else(|e| e.into_inner())` recovers from poisoning so a single panicking test doesn't cascade-fail the rest.

Then drop `--skip test_env_var_overrides` from all three CI invocations (macos default, macos metal, linux default). Kept: the unrelated `--skip test_health_with_real_backend` (live network test) and `--test-threads=1` on macos metal (separate `Device::new_metal(0)` issue).

No new dependencies — std `Mutex` is sufficient (Rust 1.63+ supports `const fn Mutex::new`).

## Verification

```
$ cargo test -p kiln-server --lib config::tests --locked
test result: ok. 24 passed; 0 failed; 0 ignored

$ for i in $(seq 1 10); do cargo test -p kiln-server --lib config::tests --locked; done
# all 10 runs: test result: ok. 24 passed.

$ for i in $(seq 1 5); do cargo test -p kiln-server --lib config::tests --locked -- --test-threads=8; done
# all 5 runs under explicit parallelism: test result: ok.
```

## Tests touched

All 9 env-mutating tests in `config::tests`:
- `test_env_var_overrides`
- `test_adapters_max_disk_bytes_env_override`
- `test_adapters_composed_cache_max_bytes_env_override`
- `test_adapters_composed_cache_max_entries_env_override`
- `test_adapters_composed_cache_zero_disables`
- `test_training_webhook_env_empty_string_clears_toml_value`
- `test_load_missing_file_returns_defaults`
- `test_load_explicit_path`
- `test_served_model_id_env_var_overrides_toml`

## Unblocks

#622 (kiln-v0.2.7 release cut).