### PR TITLE
docs(site): scaffold landing page + Pages workflow (Phase 9)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,45 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/site/**'
+      - 'assets/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - name: Assemble site
+        run: |
+          mkdir -p _site
+          cp -r docs/site/. _site/
+          mkdir -p _site/assets
+          cp assets/logo.png _site/assets/logo.png
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 </p>
 
 <p align="center">
+  <a href="https://ericflo.github.io/kiln/">Website</a> &middot;
   <a href="QUICKSTART.md">Quickstart</a> &middot;
   <a href="ARCHITECTURE.md">Architecture</a> &middot;
   <a href="kiln.example.toml">Configuration</a>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -1,0 +1,315 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Kiln &mdash; Your model gets better every time you use it</title>
+  <meta name="description" content="A single-GPU inference server with live LoRA training. Pure Rust. Single binary. Targets Qwen3.5-4B with continuous batching, paged KV cache, hot-swap adapters, and SFT + GRPO training over HTTP.">
+  <link rel="canonical" href="https://ericflo.github.io/kiln/">
+  <link rel="icon" type="image/png" href="assets/logo.png">
+
+  <meta property="og:title" content="Kiln &mdash; Your model gets better every time you use it">
+  <meta property="og:description" content="A single-GPU inference server with live LoRA training. Pure Rust. Single binary.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://ericflo.github.io/kiln/">
+  <meta property="og:image" content="https://ericflo.github.io/kiln/assets/logo.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Kiln &mdash; Your model gets better every time you use it">
+  <meta name="twitter:description" content="A single-GPU inference server with live LoRA training. Pure Rust. Single binary.">
+  <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/logo.png">
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b0d10;
+      --bg-soft: #11141a;
+      --bg-soft-2: #161a22;
+      --line: #1f2530;
+      --line-2: #2a3140;
+      --fg: #e6e9ef;
+      --fg-dim: #a4adbb;
+      --fg-mute: #6f7888;
+      --accent: #f97316;
+      --accent-soft: rgba(249, 115, 22, 0.12);
+    }
+    html { background: var(--bg); }
+    body {
+      background: var(--bg);
+      color: var(--fg);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      font-feature-settings: "ss01", "cv02", "cv11";
+      -webkit-font-smoothing: antialiased;
+    }
+    code, pre, kbd, samp {
+      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    }
+    pre {
+      background: var(--bg-soft);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 1rem 1.1rem;
+      overflow-x: auto;
+      font-size: 13.5px;
+      line-height: 1.55;
+      color: #d8dde7;
+    }
+    pre code { background: transparent; padding: 0; color: inherit; }
+    p code, li code, td code, h2 code, h3 code {
+      background: var(--bg-soft);
+      border: 1px solid var(--line);
+      padding: 0.05rem 0.4rem;
+      border-radius: 5px;
+      font-size: 0.875em;
+      color: #f3c891;
+    }
+    .hero-glow {
+      background:
+        radial-gradient(60% 50% at 50% 0%, rgba(249,115,22,0.10), transparent 70%),
+        radial-gradient(40% 35% at 80% 20%, rgba(56,189,248,0.06), transparent 70%);
+    }
+    .card {
+      background: var(--bg-soft);
+      border: 1px solid var(--line);
+      border-radius: 12px;
+    }
+    .card:hover { border-color: var(--line-2); }
+    .btn-primary {
+      background: var(--accent);
+      color: #1a0c00;
+      font-weight: 600;
+    }
+    .btn-primary:hover { filter: brightness(1.08); }
+    .btn-secondary {
+      background: transparent;
+      color: var(--fg);
+      border: 1px solid var(--line-2);
+    }
+    .btn-secondary:hover { background: var(--bg-soft); }
+    .divider {
+      border-top: 1px solid var(--line);
+    }
+    .pill {
+      background: var(--accent-soft);
+      color: var(--accent);
+      border: 1px solid rgba(249,115,22,0.35);
+    }
+    a { color: #f3c891; }
+    a:hover { color: var(--accent); }
+    /* the orange link color reads poorly on the buttons; reset there */
+    a.btn-primary, a.btn-primary:hover { color: #1a0c00; }
+    a.btn-secondary, a.btn-secondary:hover { color: var(--fg); }
+    .num {
+      font-variant-numeric: tabular-nums;
+    }
+  </style>
+</head>
+<body class="min-h-screen">
+  <!-- nav -->
+  <header class="border-b" style="border-color: var(--line);">
+    <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="/" class="flex items-center gap-2.5">
+        <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
+        <span class="text-lg font-semibold tracking-tight">Kiln</span>
+      </a>
+      <nav class="flex items-center gap-5 text-sm" style="color: var(--fg-dim);">
+        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">Architecture</a>
+        <a href="https://github.com/ericflo/kiln" class="hidden sm:inline">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- hero -->
+  <section class="hero-glow">
+    <div class="max-w-5xl mx-auto px-6 pt-20 pb-16">
+      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">v0.2.7 &middot; pre-1.0 preview</span>
+      <h1 class="text-5xl sm:text-6xl font-bold tracking-tight mb-5">
+        Your model gets better<br>every time you use it.
+      </h1>
+      <p class="text-xl max-w-2xl leading-relaxed mb-8" style="color: var(--fg-dim);">
+        Kiln is a single-GPU inference server with live LoRA training. Pure Rust. Single binary.
+        Submit corrections or scored completions over HTTP and the model improves in seconds &mdash;
+        no restarts, no separate training pipeline, no second copy of the weights.
+      </p>
+      <div class="flex flex-wrap gap-3">
+        <a href="https://github.com/ericflo/kiln" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+          GitHub &rarr;
+        </a>
+        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+          Quickstart &rarr;
+        </a>
+        <a href="#install" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+          Install
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- pitch -->
+  <section class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-16">
+      <h2 class="text-2xl font-semibold tracking-tight mb-4">The training loop, collapsed.</h2>
+      <p class="leading-relaxed mb-4" style="color: var(--fg-dim);">
+        Today, improving a deployed model looks like: collect failure examples, format them, upload to a
+        training service, wait hours, download new weights, redeploy, hope. Kiln collapses that into one
+        API call.
+      </p>
+<pre><code><span style="color:#7f8694"># Submit a correction &mdash; the model learns it in seconds</span>
+curl http://localhost:8420/v1/train/sft \
+  -H "Content-Type: application/json" \
+  -d '{
+    "examples": [
+      {"messages": [
+        {"role": "user", "content": "Summarize this contract clause..."},
+        {"role": "assistant", "content": "The clause establishes..."}
+      ]}
+    ]
+  }'
+
+<span style="color:#7f8694"># The next request already uses the updated weights</span>
+curl http://localhost:8420/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "Summarize this contract clause..."}]}'</code></pre>
+      <p class="leading-relaxed mt-6" style="color: var(--fg-dim);">
+        A 4B model continuously tuned to your specific workload will outperform a generic 70B model on the
+        tasks you actually care about &mdash; on hardware you already own. Kiln targets a single model
+        (<a href="https://huggingface.co/Qwen/Qwen3.5-4B">Qwen3.5-4B</a>) and tunes the scheduler, memory
+        manager, and kernels for it. This isn't a general-purpose framework. It's a scalpel.
+      </p>
+    </div>
+  </section>
+
+  <!-- features -->
+  <section class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-16">
+      <h2 class="text-2xl font-semibold tracking-tight mb-8">What you get</h2>
+      <div class="grid sm:grid-cols-2 gap-4">
+        <div class="card p-5">
+          <h3 class="font-semibold mb-2">Continuous batching &amp; paged KV cache</h3>
+          <p class="text-sm leading-relaxed" style="color: var(--fg-dim);">
+            Sarathi-style chunked prefill keeps decode requests from stalling behind long prompts.
+            Virtual-memory KV blocks eliminate fragmentation. 128K context fits in
+            <span class="num">~13 GB</span> on 24 GB GPUs.
+          </p>
+        </div>
+        <div class="card p-5">
+          <h3 class="font-semibold mb-2">Live LoRA training over HTTP</h3>
+          <p class="text-sm leading-relaxed" style="color: var(--fg-dim);">
+            <code>POST /v1/train/sft</code> with chat examples or <code>POST /v1/train/grpo</code> with
+            scored completions. Runs in-process on the loaded model &mdash; no second copy in VRAM, no
+            Python sidecar.
+          </p>
+        </div>
+        <div class="card p-5">
+          <h3 class="font-semibold mb-2">Hot-swap adapters in seconds</h3>
+          <p class="text-sm leading-relaxed" style="color: var(--fg-dim);">
+            New adapter weights activate atomically at iteration boundaries. Zero downtime.
+            Load, unload, merge (TIES, weighted-average, concat), upload, download, compose &mdash;
+            full adapter lifecycle.
+          </p>
+        </div>
+        <div class="card p-5">
+          <h3 class="font-semibold mb-2">Single Rust binary, single GPU</h3>
+          <p class="text-sm leading-relaxed" style="color: var(--fg-dim);">
+            One process, one model in memory, one binary to deploy. RTX 3090 / 4090 / A6000 on the CUDA
+            side; M-series Macs on Metal. OpenAI-compatible API with SSE streaming.
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- the GRPO loop -->
+  <section class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-16">
+      <h2 class="text-2xl font-semibold tracking-tight mb-4">The GRPO loop</h2>
+      <p class="leading-relaxed mb-6 max-w-3xl" style="color: var(--fg-dim);">
+        Generate completions, score them with your own reward function, feed the results back. The model
+        learns what &ldquo;good&rdquo; means for your use case. Your reward function can be anything &mdash;
+        regex, unit tests, another model, human eval.
+      </p>
+<pre><code><span style="color:#7f8694"># 1. Generate candidates</span>
+responses = [client.chat.completions.create(
+    model="qwen3.5-4b-kiln", messages=[...], temperature=0.7
+) for _ in range(8)]
+
+<span style="color:#7f8694"># 2. Score them however you want</span>
+scored = [{"text": r.choices[0].message.content, "reward": my_score(r)}
+          for r in responses]
+
+<span style="color:#7f8694"># 3. Submit &mdash; server trains and hot-swaps immediately</span>
+requests.post("http://localhost:8420/v1/train/grpo",
+              json={"groups": [{"prompt": prompt, "completions": scored}]})
+
+<span style="color:#7f8694"># 4. Next inference already uses the improved weights</span></code></pre>
+      <p class="text-sm mt-5" style="color: var(--fg-mute);">
+        See <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">docs/GRPO_GUIDE.md</a>
+        for worked verifiable-rewards examples (math, JSON, code).
+      </p>
+    </div>
+  </section>
+
+  <!-- install -->
+  <section id="install" class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-16">
+      <h2 class="text-2xl font-semibold tracking-tight mb-2">Install</h2>
+      <p class="text-sm mb-8" style="color: var(--fg-mute);">
+        Latest release: <a href="https://github.com/ericflo/kiln/releases/tag/kiln-v0.2.7">kiln-v0.2.7</a>.
+        Prerequisites: NVIDIA GPU with 24 GB+ VRAM and CUDA 12.4 <em>or</em> Apple Silicon Mac with 16 GB+ unified memory.
+      </p>
+
+      <h3 class="font-semibold mb-2 mt-2">Linux x86_64 &middot; CUDA 12.4</h3>
+<pre><code>curl -L -o kiln.tar.gz \
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.7/kiln-0.2.7-x86_64-unknown-linux-gnu-cuda124.tar.gz
+tar -xzf kiln.tar.gz
+KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
+
+      <h3 class="font-semibold mb-2 mt-6">macOS &middot; Apple Silicon (Metal)</h3>
+<pre><code>curl -L -o kiln.tar.gz \
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.7/kiln-0.2.7-aarch64-apple-darwin-metal.tar.gz
+tar -xzf kiln.tar.gz
+KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
+
+      <h3 class="font-semibold mb-2 mt-6">Windows x86_64 &middot; CUDA 12.4</h3>
+<pre><code>Invoke-WebRequest -Uri `
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.7/kiln-0.2.7-x86_64-pc-windows-msvc-cuda124.zip `
+  -OutFile kiln.zip
+Expand-Archive kiln.zip
+$env:KILN_MODEL_PATH = ".\Qwen3.5-4B"; .\kiln\kiln.exe serve</code></pre>
+
+      <h3 class="font-semibold mb-2 mt-6">Docker (Linux + NVIDIA Container Toolkit)</h3>
+<pre><code>docker pull ghcr.io/ericflo/kiln-server:latest
+docker run --gpus all -p 8420:8420 \
+  -v /path/to/Qwen3.5-4B:/models \
+  ghcr.io/ericflo/kiln-server:latest serve</code></pre>
+
+      <p class="text-sm mt-6" style="color: var(--fg-mute);">
+        Each release is signed and SHA-256 checksums are published as <code>.sha256</code> sidecars on the
+        <a href="https://github.com/ericflo/kiln/releases">releases page</a>. The
+        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a> walks through
+        downloading model weights, the first chat completion, the first SFT POST, and the first GRPO loop.
+      </p>
+    </div>
+  </section>
+
+  <!-- footer -->
+  <footer class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">
+      <div class="flex items-center gap-2.5">
+        <img src="assets/logo.png" alt="" width="20" height="20" class="rounded">
+        <span>Kiln &middot; MIT licensed</span>
+      </div>
+      <nav class="flex flex-wrap gap-x-5 gap-y-1">
+        <a href="https://github.com/ericflo/kiln">Repo</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">Architecture</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/SECURITY.md">Security</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/LICENSE">License</a>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## What
- New static landing page at `docs/site/index.html` (Tailwind via CDN, no build step, single file).
- New `.github/workflows/pages.yml` deploys `docs/site/` + `assets/` to GitHub Pages on push to `main`.
- `README.md` links the new website as the first item in the centered nav block.

## Why
Last unchecked Phase 9 release-prep item. v0.2.7 release pipeline is fully working (Linux/macOS/Windows binaries, GHCR Docker image, security audit closure all shipped 2026-04-29). Only "Landing page / project website" remained on the v0.1 checklist.

Messaging is sourced directly from the existing `README.md` (hero line, the Why-section curl example, the "scalpel not framework" framing) so it stays canonical. Only Phase 7+8 features that have actually shipped are advertised; nothing speculative.

## Verify locally
```
python3 -m http.server --bind 127.0.0.1 8765 --directory docs/site
```
Then open http://127.0.0.1:8765/ — the asset path is `assets/logo.png`, which is satisfied at deploy time by the workflow copying repo-root `assets/` into `_site/assets/`.

## Post-merge step (one-time, manual)
After merge, GitHub Pages must be enabled once in repo settings (Settings → Pages → Source: "GitHub Actions"). The workflow then publishes on every push to `main`. Live URL: https://ericflo.github.io/kiln/

## Out of scope
- Custom domain (`kiln.dev` or similar) — can swap canonical URL + add a `CNAME` later.
- Multi-page docs site (Astro / Docusaurus / mdBook) — README, QUICKSTART, ARCHITECTURE, GRPO_GUIDE remain authoritative; the landing page just markets and links.
- v0.2.7 release-asset URLs are hardcoded for now; future releases can be auto-stamped from `latest` once a docs build step is justified.