### PR TITLE
fix(ci): gate Apple codesign secrets to tagged releases

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -94,7 +94,16 @@ jobs:
           chmod 600 "$RUNNER_TEMP/appstore/AuthKey.p8"
           echo "APPLE_API_KEY_PATH=$RUNNER_TEMP/appstore/AuthKey.p8" >> "$GITHUB_ENV"
 
-      - name: Build (tauri-action)
+      # Two mutually exclusive Build steps so we can pass Apple codesign
+      # secrets to tauri-action ONLY on tagged releases. On PR/main/
+      # dependabot runs, GitHub does not expose secrets to fork-equivalent
+      # PRs, so the secret expressions evaluate to empty strings.
+      # tauri-bundler 2.x treats env vars set to empty strings as "perform
+      # codesign" and then fails when `security import` is called with no
+      # certificate. The only reliable way to make it skip codesigning is
+      # to NOT pass the env vars at all — which means a separate step.
+      - name: Build (tauri-action, tagged release with codesign)
+        if: startsWith(github.ref, 'refs/tags/desktop-v')
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -108,27 +117,37 @@ jobs:
           # staples the .app bundle automatically. A follow-up step below
           # notarizes and staples the .dmg wrapper, which tauri-action
           # does not handle.
-          #
-          # Only set these on tagged releases (refs/tags/desktop-v*). On
-          # PR/main/dependabot runs, GitHub does not expose secrets to
-          # fork-equivalent PRs, so unconditionally referencing them
-          # produces empty strings — and tauri-action then fails trying
-          # to import an empty keychain certificate. PR/main builds
-          # produce unsigned debug bundles, which is what we want for CI
-          # verification anyway.
-          APPLE_CERTIFICATE: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.APPLE_CERTIFICATE || '' }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
-          APPLE_SIGNING_IDENTITY: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.APPLE_SIGNING_IDENTITY || '' }}
-          APPLE_API_ISSUER: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.APPLE_API_ISSUER || '' }}
-          APPLE_API_KEY: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.APPLE_API_KEY || '' }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           # APPLE_API_KEY_PATH is exported by the "Write ... key to disk" step above.
         with:
           projectPath: desktop
-          tagName: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && github.ref_name || '' }}
-          releaseName: 'Kiln Desktop ${{ startsWith(github.ref, ''refs/tags/desktop-v'') && github.ref_name || '''' }}'
+          tagName: ${{ github.ref_name }}
+          releaseName: 'Kiln Desktop ${{ github.ref_name }}'
           releaseBody: ${{ env.RELEASE_BODY }}
           releaseDraft: true
           prerelease: false
+          args: ${{ matrix.args }}
+
+      - name: Build (tauri-action, PR/main unsigned)
+        if: "!startsWith(github.ref, 'refs/tags/desktop-v')"
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TAURI_SIGNING_* are keypair-based (not Apple keychain) and work
+          # on PRs because tauri-action treats empty values as "skip
+          # signing." Pass them through so updater bundles get signed when
+          # secrets ARE available (push to main from a non-fork branch).
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Intentionally NO APPLE_* env vars here — see comment above the
+          # tagged-release step. Empty values trigger codesign attempts in
+          # tauri-bundler 2.x and fail with `security import` errors.
+        with:
+          projectPath: desktop
           args: ${{ matrix.args }}
 
       - name: Notarize + staple .dmg and re-upload (macOS)

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -108,11 +108,19 @@ jobs:
           # staples the .app bundle automatically. A follow-up step below
           # notarizes and staples the .dmg wrapper, which tauri-action
           # does not handle.
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          #
+          # Only set these on tagged releases (refs/tags/desktop-v*). On
+          # PR/main/dependabot runs, GitHub does not expose secrets to
+          # fork-equivalent PRs, so unconditionally referencing them
+          # produces empty strings — and tauri-action then fails trying
+          # to import an empty keychain certificate. PR/main builds
+          # produce unsigned debug bundles, which is what we want for CI
+          # verification anyway.
+          APPLE_CERTIFICATE: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.APPLE_CERTIFICATE || '' }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+          APPLE_SIGNING_IDENTITY: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.APPLE_SIGNING_IDENTITY || '' }}
+          APPLE_API_ISSUER: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.APPLE_API_ISSUER || '' }}
+          APPLE_API_KEY: ${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.APPLE_API_KEY || '' }}
           # APPLE_API_KEY_PATH is exported by the "Write ... key to disk" step above.
         with:
           projectPath: desktop


### PR DESCRIPTION
Unblocks dependabot PRs #614 and #615.

## Problem

`.github/workflows/desktop-build.yml` passes `APPLE_CERTIFICATE` / `APPLE_CERTIFICATE_PASSWORD` / `APPLE_SIGNING_IDENTITY` / `APPLE_API_ISSUER` / `APPLE_API_KEY` to `tauri-apps/tauri-action@v0` unconditionally. Dependabot PRs (and any fork-equivalent PR) cannot access repo secrets, so these become empty strings, and tauri-bundler fails trying to import an empty keychain certificate:

```
security: SecKeychainItemImport: One or more parameters passed to a function were not valid.
failed to bundle project failed codesign application: failed to run command security import: failed to import keychain certificate
```

## First attempt (wouldn't work)

Initial fix wrapped each secret in `${{ startsWith(github.ref, 'refs/tags/desktop-v') && secrets.X || '' }}`. Verified this is functionally equivalent to the original on PRs — `secrets.X` already evaluates to empty string for fork-equivalent PRs, and tauri-bundler 2.x reads via `std::env::var_os`, which returns `Some("")` for env vars set to empty. The bundler then invokes `security import` with an empty cert and fails. CI confirmed: Linux + Windows passed, macOS still failed with the same error in 3m19s.

## Working fix (this PR)

Split the single `Build (tauri-action)` step into two mutually exclusive steps gated by `startsWith(github.ref, 'refs/tags/desktop-v')`:

- **tagged release** — all Apple secrets passed in env, `releaseDraft: true`, `releaseBody` set, `tagName` + `releaseName` populated. Same behavior as before for `desktop-v*` pushes.
- **PR/main unsigned** — no `APPLE_*` env vars at all (so tauri-bundler's `var_os` returns `None` and skips codesigning entirely). Keeps `TAURI_SIGNING_*` because those are keypair-based, not Apple keychain — tauri-action handles empty values for those gracefully. No release publishing.

Result: PR/main builds produce unsigned debug bundles (correct for CI verification), tagged builds keep full codesigning + notarization (unchanged for releases).

## Verification

This PR's CI run on macOS should now compile + bundle without attempting codesigning. The two stuck dependabot PRs can then be rebased to pick up the workflow change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)