### PR TITLE
ci: attach build provenance attestations to release artifacts (Phase 9)

### DIFF
--- a/.github/workflows/docker-server-release.yml
+++ b/.github/workflows/docker-server-release.yml
@@ -32,6 +32,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Required by actions/attest-build-provenance: id-token mints a
+      # short-lived signing certificate from Sigstore Fulcio via OIDC,
+      # attestations writes the resulting attestation to the repo's
+      # attestation store. See https://docs.github.com/actions/security-guides/using-artifact-attestations.
+      id-token: write
+      attestations: write
     steps:
       - name: Free disk space
         # The CUDA 12.4 devel base image (~10 GB) plus the cargo target
@@ -79,6 +85,7 @@ jobs:
           echo "Computed VERSION=${VERSION}"
 
       - name: Build and push image
+        id: push
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -94,6 +101,18 @@ jobs:
           # manifest (not just an OCI index). Older Docker daemons —
           # including the one RunPod ships — reject OCI-only pulls with
           # "denied: denied" even for public packages. Same rationale as
-          # `runpod-image.yml`.
+          # `runpod-image.yml`. Build provenance is still emitted as a
+          # separate sigstore attestation in the next step.
           provenance: false
           sbom: false
+
+      - name: Attest build provenance (kiln-server image)
+        # Only attest on real tag pushes — `workflow_dispatch` runs build
+        # the image but skip `push: true`, which means there's no published
+        # digest to bind an attestation to.
+        if: startsWith(github.ref, 'refs/tags/kiln-v')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -23,6 +23,12 @@ on:
 
 permissions:
   contents: write
+  # Required by actions/attest-build-provenance to mint a signing certificate
+  # from Sigstore's Fulcio CA via OIDC and write the resulting attestation
+  # back to the repository's attestation store. See
+  # https://docs.github.com/actions/security-guides/using-artifact-attestations.
+  id-token: write
+  attestations: write
 
 jobs:
   macos-metal:
@@ -121,6 +127,12 @@ jobs:
           shasum -a 256 "$ARTIFACT" | awk '{print $1}' > "$ARTIFACT.sha256"
           echo "Produced $ARTIFACT ($(wc -c < "$ARTIFACT") bytes, sha256=$(cat "$ARTIFACT.sha256"))"
           echo "ARTIFACT=$ARTIFACT" >> "$GITHUB_ENV"
+
+      - name: Attest build provenance (macOS Metal tarball)
+        if: startsWith(github.ref, 'refs/tags/kiln-v')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ env.ARTIFACT }}
 
       - name: Upload to GitHub release
         if: startsWith(github.ref, 'refs/tags/kiln-v')
@@ -237,6 +249,12 @@ jobs:
           sha256sum "$ARTIFACT" | awk '{print $1}' > "$ARTIFACT.sha256"
           echo "Produced $ARTIFACT ($(wc -c < "$ARTIFACT") bytes, sha256=$(cat "$ARTIFACT.sha256"))"
           echo "ARTIFACT=$ARTIFACT" >> "$GITHUB_ENV"
+
+      - name: Attest build provenance (Linux CUDA tarball)
+        if: startsWith(github.ref, 'refs/tags/kiln-v')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ env.ARTIFACT }}
 
       - name: Upload to GitHub release
         if: startsWith(github.ref, 'refs/tags/kiln-v')
@@ -356,6 +374,12 @@ jobs:
           $size = (Get-Item $artifact).Length
           Write-Host "Produced $artifact ($size bytes, sha256=$hash)"
           "ARTIFACT=$artifact" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+      - name: Attest build provenance (Windows CUDA zip)
+        if: startsWith(github.ref, 'refs/tags/kiln-v')
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: ${{ env.ARTIFACT }}
 
       - name: Upload to GitHub release
         if: startsWith(github.ref, 'refs/tags/kiln-v')

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,6 +56,24 @@ Some things look like vulnerabilities but are documented design choices. Please 
 
 If you think one of the above *should* be in scope, open a normal issue or discussion to argue the design — that is the right channel for it.
 
+## Supply-chain provenance
+
+Every `kiln-v*` release ships with [build provenance attestations](https://docs.github.com/actions/security-guides/using-artifact-attestations) so you can verify that an artifact was produced by this repository's GitHub Actions workflow and not tampered with after the fact. The attestation is a Sigstore-signed in-toto statement linking the artifact's SHA-256 digest to the workflow run, commit, and source repository.
+
+To verify a downloaded binary tarball or zip:
+
+```sh
+gh attestation verify kiln-<version>-<target>.tar.gz --repo ericflo/kiln
+```
+
+To verify the published Docker image:
+
+```sh
+gh attestation verify oci://ghcr.io/ericflo/kiln-server:<tag> --repo ericflo/kiln
+```
+
+Both commands require [`gh`](https://cli.github.com/) 2.49 or newer. They exit non-zero if the artifact's digest does not match a recorded attestation, so they are safe to drop into a deployment script before unpacking the tarball or pulling the image.
+
 ## Disclosure policy
 
 We prefer coordinated disclosure. The default window is **90 days from initial acknowledgment** before public disclosure, extendable by mutual agreement if a fix is genuinely in flight.


### PR DESCRIPTION
## What

Add GitHub [build provenance attestations](https://docs.github.com/actions/security-guides/using-artifact-attestations) to the kiln release workflows so every published binary and Docker image carries a Sigstore-signed in-toto statement linking its SHA-256 digest back to the workflow run that produced it.

### Changes

- `.github/workflows/server-release.yml`
  - Top-level permissions gain `id-token: write` and `attestations: write` (required for OIDC + attestation upload).
  - Each platform job (`macos-metal`, `linux-cuda`, `windows-cuda`) gets one `actions/attest-build-provenance@v2` step, gated on `startsWith(github.ref, 'refs/tags/kiln-v')` and inserted between artifact packaging and `gh release upload`. Only the primary tarball/zip is attested — `.sha256` sidecars are skipped (they are checksums, not build outputs).
- `.github/workflows/docker-server-release.yml`
  - Same `id-token` / `attestations` permissions bump.
  - The `docker/build-push-action@v7` step now has `id: push`, and a follow-up `actions/attest-build-provenance@v2` step pins an attestation to the pushed image digest with `subject-name: ghcr.io/ericflo/kiln-server` + `subject-digest: ${{ steps.push.outputs.digest }}`. `push-to-registry: true` writes the attestation referrer to GHCR alongside the GitHub attestation store.
  - The attest step is gated on tag pushes only, so `workflow_dispatch` smoke runs (which skip `push:`) don't try to attest a digest that doesn't exist.
- `SECURITY.md`: new "Supply-chain provenance" section with `gh attestation verify` recipes for both binary tarballs and the Docker image.

### Why

Closes the "Reproducible builds (deterministic Docker image)" item in the Phase 9 release-prep checklist by giving downstream users a cryptographic answer to "did this artifact really come from `ericflo/kiln`'s CI?". Verification is a one-liner:

```sh
gh attestation verify kiln-0.2.7-aarch64-apple-darwin-metal.tar.gz --repo ericflo/kiln
gh attestation verify oci://ghcr.io/ericflo/kiln-server:0.2.7 --repo ericflo/kiln
```

### Scope

CI / docs only. No kiln source changes; no GPU pod required to validate. SBOM generation is intentionally out of scope — that can be a separate follow-up if useful.

### Test plan

- [x] Both workflow YAML files parse cleanly (`yaml.safe_load`).
- [ ] First `kiln-v*` tag after merge: confirm the `attest-build-provenance` step succeeds in each platform job and that `gh attestation verify <artifact> --repo ericflo/kiln` exits 0 against a published asset.
- [ ] Same tag: confirm the docker-server-release workflow's attest step writes both a GitHub attestation entry and a referrer manifest in GHCR (`gh attestation verify oci://ghcr.io/ericflo/kiln-server:<tag> --repo ericflo/kiln`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)