### PR TITLE
chore(release): cut kiln-v0.2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,34 @@
 
 ## Unreleased
 
+## kiln-v0.2.8 — 2026-04-29
+
+Patch release: post-v0.2.7 dep bumps and CI hygiene. First release that ships
+[Sigstore-signed build provenance attestations](SECURITY.md#supply-chain-provenance)
+for `kiln-v*` artifacts and the GHCR image.
+
+### Reproducibility / release
+- ci: attach build provenance attestations to release artifacts via `actions/attest-build-provenance`. `server-release.yml` and `docker-server-release.yml` now mint Sigstore-signed attestations bound to each artifact's sha256 and the workflow run; verify with `gh attestation verify <artifact> -R ericflo/kiln` (#627).
+
+### CI / release
+- ci: gate Apple codesign secrets (`APPLE_*`) to tagged releases so non-tag CI runs (PRs, branches) skip macOS code signing instead of failing on missing secrets (#625).
+- ci: also gate Tauri signing secrets (`TAURI_SIGNING_*`) to tagged releases for the same reason as #625 (#626).
+- chore(actions): bump `actions/upload-artifact` from 4 to 7 (#614).
+- chore(actions): bump `actions/checkout` from 4 to 6 (#615).
+- chore(actions): bump `docker/metadata-action` from 5 to 6 (#613).
+
+### Dependencies
+- chore(deps): bump `rand` from 0.9.4 to 0.10.1 (#616).
+- chore(deps): bump `safetensors` from 0.5.3 to 0.7.0 (#617).
+- chore(deps): bump `toml` from 0.8.23 to 1.1.2+spec-1.1.0 (#618).
+- chore(deps): bump `tokenizers` from 0.22.2 to 0.23.1 (#619).
+
+### Documentation
+- docs(site): scaffold landing page + GitHub Pages workflow under `docs/site/` so https://ericflo.github.io/kiln/ has a published presence (Phase 9) (#624).
+
+### Tests
+- fix(test): serialize env-mutating config tests to eliminate flakiness when run in parallel (#623).
+
 ## kiln-v0.2.7 — 2026-04-28
 
 Security release: closes all 12 findings in `docs/audits/security-audit-v0.1.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "candle-core",
  "cc",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "candle-core",
  "cc",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "candle-core",
  "cc",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1816,11 +1816,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.7"
+version = "0.2.8"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "candle-core",
  "cc",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.7"
+version = "0.2.8"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## Summary
Cut release `kiln-v0.2.8` containing the post-`v0.2.7` work — primarily Dependabot dep bumps, CI hygiene fixes, and the first release that ships [Sigstore-signed build provenance attestations](SECURITY.md#supply-chain-provenance) (#627).

12 PRs merged since the v0.2.7 cut: #613-#619 (Dependabot), #623 (test serialization), #624 (Pages site scaffold), #625-#626 (gate signing secrets to tagged releases), #627 (provenance attestations).

## Changes
- Bump workspace version 0.2.6 → 0.2.7 → 0.2.8
- Roll `## Unreleased` → `## kiln-v0.2.8 — 2026-04-29` in CHANGELOG, grouped under Reproducibility/release, CI/release, Dependencies, Documentation, Tests
- Refresh Cargo.lock (12 workspace member bumps, no transitive dep changes)

## After merge
- Push tag `kiln-v0.2.8` from main → triggers `server-release.yml` (binary releases) + `docker-server-release.yml` (GHCR image), both of which now mint build provenance attestations via #627.

## Test plan
- [x] `cargo update --workspace` succeeds locally (Cargo.lock refreshed cleanly)
- [x] CHANGELOG diff is review-friendly
- [ ] CI green