### PR TITLE
server: deserialize OpenAI tools and pass to Jinja chat template

### DIFF
--- a/crates/kiln-core/src/tokenizer.rs
+++ b/crates/kiln-core/src/tokenizer.rs
@@ -15,10 +15,22 @@ pub enum TokenizerError {
 }
 
 /// A chat message for template formatting.
-#[derive(Debug, Clone, serde::Serialize)]
+///
+/// `tool_calls`, `name`, and `tool_call_id` are skipped on serialize when None
+/// so plain chat conversations render byte-identically to the pre-tools shape.
+/// When populated they let Qwen3.5-style chat templates render past assistant
+/// tool calls and `role: "tool"` responses correctly via `{% if message.tool_calls %}`
+/// branches.
+#[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct ChatMessage {
     pub role: String,
     pub content: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<serde_json::Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
 }
 
 /// Wraps the HuggingFace tokenizers crate for Kiln's tokenization needs.
@@ -96,8 +108,38 @@ impl KilnTokenizer {
     /// reasoning, and `<tool_response>` handling. Load the model's real
     /// `chat_template` via `with_chat_template` for production use.
     pub fn apply_chat_template(&self, messages: &[ChatMessage]) -> Result<String, TokenizerError> {
+        self.apply_chat_template_with_tools(messages, None)
+    }
+
+    /// Same as [`apply_chat_template`] but also threads OpenAI-style tool/function
+    /// definitions into the Jinja chat-template context as `tools`. Templates
+    /// that branch on `{% if tools %}` (e.g. Qwen3.5's official template) emit
+    /// their tool-calling prelude only when this is `Some(non-empty)`. Pass
+    /// `None` (or an empty slice) for plain chat.
+    ///
+    /// The `tools` slice is forwarded as opaque JSON: kiln does not validate
+    /// the OpenAI tool schema, it just hands the values to the template.
+    pub fn apply_chat_template_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[serde_json::Value]>,
+    ) -> Result<String, TokenizerError> {
+        self.apply_chat_template_full(messages, tools, None)
+    }
+
+    /// Full-context variant: also threads `tool_choice` into the Jinja
+    /// context. Most templates ignore `tool_choice`; this exists so OpenAI
+    /// clients that send `"none" | "auto" | "required"` (or a named-function
+    /// object) round-trip through templates that DO consult it without losing
+    /// the field. Pass `None` to omit.
+    pub fn apply_chat_template_full(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[serde_json::Value]>,
+        tool_choice: Option<&serde_json::Value>,
+    ) -> Result<String, TokenizerError> {
         match &self.chat_template {
-            Some(template) => self.render_jinja_template(template, messages),
+            Some(template) => self.render_jinja_template(template, messages, tools, tool_choice),
             None => Ok(Self::apply_chatml(messages)),
         }
     }
@@ -129,6 +171,8 @@ impl KilnTokenizer {
         &self,
         template: &str,
         messages: &[ChatMessage],
+        tools: Option<&[serde_json::Value]>,
+        tool_choice: Option<&serde_json::Value>,
     ) -> Result<String, TokenizerError> {
         let mut env = minijinja::Environment::new();
         // Real chat templates (e.g. Qwen3.5's `chat_template.jinja`) call
@@ -153,8 +197,21 @@ impl KilnTokenizer {
             .get_template("chat")
             .map_err(|e| TokenizerError::ChatTemplate(e.to_string()))?;
 
+        // Empty `tools` is treated as "no tools" so `{% if tools %}` branches
+        // do not fire — matches HuggingFace's tokenizer convention and avoids
+        // emitting an empty `<tools></tools>` block.
+        let tools_value = tools
+            .filter(|t| !t.is_empty())
+            .map(|t| serde_json::Value::Array(t.to_vec()))
+            .unwrap_or(serde_json::Value::Null);
+        let tool_choice_value = tool_choice
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+
         tmpl.render(minijinja::context! {
             messages => messages,
+            tools => tools_value,
+            tool_choice => tool_choice_value,
             add_generation_prompt => true,
         })
         .map_err(|e| TokenizerError::ChatTemplate(e.to_string()))
@@ -204,6 +261,7 @@ mod tests {
         let messages = vec![ChatMessage {
             role: "user".to_string(),
             content: "Hello".to_string(),
+            ..Default::default()
         }];
         let prompt = tok.apply_chat_template(&messages).unwrap();
         assert_eq!(
@@ -219,18 +277,22 @@ mod tests {
             ChatMessage {
                 role: "system".to_string(),
                 content: "You are helpful.".to_string(),
+                ..Default::default()
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: "Hi".to_string(),
+                ..Default::default()
             },
             ChatMessage {
                 role: "assistant".to_string(),
                 content: "Hello!".to_string(),
+                ..Default::default()
             },
             ChatMessage {
                 role: "user".to_string(),
                 content: "How are you?".to_string(),
+                ..Default::default()
             },
         ];
         let prompt = tok.apply_chat_template(&messages).unwrap();
@@ -281,5 +343,142 @@ mod tests {
         let tok = KilnTokenizer::from_pretrained("Qwen/Qwen3.5-4B").unwrap();
         let eos = tok.eos_token_ids();
         assert!(!eos.is_empty(), "Should find at least one EOS token");
+    }
+
+    /// Tiny chat template that exercises the same surface real HF templates
+    /// rely on: iterates `messages`, branches on `message.tool_calls` and on
+    /// the top-level `tools` context entry. Used to prove that both halves of
+    /// the tools wiring actually reach the Jinja renderer.
+    const TOOLS_TEST_TEMPLATE: &str = "\
+{%- if tools %}<tools>\
+{%- for t in tools %}{{ t.name }};{% endfor %}\
+</tools>{% endif -%}\
+{%- for message in messages -%}\
+[{{ message.role }}]\
+{%- if message.tool_calls %}TOOLCALLS:\
+{%- for tc in message.tool_calls %}{{ tc.name }};{% endfor %}{%- endif -%}\
+{%- if message.tool_call_id %}TCID:{{ message.tool_call_id }};{% endif -%}\
+{%- if message.name %}NAME:{{ message.name }};{% endif -%}\
+{{ message.content }}\
+{%- endfor -%}";
+
+    fn tokenizer_with_template(template: &str) -> KilnTokenizer {
+        let json = br#"{
+            "version": "1.0",
+            "model": {
+                "type": "BPE",
+                "vocab": {"a": 0, "b": 1},
+                "merges": []
+            }
+        }"#;
+        KilnTokenizer {
+            inner: Tokenizer::from_bytes(json.as_slice()).unwrap(),
+            chat_template: Some(template.to_string()),
+        }
+    }
+
+    #[test]
+    fn test_jinja_renders_tools_when_present() {
+        let tok = tokenizer_with_template(TOOLS_TEST_TEMPLATE);
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "Run ls".to_string(),
+            ..Default::default()
+        }];
+        let tools = vec![
+            serde_json::json!({"name": "Bash", "description": "Run a command"}),
+            serde_json::json!({"name": "Read", "description": "Read a file"}),
+        ];
+        let prompt = tok
+            .apply_chat_template_with_tools(&messages, Some(&tools))
+            .unwrap();
+        assert!(
+            prompt.contains("<tools>"),
+            "tools block missing from prompt: {prompt:?}"
+        );
+        assert!(prompt.contains("Bash;"), "tool name missing: {prompt:?}");
+        assert!(prompt.contains("Read;"), "tool name missing: {prompt:?}");
+    }
+
+    #[test]
+    fn test_jinja_omits_tools_block_when_none() {
+        let tok = tokenizer_with_template(TOOLS_TEST_TEMPLATE);
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "Hello".to_string(),
+            ..Default::default()
+        }];
+        let prompt = tok.apply_chat_template_with_tools(&messages, None).unwrap();
+        assert!(
+            !prompt.contains("<tools>"),
+            "tools block leaked into prompt: {prompt:?}"
+        );
+        // Default apply_chat_template (no tools arg) must behave identically.
+        let prompt_default = tok.apply_chat_template(&messages).unwrap();
+        assert_eq!(prompt, prompt_default);
+    }
+
+    #[test]
+    fn test_jinja_omits_tools_block_when_empty_slice() {
+        let tok = tokenizer_with_template(TOOLS_TEST_TEMPLATE);
+        let messages = vec![ChatMessage {
+            role: "user".to_string(),
+            content: "Hi".to_string(),
+            ..Default::default()
+        }];
+        let prompt = tok
+            .apply_chat_template_with_tools(&messages, Some(&[]))
+            .unwrap();
+        assert!(
+            !prompt.contains("<tools>"),
+            "empty tools slice should not render tools block: {prompt:?}"
+        );
+    }
+
+    #[test]
+    fn test_jinja_renders_message_tool_calls_and_tool_responses() {
+        let tok = tokenizer_with_template(TOOLS_TEST_TEMPLATE);
+        let messages = vec![
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "calling".to_string(),
+                tool_calls: Some(vec![serde_json::json!({"name": "Bash"})]),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: "ok".to_string(),
+                name: Some("Bash".to_string()),
+                tool_call_id: Some("call_42".to_string()),
+                ..Default::default()
+            },
+        ];
+        let prompt = tok.apply_chat_template(&messages).unwrap();
+        assert!(
+            prompt.contains("TOOLCALLS:Bash;"),
+            "assistant tool_calls missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("TCID:call_42;"),
+            "tool_call_id missing: {prompt:?}"
+        );
+        assert!(prompt.contains("NAME:Bash;"), "name missing: {prompt:?}");
+    }
+
+    #[test]
+    fn test_chat_message_default_skips_optional_fields_in_serialize() {
+        let m = ChatMessage {
+            role: "user".to_string(),
+            content: "hi".to_string(),
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&m).unwrap();
+        // Optional fields must be absent when None so plain conversations
+        // round-trip identically to the pre-tools shape.
+        assert!(v.get("tool_calls").is_none());
+        assert!(v.get("name").is_none());
+        assert!(v.get("tool_call_id").is_none());
+        assert_eq!(v["role"], "user");
+        assert_eq!(v["content"], "hi");
     }
 }

--- a/crates/kiln-server/examples/flce_preflight_bench.rs
+++ b/crates/kiln-server/examples/flce_preflight_bench.rs
@@ -77,10 +77,12 @@ fn build_example(tokenizer: &KilnTokenizer, target_t: usize) -> Result<(SftExamp
             kiln_core::tokenizer::ChatMessage {
                 role: "user".to_string(),
                 content: user.clone(),
+                ..Default::default()
             },
             kiln_core::tokenizer::ChatMessage {
                 role: "assistant".to_string(),
                 content: assistant.clone(),
+                ..Default::default()
             },
         ];
         let text = tokenizer
@@ -99,10 +101,12 @@ fn build_example(tokenizer: &KilnTokenizer, target_t: usize) -> Result<(SftExamp
                             kiln_core::tokenizer::ChatMessage {
                                 role: "user".to_string(),
                                 content: user.clone(),
+                                ..Default::default()
                             },
                             kiln_core::tokenizer::ChatMessage {
                                 role: "assistant".to_string(),
                                 content: assistant.clone(),
+                                ..Default::default()
                             },
                         ])
                         .map_err(|e| anyhow::anyhow!("{e}"))?,
@@ -126,10 +130,12 @@ fn build_example(tokenizer: &KilnTokenizer, target_t: usize) -> Result<(SftExamp
         kiln_core::tokenizer::ChatMessage {
             role: "user".to_string(),
             content: user.clone(),
+            ..Default::default()
         },
         kiln_core::tokenizer::ChatMessage {
             role: "assistant".to_string(),
             content: assistant.clone(),
+            ..Default::default()
         },
     ];
     let final_text = tokenizer

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -317,6 +317,22 @@ pub struct ChatCompletionRequest {
     /// keyed by a hash of the (name, scale) pairs.
     #[serde(default)]
     pub adapters: Option<Vec<AdapterRef>>,
+    /// OpenAI-style tool/function definitions. Forwarded as opaque JSON into
+    /// the chat template's Jinja context as `tools`. Templates that branch on
+    /// `{% if tools %}` (e.g. Qwen3.5-4B's official template emits its
+    /// `<tools>` schemas + tool-calling prelude only when this is set) require
+    /// this round-trip — without it the model never sees the tool schemas at
+    /// inference time and can't produce tool calls at all.
+    #[serde(default)]
+    pub tools: Option<Vec<serde_json::Value>>,
+    /// OpenAI-style `tool_choice` (`"none" | "auto" | "required"` or an object
+    /// naming a specific tool). Accepted at the API edge so OpenAI clients
+    /// don't see "unknown field" errors; threaded into the template context as
+    /// `tool_choice` so HF templates that branch on it render correctly. Kiln
+    /// itself does not enforce the choice at the sampler — that's caller
+    /// responsibility for now.
+    #[serde(default)]
+    pub tool_choice: Option<serde_json::Value>,
 }
 
 /// A single source adapter for per-request composition.
@@ -329,7 +345,7 @@ pub struct AdapterRef {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Message {
     pub role: String,
-    #[serde(deserialize_with = "deserialize_content")]
+    #[serde(default, deserialize_with = "deserialize_optional_content")]
     pub content: String,
     /// llama.cpp / DeepSeek-style chain-of-thought channel. Populated for
     /// reasoning models (Qwen3.5, DeepSeek R1, …) when the model emitted a
@@ -339,12 +355,44 @@ pub struct Message {
     /// the OpenAI shape.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning_content: Option<String>,
+    /// Tool calls emitted by the assistant on a prior turn (OpenAI shape:
+    /// `[{"id": "call_…", "type": "function", "function": {"name": …,
+    /// "arguments": "…"}}, …]`). Round-tripped into the chat template so
+    /// multi-turn tool-use conversations render correctly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<serde_json::Value>>,
+    /// Function name on assistant messages with named function calls, OR the
+    /// tool name on `role: "tool"` messages. Some templates branch on this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// On `role: "tool"` messages, identifies which assistant `tool_calls[*]`
+    /// entry this message responds to. Required by OpenAI for multi-tool
+    /// assistant turns; templates use it to pair the tool response with the
+    /// originating tool call.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
 }
 
-/// Accept `content` as either a plain string or an OpenAI-style array of
-/// content parts (`[{"type": "text", "text": "..."}, ...]`). Text parts are
-/// concatenated in order; non-text parts are ignored since kiln is text-only.
-fn deserialize_content<'de, D>(deserializer: D) -> Result<String, D::Error>
+/// Convert an API `Message` to the core tokenizer's `ChatMessage`, propagating
+/// the OpenAI tool fields (`tool_calls`, `name`, `tool_call_id`) so the chat
+/// template renders past assistant tool calls and `role: "tool"` responses.
+fn message_to_chat(m: &Message) -> ChatMessage {
+    ChatMessage {
+        role: m.role.clone(),
+        content: m.content.clone(),
+        tool_calls: m.tool_calls.clone(),
+        name: m.name.clone(),
+        tool_call_id: m.tool_call_id.clone(),
+    }
+}
+
+/// Accept `content` as either a plain string, an OpenAI-style array of
+/// content parts (`[{"type": "text", "text": "..."}, ...]`), `null`, or
+/// missing. Text parts are concatenated in order; non-text parts are ignored
+/// since kiln is text-only. `null` and missing both yield an empty string —
+/// the assistant-tool-calls-only OpenAI shape (`{"role": "assistant",
+/// "content": null, "tool_calls": [...]}`) deserializes cleanly.
+fn deserialize_optional_content<'de, D>(deserializer: D) -> Result<String, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -355,9 +403,13 @@ where
         Parts(Vec<serde_json::Value>),
     }
 
-    match Content::deserialize(deserializer)? {
-        Content::Text(s) => Ok(s),
-        Content::Parts(parts) => {
+    // `Option<T>` handles both the missing-key case (via `#[serde(default)]`
+    // on the field) and an explicit `null` value, falling through to the
+    // untagged enum for plain strings and arrays.
+    match Option::<Content>::deserialize(deserializer)? {
+        None => Ok(String::new()),
+        Some(Content::Text(s)) => Ok(s),
+        Some(Content::Parts(parts)) => {
             let mut out = String::new();
             for part in parts {
                 let Some(obj) = part.as_object() else {
@@ -579,20 +631,16 @@ async fn chat_completions_inner(
     // just generation. Streaming and non-streaming paths both consume this.
     let request_start = std::time::Instant::now();
 
-    // Convert request messages to ChatMessage for template formatting
-    let chat_messages: Vec<ChatMessage> = req
-        .messages
-        .iter()
-        .map(|m| ChatMessage {
-            role: m.role.clone(),
-            content: m.content.clone(),
-        })
-        .collect();
+    // Convert request messages to ChatMessage for template formatting,
+    // forwarding `tool_calls` / `name` / `tool_call_id` so multi-turn
+    // tool-use conversations render correctly. Tools schema is threaded
+    // separately via `apply_chat_template_with_tools`.
+    let chat_messages: Vec<ChatMessage> = req.messages.iter().map(message_to_chat).collect();
 
     // Apply chat template and tokenize
     let prompt_text = state
         .tokenizer
-        .apply_chat_template(&chat_messages)
+        .apply_chat_template_full(&chat_messages, req.tools.as_deref(), req.tool_choice.as_ref())
         .map_err(ApiError::chat_template_failed)?;
     let prompt_tokens = state
         .tokenizer
@@ -1326,6 +1374,9 @@ async fn generate_real(
                 role: "assistant".to_string(),
                 content: completion_text,
                 reasoning_content,
+                tool_calls: None,
+                name: None,
+                tool_call_id: None,
             },
             finish_reason: finish_reason.to_string(),
         }],
@@ -1959,6 +2010,9 @@ async fn generate_mock(
                 content: completion_text,
                 // Mock backend never emits a reasoning block.
                 reasoning_content: None,
+                tool_calls: None,
+                name: None,
+                tool_call_id: None,
             },
             finish_reason: "stop".to_string(),
         }],
@@ -2189,6 +2243,9 @@ async fn batch_completions_inner(
                     // Batch input messages never carry historical reasoning;
                     // the chat template renders them as plain text turns.
                     reasoning_content: None,
+                    tool_calls: None,
+                    name: None,
+                    tool_call_id: None,
                 })
                 .collect();
             let synth_req = ChatCompletionRequest {
@@ -2203,6 +2260,8 @@ async fn batch_completions_inner(
                 seed: derived_seed,
                 adapter: None,
                 adapters: None,
+                tools: None,
+                tool_choice: None,
             };
             let state_clone = state.clone();
             handles.push(tokio::spawn(async move {
@@ -2277,18 +2336,11 @@ async fn generate_one_response(
 ) -> Result<ChatCompletionResponse, ApiError> {
     let request_start = std::time::Instant::now();
 
-    let chat_messages: Vec<ChatMessage> = req
-        .messages
-        .iter()
-        .map(|m| ChatMessage {
-            role: m.role.clone(),
-            content: m.content.clone(),
-        })
-        .collect();
+    let chat_messages: Vec<ChatMessage> = req.messages.iter().map(message_to_chat).collect();
 
     let prompt_text = state
         .tokenizer
-        .apply_chat_template(&chat_messages)
+        .apply_chat_template_full(&chat_messages, req.tools.as_deref(), req.tool_choice.as_ref())
         .map_err(ApiError::chat_template_failed)?;
     let prompt_tokens = state
         .tokenizer
@@ -2420,6 +2472,77 @@ mod tests {
         );
         assert_eq!(req.messages[0].content, "be nice");
         assert_eq!(req.messages[1].content, "hi");
+    }
+
+    #[test]
+    fn tools_round_trip_preserved_on_request() {
+        let json = r#"{
+            "messages":[{"role":"user","content":"run ls"}],
+            "tools":[
+                {"type":"function","function":{"name":"Bash","description":"Run a command","parameters":{"type":"object"}}},
+                {"type":"function","function":{"name":"Read","description":"Read a file","parameters":{"type":"object"}}}
+            ],
+            "tool_choice":"auto"
+        }"#;
+        let req = parse_request(json);
+        let tools = req.tools.expect("tools should deserialize");
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0]["function"]["name"], "Bash");
+        assert_eq!(tools[1]["function"]["name"], "Read");
+        assert_eq!(req.tool_choice.as_ref().and_then(|v| v.as_str()), Some("auto"));
+    }
+
+    #[test]
+    fn message_tool_calls_round_trip_preserved() {
+        let json = r#"{
+            "messages":[
+                {"role":"assistant","content":null,"tool_calls":[
+                    {"id":"call_42","type":"function","function":{"name":"Bash","arguments":"{\"command\":\"ls\"}"}}
+                ]},
+                {"role":"tool","name":"Bash","tool_call_id":"call_42","content":"file.txt"}
+            ]
+        }"#;
+        let req = parse_request(json);
+        // Assistant message with content:null lands as empty string + tool_calls populated.
+        assert_eq!(req.messages[0].role, "assistant");
+        assert_eq!(req.messages[0].content, "");
+        let calls = req.messages[0].tool_calls.as_ref().expect("tool_calls present");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["id"], "call_42");
+        assert_eq!(calls[0]["function"]["name"], "Bash");
+        // Tool response with id + name.
+        assert_eq!(req.messages[1].role, "tool");
+        assert_eq!(req.messages[1].tool_call_id.as_deref(), Some("call_42"));
+        assert_eq!(req.messages[1].name.as_deref(), Some("Bash"));
+        assert_eq!(req.messages[1].content, "file.txt");
+    }
+
+    #[test]
+    fn tools_absent_request_keeps_options_none() {
+        let req = parse_request(r#"{"messages":[{"role":"user","content":"hi"}]}"#);
+        assert!(req.tools.is_none(), "tools should default to None when absent");
+        assert!(req.tool_choice.is_none(), "tool_choice should default to None");
+        assert!(req.messages[0].tool_calls.is_none());
+        assert!(req.messages[0].name.is_none());
+        assert!(req.messages[0].tool_call_id.is_none());
+    }
+
+    #[test]
+    fn message_to_chat_propagates_tool_fields() {
+        let m = Message {
+            role: "tool".to_string(),
+            content: "ok".to_string(),
+            reasoning_content: None,
+            tool_calls: None,
+            name: Some("Bash".to_string()),
+            tool_call_id: Some("call_1".to_string()),
+        };
+        let chat = message_to_chat(&m);
+        assert_eq!(chat.role, "tool");
+        assert_eq!(chat.content, "ok");
+        assert_eq!(chat.name.as_deref(), Some("Bash"));
+        assert_eq!(chat.tool_call_id.as_deref(), Some("call_1"));
+        assert!(chat.tool_calls.is_none());
     }
 
     #[test]

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -1706,6 +1706,7 @@ fn bench_latency_paged_mtp(
         let messages = [ChatMessage {
             role: "user".to_string(),
             content: raw_prompt,
+            ..Default::default()
         }];
         tokenizer
             .apply_chat_template(&messages)

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -27,6 +27,7 @@ fn to_core_messages(msgs: &[ChatMessage]) -> Vec<kiln_core::tokenizer::ChatMessa
         .map(|m| kiln_core::tokenizer::ChatMessage {
             role: m.role.clone(),
             content: m.content.clone(),
+            ..Default::default()
         })
         .collect()
 }
@@ -794,6 +795,7 @@ fn tokenize_grpo_group(group: &GrpoGroup, tokenizer: &KilnTokenizer) -> Result<T
         full_messages.push(kiln_core::tokenizer::ChatMessage {
             role: "assistant".to_string(),
             content: scored.text.clone(),
+            ..Default::default()
         });
 
         let full_text = tokenizer


### PR DESCRIPTION
## What

The `/v1/chat/completions` endpoint silently dropped OpenAI's `tools`,
`tool_choice`, and per-message `tool_calls` / `name` / `tool_call_id`
fields at the API edge: `ChatCompletionRequest` and `Message` lacked the
fields, and serde's permissive default ignored them rather than failing.
Even when callers sent tool schemas, the chat template never saw them
because `render_jinja_template` only added `messages` to the Jinja
context.

This PR adds the missing fields to both structs, threads them through
into the Jinja context, and wires `apply_chat_template_full(messages,
tools, tool_choice)` into all three completion paths
(`chat_completions`, `generate_one_response`, `batch_completions`).

## Why

Qwen3.5-4B's official chat template gates its `<tools>` block and the
`<IMPORTANT>` tool-calling prelude on `{% if tools %}`. Without `tools`
in the Jinja context that branch never fires, so the model never sees
the schemas or the calling format at inference time.

corrections-experiment Phase 2 round-2 bug hunt (task
`c19f78bef244308efc729405`) traced the project's ~3% tool-use accept
rate to exactly this gap: the serde structs silently swallowed the
`tools` field and the renderer never plumbed it into the template
context. Fixing this is the headline gate before any further Phase 2
re-probe work.

## How verified

CPU-only — no GPU pod required.

Added 8 unit tests covering both halves of the wiring:

**Tokenizer / Jinja-context (`crates/kiln-core/src/tokenizer.rs`)**

- `test_jinja_renders_tools_when_present` — passes a 2-tool schema and a
  tiny template that emits `<tools>` plus tool names; asserts both reach
  the rendered output.
- `test_jinja_omits_tools_block_when_none` — `tools=None` keeps the
  template's `{% if tools %}` branch off and matches the no-tools-arg
  default render byte-for-byte.
- `test_jinja_omits_tools_block_when_empty_slice` — `tools=Some(&[])`
  also suppresses the block (matches HF tokenizer convention).
- `test_jinja_renders_message_tool_calls_and_tool_responses` — assistant
  `tool_calls` plus a `role:tool` message with `tool_call_id`/`name`
  reach the template via `{% if message.tool_calls %}` /
  `{% if message.tool_call_id %}` branches.
- `test_chat_message_default_skips_optional_fields_in_serialize` — plain
  `ChatMessage` serialization stays byte-identical to the pre-tools
  shape.

**API deserialization (`crates/kiln-server/src/api/completions.rs`)**

- `tools_round_trip_preserved_on_request` — `tools` + `tool_choice` on
  the request survive deserialization end-to-end.
- `message_tool_calls_round_trip_preserved` — assistant
  `{role: assistant, content: null, tool_calls: [...]}` plus
  `{role: tool, tool_call_id, name, content}` deserialize cleanly,
  including the `content: null` case.
- `tools_absent_request_keeps_options_none` — regression guard: if a
  caller omits `tools` everything stays `None`, no panics, no defaults
  spuriously populated.
- `message_to_chat_propagates_tool_fields` — API `Message` → core
  `ChatMessage` conversion carries `tool_calls`, `name`, `tool_call_id`
  through.

Test run: `cargo test --package kiln-core --package kiln-server
--package kiln-train --lib` — 148/148 passing locally.

## Compatibility notes

- All new fields are `Option`, default to `None`. No existing caller
  needs changes.
- `Message::content` deserializer now also accepts `null` and missing
  values (yields `""`). This is the OpenAI assistant-tool-calls-only
  shape and is safer than the prior strict-string behavior — strings
  and content-parts arrays still work unchanged (covered by the existing
  `accept-content-parts` tests from PR #196).
- `ChatMessage` in `kiln-core` gains three optional fields with
  `#[serde(skip_serializing_if = "Option::is_none")]` so plain
  conversations render byte-identically and templates that don't
  reference `message.tool_calls` etc. are unaffected.
- Empty `tools` slices are coerced to JSON `null` before reaching the
  template so `{% if tools %}` does not fire on `[]`. Matches HF's
  tokenizer convention.

## Refs

- corrections-experiment round-2 bug hunt: task `c19f78bef244308efc729405`
- This task: `de35f1791b8dac7d5177ed7f`