### PR TITLE
phase10: GDN training-time streaming prefill audit (Finding 2 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+### Audits
+- Audited whether the existing Phase 7 streaming GDN prefill (`KILN_STREAMING_PREFILL`) is reachable from the SFT training path as a remediation for Finding 2 of the Phase A validation (T=8192/T=16384 SFT OOM on A6000). **Result: RED — streaming dispatch lives only in `model_forward_paged_streaming*`, none of which the trainer calls; the env flag is parsed but has no effect on training.** Empirical confirmation on A6000: T=2048 STREAMING ON peak VRAM matches STREAMING unset to 0 MiB and loss is bit-identical; T=8192 STREAMING ON at three tile sizes (default/4096/2048) all OOM identically at the 48 GB ceiling in 0.7 s. Closing Finding 2 requires net-new implementation work (e.g., a streaming branch inside `model_forward_segment`), not configuration. See `docs/audits/PHASE10_GDN_TRAINING_STREAMING.md` for source/empirical evidence and the remediation menu. Raw log: `docs/flce_phase_a_streaming_raw_2026-04-29.log`.
+
 ### Validation
 - Validated Phase 10 Phase A FLCE on A6000 (48 GB) at T ∈ {2048, 8192, 16384} with rank-8 LoRA and gradient checkpointing ON. **Result: RED — Phase A is insufficient on A6000.** Two findings: (1) `KILN_USE_FLCE=1` fails before completing a step at T=2048 with `matmul is only supported for contiguous tensors` — the V-axis chunk of `embed_tokens_t` is non-contiguous and the chunked-vocab matmul rejects it; (2) even with that bug fixed, T=8192 and T=16384 still pin peak VRAM at the 48 GB A6000 ceiling, indicating GDN-side activations (not the head) dominate at long T. See `docs/audits/PHASE10_FLCE_PREFLIGHT.md` (Phase A validation section, 2026-04-29) for the table, raw log, and required follow-ups. Bench: `crates/kiln-server/examples/flce_phase_a_validation_bench.rs`.
 

--- a/crates/kiln-server/examples/flce_phase_a_validation_bench.rs
+++ b/crates/kiln-server/examples/flce_phase_a_validation_bench.rs
@@ -519,36 +519,12 @@ fn main() -> Result<()> {
     let parity_on_loss = r.final_loss;
     rows.push(r);
 
-    // 3. T=8192, FLCE ON.
-    let r = run_one(
-        8192,
-        true,
-        None,
-        None,
-        &tokenizer,
-        &model_config,
-        &gpu_weights,
-        baseline_mib,
-    )?;
-    rows.push(r);
-
-    // 4. T=16384, FLCE ON.
-    let r = run_one(
-        16384,
-        true,
-        None,
-        None,
-        &tokenizer,
-        &model_config,
-        &gpu_weights,
-        baseline_mib,
-    )?;
-    rows.push(r);
-
-    // 5. Control: T=2048 FLCE ON STREAMING ON (default tile). If streaming
-    //    were reachable from the SFT path, peak VRAM would change here vs
-    //    cell 2; if it's unreachable (the audit's hypothesis), peak should
-    //    match cell 2 within nvidia-smi 50 ms polling noise.
+    // 3. Control (BEFORE the OOM cells): T=2048 FLCE ON STREAMING ON
+    //    (default tile). If streaming were reachable from the SFT path, peak
+    //    VRAM would change here vs cell 2; if it's unreachable (the audit's
+    //    hypothesis), peak should match cell 2 within nvidia-smi 50 ms
+    //    polling noise. We run this BEFORE cells 4/5 so post-OOM CUDA
+    //    allocator residue does not contaminate the peak measurement.
     let r = run_one(
         2048,
         true,
@@ -562,7 +538,36 @@ fn main() -> Result<()> {
     let stream_on_t2048_loss = r.final_loss;
     rows.push(r);
 
-    // 6. Headline: T=8192 FLCE ON STREAMING ON (default tile = 8192).
+    // 4. T=8192, FLCE ON.
+    let r = run_one(
+        8192,
+        true,
+        None,
+        None,
+        &tokenizer,
+        &model_config,
+        &gpu_weights,
+        baseline_mib,
+    )?;
+    rows.push(r);
+
+    // 5. T=16384, FLCE ON.
+    let r = run_one(
+        16384,
+        true,
+        None,
+        None,
+        &tokenizer,
+        &model_config,
+        &gpu_weights,
+        baseline_mib,
+    )?;
+    rows.push(r);
+
+    // 6. Headline: T=8192 FLCE ON STREAMING ON (default tile = 8192). At the
+    //    default tile size (which equals T=8192) no actual tiling happens
+    //    even if streaming were reachable, so this primarily tests that the
+    //    flag is parsed without crashing.
     let r = run_one(
         8192,
         true,
@@ -575,7 +580,7 @@ fn main() -> Result<()> {
     )?;
     rows.push(r);
 
-    // 7. T=8192 FLCE ON STREAMING ON tile=4096 (smaller tile).
+    // 7. T=8192 FLCE ON STREAMING ON tile=4096 (would tile into 2 chunks).
     let r = run_one(
         8192,
         true,
@@ -588,7 +593,9 @@ fn main() -> Result<()> {
     )?;
     rows.push(r);
 
-    // 8. T=8192 FLCE ON STREAMING ON tile=2048 (smallest tile multiple of 64).
+    // 8. T=8192 FLCE ON STREAMING ON tile=2048 (would tile into 4 chunks —
+    //    if streaming were reachable, this is the most aggressive memory
+    //    reduction available and should show the largest peak VRAM delta).
     let r = run_one(
         8192,
         true,

--- a/crates/kiln-server/examples/flce_phase_a_validation_bench.rs
+++ b/crates/kiln-server/examples/flce_phase_a_validation_bench.rs
@@ -10,11 +10,18 @@
 //! check that it actually unblocks long-context SFT on the GPU we ship on
 //! (A6000 48 GB) has not been done. This bench closes that gap.
 //!
-//! Cells measured:
+//! Cells measured (Phase A baseline + Phase 10 GDN-streaming-audit):
 //!   1. T=2048, FLCE OFF — baseline loss (parity reference)
 //!   2. T=2048, FLCE ON  — loss must match (1) to within 1e-3 (parity check)
 //!   3. T=8192, FLCE ON  — must complete without OOM (Phase A's headline claim)
 //!   4. T=16384, FLCE ON — must complete without OOM (Phase A's headline claim)
+//!   5. T=2048, FLCE ON, STREAMING ON tile=default — control: peak VRAM
+//!      should match cell (2) within polling noise if the streaming dispatch
+//!      is unreachable from the SFT path.
+//!   6. T=8192, FLCE ON, STREAMING ON tile=default — headline: does
+//!      `KILN_STREAMING_PREFILL=1` unblock T=8192 SFT on A6000?
+//!   7. T=8192, FLCE ON, STREAMING ON tile=4096
+//!   8. T=8192, FLCE ON, STREAMING ON tile=2048
 //!
 //! Each cell records peak VRAM (background `nvidia-smi` poller @ 50 ms),
 //! step wall-time, and final loss (captured via the `sft_train` progress
@@ -28,8 +35,9 @@
 //!   KILN_GRAD_CHECKPOINT_SEGMENTS  (default 4; matches the preflight)
 //!   KILN_NO_GRAD_CHECKPOINT=1      (disables checkpointing — not recommended)
 //!
-//! The bench sets/unsets `KILN_USE_FLCE` itself, so do NOT export it before
-//! invoking the binary.
+//! The bench sets/unsets `KILN_USE_FLCE`, `KILN_STREAMING_PREFILL`, and
+//! `KILN_STREAMING_TILE_TOKENS` itself, so do NOT export them before invoking
+//! the binary.
 
 use anyhow::{Context, Result};
 use candle_core::Device;
@@ -72,6 +80,13 @@ struct Row {
     target_t: usize,
     actual_t: usize,
     use_flce: bool,
+    /// Streaming GDN prefill toggle. `None` means the env var is unset (matches
+    /// the historical Phase A cells); `Some(true)` / `Some(false)` set
+    /// `KILN_STREAMING_PREFILL=1|0` for the cell.
+    streaming: Option<bool>,
+    /// Optional `KILN_STREAMING_TILE_TOKENS` override for the cell. `None`
+    /// leaves the env unset (default tile = 8192 tokens).
+    tile_tokens: Option<usize>,
     baseline_mib: u64,
     peak_mib: u64,
     delta_mib: u64,
@@ -192,20 +207,36 @@ fn build_example(tokenizer: &KilnTokenizer, target_t: usize) -> Result<(SftExamp
 
 /// Run one SFT step at the given T with the given FLCE setting. Captures peak
 /// VRAM, step wall-time, final loss (via progress callback), and status.
+///
+/// `streaming`: if `Some(b)` sets `KILN_STREAMING_PREFILL=b`, otherwise unsets
+/// it. `tile_tokens`: if `Some(n)` sets `KILN_STREAMING_TILE_TOKENS=n`,
+/// otherwise unsets it. Both env reads happen inside `kiln-model::forward` on
+/// every prefill, so per-cell mutation works the same way `KILN_USE_FLCE` does.
+#[allow(clippy::too_many_arguments)]
 fn run_one(
     target_t: usize,
     use_flce: bool,
+    streaming: Option<bool>,
+    tile_tokens: Option<usize>,
     tokenizer: &KilnTokenizer,
     model_config: &ModelConfig,
     weights: &GpuWeights,
     baseline_mib: u64,
 ) -> Result<Row> {
+    let stream_label = match streaming {
+        Some(true) => "ON",
+        Some(false) => "OFF",
+        None => "unset",
+    };
+    let tile_label = tile_tokens
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "default".to_string());
     eprintln!(
-        "\n--- T target = {target_t}  FLCE = {} ---",
+        "\n--- T target = {target_t}  FLCE = {}  STREAMING = {stream_label}  TILE = {tile_label} ---",
         if use_flce { "ON" } else { "OFF" }
     );
 
-    // Set the env var deterministically for this run. SAFETY: bench is single-
+    // Set the env vars deterministically for this run. SAFETY: bench is single-
     // threaded at the env-var level (one `run_one` at a time, no concurrent
     // training threads). See std::env::set_var docs for the multi-threaded
     // caveat we explicitly avoid here.
@@ -213,6 +244,15 @@ fn run_one(
         unsafe { std::env::set_var("KILN_USE_FLCE", "1") };
     } else {
         unsafe { std::env::remove_var("KILN_USE_FLCE") };
+    }
+    match streaming {
+        Some(true) => unsafe { std::env::set_var("KILN_STREAMING_PREFILL", "1") },
+        Some(false) => unsafe { std::env::set_var("KILN_STREAMING_PREFILL", "0") },
+        None => unsafe { std::env::remove_var("KILN_STREAMING_PREFILL") },
+    }
+    match tile_tokens {
+        Some(n) => unsafe { std::env::set_var("KILN_STREAMING_TILE_TOKENS", n.to_string()) },
+        None => unsafe { std::env::remove_var("KILN_STREAMING_TILE_TOKENS") },
     }
 
     let (example, actual_t) = build_example(tokenizer, target_t)?;
@@ -327,6 +367,8 @@ fn run_one(
         target_t,
         actual_t,
         use_flce,
+        streaming,
+        tile_tokens,
         baseline_mib,
         peak_mib,
         delta_mib,
@@ -359,11 +401,22 @@ fn print_row(r: &Row) {
         Some(v) => format!("{v:.6}"),
         None => "n/a".into(),
     };
+    let stream_label = match r.streaming {
+        Some(true) => "ON",
+        Some(false) => "OFF",
+        None => "unset",
+    };
+    let tile_label = r
+        .tile_tokens
+        .map(|n| n.to_string())
+        .unwrap_or_else(|| "default".to_string());
     println!(
-        "{:<10} {:<10} {:<6} {:<14} {:<12} {:<12} {:<10} {:<10} {:<12}",
+        "{:<10} {:<10} {:<6} {:<7} {:<8} {:<14} {:<12} {:<12} {:<10} {:<10} {:<12}",
         r.target_t,
         r.actual_t,
         if r.use_flce { "ON" } else { "OFF" },
+        stream_label,
+        tile_label,
         r.peak_mib,
         r.delta_mib,
         format!("{abc:.3}"),
@@ -379,8 +432,10 @@ fn main() -> Result<()> {
         .with_writer(std::io::stderr)
         .init();
 
-    // Make sure we don't inherit a stale KILN_USE_FLCE from the shell.
+    // Make sure we don't inherit stale toggles from the shell.
     unsafe { std::env::remove_var("KILN_USE_FLCE") };
+    unsafe { std::env::remove_var("KILN_STREAMING_PREFILL") };
+    unsafe { std::env::remove_var("KILN_STREAMING_TILE_TOKENS") };
 
     let model_path = parse_model_path()?;
 
@@ -422,6 +477,8 @@ fn main() -> Result<()> {
     let _ = run_one(
         256,
         false,
+        None,
+        None,
         &tokenizer,
         &model_config,
         &gpu_weights,
@@ -430,13 +487,16 @@ fn main() -> Result<()> {
     let baseline_mib = current_vram_mib();
     eprintln!("Baseline VRAM (post-warmup): {} MiB", baseline_mib);
 
-    // The four cells.
+    // Cells: original Phase A baseline (1-4) + streaming-prefill follow-up
+    // (5-8) for the GDN training-streaming audit.
     let mut rows: Vec<Row> = Vec::new();
 
     // 1. T=2048, FLCE OFF — parity reference.
     let r = run_one(
         2048,
         false,
+        None,
+        None,
         &tokenizer,
         &model_config,
         &gpu_weights,
@@ -449,6 +509,8 @@ fn main() -> Result<()> {
     let r = run_one(
         2048,
         true,
+        None,
+        None,
         &tokenizer,
         &model_config,
         &gpu_weights,
@@ -461,6 +523,8 @@ fn main() -> Result<()> {
     let r = run_one(
         8192,
         true,
+        None,
+        None,
         &tokenizer,
         &model_config,
         &gpu_weights,
@@ -472,6 +536,64 @@ fn main() -> Result<()> {
     let r = run_one(
         16384,
         true,
+        None,
+        None,
+        &tokenizer,
+        &model_config,
+        &gpu_weights,
+        baseline_mib,
+    )?;
+    rows.push(r);
+
+    // 5. Control: T=2048 FLCE ON STREAMING ON (default tile). If streaming
+    //    were reachable from the SFT path, peak VRAM would change here vs
+    //    cell 2; if it's unreachable (the audit's hypothesis), peak should
+    //    match cell 2 within nvidia-smi 50 ms polling noise.
+    let r = run_one(
+        2048,
+        true,
+        Some(true),
+        None,
+        &tokenizer,
+        &model_config,
+        &gpu_weights,
+        baseline_mib,
+    )?;
+    let stream_on_t2048_loss = r.final_loss;
+    rows.push(r);
+
+    // 6. Headline: T=8192 FLCE ON STREAMING ON (default tile = 8192).
+    let r = run_one(
+        8192,
+        true,
+        Some(true),
+        None,
+        &tokenizer,
+        &model_config,
+        &gpu_weights,
+        baseline_mib,
+    )?;
+    rows.push(r);
+
+    // 7. T=8192 FLCE ON STREAMING ON tile=4096 (smaller tile).
+    let r = run_one(
+        8192,
+        true,
+        Some(true),
+        Some(4096),
+        &tokenizer,
+        &model_config,
+        &gpu_weights,
+        baseline_mib,
+    )?;
+    rows.push(r);
+
+    // 8. T=8192 FLCE ON STREAMING ON tile=2048 (smallest tile multiple of 64).
+    let r = run_one(
+        8192,
+        true,
+        Some(true),
+        Some(2048),
         &tokenizer,
         &model_config,
         &gpu_weights,
@@ -480,10 +602,19 @@ fn main() -> Result<()> {
     rows.push(r);
 
     // Final structured table to stdout.
-    println!("\n=== FLCE Phase A validation results ===");
+    println!("\n=== FLCE Phase A + GDN-streaming-audit validation results ===");
     println!(
-        "{:<10} {:<10} {:<6} {:<14} {:<12} {:<12} {:<10} {:<10} {:<12}",
-        "target_T", "actual_T", "FLCE", "peak_VRAM_MiB", "delta_MiB", "abc_GB", "abc/peak", "step_s",
+        "{:<10} {:<10} {:<6} {:<7} {:<8} {:<14} {:<12} {:<12} {:<10} {:<10} {:<12}",
+        "target_T",
+        "actual_T",
+        "FLCE",
+        "STREAM",
+        "TILE",
+        "peak_VRAM_MiB",
+        "delta_MiB",
+        "abc_GB",
+        "abc/peak",
+        "step_s",
         "loss"
     );
     for r in &rows {
@@ -511,21 +642,35 @@ fn main() -> Result<()> {
         },
     );
 
-    // Per-cell verdicts.
-    let cell = |t: usize, flce: bool| -> Option<&Row> {
-        rows.iter().find(|r| r.target_t == t && r.use_flce == flce)
+    // Per-cell verdicts. The original Phase A cells use streaming=None;
+    // the GDN-streaming audit cells use streaming=Some(true).
+    let cell = |t: usize, flce: bool, streaming: Option<bool>, tile: Option<usize>| -> Option<&Row> {
+        rows.iter().find(|r| {
+            r.target_t == t
+                && r.use_flce == flce
+                && r.streaming == streaming
+                && r.tile_tokens == tile
+        })
     };
-    let t2048_off = cell(2048, false);
-    let t2048_on = cell(2048, true);
-    let t8192_on = cell(8192, true);
-    let t16384_on = cell(16384, true);
+    let t2048_off = cell(2048, false, None, None);
+    let t2048_on = cell(2048, true, None, None);
+    let t8192_on = cell(8192, true, None, None);
+    let t16384_on = cell(16384, true, None, None);
+    let t2048_on_stream = cell(2048, true, Some(true), None);
+    let t8192_on_stream = cell(8192, true, Some(true), None);
+    let t8192_on_stream_4096 = cell(8192, true, Some(true), Some(4096));
+    let t8192_on_stream_2048 = cell(8192, true, Some(true), Some(2048));
 
     println!("\n=== Cell summary ===");
     for (label, r) in [
-        ("T=2048   FLCE=OFF", t2048_off),
-        ("T=2048   FLCE=ON ", t2048_on),
-        ("T=8192   FLCE=ON ", t8192_on),
-        ("T=16384  FLCE=ON ", t16384_on),
+        ("T=2048   FLCE=ON  STREAM=unset           ", t2048_on),
+        ("T=2048   FLCE=OFF STREAM=unset           ", t2048_off),
+        ("T=8192   FLCE=ON  STREAM=unset           ", t8192_on),
+        ("T=16384  FLCE=ON  STREAM=unset           ", t16384_on),
+        ("T=2048   FLCE=ON  STREAM=ON  tile=default", t2048_on_stream),
+        ("T=8192   FLCE=ON  STREAM=ON  tile=default", t8192_on_stream),
+        ("T=8192   FLCE=ON  STREAM=ON  tile=4096   ", t8192_on_stream_4096),
+        ("T=8192   FLCE=ON  STREAM=ON  tile=2048   ", t8192_on_stream_2048),
     ] {
         match r {
             Some(r) => println!(
@@ -543,14 +688,61 @@ fn main() -> Result<()> {
         && matches!(t16384_on.map(|r| &r.status), Some(Status::Ok));
     let parity_ok = parity_pass.unwrap_or(false);
 
-    let verdict = if phase_a_unblocked && parity_ok {
+    let phase_a_verdict = if phase_a_unblocked && parity_ok {
         "GREEN — Phase A unblocks long-context SFT on A6000"
     } else if phase_a_unblocked && !parity_ok {
         "AMBER — Phase A unblocks long-context SFT but parity exceeds tolerance"
     } else {
         "RED — Phase A insufficient on A6000"
     };
-    println!("\n=== Verdict: {verdict} ===");
+    println!("\n=== Phase A verdict: {phase_a_verdict} ===");
+
+    // GDN-streaming-audit verdict. The hypothesis is that streaming GDN
+    // prefill is unreachable from `sft_train` (training calls
+    // `model_forward_segment`, which does not dispatch through
+    // `model_forward_paged_streaming*`). Falsifying the hypothesis would mean
+    // T=8192 + STREAMING ON completes without OOM, or T=2048 + STREAMING ON
+    // shows a peak-VRAM delta vs T=2048 + STREAMING unset that is meaningfully
+    // larger than the nvidia-smi 50 ms polling noise (~50-100 MiB).
+    let stream_t8192_ok = matches!(t8192_on_stream.map(|r| &r.status), Some(Status::Ok));
+    let stream_t8192_4096_ok =
+        matches!(t8192_on_stream_4096.map(|r| &r.status), Some(Status::Ok));
+    let stream_t8192_2048_ok =
+        matches!(t8192_on_stream_2048.map(|r| &r.status), Some(Status::Ok));
+    let any_8192_stream_ok = stream_t8192_ok || stream_t8192_4096_ok || stream_t8192_2048_ok;
+
+    let t2048_peak_delta_mib = match (t2048_on, t2048_on_stream) {
+        (Some(a), Some(b)) => Some(b.peak_mib as i64 - a.peak_mib as i64),
+        _ => None,
+    };
+
+    let stream_audit_verdict = if any_8192_stream_ok {
+        "GREEN — streaming GDN prefill at T=8192 SFT unblocks long-context training on A6000"
+    } else {
+        // T=8192 still OOM with streaming ON. Check the T=2048 control to
+        // confirm streaming has no effect on training-time peak (not just
+        // insufficient).
+        match t2048_peak_delta_mib {
+            Some(delta) if delta.abs() <= 200 => {
+                "RED — KILN_STREAMING_PREFILL has no effect on SFT path; \
+                 streaming dispatch is not wired into training-time forward (model_forward_segment)"
+            }
+            Some(delta) if delta < 0 => {
+                "AMBER — T=8192 still OOMs with streaming ON, but T=2048 shows a peak-VRAM \
+                 reduction; partial reachability suspected"
+            }
+            _ => {
+                "RED — streaming GDN prefill at T=8192 SFT still OOMs on A6000"
+            }
+        }
+    };
+    println!("\n=== GDN-streaming-audit verdict: {stream_audit_verdict} ===");
+    if let Some(delta) = t2048_peak_delta_mib {
+        println!(
+            "T=2048 peak delta (STREAMING ON vs unset): {} MiB  (control for streaming reachability)",
+            delta
+        );
+    }
 
     // Machine-readable JSON for the audit doc.
     let json = serde_json::json!({
@@ -564,12 +756,17 @@ fn main() -> Result<()> {
             "tolerance": PARITY_TOLERANCE,
             "pass": parity_pass,
         },
-        "verdict": verdict,
+        "phase_a_verdict": phase_a_verdict,
+        "stream_audit_verdict": stream_audit_verdict,
+        "stream_audit_t2048_peak_delta_mib": t2048_peak_delta_mib,
+        "stream_on_t2048_loss": stream_on_t2048_loss,
         "rows": rows.iter().map(|r| {
             serde_json::json!({
                 "target_t": r.target_t,
                 "actual_t": r.actual_t,
                 "use_flce": r.use_flce,
+                "streaming": r.streaming,
+                "tile_tokens": r.tile_tokens,
                 "baseline_mib": r.baseline_mib,
                 "peak_mib": r.peak_mib,
                 "delta_mib": r.delta_mib,

--- a/docs/audits/PHASE10_FLCE_PREFLIGHT.md
+++ b/docs/audits/PHASE10_FLCE_PREFLIGHT.md
@@ -355,3 +355,32 @@ naive `log_sum_exp - gather` reference.
 - **Phase B (CUDA fused FLCE kernel) and GDN-side activation cleanup are
   still required** before T=8192 / T=16384 SFT will fit on A6000. See
   "Required follow-ups" §2 above.
+
+## Phase A streaming check — 2026-04-29
+
+Status: **RED — `KILN_STREAMING_PREFILL` has no effect on the SFT path**
+
+Required follow-up §2 above asked: "investigate streaming/chunked GDN
+prefill for the training-time forward (existing kiln-gdn-prefill
+streaming code already cuts inference peak roughly in half at 128k)."
+The audit doc [`PHASE10_GDN_TRAINING_STREAMING.md`](./PHASE10_GDN_TRAINING_STREAMING.md)
+closes that question with both source-level and empirical evidence.
+
+Headline: the existing Phase 7 streaming dispatch lives only in
+`model_forward_paged_streaming{,_with,…}` (`forward.rs:7014-7222`). The
+SFT path calls `model_forward_segment` / `model_forward_no_head`, which
+do not reference any streaming entry point. Setting
+`KILN_STREAMING_PREFILL=1` during a training step is parsed but never
+acted on. The empirical bench confirms this: at T=2048, peak VRAM with
+streaming on equals peak VRAM with streaming unset to within 0 MiB,
+and the loss matches bit-for-bit. At T=8192, three different tile
+sizes (default/4096/2048) all OOM identically at the GPU ceiling
+(48 490 MiB) in 0.7 s — indistinguishable from the streaming-unset
+T=8192 OOM cell.
+
+Implication: closing Finding 2 above requires **net-new
+implementation work**, not configuration. The smallest change that
+could plausibly work is a streaming branch inside
+`model_forward_segment` that tiles along T while threading
+`LinearAttentionState`. See the audit doc for the remediation menu
+and scope estimates.

--- a/docs/audits/PHASE10_GDN_TRAINING_STREAMING.md
+++ b/docs/audits/PHASE10_GDN_TRAINING_STREAMING.md
@@ -1,0 +1,292 @@
+# Phase 10 — GDN training-time streaming-prefill audit (Finding 2 follow-up)
+
+Date: 2026-04-29
+Status: **RED — `KILN_STREAMING_PREFILL` has no effect on the SFT path; streaming GDN prefill is unreachable from training-time forward**
+Hardware: NVIDIA RTX A6000 (48 GB VRAM, driver 565.57.01), CUDA 12.4
+Commit: `15e3829` on `ce/phase10-gdn-streaming-audit`, off `306d26a` main (post-PR #633 FLCE Finding 1 fix)
+Bench: `crates/kiln-server/examples/flce_phase_a_validation_bench.rs`
+Raw log: `docs/flce_phase_a_streaming_raw_2026-04-29.log`
+
+## Purpose
+
+The Phase A validation (`docs/audits/PHASE10_FLCE_PREFLIGHT.md`, "Phase A
+validation — 2026-04-29") closed with two findings. Finding 1 (a
+`matmul-not-contiguous` defect in chunked-vocab FLCE) was fixed in PR #633.
+Finding 2 — that even with the head's retained tensors removed, T=8192 and
+T=16384 SFT still OOM on A6000 because per-segment GDN prefill activations
+dominate peak memory — is the remaining blocker for long-context SFT and
+required follow-up §2 in that doc.
+
+This audit asks one specific question: **is the existing
+`KILN_STREAMING_PREFILL` machinery (Phase 7, PRs #228/#231/#509) reachable
+from the SFT training path?** If yes, setting `KILN_STREAMING_PREFILL=1`
+during a training step at T≥8192 should change peak VRAM measurably and the
+remediation is a small wiring change. If no, training-time GDN streaming
+requires net-new implementation work and a different scope estimate applies.
+
+## Hypothesis
+
+Streaming GDN prefill is implemented in
+`crates/kiln-model/src/forward.rs` as `model_forward_paged_streaming{,_with,
+_last_token_with_last_hidden{,_with}}`, with env-driven dispatch through
+`streaming_prefill_enabled_for(device, seq_len)` and tile size from
+`streaming_tile_tokens_for(device)`. Both env hooks read the process
+environment on every prefill call. The inference paths invoke streaming
+when long prompts are detected; the training path may or may not.
+
+The training path goes through `kiln_train::trainer::sft_train` →
+`checkpointed_forward_backward` (or `standard_forward_backward`) →
+`model_forward_segment` (per gradient-checkpoint segment) and either
+`model_forward_head` + `cross_entropy_loss` or `model_forward_no_head` +
+`fused_linear_cross_entropy`.
+
+If `model_forward_segment` (and friends) do not call any of the
+`model_forward_paged_streaming*` entry points, training-time forward will
+ignore `KILN_STREAMING_PREFILL` regardless of how it is set.
+
+## Source-level audit
+
+Verified locally against `306d26a` main (the post-#633 fix). Greps and
+reads of the files listed below.
+
+### 1. Is streaming GDN prefill currently reachable from `sft_train`?
+
+**No.** All streaming dispatch in `forward.rs` lives in
+`model_forward_paged_streaming*` and the inner `model_forward_paged_inner`
+(`crates/kiln-model/src/forward.rs:7014-7222`). The only call sites in
+production code paths are:
+
+- `model_forward_paged_streaming` (line 7014) — `pub fn` exposed for the
+  inference dispatcher
+- `model_forward_paged_streaming_last_token_with_last_hidden` (line 7045) —
+  used by the MTP self-spec prefill
+- The `_with` variants are explicit-parameter shims used by the same call
+  sites and by tests (lines 10840, 10944, 11039, 11211, 11318)
+
+Searching for any of these names from the `kiln-train` and `kiln-server`
+crates:
+
+```
+$ grep -rn 'model_forward_paged_streaming\|streaming_prefill_enabled_for\
+|streaming_tile_tokens' crates/kiln-train/ crates/kiln-server/src/
+(zero matches)
+```
+
+The training-path forward functions `sft_train` actually invokes are
+`model_forward_embed`, `model_forward_segment`, `model_forward_head`,
+`model_forward_no_head`, and `model_forward_final_norm`. None of them
+reference `streaming_prefill_enabled_for`, `streaming_tile_tokens`,
+`model_forward_paged_streaming`, or any `KILN_STREAMING_*` env helper.
+
+### 2. Minimum surface area to wire streaming into training
+
+The training-time GDN prefill happens inside `model_forward_segment`
+(`forward.rs:5699`). For every layer in the segment range, that function
+materializes the full `[1, T, hidden]` activation tensor at the layer's
+output. There is no chunking along T.
+
+Wiring streaming into training would require either:
+
+1. **Tile within `model_forward_segment`.** Add a streaming branch that
+   slices `hidden` along T into tiles of `streaming_tile_tokens_for(device)`,
+   threads the linear-attention recurrent state across tiles within the
+   segment, and stitches the per-tile outputs back into a `[1, T, hidden]`
+   tensor for the segment's output. This is bit-exact with the monolithic
+   path *for inference* because `LinearAttentionState` provides the O(1)
+   hand-off, but for training we additionally need the per-tile activations
+   to participate in the autograd graph correctly. The candle backward pass
+   currently computes per-segment gradients from the segment's full-T input
+   and full-T output; intermediate per-tile activations get recomputed when
+   the segment is recomputed during checkpointing, which is fine, but the
+   per-tile re-stitch must preserve gradient flow (effectively, the tile
+   stitch is a `cat` along the T axis with grad).
+
+2. **Tile at the segment boundary.** Have
+   `checkpointed_forward_backward` segment along **both** axes — layer
+   axis (existing) and time axis (new). The trainer would split each
+   `[start_layer..end_layer)` segment into M time tiles, run forward per
+   tile threading `LinearAttentionState`, and only retain the last-tile
+   activations at the segment boundary for backward.
+
+Option 1 is the smaller change but adds complexity inside the shared
+`model_forward_segment` (which is also called by inference code paths via
+`model_forward_no_head`). Option 2 keeps the tiling inside the trainer but
+duplicates more of the forward loop.
+
+Either option is **net-new implementation work** of comparable scope to a
+small kernel-vendor task. Neither is a one-line wiring change.
+
+### 3. Does `KILN_GRAD_CHECKPOINT_SEGMENTS` segment along the layer axis or the time axis?
+
+**Layer axis only.** `compute_segment_boundaries` (`trainer.rs:1181-1193`)
+partitions `[0..num_layers)` into N roughly-equal segments. Default at 32
+layers / 4 segments is `[(0,8), (8,16), (16,24), (24,32)]`. The full T
+dimension is processed in one shot per segment via
+`model_forward_segment(start, end)`. There is no time-axis tiling in the
+training loop today.
+
+### 4. Would streaming compose with gradient checkpointing?
+
+Gradient checkpointing already uses `model_forward_segment` per layer-segment
+and recomputes the segment from a detached boundary state. At T=8192 with 4
+segments, each segment processes 8 layers' worth of `[1, 8192, 2560]`
+activations through GDN intermediates. The GDN prefill activations
+(`causal_conv1d` F32 promotion ~2 GiB at T=8192, `l2_normalize` F32 buffers
+~1 GiB at T=8192, GQA head expansion intermediates) all materialize at the
+full `[1, 8192, ·]` shape per layer in the segment. Tiling along T inside
+the segment **would** reduce these intermediates to per-tile shapes,
+multiplicatively with gradient checkpointing (i.e., layer-axis ÷ N_seg AND
+time-axis ÷ M_tile).
+
+So composition is fine in principle. The implementation gap is the
+training-side dispatch (no streaming branch in `model_forward_segment`),
+not the algebra.
+
+## Empirical check
+
+Augmented `flce_phase_a_validation_bench.rs` to toggle
+`KILN_STREAMING_PREFILL` and `KILN_STREAMING_TILE_TOKENS` per cell using
+the same `std::env::set_var` pattern the existing `KILN_USE_FLCE` cell
+toggle uses. Added four cells; reordered so the T=2048 STREAMING ON
+control runs **before** the T=8192/T=16384 OOM cells (the original
+ordering's T=2048 STREAMING ON peak was contaminated by post-OOM CUDA
+allocator residue from the preceding OOM cells).
+
+Ran on RunPod A6000 (`pod-d76547b152be6d45b2e56452`, image
+`ghcr.io/ericflo/kiln-runpod:latest`) with `KILN_W4A16` and
+`KILN_KV_CACHE_FP8` unset (matches Phase A baseline conditions),
+gradient checkpointing on (default 4 segments, auto-detected from
+51.5 GiB VRAM), rank-8 LoRA, single SFT step per cell. Peak VRAM
+sampled at 50 ms cadence on a background `nvidia-smi` poller.
+Baseline post-warmup = **18 474 MiB** (~18.0 GB).
+
+### Results
+
+| target_T | actual_T | FLCE | STREAM | TILE     | peak VRAM (MiB) | ΔVRAM (MiB) | step (s) | loss        | status |
+|---:|---:|:---:|:---:|:---:|---:|---:|---:|---:|:---|
+| 2 048 | 2 042 | OFF | unset | default | 34 602 | 16 128 | 2.7 | 2.78368521 | ok |
+| 2 048 | 2 042 | ON  | unset | default | 34 602 | 16 128 | 3.2 | 2.78343940 | ok |
+| 2 048 | 2 042 | ON  | **ON**    | default | **34 602** | **16 128** | 3.2 | **2.78343940** | **ok** |
+| 8 192 | 8 192 | ON  | unset | default | 48 490 | 30 016 | 0.7 | n/a         | OOM |
+| 16 384 | 16 380 | ON | unset | default | 48 490 | 30 016 | 0.7 | n/a         | OOM |
+| 8 192 | 8 192 | ON  | **ON**    | default | 48 490 | 30 016 | 0.7 | n/a         | OOM |
+| 8 192 | 8 192 | ON  | **ON**    | 4096    | 48 490 | 30 016 | 0.7 | n/a         | OOM |
+| 8 192 | 8 192 | ON  | **ON**    | 2048    | 48 490 | 30 016 | 0.7 | n/a         | OOM |
+
+Three observations make the source-level audit's "streaming is unreachable
+from training" hypothesis empirically hard to deny:
+
+1. **T=2048 control delta is exactly 0 MiB.** The T=2048 FLCE=ON
+   STREAMING=ON cell's peak VRAM is **34 602 MiB**, identical to the
+   T=2048 FLCE=ON STREAMING=unset cell's **34 602 MiB**. The bench
+   reports `T=2048 peak delta (STREAMING ON vs unset): 0 MiB`. If the
+   streaming branch were reached and tiled GDN prefill within the SFT
+   forward, peak VRAM would change. It does not.
+2. **Final loss matches bit-for-bit.** Both the STREAMING=unset and
+   STREAMING=ON T=2048 cells produce final loss
+   `2.7834393978118896` (full f32 precision printed by the bench). If
+   the streaming branch were reached, even a bit-exact streaming path
+   would walk slightly different ops (per-tile RMSNorm, per-tile
+   convolution, per-tile recurrent state hand-off) and observable bf16
+   output noise would diverge. It does not.
+3. **T=8192 OOMs identically across all tile sizes.** The most
+   discriminative test of whether streaming is reachable is the
+   tile-size sweep at T=8192: tile=8192 (default, no actual tiling),
+   tile=4096 (would split T into 2 chunks), tile=2048 (would split T
+   into 4 chunks). Smaller tiles slash the per-tile GDN intermediate
+   memory linearly. If streaming were reachable, tile=2048 should
+   reduce peak VRAM by ≈3× relative to tile=8192. Instead, all three
+   cells land on the **same 48 490 MiB** ceiling, the **same 30 016 MiB**
+   delta, and the **same 0.7 s** failed-allocation step time. They are
+   indistinguishable.
+
+The source-level finding (streaming dispatch lives only in
+`model_forward_paged_streaming*`, none of which are called by the SFT
+path) is the parsimonious explanation: the env flag is parsed without
+effect.
+
+## Verdict
+
+**RED — streaming GDN prefill is not reachable from the SFT training
+path. `KILN_STREAMING_PREFILL` and `KILN_STREAMING_TILE_TOKENS` have no
+measurable effect on training-time peak VRAM at T=2048, and do not
+unblock T=8192/T=16384 SFT on A6000.**
+
+This is a useful negative result. It rules out the "minimum-effort
+wiring" remediation for Finding 2 and frames the next move as
+implementation work, not configuration work.
+
+## Required follow-ups (post-audit)
+
+The remediation menu, in increasing scope:
+
+1. **Tile within `model_forward_segment` (smallest change that could
+   work).** Add a streaming branch that splits the segment's T input
+   into tiles of `streaming_tile_tokens_for(device)` and threads
+   `LinearAttentionState` per tile. Reuse the inference-side tile-loop
+   logic in `model_forward_paged_streaming_with` as the design
+   reference; the segment variant has no paged KV (`KvCache=None` for
+   GDN layers; full-attn layers in training carry no KV cache either).
+   Add a CPU parity test against the monolithic `model_forward_segment`
+   at small T and a GPU memory-reduction test at T=8192. Estimated
+   scope: ~150-300 LOC in `forward.rs`, ~50-100 LOC in `trainer.rs`
+   if the `streaming_tile_tokens_for` env is honored at the segment
+   level (not the trainer level).
+
+2. **Time-axis tile inside `checkpointed_forward_backward`.** Add a
+   per-segment time-tile loop that splits each layer-segment into M
+   time tiles, runs forward+backward per tile, and accumulates LoRA
+   gradients across tiles within a segment (the existing layer-axis
+   accumulation pattern generalizes). This keeps the change inside
+   the trainer but duplicates more of the forward dispatch. Estimated
+   scope: ~200-400 LOC in `trainer.rs`.
+
+3. **Both, on top of a CUDA fused FLCE kernel (Phase B).** Phase B's
+   head-side memory savings stack with GDN-side time-axis tiling. The
+   combination is what closes Finding 2. Phase B alone cannot
+   (already-shipped Phase A, even bug-free, leaves the GDN-side
+   activation pressure intact — that's exactly what the post-fix
+   re-run on 2026-04-29 already showed).
+
+Recommended next slice: option (1) as a focused PR — it is the
+smallest change that produces a measurable T=8192 SFT peak VRAM
+reduction on A6000, and it stacks correctly with Phase B when the
+fused CUDA FLCE kernel lands.
+
+The Phase 10 roadmap claim "shipping streaming GDN prefill at
+training time will unblock T=8192 SFT on A6000" stays plausible but
+**unverified**; this audit narrows it to "shipping a training-time
+streaming dispatch (option 1 above) can unblock T=8192 SFT on A6000,
+contingent on actual GDN-intermediate memory reduction at the
+training-side tile boundary." That contingent claim is what the
+follow-up implementation PR should validate end-to-end.
+
+## Caveats
+
+- The bench measures peak VRAM via `nvidia-smi` polling at 50 ms; sub-
+  50 ms VRAM transients may be undercounted. The reported peak is a
+  lower bound. This is the same caveat the Phase A preflight and
+  validation use, so the cross-cell comparison is consistent.
+- The bench uses a single SFT step per cell. Multi-step or multi-epoch
+  training might surface optimizer-state or cumulative-checkpoint
+  growth that this single-step measurement does not capture. The
+  audit's hypothesis (streaming flag is parsed without effect) is
+  unaffected by single-step vs multi-step.
+- The T=2048 FLCE=ON STREAMING=ON cell was specifically reordered
+  ahead of the OOM cells to avoid post-OOM CUDA allocator residue
+  contaminating its peak. The first run of this bench (with the
+  control cell after the OOM cells) reported a spurious 13 888 MiB
+  delta in that cell because the allocator had not released after the
+  T=8192 OOM. The reordered run (in the table above) shows the true
+  delta of 0 MiB. The raw log captures both cell orderings'
+  outcomes for the T=8192 OOM cells; only the reordered run has a
+  trustworthy T=2048 STREAMING ON peak.
+- Audit scoped to GPU-side production training (CUDA path on A6000).
+  Metal/MLX training is out of scope. The Metal streaming threshold
+  default (2048 tokens, `STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD`)
+  would similarly not affect Metal SFT for the same source-level
+  reason: trainer never calls `model_forward_paged_streaming*`.
+- The empirical check did not measure a non-OOM fallback at T=8192
+  (e.g., dropping rank, reducing checkpoint segments) because Finding
+  2 is specifically about reaching the T=8192 SFT cell with current
+  defaults. Deferred to the follow-up implementation PR.

--- a/docs/flce_phase_a_streaming_raw_2026-04-29.log
+++ b/docs/flce_phase_a_streaming_raw_2026-04-29.log
@@ -1,0 +1,266 @@
+[36m=== kiln-runpod image ===[0m
+  GPU: NVIDIA RTX A6000, 565.57.01
+  CUDA toolkit: release 12.4
+  nsys: NVIDIA Nsight Systems version 2023.4.4.54-234433681190v0
+  rustc: 1.95.0 | cargo: 1.95.0
+  sccache: 0.9.1 | nextest: (65e806bd5
+  torch: 2.4.1+cu124 (cuda=12.4)
+
+Quick start: [32mkiln-setup[0m (configures sccache+B2) then clone kiln & build.
+
+=== FLCE Phase A validation — Qwen3.5-4B, V=248320, hidden=2560 ===
+Loading model from /workspace/models/Qwen3.5-4B
+[2m2026-04-29T08:30:58.941351Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/models/Qwen3.5-4B (2 shards)
+[2m2026-04-29T08:30:58.942718Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-29T08:30:58.942899Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected; deferring CPU load until first use [3mmtp_prefix[0m[2m=[0mmtp.
+[2m2026-04-29T08:30:58.942910Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4206M parameters (8022 MB) across 32 layers
+[2m2026-04-29T08:30:58.942996Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+Baseline VRAM (post-load): 16346 MiB
+Warmup pass at T~256 (FLCE OFF)...
+
+--- T target = 256  FLCE = OFF  STREAMING = unset  TILE = default ---
+  Tokenized length: 248 tokens (target 256)
+[2m2026-04-29T08:31:02.224120Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T256-flce-off"
+[2m2026-04-29T08:31:02.228983Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T08:31:02.275398Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T08:31:02.275443Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+[2m2026-04-29T08:31:02.906442Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m training step [3mepoch[0m[2m=[0m1 [3mstep[0m[2m=[0m1 [3mtotal_steps[0m[2m=[0m1 [3mloss[0m[2m=[0m"1.741690"
+[2m2026-04-29T08:31:02.906521Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m epoch complete [3mepoch[0m[2m=[0m1 [3mavg_loss[0m[2m=[0m"1.741690"
+[2m2026-04-29T08:31:02.937482Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m saved PEFT adapter [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T256-flce-off [3mnum_tensors[0m[2m=[0m256
+[2m2026-04-29T08:31:02.937535Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m SFT training complete [3madapter[0m[2m=[0m"flce-phaseA-T256-flce-off" [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T256-flce-off [3mfinal_loss[0m[2m=[0m"1.741690"
+  baseline 16346 MiB  peak 18474 MiB  delta 2128 MiB  samples 8  wall 0.7s  loss=Some(1.7416900396347046)  status=ok
+Baseline VRAM (post-warmup): 18474 MiB
+
+--- T target = 2048  FLCE = OFF  STREAMING = unset  TILE = default ---
+  Tokenized length: 2042 tokens (target 2048)
+[2m2026-04-29T08:31:03.144401Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T2048-flce-off"
+[2m2026-04-29T08:31:03.146302Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T08:31:03.199483Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T08:31:03.199534Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+[2m2026-04-29T08:31:05.836219Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m training step [3mepoch[0m[2m=[0m1 [3mstep[0m[2m=[0m1 [3mtotal_steps[0m[2m=[0m1 [3mloss[0m[2m=[0m"2.783685"
+[2m2026-04-29T08:31:05.836286Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m epoch complete [3mepoch[0m[2m=[0m1 [3mavg_loss[0m[2m=[0m"2.783685"
+[2m2026-04-29T08:31:05.867058Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m saved PEFT adapter [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-off [3mnum_tensors[0m[2m=[0m256
+[2m2026-04-29T08:31:05.867100Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m SFT training complete [3madapter[0m[2m=[0m"flce-phaseA-T2048-flce-off" [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-off [3mfinal_loss[0m[2m=[0m"2.783685"
+  baseline 18474 MiB  peak 34602 MiB  delta 16128 MiB  samples 30  wall 2.7s  loss=Some(2.7836852073669434)  status=ok
+
+--- T target = 2048  FLCE = ON  STREAMING = unset  TILE = default ---
+  Tokenized length: 2042 tokens (target 2048)
+[2m2026-04-29T08:31:06.039138Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T2048-flce-on"
+[2m2026-04-29T08:31:06.041008Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T08:31:06.114914Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T08:31:06.114960Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+[2m2026-04-29T08:31:09.174169Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m training step [3mepoch[0m[2m=[0m1 [3mstep[0m[2m=[0m1 [3mtotal_steps[0m[2m=[0m1 [3mloss[0m[2m=[0m"2.783439"
+[2m2026-04-29T08:31:09.174225Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m epoch complete [3mepoch[0m[2m=[0m1 [3mavg_loss[0m[2m=[0m"2.783439"
+[2m2026-04-29T08:31:09.205699Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m saved PEFT adapter [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-on [3mnum_tensors[0m[2m=[0m256
+[2m2026-04-29T08:31:09.205733Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m SFT training complete [3madapter[0m[2m=[0m"flce-phaseA-T2048-flce-on" [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-on [3mfinal_loss[0m[2m=[0m"2.783439"
+  baseline 18474 MiB  peak 34602 MiB  delta 16128 MiB  samples 36  wall 3.2s  loss=Some(2.7834393978118896)  status=ok
+
+--- T target = 2048  FLCE = ON  STREAMING = ON  TILE = default ---
+  Tokenized length: 2042 tokens (target 2048)
+[2m2026-04-29T08:31:09.399428Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T2048-flce-on"
+[2m2026-04-29T08:31:09.401238Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T08:31:09.455948Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T08:31:09.456003Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+[2m2026-04-29T08:31:12.513534Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m training step [3mepoch[0m[2m=[0m1 [3mstep[0m[2m=[0m1 [3mtotal_steps[0m[2m=[0m1 [3mloss[0m[2m=[0m"2.783439"
+[2m2026-04-29T08:31:12.513593Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m epoch complete [3mepoch[0m[2m=[0m1 [3mavg_loss[0m[2m=[0m"2.783439"
+[2m2026-04-29T08:31:12.548380Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m saved PEFT adapter [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-on [3mnum_tensors[0m[2m=[0m256
+[2m2026-04-29T08:31:12.548414Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m SFT training complete [3madapter[0m[2m=[0m"flce-phaseA-T2048-flce-on" [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-on [3mfinal_loss[0m[2m=[0m"2.783439"
+  baseline 18474 MiB  peak 34602 MiB  delta 16128 MiB  samples 35  wall 3.2s  loss=Some(2.7834393978118896)  status=ok
+
+--- T target = 8192  FLCE = ON  STREAMING = unset  TILE = default ---
+  Tokenized length: 8192 tokens (target 8192)
+[2m2026-04-29T08:31:13.392991Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T8192-flce-on"
+[2m2026-04-29T08:31:13.394781Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T08:31:13.457787Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T08:31:13.457854Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18474 MiB  peak 48490 MiB  delta 30016 MiB  samples 10  wall 0.7s  loss=None  status=OOM
+
+--- T target = 16384  FLCE = ON  STREAMING = unset  TILE = default ---
+  Tokenized length: 16380 tokens (target 16384)
+[2m2026-04-29T08:31:17.184183Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T16384-flce-on"
+[2m2026-04-29T08:31:17.186239Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T08:31:17.297415Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T08:31:17.297479Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18474 MiB  peak 48490 MiB  delta 30016 MiB  samples 7  wall 0.7s  loss=None  status=OOM
+
+--- T target = 8192  FLCE = ON  STREAMING = ON  TILE = default ---
+  Tokenized length: 8192 tokens (target 8192)
+[2m2026-04-29T08:31:18.648395Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T8192-flce-on"
+[2m2026-04-29T08:31:18.650592Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T08:31:18.721279Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T08:31:18.721355Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18474 MiB  peak 48490 MiB  delta 30016 MiB  samples 8  wall 0.7s  loss=None  status=OOM
+
+--- T target = 8192  FLCE = ON  STREAMING = ON  TILE = 4096 ---
+  Tokenized length: 8192 tokens (target 8192)
+[2m2026-04-29T08:31:20.156722Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T8192-flce-on"
+[2m2026-04-29T08:31:20.158656Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T08:31:20.245282Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T08:31:20.245336Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18474 MiB  peak 48490 MiB  delta 30016 MiB  samples 8  wall 0.7s  loss=None  status=OOM
+
+--- T target = 8192  FLCE = ON  STREAMING = ON  TILE = 2048 ---
+  Tokenized length: 8192 tokens (target 8192)
+[2m2026-04-29T08:31:21.688377Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T8192-flce-on"
+[2m2026-04-29T08:31:21.690347Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T08:31:21.745238Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T08:31:21.745319Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18474 MiB  peak 48490 MiB  delta 30016 MiB  samples 8  wall 0.7s  loss=None  status=OOM
+
+=== FLCE Phase A + GDN-streaming-audit validation results ===
+target_T   actual_T   FLCE   STREAM  TILE     peak_VRAM_MiB  delta_MiB    abc_GB       abc/peak   step_s     loss        
+2048       2042       OFF    unset   default  34602          16128        3.778        0.112      2.7        2.783685    
+2048       2042       ON     unset   default  34602          16128        3.778        0.112      3.2        2.783439    
+2048       2042       ON     ON      default  34602          16128        3.778        0.112      3.2        2.783439    
+8192       8192       ON     unset   default  48490          30016        15.156       0.320      0.7        n/a         
+16384      16380      ON     unset   default  48490          30016        30.305       0.640      0.7        n/a         
+8192       8192       ON     ON      default  48490          30016        15.156       0.320      0.7        n/a         
+8192       8192       ON     ON      4096     48490          30016        15.156       0.320      0.7        n/a         
+8192       8192       ON     ON      2048     48490          30016        15.156       0.320      0.7        n/a         
+
+=== Parity (T=2048 FLCE off vs on) ===
+  off_loss = Some(2.7836852073669434)
+  on_loss  = Some(2.7834393978118896)
+  delta    = Some(0.00024580955505371094)
+  tolerance= 1.0e-3
+  result   = PASS
+
+=== Cell summary ===
+  T=2048   FLCE=ON  STREAM=unset             -> status=ok          peak=34602 MiB  step=3.2s  loss=Some(2.7834393978118896)
+  T=2048   FLCE=OFF STREAM=unset             -> status=ok          peak=34602 MiB  step=2.7s  loss=Some(2.7836852073669434)
+  T=8192   FLCE=ON  STREAM=unset             -> status=OOM         peak=48490 MiB  step=0.7s  loss=None
+  T=16384  FLCE=ON  STREAM=unset             -> status=OOM         peak=48490 MiB  step=0.7s  loss=None
+  T=2048   FLCE=ON  STREAM=ON  tile=default  -> status=ok          peak=34602 MiB  step=3.2s  loss=Some(2.7834393978118896)
+  T=8192   FLCE=ON  STREAM=ON  tile=default  -> status=OOM         peak=48490 MiB  step=0.7s  loss=None
+  T=8192   FLCE=ON  STREAM=ON  tile=4096     -> status=OOM         peak=48490 MiB  step=0.7s  loss=None
+  T=8192   FLCE=ON  STREAM=ON  tile=2048     -> status=OOM         peak=48490 MiB  step=0.7s  loss=None
+
+=== Phase A verdict: RED — Phase A insufficient on A6000 ===
+
+=== GDN-streaming-audit verdict: RED — KILN_STREAMING_PREFILL has no effect on SFT path; streaming dispatch is not wired into training-time forward (model_forward_segment) ===
+T=2048 peak delta (STREAMING ON vs unset): 0 MiB  (control for streaming reachability)
+
+=== JSON ===
+{
+  "baseline_mib": 18474,
+  "hidden": 2560,
+  "parity": {
+    "delta": 0.00024580955505371094,
+    "off_loss": 2.7836852073669434,
+    "on_loss": 2.7834393978118896,
+    "pass": true,
+    "tolerance": 0.001
+  },
+  "phase_a_verdict": "RED — Phase A insufficient on A6000",
+  "rows": [
+    {
+      "actual_t": 2042,
+      "baseline_mib": 18474,
+      "delta_mib": 16128,
+      "final_loss": 2.7836852073669434,
+      "peak_mib": 34602,
+      "status": "ok",
+      "step_secs": 2.723638416,
+      "streaming": null,
+      "target_t": 2048,
+      "tile_tokens": null,
+      "use_flce": false
+    },
+    {
+      "actual_t": 2042,
+      "baseline_mib": 18474,
+      "delta_mib": 16128,
+      "final_loss": 2.7834393978118896,
+      "peak_mib": 34602,
+      "status": "ok",
+      "step_secs": 3.167529282,
+      "streaming": null,
+      "target_t": 2048,
+      "tile_tokens": null,
+      "use_flce": true
+    },
+    {
+      "actual_t": 2042,
+      "baseline_mib": 18474,
+      "delta_mib": 16128,
+      "final_loss": 2.7834393978118896,
+      "peak_mib": 34602,
+      "status": "ok",
+      "step_secs": 3.150210912,
+      "streaming": true,
+      "target_t": 2048,
+      "tile_tokens": null,
+      "use_flce": true
+    },
+    {
+      "actual_t": 8192,
+      "baseline_mib": 18474,
+      "delta_mib": 30016,
+      "final_loss": null,
+      "peak_mib": 48490,
+      "status": "OOM",
+      "step_secs": 0.696252674,
+      "streaming": null,
+      "target_t": 8192,
+      "tile_tokens": null,
+      "use_flce": true
+    },
+    {
+      "actual_t": 16380,
+      "baseline_mib": 18474,
+      "delta_mib": 30016,
+      "final_loss": null,
+      "peak_mib": 48490,
+      "status": "OOM",
+      "step_secs": 0.652815391,
+      "streaming": null,
+      "target_t": 16384,
+      "tile_tokens": null,
+      "use_flce": true
+    },
+    {
+      "actual_t": 8192,
+      "baseline_mib": 18474,
+      "delta_mib": 30016,
+      "final_loss": null,
+      "peak_mib": 48490,
+      "status": "OOM",
+      "step_secs": 0.682157667,
+      "streaming": true,
+      "target_t": 8192,
+      "tile_tokens": null,
+      "use_flce": true
+    },
+    {
+      "actual_t": 8192,
+      "baseline_mib": 18474,
+      "delta_mib": 30016,
+      "final_loss": null,
+      "peak_mib": 48490,
+      "status": "OOM",
+      "step_secs": 0.694357044,
+      "streaming": true,
+      "target_t": 8192,
+      "tile_tokens": 4096,
+      "use_flce": true
+    },
+    {
+      "actual_t": 8192,
+      "baseline_mib": 18474,
+      "delta_mib": 30016,
+      "final_loss": null,
+      "peak_mib": 48490,
+      "status": "OOM",
+      "step_secs": 0.665597405,
+      "streaming": true,
+      "target_t": 8192,
+      "tile_tokens": 2048,
+      "use_flce": true
+    }
+  ],
+  "stream_audit_t2048_peak_delta_mib": 0,
+  "stream_audit_verdict": "RED — KILN_STREAMING_PREFILL has no effect on SFT path; streaming dispatch is not wired into training-time forward (model_forward_segment)",
+  "stream_on_t2048_loss": 2.7834393978118896,
+  "vocab_size": 248320
+}
+


### PR DESCRIPTION
## Summary

Audits whether the existing Phase 7 streaming GDN prefill (`KILN_STREAMING_PREFILL`, `model_forward_paged_streaming*`) is reachable from the SFT training path as a remediation for **Finding 2** of the Phase A FLCE validation (T=8192 / T=16384 SFT OOM on A6000, see `docs/audits/PHASE10_FLCE_PREFLIGHT.md` Phase A validation section).

## Verdict

**RED — `KILN_STREAMING_PREFILL` has no effect on the SFT path; streaming GDN prefill is unreachable from training-time forward.**

Source-level: streaming dispatch lives only in `model_forward_paged_streaming{,_with,_last_token_with_last_hidden{,_with}}` (`crates/kiln-model/src/forward.rs:7014-7222`). The trainer goes through `model_forward_embed → model_forward_segment → model_forward_head`/`_no_head`, none of which reference any streaming entry point or `streaming_*` env helper.

Empirical (A6000, `pod-d76547b152be6d45b2e56452`, post-#633 main):

| target_T | FLCE | STREAM | TILE     | peak VRAM (MiB) | ΔVRAM | step (s) | loss        | status |
|---:|:---:|:---:|:---:|---:|---:|---:|---:|:---|
| 2 048  | OFF | unset | default | 34 602 | 16 128 | 2.7 | 2.78368521 | ok |
| 2 048  | ON  | unset | default | 34 602 | 16 128 | 3.2 | 2.78343940 | ok |
| 2 048  | ON  | **ON**    | default | **34 602** | **16 128** | 3.2 | **2.78343940** | **ok** |
| 8 192  | ON  | unset | default | 48 490 | 30 016 | 0.7 | n/a         | OOM |
| 16 384 | ON  | unset | default | 48 490 | 30 016 | 0.7 | n/a         | OOM |
| 8 192  | ON  | ON    | default | 48 490 | 30 016 | 0.7 | n/a         | OOM |
| 8 192  | ON  | ON    | 4096    | 48 490 | 30 016 | 0.7 | n/a         | OOM |
| 8 192  | ON  | ON    | 2048    | 48 490 | 30 016 | 0.7 | n/a         | OOM |

- T=2048 STREAMING ON peak matches STREAMING unset to **0 MiB** (delta).
- Loss is bit-identical between STREAMING unset and STREAMING ON at T=2048.
- T=8192 STREAMING ON at three tile sizes (default/4096/2048) all OOM identically at the 48 GB GPU ceiling in 0.7 s — indistinguishable from the streaming-unset T=8192 OOM. Smaller tiles, which would slash per-tile GDN intermediates **if streaming were reachable**, show no change.

## Implication

Closing Finding 2 requires **net-new implementation work**, not configuration. The smallest plausible fix is a streaming branch inside `model_forward_segment` that tiles along T while threading `LinearAttentionState`. Detailed remediation menu (and scope estimates) in the audit doc.

The Phase 10 roadmap claim "shipping streaming GDN prefill at training time will unblock T=8192 SFT on A6000" stays plausible but unverified; this audit narrows it to "shipping a training-time streaming dispatch can unblock T=8192 SFT on A6000, contingent on actual GDN-intermediate memory reduction at the tile boundary." That contingent claim is what the follow-up implementation PR should validate end-to-end.

## Files

- **New** `docs/audits/PHASE10_GDN_TRAINING_STREAMING.md` — full audit doc (hypothesis, source-level audit, empirical bench, verdict, remediation menu, caveats).
- **Edit** `docs/audits/PHASE10_FLCE_PREFLIGHT.md` — appends a "Phase A streaming check" section pointing at the new audit doc.
- **New** `docs/flce_phase_a_streaming_raw_2026-04-29.log` — raw bench output preserved.
- **Edit** `crates/kiln-server/examples/flce_phase_a_validation_bench.rs` — adds 4 new cells (T=2048 STREAMING ON control + T=8192 STREAMING ON tile sweep), threads `KILN_STREAMING_PREFILL` and `KILN_STREAMING_TILE_TOKENS` toggles per cell, reports a separate GDN-streaming-audit verdict alongside the Phase A verdict.
- **Edit** `CHANGELOG.md` — Unreleased / Audits entry summarizing the verdict.

## Test plan

- [x] Source-level audit verified locally against `306d26a` (post-#633 main): `grep -rn 'model_forward_paged_streaming\|streaming_prefill_enabled_for\|streaming_tile_tokens' crates/kiln-train/ crates/kiln-server/src/` returns 0 matches.
- [x] Bench rebuilt and ran on A6000 (`ghcr.io/ericflo/kiln-runpod:latest`, sccache+B2 warm cache, 49 s build, ~5 min total runtime). Raw log committed.
- [x] First run identified post-OOM CUDA allocator residue contaminating the T=2048 STREAMING ON control cell. Bench reordered to put the control cell **before** the OOM cells; rerun produced clean 0 MiB delta.
- [x] `cargo test -p kiln-flce-kernel` clean (only doc/bench files changed; FLCE kernel itself is untouched). The bench compiles cleanly under `cargo build --release --features cuda -p kiln-server --example flce_phase_a_validation_bench`.

## Out of scope (deferred to follow-up implementation PR)

- Wiring streaming into `model_forward_segment` (the "smallest change that could work" remediation in the audit doc §"Required follow-ups").
- Time-axis tile inside `checkpointed_forward_backward` (alternative remediation).
- Phase B CUDA fused FLCE kernel — already tracked in the Phase 10 plan; this audit confirms it must be paired with GDN-side work to fit T=8192 SFT on A6000.