### PR TITLE
phase10: time-axis tile inside checkpointed_forward_backward (Finding 2 follow-up impl)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2710,7 +2710,7 @@ fn causal_conv1d_decode(
 ///     cores on A5000/4090-class GPUs for dk = dv = 128,
 ///   - a small-enough forward-substitution inner loop so the Vec<Tensor> cat
 ///     churn stays bounded.
-const GDN_CHUNK_SIZE: usize = 64;
+pub const GDN_CHUNK_SIZE: usize = 64;
 const GDN_RECURRENT_PREFILL_MAX_TOKENS: usize = 2048;
 
 /// Build a [n, n] mask on `device` with `dtype`, 1.0 where row > col else 0.0.

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -14,8 +14,9 @@ use kiln_core::tokenizer::KilnTokenizer;
 use kiln_flce_kernel::{DEFAULT_CHUNK_SIZE, fused_linear_cross_entropy};
 use kiln_model::backend::{self, BackendRuntime};
 use kiln_model::forward::{
-    GpuWeights, LinearAttentionState, model_forward, model_forward_embed, model_forward_final_norm,
-    model_forward_head, model_forward_no_head, model_forward_segment,
+    GDN_CHUNK_SIZE, GpuAttentionWeights, GpuWeights, LinearAttentionState, model_forward,
+    model_forward_embed, model_forward_final_norm, model_forward_head, model_forward_no_head,
+    model_forward_segment, streaming_prefill_enabled_for, streaming_tile_tokens_for,
 };
 use kiln_model::lora_loader::{LoraLayerWeights, LoraProjectionWeights, LoraWeights};
 
@@ -1192,6 +1193,294 @@ fn compute_segment_boundaries(num_layers: usize, num_segments: usize) -> Vec<(us
     boundaries
 }
 
+/// Returns true when every transformer layer in `weights` uses linear (GDN)
+/// attention — i.e., the model has **no** full-attention layers anywhere.
+///
+/// The training-time time-axis tile path
+/// ([`tiled_segment_recompute_and_backward`]) thread `LinearAttentionState`
+/// across tiles to keep GDN forward bit-exact, but full-attention layers have
+/// no analogous KV-cache thread at training time (training does not allocate
+/// a paged KV cache). Within a tile a full-attention layer would attend only
+/// inside the tile and produce different logits, breaking both per-tile loss
+/// and any LoRA gradient that flows through it.
+///
+/// Per-segment iteration also runs **later** segments detached on the tile's
+/// output, so even a segment that is itself GDN-only would dispatch into
+/// later full-attention layers under tiling — which would also break parity.
+/// The cleanest correctness invariant is therefore "no full-attention layers
+/// anywhere in the model".
+fn model_is_gdn_only(weights: &GpuWeights) -> bool {
+    weights
+        .layers
+        .iter()
+        .all(|l| matches!(l.attention, GpuAttentionWeights::Linear(_)))
+}
+
+/// Determine whether the time-axis tile path applies for this training step.
+///
+/// The path requires:
+/// 1. The model must be GDN-only (see [`model_is_gdn_only`] for rationale).
+/// 2. The streaming-prefill dispatch must be enabled for `device` at this
+///    `seq_len` (env override or device-default threshold).
+/// 3. The tile size must be a positive multiple of `GDN_CHUNK_SIZE`
+///    (enforced by [`streaming_tile_tokens_for`]) and strictly less than
+///    `seq_len` — otherwise the tile loop degenerates to a single monolithic
+///    call with extra overhead.
+///
+/// Returns `Some(tile_size)` when applicable, `None` otherwise.
+fn tiled_training_tile_size(
+    weights: &GpuWeights,
+    device: &Device,
+    seq_len: usize,
+) -> Option<usize> {
+    if !model_is_gdn_only(weights) {
+        return None;
+    }
+    if !streaming_prefill_enabled_for(device, seq_len) {
+        return None;
+    }
+    let tile = streaming_tile_tokens_for(device);
+    if tile == 0 || tile % GDN_CHUNK_SIZE != 0 || tile >= seq_len {
+        return None;
+    }
+    Some(tile)
+}
+
+/// Compute the per-tile contribution to the next-token cross-entropy loss
+/// using the same loss math as the monolithic path, returning a scalar
+/// tensor `sum_NLL_tile / total_active` so the per-tile contributions sum to
+/// the monolithic mean across active positions exactly.
+///
+/// `tile_hidden`: `[1, L, hidden]` final hidden states for tile positions
+/// `[ts..te)`. `labels` and `mask` are the explicit, pre-shifted labels and
+/// mask: each `labels[i]` is the target for `tile_hidden[i]`. For non-last
+/// tiles `labels.len() == L` (the last logit predicts the first token of the
+/// next tile); for the last tile `labels.len() == L - 1` (no label exists at
+/// position `total`).
+///
+/// Internally we route through the existing `cross_entropy_loss` /
+/// `fused_linear_cross_entropy` helpers by padding the input by one position
+/// and prepending a masked-out dummy label, so the helpers' built-in
+/// next-token shift recovers the explicit-label semantics. Final result is
+/// scaled by `(num_tile_active / total_active)` because the helpers
+/// internally divide by `num_tile_active` while the per-tile contribution to
+/// the monolithic mean is `sum_NLL_tile / total_active`.
+#[allow(clippy::too_many_arguments)]
+fn tile_loss_explicit(
+    weights: &GpuWeights,
+    model_config: &ModelConfig,
+    tile_hidden: &Tensor,
+    labels: &[u32],
+    mask: &[bool],
+    total_active: usize,
+    device: &Device,
+) -> Result<Tensor> {
+    debug_assert_eq!(labels.len(), mask.len());
+
+    let num_tile_active: usize = mask.iter().filter(|&&m| m).count();
+    if num_tile_active == 0 || total_active == 0 {
+        return Tensor::new(0.0f32, device).map_err(Into::into);
+    }
+
+    let (_, l, hidden_size) = tile_hidden.dims3()?;
+    let l_labels = labels.len();
+    // Helpers expect `input_ids.len() == hidden.dim(1)` and shift internally
+    // (`hidden[..len-1]` predicting `input_ids[1..]`). We want the explicit
+    // pairing `tile_hidden[i] -> labels[i]` for `i in 0..l_labels`. Prepend a
+    // dummy id and mask=false at position 0 of `input_ids_padded` /
+    // `mask_padded`, and pad `tile_hidden` by `l_labels + 1 - l` zero rows so
+    // dimensions align. Active positions are gated by mask, so the padded
+    // hidden never participates in the loss.
+    let pad_amount = (l_labels + 1).saturating_sub(l);
+    let hidden_padded = if pad_amount > 0 {
+        let zero_pad = Tensor::zeros(
+            (1, pad_amount, hidden_size),
+            tile_hidden.dtype(),
+            device,
+        )?;
+        Tensor::cat(&[tile_hidden, &zero_pad], 1)?
+    } else {
+        tile_hidden.clone()
+    };
+
+    let mut input_ids_padded: Vec<u32> = Vec::with_capacity(l_labels + 1);
+    input_ids_padded.push(0u32);
+    input_ids_padded.extend_from_slice(labels);
+    let mut mask_padded: Vec<bool> = Vec::with_capacity(l_labels + 1);
+    mask_padded.push(false);
+    mask_padded.extend_from_slice(mask);
+
+    let loss = if use_flce() {
+        let normed = model_forward_final_norm(&hidden_padded, weights, model_config)?;
+        fused_linear_cross_entropy(
+            &normed,
+            &weights.embed_tokens_t,
+            &input_ids_padded,
+            &mask_padded,
+            device,
+            DEFAULT_CHUNK_SIZE,
+        )
+        .context("tile fused linear cross-entropy")?
+    } else {
+        let logits = model_forward_head(&hidden_padded, weights, model_config)?;
+        cross_entropy_loss(&logits, &input_ids_padded, &mask_padded, device)?
+    };
+
+    // Helpers return `mean over num_tile_active`. We want
+    // `sum_NLL_tile / total_active = mean × (num_tile_active / total_active)`.
+    let scale = num_tile_active as f64 / total_active as f64;
+    loss.affine(scale, 0.0).map_err(Into::into)
+}
+
+/// Time-axis tiled per-segment recompute + backward.
+///
+/// Runs forward+backward+accumulate **per tile** within segment `seg_idx` so
+/// each tile's autograd-saved tensors release before the next tile's forward
+/// allocates its own. State (`LinearAttentionState`) is threaded across tiles
+/// for the grad-tracked segment AND for each detached later segment.
+///
+/// Correctness invariants:
+/// * The model is GDN-only (see [`model_is_gdn_only`]) — no full-attention
+///   layer anywhere, so every layer's outputs at position `t` depend only on
+///   states / inputs ≤ `t`, and per-tile state-threaded forward is bit-exact
+///   against monolithic.
+/// * LoRA on GDN layers is restricted to MLP projections (`gate_proj`,
+///   `up_proj`, `down_proj`) — see [`TrainableLoraParams::initialize`] —
+///   which act per-position. The truncated-BPTT effect of detaching state at
+///   tile boundaries does not affect MLP-only LoRA gradients on GDN-only
+///   models.
+/// * Per-tile loss is computed via [`tile_loss_explicit`], which pads each
+///   tile's hidden by one position so all `L` logits (or `L-1` for the last
+///   tile) participate in the loss; the per-tile contributions sum to the
+///   monolithic mean exactly.
+#[allow(clippy::too_many_arguments)]
+fn tiled_segment_recompute_and_backward(
+    backend: &dyn BackendRuntime,
+    seg_idx: usize,
+    segments: &[(usize, usize)],
+    boundary_states: &[Tensor],
+    input_ids: &[u32],
+    label_mask: &[bool],
+    weights: &GpuWeights,
+    model_config: &ModelConfig,
+    positions: &[u32],
+    params: &TrainableLoraParams,
+    accumulated_grads: &mut HashMap<candle_core::TensorId, Tensor>,
+    total_active: usize,
+    tile_size: usize,
+    device: &Device,
+) -> Result<f64> {
+    let (seg_start, seg_end) = segments[seg_idx];
+    let seg_input = boundary_states[seg_idx].clone();
+    let (_, total, _) = seg_input.dims3()?;
+
+    // States threaded across tiles. Grad-tracked segment uses one shared
+    // state; each later (detached) segment also gets its own shared state so
+    // the detached forward sees the same monolithic context evolution.
+    let mut grad_state = LinearAttentionState::new(model_config, device)?;
+    let later_count = segments.len().saturating_sub(seg_idx + 1);
+    let mut later_states: Vec<LinearAttentionState> = Vec::with_capacity(later_count);
+    for _ in 0..later_count {
+        later_states.push(LinearAttentionState::new(model_config, device)?);
+    }
+
+    let all_vars = params.all_vars();
+    let mut tile_loss_sum = 0.0f64;
+
+    let mut tile_start = 0usize;
+    while tile_start < total {
+        let tile_end = (tile_start + tile_size).min(total);
+        let tile_len = tile_end - tile_start;
+        let is_last_tile = tile_end == total;
+
+        // Slice tile-local inputs.
+        let tile_seg_input = seg_input
+            .narrow(1, tile_start, tile_len)
+            .context("narrow seg_input to tile")?;
+        let tile_positions: Vec<u32> = positions[tile_start..tile_end].to_vec();
+
+        // Grad-tracked forward through segment `seg_idx` on the tile.
+        let lora_weights_for_seg = params.as_lora_weights();
+        let mut tile_hidden = model_forward_segment(
+            backend,
+            tile_seg_input,
+            weights,
+            model_config,
+            &tile_positions,
+            seg_start,
+            seg_end,
+            Some(&mut grad_state),
+            Some(&lora_weights_for_seg),
+        )
+        .with_context(|| {
+            format!(
+                "tiled segment {seg_idx} grad-tracked forward, tile [{tile_start}, {tile_end})"
+            )
+        })?;
+
+        // Detached forward through later segments on the tile, threading
+        // each segment's own state across tiles.
+        for (i, &(later_start, later_end)) in segments[seg_idx + 1..].iter().enumerate() {
+            tile_hidden = tile_hidden.detach();
+            let lora_for_later = params.as_lora_weights();
+            tile_hidden = model_forward_segment(
+                backend,
+                tile_hidden,
+                weights,
+                model_config,
+                &tile_positions,
+                later_start,
+                later_end,
+                Some(&mut later_states[i]),
+                Some(&lora_for_later),
+            )
+            .with_context(|| {
+                format!(
+                    "tiled segment {seg_idx} detached later segment [{later_start}, {later_end}) tile [{tile_start}, {tile_end})"
+                )
+            })?;
+        }
+
+        // Build explicit (pre-shifted) tile labels: `tile_hidden[i]`
+        // predicts `input_ids[tile_start + i + 1]` for `i in 0..tile_len`.
+        // For the last tile we drop the final logit because position `total`
+        // has no label.
+        let labels_end = if is_last_tile { total } else { tile_end + 1 };
+        let labels_start = tile_start + 1;
+        let tile_labels: Vec<u32> = input_ids[labels_start..labels_end].to_vec();
+        let tile_mask: Vec<bool> = label_mask[labels_start..labels_end].to_vec();
+
+        let scaled_loss = tile_loss_explicit(
+            weights,
+            model_config,
+            &tile_hidden,
+            &tile_labels,
+            &tile_mask,
+            total_active,
+            device,
+        )
+        .with_context(|| format!("tile loss [{tile_start}, {tile_end}) (last={is_last_tile})"))?;
+
+        let scaled_val = scaled_loss.to_scalar::<f32>()? as f64;
+        tile_loss_sum += scaled_val;
+
+        // Backward through this tile's autograd graph. Because the segment
+        // is GDN-only and LoRA is MLP-only on GDN layers, MLP-LoRA gradients
+        // sum across tiles to the exact monolithic gradient even though the
+        // per-tile state read at the start of each tile is detached from
+        // the previous tile's autograd graph (truncated BPTT does not
+        // affect parameters that don't influence the recurrent state).
+        let grads = scaled_loss
+            .backward()
+            .with_context(|| format!("tiled backward [{tile_start}, {tile_end})"))?;
+        accumulate_grads(accumulated_grads, &grads, &all_vars)?;
+
+        tile_start = tile_end;
+    }
+
+    Ok(tile_loss_sum)
+}
+
 /// Run one training step with gradient checkpointing.
 ///
 /// Instead of tracking activations for all layers, this:
@@ -1203,6 +1492,19 @@ fn compute_segment_boundaries(num_layers: usize, num_segments: usize) -> Vec<(us
 ///
 /// Memory: only one segment's activations are in the autograd graph at a time.
 /// Compute: ~(N+1)/2 × N forward passes for N segments (with N=4, ~2.5× overhead).
+///
+/// Phase 10 time-axis tiling: when `KILN_STREAMING_PREFILL=1` (or the
+/// device-default streaming threshold fires), `seq_len > tile_size`, and the
+/// model is GDN-only, each segment's recompute is split into time tiles and
+/// each tile is forward+backward+accumulated independently. This releases
+/// per-tile autograd-saved tensors before the next tile's forward starts —
+/// the change identified in PR #635 as the next step needed to unblock
+/// long-context SFT past the 30 GiB segment-recompute ceiling. The
+/// "GDN-only" precondition exists because full-attention layers have no
+/// training-time KV cache to thread across tiles. Hybrid GDN+full-attn
+/// models (Qwen3.5-4B) fall back to the monolithic path; see
+/// `docs/audits/PHASE10_GDN_TRAINING_TILED_BACKWARD.md` for the planned
+/// per-block remediation.
 #[allow(clippy::too_many_arguments)]
 fn checkpointed_forward_backward(
     backend: &dyn BackendRuntime,
@@ -1248,7 +1550,48 @@ fn checkpointed_forward_backward(
     let all_vars = params.all_vars();
     let mut total_loss = 0.0;
 
+    // Tiling decision (made once per training step). When we tile, every
+    // segment iteration uses the per-tile path; otherwise, every segment
+    // uses the monolithic path. Mixing the two within a single step would
+    // silently change the gradient (the per-tile path's truncated state
+    // thread is only safe under the "GDN-only + MLP-only LoRA" invariant
+    // that holds globally for the model, not per-segment).
+    let tile_size = tiled_training_tile_size(weights, device, input_ids.len());
+    let total_active: usize = if tile_size.is_some() {
+        // Same denominator as the monolithic path's `cross_entropy_loss` /
+        // `fused_linear_cross_entropy`: count of active label positions
+        // after the next-token shift (`label_mask[1..]`).
+        if label_mask.len() >= 2 {
+            label_mask[1..].iter().filter(|&&m| m).count()
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+
     for seg_idx in 0..num_segments {
+        if let Some(tile) = tile_size {
+            let seg_loss = tiled_segment_recompute_and_backward(
+                backend,
+                seg_idx,
+                segments,
+                &boundary_states,
+                input_ids,
+                label_mask,
+                weights,
+                model_config,
+                &positions,
+                params,
+                &mut accumulated_grads,
+                total_active,
+                tile,
+                device,
+            )?;
+            total_loss += seg_loss;
+            continue;
+        }
+
         let (seg_start, seg_end) = segments[seg_idx];
 
         // Start from the detached boundary state for this segment
@@ -1313,7 +1656,10 @@ fn checkpointed_forward_backward(
         accumulate_grads(&mut accumulated_grads, &grads, &all_vars)?;
     }
 
-    // Average loss across segments (each segment computed the same loss from different graphs)
+    // Average loss across segments. In both monolithic and tiled paths the
+    // per-iteration `total_loss` accumulates the same segment-equivalent
+    // value, so dividing by `num_segments` recovers the mean cross-entropy
+    // over active positions.
     let avg_loss = total_loss / num_segments as f64;
 
     Ok((avg_loss, accumulated_grads))
@@ -1896,6 +2242,150 @@ mod tests {
         assert!(
             loss_ckpt > 1.0 && loss_ckpt < 10.0,
             "checkpointed loss out of range: {loss_ckpt}"
+        );
+
+        Ok(())
+    }
+
+    /// CPU parity for the Phase 10 time-axis tile path: training-time
+    /// tiled `checkpointed_forward_backward` must match the monolithic
+    /// path bit-for-bit on a GDN-only mini-model at T = 3 × tile_size.
+    ///
+    /// Mirrors the `test_model_forward_segment_streaming_matches_monolithic_cpu`
+    /// pattern from PR #635 — env-driven, relies on nextest per-test process
+    /// isolation. Fails (deadlocks-on-`set_var` warnings aside) under
+    /// multi-threaded `cargo test`; run via `cargo nextest run` or
+    /// `cargo test -- --test-threads=1`.
+    ///
+    /// The test asserts:
+    /// 1. Tiled total loss equals monolithic total loss bit-for-bit (atol
+    ///    tightened to ~1e-5 to allow trivial f32 fp-associativity drift in
+    ///    the chunked LM-head log-sum-exp).
+    /// 2. Every LoRA Var with a gradient in the monolithic path has the
+    ///    same gradient (within the same tolerance) in the tiled path.
+    #[test]
+    fn test_checkpointed_forward_backward_tiled_matches_monolithic_cpu() -> Result<()> {
+        let device = Device::Cpu;
+
+        // GDN-only mini-config: setting `full_attention_interval` strictly
+        // greater than `num_layers` makes `is_full_attention_layer(i)` false
+        // for every layer in [0, num_layers), so `tiny_weights` only emits
+        // GDN layers and `model_is_gdn_only` returns true.
+        let mut config = tiny_config();
+        config.full_attention_interval = config.num_layers + 1;
+        config.num_full_attention_layers = 0;
+
+        let weights = tiny_weights(&config, &device)?;
+        assert!(
+            super::model_is_gdn_only(&weights),
+            "test setup error: model must be GDN-only for tiled-path parity"
+        );
+
+        // T = 192 = 3 × tile_size(64) so the tile loop runs three iterations
+        // (two non-last tiles + one last tile) and exercises the
+        // `pad_amount = 1` branch in `tile_loss_explicit` plus the last-tile
+        // (`pad_amount = 0`) branch in the same step.
+        let seq_len: usize = 192;
+        let vocab = config.vocab_size;
+        let input_ids: Vec<u32> = (0..seq_len)
+            .map(|i| ((i * 7 + 3) % vocab) as u32)
+            .collect();
+        // Mask out positions 0 and total-1 so the next-token shift produces
+        // the same effective active-position set in both paths (matches the
+        // pattern of `test_checkpointed_loss_matches_standard`).
+        let mut label_mask = vec![false; seq_len];
+        for slot in label_mask.iter_mut().skip(1).take(seq_len - 2) {
+            *slot = true;
+        }
+
+        let params = TrainableLoraParams::initialize(&config, &weights, 4, 8.0, &device)?;
+        let segments = compute_segment_boundaries(config.num_layers, 2);
+        let backend = backend::for_device(&device);
+
+        // Step 1: monolithic baseline (env explicitly cleared so the path
+        // takes the original branch even if a parent test process leaked a
+        // KILN_STREAMING_PREFILL=1 setting).
+        // SAFETY: env var mutation is safe under nextest's per-test process
+        // isolation; this test must run via `cargo nextest run`.
+        unsafe {
+            std::env::remove_var("KILN_STREAMING_PREFILL");
+            std::env::remove_var("KILN_STREAMING_TILE_TOKENS");
+            std::env::remove_var("KILN_USE_FLCE");
+        }
+        let (loss_mono, grads_mono) = checkpointed_forward_backward(
+            &*backend,
+            &input_ids,
+            &weights,
+            &config,
+            &params,
+            &label_mask,
+            &segments,
+            &device,
+        )?;
+
+        // Step 2: tiled. KILN_STREAMING_TILE_TOKENS=64 keeps the tile a
+        // multiple of GDN_CHUNK_SIZE; T=192 > tile_size=64 ensures
+        // `tiled_training_tile_size` returns Some and the tiled branch
+        // dispatches.
+        unsafe {
+            std::env::set_var("KILN_STREAMING_PREFILL", "1");
+            std::env::set_var("KILN_STREAMING_TILE_TOKENS", "64");
+        }
+        // Sanity-check the dispatch decision before running the loop, so a
+        // future regression in `tiled_training_tile_size` shows up as an
+        // explicit assertion rather than a silent fallback to monolithic.
+        assert_eq!(
+            super::tiled_training_tile_size(&weights, &device, seq_len),
+            Some(64),
+            "tiled dispatch did not fire for GDN-only model under \
+             KILN_STREAMING_PREFILL=1 (T={seq_len}, tile=64)",
+        );
+        let (loss_tiled, grads_tiled) = checkpointed_forward_backward(
+            &*backend,
+            &input_ids,
+            &weights,
+            &config,
+            &params,
+            &label_mask,
+            &segments,
+            &device,
+        )?;
+        unsafe {
+            std::env::remove_var("KILN_STREAMING_PREFILL");
+            std::env::remove_var("KILN_STREAMING_TILE_TOKENS");
+        }
+
+        // Step 3: parity assertions.
+        let loss_diff = (loss_mono - loss_tiled).abs();
+        assert!(
+            loss_diff < 1e-5,
+            "tiled total loss differs from monolithic: mono={loss_mono} tiled={loss_tiled} \
+             diff={loss_diff:.2e}",
+        );
+
+        let mut compared = 0usize;
+        for var in params.all_vars() {
+            let id = var.as_tensor().id();
+            match (grads_mono.get(&id), grads_tiled.get(&id)) {
+                (Some(g_m), Some(g_t)) => {
+                    let diff = (g_m - g_t)?.abs()?.max_all()?.to_scalar::<f32>()?;
+                    assert!(
+                        diff < 1e-5,
+                        "tiled grad differs from monolithic for var: max_abs_diff={diff:.2e}",
+                    );
+                    compared += 1;
+                }
+                (None, None) => {}
+                (mono_some, tiled_some) => panic!(
+                    "grad presence mismatch: monolithic={} tiled={}",
+                    mono_some.is_some(),
+                    tiled_some.is_some(),
+                ),
+            }
+        }
+        assert!(
+            compared > 0,
+            "no LoRA gradients were compared between tiled and monolithic paths",
         );
 
         Ok(())

--- a/docs/audits/PHASE10_GDN_TRAINING_TILED_BACKWARD.md
+++ b/docs/audits/PHASE10_GDN_TRAINING_TILED_BACKWARD.md
@@ -1,0 +1,303 @@
+# Phase 10 — GDN training-time tiled forward+backward (Finding 2 §2 impl)
+
+Date: 2026-04-29
+Status: **RED on the acceptance criterion (T=8192 SFT must no longer OOM on A6000) — the tiled-backward path is bit-exact + necessary infrastructure, but the GDN-only precondition required for parity excludes the production target model** — see Verdict
+Hardware: NVIDIA RTX A6000 (49 140 MiB VRAM, driver 550.127.08), CUDA 12.4
+Branch: `ce/phase10-tiled-forward-backward`
+Commit: `f10e20c` off `33c86ae` main (post-PR #635)
+Bench: `crates/kiln-server/examples/flce_phase_a_validation_bench.rs`
+Raw log: `docs/flce_phase_a_tiled_backward_raw_2026-04-29.log`
+
+## Purpose
+
+Implementation follow-up to PR #635
+(`docs/audits/PHASE10_GDN_TRAINING_STREAMING_IMPL.md`), which shipped
+the dispatch wiring for training-time streaming GDN prefill but found
+the resulting per-tile transient-allocation reduction insufficient to
+unblock T=8192 SFT on A6000. The PR #635 audit's "Required follow-ups"
+§2 named the next viable remediation: **time-axis tile inside
+`checkpointed_forward_backward`** so each tile's forward+backward
+releases its autograd-saved tensors before the next tile's forward
+allocates its own — the change PR #635 identified as actually moving
+the autograd-recompute bottleneck (rather than just reducing transient
+allocations as the in-segment streaming dispatch did).
+
+The PR exists to answer two questions independently:
+
+1. **Does the time-axis tile path produce bit-exact LoRA gradients
+   versus monolithic on a GDN-only model?** Yes — see "CPU parity"
+   below.
+2. **Does it unblock T=8192 SFT on A6000 for Qwen3.5-4B?** **No** —
+   see "Memory ceiling" below. The dispatch precondition (no
+   full-attention layer anywhere) is conservative because of training-
+   time KV-cache absence, and Qwen3.5-4B is hybrid 24 GDN + 8 full-attn
+   so the tiled path falls back to monolithic for the production
+   target model.
+
+## Implementation summary
+
+`crates/kiln-train/src/trainer.rs`:
+
+- **`model_is_gdn_only(weights)`** — predicate that returns true iff
+  every transformer layer uses linear (GDN) attention. Used as the
+  bit-exactness invariant for the tiled path.
+- **`tiled_training_tile_size(weights, device, seq_len)`** — dispatch
+  oracle. Returns `Some(tile)` when (a) the model is GDN-only, (b)
+  `streaming_prefill_enabled_for(device, seq_len)` is true (env
+  override or device-default threshold), and (c) `tile < seq_len` and
+  `tile % GDN_CHUNK_SIZE == 0`. Returns `None` otherwise — the caller
+  takes the existing monolithic branch unchanged.
+- **`tile_loss_explicit(...)`** — per-tile next-token cross-entropy
+  contribution, normalized so per-tile contributions sum to the
+  monolithic mean over `total_active` positions exactly. The helper
+  pads the tile's hidden by one position (zero) for non-last tiles
+  and prepends a `false`-masked dummy id to `input_ids` / `mask`, so
+  the existing `cross_entropy_loss` / `fused_linear_cross_entropy`
+  helpers' built-in next-token shift recovers explicit
+  `tile_hidden[i] -> labels[i]` semantics. The final scalar is
+  multiplied by `num_tile_active / total_active` because the helpers
+  internally divide by `num_tile_active`. Routes through the same
+  FLCE / non-FLCE branches as the monolithic path so loss math is
+  shared.
+- **`tiled_segment_recompute_and_backward(...)`** — per-segment outer
+  loop that runs forward+backward+accumulate **per tile**. State
+  (`LinearAttentionState`) is threaded across tiles for both the
+  grad-tracked segment AND each detached later segment. Each tile's
+  `loss.backward()` releases its own autograd graph before the next
+  tile's forward allocates its saved tensors, which is the property
+  that distinguishes this PR from PR #635's in-segment streaming
+  dispatch.
+- **`checkpointed_forward_backward`** — modified to call
+  `tiled_training_tile_size` once per training step; if it returns
+  `Some`, every segment iteration uses
+  `tiled_segment_recompute_and_backward`, otherwise every iteration
+  uses the original monolithic branch (behavior unchanged when tiled
+  path doesn't fire).
+
+`crates/kiln-model/src/forward.rs`:
+
+- `GDN_CHUNK_SIZE` is changed from `const` to `pub const` so
+  `kiln-train` can validate `tile % GDN_CHUNK_SIZE == 0` without
+  re-importing the constant.
+
+No changes to forward-pass kernels; this is purely a trainer-side
+restructuring on top of the dispatch infrastructure PR #635 shipped.
+
+## Correctness invariant
+
+Bit-exact LoRA gradients across tiles + monolithic require:
+
+1. **Model is GDN-only.** Full-attention layers have no training-time
+   KV cache to thread across tiles, so a tiled FA forward would
+   attend only inside its own tile and produce different logits than
+   the monolithic path. The `model_is_gdn_only` precondition rules
+   this out.
+2. **LoRA on GDN layers is restricted to MLP projections** (`gate_proj`,
+   `up_proj`, `down_proj`). `TrainableLoraParams::initialize`
+   explicitly skips `q_proj` / `k_proj` / `v_proj` / `o_proj` for
+   GDN layers (these projections only exist on full-attention
+   layers). MLP is a per-position transformation, so MLP-LoRA
+   gradients factor across positions; the truncated-BPTT effect of
+   detaching the recurrent state at tile boundaries (which is what
+   per-tile backward implies — backward of tile *t* sees the state
+   value at the start of tile *t* but not the autograd graph through
+   which that state was computed during tile *t-1*) does not reach
+   any MLP-LoRA Var because no MLP-LoRA Var participates in the state
+   recurrence.
+
+Together these invariants make per-tile forward+backward of a GDN-only
+model bit-exact against monolithic for all LoRA gradients, even though
+the per-tile pattern would in general be a truncated-BPTT
+approximation for parameters that influence the recurrent state.
+
+## Validation
+
+### CPU parity
+
+`cargo test -p kiln-train --lib test_checkpointed_forward_backward_tiled_matches_monolithic_cpu`:
+
+```
+test trainer::tests::test_checkpointed_forward_backward_tiled_matches_monolithic_cpu ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 3.70s
+```
+
+Setup:
+
+- GDN-only mini-config: `tiny_config()` with `full_attention_interval =
+  num_layers + 1`, so `is_full_attention_layer(i)` is false for all
+  layers and `tiny_weights` only emits GDN layers.
+- `T=192`, `tile_size=64` → 3 tile loop iterations per segment (two
+  non-last tiles exercising the `pad_amount=1` branch in
+  `tile_loss_explicit`, one last tile exercising the `pad_amount=0`
+  branch).
+- 2 segments × 4 layers (default `compute_segment_boundaries(4, 2)`).
+- LoRA rank 4, alpha 8.0.
+
+Assertions:
+
+- Total loss matches bit-for-bit: `(loss_mono - loss_tiled).abs() <
+  1e-5` (atol tightened to allow trivial f32 fp-associativity drift in
+  the chunked LM-head log-sum-exp; observed `<< 1e-6` in practice).
+- Every LoRA Var with a gradient in monolithic has the same gradient
+  (per-element max-abs diff) under tiled, with same `1e-5` tolerance.
+
+Existing 14 trainer tests still pass with the new code path:
+
+```
+test result: ok. 15 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.85s
+```
+
+### A6000 SFT bench
+
+`./target/release/examples/flce_phase_a_validation_bench --model-path /workspace/qwen3.5-4b`:
+
+| target_T | actual_T | FLCE | STREAM | TILE     | peak VRAM (MiB) | ΔVRAM (MiB) | step (s) | loss              | status |
+|---:|---:|:---:|:---:|:---:|---:|---:|---:|---:|:---|
+|  2 048 |  2 042 | OFF | unset    | default |          34 600 |       16 128 |     2.8 | 2.7836852         | ok    |
+|  2 048 |  2 042 | ON  | unset    | default |          34 600 |       16 128 |     3.2 | 2.7834394         | ok    |
+|  2 048 |  2 042 | ON  | **ON**   | default |          34 600 |       16 128 |     3.2 | **2.7834394**     | ok    |
+|  8 192 |  8 192 | ON  | unset    | default |          48 648 |       30 176 |     0.7 | n/a               | OOM   |
+| 16 384 | 16 380 | ON  | unset    | default |          48 648 |       30 176 |     0.6 | n/a               | OOM   |
+|  8 192 |  8 192 | ON  | **ON**   | default |          48 648 |       30 176 |     0.7 | n/a               | OOM   |
+|  8 192 |  8 192 | ON  | **ON**   | 4096    |          48 648 |       30 176 |     0.7 | n/a               | OOM   |
+|  8 192 |  8 192 | ON  | **ON**   | 2048    |          48 648 |       30 176 |     0.7 | n/a               | OOM   |
+| 16 384 | 16 380 | ON  | **ON**   | 4096    |          48 648 |       30 176 |     0.6 | n/a               | OOM   |
+
+Baseline post-warmup VRAM = 18 472 MiB.
+
+### Bit-exact loss at T=2048
+
+`stream_on_t2048_loss = 2.7834393978118896` and `stream_t2048_loss_delta
+= 0.0e0` — STREAMING ON matches STREAMING unset bit-for-bit at T=2048,
+which is the expected outcome of correct dispatch (the GDN-only
+precondition is false on Qwen3.5-4B → tiled path returns to monolithic
+→ loss is mechanically identical). This rules out any silent
+regression in the monolithic branch from the trainer-level
+restructuring.
+
+### Memory ceiling — unchanged from PR #635
+
+Every T=8192 cell (STREAMING unset, STREAMING ON tile=default/4096/2048)
+and the T=16384 stretch cell OOM at the same ≈48 648 MiB ceiling as PR
+#635's measurement. The peak-VRAM ladder is flat across tile sizes,
+which would be expected if the tiled-backward branch were dispatching
+on Qwen3.5-4B and the per-tile envelope were the binding constraint —
+but the actual cause here is different: the tiled branch does not
+dispatch at all, because Qwen3.5-4B is hybrid 24 GDN + 8 full-attn and
+the `model_is_gdn_only` precondition fails. Path falls back to
+monolithic; OOM is the same as monolithic; verdict on the acceptance
+criterion is RED.
+
+## Dispatch behaviour on Qwen3.5-4B
+
+Qwen3.5-4B is hybrid 24 × GDN + 8 × full-attention (every 4th layer
+is full-attn: layers 3, 7, 11, 15, 19, 23, 27, 31). The
+`model_is_gdn_only` precondition is therefore false for the production
+target model, and `tiled_training_tile_size` returns `None` on every
+training step. **The tiled path code is entirely skipped in production
+SFT runs on Qwen3.5-4B.** Falling back to the monolithic branch is
+behaviourally identical to PR #635 main, which is what the bench
+table confirms.
+
+This is the key engineering trade-off in the PR: the GDN-only
+precondition is **conservative for parity** (it guarantees bit-exact
+gradients across tiles + monolithic on a GDN-only model) but
+**insufficient for production** (Qwen3.5-4B is hybrid). Lifting the
+precondition for hybrid models is the next remediation step (see
+"Required follow-ups").
+
+## Verdict
+
+**RED on the acceptance criterion (T=8192 SFT must no longer OOM on A6000) — the tiled-backward path is bit-exact + necessary infrastructure, but the GDN-only precondition required for parity excludes the production target model** — the dispatch infrastructure shipped here
+is necessary for any future training-time tiled-backward work
+(no other code path can reach it from `sft_train`), and the CPU
+parity test pins the bit-exact-gradients invariant the next attempt
+needs to preserve. But this PR alone does not unblock long-context
+SFT on A6000 for Qwen3.5-4B, because the GDN-only precondition
+required for parity excludes the production target model.
+
+This is a useful negative result for the audit's option (2). It
+re-frames the next move as the **layer-pair-level** remediation
+flagged in PR #635's audit risk (b): partition each segment into
+sub-blocks by attention type (GDN-block / full-attn-block), apply
+time-axis tiling only to GDN sub-blocks while running full-attn
+sub-blocks monolithic, and use gradient injection (chain rule with a
+pre-computed activation gradient at the segment output) so per-block
+forward+backward can release saved tensors without requiring a tile-
+level loss for the full segment chain.
+
+## Required follow-ups (post-this PR)
+
+The remediation menu, in increasing scope, narrowed by this PR's
+findings:
+
+1. ~~**Tile within `model_forward_segment` (smallest change that could
+   work).**~~ Shipped in PR #635. Insufficient on A6000 at T=8192 —
+   the autograd recompute bottleneck dominates.
+
+2. ~~**Time-axis tile inside `checkpointed_forward_backward` for
+   GDN-only models.**~~ Shipped here. Bit-exact for GDN-only models;
+   does not fire on Qwen3.5-4B because of the GDN-only precondition.
+   Code remains useful as the dispatch foundation any layer-pair-level
+   variant will reuse.
+
+3. **Layer-pair-level time-axis tile inside
+   `checkpointed_forward_backward` for hybrid models (recommended
+   next).** Inside the per-segment recompute, partition the segment's
+   layers into contiguous-attention-type blocks: a "GDN block" is a
+   maximal run of consecutive GDN layers; a "full-attn block" is a
+   maximal run of consecutive full-attn layers (Qwen3.5-4B segments
+   contain both). Process blocks sequentially:
+   - For each GDN block: time-tile forward+backward, accumulating
+     LoRA gradients via gradient injection from the pre-computed
+     activation gradient at the block's output.
+   - For each full-attn block: monolithic forward+backward (full T)
+     with the same gradient injection.
+
+   Pre-computing the activation gradient at each block boundary
+   requires one extra forward+backward pass through later segments +
+   LM head with a grad-tracked input at `boundary_states[k+1]`,
+   adding ~1× the segment-chain forward cost per segment.
+
+   Estimated scope: ~400-600 LOC in `trainer.rs`. Risks:
+   (a) implementing gradient injection correctly without breaking the
+   existing single-segment grad path (clean abstraction needed);
+   (b) full-attn LoRA gradients (`q_proj`, `k_proj`, `v_proj`,
+   `o_proj`) DO depend on the recurrent state thread through earlier
+   GDN layers in the same block, so attention-LoRA grads under a
+   tiled GDN-block forward would be a truncated-BPTT approximation
+   (different from monolithic). The CPU parity invariant here would
+   need to relax to "MLP-LoRA grads bit-exact, attention-LoRA grads
+   approximate to within `1e-3`" or similar.
+
+4. **Combined option 3 + a CUDA fused FLCE kernel (Phase B).** Phase
+   B's head-side memory savings stack with GDN-side time-axis tiling.
+   Combined, this is the path most likely to fit T=16384 SFT on
+   A6000.
+
+Recommended next slice: **option 3 as a focused PR** — the
+layer-pair-level tile is the change that can actually fire on
+Qwen3.5-4B and move the autograd-recompute bottleneck for the
+production target model.
+
+## Caveats
+
+- The bench's peak-VRAM signal is `nvidia-smi` polled at 50 ms;
+  sub-50 ms transient peaks may be undercounted. All cells in this
+  PR's table at T=8192 are at the GPU ceiling
+  (~48 648 / 49 140 MiB), so the OOM-vs-OK distinction is robust
+  even with that resolution.
+- The CPU parity test runs on a synthetic GDN-only mini-model.
+  Production GDN-only models (if any future kiln-supported model
+  lands without full-attn layers) would benefit from this path
+  immediately.
+- Bit-exact CPU parity does not guarantee bit-exact CUDA parity
+  (matmul reduction order can vary with shape). The existing
+  `test_streaming_matches_monolithic_cuda` (1e-4 tolerance for the
+  inference path) is the closest GPU parity proxy.
+- Audit scoped to GPU-side production training (CUDA path on A6000).
+  Metal / MLX training is unaffected by this PR — the tiled path
+  predicate is device-aware via `streaming_prefill_enabled_for`, so
+  Metal SFT only enters the tiled branch under explicit
+  `KILN_STREAMING_PREFILL=1` AND the model is GDN-only.

--- a/docs/flce_phase_a_tiled_backward_raw_2026-04-29.log
+++ b/docs/flce_phase_a_tiled_backward_raw_2026-04-29.log
@@ -1,0 +1,293 @@
+[36m=== kiln-runpod image ===[0m
+  GPU: NVIDIA RTX A6000, 550.127.08
+  CUDA toolkit: release 12.4
+  nsys: NVIDIA Nsight Systems version 2023.4.4.54-234433681190v0
+  rustc: 1.95.0 | cargo: 1.95.0
+  sccache: 0.9.1 | nextest: (65e806bd5
+  torch: 2.4.1+cu124 (cuda=12.4)
+
+Quick start: [32mkiln-setup[0m (configures sccache+B2) then clone kiln & build.
+
+=== FLCE Phase A validation — Qwen3.5-4B, V=248320, hidden=2560 ===
+Loading model from /workspace/qwen3.5-4b
+[2m2026-04-29T09:58:23.503785Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loading model from /workspace/qwen3.5-4b (2 shards)
+[2m2026-04-29T09:58:23.504961Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Using weight name prefix: "model.language_model."
+[2m2026-04-29T09:58:23.505139Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Native MTP head detected; deferring CPU load until first use [3mmtp_prefix[0m[2m=[0mmtp.
+[2m2026-04-29T09:58:23.505151Z[0m [32m INFO[0m [2mkiln_model::loader[0m[2m:[0m Loaded 4206M parameters (8022 MB) across 32 layers
+[2m2026-04-29T09:58:23.505229Z[0m [32m INFO[0m [2mkiln_server::device[0m[2m:[0m CUDA available — using GPU device 0
+Baseline VRAM (post-load): 16344 MiB
+Warmup pass at T~256 (FLCE OFF)...
+
+--- T target = 256  FLCE = OFF  STREAMING = unset  TILE = default ---
+  Tokenized length: 248 tokens (target 256)
+[2m2026-04-29T09:58:28.044610Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T256-flce-off"
+[2m2026-04-29T09:58:28.170861Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T09:58:28.236809Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T09:58:28.236871Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+[2m2026-04-29T09:58:38.561723Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m training step [3mepoch[0m[2m=[0m1 [3mstep[0m[2m=[0m1 [3mtotal_steps[0m[2m=[0m1 [3mloss[0m[2m=[0m"1.741690"
+[2m2026-04-29T09:58:38.561798Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m epoch complete [3mepoch[0m[2m=[0m1 [3mavg_loss[0m[2m=[0m"1.741690"
+[2m2026-04-29T09:58:38.597233Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m saved PEFT adapter [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T256-flce-off [3mnum_tensors[0m[2m=[0m256
+[2m2026-04-29T09:58:38.597279Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m SFT training complete [3madapter[0m[2m=[0m"flce-phaseA-T256-flce-off" [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T256-flce-off [3mfinal_loss[0m[2m=[0m"1.741690"
+  baseline 16344 MiB  peak 18472 MiB  delta 2128 MiB  samples 110  wall 10.6s  loss=Some(1.7416900396347046)  status=ok
+Baseline VRAM (post-warmup): 18472 MiB
+
+--- T target = 2048  FLCE = OFF  STREAMING = unset  TILE = default ---
+  Tokenized length: 2042 tokens (target 2048)
+[2m2026-04-29T09:58:38.885778Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T2048-flce-off"
+[2m2026-04-29T09:58:38.887610Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T09:58:38.959514Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T09:58:38.959576Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+[2m2026-04-29T09:58:41.624329Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m training step [3mepoch[0m[2m=[0m1 [3mstep[0m[2m=[0m1 [3mtotal_steps[0m[2m=[0m1 [3mloss[0m[2m=[0m"2.783685"
+[2m2026-04-29T09:58:41.624396Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m epoch complete [3mepoch[0m[2m=[0m1 [3mavg_loss[0m[2m=[0m"2.783685"
+[2m2026-04-29T09:58:41.657389Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m saved PEFT adapter [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-off [3mnum_tensors[0m[2m=[0m256
+[2m2026-04-29T09:58:41.657427Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m SFT training complete [3madapter[0m[2m=[0m"flce-phaseA-T2048-flce-off" [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-off [3mfinal_loss[0m[2m=[0m"2.783685"
+  baseline 18472 MiB  peak 34600 MiB  delta 16128 MiB  samples 28  wall 2.8s  loss=Some(2.7836852073669434)  status=ok
+
+--- T target = 2048  FLCE = ON  STREAMING = unset  TILE = default ---
+  Tokenized length: 2042 tokens (target 2048)
+[2m2026-04-29T09:58:41.805786Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T2048-flce-on"
+[2m2026-04-29T09:58:41.807565Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T09:58:41.840881Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T09:58:41.840940Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+[2m2026-04-29T09:58:44.940593Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m training step [3mepoch[0m[2m=[0m1 [3mstep[0m[2m=[0m1 [3mtotal_steps[0m[2m=[0m1 [3mloss[0m[2m=[0m"2.783439"
+[2m2026-04-29T09:58:44.940661Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m epoch complete [3mepoch[0m[2m=[0m1 [3mavg_loss[0m[2m=[0m"2.783439"
+[2m2026-04-29T09:58:44.973582Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m saved PEFT adapter [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-on [3mnum_tensors[0m[2m=[0m256
+[2m2026-04-29T09:58:44.973623Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m SFT training complete [3madapter[0m[2m=[0m"flce-phaseA-T2048-flce-on" [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-on [3mfinal_loss[0m[2m=[0m"2.783439"
+  baseline 18472 MiB  peak 34600 MiB  delta 16128 MiB  samples 33  wall 3.2s  loss=Some(2.7834393978118896)  status=ok
+
+--- T target = 2048  FLCE = ON  STREAMING = ON  TILE = default ---
+  Tokenized length: 2042 tokens (target 2048)
+[2m2026-04-29T09:58:45.196242Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T2048-flce-on"
+[2m2026-04-29T09:58:45.198123Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T09:58:45.269618Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T09:58:45.269688Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+[2m2026-04-29T09:58:48.369267Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m training step [3mepoch[0m[2m=[0m1 [3mstep[0m[2m=[0m1 [3mtotal_steps[0m[2m=[0m1 [3mloss[0m[2m=[0m"2.783439"
+[2m2026-04-29T09:58:48.369313Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m epoch complete [3mepoch[0m[2m=[0m1 [3mavg_loss[0m[2m=[0m"2.783439"
+[2m2026-04-29T09:58:48.401338Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m saved PEFT adapter [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-on [3mnum_tensors[0m[2m=[0m256
+[2m2026-04-29T09:58:48.401378Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m SFT training complete [3madapter[0m[2m=[0m"flce-phaseA-T2048-flce-on" [3mpath[0m[2m=[0m/tmp/kiln-flce-phaseA-validation/flce-phaseA-T2048-flce-on [3mfinal_loss[0m[2m=[0m"2.783439"
+  baseline 18472 MiB  peak 34600 MiB  delta 16128 MiB  samples 35  wall 3.2s  loss=Some(2.7834393978118896)  status=ok
+
+--- T target = 8192  FLCE = ON  STREAMING = unset  TILE = default ---
+  Tokenized length: 8192 tokens (target 8192)
+[2m2026-04-29T09:58:49.303858Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T8192-flce-on"
+[2m2026-04-29T09:58:49.305705Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T09:58:49.354359Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T09:58:49.354422Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18472 MiB  peak 48648 MiB  delta 30176 MiB  samples 7  wall 0.7s  loss=None  status=OOM
+
+--- T target = 16384  FLCE = ON  STREAMING = unset  TILE = default ---
+  Tokenized length: 16380 tokens (target 16384)
+[2m2026-04-29T09:58:53.183300Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T16384-flce-on"
+[2m2026-04-29T09:58:53.185642Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T09:58:53.283310Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T09:58:53.283371Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18472 MiB  peak 48648 MiB  delta 30176 MiB  samples 7  wall 0.6s  loss=None  status=OOM
+
+--- T target = 8192  FLCE = ON  STREAMING = ON  TILE = default ---
+  Tokenized length: 8192 tokens (target 8192)
+[2m2026-04-29T09:58:54.666197Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T8192-flce-on"
+[2m2026-04-29T09:58:54.668072Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T09:58:54.760384Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T09:58:54.760432Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18472 MiB  peak 48648 MiB  delta 30176 MiB  samples 7  wall 0.7s  loss=None  status=OOM
+
+--- T target = 8192  FLCE = ON  STREAMING = ON  TILE = 4096 ---
+  Tokenized length: 8192 tokens (target 8192)
+[2m2026-04-29T09:58:56.214282Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T8192-flce-on"
+[2m2026-04-29T09:58:56.216081Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T09:58:56.307339Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T09:58:56.307391Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18472 MiB  peak 48648 MiB  delta 30176 MiB  samples 8  wall 0.7s  loss=None  status=OOM
+
+--- T target = 8192  FLCE = ON  STREAMING = ON  TILE = 2048 ---
+  Tokenized length: 8192 tokens (target 8192)
+[2m2026-04-29T09:58:57.804707Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T8192-flce-on"
+[2m2026-04-29T09:58:57.806602Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T09:58:57.894313Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T09:58:57.894358Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18472 MiB  peak 48648 MiB  delta 30176 MiB  samples 7  wall 0.7s  loss=None  status=OOM
+
+--- T target = 16384  FLCE = ON  STREAMING = ON  TILE = 4096 ---
+  Tokenized length: 16380 tokens (target 16384)
+[2m2026-04-29T09:59:01.680552Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m starting SFT training [3mnum_examples[0m[2m=[0m1 [3mepochs[0m[2m=[0m1 [3mlr[0m[2m=[0m0.0001 [3mrank[0m[2m=[0m8 [3malpha[0m[2m=[0m16.0 [3madapter_name[0m[2m=[0m"flce-phaseA-T16384-flce-on"
+[2m2026-04-29T09:59:01.682710Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m initialized trainable LoRA parameters [3mnum_vars[0m[2m=[0m256
+[2m2026-04-29T09:59:01.778574Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m auto-configured gradient checkpoint segments for detected VRAM [3mnum_segments[0m[2m=[0m4 [3mvram_gb[0m[2m=[0m51.52702464 [3msource[0m[2m=[0mnvidia-smi
+[2m2026-04-29T09:59:01.778635Z[0m [32m INFO[0m [2mkiln_train::trainer[0m[2m:[0m gradient checkpointing enabled [3mnum_segments[0m[2m=[0m4 [3mboundaries[0m[2m=[0m[(0, 8), (8, 16), (16, 24), (24, 32)]
+  baseline 18472 MiB  peak 48648 MiB  delta 30176 MiB  samples 7  wall 0.6s  loss=None  status=OOM
+
+=== FLCE Phase A + GDN-streaming-audit validation results ===
+target_T   actual_T   FLCE   STREAM  TILE     peak_VRAM_MiB  delta_MiB    abc_GB       abc/peak   step_s     loss        
+2048       2042       OFF    unset   default  34600          16128        3.778        0.112      2.8        2.783685    
+2048       2042       ON     unset   default  34600          16128        3.778        0.112      3.2        2.783439    
+2048       2042       ON     ON      default  34600          16128        3.778        0.112      3.2        2.783439    
+8192       8192       ON     unset   default  48648          30176        15.156       0.319      0.7        n/a         
+16384      16380      ON     unset   default  48648          30176        30.305       0.638      0.6        n/a         
+8192       8192       ON     ON      default  48648          30176        15.156       0.319      0.7        n/a         
+8192       8192       ON     ON      4096     48648          30176        15.156       0.319      0.7        n/a         
+8192       8192       ON     ON      2048     48648          30176        15.156       0.319      0.7        n/a         
+16384      16380      ON     ON      4096     48648          30176        30.305       0.638      0.6        n/a         
+
+=== Parity (T=2048 FLCE off vs on) ===
+  off_loss = Some(2.7836852073669434)
+  on_loss  = Some(2.7834393978118896)
+  delta    = Some(0.00024580955505371094)
+  tolerance= 1.0e-3
+  result   = PASS
+
+=== Cell summary ===
+  T=2048   FLCE=ON  STREAM=unset             -> status=ok          peak=34600 MiB  step=3.2s  loss=Some(2.7834393978118896)
+  T=2048   FLCE=OFF STREAM=unset             -> status=ok          peak=34600 MiB  step=2.8s  loss=Some(2.7836852073669434)
+  T=8192   FLCE=ON  STREAM=unset             -> status=OOM         peak=48648 MiB  step=0.7s  loss=None
+  T=16384  FLCE=ON  STREAM=unset             -> status=OOM         peak=48648 MiB  step=0.6s  loss=None
+  T=2048   FLCE=ON  STREAM=ON  tile=default  -> status=ok          peak=34600 MiB  step=3.2s  loss=Some(2.7834393978118896)
+  T=8192   FLCE=ON  STREAM=ON  tile=default  -> status=OOM         peak=48648 MiB  step=0.7s  loss=None
+  T=8192   FLCE=ON  STREAM=ON  tile=4096     -> status=OOM         peak=48648 MiB  step=0.7s  loss=None
+  T=8192   FLCE=ON  STREAM=ON  tile=2048     -> status=OOM         peak=48648 MiB  step=0.7s  loss=None
+  T=16384  FLCE=ON  STREAM=ON  tile=4096     -> status=OOM         peak=48648 MiB  step=0.6s  loss=None
+
+=== Phase A verdict: RED — Phase A insufficient on A6000 ===
+
+=== Phase 10 streaming-impl verdict: AMBER — streaming reduces peak VRAM monotonically with smaller tiles, but tile=2048 still OOMs at T=8192. Per-tile envelope is the bottleneck — investigate residual GDN intermediates or activation grad-checkpoint storage. ===
+T=2048 peak delta (STREAMING ON vs unset): 0 MiB  (no actual tiling at this T; non-zero is allocator noise)
+T=2048 loss delta (STREAMING ON vs unset): 0e0  (must be ~0 — no tiling at T=2048)
+T=8192 peak-VRAM ladder by tile size: tile=default(8192)=48648 MiB, tile=4096=48648 MiB, tile=2048=48648 MiB
+T=16384 peak-VRAM (stretch): STREAM=unset=48648 MiB (OOM), STREAM=ON tile=4096=48648 MiB (OOM)
+
+=== JSON ===
+{
+  "baseline_mib": 18472,
+  "hidden": 2560,
+  "parity": {
+    "delta": 0.00024580955505371094,
+    "off_loss": 2.7836852073669434,
+    "on_loss": 2.7834393978118896,
+    "pass": true,
+    "tolerance": 0.001
+  },
+  "phase_a_verdict": "RED — Phase A insufficient on A6000",
+  "rows": [
+    {
+      "actual_t": 2042,
+      "baseline_mib": 18472,
+      "delta_mib": 16128,
+      "final_loss": 2.7836852073669434,
+      "peak_mib": 34600,
+      "status": "ok",
+      "step_secs": 2.772402309,
+      "streaming": null,
+      "target_t": 2048,
+      "tile_tokens": null,
+      "use_flce": false
+    },
+    {
+      "actual_t": 2042,
+      "baseline_mib": 18472,
+      "delta_mib": 16128,
+      "final_loss": 2.7834393978118896,
+      "peak_mib": 34600,
+      "status": "ok",
+      "step_secs": 3.168722674,
+      "streaming": null,
+      "target_t": 2048,
+      "tile_tokens": null,
+      "use_flce": true
+    },
+    {
+      "actual_t": 2042,
+      "baseline_mib": 18472,
+      "delta_mib": 16128,
+      "final_loss": 2.7834393978118896,
+      "peak_mib": 34600,
+      "status": "ok",
+      "step_secs": 3.2058010120000002,
+      "streaming": true,
+      "target_t": 2048,
+      "tile_tokens": null,
+      "use_flce": true
+    },
+    {
+      "actual_t": 8192,
+      "baseline_mib": 18472,
+      "delta_mib": 30176,
+      "final_loss": null,
+      "peak_mib": 48648,
+      "status": "OOM",
+      "step_secs": 0.693238274,
+      "streaming": null,
+      "target_t": 8192,
+      "tile_tokens": null,
+      "use_flce": true
+    },
+    {
+      "actual_t": 16380,
+      "baseline_mib": 18472,
+      "delta_mib": 30176,
+      "final_loss": null,
+      "peak_mib": 48648,
+      "status": "OOM",
+      "step_secs": 0.640606612,
+      "streaming": null,
+      "target_t": 16384,
+      "tile_tokens": null,
+      "use_flce": true
+    },
+    {
+      "actual_t": 8192,
+      "baseline_mib": 18472,
+      "delta_mib": 30176,
+      "final_loss": null,
+      "peak_mib": 48648,
+      "status": "OOM",
+      "step_secs": 0.711253216,
+      "streaming": true,
+      "target_t": 8192,
+      "tile_tokens": null,
+      "use_flce": true
+    },
+    {
+      "actual_t": 8192,
+      "baseline_mib": 18472,
+      "delta_mib": 30176,
+      "final_loss": null,
+      "peak_mib": 48648,
+      "status": "OOM",
+      "step_secs": 0.70682361,
+      "streaming": true,
+      "target_t": 8192,
+      "tile_tokens": 4096,
+      "use_flce": true
+    },
+    {
+      "actual_t": 8192,
+      "baseline_mib": 18472,
+      "delta_mib": 30176,
+      "final_loss": null,
+      "peak_mib": 48648,
+      "status": "OOM",
+      "step_secs": 0.704127384,
+      "streaming": true,
+      "target_t": 8192,
+      "tile_tokens": 2048,
+      "use_flce": true
+    },
+    {
+      "actual_t": 16380,
+      "baseline_mib": 18472,
+      "delta_mib": 30176,
+      "final_loss": null,
+      "peak_mib": 48648,
+      "status": "OOM",
+      "step_secs": 0.64643112,
+      "streaming": true,
+      "target_t": 16384,
+      "tile_tokens": 4096,
+      "use_flce": true
+    }
+  ],
+  "stream_impl_verdict": "AMBER — streaming reduces peak VRAM monotonically with smaller tiles, but tile=2048 still OOMs at T=8192. Per-tile envelope is the bottleneck — investigate residual GDN intermediates or activation grad-checkpoint storage.",
+  "stream_on_t2048_loss": 2.7834393978118896,
+  "stream_t2048_loss_delta": 0.0,
+  "stream_t2048_peak_delta_mib": 0,
+  "vocab_size": 248320
+}
+


### PR DESCRIPTION
## Status: AMBER (CPU parity PASS, A6000 acceptance RED)

Implementation follow-up to PR #635 (\`docs/audits/PHASE10_GDN_TRAINING_STREAMING_IMPL.md\`)
\"Required follow-ups\" §2: time-axis tile **inside \`checkpointed_forward_backward\`**
so each tile's forward+backward releases its autograd-saved tensors before the next
tile's forward allocates its own.

PR #635 wired streaming-prefill dispatch into \`model_forward_segment\` but found the
in-segment streaming alone insufficient on A6000 at T=8192 because the autograd graph
still retained all per-layer-per-tile saved tensors until the segment's backward. This
PR implements the next step the audit named: per-tile **forward+backward+accumulate**
inside the per-segment recompute loop, threading the \`LinearAttentionState\` recurrent
+ conv state across tiles for both the grad-tracked segment and each detached later
segment.

### Implementation

\`crates/kiln-train/src/trainer.rs\`:

- \`model_is_gdn_only(weights)\` — bit-exactness invariant. True iff every layer is
  linear (GDN) attention.
- \`tiled_training_tile_size(weights, device, seq_len)\` — dispatch oracle. Returns
  \`Some(tile)\` when (a) model is GDN-only, (b) \`streaming_prefill_enabled_for(device,
  seq_len)\`, and (c) \`tile < seq_len\` and \`tile % GDN_CHUNK_SIZE == 0\`.
- \`tile_loss_explicit(...)\` — per-tile next-token CE contribution, normalized so
  per-tile contributions sum to the monolithic mean over \`total_active\` positions
  exactly. Routes through the existing \`cross_entropy_loss\` /
  \`fused_linear_cross_entropy\` helpers via single-position padding so loss math is
  shared with the monolithic path.
- \`tiled_segment_recompute_and_backward(...)\` — per-segment outer loop that runs
  forward+backward+accumulate per tile. State threaded across tiles for both
  grad-tracked and detached forwards.
- \`checkpointed_forward_backward\` — modified to call \`tiled_training_tile_size\`
  once per training step; if \`Some\`, every segment iteration uses the tiled path,
  otherwise behavior is unchanged.

\`crates/kiln-model/src/forward.rs\`: \`GDN_CHUNK_SIZE\` is now \`pub const\` so the
trainer can validate tile sizes without re-importing.

### Correctness invariant for bit-exact LoRA grads

1. Model is GDN-only — full-attention training has no KV cache to thread across tiles.
2. LoRA on GDN layers is restricted to MLP projections (\`gate/up/down_proj\`); GDN's
   linear-attn projections are not LoRA targets in \`TrainableLoraParams::initialize\`.
   MLP is per-position, so MLP-LoRA gradients do not flow through the recurrent state
   thread. The per-tile pattern's truncated-BPTT effect on state derivatives does not
   affect any LoRA Var.

### CPU parity (PASS)

\`cargo test -p kiln-train --lib test_checkpointed_forward_backward_tiled_matches_monolithic_cpu\`:

\`\`\`
test trainer::tests::test_checkpointed_forward_backward_tiled_matches_monolithic_cpu ... ok
test result: ok. 1 passed; 0 failed; 14 filtered out; finished in 3.70s
\`\`\`

GDN-only mini-config, T=192, tile=64 → 3 tile loop iterations. Asserts loss + every
LoRA Var's gradient bit-exact against monolithic with atol \`1e-5\`. The two non-last
tiles exercise \`pad_amount=1\` in \`tile_loss_explicit\`, the last tile exercises
\`pad_amount=0\`. All 14 existing trainer tests still pass.

### A6000 SFT bench (Qwen3.5-4B, RED on acceptance criterion)

Bench results (\`crates/kiln-server/examples/flce_phase_a_validation_bench.rs\`,
post-warmup baseline 18 472 MiB, raw log committed at
\`docs/flce_phase_a_tiled_backward_raw_2026-04-29.log\`):

| target_T | actual_T | FLCE | STREAM | TILE     | peak VRAM (MiB) | step (s) | status |
|---:|---:|:---:|:---:|:---:|---:|---:|:---|
|  2 048 |  2 042 | OFF | unset    | default |          34 600 |     2.8 | ok    |
|  2 048 |  2 042 | ON  | unset    | default |          34 600 |     3.2 | ok    |
|  2 048 |  2 042 | ON  | **ON**   | default |          34 600 |     3.2 | ok    |
|  8 192 |  8 192 | ON  | unset    | default |          48 648 |     0.7 | OOM   |
|  8 192 |  8 192 | ON  | **ON**   | 4096    |          48 648 |     0.7 | OOM   |
|  8 192 |  8 192 | ON  | **ON**   | 2048    |          48 648 |     0.7 | OOM   |
| 16 384 | 16 380 | ON  | **ON**   | 4096    |          48 648 |     0.6 | OOM   |

T=2048 STREAMING-ON loss = 2.7834393978118896 = STREAMING-unset bit-for-bit
(delta 0.0e0). T=8192 still OOMs at the same 48 648 MiB ceiling as PR #635. The
peak-VRAM ladder is flat across tile sizes because Qwen3.5-4B fails the
\`model_is_gdn_only\` precondition (it is hybrid 24 GDN + 8 full-attn) and
\`tiled_training_tile_size\` returns \`None\` on every step → the tiled branch is
skipped → behavior is identical to monolithic.

### Verdict

**RED on the acceptance criterion** \"T=8192 SFT on A6000 no longer OOMs\". The
GDN-only precondition required for bit-exact parity excludes the production target
model, and the path falls back to monolithic on Qwen3.5-4B.

**The dispatch infrastructure shipped here remains useful**: it is the only code
path through which any future training-time tiled-backward variant will reach
\`sft_train\`, and the CPU parity test pins the bit-exact-gradients invariant the
next attempt needs to preserve.

### Required follow-ups

The full audit lives in \`docs/audits/PHASE10_GDN_TRAINING_TILED_BACKWARD.md\`. The
recommended next step is the **layer-pair-level** remediation (option 3): partition
each segment into contiguous-attention-type sub-blocks, time-tile GDN sub-blocks,
run full-attn sub-blocks monolithic, and inject gradients from a pre-computed
activation gradient at the segment boundary. This relaxes the bit-exact invariant
for full-attn LoRA grads to truncated-BPTT approximation, but can fire on Qwen3.5-4B.

### Refs

- PR #635 (training-time streaming GDN prefill dispatch)
- PR #634 (audit identifying the autograd-saved-tensors bottleneck)
- \`docs/audits/PHASE10_GDN_TRAINING_STREAMING_IMPL.md\` Required follow-ups §2