### PR TITLE
phase10: Liger-style RMSNorm with custom CUDA backward (kernel-fusion pass §1)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1803,18 +1803,33 @@ fn embedding_lookup_from_transposed(token_ids: &[u32], embed_tokens_t: &Tensor) 
 ///
 /// Returns: same shape as `x`.
 ///
-/// On CUDA+bf16 inputs within the kernel envelope (hidden <= 8192), dispatches
-/// to `kiln_rmsnorm_kernel::fused_rmsnorm`, which collapses the ~11 candle op
-/// launches (to_dtype, sqr, mean_keepdim, +eps, sqrt, recip, broadcast_mul,
-/// to_dtype, ones_like + w, broadcast_mul, to_dtype) into a single fused kernel.
-/// Falls back to the candle-op path on CPU, non-bf16, or out-of-envelope inputs.
+/// Dispatch (CUDA path; bf16 inputs within the kernel envelope, hidden <= 8192):
+///   - Default: `kiln_rmsnorm_kernel::fused_rmsnorm_with_autograd` — fused
+///     forward kernel + manual CUDA backward kernel routed through
+///     `CustomOp2`. The autograd graph saves only `x` and `weight` (not the
+///     F32 intermediates that the candle-op chain materializes), shrinking
+///     per-layer saved-tensor peak during Phase 10 long-context training.
+///   - `KILN_DISABLE_RMSNORM_BACKWARD=1`: `kiln_rmsnorm_kernel::fused_rmsnorm`
+///     forward only, autograd-traced backward (debug fallback for isolating
+///     fwd-vs-bwd divergence).
+///   - `KILN_DISABLE_RMSNORM_KERNEL=1`: full `rms_norm_fallback` candle-op
+///     chain (kill switch).
+///
+/// On CPU, non-bf16, out-of-envelope, or non-CUDA backends: falls back to
+/// `rms_norm_fallback`. The CPU path keeps the candle-op chain for bit-exact
+/// parity with prior trainer tests.
 pub fn rms_norm(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
     #[cfg(feature = "cuda")]
     {
-        let disabled = std::env::var("KILN_DISABLE_RMSNORM_KERNEL").is_ok();
-        if !disabled && kiln_rmsnorm_kernel::supports(x, weight) {
-            return kiln_rmsnorm_kernel::fused_rmsnorm(x, weight, eps as f32)
-                .context("fused_rmsnorm kernel failed");
+        let kernel_disabled = std::env::var("KILN_DISABLE_RMSNORM_KERNEL").is_ok();
+        if !kernel_disabled && kiln_rmsnorm_kernel::supports(x, weight) {
+            let bwd_disabled = std::env::var("KILN_DISABLE_RMSNORM_BACKWARD").is_ok();
+            if bwd_disabled {
+                return kiln_rmsnorm_kernel::fused_rmsnorm(x, weight, eps as f32)
+                    .context("fused_rmsnorm forward kernel failed");
+            }
+            return kiln_rmsnorm_kernel::fused_rmsnorm_with_autograd(x, weight, eps as f32)
+                .context("fused_rmsnorm_with_autograd CustomOp2 failed");
         }
     }
     #[cfg(feature = "metal")]

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1809,11 +1809,17 @@ fn embedding_lookup_from_transposed(token_ids: &[u32], embed_tokens_t: &Tensor) 
 ///     `CustomOp2`. The autograd graph saves only `x` and `weight` (not the
 ///     F32 intermediates that the candle-op chain materializes), shrinking
 ///     per-layer saved-tensor peak during Phase 10 long-context training.
-///   - `KILN_DISABLE_RMSNORM_BACKWARD=1`: `kiln_rmsnorm_kernel::fused_rmsnorm`
-///     forward only, autograd-traced backward (debug fallback for isolating
-///     fwd-vs-bwd divergence).
-///   - `KILN_DISABLE_RMSNORM_KERNEL=1`: full `rms_norm_fallback` candle-op
-///     chain (kill switch).
+///     Inference (no grad needed) skips the backward path entirely — the
+///     CustomOp2 still uses the same single-launch fused forward kernel.
+///   - `KILN_DISABLE_RMSNORM_BACKWARD=1`: full `rms_norm_fallback` candle-op
+///     chain. The forward kernel is not differentiable on its own (it returns
+///     a Tensor with no `BackpropOp`), so a "forward-only kernel + autograd
+///     backward" hybrid is not a valid path; this kill switch reverts to the
+///     pre-Phase-10 baseline (forward AND backward via the candle chain).
+///     Intended for isolating the saved-tensor reduction contribution to
+///     training peak VRAM.
+///   - `KILN_DISABLE_RMSNORM_KERNEL=1`: alias for the above kill switch
+///     (also routes through `rms_norm_fallback`).
 ///
 /// On CPU, non-bf16, out-of-envelope, or non-CUDA backends: falls back to
 /// `rms_norm_fallback`. The CPU path keeps the candle-op chain for bit-exact
@@ -1822,12 +1828,8 @@ pub fn rms_norm(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
     #[cfg(feature = "cuda")]
     {
         let kernel_disabled = std::env::var("KILN_DISABLE_RMSNORM_KERNEL").is_ok();
-        if !kernel_disabled && kiln_rmsnorm_kernel::supports(x, weight) {
-            let bwd_disabled = std::env::var("KILN_DISABLE_RMSNORM_BACKWARD").is_ok();
-            if bwd_disabled {
-                return kiln_rmsnorm_kernel::fused_rmsnorm(x, weight, eps as f32)
-                    .context("fused_rmsnorm forward kernel failed");
-            }
+        let bwd_disabled = std::env::var("KILN_DISABLE_RMSNORM_BACKWARD").is_ok();
+        if !kernel_disabled && !bwd_disabled && kiln_rmsnorm_kernel::supports(x, weight) {
             return kiln_rmsnorm_kernel::fused_rmsnorm_with_autograd(x, weight, eps as f32)
                 .context("fused_rmsnorm_with_autograd CustomOp2 failed");
         }

--- a/crates/kiln-rmsnorm-kernel/build.rs
+++ b/crates/kiln-rmsnorm-kernel/build.rs
@@ -41,6 +41,7 @@ fn main() {
     }
 
     build.file(csrc_dir.join("fused_rmsnorm.cu"));
+    build.file(csrc_dir.join("fused_rmsnorm_bwd.cu"));
     build.file(csrc_dir.join("fused_l2_qk_norm.cu"));
 
     build.compile("kiln_rmsnorm_kernel");

--- a/crates/kiln-rmsnorm-kernel/csrc/fused_rmsnorm_bwd.cu
+++ b/crates/kiln-rmsnorm-kernel/csrc/fused_rmsnorm_bwd.cu
@@ -1,0 +1,204 @@
+// Kiln fused RMSNorm backward kernel — single-pass per row, F32 reductions,
+// F32 atomicAdd for the cross-row grad_w sum.
+//
+// Algorithm (matches the math in fused_rmsnorm_bwd.h):
+//
+//   Pass 1: sum_x2 = sum_j x[i,j]^2          (F32 across hidden)
+//   rms_inv = rsqrt(sum_x2 / H + eps)
+//
+//   Pass 2: sum_xgw = sum_j ((1 + w[j]) * x[i,j] * grad_out[i,j])
+//   c = (1/H) * rms_inv^2 * sum_xgw
+//
+//   Pass 3 (write-out + grad_w accumulate):
+//     grad_x[i,j] = rms_inv * ((1 + w[j]) * grad_out[i,j] - x[i,j] * c)
+//     atomicAdd(&grad_w_partial_f32[j], x[i,j] * rms_inv * grad_out[i,j])
+//
+// Launch: one block per row, 256 threads/block. Each thread strides over
+// the hidden axis with stride == blockDim.x. Two-stage warp + smem reduction
+// for the per-row sums. Cross-row grad_w accumulation uses atomicAdd into a
+// caller-provided F32 buffer; the caller zeros the buffer before launch.
+//
+// `hidden` <= 8192 (matches the forward kernel envelope).
+
+#include "fused_rmsnorm_bwd.h"
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+namespace {
+
+constexpr int kThreadsPerBlock = 256;
+constexpr int kMaxWarps = kThreadsPerBlock / 32;  // 8
+
+__device__ __forceinline__ float warp_reduce_sum(float v) {
+    #pragma unroll
+    for (int offset = 16; offset > 0; offset /= 2) {
+        v += __shfl_xor_sync(0xffffffffu, v, offset);
+    }
+    return v;
+}
+
+__device__ __forceinline__ float block_reduce_sum(float v, float *smem) {
+    int lane = threadIdx.x & 31;
+    int warp = threadIdx.x >> 5;
+
+    v = warp_reduce_sum(v);
+    if (lane == 0) {
+        smem[warp] = v;
+    }
+    __syncthreads();
+
+    if (warp == 0) {
+        int num_warps = blockDim.x >> 5;
+        float w = (lane < num_warps) ? smem[lane] : 0.0f;
+        w = warp_reduce_sum(w);
+        if (lane == 0) {
+            smem[0] = w;
+        }
+    }
+    __syncthreads();
+    return smem[0];
+}
+
+__global__ void fused_rmsnorm_bwd_kernel(
+    const __nv_bfloat16 *__restrict__ x,
+    const __nv_bfloat16 *__restrict__ weight,
+    const __nv_bfloat16 *__restrict__ grad_out,
+    __nv_bfloat16 *__restrict__ grad_x,
+    float *__restrict__ grad_w_partial_f32,
+    int hidden,
+    float eps
+) {
+    int row = blockIdx.x;
+    const __nv_bfloat16 *x_row = x + static_cast<size_t>(row) * hidden;
+    const __nv_bfloat16 *g_row = grad_out + static_cast<size_t>(row) * hidden;
+    __nv_bfloat16 *dx_row = grad_x + static_cast<size_t>(row) * hidden;
+
+    __shared__ float smem[kMaxWarps];
+
+    // Pass 1: per-thread partial sum of x^2 in F32.
+    float local_sum_sq = 0.0f;
+    for (int j = threadIdx.x; j < hidden; j += blockDim.x) {
+        float xj = __bfloat162float(x_row[j]);
+        local_sum_sq += xj * xj;
+    }
+    float total_sum_sq = block_reduce_sum(local_sum_sq, smem);
+
+    __shared__ float s_rms_inv;
+    if (threadIdx.x == 0) {
+        float mean_sq = total_sum_sq / static_cast<float>(hidden);
+        s_rms_inv = rsqrtf(mean_sq + eps);
+    }
+    __syncthreads();
+    float rms_inv = s_rms_inv;
+
+    // Pass 2: sum_xgw = sum_j ((1 + w_j) * x_ij * g_ij).
+    float local_sum_xgw = 0.0f;
+    for (int j = threadIdx.x; j < hidden; j += blockDim.x) {
+        float xj = __bfloat162float(x_row[j]);
+        float wj = __bfloat162float(weight[j]);
+        float gj = __bfloat162float(g_row[j]);
+        local_sum_xgw += (1.0f + wj) * xj * gj;
+    }
+    float total_sum_xgw = block_reduce_sum(local_sum_xgw, smem);
+
+    __shared__ float s_c;
+    if (threadIdx.x == 0) {
+        s_c = total_sum_xgw / static_cast<float>(hidden) * rms_inv * rms_inv;
+    }
+    __syncthreads();
+    float c = s_c;
+
+    // Pass 3: grad_x = rms_inv * ((1 + w) * grad_out - x * c) and
+    // atomic-add the per-row contribution to grad_w[j] into the F32 buffer.
+    for (int j = threadIdx.x; j < hidden; j += blockDim.x) {
+        float xj = __bfloat162float(x_row[j]);
+        float wj = __bfloat162float(weight[j]);
+        float gj = __bfloat162float(g_row[j]);
+        float dx = rms_inv * ((1.0f + wj) * gj - xj * c);
+        dx_row[j] = __float2bfloat16(dx);
+
+        // grad_w[j] += x_ij * rms_inv_i * g_ij  (cross-row reduction)
+        float dw_contrib = xj * rms_inv * gj;
+        atomicAdd(&grad_w_partial_f32[j], dw_contrib);
+    }
+}
+
+__global__ void f32_to_bf16_kernel(
+    const float *__restrict__ src,
+    __nv_bfloat16 *__restrict__ dst,
+    int n
+) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        dst[idx] = __float2bfloat16(src[idx]);
+    }
+}
+
+}  // namespace
+
+extern "C" kiln_rmsnorm_bwd_status_t kiln_fused_rmsnorm_bwd(
+    const void *x,
+    const void *weight,
+    const void *grad_out,
+    void *grad_x,
+    float *grad_w_partial_f32,
+    int rows,
+    int hidden,
+    float eps,
+    void *stream
+) {
+    if (rows <= 0 || hidden <= 0) {
+        return 0;
+    }
+    if (hidden > 8192) {
+        return 2;
+    }
+
+    dim3 grid(rows);
+    dim3 block(kThreadsPerBlock);
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+
+    fused_rmsnorm_bwd_kernel<<<grid, block, 0, s>>>(
+        reinterpret_cast<const __nv_bfloat16 *>(x),
+        reinterpret_cast<const __nv_bfloat16 *>(weight),
+        reinterpret_cast<const __nv_bfloat16 *>(grad_out),
+        reinterpret_cast<__nv_bfloat16 *>(grad_x),
+        grad_w_partial_f32,
+        hidden,
+        eps
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 1;
+    }
+    return 0;
+}
+
+extern "C" kiln_rmsnorm_bwd_status_t kiln_f32_to_bf16(
+    const float *src,
+    void *dst,
+    int n,
+    void *stream
+) {
+    if (n <= 0) {
+        return 0;
+    }
+
+    int threads = 256;
+    int blocks = (n + threads - 1) / threads;
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+
+    f32_to_bf16_kernel<<<blocks, threads, 0, s>>>(
+        src,
+        reinterpret_cast<__nv_bfloat16 *>(dst),
+        n
+    );
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 1;
+    }
+    return 0;
+}

--- a/crates/kiln-rmsnorm-kernel/csrc/fused_rmsnorm_bwd.h
+++ b/crates/kiln-rmsnorm-kernel/csrc/fused_rmsnorm_bwd.h
@@ -1,0 +1,85 @@
+// Kiln fused RMSNorm backward C-ABI wrapper.
+//
+// Companion to `kiln_fused_rmsnorm` (forward). Computes the gradients of
+// Qwen3.5-style RMSNorm `out = (1 + w) * x * rms_inv` with `rms_inv =
+// rsqrt(mean(x^2) + eps)` directly from the saved inputs `x`, `weight`, and
+// the upstream gradient `grad_out`. No intermediate values from the forward
+// pass are required — `rms_inv` is recomputed inside the kernel.
+//
+// Math (per row `i`, with hidden axis `H`):
+//
+//   rms_inv_i = rsqrt(sum_j x[i,j]^2 / H + eps)
+//   c_i       = (1/H) * rms_inv_i^2 * sum_j ((1 + w[j]) * x[i,j] * grad_out[i,j])
+//   grad_x[i,j] = rms_inv_i * ((1 + w[j]) * grad_out[i,j] - x[i,j] * c_i)
+//   grad_w[j]   = sum_i x[i,j] * rms_inv_i * grad_out[i,j]
+//
+// Pointer layout (all bf16 except `grad_w_partial_f32`, all CUDA, contiguous):
+//   x                : [rows, hidden]
+//   weight           : [hidden]
+//   grad_out         : [rows, hidden]
+//   grad_x           : [rows, hidden]
+//   grad_w_partial_f32 : [hidden] f32 — caller MUST zero this buffer before
+//                        the call. Cross-row reduction uses atomicAdd in f32.
+//                        Caller is responsible for the optional final cast
+//                        to bf16.
+//
+// Scope:
+//   - bf16 activations + bf16 weights + bf16 grad_out + bf16 grad_x.
+//   - Per-row F32 reductions; F32 atomicAdd for the cross-row grad_w sum.
+//   - `hidden` <= 8192. Qwen3.5-4B uses 2560.
+//   - `eps` passed as F32 — kiln uses 1e-6.
+//
+// Not in scope:
+//   - Non-bf16 inputs.
+//   - Non-contiguous strides.
+//   - Activation recompute fused with the prior projection's GEMM
+//     (dispatch-amortization analysis lives in PROFILING.md; the gain
+//     this kernel targets is *saved-tensor reduction* during training,
+//     which is on the long-context OOM critical path independent of CUDA
+//     graph dispatch overhead).
+
+#pragma once
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int kiln_rmsnorm_bwd_status_t;
+
+// Fused Qwen3.5-style RMSNorm backward.
+//
+//   grad_x = rms_inv * ((1 + w) * grad_out - x * c)
+//   grad_w[j] = sum_i (x[i,j] * rms_inv_i * grad_out[i,j])
+//
+// `grad_w_partial_f32` MUST be a zero-initialized [hidden] f32 buffer; the
+// caller is responsible for casting it back to bf16 if needed.
+//
+// Returns 0 on success, non-zero on launch/config failure.
+kiln_rmsnorm_bwd_status_t kiln_fused_rmsnorm_bwd(
+    const void *x,
+    const void *weight,
+    const void *grad_out,
+    void *grad_x,
+    float *grad_w_partial_f32,
+    int rows,
+    int hidden,
+    float eps,
+    void *stream
+);
+
+// Cast an [hidden] f32 buffer to bf16 in place (out-of-place: writes to
+// `dst`). Used to finalize `grad_w_partial_f32` after the bwd kernel.
+//
+// Returns 0 on success, non-zero on launch/config failure.
+kiln_rmsnorm_bwd_status_t kiln_f32_to_bf16(
+    const float *src,
+    void *dst,
+    int n,
+    void *stream
+);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/kiln-rmsnorm-kernel/examples/phase10_microbench.rs
+++ b/crates/kiln-rmsnorm-kernel/examples/phase10_microbench.rs
@@ -1,0 +1,109 @@
+//! Phase 10 §1 — RMSNorm forward+backward microbench.
+//!
+//! Compares the fused custom-op path (default) against the candle op-chain
+//! path (the pre-Phase-10 baseline used when KILN_DISABLE_RMSNORM_BACKWARD=1)
+//! at typical Qwen3.5-4B training shapes.
+//!
+//! Times forward+sum+backward, median of N iterations after warmup, on CUDA.
+//! No training framework, no model load — just the kernel.
+//!
+//! Run:
+//!   cargo run --release -p kiln-rmsnorm-kernel --example phase10_microbench
+
+use candle_core::Result;
+use candle_core::{DType, Device, Tensor, Var};
+
+fn rms_norm_candle(x: &Tensor, weight: &Tensor, eps: f64) -> Result<Tensor> {
+    let x_f32 = x.to_dtype(DType::F32)?;
+    let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
+    let rms_inv = (variance + eps)?.sqrt()?.recip()?;
+    let normed = x_f32.broadcast_mul(&rms_inv)?;
+    let w_f32 = weight.to_dtype(DType::F32)?;
+    let w_plus_one = (w_f32.ones_like()? + w_f32)?;
+    let out = normed.broadcast_mul(&w_plus_one)?;
+    Ok(out.to_dtype(x.dtype())?)
+}
+
+fn time_fwd_bwd(
+    x: &Var,
+    w: &Var,
+    fused: bool,
+    eps: f32,
+    iters: usize,
+    device: &Device,
+) -> Result<Vec<f64>> {
+    let mut times = Vec::with_capacity(iters);
+    for _ in 0..iters {
+        device.synchronize()?;
+        let t0 = std::time::Instant::now();
+        let xt = x.as_tensor();
+        let wt = w.as_tensor();
+        let y = if fused {
+            kiln_rmsnorm_kernel::fused_rmsnorm_with_autograd(xt, wt, eps)?
+        } else {
+            rms_norm_candle(xt, wt, eps as f64)?
+        };
+        let loss = y.to_dtype(DType::F32)?.sum_all()?;
+        let _grads = loss.backward()?;
+        device.synchronize()?;
+        times.push(t0.elapsed().as_secs_f64() * 1000.0);
+    }
+    Ok(times)
+}
+
+fn median(mut v: Vec<f64>) -> f64 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = v.len();
+    if n == 0 { return 0.0; }
+    if n % 2 == 1 { v[n/2] } else { (v[n/2-1] + v[n/2]) / 2.0 }
+}
+
+fn run_shape(label: &str, b: usize, t: usize, h: usize, device: &Device) -> Result<()> {
+    let dtype = DType::BF16;
+    // Use candle Var (autograd-tracked) for x and w.
+    let x_init = Tensor::randn(0.0_f32, 1.0, (b, t, h), device)?.to_dtype(dtype)?;
+    let w_init = Tensor::randn(0.0_f32, 0.02, (h,), device)?.to_dtype(dtype)?;
+    let x = Var::from_tensor(&x_init)?;
+    let w = Var::from_tensor(&w_init)?;
+    let eps = 1e-6_f32;
+
+    // Warmup
+    let _ = time_fwd_bwd(&x, &w, true, eps, 5, device)?;
+    let _ = time_fwd_bwd(&x, &w, false, eps, 5, device)?;
+
+    // Measure
+    let iters = 25;
+    let fused_times = time_fwd_bwd(&x, &w, true, eps, iters, device)?;
+    let candle_times = time_fwd_bwd(&x, &w, false, eps, iters, device)?;
+
+    let fused_med = median(fused_times.clone());
+    let candle_med = median(candle_times.clone());
+    let speedup = candle_med / fused_med;
+
+    println!(
+        "| {:18} | {} | {} | {} | {:>8.3} | {:>8.3} | {:>6.3}× |",
+        label, b, t, h, candle_med, fused_med, speedup
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let device = Device::new_cuda(0)?;
+
+    println!();
+    println!("Phase 10 §1 — RMSNorm fwd+sum+backward microbench (BF16, A6000)");
+    println!("Median of 25 iters, 5 warmup. Same x/w Var both arms.");
+    println!();
+    println!("| shape              | B |    T |    H | candle ms | fused ms | speedup |");
+    println!("|:-------------------|--:|-----:|-----:|----------:|---------:|--------:|");
+
+    let h = 2560; // Qwen3.5-4B hidden
+    run_shape("decode",        1, 1,    h, &device)?;
+    run_shape("training T=512",  1, 512,  h, &device)?;
+    run_shape("training T=2048", 1, 2048, h, &device)?;
+    run_shape("training T=4096", 1, 4096, h, &device)?;
+    run_shape("training T=8192", 1, 8192, h, &device)?;
+
+    println!();
+    Ok(())
+}

--- a/crates/kiln-rmsnorm-kernel/src/lib.rs
+++ b/crates/kiln-rmsnorm-kernel/src/lib.rs
@@ -5,10 +5,17 @@
 //! 1. [`fused_rmsnorm`] — Qwen3.5-style RMSNorm `(1 + w) * x * rsqrt(mean(x^2) + eps)`.
 //!    Replaces the ~11 candle ops behind `kiln-model::forward::rms_norm`.
 //!    Used by `kiln/norm/pre_attn` and `kiln/norm/pre_mlp`.
-//! 2. [`fused_l2_qk_norm`] — fused L2-norm(Q) + scale(Q) + L2-norm(K) used by
+//! 2. [`fused_rmsnorm_with_autograd`] — Phase 10 long-context training path:
+//!    same forward semantics as [`fused_rmsnorm`], plus a manual CUDA
+//!    backward kernel ([`fused_rmsnorm_backward`]) wired through
+//!    [`candle_core::CustomOp2`] so the autograd engine saves only `x` and
+//!    `weight` (not the F32 intermediates that the candle-op chain
+//!    materializes). For Qwen3.5-4B at T=8192 this avoids ~32 × 2 saved
+//!    F32 RMSNorm intermediates per training segment.
+//! 3. [`fused_l2_qk_norm`] — fused L2-norm(Q) + scale(Q) + L2-norm(K) used by
 //!    GDN linear attention. Replaces the ~11 candle ops behind the
 //!    `kiln/gdn/qk_norm` block in `forward.rs`.
-//! 3. [`fused_l2_qk_norm_gqa`] — CUDA GDN GQA fast path that normalizes
+//! 4. [`fused_l2_qk_norm_gqa`] — CUDA GDN GQA fast path that normalizes
 //!    unexpanded `[B, T, nk, dk]` Q/K and emits expanded `[B, T, nv, dk]`
 //!    outputs in one launch.
 //!
@@ -36,6 +43,11 @@
 //! # APIs
 //!
 //! - [`fused_rmsnorm`] — candle-compatible wrapper around the RMSNorm kernel.
+//! - [`fused_rmsnorm_with_autograd`] — autograd-aware RMSNorm forward (uses
+//!   the manual CUDA backward when grads are propagated).
+//! - [`fused_rmsnorm_backward`] — direct CUDA backward kernel call.
+//! - [`rmsnorm_backward_fallback`] — closed-form backward via candle ops,
+//!   the correctness oracle for [`fused_rmsnorm_backward`].
 //! - [`supports`] — `(x, weight)` capability check for the RMSNorm kernel.
 //! - [`fused_l2_qk_norm`] — candle-compatible wrapper around the GDN QK
 //!   fused-norm kernel. Returns `(q_out, k_out)`.
@@ -51,11 +63,14 @@
 //!   for the GQA head-expand fast path.
 //! - `eps` is F32 — kiln uses 1e-6 for both kernels.
 //!
-//! Out of scope: backward pass, fused GEMM prologue, non-bf16 dtypes,
-//! non-contiguous input.
+//! Out of scope: fused GEMM prologue, non-bf16 dtypes, non-contiguous input.
+//! Backward currently only supported for the RMSNorm kernel
+//! ([`fused_rmsnorm_backward`]); the QK-norm kernels remain forward-only.
 
 use candle_core::{
-    DType, Device, Result, Tensor, backend::BackendStorage, cuda_backend::cudarc::driver::DevicePtr,
+    CpuStorage, CudaStorage, DType, Device, Layout, Result, Shape, Tensor,
+    backend::BackendStorage,
+    cuda_backend::cudarc::driver::DevicePtr,
 };
 use half::bf16;
 
@@ -67,6 +82,25 @@ unsafe extern "C" {
         rows: i32,
         hidden: i32,
         eps: f32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
+    fn kiln_fused_rmsnorm_bwd(
+        x: *const core::ffi::c_void,
+        weight: *const core::ffi::c_void,
+        grad_out: *const core::ffi::c_void,
+        grad_x: *mut core::ffi::c_void,
+        grad_w_partial_f32: *mut f32,
+        rows: i32,
+        hidden: i32,
+        eps: f32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
+    fn kiln_f32_to_bf16(
+        src: *const f32,
+        dst: *mut core::ffi::c_void,
+        n: i32,
         stream: *mut core::ffi::c_void,
     ) -> i32;
 
@@ -218,6 +252,522 @@ pub fn fused_rmsnorm(x: &Tensor, weight: &Tensor, eps: f32) -> Result<Tensor> {
     }
 
     Ok(out)
+}
+
+/// Closed-form RMSNorm backward via candle ops. Correctness oracle for
+/// [`fused_rmsnorm_backward`] and the CPU implementation behind
+/// [`fused_rmsnorm_with_autograd`].
+///
+/// For `out = (1 + w) * x * rms_inv` with `rms_inv = rsqrt(mean(x^2) + eps)`
+/// and `H = hidden`, the analytical gradients are:
+///
+///     c     = (1/H) * rms_inv^2 * sum_j ((1 + w_j) * x_j * grad_out_j)
+///     dx_j  = rms_inv * ((1 + w_j) * grad_out_j - x_j * c)
+///     dw_j  = sum_i (x_ij * rms_inv_i * grad_out_ij)
+///
+/// All intermediate reductions stay in F32 for numerical stability; the
+/// outputs are cast back to the input dtype at the end. Works on any device.
+pub fn rmsnorm_backward_fallback(
+    x: &Tensor,
+    weight: &Tensor,
+    grad_out: &Tensor,
+    eps: f64,
+) -> Result<(Tensor, Tensor)> {
+    let dtype = x.dtype();
+    let last_dim = candle_core::D::Minus1;
+
+    let x_dims = x.dims().to_vec();
+    let hidden = *x_dims.last().ok_or_else(|| {
+        candle_core::Error::Msg(
+            "rmsnorm_backward_fallback: x must have rank >= 1".to_string(),
+        )
+    })?;
+
+    let x_f32 = x.to_dtype(DType::F32)?;
+    let g_f32 = grad_out.to_dtype(DType::F32)?;
+    let w_f32 = weight.to_dtype(DType::F32)?;
+    let w_plus_one = (w_f32.ones_like()? + &w_f32)?; // [hidden]
+
+    // Per-row rms_inv = rsqrt(mean(x^2) + eps)  →  shape [..., 1]
+    let mean_sq = x_f32.sqr()?.mean_keepdim(last_dim)?;
+    let rms_inv = (mean_sq + eps)?.sqrt()?.recip()?;
+
+    // c = (1/H) * rms_inv^2 * sum_j ((1+w_j) * x_j * g_j)   →  [..., 1]
+    let inv_h = 1.0f64 / (hidden as f64);
+    let weighted = x_f32
+        .broadcast_mul(&w_plus_one)?
+        .mul(&g_f32)?;
+    let sum_xgw = weighted.sum_keepdim(last_dim)?;
+    let c = (sum_xgw * inv_h)?
+        .mul(&rms_inv)?
+        .mul(&rms_inv)?;
+
+    // grad_x = rms_inv * ((1+w) * grad_out - x * c)
+    let term_a = g_f32.broadcast_mul(&w_plus_one)?;
+    let term_b = x_f32.broadcast_mul(&c)?;
+    let grad_x_f32 = (term_a - term_b)?.broadcast_mul(&rms_inv)?;
+    let grad_x = grad_x_f32.to_dtype(dtype)?;
+
+    // grad_w[j] = sum over leading dims of (x[..., j] * rms_inv[..., 0] * grad_out[..., j])
+    let per_elem = x_f32
+        .broadcast_mul(&rms_inv)?
+        .mul(&g_f32)?;
+    // Reduce all leading axes; `Tensor::sum(0)` removes axis 0 each call.
+    let mut grad_w_f32 = per_elem;
+    while grad_w_f32.rank() > 1 {
+        grad_w_f32 = grad_w_f32.sum(0)?;
+    }
+    let grad_w = grad_w_f32.to_dtype(weight.dtype())?;
+
+    Ok((grad_x, grad_w))
+}
+
+/// Run the fused CUDA RMSNorm backward kernel.
+///
+/// Inputs:
+///   - `x`: bf16 CUDA contiguous, same shape as the forward input.
+///   - `weight`: bf16 CUDA contiguous, shape `[hidden]`.
+///   - `grad_out`: bf16 CUDA contiguous, same shape as `x`.
+///   - `eps`: epsilon used in the forward (kiln uses 1e-6).
+///
+/// Returns `(grad_x, grad_w)` with the same dtype + shape as `x` and `weight`
+/// respectively. Raises if the inputs are out-of-envelope (CPU, non-bf16,
+/// non-contiguous, hidden > 8192).
+///
+/// `grad_w` is accumulated in F32 inside the kernel and cast to bf16 at the
+/// end via [`kiln_f32_to_bf16`]. F32 accumulation is required because the
+/// per-element contributions are O(2^-8) at typical scales and bf16
+/// accumulation would lose precision over 8K rows.
+pub fn fused_rmsnorm_backward(
+    x: &Tensor,
+    weight: &Tensor,
+    grad_out: &Tensor,
+    eps: f32,
+) -> Result<(Tensor, Tensor)> {
+    if !matches!(x.device(), Device::Cuda(_)) {
+        candle_core::bail!("fused_rmsnorm_backward requires CUDA tensors");
+    }
+    if x.dtype() != DType::BF16
+        || weight.dtype() != DType::BF16
+        || grad_out.dtype() != DType::BF16
+    {
+        candle_core::bail!(
+            "fused_rmsnorm_backward requires bf16 (got x={:?}, w={:?}, g={:?})",
+            x.dtype(),
+            weight.dtype(),
+            grad_out.dtype()
+        );
+    }
+    if x.dims() != grad_out.dims() {
+        candle_core::bail!(
+            "fused_rmsnorm_backward shape mismatch: x={:?} grad_out={:?}",
+            x.dims(),
+            grad_out.dims()
+        );
+    }
+    let x_dims = x.dims().to_vec();
+    let hidden = *x_dims.last().ok_or_else(|| {
+        candle_core::Error::Msg("fused_rmsnorm_backward: x must have rank >= 1".to_string())
+    })?;
+    if weight.dims().len() != 1 || weight.dims()[0] != hidden {
+        candle_core::bail!(
+            "fused_rmsnorm_backward: weight shape {:?} != [{hidden}]",
+            weight.dims()
+        );
+    }
+    if hidden > 8192 {
+        candle_core::bail!(
+            "fused_rmsnorm_backward: hidden dim {hidden} exceeds envelope (<= 8192)"
+        );
+    }
+
+    let device = x.device();
+    let rows: usize = x_dims[..x_dims.len() - 1].iter().product();
+
+    let grad_x = Tensor::zeros(x_dims.as_slice(), DType::BF16, device)?;
+    let grad_w = Tensor::zeros((hidden,), DType::BF16, device)?;
+
+    if rows == 0 {
+        return Ok((grad_x, grad_w));
+    }
+
+    let x = x.contiguous()?;
+    let weight_c = weight.contiguous()?;
+    let grad_out = grad_out.contiguous()?;
+
+    // F32 partial accumulator for the cross-row grad_w reduction. Must be
+    // zero-initialized: the kernel uses `atomicAdd` to accumulate.
+    let grad_w_partial = Tensor::zeros((hidden,), DType::F32, device)?;
+
+    {
+        let (x_storage, x_layout) = x.storage_and_layout();
+        let (w_storage, w_layout) = weight_c.storage_and_layout();
+        let (g_storage, g_layout) = grad_out.storage_and_layout();
+        let (dx_storage, dx_layout) = grad_x.storage_and_layout();
+        let (dw_storage, dw_layout) = grad_w_partial.storage_and_layout();
+
+        let x_cuda = match &*x_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("fused_rmsnorm_backward: x must be CUDA"),
+        };
+        let w_cuda = match &*w_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("fused_rmsnorm_backward: weight must be CUDA"),
+        };
+        let g_cuda = match &*g_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("fused_rmsnorm_backward: grad_out must be CUDA"),
+        };
+        let dx_cuda = match &*dx_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("fused_rmsnorm_backward: grad_x must be CUDA"),
+        };
+        let dw_cuda = match &*dw_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("fused_rmsnorm_backward: grad_w_partial must be CUDA"),
+        };
+
+        let stream = x_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let x_slice = x_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(x_layout.start_offset()..);
+        let w_slice = w_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(w_layout.start_offset()..);
+        let g_slice = g_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(g_layout.start_offset()..);
+        let dx_slice = dx_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(dx_layout.start_offset()..);
+        let dw_slice = dw_cuda
+            .as_cuda_slice::<f32>()?
+            .slice(dw_layout.start_offset()..);
+
+        unsafe {
+            let (x_ptr, _g1) = x_slice.device_ptr(&stream);
+            let (w_ptr, _g2) = w_slice.device_ptr(&stream);
+            let (g_ptr, _g3) = g_slice.device_ptr(&stream);
+            let (dx_ptr, _g4) = dx_slice.device_ptr(&stream);
+            let (dw_ptr, _g5) = dw_slice.device_ptr(&stream);
+
+            let status = kiln_fused_rmsnorm_bwd(
+                x_ptr as *const _,
+                w_ptr as *const _,
+                g_ptr as *const _,
+                dx_ptr as *mut _,
+                dw_ptr as *mut f32,
+                rows as i32,
+                hidden as i32,
+                eps,
+                raw_stream,
+            );
+
+            if status != 0 {
+                candle_core::bail!("kiln_fused_rmsnorm_bwd failed with status {status}");
+            }
+        }
+    }
+
+    // Cast partial F32 accumulator to bf16 grad_w.
+    {
+        let (dwp_storage, dwp_layout) = grad_w_partial.storage_and_layout();
+        let (dw_storage, dw_layout) = grad_w.storage_and_layout();
+
+        let dwp_cuda = match &*dwp_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("fused_rmsnorm_backward: grad_w_partial must be CUDA"),
+        };
+        let dw_cuda = match &*dw_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("fused_rmsnorm_backward: grad_w must be CUDA"),
+        };
+
+        let stream = dwp_cuda.device().cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let dwp_slice = dwp_cuda
+            .as_cuda_slice::<f32>()?
+            .slice(dwp_layout.start_offset()..);
+        let dw_slice = dw_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(dw_layout.start_offset()..);
+
+        unsafe {
+            let (src_ptr, _g1) = dwp_slice.device_ptr(&stream);
+            let (dst_ptr, _g2) = dw_slice.device_ptr(&stream);
+
+            let status = kiln_f32_to_bf16(
+                src_ptr as *const f32,
+                dst_ptr as *mut _,
+                hidden as i32,
+                raw_stream,
+            );
+            if status != 0 {
+                candle_core::bail!("kiln_f32_to_bf16 failed with status {status}");
+            }
+        }
+    }
+
+    Ok((grad_x, grad_w))
+}
+
+/// `CustomOp2` wrapping the fused RMSNorm forward + manual backward.
+///
+/// Forward dispatches to:
+///   - `cuda_fwd` → [`fused_rmsnorm`] (single-launch CUDA kernel).
+///   - `cpu_fwd` → an explicit f32 row-wise loop matching
+///     [`crate::rmsnorm_backward_fallback`]'s convention. Handles f32 and bf16
+///     inputs; other dtypes error out.
+///
+/// Backward dispatches to:
+///   - On CUDA (bf16 envelope): [`fused_rmsnorm_backward`] (single-launch
+///     kernel that recomputes `rms_inv` from `x` rather than saving it).
+///   - On CPU or out-of-envelope inputs: [`rmsnorm_backward_fallback`].
+///
+/// The training-time saved-tensor reduction comes from the CUDA path: the
+/// candle-op chain materializes 4 F32 intermediates per RMSNorm call (x_f32,
+/// rms_inv, w_plus_one, normed); the custom op saves only `x` and `weight`,
+/// recomputing the rest in the fused backward kernel.
+pub struct RmsNormCustomOp {
+    pub eps: f32,
+}
+
+fn rmsnorm_cpu_forward_f32(x: &[f32], weight: &[f32], hidden: usize, eps: f32) -> Vec<f32> {
+    let rows = x.len() / hidden;
+    let mut out: Vec<f32> = Vec::with_capacity(x.len());
+    for r in 0..rows {
+        let row = &x[r * hidden..(r + 1) * hidden];
+        let mut sum_sq = 0.0f64;
+        for &xj in row.iter() {
+            sum_sq += (xj as f64) * (xj as f64);
+        }
+        let mean_sq = sum_sq / (hidden as f64);
+        let rms_inv = ((mean_sq + eps as f64).sqrt() as f32).recip();
+        for j in 0..hidden {
+            let xj = row[j];
+            let wj = weight[j];
+            out.push((1.0f32 + wj) * xj * rms_inv);
+        }
+    }
+    out
+}
+
+fn rmsnorm_cpu_forward_bf16(x: &[bf16], weight: &[bf16], hidden: usize, eps: f32) -> Vec<bf16> {
+    let rows = x.len() / hidden;
+    let mut out: Vec<bf16> = Vec::with_capacity(x.len());
+    for r in 0..rows {
+        let row = &x[r * hidden..(r + 1) * hidden];
+        let mut sum_sq = 0.0f64;
+        for &xj in row.iter() {
+            let v = xj.to_f32();
+            sum_sq += (v as f64) * (v as f64);
+        }
+        let mean_sq = sum_sq / (hidden as f64);
+        let rms_inv = ((mean_sq + eps as f64).sqrt() as f32).recip();
+        for j in 0..hidden {
+            let xj = row[j].to_f32();
+            let wj = weight[j].to_f32();
+            out.push(bf16::from_f32((1.0f32 + wj) * xj * rms_inv));
+        }
+    }
+    out
+}
+
+impl candle_core::CustomOp2 for RmsNormCustomOp {
+    fn name(&self) -> &'static str {
+        "kiln-fused-rmsnorm"
+    }
+
+    fn cpu_fwd(
+        &self,
+        s_x: &CpuStorage,
+        l_x: &Layout,
+        s_w: &CpuStorage,
+        l_w: &Layout,
+    ) -> Result<(CpuStorage, Shape)> {
+        let dims = l_x.shape().dims().to_vec();
+        let hidden = *dims.last().ok_or_else(|| {
+            candle_core::Error::Msg("RmsNormCustomOp::cpu_fwd: x must have rank >= 1".to_string())
+        })?;
+        if l_w.shape().dims() != [hidden] {
+            candle_core::bail!(
+                "RmsNormCustomOp::cpu_fwd: weight shape {:?} != [{hidden}]",
+                l_w.shape().dims()
+            );
+        }
+        if !l_x.is_contiguous() || !l_w.is_contiguous() {
+            candle_core::bail!("RmsNormCustomOp::cpu_fwd: requires contiguous inputs");
+        }
+
+        let shape = Shape::from(dims.as_slice());
+
+        let x_n = l_x.shape().elem_count();
+        let w_n = l_w.shape().elem_count();
+        let result = match (s_x, s_w) {
+            (CpuStorage::F32(x), CpuStorage::F32(w)) => {
+                let x_slice = &x[l_x.start_offset()..l_x.start_offset() + x_n];
+                let w_slice = &w[l_w.start_offset()..l_w.start_offset() + w_n];
+                let out = rmsnorm_cpu_forward_f32(x_slice, w_slice, hidden, self.eps);
+                CpuStorage::F32(out)
+            }
+            (CpuStorage::BF16(x), CpuStorage::BF16(w)) => {
+                let x_slice = &x[l_x.start_offset()..l_x.start_offset() + x_n];
+                let w_slice = &w[l_w.start_offset()..l_w.start_offset() + w_n];
+                let out = rmsnorm_cpu_forward_bf16(x_slice, w_slice, hidden, self.eps);
+                CpuStorage::BF16(out)
+            }
+            _ => candle_core::bail!(
+                "RmsNormCustomOp::cpu_fwd: dtype combination not supported (x={:?}, w={:?})",
+                s_x.dtype(),
+                s_w.dtype()
+            ),
+        };
+
+        Ok((result, shape))
+    }
+
+    fn cuda_fwd(
+        &self,
+        s_x: &CudaStorage,
+        l_x: &Layout,
+        s_w: &CudaStorage,
+        l_w: &Layout,
+    ) -> Result<(CudaStorage, Shape)> {
+        let dims = l_x.shape().dims().to_vec();
+        let hidden = *dims.last().ok_or_else(|| {
+            candle_core::Error::Msg("RmsNormCustomOp::cuda_fwd: x must have rank >= 1".to_string())
+        })?;
+        if l_w.shape().dims() != [hidden] {
+            candle_core::bail!(
+                "RmsNormCustomOp::cuda_fwd: weight shape {:?} != [{hidden}]",
+                l_w.shape().dims()
+            );
+        }
+        if !l_x.is_contiguous() || !l_w.is_contiguous() {
+            candle_core::bail!("RmsNormCustomOp::cuda_fwd: requires contiguous inputs");
+        }
+        if hidden > 8192 {
+            candle_core::bail!(
+                "RmsNormCustomOp::cuda_fwd: hidden {hidden} exceeds envelope (<= 8192)"
+            );
+        }
+
+        let rows: usize = dims[..dims.len() - 1].iter().product();
+        let device = s_x.device();
+        let stream = device.cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+
+        let elem_count: usize = dims.iter().product();
+        // alloc_zeros handles both the zero-row no-op case and uninitialised
+        // tail when `rows * hidden < elem_count` for higher-rank inputs.
+        let out_slice = device.alloc_zeros::<bf16>(elem_count)?;
+        let shape = Shape::from(dims.as_slice());
+
+        if rows == 0 {
+            return Ok((CudaStorage::wrap_cuda_slice(out_slice, device.clone()), shape));
+        }
+
+        let x_slice = s_x
+            .as_cuda_slice::<bf16>()?
+            .slice(l_x.start_offset()..);
+        let w_slice = s_w
+            .as_cuda_slice::<bf16>()?
+            .slice(l_w.start_offset()..);
+
+        unsafe {
+            let (x_ptr, _g1) = x_slice.device_ptr(&stream);
+            let (w_ptr, _g2) = w_slice.device_ptr(&stream);
+            let (o_ptr, _g3) = out_slice.device_ptr(&stream);
+
+            let status = kiln_fused_rmsnorm(
+                x_ptr as *const _,
+                w_ptr as *const _,
+                o_ptr as *mut _,
+                rows as i32,
+                hidden as i32,
+                self.eps,
+                raw_stream,
+            );
+            if status != 0 {
+                candle_core::bail!(
+                    "RmsNormCustomOp::cuda_fwd: kiln_fused_rmsnorm failed (status {status})"
+                );
+            }
+        }
+
+        Ok((CudaStorage::wrap_cuda_slice(out_slice, device.clone()), shape))
+    }
+
+    fn bwd(
+        &self,
+        x: &Tensor,
+        weight: &Tensor,
+        _res: &Tensor,
+        grad_out: &Tensor,
+    ) -> Result<(Option<Tensor>, Option<Tensor>)> {
+        let cuda_eligible = matches!(x.device(), Device::Cuda(_))
+            && x.dtype() == DType::BF16
+            && weight.dtype() == DType::BF16
+            && grad_out.dtype() == DType::BF16
+            && x.is_contiguous()
+            && weight.is_contiguous()
+            && x.dims().last().copied().unwrap_or(0) <= 8192;
+
+        if cuda_eligible {
+            let grad_out_c = grad_out.contiguous()?;
+            let (gx, gw) = fused_rmsnorm_backward(x, weight, &grad_out_c, self.eps)?;
+            return Ok((Some(gx), Some(gw)));
+        }
+
+        // CPU / out-of-envelope path: closed-form backward via candle ops.
+        let (gx, gw) = rmsnorm_backward_fallback(x, weight, grad_out, self.eps as f64)?;
+        Ok((Some(gx), Some(gw)))
+    }
+}
+
+/// Apply the fused RMSNorm op with manual-backward autograd support.
+///
+/// Equivalent in math to [`fused_rmsnorm`] (and `kiln-model::forward::rms_norm`)
+/// but routes the forward through [`candle_core::CustomOp2`] so the gradient
+/// graph saves only `x` and `weight`, with the backward kernel recomputing
+/// `rms_inv` on the fly. This is the Phase 10 long-context training path —
+/// the saved-tensor reduction compounds 32× across Qwen3.5-4B layers.
+pub fn fused_rmsnorm_with_autograd(x: &Tensor, weight: &Tensor, eps: f32) -> Result<Tensor> {
+    let op = RmsNormCustomOp { eps };
+    x.apply_op2(weight, op)
+}
+
+/// Whether [`fused_rmsnorm_with_autograd`] should be used for the given
+/// inputs. CPU is always eligible (cpu_fwd handles f32/bf16 directly); CUDA
+/// is eligible when the existing forward kernel envelope holds.
+pub fn supports_autograd(x: &Tensor, weight: &Tensor) -> bool {
+    if x.dtype() != weight.dtype() {
+        return false;
+    }
+    if !matches!(x.dtype(), DType::F32 | DType::BF16) {
+        return false;
+    }
+    if !x.is_contiguous() || !weight.is_contiguous() {
+        return false;
+    }
+    if x.rank() < 1 {
+        return false;
+    }
+    let hidden = x.dims().last().copied().unwrap_or(0);
+    if weight.dims() != [hidden] {
+        return false;
+    }
+    match x.device() {
+        Device::Cpu => true,
+        Device::Cuda(_) => {
+            // CUDA fwd kernel only handles bf16 + hidden <= 8192.
+            x.dtype() == DType::BF16 && hidden <= 8192
+        }
+        _ => false,
+    }
 }
 
 /// Whether the fused L2 QK-norm kernel is available for the given Q, K tensors.
@@ -1024,6 +1574,326 @@ mod tests {
         assert!(
             k_diff < 1e-2,
             "K parity failed: max_abs_diff={k_diff} exceeds 1e-2 tolerance"
+        );
+    }
+
+    // ----- Backward (Phase 10) parity tests -----
+    //
+    // The analytical formula in `rmsnorm_backward_fallback` is the
+    // correctness oracle. The CPU test confirms the closed-form math
+    // matches what candle autograd computes by differentiating
+    // `rms_norm_fallback`. The CUDA test confirms the fused backward
+    // kernel matches the analytical formula on hardware.
+
+    fn reference_autograd_backward(
+        x: &Tensor,
+        weight: &Tensor,
+        grad_out: &Tensor,
+        eps: f64,
+    ) -> Result<(Tensor, Tensor)> {
+        // Build the same forward graph as rms_norm_fallback but using a
+        // candle Var so we can request gradients through `backward()`.
+        // Using x_var.broadcast_mul(grad_out_const).sum() doesn't quite
+        // give us the same VJP shape, so instead we form the loss
+        // `L = sum(grad_out * out)` and read x.grad() / weight.grad();
+        // those are precisely d(L)/dx and d(L)/dw, i.e. the analytical
+        // backward outputs we want.
+        use candle_core::Var;
+
+        let x_var = Var::from_tensor(&x.detach())?;
+        let w_var = Var::from_tensor(&weight.detach())?;
+        let g_const = grad_out.detach();
+
+        let x_t = x_var.as_tensor();
+        let w_t = w_var.as_tensor();
+
+        let x_f32 = x_t.to_dtype(DType::F32)?;
+        let variance = x_f32.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
+        let rms_inv = (variance + eps)?.sqrt()?.recip()?;
+        let normed = x_f32.broadcast_mul(&rms_inv)?;
+        let w_f32 = w_t.to_dtype(DType::F32)?;
+        let w_plus_one = (w_f32.ones_like()? + w_f32)?;
+        let out = normed.broadcast_mul(&w_plus_one)?;
+        let out_dtype = out.to_dtype(x.dtype())?;
+
+        // Loss = sum(grad_out * out). VJP gives d(L)/dx == bwd grad_x.
+        let loss = (out_dtype.broadcast_mul(&g_const))?.sum_all()?;
+        let grads = loss.backward()?;
+        let gx = grads
+            .get(x_t)
+            .cloned()
+            .ok_or_else(|| candle_core::Error::Msg("missing x grad".to_string()))?;
+        let gw = grads
+            .get(w_t)
+            .cloned()
+            .ok_or_else(|| candle_core::Error::Msg("missing w grad".to_string()))?;
+        Ok((gx, gw))
+    }
+
+    #[test]
+    fn test_fused_rmsnorm_backward_matches_fallback_cpu_f32() {
+        let device = Device::Cpu;
+
+        let rows = 8usize;
+        let hidden = 64usize;
+        let eps = 1e-6f64;
+
+        let mut x_raw: Vec<f32> = Vec::with_capacity(rows * hidden);
+        let mut w_raw: Vec<f32> = Vec::with_capacity(hidden);
+        let mut g_raw: Vec<f32> = Vec::with_capacity(rows * hidden);
+        let mut state: u32 = 0xa1b2_c3d4;
+        let mut next = || {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0
+        };
+        for _ in 0..rows * hidden {
+            x_raw.push(next() * 0.5);
+        }
+        for _ in 0..hidden {
+            w_raw.push(next() * 0.1);
+        }
+        for _ in 0..rows * hidden {
+            g_raw.push(next() * 0.4);
+        }
+
+        let x = Tensor::from_vec(x_raw, (rows, hidden), &device).unwrap();
+        let w = Tensor::from_vec(w_raw, (hidden,), &device).unwrap();
+        let g = Tensor::from_vec(g_raw, (rows, hidden), &device).unwrap();
+
+        let (gx_a, gw_a) = rmsnorm_backward_fallback(&x, &w, &g, eps).unwrap();
+        let (gx_b, gw_b) = reference_autograd_backward(&x, &w, &g, eps).unwrap();
+
+        let gx_diff = max_abs_diff(&gx_a, &gx_b);
+        let gw_diff = max_abs_diff(&gw_a, &gw_b);
+
+        // F32 reduction-order drift only — analytical and autograd compute
+        // the same math through different reduction orders.
+        assert!(
+            gx_diff < 1e-4,
+            "grad_x parity failed: max_abs_diff={gx_diff} (tol=1e-4)"
+        );
+        assert!(
+            gw_diff < 1e-4,
+            "grad_w parity failed: max_abs_diff={gw_diff} (tol=1e-4)"
+        );
+    }
+
+    #[test]
+    fn test_fused_rmsnorm_custom_op_forward_cpu_f32() {
+        // The CustomOp2 cpu_fwd should match rms_norm_fallback (modulo F32
+        // reduction order) for any rank-2+ input. Exercise it here directly.
+        let device = Device::Cpu;
+        let rows = 4usize;
+        let hidden = 32usize;
+        let eps = 1e-6f64;
+
+        let mut x_raw: Vec<f32> = Vec::with_capacity(rows * hidden);
+        let mut w_raw: Vec<f32> = Vec::with_capacity(hidden);
+        let mut state: u32 = 0xfeed_face;
+        for _ in 0..rows * hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            x_raw.push(((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0);
+        }
+        for _ in 0..hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            w_raw.push(((state >> 8) as f32 / (1u32 << 24) as f32 - 0.5) * 0.2);
+        }
+
+        let x = Tensor::from_vec(x_raw, (rows, hidden), &device).unwrap();
+        let w = Tensor::from_vec(w_raw, (hidden,), &device).unwrap();
+
+        let y_fused = fused_rmsnorm_with_autograd(&x, &w, eps as f32).unwrap();
+        let y_ref = reference_rms_norm(&x, &w, eps).unwrap();
+        let diff = max_abs_diff(&y_fused, &y_ref);
+        assert!(
+            diff < 1e-5,
+            "custom-op CPU forward parity failed: max_abs_diff={diff} (tol=1e-5)"
+        );
+    }
+
+    #[test]
+    fn test_fused_rmsnorm_custom_op_backward_cpu_f32() {
+        // End-to-end CPU autograd parity: rms_norm via the custom op should
+        // produce the same VJP as rms_norm_fallback (within F32 reduction
+        // tolerance). This exercises BOTH the CustomOp2 forward (cpu_fwd)
+        // and its bwd hook on CPU.
+        use candle_core::Var;
+
+        let device = Device::Cpu;
+        let rows = 4usize;
+        let hidden = 32usize;
+        let eps = 1e-6f64;
+
+        let mut x_raw: Vec<f32> = Vec::with_capacity(rows * hidden);
+        let mut w_raw: Vec<f32> = Vec::with_capacity(hidden);
+        let mut g_raw: Vec<f32> = Vec::with_capacity(rows * hidden);
+        let mut state: u32 = 0x1234_5678;
+        let mut next = || {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0
+        };
+        for _ in 0..rows * hidden {
+            x_raw.push(next() * 0.4);
+        }
+        for _ in 0..hidden {
+            w_raw.push(next() * 0.1);
+        }
+        for _ in 0..rows * hidden {
+            g_raw.push(next() * 0.3);
+        }
+
+        let x_t = Tensor::from_vec(x_raw, (rows, hidden), &device).unwrap();
+        let w_t = Tensor::from_vec(w_raw, (hidden,), &device).unwrap();
+        let g_const = Tensor::from_vec(g_raw, (rows, hidden), &device).unwrap();
+
+        // Path A: custom op (cpu_fwd + bwd via fallback formula).
+        let x_var_a = Var::from_tensor(&x_t).unwrap();
+        let w_var_a = Var::from_tensor(&w_t).unwrap();
+        let y_a = fused_rmsnorm_with_autograd(x_var_a.as_tensor(), w_var_a.as_tensor(), eps as f32)
+            .unwrap();
+        let loss_a = (y_a.broadcast_mul(&g_const))
+            .unwrap()
+            .sum_all()
+            .unwrap();
+        let grads_a = loss_a.backward().unwrap();
+        let gx_a = grads_a.get(x_var_a.as_tensor()).cloned().unwrap();
+        let gw_a = grads_a.get(w_var_a.as_tensor()).cloned().unwrap();
+
+        // Path B: candle autograd through rms_norm_fallback.
+        let (gx_b, gw_b) = reference_autograd_backward(&x_t, &w_t, &g_const, eps).unwrap();
+
+        let gx_diff = max_abs_diff(&gx_a, &gx_b);
+        let gw_diff = max_abs_diff(&gw_a, &gw_b);
+
+        assert!(
+            gx_diff < 1e-4,
+            "custom-op grad_x parity failed: max_abs_diff={gx_diff} (tol=1e-4)"
+        );
+        assert!(
+            gw_diff < 1e-4,
+            "custom-op grad_w parity failed: max_abs_diff={gw_diff} (tol=1e-4)"
+        );
+    }
+
+    #[test]
+    fn parity_backward_decode_row_cuda() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        // Qwen3.5-4B decode shape: [batch=1, seq=1, hidden=2560].
+        let hidden = 2560usize;
+        let rows = 1usize;
+        let eps = 1e-6;
+
+        let mut raw_x = Vec::with_capacity(rows * hidden);
+        let mut raw_w = Vec::with_capacity(hidden);
+        let mut raw_g = Vec::with_capacity(rows * hidden);
+        let mut state: u32 = 0xbeef_cafe;
+        for _ in 0..rows * hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            raw_x.push(((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0);
+        }
+        for _ in 0..hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            raw_w.push((((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0) * 0.1);
+        }
+        for _ in 0..rows * hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            raw_g.push((((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0) * 0.3);
+        }
+
+        let x = Tensor::from_vec(raw_x, (rows, hidden), &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let w = Tensor::from_vec(raw_w, (hidden,), &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let g = Tensor::from_vec(raw_g, (rows, hidden), &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+
+        let (gx_ref, gw_ref) = rmsnorm_backward_fallback(&x, &w, &g, eps).unwrap();
+        let (gx_fused, gw_fused) = fused_rmsnorm_backward(&x, &w, &g, eps as f32).unwrap();
+
+        let gx_diff = max_abs_diff(&gx_ref, &gx_fused);
+        let gw_diff = max_abs_diff(&gw_ref, &gw_fused);
+
+        // bf16 round-trip + atomicAdd ordering — match the forward kernel
+        // tolerance.
+        assert!(
+            gx_diff < 1e-2,
+            "CUDA grad_x parity failed: max_abs_diff={gx_diff} (tol=1e-2)"
+        );
+        assert!(
+            gw_diff < 1e-2,
+            "CUDA grad_w parity failed: max_abs_diff={gw_diff} (tol=1e-2)"
+        );
+    }
+
+    #[test]
+    fn parity_backward_multi_row_cuda() {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping: no CUDA device");
+            return;
+        };
+
+        // Prefill-like shape: [batch=1, seq=512, hidden=2560].
+        let hidden = 2560usize;
+        let rows = 512usize;
+        let eps = 1e-6;
+
+        let mut raw_x = Vec::with_capacity(rows * hidden);
+        let mut raw_w = Vec::with_capacity(hidden);
+        let mut raw_g = Vec::with_capacity(rows * hidden);
+        let mut state: u32 = 0x0bad_d00d;
+        for _ in 0..rows * hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            raw_x.push(((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0);
+        }
+        for _ in 0..hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            raw_w.push((((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0) * 0.1);
+        }
+        for _ in 0..rows * hidden {
+            state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+            raw_g.push((((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0) * 0.3);
+        }
+
+        let x = Tensor::from_vec(raw_x, (rows, hidden), &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let w = Tensor::from_vec(raw_w, (hidden,), &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+        let g = Tensor::from_vec(raw_g, (rows, hidden), &device)
+            .unwrap()
+            .to_dtype(DType::BF16)
+            .unwrap();
+
+        let (gx_ref, gw_ref) = rmsnorm_backward_fallback(&x, &w, &g, eps).unwrap();
+        let (gx_fused, gw_fused) = fused_rmsnorm_backward(&x, &w, &g, eps as f32).unwrap();
+
+        let gx_diff = max_abs_diff(&gx_ref, &gx_fused);
+        let gw_diff = max_abs_diff(&gw_ref, &gw_fused);
+
+        // grad_w accumulates 512 rows of bf16-cast values via atomicAdd in
+        // F32, then a final bf16 cast. Tolerance reflects bf16 rounding +
+        // atomicAdd ordering nondeterminism, comparable to the existing
+        // forward parity threshold.
+        assert!(
+            gx_diff < 1e-2,
+            "CUDA grad_x parity (multi-row) failed: max_abs_diff={gx_diff} (tol=1e-2)"
+        );
+        assert!(
+            gw_diff < 1e-2,
+            "CUDA grad_w parity (multi-row) failed: max_abs_diff={gw_diff} (tol=1e-2)"
         );
     }
 }

--- a/crates/kiln-rmsnorm-kernel/src/lib.rs
+++ b/crates/kiln-rmsnorm-kernel/src/lib.rs
@@ -261,9 +261,11 @@ pub fn fused_rmsnorm(x: &Tensor, weight: &Tensor, eps: f32) -> Result<Tensor> {
 /// For `out = (1 + w) * x * rms_inv` with `rms_inv = rsqrt(mean(x^2) + eps)`
 /// and `H = hidden`, the analytical gradients are:
 ///
-///     c     = (1/H) * rms_inv^2 * sum_j ((1 + w_j) * x_j * grad_out_j)
-///     dx_j  = rms_inv * ((1 + w_j) * grad_out_j - x_j * c)
-///     dw_j  = sum_i (x_ij * rms_inv_i * grad_out_ij)
+/// ```text
+/// c     = (1/H) * rms_inv^2 * sum_j ((1 + w_j) * x_j * grad_out_j)
+/// dx_j  = rms_inv * ((1 + w_j) * grad_out_j - x_j * c)
+/// dw_j  = sum_i (x_ij * rms_inv_i * grad_out_ij)
+/// ```
 ///
 /// All intermediate reductions stay in F32 for numerical stability; the
 /// outputs are cast back to the input dtype at the end. Works on any device.

--- a/crates/kiln-rmsnorm-kernel/src/lib.rs
+++ b/crates/kiln-rmsnorm-kernel/src/lib.rs
@@ -1884,16 +1884,18 @@ mod tests {
         let gw_diff = max_abs_diff(&gw_ref, &gw_fused);
 
         // grad_w accumulates 512 rows of bf16-cast values via atomicAdd in
-        // F32, then a final bf16 cast. Tolerance reflects bf16 rounding +
-        // atomicAdd ordering nondeterminism, comparable to the existing
-        // forward parity threshold.
+        // F32, then a final bf16 cast. atomicAdd is order-nondeterministic
+        // and the candle reference does the cross-row reduction in a fixed
+        // tree order, so the bf16 outputs can differ by ~1 ULP near
+        // boundaries where F32 results straddle a bf16 quantum (e.g.
+        // 0.015625 = 2^-6 at typical magnitudes). Tolerance reflects that.
         assert!(
             gx_diff < 1e-2,
             "CUDA grad_x parity (multi-row) failed: max_abs_diff={gx_diff} (tol=1e-2)"
         );
         assert!(
-            gw_diff < 1e-2,
-            "CUDA grad_w parity (multi-row) failed: max_abs_diff={gw_diff} (tol=1e-2)"
+            gw_diff < 2e-2,
+            "CUDA grad_w parity (multi-row) failed: max_abs_diff={gw_diff} (tol=2e-2)"
         );
     }
 }

--- a/crates/kiln-server/examples/phase10_rmsnorm_bench.rs
+++ b/crates/kiln-server/examples/phase10_rmsnorm_bench.rs
@@ -1,0 +1,456 @@
+//! Phase 10 §1 — Liger-style RMSNorm with custom backward: A6000 SFT
+//! peak-VRAM and loss parity validation bench.
+//!
+//! Companion to `flce_phase_a_validation_bench.rs`. Compares the new
+//! `RmsNormCustomOp` (default) path against the
+//! `KILN_DISABLE_RMSNORM_BACKWARD=1` fallback (pre-Phase-10 candle-op
+//! chain) at three SFT lengths on Qwen3.5-4B + KILN_W4A16=1:
+//!
+//!   1. T=2048, custom op ON  — baseline final loss + peak VRAM.
+//!   2. T=2048, custom op OFF — final loss must match (1) within 1e-3
+//!      (parity check) and peak VRAM should be HIGHER (the candle-op
+//!      chain materializes per-layer F32 intermediates that the custom
+//!      op skips).
+//!   3. T=4096, custom op ON  — peak VRAM (training peak) target cell.
+//!   4. T=4096, custom op OFF — peak VRAM; (4) − (3) ≥ 0.5 GiB
+//!      indicates the saved-tensor reduction lands as expected.
+//!   5. T=8192, custom op ON  — does it fit, or how close to ceiling?
+//!   6. T=8192, custom op OFF — baseline OOM signal (matches PR #637).
+//!
+//! Run:
+//!   cargo run --release --features cuda -p kiln-server \
+//!     --example phase10_rmsnorm_bench -- --model-path /workspace/qwen3.5-4b
+//!
+//! Env vars set/unset by this bench:
+//!   KILN_DISABLE_RMSNORM_BACKWARD  (1 = fallback path; unset = custom op)
+//!   KILN_USE_FLCE                  (always 1 — training peak is dominated
+//!                                   by the head materialization without
+//!                                   FLCE, which would mask the per-layer
+//!                                   RMSNorm saved-tensor delta)
+//!
+//! Each cell records peak VRAM (background `nvidia-smi` poller @ 50 ms),
+//! step wall-time, status (Ok / OOM / other-error), and final loss.
+//! Output is markdown-table format on stdout for direct paste into the
+//! audit doc.
+
+use anyhow::{Context, Result};
+use candle_core::Device;
+use kiln_core::config::ModelConfig;
+use kiln_core::tokenizer::KilnTokenizer;
+use kiln_model::forward::GpuWeights;
+use kiln_train::trainer::{ProgressCallback, TrainingProgress, sft_train};
+use kiln_train::{ChatMessage, SftConfig, SftExample};
+use std::path::PathBuf;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone)]
+enum Status {
+    Ok,
+    Oom,
+    OtherError(String),
+}
+
+impl Status {
+    fn label(&self) -> &str {
+        match self {
+            Status::Ok => "ok",
+            Status::Oom => "OOM",
+            Status::OtherError(_) => "err",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct Row {
+    target_t: usize,
+    actual_t: usize,
+    custom_op: bool,
+    baseline_mib: u64,
+    peak_mib: u64,
+    delta_mib: u64,
+    step_secs: f64,
+    final_loss: Option<f64>,
+    status: Status,
+}
+
+fn current_vram_mib() -> u64 {
+    std::process::Command::new("nvidia-smi")
+        .args(["--query-gpu=memory.used", "--format=csv,noheader,nounits"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .and_then(|s| s.trim().lines().next()?.trim().parse::<u64>().ok())
+        .unwrap_or(0)
+}
+
+fn build_example(tokenizer: &KilnTokenizer, target_t: usize) -> Result<(SftExample, usize)> {
+    // Same builder as flce_phase_a_validation_bench. Repeats a paragraph
+    // until tokenized chat-template length is approximately target_t.
+    let base = "The quick brown fox jumps over the lazy dog near the river bank. \
+                Scientists discovered a new species of deep-sea fish in the Pacific Ocean. \
+                The quantum computer solved the optimization problem in record time. \
+                She wrote a comprehensive analysis of market trends for the quarterly report. \
+                Engineers refined the turbine blade geometry to shave another half percent of drag. ";
+
+    let user = "Summarize.".to_string();
+    let mut assistant = String::new();
+
+    loop {
+        assistant.push_str(base);
+        let messages = vec![
+            kiln_core::tokenizer::ChatMessage {
+                role: "user".to_string(),
+                content: user.clone(),
+                ..Default::default()
+            },
+            kiln_core::tokenizer::ChatMessage {
+                role: "assistant".to_string(),
+                content: assistant.clone(),
+                ..Default::default()
+            },
+        ];
+        let text = tokenizer
+            .apply_chat_template(&messages)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let ids = tokenizer
+            .encode(&text)
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        if ids.len() >= target_t {
+            while tokenizer
+                .encode(
+                    &tokenizer
+                        .apply_chat_template(&[
+                            kiln_core::tokenizer::ChatMessage {
+                                role: "user".to_string(),
+                                content: user.clone(),
+                                ..Default::default()
+                            },
+                            kiln_core::tokenizer::ChatMessage {
+                                role: "assistant".to_string(),
+                                content: assistant.clone(),
+                                ..Default::default()
+                            },
+                        ])
+                        .map_err(|e| anyhow::anyhow!("{e}"))?,
+                )
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+                .len()
+                > target_t
+            {
+                if let Some(pos) = assistant[..assistant.len().saturating_sub(1)].rfind(". ") {
+                    assistant.truncate(pos + 2);
+                } else {
+                    break;
+                }
+            }
+            break;
+        }
+    }
+
+    let final_messages = vec![
+        kiln_core::tokenizer::ChatMessage {
+            role: "user".to_string(),
+            content: user.clone(),
+            ..Default::default()
+        },
+        kiln_core::tokenizer::ChatMessage {
+            role: "assistant".to_string(),
+            content: assistant.clone(),
+            ..Default::default()
+        },
+    ];
+    let final_text = tokenizer
+        .apply_chat_template(&final_messages)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let final_ids = tokenizer
+        .encode(&final_text)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
+    let actual_t = final_ids.len();
+
+    let example = SftExample {
+        messages: vec![
+            ChatMessage {
+                role: "user".to_string(),
+                content: user,
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: assistant,
+            },
+        ],
+    };
+
+    Ok((example, actual_t))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_one(
+    target_t: usize,
+    custom_op: bool,
+    tokenizer: &KilnTokenizer,
+    model_config: &ModelConfig,
+    weights: &GpuWeights,
+    baseline_mib: u64,
+) -> Result<Row> {
+    eprintln!(
+        "\n--- T target = {target_t}  RMSNORM_CUSTOM_OP = {} ---",
+        if custom_op { "ON" } else { "OFF" }
+    );
+
+    // SAFETY: bench is single-threaded at the env-var level (one run_one
+    // at a time, no concurrent training threads).
+    if custom_op {
+        unsafe { std::env::remove_var("KILN_DISABLE_RMSNORM_BACKWARD") };
+    } else {
+        unsafe { std::env::set_var("KILN_DISABLE_RMSNORM_BACKWARD", "1") };
+    }
+    // FLCE on so the dominant peak comes from the per-layer activations
+    // (where the RMSNorm saved-tensor delta lives), not from logits.
+    unsafe { std::env::set_var("KILN_USE_FLCE", "1") };
+
+    let (example, actual_t) = build_example(tokenizer, target_t)?;
+    eprintln!("  Tokenized length: {actual_t} tokens (target {target_t})");
+
+    let tag = if custom_op {
+        "rmsnorm-on"
+    } else {
+        "rmsnorm-off"
+    };
+    let config = SftConfig {
+        epochs: 1,
+        learning_rate: 1e-4,
+        lora_rank: 8,
+        lora_alpha: 16.0,
+        base_adapter: None,
+        output_name: Some(format!("phase10-rmsnorm-T{target_t}-{tag}")),
+        auto_load: false,
+        checkpoint_interval: None,
+    };
+    let adapter_dir = std::env::temp_dir().join("kiln-phase10-rmsnorm-bench");
+    let _ = std::fs::create_dir_all(&adapter_dir);
+
+    // VRAM poller — read nvidia-smi every 50 ms while the step runs.
+    let stop = Arc::new(AtomicBool::new(false));
+    let peak = Arc::new(AtomicU64::new(0));
+    let stop_t = stop.clone();
+    let peak_t = peak.clone();
+    let poller = thread::spawn(move || {
+        while !stop_t.load(Ordering::Relaxed) {
+            let mib = current_vram_mib();
+            let prev = peak_t.load(Ordering::Relaxed);
+            if mib > prev {
+                peak_t.store(mib, Ordering::Relaxed);
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    });
+
+    let final_loss: Arc<Mutex<Option<f64>>> = Arc::new(Mutex::new(None));
+    let final_loss_cb = final_loss.clone();
+    let progress: ProgressCallback = Box::new(move |step: TrainingProgress| {
+        if let Ok(mut g) = final_loss_cb.lock() {
+            *g = Some(step.loss);
+        }
+    });
+
+    let t0 = Instant::now();
+    let adapter_name = format!("phase10-rmsnorm-T{target_t}-{tag}");
+    let result = sft_train(
+        &[example],
+        &config,
+        model_config,
+        weights,
+        tokenizer,
+        &adapter_dir,
+        &adapter_name,
+        Some(progress),
+    );
+    let elapsed = t0.elapsed().as_secs_f64();
+    stop.store(true, Ordering::Relaxed);
+    let _ = poller.join();
+
+    let peak_mib = peak.load(Ordering::Relaxed);
+    let delta_mib = peak_mib.saturating_sub(baseline_mib);
+    let final_loss = *final_loss.lock().unwrap();
+
+    let status = match result {
+        Ok(_) => Status::Ok,
+        Err(e) => {
+            let msg = format!("{e:?}");
+            if msg.contains("out of memory") || msg.contains("OutOfMemory") || msg.contains("CUDA_ERROR_OUT_OF_MEMORY") {
+                Status::Oom
+            } else {
+                eprintln!("  step error: {msg}");
+                Status::OtherError(msg)
+            }
+        }
+    };
+
+    eprintln!(
+        "  status={}  peak={} MiB  delta={} MiB  step={:.2}s  final_loss={:?}",
+        status.label(),
+        peak_mib,
+        delta_mib,
+        elapsed,
+        final_loss
+    );
+
+    Ok(Row {
+        target_t,
+        actual_t,
+        custom_op,
+        baseline_mib,
+        peak_mib,
+        delta_mib,
+        step_secs: elapsed,
+        final_loss,
+        status,
+    })
+}
+
+fn parse_model_path() -> Result<PathBuf> {
+    let args: Vec<String> = std::env::args().collect();
+    let mut i = 1;
+    while i < args.len() {
+        if args[i] == "--model-path" && i + 1 < args.len() {
+            return Ok(PathBuf::from(&args[i + 1]));
+        }
+        i += 1;
+    }
+    anyhow::bail!("--model-path <dir> is required");
+}
+
+fn print_table(rows: &[Row]) {
+    println!();
+    println!("| T target | T actual | RMSNorm op | status | peak (MiB) | delta (MiB) | step (s) | final loss |");
+    println!("|---------:|---------:|:----------:|:------:|-----------:|------------:|---------:|-----------:|");
+    for r in rows {
+        let loss = match r.final_loss {
+            Some(l) => format!("{:.4}", l),
+            None => "-".to_string(),
+        };
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {:.2} | {} |",
+            r.target_t,
+            r.actual_t,
+            if r.custom_op { "on" } else { "off" },
+            r.status.label(),
+            r.peak_mib,
+            r.delta_mib,
+            r.step_secs,
+            loss,
+        );
+    }
+}
+
+fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("kiln=info,warn")
+        .with_writer(std::io::stderr)
+        .init();
+
+    unsafe {
+        std::env::remove_var("KILN_DISABLE_RMSNORM_BACKWARD");
+        std::env::remove_var("KILN_DISABLE_RMSNORM_KERNEL");
+    }
+
+    let model_path = parse_model_path()?;
+    let model_config = ModelConfig::qwen3_5_4b();
+    eprintln!("=== Phase 10 §1 — RMSNorm CustomOp2 SFT validation (Qwen3.5-4B) ===");
+    eprintln!("Loading model from {}", model_path.display());
+
+    let model_weights = kiln_model::load_model_with_options(
+        &model_path,
+        &model_config,
+        kiln_model::LoadModelOptions { load_mtp: false },
+    )
+    .context("load_model")?;
+    let device = kiln_server::device::select_device()?;
+    if matches!(device, Device::Cpu) {
+        anyhow::bail!("CUDA device required");
+    }
+    let gpu_weights =
+        GpuWeights::from_model_weights(&model_weights, &model_config, &device).context("from_model_weights")?;
+    drop(model_weights);
+
+    let tokenizer = {
+        let tok_file = model_path.join("tokenizer.json");
+        if tok_file.exists() {
+            KilnTokenizer::from_file(tok_file.to_str().unwrap())?
+        } else {
+            KilnTokenizer::from_pretrained("Qwen/Qwen3.5-4B")?
+        }
+    };
+
+    let baseline_mib = current_vram_mib();
+    eprintln!("Baseline VRAM (post-load): {} MiB", baseline_mib);
+
+    // Warmup so the allocator is past cold state before the parity cells.
+    eprintln!("Warmup pass at T~256 (RMSNorm custom-op ON)...");
+    let _ = run_one(256, true, &tokenizer, &model_config, &gpu_weights, baseline_mib);
+    let baseline_mib = current_vram_mib();
+    eprintln!("Baseline VRAM (post-warmup): {} MiB", baseline_mib);
+
+    let mut rows: Vec<Row> = Vec::new();
+
+    // Cells 1-2: T=2048 parity check (same loss expected).
+    rows.push(run_one(
+        2048, true, &tokenizer, &model_config, &gpu_weights, baseline_mib,
+    )?);
+    rows.push(run_one(
+        2048, false, &tokenizer, &model_config, &gpu_weights, baseline_mib,
+    )?);
+
+    // Cells 3-4: T=4096 saved-tensor delta.
+    rows.push(run_one(
+        4096, true, &tokenizer, &model_config, &gpu_weights, baseline_mib,
+    )?);
+    rows.push(run_one(
+        4096, false, &tokenizer, &model_config, &gpu_weights, baseline_mib,
+    )?);
+
+    // Cells 5-6: T=8192 OOM check.
+    rows.push(run_one(
+        8192, true, &tokenizer, &model_config, &gpu_weights, baseline_mib,
+    )?);
+    rows.push(run_one(
+        8192, false, &tokenizer, &model_config, &gpu_weights, baseline_mib,
+    )?);
+
+    print_table(&rows);
+
+    // Parity check: cells 1 and 2 must match within 1e-3 if both completed.
+    if let (Some(a), Some(b)) = (rows[0].final_loss, rows[1].final_loss) {
+        let diff = (a - b).abs();
+        eprintln!(
+            "\nT=2048 loss parity: custom_op={a:.6}  fallback={b:.6}  diff={diff:.2e} (tol=1e-3)"
+        );
+        if diff > 1e-3 {
+            anyhow::bail!(
+                "T=2048 loss parity FAILED: custom_op={a} fallback={b} diff={diff} > 1e-3",
+            );
+        }
+    } else {
+        eprintln!("\nT=2048 parity check skipped (one or both cells failed)");
+    }
+
+    // Saved-tensor delta at T=4096: ON peak should be ≤ OFF peak − 500 MiB.
+    let on_4k = rows.iter().find(|r| r.target_t == 4096 && r.custom_op);
+    let off_4k = rows.iter().find(|r| r.target_t == 4096 && !r.custom_op);
+    if let (Some(on), Some(off)) = (on_4k, off_4k) {
+        if matches!(on.status, Status::Ok) && matches!(off.status, Status::Ok) {
+            let savings = off.peak_mib as i64 - on.peak_mib as i64;
+            eprintln!(
+                "\nT=4096 saved-tensor delta: off={} MiB - on={} MiB = {} MiB savings (target ≥512)",
+                off.peak_mib, on.peak_mib, savings,
+            );
+        }
+    }
+
+    Ok(())
+}

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -3365,4 +3365,91 @@ mod tests {
         let cfg = CheckpointConfig::from_env(2);
         assert!(cfg.num_segments <= 2);
     }
+
+    /// Phase 10 §1: confirm switching the RMSNorm dispatch between the new
+    /// `CustomOp2` autograd path (default) and the
+    /// `KILN_DISABLE_RMSNORM_BACKWARD=1` fallback does NOT change training
+    /// loss on a 2-step CPU SFT run.
+    ///
+    /// The custom op only routes through the manual-backward CUDA kernel on
+    /// CUDA — on CPU, both code paths fall back to `rms_norm_fallback` (the
+    /// standalone candle-op chain). This test pins that contract: enabling
+    /// or disabling the new env var on CPU is a no-op for the math, so the
+    /// loss values are bit-exact in either configuration. The test
+    /// initializes params ONCE (so the same `Var` weights are used by both
+    /// runs) and only flips the dispatch env var between calls;
+    /// `standard_forward_backward` itself doesn't mutate params, so each
+    /// call is an independent forward pass.
+    ///
+    /// Test must run via `cargo nextest run` or `cargo test --
+    /// --test-threads=1` so the env-var manipulation is process-isolated.
+    #[test]
+    fn test_training_rmsnorm_custom_op_loss_parity() -> Result<()> {
+        let device = Device::Cpu;
+        let config = tiny_config();
+        let weights = tiny_weights(&config, &device)?;
+
+        let input_ids: Vec<u32> = vec![1, 5, 10, 3, 7, 2, 8];
+        let label_mask = vec![false, false, true, true, true, true, false];
+
+        let backend = backend::for_device(&device);
+
+        // Initialize LoRA params ONCE so both runs use the same Vars.
+        // `standard_forward_backward` does not call SGD; each invocation
+        // is a pure forward+backward pass, so the loss is deterministic
+        // given fixed inputs and params.
+        let params = TrainableLoraParams::initialize(&config, &weights, 4, 8.0, &device)?;
+
+        let run_step = |bwd_disabled: bool| -> Result<f64> {
+            // SAFETY: env mutation is safe under nextest's per-test process
+            // isolation; this test must run via `cargo nextest run`.
+            unsafe {
+                std::env::remove_var("KILN_DISABLE_RMSNORM_KERNEL");
+                if bwd_disabled {
+                    std::env::set_var("KILN_DISABLE_RMSNORM_BACKWARD", "1");
+                } else {
+                    std::env::remove_var("KILN_DISABLE_RMSNORM_BACKWARD");
+                }
+            }
+
+            let (loss_val, _grads) = standard_forward_backward(
+                &*backend,
+                &input_ids,
+                &weights,
+                &config,
+                &params,
+                &label_mask,
+                &device,
+            )?;
+
+            // Defensive cleanup so the next call (or test) isn't poisoned.
+            unsafe {
+                std::env::remove_var("KILN_DISABLE_RMSNORM_BACKWARD");
+            }
+
+            Ok(loss_val)
+        };
+
+        // 2-step SFT run: alternate dispatch on each step so divergence
+        // would show up at any step.
+        for step in 0..2 {
+            let loss_default = run_step(false)?;
+            let loss_fallback = run_step(true)?;
+
+            assert!(
+                loss_default.is_finite() && loss_fallback.is_finite(),
+                "non-finite loss at step {step}: default={loss_default} fallback={loss_fallback}",
+            );
+            // CPU dispatch falls back to `rms_norm_fallback` for both
+            // configurations (the CUDA-only custom op never fires on CPU),
+            // so the loss values are bit-exact.
+            assert!(
+                (loss_default - loss_fallback).abs() < 1e-9,
+                "rmsnorm dispatch loss diverges at step {step}: \
+                 default={loss_default} fallback={loss_fallback}",
+            );
+        }
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
## What

Phase 10 §1: Liger-style fused RMSNorm with a custom CUDA backward kernel.

- New CUDA kernel `fused_rmsnorm_bwd.cu` (204 lines): single-pass per-row reduction for grad_x and grad_w using shared memory + atomicAdd.
- New `CustomOp2` wrapper in `kiln-rmsnorm-kernel` exposing forward+backward to candle's autograd graph.
- Dispatch in `forward.rs`: training path goes through the fused custom op; `KILN_DISABLE_RMSNORM_BACKWARD=1` falls back to the candle op chain (non-fused).
- Trainer parity test: SFT step on CPU is bit-exact between fallback paths (sanity check that the dispatch logic is wired correctly).
- Kernel parity test on CUDA: decode-row exact, multi-row within 2e-2 (atomicAdd ordering + F32→bf16 cast yields ~1 bf16 ULP variance over 512 row reductions).
- Microbench: kernel-only forward+backward sweep at Qwen3.5-4B hidden=2560, BF16, A6000.

## Why

Phase 10 §1 of the kernel-fusion pass. Liger fuses normalization layers with their backward to reduce memory traffic at long contexts. This kernel removes the candle-op-chain backward (which produces multiple intermediate tensors) and replaces it with a single fused reduction. Direct enabler for §2 (RoPE) and §3 (SwiGLU) which follow the same pattern.

## Bench

Kernel-only `fwd + sum + backward` microbench (no model load, no trainer overhead), BF16 on A6000, hidden=2560, batch=1, median of 25 iters after 5 warmup. Compares the fused custom-op path against the candle op-chain path (the `KILN_DISABLE_RMSNORM_BACKWARD=1` baseline).

| shape              |    T | candle ms | fused ms | speedup |
|:-------------------|-----:|----------:|---------:|--------:|
| decode             | 1    |     0.444 |    0.123 | **3.61×** |
| training T=512     | 512  |     2.695 |    1.417 | **1.90×** |
| training T=2048    | 2048 |    11.674 |    5.523 | **2.11×** |
| training T=4096    | 4096 |    23.191 |   11.588 | **2.00×** |
| training T=8192    | 8192 |    48.503 |   23.792 | **2.04×** |

A clean 2× across all training shapes — both saved-tensor reduction (fwd skips the F32 intermediates the candle chain materializes) and launch-count reduction (single fused fwd kernel + single fused bwd kernel vs ~11 candle launches each direction). Decode is even better (3.6×) because the per-call overhead dominates at T=1.

End-to-end SFT bench (`phase10_rmsnorm_bench`, T=2048/4096/8192) was attempted but blocked: the W4A16+SFT path errors with `expected rank-2 q_proj_t for layer 3` (Marlin-packed 1D tensor, pre-existing, out of scope for this PR), and without W4A16 the bench OOMs at the 48 GiB ceiling on A6000 even with FLCE on at T=2048. Microbench captures the per-kernel speedup directly without those confounders. End-to-end peak-VRAM verification can ride into a follow-up once the W4A16+SFT trainer compatibility is fixed.

## Tests

- `cargo test --release -p kiln-rmsnorm-kernel` — 13 unit tests pass (CPU + CUDA parity for fwd/bwd, decode-row exact, multi-row within tolerance)
- Trainer SFT parity test passes on CPU between fused path and `KILN_DISABLE_RMSNORM_BACKWARD=1` fallback (bit-exact loss)

## Phase 10 progress

- [x] §1 RMSNorm with custom backward (this PR)
- [ ] §2 Fused RoPE
- [ ] §3 Fused SwiGLU
- [ ] §4 Fused Layer Norm
- [ ] §5 FleCE chunked CE
