### PR TITLE
template: fix tools-bearing chat-template render (tojson + arguments dict)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,6 +2075,7 @@ checksum = "805bfd7352166bae857ee569628b52bcd85a1cecf7810861ebceb1686b72b75d"
 dependencies = [
  "memo-map",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,11 @@ chrono = { version = "0.4", features = ["serde"] }
 
 # Tokenization
 tokenizers = { version = "0.23", features = ["http"] }
-minijinja = "2"
+# `json` enables the `tojson` filter, which Qwen3.5-4B's chat_template uses
+# to emit each tool definition (`{{ tool | tojson }}`). Without it, every
+# tools-bearing /v1/chat/completions request 4xx's with
+# `unknown filter: tojson`. See PR comment for the load-bearing call site.
+minijinja = { version = "2", features = ["json"] }
 minijinja-contrib = { version = "2", features = ["pycompat"] }
 
 # Model loading

--- a/crates/kiln-core/src/tokenizer.rs
+++ b/crates/kiln-core/src/tokenizer.rs
@@ -208,8 +208,41 @@ impl KilnTokenizer {
             .cloned()
             .unwrap_or(serde_json::Value::Null);
 
+        // Deserialize tool_call arguments from JSON-string to structured
+        // serde_json::Value before handing the messages to the Jinja
+        // template. The OpenAI Chat Completions spec defines
+        // `tool_calls[*].function.arguments` as a JSON-encoded string
+        // (https://platform.openai.com/docs/api-reference/chat/object), so
+        // OpenAI-compatible clients (and the kiln-server completions API)
+        // forward it as a string. HuggingFace chat templates — including
+        // Qwen3.5-4B's bundled `chat_template.jinja` — iterate it as a dict
+        // via `{% for k, v in tool_call.arguments|items %}`. Without this
+        // conversion the `|items` filter throws
+        // "cannot convert value into pairs" on every multi-turn request that
+        // carries prior assistant tool_calls.
+        //
+        // Both the OpenAI `{function: {name, arguments}}` envelope and the
+        // flatter `{name, arguments}` shape some templates assume are
+        // handled. If `arguments` is already a JSON object/array (i.e. the
+        // caller pre-parsed it), it's left alone.
+        let messages_value: Vec<serde_json::Value> = messages
+            .iter()
+            .map(|m| {
+                let mut v = serde_json::to_value(m).unwrap_or(serde_json::Value::Null);
+                if let Some(tcs) = v.get_mut("tool_calls").and_then(|t| t.as_array_mut()) {
+                    for tc in tcs {
+                        deserialize_arguments_in_place(tc);
+                        if let Some(function) = tc.get_mut("function") {
+                            deserialize_arguments_in_place(function);
+                        }
+                    }
+                }
+                v
+            })
+            .collect();
+
         tmpl.render(minijinja::context! {
-            messages => messages,
+            messages => messages_value,
             tools => tools_value,
             tool_choice => tool_choice_value,
             add_generation_prompt => true,
@@ -232,6 +265,24 @@ impl KilnTokenizer {
         }
         prompt.push_str("<|im_start|>assistant\n");
         prompt
+    }
+}
+
+/// If `value` has an `arguments` field that is a JSON-encoded string, replace
+/// it in place with the parsed `serde_json::Value`. Used to convert the OpenAI
+/// `tool_calls[*].function.arguments` string form to the dict form HF chat
+/// templates iterate via `arguments|items`. A no-op when `arguments` is missing,
+/// already structured, or a non-JSON string (left untouched in that case so the
+/// chat template can decide how to handle it).
+fn deserialize_arguments_in_place(value: &mut serde_json::Value) {
+    let Some(args) = value.get_mut("arguments") else {
+        return;
+    };
+    let Some(s) = args.as_str() else {
+        return;
+    };
+    if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(s) {
+        *args = parsed;
     }
 }
 
@@ -480,5 +531,265 @@ mod tests {
         assert!(v.get("tool_call_id").is_none());
         assert_eq!(v["role"], "user");
         assert_eq!(v["content"], "hi");
+    }
+
+    /// `tojson` filter must be available on the minijinja env. Bundled HF
+    /// chat templates (Qwen3.5, Llama-3, Mistral) call it unconditionally
+    /// when rendering tools. If minijinja is depended on without the `json`
+    /// feature, this filter is missing and every tools-bearing render
+    /// errors with `unknown filter: tojson`. Regression test for the
+    /// "structurally wired but feature-gated off" failure mode in PR #632.
+    #[test]
+    fn test_jinja_tojson_filter_is_available() {
+        let template = "{{ data | tojson }}";
+        let tok = tokenizer_with_template(template);
+        let prompt = tok.apply_chat_template(&[]).unwrap();
+        // `data` is unset in the template context, so `tojson` of `Undefined`
+        // emits `null` — that's fine, what matters is the filter resolved.
+        assert!(
+            prompt.contains("null"),
+            "tojson filter did not produce expected output: {prompt:?}"
+        );
+
+        // Also exercise the realistic shape: tools array forwarded into the
+        // template, each tool rendered via `| tojson`. Mirrors line 50 of
+        // Qwen3.5-4B's chat_template.jinja.
+        let tools_template = "\
+{%- for tool in tools -%}\
+T:{{ tool | tojson }};\
+{%- endfor -%}";
+        let tok = tokenizer_with_template(tools_template);
+        let tools = vec![serde_json::json!({"name": "Bash", "description": "Run a command"})];
+        let prompt = tok
+            .apply_chat_template_with_tools(&[], Some(&tools))
+            .unwrap();
+        assert!(
+            prompt.contains("\"name\":\"Bash\""),
+            "tojson did not serialize tool dict: {prompt:?}"
+        );
+    }
+
+    /// Multi-turn conversation with prior assistant `tool_calls`. The Qwen3.5
+    /// chat template iterates `tool_call.arguments|items`, which requires a
+    /// dict. The OpenAI Chat Completions spec sends arguments as a
+    /// JSON-encoded string. Without the in-place deserialization the render
+    /// crashes with `cannot convert value into pairs`. Both the
+    /// `{function: {...}}` and flat `{name, arguments}` envelopes must work.
+    #[test]
+    fn test_jinja_tool_call_arguments_string_is_iterable_as_dict() {
+        // Mirrors line 120 of Qwen3.5-4B's chat_template.jinja:
+        //   {%- for args_name, args_value in tool_call.arguments|items %}
+        let template = "\
+{%- for message in messages -%}\
+[{{ message.role }}]\
+{%- if message.tool_calls -%}\
+{%- for tc in message.tool_calls -%}\
+{%- set args = tc.function.arguments if tc.function is defined else tc.arguments -%}\
+{%- for k, v in args | items -%}\
+ARG:{{ k }}={{ v }};\
+{%- endfor -%}\
+{%- endfor -%}\
+{%- endif -%}\
+{{ message.content }}\
+{%- endfor -%}";
+        let tok = tokenizer_with_template(template);
+        let messages = vec![
+            ChatMessage {
+                role: "user".to_string(),
+                content: "list files".to_string(),
+                ..Default::default()
+            },
+            // OpenAI envelope: tool_calls[*] = {id, type, function: {name, arguments: "<json string>"}}
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "".to_string(),
+                tool_calls: Some(vec![serde_json::json!({
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "Bash",
+                        "arguments": r#"{"command": "ls", "cwd": "/tmp"}"#
+                    }
+                })]),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: "a.txt".to_string(),
+                name: Some("Bash".to_string()),
+                tool_call_id: Some("call_1".to_string()),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "thanks".to_string(),
+                ..Default::default()
+            },
+        ];
+        let prompt = tok.apply_chat_template(&messages).expect(
+            "render failed — likely arguments-as-string not deserialized to dict before |items",
+        );
+        assert!(
+            prompt.contains("ARG:command=ls;"),
+            "argument key/value missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("ARG:cwd=/tmp;"),
+            "second argument missing: {prompt:?}"
+        );
+
+        // Also exercise the flat envelope (no nested function key).
+        let messages_flat = vec![ChatMessage {
+            role: "assistant".to_string(),
+            content: "".to_string(),
+            tool_calls: Some(vec![serde_json::json!({
+                "name": "Read",
+                "arguments": r#"{"path": "/etc/hosts"}"#
+            })]),
+            ..Default::default()
+        }];
+        let prompt = tok.apply_chat_template(&messages_flat).expect("flat-envelope render failed");
+        assert!(
+            prompt.contains("ARG:path=/etc/hosts;"),
+            "flat-envelope argument missing: {prompt:?}"
+        );
+    }
+
+    /// End-to-end render of Qwen3.5-4B's actual bundled `chat_template.jinja`
+    /// against a realistic tools-bearing multi-turn conversation. This is the
+    /// load-bearing fixture that pins both fixes from this PR (the `json`
+    /// feature on minijinja and the `arguments`-string-to-dict
+    /// deserialization). Either bug regressing causes this test to fail with
+    /// `unknown filter: tojson` or `cannot convert value into pairs`.
+    #[test]
+    fn test_qwen35_4b_chat_template_renders_tools_and_tool_calls() {
+        let template =
+            include_str!("../test_fixtures/qwen35_4b_chat_template.jinja");
+        let tok = tokenizer_with_template(template);
+
+        let tools = vec![
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "Bash",
+                    "description": "Run a shell command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "Command to run"}
+                        },
+                        "required": ["command"]
+                    }
+                }
+            }),
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "Read",
+                    "description": "Read a file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"}
+                        },
+                        "required": ["path"]
+                    }
+                }
+            }),
+        ];
+
+        let messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You are a coding agent.".to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Show me what's in /etc.".to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "".to_string(),
+                tool_calls: Some(vec![serde_json::json!({
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "Bash",
+                        "arguments": r#"{"command": "ls /etc"}"#
+                    }
+                })]),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: "hosts\nresolv.conf".to_string(),
+                name: Some("Bash".to_string()),
+                tool_call_id: Some("call_1".to_string()),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Now read /etc/hosts.".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let prompt = tok
+            .apply_chat_template_with_tools(&messages, Some(&tools))
+            .expect("Qwen3.5-4B chat template rendered without error");
+
+        // Tools block must appear (proves `tools | tojson` worked).
+        assert!(prompt.contains("<tools>"), "tools block missing: prompt was {prompt:?}");
+        assert!(prompt.contains("\"Bash\""), "Bash tool not serialized");
+        assert!(prompt.contains("\"Read\""), "Read tool not serialized");
+
+        // Past assistant tool_call must render in pi-XML form (proves the
+        // arguments-as-dict path worked).
+        assert!(
+            prompt.contains("<function=Bash>"),
+            "prior assistant tool_call did not render in Qwen pi-XML: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("<parameter=command>"),
+            "tool_call argument not iterated as dict: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("ls /etc"),
+            "argument value missing from rendered tool_call: {prompt:?}"
+        );
+
+        // Tool response wrapping must appear too.
+        assert!(
+            prompt.contains("<tool_response>"),
+            "tool response not wrapped: {prompt:?}"
+        );
+    }
+
+    /// `deserialize_arguments_in_place` is a no-op when arguments is already
+    /// a dict (caller pre-parsed) or missing entirely, and silently leaves
+    /// non-JSON strings untouched (the template can decide what to do).
+    #[test]
+    fn test_deserialize_arguments_in_place_handles_edge_cases() {
+        // Already-parsed dict: untouched.
+        let mut v = serde_json::json!({"arguments": {"a": 1}});
+        deserialize_arguments_in_place(&mut v);
+        assert_eq!(v["arguments"]["a"], 1);
+
+        // No arguments field: untouched.
+        let mut v = serde_json::json!({"name": "Bash"});
+        deserialize_arguments_in_place(&mut v);
+        assert_eq!(v.get("arguments"), None);
+
+        // Non-JSON string: left as-is so template logic sees it.
+        let mut v = serde_json::json!({"arguments": "not-json-at-all"});
+        deserialize_arguments_in_place(&mut v);
+        assert_eq!(v["arguments"], "not-json-at-all");
+
+        // Empty object as JSON string: parses to empty dict.
+        let mut v = serde_json::json!({"arguments": "{}"});
+        deserialize_arguments_in_place(&mut v);
+        assert_eq!(v["arguments"], serde_json::json!({}));
     }
 }

--- a/crates/kiln-core/test_fixtures/qwen35_4b_chat_template.jinja
+++ b/crates/kiln-core/test_fixtures/qwen35_4b_chat_template.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}


### PR DESCRIPTION
## Summary

Two coupled bugs in the chat-template render path that PR #632 exposed but didn't fix. Both surface only when a request carries a non-empty `tools` array **or** a prior assistant `tool_calls`. They block the corrections-experiment Phase 2 workload (multi-turn tool-using agents) and any pi-harness style request.

- **Bug 1 (`Cargo.toml`)** — workspace `minijinja = "2"` was missing the `json` feature, so `tojson` was an unknown filter and Qwen3.5-4B's `chat_template.jinja` line 50 (`{{ tool | tojson }}`) 4xx'd every tools-bearing request with `chat template error: unknown filter: tojson`.
- **Bug 3 (`crates/kiln-core/src/tokenizer.rs`)** — OpenAI sends `tool_calls[*].function.arguments` as a JSON-encoded string. Qwen3.5-4B's template iterates it as a dict via `{%- for args_name, args_value in tool_call.arguments|items %}` (line 120). Without pre-deserialization the `|items` filter throws `cannot convert value into pairs` on every multi-turn trajectory carrying a prior assistant tool_call.

## Why these slipped through PR #632

The PR's `TOOLS_TEST_TEMPLATE` is hand-written and exercises neither `tojson` nor `arguments|items`. It proved kiln *forwards* `tools` and `tool_calls` into the Jinja context, not that forwarding is *renderable* by the templates kiln actually serves in production.

## What's tested

- `test_jinja_tojson_filter_is_available` — direct regression for bug 1.
- `test_jinja_tool_call_arguments_string_is_iterable_as_dict` — covers both OpenAI nested-`function` envelope and the flat envelope.
- `test_qwen35_4b_chat_template_renders_tools_and_tool_calls` — load-bearing E2E test that bundles Qwen3.5-4B's real `chat_template.jinja` as a fixture and renders a realistic tools + multi-turn tool_calls conversation against it. Pins both fixes simultaneously.
- `test_deserialize_arguments_in_place_handles_edge_cases` — covers no-op paths (already-parsed dict, missing field, non-JSON string, empty `{}`).

Both bugs were also verified by reverting each fix in turn and watching the test fail with the exact error the field report (`b2://clouderic/corrections-experiment/phase2-round3/REPORT.md`) saw on the live elicitation pipeline.

## Test plan
- [x] `cargo nextest run -p kiln-core` — 40 passing, 3 ignored (network)
- [x] Negative test 1: drop `features = ["json"]` → `test_jinja_tojson_filter_is_available` fails with `unknown filter: filter tojson is unknown (in chat:1)`
- [x] Negative test 2: revert `messages_value` substitution → `test_qwen35_4b_chat_template_renders_tools_and_tool_calls` fails with `cannot convert value into pairs (in chat:120)`
- [x] `cargo check` (workspace) clean

## Followups

- Adding an end-to-end CI smoke test that boots a kiln server, sends a tools-bearing `/v1/chat/completions`, and asserts a 200 with structured tool_call output would catch this whole class of regression. The unit tests in this PR are the next-best thing but only exercise the template render path, not the full server stack. Will be tracked separately.

Refs: corrections-experiment Phase 2 round-3 re-run report (2026-04-29) — `b2://clouderic/corrections-experiment/phase2-round3/REPORT.md`