### PR TITLE
memory: relax auto KV cache cap on CUDA (let memory-aware sizing drive)

### DIFF
--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -788,13 +788,26 @@ fn cap_auto_num_blocks(
     is_metal: bool,
     total_vram_bytes: u64,
 ) -> usize {
-    let model_cap_blocks = max_position_embeddings
-        .div_ceil(block_size)
-        .max(MIN_AUTO_KV_BLOCKS);
+    // On Metal (unified memory), an eagerly-zeroed KV cache larger than the
+    // model context can dominate memory pressure on the rest of the system,
+    // so we keep the historical "≤ one full context, further capped by
+    // detected memory tier" behavior.
+    //
+    // On CUDA / CPU, memory-aware sizing already drove `raw_blocks` from the
+    // available VRAM × `inference_memory_fraction` budget. Capping again at
+    // one model-context-worth of blocks (≈16K for Qwen3.5-4B's 256K window)
+    // bottlenecks concurrent serving: 4 in-flight 25K-token prompts +
+    // generation already exhaust 6.5K blocks each, leaving the auto cap
+    // routinely OOM-borderline under realistic load even on a 48 GiB A40.
+    // Trust the memory-aware ceiling here; users who want a stricter cap can
+    // still set `KILN_NUM_BLOCKS` or `memory.num_blocks` explicitly.
     let runtime_cap_blocks = if is_metal {
+        let model_cap_blocks = max_position_embeddings
+            .div_ceil(block_size)
+            .max(MIN_AUTO_KV_BLOCKS);
         model_cap_blocks.min(metal_auto_max_kv_blocks(total_vram_bytes))
     } else {
-        model_cap_blocks
+        usize::MAX
     };
 
     raw_blocks.max(MIN_AUTO_KV_BLOCKS).min(runtime_cap_blocks)
@@ -1028,18 +1041,48 @@ mod tests {
     }
 
     #[test]
-    fn test_auto_num_blocks_caps_at_model_context() {
-        // Qwen3.5's 262K context is 16,384 blocks at block_size=16. There is
-        // no reason to auto-allocate more KV cache than the model can address.
+    fn test_auto_num_blocks_no_model_context_cap_on_cuda() {
+        // On CUDA, raw_blocks comes from the memory-aware sizing path
+        // (available VRAM × inference fraction ÷ bytes-per-block), which
+        // already accounts for what the GPU can hold. Clipping it to a single
+        // model-context-worth of blocks (≈16K for Qwen3.5-4B's 256K window)
+        // would bottleneck concurrent serving — multiple in-flight long
+        // prompts collectively address more than one window's worth of KV
+        // cache. cap_auto_num_blocks must trust the memory-aware ceiling
+        // here.
         assert_eq!(
             cap_auto_num_blocks(
                 50_000,
                 262_144,
                 DEFAULT_BLOCK_SIZE,
+                false, // is_metal
+                48 * 1024 * 1024 * 1024,
+            ),
+            50_000
+        );
+        // raw_blocks well under the model-context size still passes through —
+        // this is the small-VRAM CUDA path (e.g. A10 / consumer card).
+        assert_eq!(
+            cap_auto_num_blocks(
+                4_096,
+                262_144,
+                DEFAULT_BLOCK_SIZE,
                 false,
                 10 * 1024 * 1024 * 1024,
             ),
-            16_384
+            4_096
+        );
+        // raw_blocks above the model-context size on a large-VRAM CUDA host
+        // is preserved (multi-tenant headroom). Pre-fix this returned 16_384.
+        assert_eq!(
+            cap_auto_num_blocks(
+                65_000,
+                262_144,
+                DEFAULT_BLOCK_SIZE,
+                false,
+                80 * 1024 * 1024 * 1024,
+            ),
+            65_000
         );
     }
 

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -31,7 +31,12 @@ model_id = "Qwen/Qwen3.5-4B"
                                       # dequantizes INT4 weights to BF16 during loading.
 
 [memory]
-# num_blocks = 256                   # KV cache blocks (auto-sized from VRAM if omitted)
+# num_blocks = 256                   # KV cache blocks (auto-sized from VRAM if omitted).
+                                      # Each block holds 16 tokens of K+V across all
+                                      # full-attention layers. CUDA auto-sizing fills
+                                      # `inference_memory_fraction` of free VRAM with
+                                      # blocks; explicit values override this. Also
+                                      # settable via KILN_NUM_BLOCKS env var.
 # gpu_memory_gb = 24.0               # Override detected VRAM (for testing)
 inference_memory_fraction = 0.7       # Fraction of VRAM for inference (rest for training)
 # training_memory_gb = 4.0           # Override auto-calculated training budget


### PR DESCRIPTION
## What

`cap_auto_num_blocks` clipped `raw_blocks` to `max_position_embeddings.div_ceil(block_size)` on every device. For Qwen3.5-4B (256 k context, block_size=16) that is a hard ceiling of 16 384 blocks — about 8.6 GiB of KV cache on the BF16 paged layout.

The memory-aware sizing path that produces `raw_blocks` already chose `available_for_kv = (total_vram - model_bytes) * inference_memory_fraction`, i.e. the cap is redundant with that ceiling on CUDA. Worse, on a 48 GiB A40 serving Qwen3.5-4B with `inference_memory_fraction = 0.95` and `training_memory_gb = 0.5` the memory-aware path raw value is ~68 k blocks (~36 GiB), but the clamp drops it to 16 384 — leaving 25-30 GiB of free VRAM unused as KV cache headroom while concurrent serving routinely OOMs.

## Why

That ceiling is structurally too low for multi-tenant or correction-style workloads. With workers=2 and ~25 k-token prompts + 1-2 k generation, kiln saw `kiln_active_requests=10`, `kiln_blocks_used=14834/16384` (90% utilization) within minutes of warm-up, then started returning `Text generation failed: prefill forward pass (paged) failed: out of memory: no free blocks available` 500s — the corrections-experiment Phase 2 round-3 failure mode (see #656). Multiple in-flight long prompts collectively address more KV than one full context window, which is exactly what serving (vs. single-request inference) requires.

## Change

`cap_auto_num_blocks`:
- **Metal**: unchanged. Eagerly-zeroed KV cache on unified memory still capped at `min(model_context_blocks, metal_memory_tier_cap)`.
- **CUDA / CPU**: `runtime_cap_blocks = usize::MAX`. The memory-aware ceiling inside `AppState::new_real` is the authoritative bound. Users who want a stricter cap (e.g. to leave VRAM for non-LoRA fine-tuning) keep `KILN_NUM_BLOCKS` / `memory.num_blocks` as explicit overrides.

## Tests

- Replaces `test_auto_num_blocks_caps_at_model_context` with `test_auto_num_blocks_no_model_context_cap_on_cuda` covering three CUDA cases:
  - raw 50 k blocks → 50 k (no clamp; was 16 384)
  - raw 4 k blocks → 4 k (small-VRAM passthrough unchanged)
  - raw 65 k blocks → 65 k (large-VRAM multi-tenant headroom; was 16 384)
- Existing Metal and minimum-blocks tests unchanged and still pass.
- Full `cargo test -p kiln-server --lib state::` (11 tests) green.

## Discoverability

Updated `kiln.example.toml` to call out that CUDA auto-sizing fills `inference_memory_fraction` of free VRAM with blocks, and mention the `KILN_NUM_BLOCKS` env override for users who want an explicit ceiling.

## What this does NOT fix

The `begin_capture: ... operation not permitted when stream is capturing` warning at startup that drops decode to eager mode is a separate bug, as is any block-allocator fragmentation under sustained load. See follow-up issue #656 for tracking — this change unblocks the workload-realistic auto-sizing case where the cap was the root cause.

## Test plan

- [x] `cargo test -p kiln-server --lib state::` passes (11/11)
- [x] Negative case verified by reverting the change in-tree — pre-fix asserts `cap_auto_num_blocks(50_000, ..., is_metal=false, ...) == 16_384`; post-fix asserts `== 50_000`.
- [ ] A40 / A6000 e2e: rerun corrections-experiment Phase 2 elicit (workers=2, ~25k-token prompts) on the post-merge kiln to confirm the OOM-500s no longer fire under the same load. Tracked in #656.

Refs: corrections-experiment Phase 2 round-3 report (2026-04-29), #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)