### PR TITLE
ci(chat-template): vendor Llama 3.1 + Qwen2.5 fixtures with stress-render tests (closes #657)

### DIFF
--- a/crates/kiln-core/src/tokenizer.rs
+++ b/crates/kiln-core/src/tokenizer.rs
@@ -767,6 +767,267 @@ ARG:{{ k }}={{ v }};\
         );
     }
 
+    /// End-to-end render of Meta's official Llama 3.1 8B Instruct
+    /// `chat_template.jinja` against a tools-bearing multi-turn conversation.
+    /// Companion to the Qwen3.5-4B render test — extends per-template
+    /// fixture coverage to a second high-traffic model family with a
+    /// distinct tool-call shape (`<|start_header_id|>` framing,
+    /// `{"name": ..., "parameters": ...}` wire form via `arguments | tojson`).
+    /// Closes kiln#657.
+    #[test]
+    fn test_llama31_8b_instruct_chat_template_renders_tools_and_tool_calls() {
+        let template = include_str!(
+            "../test_fixtures/llama31_8b_instruct_chat_template.jinja"
+        );
+        let tok = tokenizer_with_template(template);
+
+        let tools = vec![serde_json::json!({
+            "type": "function",
+            "function": {
+                "name": "Bash",
+                "description": "Run a shell command",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {"type": "string", "description": "Command to run"}
+                    },
+                    "required": ["command"]
+                }
+            }
+        })];
+
+        // Llama 3.1's template raises if tool_calls.length != 1, so the
+        // stress conversation has exactly one prior assistant tool_call.
+        let messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You are a coding agent.".to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Show me what's in /etc.".to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "".to_string(),
+                tool_calls: Some(vec![serde_json::json!({
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "Bash",
+                        "arguments": r#"{"command": "ls /etc"}"#
+                    }
+                })]),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: "hosts\nresolv.conf".to_string(),
+                name: Some("Bash".to_string()),
+                tool_call_id: Some("call_1".to_string()),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Now read /etc/hosts.".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let prompt = tok
+            .apply_chat_template_with_tools(&messages, Some(&tools))
+            .expect("Llama 3.1 chat template rendered without error");
+
+        // Llama 3.1's distinctive header framing must appear.
+        assert!(
+            prompt.contains("<|start_header_id|>system<|end_header_id|>"),
+            "Llama 3.1 system header missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("<|eot_id|>"),
+            "Llama 3.1 eot marker missing: {prompt:?}"
+        );
+
+        // Tools block must be serialized (template uses `t | tojson(indent=4)`,
+        // proving minijinja's `json` feature is wired correctly).
+        assert!(
+            prompt.contains("\"name\": \"Bash\""),
+            "Bash tool not serialized into prompt: {prompt:?}"
+        );
+
+        // Past assistant tool_call must render in Llama 3.1's wire form,
+        // proving the arguments-as-dict path worked through `tojson`.
+        assert!(
+            prompt.contains("<|start_header_id|>assistant<|end_header_id|>"),
+            "assistant header missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"parameters\""),
+            "Llama 3.1 parameters key missing from rendered tool_call: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"command\""),
+            "tool_call argument key missing — `arguments` likely not deserialized to dict: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("ls /etc"),
+            "argument value missing from rendered tool_call: {prompt:?}"
+        );
+
+        // Tool response must be framed as ipython turn (Llama 3.1 maps
+        // role=tool onto its ipython header).
+        assert!(
+            prompt.contains("<|start_header_id|>ipython<|end_header_id|>"),
+            "Llama 3.1 ipython framing for tool response missing: {prompt:?}"
+        );
+
+        // Tool response content must round-trip into the rendered prompt.
+        assert!(
+            prompt.contains("hosts"),
+            "tool response content missing from prompt: {prompt:?}"
+        );
+    }
+
+    /// End-to-end render of Qwen2.5 7B Instruct's official
+    /// `chat_template.jinja` against a tools-bearing multi-turn conversation.
+    /// Distinct from the Qwen3.5-4B fixture: Qwen2.5 emits
+    /// `<tool_call>{"name":...,"arguments":...}</tool_call>` JSON inline
+    /// (vs. Qwen3.5's `<function=...><parameter=...>` pi-XML), so it
+    /// exercises a different code path through `arguments | tojson`.
+    /// Closes kiln#657.
+    #[test]
+    fn test_qwen25_7b_instruct_chat_template_renders_tools_and_tool_calls() {
+        let template = include_str!(
+            "../test_fixtures/qwen25_7b_instruct_chat_template.jinja"
+        );
+        let tok = tokenizer_with_template(template);
+
+        let tools = vec![
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "Bash",
+                    "description": "Run a shell command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "Command to run"}
+                        },
+                        "required": ["command"]
+                    }
+                }
+            }),
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "Read",
+                    "description": "Read a file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"}
+                        },
+                        "required": ["path"]
+                    }
+                }
+            }),
+        ];
+
+        let messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You are a coding agent.".to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Show me what's in /etc.".to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "".to_string(),
+                tool_calls: Some(vec![serde_json::json!({
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "Bash",
+                        "arguments": r#"{"command": "ls /etc"}"#
+                    }
+                })]),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: "hosts\nresolv.conf".to_string(),
+                name: Some("Bash".to_string()),
+                tool_call_id: Some("call_1".to_string()),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Now read /etc/hosts.".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let prompt = tok
+            .apply_chat_template_with_tools(&messages, Some(&tools))
+            .expect("Qwen2.5 chat template rendered without error");
+
+        // Tools block must be serialized via `tool | tojson` — proves
+        // minijinja's `json` feature is wired and the template's `<tools>`
+        // wrapper is firing.
+        assert!(
+            prompt.contains("<tools>"),
+            "Qwen2.5 tools wrapper missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"Bash\""),
+            "Bash tool not serialized: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"Read\""),
+            "Read tool not serialized: {prompt:?}"
+        );
+
+        // Past assistant tool_call must render in Qwen2.5's `<tool_call>`
+        // JSON wire form. Argument keys/values must round-trip — proves
+        // `arguments | tojson` saw a dict, not a JSON-encoded string.
+        assert!(
+            prompt.contains("<tool_call>"),
+            "Qwen2.5 tool_call wrapper missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"name\": \"Bash\""),
+            "tool_call name missing from rendered prompt: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"command\""),
+            "tool_call argument key missing — `arguments` likely not deserialized to dict: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("ls /etc"),
+            "argument value missing from rendered tool_call: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("</tool_call>"),
+            "Qwen2.5 tool_call closing tag missing: {prompt:?}"
+        );
+
+        // Tool response must be wrapped in `<tool_response>` framing.
+        assert!(
+            prompt.contains("<tool_response>"),
+            "Qwen2.5 tool_response wrapper missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("hosts"),
+            "tool response content missing from prompt: {prompt:?}"
+        );
+    }
+
     /// `deserialize_arguments_in_place` is a no-op when arguments is already
     /// a dict (caller pre-parsed) or missing entirely, and silently leaves
     /// non-JSON strings untouched (the template can decide what to do).

--- a/crates/kiln-core/test_fixtures/llama31_8b_instruct_chat_template.jinja
+++ b/crates/kiln-core/test_fixtures/llama31_8b_instruct_chat_template.jinja
@@ -1,0 +1,109 @@
+{{- bos_token }}
+{%- if custom_tools is defined %}
+    {%- set tools = custom_tools %}
+{%- endif %}
+{%- if not tools_in_user_message is defined %}
+    {%- set tools_in_user_message = true %}
+{%- endif %}
+{%- if not date_string is defined %}
+    {%- set date_string = "26 Jul 2024" %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+
+{#- This block extracts the system message, so we can slot it into the right place. #}
+{%- if messages[0]['role'] == 'system' %}
+    {%- set system_message = messages[0]['content']|trim %}
+    {%- set messages = messages[1:] %}
+{%- else %}
+    {%- set system_message = "" %}
+{%- endif %}
+
+{#- System message + builtin tools #}
+{{- "<|start_header_id|>system<|end_header_id|>\n\n" }}
+{%- if builtin_tools is defined or tools is not none %}
+    {{- "Environment: ipython\n" }}
+{%- endif %}
+{%- if builtin_tools is defined %}
+    {{- "Tools: " + builtin_tools | reject('equalto', 'code_interpreter') | join(", ") + "\n\n"}}
+{%- endif %}
+{{- "Cutting Knowledge Date: December 2023\n" }}
+{{- "Today Date: " + date_string + "\n\n" }}
+{%- if tools is not none and not tools_in_user_message %}
+    {{- "You have access to the following functions. To call a function, please respond with JSON for a function call." }}
+    {{- 'Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}.' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+{%- endif %}
+{{- system_message }}
+{{- "<|eot_id|>" }}
+
+{#- Custom tools are passed in a user message with some extra guidance #}
+{%- if tools_in_user_message and not tools is none %}
+    {#- Extract the first user message so we can plug it in here #}
+    {%- if messages | length != 0 %}
+        {%- set first_user_message = messages[0]['content']|trim %}
+        {%- set messages = messages[1:] %}
+    {%- else %}
+        {{- raise_exception("Cannot put tools in the first user message when there's no first user message!") }}
+{%- endif %}
+    {{- '<|start_header_id|>user<|end_header_id|>\n\n' -}}
+    {{- "Given the following functions, please respond with a JSON for a function call " }}
+    {{- "with its proper arguments that best answers the given prompt.\n\n" }}
+    {{- 'Respond in the format {"name": function name, "parameters": dictionary of argument name and its value}.' }}
+    {{- "Do not use variables.\n\n" }}
+    {%- for t in tools %}
+        {{- t | tojson(indent=4) }}
+        {{- "\n\n" }}
+    {%- endfor %}
+    {{- first_user_message + "<|eot_id|>"}}
+{%- endif %}
+
+{%- for message in messages %}
+    {%- if not (message.role == 'ipython' or message.role == 'tool' or 'tool_calls' in message) %}
+        {{- '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n'+ message['content'] | trim + '<|eot_id|>' }}
+    {%- elif 'tool_calls' in message %}
+        {%- if not message.tool_calls|length == 1 %}
+            {{- raise_exception("This model only supports single tool-calls at once!") }}
+        {%- endif %}
+        {%- set tool_call = message.tool_calls[0].function %}
+        {%- if builtin_tools is defined and tool_call.name in builtin_tools %}
+            {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' -}}
+            {{- "<|python_tag|>" + tool_call.name + ".call(" }}
+            {%- for arg_name, arg_val in tool_call.arguments | items %}
+                {{- arg_name + '="' + arg_val + '"' }}
+                {%- if not loop.last %}
+                    {{- ", " }}
+                {%- endif %}
+                {%- endfor %}
+            {{- ")" }}
+        {%- else  %}
+            {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' -}}
+            {{- '{"name": "' + tool_call.name + '", ' }}
+            {{- '"parameters": ' }}
+            {{- tool_call.arguments | tojson }}
+            {{- "}" }}
+        {%- endif %}
+        {%- if builtin_tools is defined %}
+            {#- This means we're in ipython mode #}
+            {{- "<|eom_id|>" }}
+        {%- else %}
+            {{- "<|eot_id|>" }}
+        {%- endif %}
+    {%- elif message.role == "tool" or message.role == "ipython" %}
+        {{- "<|start_header_id|>ipython<|end_header_id|>\n\n" }}
+        {%- if message.content is mapping or message.content is iterable %}
+            {{- message.content | tojson }}
+        {%- else %}
+            {{- message.content }}
+        {%- endif %}
+        {{- "<|eot_id|>" }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|start_header_id|>assistant<|end_header_id|>\n\n' }}
+{%- endif %}

--- a/crates/kiln-core/test_fixtures/qwen25_7b_instruct_chat_template.jinja
+++ b/crates/kiln-core/test_fixtures/qwen25_7b_instruct_chat_template.jinja
@@ -1,0 +1,54 @@
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- messages[0]['content'] }}
+    {%- else %}
+        {{- 'You are Qwen, created by Alibaba Cloud. You are a helpful assistant.' }}
+    {%- endif %}
+    {{- "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0]['content'] + '<|im_end|>\n' }}
+    {%- else %}
+        {{- '<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- for message in messages %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) or (message.role == "assistant" and not message.tool_calls) %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role }}
+        {%- if message.content %}
+            {{- '\n' + message.content }}
+        {%- endif %}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- '\n<tool_call>\n{"name": "' }}
+            {{- tool_call.name }}
+            {{- '", "arguments": ' }}
+            {{- tool_call.arguments | tojson }}
+            {{- '}\n</tool_call>' }}
+        {%- endfor %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if (loop.index0 == 0) or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- message.content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}


### PR DESCRIPTION
## Summary

Closes #657.

Extends the per-template render-test pattern from PR #653 to two additional high-traffic HF model families. PR #653 vendored the real Qwen3.5-4B \`chat_template.jinja\` as a regression fixture after a 1-month window where every tools-bearing chat-completion 4xx'd because the unit tests in PR #632 used a hand-written minimal template that never exercised \`tojson\` or \`|items\` on \`tool_calls.arguments\`. This change generalizes that protection so the next chat-template change does not have to wait for production traffic to discover its bugs.

## Templates vendored

| Fixture | Source | Distinctive shape |
| --- | --- | --- |
| \`crates/kiln-core/test_fixtures/llama31_8b_instruct_chat_template.jinja\` | [unsloth/Llama-3.1-8B-Instruct](https://huggingface.co/unsloth/Llama-3.1-8B-Instruct/raw/main/chat_template.jinja) (byte-identical to the meta-llama gated mirror) | \`<\|start_header_id\|>\` / \`<\|eot_id\|>\` framing, single-tool-call assertion, \`{\"name\":..., \"parameters\":...}\` wire form via \`tojson\`, \`ipython\`-role tool responses |
| \`crates/kiln-core/test_fixtures/qwen25_7b_instruct_chat_template.jinja\` | [Qwen/Qwen2.5-7B-Instruct](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/raw/main/tokenizer_config.json) (\`chat_template\` field) | \`<tool_call>{\"name\":..., \"arguments\":...}</tool_call>\` JSON inline, \`<tool_response>\` wrapper — distinct from Qwen3.5-4B's pi-XML \`<function=...><parameter=...>\` shape |

Each fixture is copied verbatim from HF (the Qwen2.5 template was extracted from \`tokenizer_config.json\` with \`jq -r '.chat_template'\`).

## Tests added

Two new tests in \`crates/kiln-core/src/tokenizer.rs\`, each mirroring the PR #653 pattern:

- \`test_llama31_8b_instruct_chat_template_renders_tools_and_tool_calls\`
- \`test_qwen25_7b_instruct_chat_template_renders_tools_and_tool_calls\`

Each builds a stress conversation (system + tools + multi-turn user/assistant-with-tool_call/tool/user), renders via \`apply_chat_template_with_tools\`, and asserts that:

1. The render does not throw.
2. Tools serialize via \`tojson\` into the rendered prompt (proves \`minijinja\`'s \`json\` feature is wired).
3. Past assistant tool_call surfaces in the template's wire form (Llama: \`{\"name\":...,\"parameters\":...}\`; Qwen2.5: \`<tool_call>{\"name\":...,\"arguments\":...}</tool_call>\`).
4. Argument keys/values round-trip (proves \`arguments\` was a dict at render time, not a JSON-encoded string — same regression class as #653).
5. Tool response framing appears (Llama \`ipython\` header, Qwen2.5 \`<tool_response>\`).

## Mistral deliberately deferred

Mistral v0.3's \`[INST]\` / \`[/INST]\` tools-bearing chat template is more complex than #657's prose suggests and would meaningfully expand scope. Two fixtures (Llama 3.1 + Qwen2.5) is enough to satisfy the \"at least two additional HF chat templates\" acceptance criterion in #657. Mistral can land as a follow-up PR if anyone asks.

## Validation

\`\`\`
cargo test -p kiln-core
test result: ok. 42 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
\`\`\`

Both new tests pass on the first run. No behavior change to \`kiln-core\` source — fixture + test additions only. \`kiln-core\` has no candle/cudarc dependency, so this runs on the existing Linux + macOS CI matrix without any infrastructure change (per #657 acceptance criterion).

## Related

- #657 — issue this closes
- #653 — the proven pattern (Qwen3.5-4B fixture + render test)
- #632 — the original bug class this guards against