### PR TITLE
ci(chat-template): vendor Mistral v0.3 [INST] tools-bearing fixture with stress-render test (follow-up to #658)

### DIFF
--- a/crates/kiln-core/src/tokenizer.rs
+++ b/crates/kiln-core/src/tokenizer.rs
@@ -241,11 +241,27 @@ impl KilnTokenizer {
             })
             .collect();
 
+        // `bos_token` / `eos_token` are referenced by many HF chat templates
+        // — Mistral 7B Instruct v0.3, for example, embeds `eos_token` in
+        // `+` expressions like `" " + message["content"]|trim + eos_token`
+        // and `"]" + eos_token`. Minijinja's default Undefined behavior
+        // treats `string + undefined` as an error (only standalone
+        // `{{ undefined }}` renders empty), so leaving these out crashes
+        // any render that hits an assistant turn under Mistral. Default
+        // both to empty strings so the template renders structurally; the
+        // tokenizer's own `add_special_tokens=true` path handles real
+        // BOS/EOS injection during encode (template-emitted token strings
+        // would otherwise risk double-tokenization). Threading the actual
+        // model-specific token strings is a follow-up — when needed,
+        // populate from `KilnTokenizer::inner.get_added_tokens_decoder()`
+        // similar to `eos_token_ids`.
         tmpl.render(minijinja::context! {
             messages => messages_value,
             tools => tools_value,
             tool_choice => tool_choice_value,
             add_generation_prompt => true,
+            bos_token => "",
+            eos_token => "",
         })
         .map_err(|e| TokenizerError::ChatTemplate(e.to_string()))
     }
@@ -1025,6 +1041,204 @@ ARG:{{ k }}={{ v }};\
         assert!(
             prompt.contains("hosts"),
             "tool response content missing from prompt: {prompt:?}"
+        );
+    }
+
+    /// End-to-end render of Mistral 7B Instruct v0.3's official
+    /// `chat_template.jinja` against a tools-bearing multi-turn conversation.
+    /// Distinct from the Llama 3.1 / Qwen2.5 fixtures: Mistral uses
+    /// `[INST]` / `[/INST]` user framing with `[AVAILABLE_TOOLS]` /
+    /// `[/AVAILABLE_TOOLS]` for the tool list, `[TOOL_CALLS]` for assistant
+    /// tool-call shape (JSON list with `tool_call.function|tojson` then a
+    /// post-fixed `"id": "..."` field), and `[TOOL_RESULTS]` /
+    /// `[/TOOL_RESULTS]` for tool responses. The template enforces a strict
+    /// 9-character tool_call.id constraint and inlines the system message
+    /// into the LAST user `[INST]` block (rather than emitting a separate
+    /// system turn). Closes the Mistral coverage gap deferred from #658.
+    #[test]
+    fn test_mistral_7b_instruct_v03_chat_template_renders_tools_and_tool_calls() {
+        let template = include_str!(
+            "../test_fixtures/mistral_7b_instruct_v03_chat_template.jinja"
+        );
+        let tok = tokenizer_with_template(template);
+
+        let tools = vec![
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "Bash",
+                    "description": "Run a shell command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "Command to run"}
+                        },
+                        "required": ["command"]
+                    }
+                }
+            }),
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "Read",
+                    "description": "Read a file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"}
+                        },
+                        "required": ["path"]
+                    }
+                }
+            }),
+        ];
+
+        // Mistral's template enforces strict user/assistant alternation
+        // across all NON-tool / NON-tool_calls messages (tool messages and
+        // assistant-with-tool_calls turns are invisible to the alternation
+        // counter). We need a final user turn so the system message inlines
+        // into a `[INST]` block via `loop.last and system_message is defined`.
+        // Tool call IDs must be exactly 9 alphanumeric characters or the
+        // template raises.
+        let messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You are a coding agent.".to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Show me what's in /etc.".to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "".to_string(),
+                tool_calls: Some(vec![serde_json::json!({
+                    "id": "call12345",
+                    "type": "function",
+                    "function": {
+                        "name": "Bash",
+                        "arguments": r#"{"command": "ls /etc"}"#
+                    }
+                })]),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: "hosts resolv.conf".to_string(),
+                name: Some("Bash".to_string()),
+                tool_call_id: Some("call12345".to_string()),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "Found two files.".to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Now read /etc/hosts.".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let prompt = tok
+            .apply_chat_template_with_tools(&messages, Some(&tools))
+            .expect("Mistral v0.3 chat template rendered without error");
+
+        // Mistral's distinctive `[INST]` / `[/INST]` user framing must appear.
+        assert!(
+            prompt.contains("[INST] "),
+            "Mistral [INST] user framing missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("[/INST]"),
+            "Mistral [/INST] closing missing: {prompt:?}"
+        );
+
+        // System message inlines into the LAST user `[INST]` block (Mistral
+        // does not emit a separate system turn). Proves the
+        // `loop.last and system_message is defined` branch fires.
+        assert!(
+            prompt.contains("You are a coding agent."),
+            "Mistral system_message not inlined into final [INST]: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("Now read /etc/hosts."),
+            "Mistral final user content missing: {prompt:?}"
+        );
+
+        // Tools must be serialized via `[AVAILABLE_TOOLS]` framing on the
+        // LAST user message — proves the per-tool key/value walk and `tojson`
+        // both fired (parameters is a dict, not a string).
+        assert!(
+            prompt.contains("[AVAILABLE_TOOLS]"),
+            "Mistral [AVAILABLE_TOOLS] wrapper missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("[/AVAILABLE_TOOLS]"),
+            "Mistral [/AVAILABLE_TOOLS] closing missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"name\": \"Bash\""),
+            "Bash tool not serialized into prompt: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"name\": \"Read\""),
+            "Read tool not serialized into prompt: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"parameters\""),
+            "Mistral parameters key missing — `tojson` likely failed: {prompt:?}"
+        );
+
+        // Past assistant tool_call must render in Mistral's `[TOOL_CALLS]`
+        // JSON-list wire form. Argument keys/values must round-trip — proves
+        // `tool_call.function|tojson` saw `arguments` as a dict, not a
+        // JSON-encoded string (regression guard for kiln#632 / #653).
+        assert!(
+            prompt.contains("[TOOL_CALLS]"),
+            "Mistral [TOOL_CALLS] wrapper missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"command\""),
+            "tool_call argument key missing — `arguments` likely not deserialized to dict: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("ls /etc"),
+            "argument value missing from rendered tool_call: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"id\": \"call12345\""),
+            "Mistral tool_call.id not appended to JSON object: {prompt:?}"
+        );
+
+        // Tool response must be wrapped in `[TOOL_RESULTS]` framing with the
+        // matching `call_id` round-tripping the prior assistant tool_call.id.
+        assert!(
+            prompt.contains("[TOOL_RESULTS]"),
+            "Mistral [TOOL_RESULTS] wrapper missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("[/TOOL_RESULTS]"),
+            "Mistral [/TOOL_RESULTS] closing missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("\"call_id\": \"call12345\""),
+            "Mistral tool response call_id missing or mismatched: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("hosts"),
+            "tool response content missing from prompt: {prompt:?}"
+        );
+
+        // Inter-turn assistant text content (between tool result and final
+        // user) must round-trip — proves the plain assistant content branch
+        // (` content + eos_token`) is hit when `tool_calls` is absent.
+        assert!(
+            prompt.contains("Found two files."),
+            "Inter-turn assistant text content missing: {prompt:?}"
         );
     }
 

--- a/crates/kiln-core/test_fixtures/mistral_7b_instruct_v03_chat_template.jinja
+++ b/crates/kiln-core/test_fixtures/mistral_7b_instruct_v03_chat_template.jinja
@@ -1,0 +1,88 @@
+{%- if messages[0]["role"] == "system" %}
+    {%- set system_message = messages[0]["content"] %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+{%- if not tools is defined %}
+    {%- set tools = none %}
+{%- endif %}
+{%- set user_messages = loop_messages | selectattr("role", "equalto", "user") | list %}
+
+{#- This block checks for alternating user/assistant messages, skipping tool calling messages #}
+{%- set ns = namespace() %}
+{%- set ns.index = 0 %}
+{%- for message in loop_messages %}
+    {%- if not (message.role == "tool" or message.role == "tool_results" or (message.tool_calls is defined and message.tool_calls is not none)) %}
+        {%- if (message["role"] == "user") != (ns.index % 2 == 0) %}
+            {{- raise_exception("After the optional system message, conversation roles must alternate user/assistant/user/assistant/...") }}
+        {%- endif %}
+        {%- set ns.index = ns.index + 1 %}
+    {%- endif %}
+{%- endfor %}
+
+{{- bos_token }}
+{%- for message in loop_messages %}
+    {%- if message["role"] == "user" %}
+        {%- if tools is not none and (message == user_messages[-1]) %}
+            {{- "[AVAILABLE_TOOLS] [" }}
+            {%- for tool in tools %}
+                {%- set tool = tool.function %}
+                {{- '{"type": "function", "function": {' }}
+                {%- for key, val in tool.items() if key != "return" %}
+                    {%- if val is string %}
+                        {{- '"' + key + '": "' + val + '"' }}
+                    {%- else %}
+                        {{- '"' + key + '": ' + val|tojson }}
+                    {%- endif %}
+                    {%- if not loop.last %}
+                        {{- ", " }}
+                    {%- endif %}
+                {%- endfor %}
+                {{- "}}" }}
+                {%- if not loop.last %}
+                    {{- ", " }}
+                {%- else %}
+                    {{- "]" }}
+                {%- endif %}
+            {%- endfor %}
+            {{- "[/AVAILABLE_TOOLS]" }}
+            {%- endif %}
+        {%- if loop.last and system_message is defined %}
+            {{- "[INST] " + system_message + "\n\n" + message["content"] + "[/INST]" }}
+        {%- else %}
+            {{- "[INST] " + message["content"] + "[/INST]" }}
+        {%- endif %}
+    {%- elif message.tool_calls is defined and message.tool_calls is not none %}
+        {{- "[TOOL_CALLS] [" }}
+        {%- for tool_call in message.tool_calls %}
+            {%- set out = tool_call.function|tojson %}
+            {{- out[:-1] }}
+            {%- if not tool_call.id is defined or tool_call.id|length != 9 %}
+                {{- raise_exception("Tool call IDs should be alphanumeric strings with length 9!") }}
+            {%- endif %}
+            {{- ', "id": "' + tool_call.id + '"}' }}
+            {%- if not loop.last %}
+                {{- ", " }}
+            {%- else %}
+                {{- "]" + eos_token }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif message["role"] == "assistant" %}
+        {{- " " + message["content"]|trim + eos_token}}
+    {%- elif message["role"] == "tool_results" or message["role"] == "tool" %}
+        {%- if message.content is defined and message.content.content is defined %}
+            {%- set content = message.content.content %}
+        {%- else %}
+            {%- set content = message.content %}
+        {%- endif %}
+        {{- '[TOOL_RESULTS] {"content": ' + content|string + ", " }}
+        {%- if not message.tool_call_id is defined or message.tool_call_id|length != 9 %}
+            {{- raise_exception("Tool call IDs should be alphanumeric strings with length 9!") }}
+        {%- endif %}
+        {{- '"call_id": "' + message.tool_call_id + '"}[/TOOL_RESULTS]' }}
+    {%- else %}
+        {{- raise_exception("Only user and assistant roles are supported, with the exception of an initial optional system message!") }}
+    {%- endif %}
+{%- endfor %}
+


### PR DESCRIPTION
## Summary

Extends the per-template render-test pattern from PR #653 / PR #658 to Mistral 7B Instruct v0.3 — the third major HF chat-template family. PR #658 explicitly deferred Mistral as out-of-scope; this is the deferred follow-up.

## Vendored fixture

`crates/kiln-core/test_fixtures/mistral_7b_instruct_v03_chat_template.jinja` is byte-for-byte the `chat_template` field from [`mistralai/Mistral-7B-Instruct-v0.3/tokenizer_config.json`](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3/blob/main/tokenizer_config.json) (extracted with `jq -r '.chat_template'`).

Mistral's distinctive shape (different from Llama 3.1 / Qwen2.5):

| Element | Mistral v0.3 framing |
| --- | --- |
| User turn | `[INST] ... [/INST]` |
| Tool list | `[AVAILABLE_TOOLS] [...] [/AVAILABLE_TOOLS]` (per-tool key/value walk) |
| Assistant tool_call | `[TOOL_CALLS] [{...}]` (`tool_call.function\|tojson`, then post-fixed `\"id\": \"...\"`) |
| Tool response | `[TOOL_RESULTS] {...} [/TOOL_RESULTS]` |
| System message | Inlined into the LAST user `[INST]` block (no separate system turn) |
| ID constraint | `tool_call.id` and `tool_call_id` MUST be exactly 9 alphanumeric characters (template raises otherwise) |
| Alternation | Strict user/assistant alternation across all NON-tool / NON-tool_calls messages |

## Render test

`test_mistral_7b_instruct_v03_chat_template_renders_tools_and_tool_calls` in `crates/kiln-core/src/tokenizer.rs` mirrors the Llama 3.1 / Qwen2.5 tests: a stress conversation with system + tools + multi-turn user/assistant + tool_call + tool_result + assistant text + final user. Assertions cover every Mistral-specific framing token verified against the vendored template (no guessed strings).

## Mistral compat fix (`bos_token` / `eos_token` defaults)

The render test surfaced a real Mistral compat gap in `render_jinja_template`: many HF chat templates — Mistral v0.3 included — embed `eos_token` in `+` expressions like `" " + message[\"content\"]|trim + eos_token` and `"]" + eos_token`. Minijinja's default Undefined behavior treats `string + undefined` as an error (only standalone `{{ undefined }}` renders empty), so any render that hit a Mistral assistant turn previously crashed with `tried to use + operator on unsupported types string and undefined`.

Default both tokens to empty strings in the minijinja context so the template renders structurally. The tokenizer's own `add_special_tokens` path handles real BOS/EOS injection during encode, so empty-string defaults avoid double-tokenization risk. Threading the actual model-specific token strings (from `KilnTokenizer::inner.get_added_tokens_decoder()`) is a follow-up for templates that need them in stop sequences — not required for prompt rendering correctness.

## Validation

```
cargo test -p kiln-core
test result: ok. 43 passed; 0 failed; 3 ignored; 0 measured
```

(was 42 passing before this PR; +1 new Mistral render test)

## Related

- #658 — the PR this follows up on (explicitly deferred Mistral)
- #653 — the proven per-template render-test pattern (Qwen3.5-4B fixture)
- #632 — the original tools-bearing render bug class this guards against

🤖 Generated with [Claude Code](https://claude.com/claude-code)