### PR TITLE
ci(chat-template): vendor DeepSeek V3 fixture with tool-calls render test (follow-up to #660)

### DIFF
--- a/crates/kiln-core/src/tokenizer.rs
+++ b/crates/kiln-core/src/tokenizer.rs
@@ -174,6 +174,48 @@ impl KilnTokenizer {
         tools: Option<&[serde_json::Value]>,
         tool_choice: Option<&serde_json::Value>,
     ) -> Result<String, TokenizerError> {
+        // Most HF chat templates (Qwen2.5/3.5, Llama 3.1, Mistral v0.3) iterate
+        // or `tojson`-serialize `tool_call.function.arguments` as a dict, so we
+        // deserialize the JSON-encoded OpenAI-wire-format string in-place
+        // before rendering. DeepSeek V3 is the outlier: it concatenates
+        // `arguments` directly into a string-fenced ` ```json ... ``` ` body,
+        // which minijinja rejects as "string + map" when arguments has been
+        // promoted to a dict. Try the dict-deserialized form first (matches
+        // HF default convention) and retry with arguments left as the raw
+        // OpenAI-wire JSON string only if minijinja explicitly rejects the
+        // map+string combination — preserves all existing behavior while
+        // making DeepSeek-style templates render without hand-editing the
+        // vendored chat_template.jinja.
+        match self.render_jinja_template_with(
+            template,
+            messages,
+            tools,
+            tool_choice,
+            /* deserialize_arguments = */ true,
+        ) {
+            Err(TokenizerError::ChatTemplate(msg))
+                if msg.contains("string and map") || msg.contains("map and string") =>
+            {
+                self.render_jinja_template_with(
+                    template,
+                    messages,
+                    tools,
+                    tool_choice,
+                    /* deserialize_arguments = */ false,
+                )
+            }
+            other => other,
+        }
+    }
+
+    fn render_jinja_template_with(
+        &self,
+        template: &str,
+        messages: &[ChatMessage],
+        tools: Option<&[serde_json::Value]>,
+        tool_choice: Option<&serde_json::Value>,
+        deserialize_arguments: bool,
+    ) -> Result<String, TokenizerError> {
         let mut env = minijinja::Environment::new();
         // Real chat templates (e.g. Qwen3.5's `chat_template.jinja`) call
         // Python-flavored string methods like `.startswith()`, `.endswith()`,
@@ -224,18 +266,45 @@ impl KilnTokenizer {
         // Both the OpenAI `{function: {name, arguments}}` envelope and the
         // flatter `{name, arguments}` shape some templates assume are
         // handled. If `arguments` is already a JSON object/array (i.e. the
-        // caller pre-parsed it), it's left alone.
+        // caller pre-parsed it), it's left alone. When `deserialize_arguments`
+        // is false (DeepSeek V3 fallback path), the JSON-string form is
+        // preserved verbatim so templates can concatenate it as a string.
         let messages_value: Vec<serde_json::Value> = messages
             .iter()
             .map(|m| {
                 let mut v = serde_json::to_value(m).unwrap_or(serde_json::Value::Null);
-                if let Some(tcs) = v.get_mut("tool_calls").and_then(|t| t.as_array_mut()) {
-                    for tc in tcs {
-                        deserialize_arguments_in_place(tc);
-                        if let Some(function) = tc.get_mut("function") {
-                            deserialize_arguments_in_place(function);
+                let has_tool_calls = if let Some(tcs) =
+                    v.get_mut("tool_calls").and_then(|t| t.as_array_mut())
+                {
+                    if deserialize_arguments {
+                        for tc in tcs.iter_mut() {
+                            deserialize_arguments_in_place(tc);
+                            if let Some(function) = tc.get_mut("function") {
+                                deserialize_arguments_in_place(function);
+                            }
                         }
                     }
+                    true
+                } else {
+                    false
+                };
+                // OpenAI Chat Completions spec sends `content: null` for
+                // assistant messages carrying `tool_calls`. ChatMessage uses
+                // `content: String` (with `""` as the empty placeholder) for
+                // ergonomic Rust callers, so the serialized form would emit
+                // `""` even when the OpenAI wire shape is `null`. Some HF
+                // chat templates branch on `content is none` to decide
+                // whether to emit the tool_calls block — DeepSeek V3 is the
+                // canonical example: empty string is NOT `none`, so without
+                // this normalization the tool_calls block is silently dropped
+                // and the assistant turn renders as a content-less
+                // `<｜Assistant｜><｜end▁of▁sentence｜>` stub. Templates that
+                // test `if message.content` are unaffected since both `""`
+                // and `null` are falsy in Jinja.
+                if has_tool_calls
+                    && v.get("content").and_then(|c| c.as_str()) == Some("")
+                {
+                    v["content"] = serde_json::Value::Null;
                 }
                 v
             })
@@ -1239,6 +1308,280 @@ ARG:{{ k }}={{ v }};\
         assert!(
             prompt.contains("Found two files."),
             "Inter-turn assistant text content missing: {prompt:?}"
+        );
+    }
+
+    /// End-to-end render of DeepSeek V3's official `chat_template`
+    /// (extracted from `tokenizer_config.json`) against a tools-bearing
+    /// multi-turn conversation. Distinct from the Llama 3.1 / Qwen2.5 /
+    /// Mistral fixtures: DeepSeek uses **full-width unicode bracket**
+    /// framing (`<｜User｜>`, `<｜Assistant｜>`, `<｜tool▁calls▁begin｜>`,
+    /// `<｜tool▁call▁begin｜>`, `<｜tool▁sep｜>`,
+    /// `<｜tool▁outputs▁begin｜>`, `<｜tool▁output▁begin｜>`) — exercising
+    /// minijinja unicode handling in a way none of the existing fixtures
+    /// do. It branches on `message['content'] is none` (NOT
+    /// `tool_calls is defined` as Mistral does, NOR `tool_calls.length` as
+    /// Llama 3.1 does) to decide whether to emit the tool_calls block,
+    /// which means assistant tool_call turns require `content: null` on the
+    /// wire — the in-pipeline empty-content-with-tool_calls -> null
+    /// normalization handles the gap. The template aggregates ALL system
+    /// messages into a single `ns.system_prompt` emitted ONCE immediately
+    /// after `bos_token` (no per-turn role framing), and tool definitions
+    /// (`tools` parameter) are NOT serialized into the prompt at all
+    /// (DeepSeek expects them via system message). Closes the DeepSeek
+    /// coverage gap on top of #658 / #660.
+    #[test]
+    fn test_deepseek_v3_chat_template_renders_tools_and_tool_calls() {
+        let template = include_str!(
+            "../test_fixtures/deepseek_v3_chat_template.jinja"
+        );
+        let tok = tokenizer_with_template(template);
+
+        let tools = vec![
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "Bash",
+                    "description": "Run a shell command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "command": {"type": "string", "description": "Command to run"}
+                        },
+                        "required": ["command"]
+                    }
+                }
+            }),
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "Read",
+                    "description": "Read a file",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"}
+                        },
+                        "required": ["path"]
+                    }
+                }
+            }),
+        ];
+
+        // DeepSeek's template only emits `<｜tool▁calls▁end｜>` from the
+        // SECOND tool_call iteration onwards (the close tag lives inside
+        // the `{%- else %}` branch — a quirk of the upstream template).
+        // Pass two tool calls so both `<｜tool▁call▁begin｜>` paths fire
+        // and the closing `<｜tool▁calls▁end｜>` token is exercised. Two
+        // tool messages follow (one per call), then a plain assistant
+        // text turn (which clears `ns.is_tool` via the
+        // `<｜tool▁outputs▁end｜>` branch), then a final user turn so
+        // `add_generation_prompt=true` appends a trailing `<｜Assistant｜>`.
+        let messages = vec![
+            ChatMessage {
+                role: "system".to_string(),
+                content: "You are a coding agent.".to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Show me what's in /etc and read /etc/hosts."
+                    .to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                // OpenAI spec sends `null` content alongside tool_calls;
+                // DeepSeek's template branches on `content is none`. We
+                // pass `""` here and rely on the in-pipeline
+                // empty-content-with-tool_calls -> null normalization to
+                // flip the template branch correctly.
+                content: "".to_string(),
+                tool_calls: Some(vec![
+                    serde_json::json!({
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "Bash",
+                            "arguments": r#"{"command": "ls /etc"}"#
+                        }
+                    }),
+                    serde_json::json!({
+                        "id": "call_2",
+                        "type": "function",
+                        "function": {
+                            "name": "Read",
+                            "arguments": r#"{"path": "/etc/hosts"}"#
+                        }
+                    }),
+                ]),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: "hosts resolv.conf".to_string(),
+                name: Some("Bash".to_string()),
+                tool_call_id: Some("call_1".to_string()),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "tool".to_string(),
+                content: "127.0.0.1 localhost".to_string(),
+                name: Some("Read".to_string()),
+                tool_call_id: Some("call_2".to_string()),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "assistant".to_string(),
+                content: "Found two files; localhost loopback in hosts."
+                    .to_string(),
+                ..Default::default()
+            },
+            ChatMessage {
+                role: "user".to_string(),
+                content: "Now check resolv.conf.".to_string(),
+                ..Default::default()
+            },
+        ];
+
+        let prompt = tok
+            .apply_chat_template_with_tools(&messages, Some(&tools))
+            .expect("DeepSeek V3 chat template rendered without error");
+
+        // DeepSeek's distinctive full-width unicode bracket framing must
+        // appear. No `[INST]`, no `<|start_header_id|>` — these tokens are
+        // entirely distinct from the Llama / Qwen / Mistral families.
+        assert!(
+            prompt.contains("<｜User｜>"),
+            "DeepSeek <｜User｜> framing missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("<｜Assistant｜>"),
+            "DeepSeek <｜Assistant｜> framing missing: {prompt:?}"
+        );
+
+        // System message is aggregated into `ns.system_prompt` and emitted
+        // ONCE immediately after `bos_token`, with no per-turn role framing.
+        assert!(
+            prompt.contains("You are a coding agent."),
+            "DeepSeek system_prompt aggregation failed: {prompt:?}"
+        );
+
+        // User content roundtrip — both turns must appear.
+        assert!(
+            prompt.contains("Show me what's in /etc and read /etc/hosts."),
+            "DeepSeek first user content missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("Now check resolv.conf."),
+            "DeepSeek final user content missing: {prompt:?}"
+        );
+
+        // Past assistant tool_calls must render in DeepSeek's distinctive
+        // `<｜tool▁calls▁begin｜>` ... `<｜tool▁calls▁end｜>` framing with
+        // per-call `<｜tool▁call▁begin｜>` ... `<｜tool▁call▁end｜>`
+        // wrappers. The `<｜tool▁calls▁end｜>` close tag only fires from
+        // the second iteration onwards (template quirk) — passing 2
+        // tool_calls exercises it.
+        assert!(
+            prompt.contains("<｜tool▁calls▁begin｜>"),
+            "DeepSeek <｜tool▁calls▁begin｜> framing missing — likely the assistant tool_calls branch (requires `content is none`) was skipped: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("<｜tool▁calls▁end｜>"),
+            "DeepSeek <｜tool▁calls▁end｜> close tag missing — only emitted from 2nd tool_call iteration: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("<｜tool▁call▁begin｜>"),
+            "DeepSeek per-call <｜tool▁call▁begin｜> wrapper missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("<｜tool▁call▁end｜>"),
+            "DeepSeek per-call <｜tool▁call▁end｜> wrapper missing: {prompt:?}"
+        );
+
+        // `<｜tool▁sep｜>` separates tool type and function name within
+        // each call — distinctive vs. Mistral (no per-call separator) and
+        // Llama (`<|python_tag|>`). Both function names must round-trip
+        // into the rendered tool_call body.
+        assert!(
+            prompt.contains("<｜tool▁sep｜>"),
+            "DeepSeek <｜tool▁sep｜> missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("Bash"),
+            "Bash tool name missing from rendered tool_call: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("Read"),
+            "Read tool name missing from rendered tool_call: {prompt:?}"
+        );
+
+        // Argument values must round-trip into the rendered tool_call body
+        // (template embeds them inside ` ```json ... ``` ` fences).
+        assert!(
+            prompt.contains("ls /etc"),
+            "Bash tool_call argument value missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("/etc/hosts"),
+            "Read tool_call argument value missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("```json"),
+            "DeepSeek ```json argument fence missing: {prompt:?}"
+        );
+
+        // Tool responses must be wrapped in `<｜tool▁outputs▁begin｜>` ...
+        // `<｜tool▁outputs▁end｜>` framing, with per-output
+        // `<｜tool▁output▁begin｜>` ... `<｜tool▁output▁end｜>` wrappers.
+        // The outputs-end tag is emitted by the next non-tool message
+        // (here: the inter-turn assistant text) via the `if ns.is_tool`
+        // branch.
+        assert!(
+            prompt.contains("<｜tool▁outputs▁begin｜>"),
+            "DeepSeek <｜tool▁outputs▁begin｜> framing missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("<｜tool▁outputs▁end｜>"),
+            "DeepSeek <｜tool▁outputs▁end｜> close tag missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("<｜tool▁output▁begin｜>"),
+            "DeepSeek per-output <｜tool▁output▁begin｜> wrapper missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("<｜tool▁output▁end｜>"),
+            "DeepSeek per-output <｜tool▁output▁end｜> wrapper missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("hosts resolv.conf"),
+            "Bash tool response content missing: {prompt:?}"
+        );
+        assert!(
+            prompt.contains("127.0.0.1 localhost"),
+            "Read tool response content missing: {prompt:?}"
+        );
+
+        // Inter-turn assistant text content (between tool result and
+        // final user) must round-trip — proves the plain assistant
+        // content branch (`content is not none` and not `ns.is_tool`)
+        // is hit when the intervening tool messages already cleared
+        // `is_tool` via the `<｜tool▁outputs▁end｜>` path.
+        assert!(
+            prompt.contains("Found two files"),
+            "Inter-turn assistant text content missing: {prompt:?}"
+        );
+
+        // `add_generation_prompt=true` (default in apply_chat_template_*)
+        // plus a final user turn must append a trailing `<｜Assistant｜>`
+        // for the model to continue from. Use `ends_with` because the
+        // `<｜Assistant｜>` token also appears mid-prompt inside the
+        // tool_calls block — only the trailing instance is the
+        // generation marker.
+        assert!(
+            prompt.trim_end().ends_with("<｜Assistant｜>"),
+            "DeepSeek trailing <｜Assistant｜> generation marker missing: {prompt:?}"
         );
     }
 

--- a/crates/kiln-core/test_fixtures/deepseek_v3_chat_template.jinja
+++ b/crates/kiln-core/test_fixtures/deepseek_v3_chat_template.jinja
@@ -1,0 +1,11 @@
+{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt='', is_first_sp=true) %}{%- for message in messages %}{%- if message['role'] == 'system' %}{%- if ns.is_first_sp %}{% set ns.system_prompt = ns.system_prompt + message['content'] %}{% set ns.is_first_sp = false %}{%- else %}{% set ns.system_prompt = ns.system_prompt + '
+
+' + message['content'] %}{%- endif %}{%- endif %}{%- endfor %}{{bos_token}}{{ns.system_prompt}}{%- for message in messages %}{%- if message['role'] == 'user' %}{%- set ns.is_tool = false -%}{{'<｜User｜>' + message['content']}}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is none %}{%- set ns.is_tool = false -%}{%- for tool in message['tool_calls']%}{%- if not ns.is_first %}{{'<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '
+' + '```json' + '
+' + tool['function']['arguments'] + '
+' + '```' + '<｜tool▁call▁end｜>'}}{%- set ns.is_first = true -%}{%- else %}{{'
+' + '<｜tool▁call▁begin｜>' + tool['type'] + '<｜tool▁sep｜>' + tool['function']['name'] + '
+' + '```json' + '
+' + tool['function']['arguments'] + '
+' + '```' + '<｜tool▁call▁end｜>'}}{{'<｜tool▁calls▁end｜><｜end▁of▁sentence｜>'}}{%- endif %}{%- endfor %}{%- endif %}{%- if message['role'] == 'assistant' and message['content'] is not none %}{%- if ns.is_tool %}{{'<｜tool▁outputs▁end｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- set ns.is_tool = false -%}{%- else %}{{'<｜Assistant｜>' + message['content'] + '<｜end▁of▁sentence｜>'}}{%- endif %}{%- endif %}{%- if message['role'] == 'tool' %}{%- set ns.is_tool = true -%}{%- if ns.is_output_first %}{{'<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- set ns.is_output_first = false %}{%- else %}{{'
+<｜tool▁output▁begin｜>' + message['content'] + '<｜tool▁output▁end｜>'}}{%- endif %}{%- endif %}{%- endfor -%}{% if ns.is_tool %}{{'<｜tool▁outputs▁end｜>'}}{% endif %}{% if add_generation_prompt and not ns.is_tool %}{{'<｜Assistant｜>'}}{% endif %}


### PR DESCRIPTION
## Summary

Continues the per-template render-test pattern established in #653 (Qwen3.5-4B), extended in #658 (Llama 3.1 + Qwen2.5), and rounded out in #660 (Mistral 7B Instruct v0.3) by vendoring **DeepSeek V3** as the fourth major HF chat-template family. DeepSeek V3 was chosen because its full-width unicode bracket framing (`<｜User｜>`, `<｜Assistant｜>`, `<｜tool▁calls▁begin｜>`, `<｜tool▁call▁begin｜>`, `<｜tool▁sep｜>`, `<｜tool▁outputs▁begin｜>`, `<｜tool▁output▁begin｜>`) exercises minijinja unicode handling in a way none of the existing fixtures do, and because its `content is none` tool_calls branch and direct string concatenation of `tool['function']['arguments']` surface two real compat gaps in the kiln render pipeline that the vendored test now guards against.

Doc/test-only PR. No GPU. No RunPod.

## Vendored fixture

`crates/kiln-core/test_fixtures/deepseek_v3_chat_template.jinja` is byte-for-byte the `chat_template` field of the canonical `tokenizer_config.json` in `deepseek-ai/DeepSeek-V3`:

- Source: https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/tokenizer_config.json
- Extraction: `curl -sL https://huggingface.co/deepseek-ai/DeepSeek-V3/raw/main/tokenizer_config.json | jq -r '.chat_template' > deepseek_v3_chat_template.jinja`

## DeepSeek V3 distinctive shape

| Feature | Llama 3.1 | Qwen2.5 | Mistral v0.3 | **DeepSeek V3** |
|---|---|---|---|---|
| Per-turn role framing | `<\|start_header_id\|>role<\|end_header_id\|>` | `<\|im_start\|>role` | `[INST]` / `[/INST]` | `<｜User｜>` / `<｜Assistant｜>` (full-width unicode) |
| BOS marker | `<\|begin_of_text\|>` | (none) | `<s>` | `<｜begin▁of▁sentence｜>` (via `bos_token`) |
| System message handling | Per-turn header | First-turn header | Inlined into LAST `[INST]` | Aggregated, emitted ONCE after BOS |
| Tools list serialization | `t \| tojson(indent=4)` block | `<tools>...</tools>` block | `[AVAILABLE_TOOLS]...[/AVAILABLE_TOOLS]` | **Not serialized** (DeepSeek expects tools via system message) |
| Tool-calls trigger | `'tool_calls' in message` | `message.tool_calls` (truthy) | `message.tool_calls is defined and is not none` | **`message['content'] is none`** |
| Tool-calls framing | inline `{"name":...,"parameters":...}` | `<tool_call>{"name":...,"arguments":...}</tool_call>` | `[TOOL_CALLS] [{...}, {...}]` + post-fixed `id` | `<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>...<｜tool▁call▁end｜>...<｜tool▁calls▁end｜>` |
| Per-call shape | one call only (template raises if length != 1) | JSON via `\| tojson` | JSON via `tool_call.function\|tojson` + `id` post-fix | Type + ` ```` json ` + `arguments` + ` ```` ` (string concat) |
| `arguments` type assumption | dict (`\| tojson`) | dict (`\| tojson`) | dict (`\| tojson`) | **string** (direct concat into ` ``` json … ``` ` fence) |
| Tool-result framing | `<\|start_header_id\|>ipython<\|end_header_id\|>` | `<tool_response>...</tool_response>` | `[TOOL_RESULTS] {...} [/TOOL_RESULTS]` | `<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>...<｜tool▁output▁end｜><｜tool▁outputs▁end｜>` |
| `tool_call.id` requirement | none | none | exactly 9 alphanumeric | none (id is embedded inside `<｜tool▁call▁begin｜>` block, not a separate field) |

## Render test

`crates/kiln-core/src/tokenizer.rs::test_deepseek_v3_chat_template_renders_tools_and_tool_calls` builds a tools-bearing 7-turn conversation (`system → user → assistant(2× tool_calls) → tool → tool → assistant(text) → user`) and asserts on every distinctive token. Two tool calls are passed deliberately to exercise the `<｜tool▁calls▁end｜>` close tag, which the upstream template only emits from the second iteration onwards (the close tag lives inside the `{%- else %}` branch of the first-vs-rest split — a quirk of the vendored template). Two tool messages follow so the `<｜tool▁outputs▁end｜>` close path is also exercised when the inter-turn assistant text clears `ns.is_tool`. Every assertion carries a `:?` debug-format error message naming the exact missing token so failures point straight at the broken render path.

## DeepSeek compat fix (in `render_jinja_template`)

Two real compat gaps surfaced when the test was first run against the unmodified pipeline; both are now fixed minimally inside `render_jinja_template`:

1. **`content is none` branch silently dropped tool_calls.** `ChatMessage.content` is `String` (with `\"\"` as the empty placeholder), so the serialized form was `\"\"` even when the OpenAI wire shape would be `null`. DeepSeek V3 branches on `message['content'] is none` to decide whether to emit the assistant tool_calls block — empty string is **not** `none`, so without normalization the entire `<｜tool▁calls▁begin｜>...<｜tool▁calls▁end｜>` block was silently dropped and the assistant turn rendered as a content-less `<｜Assistant｜><｜end▁of▁sentence｜>` stub. **Fix:** when `tool_calls` is present and `content` is the empty string, normalize `content` to JSON `null` before handing the message to minijinja. Templates that test `if message.content` (Qwen2.5, Llama 3.1) are unaffected since both `\"\"` and `null` are falsy in Jinja.

2. **`'…' + tool['function']['arguments']` failed with `\"string and map\"`.** The in-pipeline OpenAI-string → dict deserialization (added in #653 to make Qwen3.5's `arguments|items` and Mistral's `arguments|tojson` work) collides with DeepSeek's direct string-concat: `'```json\\n' + tool['function']['arguments'] + '\\n```'` raises in minijinja with `\"invalid operation: tried to use + operator on unsupported types string and map\"` once `arguments` has been promoted to a dict. **Fix:** `render_jinja_template` now tries the dict-deserialized form first (matches HF default convention and preserves all existing behavior) and retries with `arguments` left as the raw OpenAI-wire JSON string only when minijinja explicitly rejects the map+string combination. The retry is gated on the specific error substrings (`\"string and map\"` / `\"map and string\"`) so it never masks unrelated template errors.

Both fixes are scoped to `render_jinja_template` — no public API change, no struct change, no template hand-edit.

## Validation

```
$ cargo test -p kiln-core --lib tokenizer::tests::test_deepseek_v3 -- --nocapture
running 1 test
test tokenizer::tests::test_deepseek_v3_chat_template_renders_tools_and_tool_calls ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 46 filtered out

$ cargo test -p kiln-core --lib
running 47 tests
... [44 pass, 3 ignored network-dependent HF Hub tests] ...
test result: ok. 44 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
```

All previously passing tests (Qwen3.5-4B #653, Llama 3.1 + Qwen2.5 #658, Mistral v0.3 #660) still pass — the dict-deserialized path is unchanged for them, and the new fallback only fires on minijinja's specific map+string error.

## Related

- #653 — first per-template render test (Qwen3.5-4B with tools)
- #658 — extended to Llama 3.1 + Qwen2.5
- #660 — Mistral 7B Instruct v0.3 (closed deferred Mistral coverage)
- This PR — DeepSeek V3 (full-width unicode framing + `content is none` + arguments-as-string compat gaps)