### PR TITLE
docs: workers=1 workaround for tools-bearing long prompts (refs #664, #656)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -265,6 +265,34 @@ Francisco.").
 > on Hugging Face. If a tool call format ever looks ambiguous, that file is
 > the source of truth.
 
+### 4.2 Known limitation: workers=1 for long tools-bearing prompts
+
+For tools-bearing chat completions with input prompts longer than roughly
+30k tokens, run your client with **at most one in-flight request at a
+time** (`workers=1`). This is a client-side workaround — there is no
+kiln-side flag to set; you control it by serializing requests in your
+driver, worker pool, or load generator.
+
+If you push two or more concurrent in-flight prefills under that workload,
+a single 300-second prefill timeout (the default
+`server.request_timeout_secs` in [`kiln.example.toml`](kiln.example.toml))
+can leave kiln in a degraded prefill state. Subsequent requests then fail
+with HTTP 500:
+
+```
+{"error":{"code":"generation_error","message":"Text generation failed: prefill forward pass (paged) failed: ..."}}
+```
+
+…until the server is restarted. With `workers=1` there is no concurrent
+prefill, no degraded state, and the failure mode does not occur.
+
+The cascade and its symptoms are tracked in
+[issue #664](https://github.com/ericflo/kiln/issues/664); the underlying
+KV-cache-exhaustion / prefill-state-cleanup investigation is in
+[issue #656](https://github.com/ericflo/kiln/issues/656). This workaround
+is expected to be removed once the prefill-watchdog and timeout-cleanup
+fixes from #664 land.
+
 ## 5. Open the Browser Dashboard
 
 Kiln ships with an embedded web dashboard. Open [http://localhost:8420/ui](http://localhost:8420/ui) in any browser:

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ curl http://localhost:8420/v1/train/sft \
 curl http://localhost:8420/v1/train/status
 ```
 
-See [QUICKSTART.md](QUICKSTART.md) for the full walkthrough including GRPO, adapter management, Docker, and systemd setup.
+See [QUICKSTART.md](QUICKSTART.md) for the full walkthrough including GRPO, adapter management, Docker, and systemd setup. For tools-bearing workloads with prompts longer than ~30k tokens, see [QUICKSTART.md §4.2](QUICKSTART.md#42-known-limitation-workers1-for-long-tools-bearing-prompts) for the `workers=1` known-limitation note ([#664](https://github.com/ericflo/kiln/issues/664)).
 
 ## Memory Budget (24GB GPU)
 


### PR DESCRIPTION
## What

Adds a 'Known limitation: workers=1' subsection to QUICKSTART.md §4.2 (right after the Tool / Function Calling section) and a one-line cross-reference in README.md, documenting the workers=1 workaround for tools-bearing chat completions with prompts >30k tokens.

## Why

#664 reports that workers=2 + tools + ~30-80k input tokens triggers a 5xx cascade after a single 300s prefill timeout: subsequent prefills return HTTP 500 ('generation_error: Text generation failed: prefill forward pass...') until the server is restarted. workers=1 resolves the cascade. Until the underlying timeout-cleanup / prefill-watchdog fixes from #664 land (related: #656 KV-cache investigation), users running tools-heavy long-context workloads need to know this workaround upfront.

The workaround is purely client-side — there is no kiln-side flag — so the doc explains it as "limit your client to at most one in-flight request" and points readers to the canonical 300s `server.request_timeout_secs` default in `kiln.example.toml` for context.

## Test plan

- [ ] Markdown renders correctly on github.com
- [ ] grep -n 'workers=1' QUICKSTART.md hits the new subsection
- [ ] grep -n '#664' QUICKSTART.md README.md hits both files
- [ ] No code changes, no CI risk