### PR TITLE
fix(server): cancel-drain spawn_blocking generation on prefill timeout (closes #664)

### DIFF
--- a/crates/kiln-model/src/cancel.rs
+++ b/crates/kiln-model/src/cancel.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+// `kiln-server` wraps blocking generation in `tokio::time::timeout`, but
+// `tokio::task::spawn_blocking` does not honor outer-future cancellation —
+// the inner closure keeps running on the blocking thread pool, holding any
+// locks it acquired (`runner.read()`, `prefix_cache.lock()`, ...). That
+// causes a cascade of 5xx on subsequent requests racing the still-held
+// state. The server signals this handle on timeout, the decode loop polls
+// `is_cancelled()` between tokens, and the closure returns early with an
+// error so the locks release cleanly.
+#[derive(Debug, Clone, Default)]
+pub struct CancelHandle {
+    flag: Arc<AtomicBool>,
+}
+
+impl CancelHandle {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        self.flag.store(true, Ordering::SeqCst);
+    }
+
+    pub fn is_cancelled(&self) -> bool {
+        self.flag.load(Ordering::SeqCst)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_starts_uncancelled() {
+        let h = CancelHandle::new();
+        assert!(!h.is_cancelled());
+    }
+
+    #[test]
+    fn cancel_sets_flag() {
+        let h = CancelHandle::new();
+        h.cancel();
+        assert!(h.is_cancelled());
+    }
+
+    #[test]
+    fn clones_share_state() {
+        let h = CancelHandle::new();
+        let h2 = h.clone();
+        h.cancel();
+        assert!(h2.is_cancelled());
+    }
+}

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -14,6 +14,7 @@ use kiln_core::token::TokenId;
 use kiln_core::tokenizer::KilnTokenizer;
 
 use crate::backend::{self, BackendRuntime};
+use crate::cancel::CancelHandle;
 use crate::cuda_graph::CudaGraphRunner;
 use crate::forward::{
     GpuWeights, LinearAttentionState, model_forward, model_forward_paged,
@@ -32,6 +33,21 @@ use crate::speculative::{
 };
 
 use kiln_core::block::{BlockManager, BlockTable};
+
+/// Returns `Err` with a stable error message if `cancel` has been signalled.
+///
+/// Decode loops poll this between tokens so that `kiln-server` can drain a
+/// `tokio::task::spawn_blocking` whose outer `tokio::time::timeout` already
+/// fired, instead of leaving it running with locks held (see #664).
+#[inline]
+fn check_cancelled(cancel: Option<&CancelHandle>) -> Result<()> {
+    if let Some(c) = cancel {
+        if c.is_cancelled() {
+            anyhow::bail!("generation cancelled by client (request timeout)");
+        }
+    }
+    Ok(())
+}
 
 /// Holds loaded model weights and tokenizer, provides text generation.
 pub struct ModelRunner {
@@ -692,8 +708,13 @@ impl ModelRunner {
             .map_err(|e| anyhow::anyhow!("{e}"))
             .context("failed to tokenize prompt")?;
 
-        let output =
-            self.generate_from_tokens_paged(&prompt_tokens, params, block_manager, paged_cache)?;
+        let output = self.generate_from_tokens_paged(
+            &prompt_tokens,
+            params,
+            block_manager,
+            paged_cache,
+            None,
+        )?;
 
         let text = self
             .tokenizer
@@ -717,6 +738,7 @@ impl ModelRunner {
         params: &SamplingParams,
         block_manager: &mut BlockManager,
         paged_cache: &mut PagedKvCache,
+        cancel: Option<&CancelHandle>,
     ) -> Result<GenerationOutput> {
         anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
 
@@ -735,8 +757,13 @@ impl ModelRunner {
         }
 
         // Run generation with paged cache; free blocks on completion (or error)
-        let result =
-            self.generate_from_tokens_paged_inner(prompt_tokens, params, paged_cache, &block_table);
+        let result = self.generate_from_tokens_paged_inner(
+            prompt_tokens,
+            params,
+            paged_cache,
+            &block_table,
+            cancel,
+        );
 
         // Always free allocated blocks
         block_manager.free_all(&allocated_blocks);
@@ -771,6 +798,7 @@ impl ModelRunner {
             params,
             block_manager,
             paged_cache,
+            None,
         )?;
 
         let text = self
@@ -796,6 +824,7 @@ impl ModelRunner {
         block_manager: &Mutex<BlockManager>,
         paged_cache: &Mutex<PagedKvCache>,
         cached_prefix: Option<PagedPrefixReuse>,
+        cancel: Option<&CancelHandle>,
     ) -> Result<PrefixCachedGenerationOutput> {
         let output = self.generate_from_tokens_paged_interleaved_with_prefix_cache(
             prompt_tokens,
@@ -803,6 +832,7 @@ impl ModelRunner {
             block_manager,
             paged_cache,
             cached_prefix,
+            cancel,
         )?;
 
         let text = self
@@ -824,18 +854,26 @@ impl ModelRunner {
 
     /// Same as [`generate_paged_shared`], but accepts an already-tokenized
     /// prompt so API callers do not render/tokenize the same prompt twice.
+    ///
+    /// The optional `cancel` handle is polled between decode tokens so that
+    /// callers (notably `kiln-server`'s `tokio::time::timeout` path) can drain
+    /// the still-running blocking work after a request timeout fires, instead
+    /// of leaving the closure running with `runner` / `prefix_cache` locks
+    /// held — see #664.
     pub fn generate_paged_shared_tokens(
         &self,
         prompt_tokens: &[TokenId],
         params: &SamplingParams,
         block_manager: &Mutex<BlockManager>,
         paged_cache: &Mutex<PagedKvCache>,
+        cancel: Option<&CancelHandle>,
     ) -> Result<GenerationOutput> {
         let output = self.generate_from_tokens_paged_shared(
             prompt_tokens,
             params,
             block_manager,
             paged_cache,
+            cancel,
         )?;
 
         let text = self
@@ -857,6 +895,7 @@ impl ModelRunner {
         params: &SamplingParams,
         block_manager: &Mutex<BlockManager>,
         paged_cache: &Mutex<PagedKvCache>,
+        cancel: Option<&CancelHandle>,
     ) -> Result<GenerationOutput> {
         anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
 
@@ -873,6 +912,7 @@ impl ModelRunner {
                 params,
                 &mut bm_guard,
                 &mut pc_guard,
+                cancel,
             );
         }
 
@@ -902,6 +942,7 @@ impl ModelRunner {
             params,
             paged_cache,
             &block_table,
+            cancel,
         );
 
         drop(reservation);
@@ -915,6 +956,7 @@ impl ModelRunner {
         block_manager: &Mutex<BlockManager>,
         paged_cache: &Mutex<PagedKvCache>,
         cached_prefix: Option<PagedPrefixReuse>,
+        cancel: Option<&CancelHandle>,
     ) -> Result<PrefixCachedGenerationOutput> {
         anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
 
@@ -953,6 +995,7 @@ impl ModelRunner {
             &block_table,
             cached_prefix,
             block_size,
+            cancel,
         );
 
         match result {
@@ -978,6 +1021,7 @@ impl ModelRunner {
         block_table: &BlockTable,
         cached_prefix: Option<PagedPrefixReuse>,
         block_size: usize,
+        cancel: Option<&CancelHandle>,
     ) -> Result<PrefixCachedGenerationOutput> {
         let cached_tokens = cached_prefix
             .as_ref()
@@ -1049,6 +1093,7 @@ impl ModelRunner {
                 paged_cache,
                 block_table,
                 &mut linear_state,
+                cancel,
             )?,
             PrefillSampleSource::GreedyToken(token) => self.decode_from_prefill_token(
                 token,
@@ -1058,6 +1103,7 @@ impl ModelRunner {
                 block_table,
                 &mut linear_state,
                 params.seed,
+                cancel,
             )?,
         };
 
@@ -1097,6 +1143,7 @@ impl ModelRunner {
         paged_cache: &Mutex<PagedKvCache>,
         block_table: &BlockTable,
         linear_state: &mut LinearAttentionState,
+        cancel: Option<&CancelHandle>,
     ) -> Result<GenerationOutput> {
         let step_seed = params.seed;
 
@@ -1119,6 +1166,7 @@ impl ModelRunner {
             block_table,
             linear_state,
             step_seed,
+            cancel,
         )
     }
 
@@ -1131,9 +1179,11 @@ impl ModelRunner {
         block_table: &BlockTable,
         linear_state: &mut LinearAttentionState,
         mut step_seed: Option<u64>,
+        cancel: Option<&CancelHandle>,
     ) -> Result<GenerationOutput> {
         let mut generated_tokens: Vec<TokenId> = Vec::new();
         for _step in 0..params.max_tokens {
+            check_cancelled(cancel)?;
             if let Some(s) = step_seed.as_mut() {
                 *s = s.wrapping_add(1);
             }
@@ -1256,6 +1306,7 @@ impl ModelRunner {
         block_manager: &Mutex<BlockManager>,
         paged_cache: &Mutex<PagedKvCache>,
         spec_config: &SpeculativeConfig,
+        cancel: Option<&CancelHandle>,
     ) -> Result<GenerationOutput> {
         anyhow::ensure!(
             params.temperature == 0.0,
@@ -1295,6 +1346,7 @@ impl ModelRunner {
             paged_cache,
             &block_table,
             spec_config,
+            cancel,
         );
 
         drop(reservation);
@@ -1319,6 +1371,7 @@ impl ModelRunner {
         params: &SamplingParams,
         paged_cache: &Mutex<PagedKvCache>,
         block_table: &BlockTable,
+        cancel: Option<&CancelHandle>,
     ) -> Result<GenerationOutput> {
         let mut linear_state = self.new_linear_state()?;
 
@@ -1371,6 +1424,7 @@ impl ModelRunner {
         };
 
         for _step in 0..params.max_tokens {
+            check_cancelled(cancel)?;
             if let Some(s) = step_seed.as_mut() {
                 *s = s.wrapping_add(1);
             }
@@ -1434,6 +1488,7 @@ impl ModelRunner {
         paged_cache: &Mutex<PagedKvCache>,
         block_table: &BlockTable,
         spec_config: &SpeculativeConfig,
+        cancel: Option<&CancelHandle>,
     ) -> Result<GenerationOutput> {
         anyhow::ensure!(!prompt_tokens.is_empty(), "prompt must not be empty");
 
@@ -1479,6 +1534,7 @@ impl ModelRunner {
         let mut last_token = greedy_sample(&logits)?;
 
         loop {
+            check_cancelled(cancel)?;
             if generated_tokens.len() >= params.max_tokens {
                 return Ok(GenerationOutput {
                     text: String::new(),
@@ -1615,6 +1671,7 @@ impl ModelRunner {
         params: &SamplingParams,
         paged_cache: &mut PagedKvCache,
         block_table: &BlockTable,
+        cancel: Option<&CancelHandle>,
     ) -> Result<GenerationOutput> {
         let mut linear_state = self.new_linear_state()?;
 
@@ -1702,6 +1759,7 @@ impl ModelRunner {
         };
 
         for _step in 0..params.max_tokens {
+            check_cancelled(cancel)?;
             if let Some(s) = step_seed.as_mut() {
                 *s = s.wrapping_add(1);
             }
@@ -4288,6 +4346,7 @@ mod tests {
             &params,
             &mut block_manager,
             &mut paged_cache,
+            None,
         )?;
 
         assert_eq!(output.token_ids.len(), 5);
@@ -4335,6 +4394,7 @@ mod tests {
             &params,
             &block_manager,
             &paged_cache,
+            None,
         )?;
 
         assert_eq!(output.token_ids.len(), 5);
@@ -4381,6 +4441,7 @@ mod tests {
             &params,
             &mut block_manager,
             &mut paged_cache,
+            None,
         )?;
 
         // Both paths should produce identical tokens with greedy sampling
@@ -4428,6 +4489,7 @@ mod tests {
             &params,
             &mut block_manager,
             &mut paged_cache,
+            None,
         )?;
 
         assert_eq!(output.token_ids.len(), 3);
@@ -4478,6 +4540,7 @@ mod tests {
                     &params,
                     block_manager.as_ref(),
                     paged_cache.as_ref(),
+                    None,
                 )
             })
         };
@@ -4492,6 +4555,7 @@ mod tests {
                     &params,
                     block_manager.as_ref(),
                     paged_cache.as_ref(),
+                    None,
                 )
             })
         };
@@ -4552,6 +4616,7 @@ mod tests {
             &params,
             &mut block_manager,
             &mut paged_cache,
+            None,
         )?;
 
         assert_eq!(output.finish_reason, FinishReason::Eos);

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod adapter_merge;
 pub mod backend;
 pub mod c1_attr;
+pub mod cancel;
 pub mod cuda_graph;
 pub mod engine;
 pub mod forward;
@@ -20,6 +21,7 @@ mod transposed_weight_cache;
 pub mod weights;
 
 pub use backend::{BackendRuntime, for_device as backend_for_device};
+pub use cancel::CancelHandle;
 pub use engine::Engine;
 pub use forward::LinearAttentionState;
 pub use generate::{

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -16,7 +16,9 @@ use kiln_core::token::TokenId;
 use kiln_core::tokenizer::ChatMessage;
 use kiln_model::adapter_merge::{merge_concat, PeftLora};
 use kiln_model::lora_loader::LoraWeights;
-use kiln_model::{GenerationOutput, ModelRunner, PagedPrefixReuse, SpeculativeConfig, StreamEvent};
+use kiln_model::{
+    CancelHandle, GenerationOutput, ModelRunner, PagedPrefixReuse, SpeculativeConfig, StreamEvent,
+};
 
 use crate::config::{SpecMethod, SpeculativeDecodingConfig};
 use crate::error::ApiError;
@@ -1201,6 +1203,15 @@ async fn generate_real(
 
     let gpu_lock = state.gpu_lock.clone();
     let timeout = state.request_timeout;
+    // Cooperative cancellation: `tokio::time::timeout` cancels the outer
+    // future, but `spawn_blocking` does not honor that — the closure keeps
+    // running on the blocking pool, holding `runner.read()` and
+    // `prefix_cache.lock()` for the rest of generation. The next request
+    // races against still-held state and 5xx's. On timeout we signal this
+    // handle and `.await` the join handle so locks release before we
+    // respond. See issue #664.
+    let cancel = CancelHandle::new();
+    let cancel_inner = cancel.clone();
     let generation = tokio::task::spawn_blocking(move || {
         // Acquire GPU coordination read lock — allows concurrent inference,
         // but blocks while training holds the write lock.
@@ -1218,6 +1229,7 @@ async fn generate_real(
                         &params,
                         bm.as_ref(),
                         pc.as_ref(),
+                        Some(&cancel_inner),
                     )
                 } else {
                     let hit = {
@@ -1237,6 +1249,7 @@ async fn generate_real(
                         bm.as_ref(),
                         pc.as_ref(),
                         cached_prefix,
+                        Some(&cancel_inner),
                     );
 
                     let mut output = match result {
@@ -1286,6 +1299,7 @@ async fn generate_real(
                         bm.as_ref(),
                         pc.as_ref(),
                         &spec_config,
+                        Some(&cancel_inner),
                     )
                 } else {
                     let flat_spec_config = SpeculativeConfig {
@@ -1306,11 +1320,21 @@ async fn generate_real(
         }
     });
 
-    let output = match tokio::time::timeout(timeout, generation).await {
+    tokio::pin!(generation);
+    let output = match tokio::time::timeout(timeout, &mut generation).await {
         Ok(join_result) => join_result
             .map_err(|e| ApiError::internal(format!("join error: {e}")))?
             .map_err(ApiError::generation_failed)?,
         Err(_) => {
+            // Signal cooperative cancellation, then await the join handle so
+            // the spawn_blocking closure releases `runner.read()` /
+            // `prefix_cache.lock()` before we return. Without this drain,
+            // subsequent /v1/chat/completions requests race against still-
+            // held state and 5xx with "prefill f..." (issue #664). The
+            // decode loops poll `is_cancelled()` between tokens, so this
+            // typically returns within one decode step after we signal.
+            cancel.cancel();
+            let _ = generation.await;
             return Err(ApiError::request_timeout(timeout.as_secs()));
         }
     };

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -416,6 +416,7 @@ fn spawn_backend_prewarm(state: AppState) {
                     &params,
                     &mut block_manager,
                     &mut paged_cache,
+                    None,
                 )
             };
 

--- a/crates/kiln-server/tests/timeout_cancel_drain.rs
+++ b/crates/kiln-server/tests/timeout_cancel_drain.rs
@@ -1,0 +1,165 @@
+//! Regression test for issue #664 — `tokio::time::timeout` cancels the
+//! outer future, but `tokio::task::spawn_blocking` does not honor that
+//! cancellation; the inner closure keeps running on the blocking thread
+//! pool and continues to hold any locks it acquired (`runner.read()`,
+//! `prefix_cache.lock()`, ...). Subsequent requests then race against the
+//! still-held state and 5xx with `prefill f...`.
+//!
+//! The fix in `kiln-server/src/api/completions.rs` is a cooperative
+//! cancellation handle (`kiln_model::CancelHandle`) that the inner decode
+//! loops poll between tokens, plus a drain step on the timeout branch:
+//! signal cancel, then `.await` the join handle so the closure releases
+//! its locks before we return 408.
+//!
+//! These tests pin the mechanism end-to-end without standing up a real
+//! `ModelRunner` (which would need GPU weights). They model the
+//! lock-contention scenario directly with `RwLock<()>` (mirroring
+//! `runner.read()`) and `Mutex<()>` (mirroring `prefix_cache.lock()`).
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+use std::time::Duration;
+
+use kiln_model::CancelHandle;
+
+/// Without the drain step, a follow-up request that needs a write-lock on
+/// the same `RwLock` deadlocks for as long as the orphaned closure runs.
+/// With cancel + drain, the read-lock releases promptly and the next
+/// request acquires its write-lock without contention.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn cancel_drain_releases_runner_read_lock_for_next_request() {
+    let runner_lock: Arc<RwLock<()>> = Arc::new(RwLock::new(()));
+    let prefix_cache_lock: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
+    let cancel = CancelHandle::new();
+
+    let runner_inner = runner_lock.clone();
+    let prefix_inner = prefix_cache_lock.clone();
+    let cancel_inner = cancel.clone();
+    let polls = Arc::new(AtomicUsize::new(0));
+    let polls_inner = polls.clone();
+
+    // Stand-in for the spawn_blocking generation closure: acquires the
+    // same locks the real path acquires (`runner.read()` then
+    // `prefix_cache.lock()`), then loops doing CPU work while polling
+    // the cancel flag the way the decode loop does.
+    let generation = tokio::task::spawn_blocking(move || {
+        let _runner_guard = runner_inner.read().unwrap();
+        let _pc_guard = prefix_inner.lock().unwrap();
+        for _ in 0..10_000 {
+            polls_inner.fetch_add(1, Ordering::SeqCst);
+            if cancel_inner.is_cancelled() {
+                return Err("cancelled");
+            }
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        Ok(())
+    });
+
+    tokio::pin!(generation);
+    let timed_out = tokio::time::timeout(Duration::from_millis(50), &mut generation)
+        .await
+        .is_err();
+    assert!(timed_out, "generation should outlast the 50ms timeout");
+
+    // Drain pattern from completions.rs: signal cancel + await join.
+    cancel.cancel();
+    let join_result = generation.await;
+    assert!(
+        join_result.is_ok(),
+        "join handle should resolve cleanly after cancel"
+    );
+    assert_eq!(
+        join_result.unwrap(),
+        Err("cancelled"),
+        "closure should observe the cancel and return early"
+    );
+
+    // The follow-up request now needs a write-lock on the same RwLock
+    // (e.g. an adapter swap) and a fresh acquisition of the prefix cache
+    // mutex. Both must succeed promptly because the drained closure
+    // released them.
+    let runner_for_next = runner_lock.clone();
+    let prefix_for_next = prefix_cache_lock.clone();
+    let next = tokio::time::timeout(Duration::from_millis(500), async move {
+        tokio::task::spawn_blocking(move || {
+            let _w = runner_for_next.write().unwrap();
+            let _p = prefix_for_next.lock().unwrap();
+        })
+        .await
+    })
+    .await;
+
+    assert!(
+        next.is_ok(),
+        "follow-up request deadlocked — locks were not released"
+    );
+    next.unwrap().expect("follow-up join should succeed");
+}
+
+/// Without the drain step, the lock stays held after the timeout fires —
+/// pin the broken behavior so a future refactor can't silently regress it.
+/// We only assert the *un*-drained case to keep the test deterministic
+/// (the orphaned thread sleeps in 2ms increments, well past the 50ms
+/// timeout we use here).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn no_drain_means_lock_still_held_after_timeout() {
+    let lock: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
+    let lock_inner = lock.clone();
+
+    let _generation = tokio::task::spawn_blocking(move || {
+        let _g = lock_inner.lock().unwrap();
+        std::thread::sleep(Duration::from_millis(500));
+    });
+
+    // Give the spawn_blocking closure a moment to actually take the lock.
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // Outer-future timeout fires; we drop the JoinHandle without awaiting.
+    let lock_for_probe = lock.clone();
+    let probe = tokio::time::timeout(
+        Duration::from_millis(50),
+        tokio::task::spawn_blocking(move || {
+            let _g = lock_for_probe.lock().unwrap();
+        }),
+    )
+    .await;
+
+    assert!(
+        probe.is_err(),
+        "without drain, the next lock acquisition must time out — \
+         this proves the cascade scenario from #664 actually requires \
+         the drain step"
+    );
+}
+
+/// Confirms the inner closure can observe a cancel signal that was
+/// delivered while it was already running (the realistic scenario:
+/// timeout fires mid-generation).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inner_closure_observes_cancel_set_after_start() {
+    let cancel = CancelHandle::new();
+    let cancel_inner = cancel.clone();
+
+    let generation = tokio::task::spawn_blocking(move || {
+        for step in 0..1_000 {
+            if cancel_inner.is_cancelled() {
+                return step;
+            }
+            std::thread::sleep(Duration::from_millis(2));
+        }
+        -1
+    });
+
+    tokio::time::sleep(Duration::from_millis(30)).await;
+    cancel.cancel();
+
+    let observed_step = generation.await.unwrap();
+    assert!(
+        observed_step >= 0,
+        "closure should have returned via cancel branch"
+    );
+    assert!(
+        observed_step < 1_000,
+        "closure should not have run to completion (got step {observed_step})"
+    );
+}


### PR DESCRIPTION
## What

Fix #664 — after a 300s `request_timeout_secs` fires under `workers=2`, ~26% of follow-up `/v1/chat/completions` requests return HTTP 500 with `generation_error: Text generation failed: prefill f...`.

## Why

`tokio::time::timeout` cancels the *outer* future, but `tokio::task::spawn_blocking` does **not** honor that cancellation — the inner closure keeps running on the blocking thread pool and continues to hold `runner.read()` and `prefix_cache.lock()`. Subsequent requests then race against the still-held state and 5xx with `prefill f...`.

## How

1. **Cooperative cancel handle** (`crates/kiln-model/src/cancel.rs`): a small `CancelHandle` wrapping `Arc<AtomicBool>` with `cancel()` / `is_cancelled()`.
2. **Plumbed through `kiln-model::generate`**: `Option<&CancelHandle>` is threaded through the 3 public paged-generation entry points and ~6 internal helpers. Each of the 4 decode loops (`decode_from_prefill_token`, `generate_from_tokens_paged_interleaved`, `generate_from_tokens_paged_speculative_interleaved`, `generate_from_tokens_paged_inner`) polls the flag at the top of every iteration and bails early via the existing `GenerationError::Cancelled`-style return.
3. **Drain on timeout** (`crates/kiln-server/src/api/completions.rs`): on the timeout `Err` branch, signal the cancel + `.await` the join handle so the closure releases its locks before the 408 returns.

```rust
tokio::pin!(generation);
let output = match tokio::time::timeout(timeout, &mut generation).await {
    Ok(join_result) => join_result
        .map_err(|e| ApiError::internal(format!(\"join error: {e}\")))?
        .map_err(ApiError::generation_failed)?,
    Err(_) => {
        cancel.cancel();
        let _ = generation.await;
        return Err(ApiError::request_timeout(timeout.as_secs()));
    }
};
```

Internal callers that don't need cancellation (prewarm, tests) pass `None`.

## Tests

New CPU-only regression test: `crates/kiln-server/tests/timeout_cancel_drain.rs`

- `cancel_drain_releases_runner_read_lock_for_next_request` — end-to-end mechanism pin using `RwLock<()>` / `Mutex<()>` stand-ins for `runner.read()` / `prefix_cache.lock()`. Confirms the follow-up write-lock acquisition succeeds promptly after the drain.
- `no_drain_means_lock_still_held_after_timeout` — pins the broken pre-fix behavior so a future refactor can't silently regress the cascade.
- `inner_closure_observes_cancel_set_after_start` — confirms the cancel signal is observed mid-generation.

The test models the lock-contention scenario directly because the Mock `ModelBackend` bypasses `runner.read()` entirely, so a real-runner CPU test isn't possible without GPU weights.

All passing locally:

```
running 3 tests
test inner_closure_observes_cancel_set_after_start ... ok
test no_drain_means_lock_still_held_after_timeout ... ok
test cancel_drain_releases_runner_read_lock_for_next_request ... ok

test result: ok. 3 passed; 0 failed; finished in 0.53s
```

Plus 260 `kiln-model` lib tests + 121 `kiln-server` lib tests still green.

Closes #664.