### PR TITLE
docs(launch): stage per-channel launch post drafts

### DIFF
--- a/docs/site/launch/README.md
+++ b/docs/site/launch/README.md
@@ -1,0 +1,97 @@
+# Kiln launch post drafts
+
+This directory stages per-channel launch announcement drafts for Phase 11
+(public-announce). The Pages workflow only renders top-level
+`docs/site/*.html` and `docs/site/assets/*` — this directory is **not** built
+or deployed; it's a versioned drafting space.
+
+**Companion artifacts:**
+
+- The live launch blog post: [`docs/site/launch.html`](../launch.html)
+  (deployed at https://ericflo.github.io/kiln/launch.html, shipped in PR #667)
+- The demo asciicast: tracked separately in the Phase 11 launch checklist.
+  No launch post should go live until the asciicast is linked from
+  `docs/site/launch.html`.
+
+## Status
+
+> **All drafts in this directory are DRAFT status.**
+> **Do not post any of them until Eric reviews them AND the demo asciicast lands.**
+
+## Files
+
+| File | Channel | Use for |
+| --- | --- | --- |
+| [`hackernews.md`](hackernews.md) | HN (Show HN) | The biggest single-shot traffic spike. Submit URL = `launch.html`. First comment posts immediately after submission. |
+| [`twitter.md`](twitter.md) | X / Twitter | An 8-tweet thread with image/asciicast suggestions and a post-thread reply template for the "is this a wrapper?" question. |
+| [`lobsters.md`](lobsters.md) | lobste.rs | Skeptical technical audience. Long-form comment that front-loads the honest tradeoffs. |
+| [`reddit-localllama.md`](reddit-localllama.md) | /r/LocalLLaMA | Hobbyist + enthusiast audience. Emphasizes the consumer-GPU angle and includes the GRPO Python snippet inline. |
+| [`discord-rust.md`](discord-rust.md) | Rust Discord `#showcase` | Rust-systems framing — vendored CUDA kernels, in-process training thread, build matrix. |
+
+## Recommended posting order and timing
+
+The order matters. Earlier posts should set up the discussion that later posts
+join — and the HN thread is the highest-leverage single venue, so it goes
+first while everything else is fresh. Run the launch within a single 24-hour
+window:
+
+1. **Hacker News (Show HN)** — Tuesday or Wednesday, **9:00–11:00 ET**.
+   The single highest-traffic shot. Submit, then post the first comment
+   within 60 seconds.
+2. **X / Twitter thread** — same day, **within 30 minutes of the HN
+   submission**. Pin tweet 1 to the profile for the launch week.
+3. **lobste.rs** — same day, **9:00–11:00 ET**. Either right after the X
+   thread or staggered ~1 hour after HN to avoid lobsters seeing it as a
+   pure HN cross-post. Lobsters explicitly dislikes "saw it on HN, here it
+   is" submissions.
+4. **/r/LocalLLaMA** — same day, **9:00–11:00 ET** (catches both US morning
+   and EU afternoon). Stagger ~30 minutes after lobsters.
+5. **Rust Discord `#showcase`** — same day, **12:00–14:00 ET** (US
+   lunchtime, EU late afternoon). Discord is conversational; stay in the
+   channel for ~1 hour to answer questions.
+
+If HN goes hot (front page), pause channels 3–5 by an hour or two so they
+don't compete with the HN thread for Eric's attention. If HN flops, still
+ship 2–5 — they reach different audiences and recovery from a bad HN day is
+boring not fatal.
+
+## After-posting checklist
+
+For each channel, after going live:
+
+- [ ] Add the live post URL back to that channel's draft file as
+      `posted_url:` in the frontmatter (so future agents can find it).
+- [ ] Update `status:` from `draft` to `posted`.
+- [ ] Watch for the first 30 minutes (Discord) / 90 minutes (HN, X) /
+      2 hours (lobste.rs, Reddit). The early window is where the founder
+      presence matters most.
+- [ ] Reply to every substantive question. One-line replies are fine for
+      "great work!" comments, but technical questions get full answers.
+- [ ] If the same question shows up across channels, copy the best answer
+      back into this README under "FAQ" so future agents can reuse it.
+
+## Cross-channel boundaries
+
+- **Don't post the same body across channels.** Each draft is rewritten for
+  its audience — HN gets crisp tradeoffs, lobste.rs gets long-form honesty,
+  /r/LocalLLaMA gets the consumer-GPU angle, Discord gets the Rust-systems
+  angle, X gets one-line hooks. Reusing a body across channels reads as
+  spam.
+- **Don't link channels at each other.** "Saw this on HN, posting here too"
+  triggers downvotes on lobste.rs and Reddit.
+- **Don't autopost.** Every submission is manual, by Eric, after review.
+
+## Pre-launch ops gate (must be green before any draft goes live)
+
+- `gh release view kiln-v0.2.8 -R ericflo/kiln` — clean
+- `gh attestation verify` against the latest release artifact — clean
+- `gh api repos/ericflo/kiln` — public, README rendered, links work
+- https://ericflo.github.io/kiln/ and https://ericflo.github.io/kiln/launch.html
+  — render correctly on mobile and desktop
+- The demo asciicast — embedded on `launch.html` and visible in the page
+
+## Where this directory came from
+
+Companion to PR #667 (live launch blog) and the upcoming demo asciicast
+task. Staged so Eric can review the channel-specific framing before any
+public post goes live.

--- a/docs/site/launch/discord-rust.md
+++ b/docs/site/launch/discord-rust.md
@@ -1,0 +1,43 @@
+---
+channel: discord-rust
+status: draft
+length: ~250 words
+---
+
+# Rust Discord #showcase post draft
+
+> **DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.**
+
+## Post body (paste directly into #showcase)
+
+> 🦀 **Showcase: Kiln — single-GPU LLM inference + live LoRA training, all in Rust**
+>
+> https://github.com/ericflo/kiln · https://ericflo.github.io/kiln/launch.html
+>
+> One binary that serves a language model and trains it in the same process, on the same GPU. You POST corrections or scored completions over HTTP, training runs on a background thread, and new LoRA weights hot-swap in atomically at the next iteration boundary — no restart, no second copy of the model in VRAM, no Python sidecar copying tensors over a socket.
+>
+> **What's interesting from a Rust-systems angle:**
+>
+> - Pure Rust, single binary. `axum` HTTP server, in-process training thread, `candle` for the autograd surface where it earns its keep, custom kernels where it didn't.
+> - Vendored CUDA kernels with thin C-ABI wrappers + Rust FFI:
+>     - `kiln-flash-attn` — flash-attention-2 (bf16, hdim 128/256, causal) with the PyTorch binding layer stripped out, our own ~300-line C-ABI shim, and `build.rs` driving `nvcc` via the `cc` crate.
+>     - `kiln-gdn-kernel` — fused Gated DeltaNet linear attention.
+>     - `kiln-marlin-gemm` — W4A16 GEMM for the MLP and projection paths.
+>     - `kiln-rmsnorm-kernel` — fused pre-norm RMSNorm.
+>     - `kiln-conv1d-kernel` — vendored mamba-ssm causal conv1d.
+> - Sarathi-style chunked-prefill scheduler with continuous batching, paged KV cache, and a block manager that gives KV cache "virtual memory" semantics.
+> - Targets one model (Qwen3.5-4B) deliberately. The scheduler knows exactly how much KV cache each layer needs because every layer is accounted for in the source.
+>
+> **Build matrix is intentionally small** — "has CUDA or doesn't." `cargo build --release --features cuda` on Linux+CUDA, `--features metal` on Apple Silicon, plain `cargo build --release` for the CPU/headless path. macOS Apple Silicon gets the Metal backend via a candle-metal JIT path.
+>
+> Reproducible builds with `--locked`, Sigstore-signed build provenance on every release artifact and the GHCR `kiln-server` image, MIT licensed, pre-1.0 (current production line is kiln-v0.2.8).
+>
+> Would love eyes on the kernel crates and the in-process training thread design. Also happy to talk about the tradeoffs of the single-model architectural choice — that's the thing I most expect pushback on.
+
+## Posting checklist
+
+- [ ] Demo asciicast linked from the launch post
+- [ ] Verify the post is under the channel's character limit (`#showcase` rules sometimes cap at 2000 chars; trim the kernel bullet list if needed)
+- [ ] Eric reviews this draft + the asciicast
+- [ ] Post during US working hours, Tue–Thu (Discord is more time-zone-mixed than HN; aim for 12:00–14:00 ET to catch both EU late-afternoon and US lunch)
+- [ ] Stay in the channel for ~1 hour to answer questions; Discord conversations are short-lived

--- a/docs/site/launch/hackernews.md
+++ b/docs/site/launch/hackernews.md
@@ -1,0 +1,52 @@
+---
+channel: hn
+status: draft
+length: ~80 chars title / ~220 words first comment
+---
+
+# Show HN: Kiln draft
+
+> **DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.**
+
+## Submission
+
+**Title** (max 80 chars; this is 73):
+
+```
+Show HN: Kiln – Single-GPU inference server with live LoRA training in Rust
+```
+
+**URL field:**
+
+```
+https://ericflo.github.io/kiln/launch.html
+```
+
+(HN strongly prefers a content URL over a bare GitHub repo for "Show HN". The launch post links to the repo, the README, the QUICKSTART, and the releases page.)
+
+## First comment (post immediately after submission)
+
+> Hi HN — author here. Kiln is a single-GPU inference server that also trains the model it's serving. Same process, same GPU, same model in VRAM. You POST corrections or scored completions over HTTP, training runs on a background thread, and new LoRA weights hot-swap in atomically at the next iteration boundary. There's no separate training pipeline, no second model loaded for the swap, and no restart.
+>
+> The piece I'm most excited about is the GRPO loop: generate candidates, score them with your own reward function (regex, unit tests, a judge model, click-through, whatever), and POST the scored batch. The model learns what "good" means for *your* workload, not a generic benchmark.
+>
+> Some things I expect people to ask up front:
+>
+> - **Why 4B?** Because a 4B model continuously tuned on your data beats a generic 70B on your task, and it fits on a 24 GB consumer GPU you might already own. The Qwen3.5-4B hybrid architecture (24 linear-attention layers + 8 full-attention) means 128K context fits in ~13 GB.
+> - **Why Rust?** Training and serving share GPU memory cooperatively in a single process. No Python sidecar, no socket-tensor-copy, no second copy of the weights.
+> - **Why one model?** Every line of code is tuned for Qwen3.5-4B. The scheduler, kernels, and block manager don't have to be general — that specificity is the source of the speed and the developer experience. Model-agnostic mode is on the post-1.0 roadmap with the honest tradeoff that kernels need a re-tune per architecture.
+> - **Why not vLLM/SGLang/llama.cpp?** They're excellent at general-purpose serving. Kiln is a scalpel for the "I want this one model to be the best version of itself for my workload" loop. If that's not your loop, those projects are probably the right answer.
+>
+> MIT, public binaries for Linux+CUDA, macOS Apple Silicon (Metal), and Windows+CUDA, plus a `ghcr.io/ericflo/kiln-server` image. Sigstore-signed build provenance on every artifact. Repo: https://github.com/ericflo/kiln. Quickstart: https://github.com/ericflo/kiln/blob/main/QUICKSTART.md.
+>
+> Happy to answer questions about the architecture, the GRPO loop, or the single-model design choice.
+
+## Posting checklist
+
+- [ ] Demo asciicast linked from the launch post (`docs/site/launch.html`)
+- [ ] Confirm `gh release view kiln-v0.2.8 -R ericflo/kiln` is clean
+- [ ] Confirm `https://ericflo.github.io/kiln/launch.html` renders on mobile + desktop
+- [ ] Eric reviews this draft and the asciicast
+- [ ] Submit Tuesday–Thursday, 9:00–11:00 ET (US morning peak for HN)
+- [ ] Post the first comment within 60 seconds of submission
+- [ ] Watch the thread for the first 90 minutes, answer every top-level question

--- a/docs/site/launch/lobsters.md
+++ b/docs/site/launch/lobsters.md
@@ -1,0 +1,61 @@
+---
+channel: lobste
+status: draft
+length: ~70 chars title / ~330 words comment
+---
+
+# lobste.rs submission draft
+
+> **DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.**
+
+## Submission
+
+**Title** (max 100 chars; this is 67):
+
+```
+Kiln: a single-GPU inference server with live LoRA training in Rust
+```
+
+**URL field:**
+
+```
+https://ericflo.github.io/kiln/launch.html
+```
+
+**Tags suggestion** (in order of relevance — confirm against the active lobste.rs tag list before posting):
+
+- `rust` — primary language
+- `ml` — machine learning
+- `ai` — AI / LLM
+- `performance` — single-GPU optimization angle
+
+(Do not use `show` unless lobste.rs has reinstated it. The tag list shifts.)
+
+## Comment to post on the submission
+
+> Author here. Some context on why I built this and where the tradeoffs live, since this audience tends to be skeptical and I'd rather front-load the honest version.
+>
+> The pitch: Kiln is one Rust binary that serves a model and trains it in the same process, on the same GPU, sharing the same model in VRAM. You POST corrections (`/v1/train/sft`) or scored completions (`/v1/train/grpo`) over HTTP, training runs on a background thread, and new LoRA weights hot-swap in atomically at the next iteration boundary. The serving thread never stops.
+>
+> Why it exists: the typical "improve a deployed model" loop today is collect failures → format → upload → wait hours → redeploy. That cost-per-iteration is so high that almost nobody iterates. The thesis is that if the loop becomes one HTTP call, you iterate constantly, and a 4B model continuously tuned to your workload outperforms a generic 70B on the tasks you actually care about.
+>
+> The honest tradeoffs:
+>
+> - **Single model.** It targets [Qwen3.5-4B](https://huggingface.co/Qwen/Qwen3.5-4B) and the scheduler, block manager, and CUDA kernels are tuned for that one architecture. Model-agnostic mode is on the post-1.0 roadmap with the explicit caveat that kernels need re-tuning per architecture.
+> - **Single GPU.** No tensor parallel, no multi-node. Multi-GPU TP is also on the post-1.0 roadmap.
+> - **Pre-1.0.** The current production line is kiln-v0.2.8. Phases 1–10 (core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, dev experience, advanced adapter features, v0.1.0 release engineering, Liger long-context training) are all closed. The roadmap from here is deliberately small and chosen by what early users actually ask for.
+>
+> What's in-tree (not vendored Python or wrapped C++): the forward pass, paged KV cache + block manager, Sarathi-style chunked-prefill scheduler, LoRA training loop, Marlin W4A16 GEMM, fused RMSNorm, GDN linear-attention kernel, vendored flash-attn-2 with our own C-ABI wrapper, fused Conv1d. All in `crates/kiln-*-kernel/` and `crates/kiln-model/src/forward.rs`.
+>
+> Repo: https://github.com/ericflo/kiln. MIT. Sigstore-signed build provenance on every release artifact and the GHCR image.
+>
+> Happy to dig into any of the architecture choices or the GRPO loop. Particularly interested in feedback on the single-model design choice from people who've shipped general-purpose inference servers.
+
+## Posting checklist
+
+- [ ] Demo asciicast linked from the launch post
+- [ ] Confirm tags against current lobste.rs taxonomy (they prune)
+- [ ] Eric reviews this draft and the asciicast
+- [ ] Submit Tuesday–Thursday, 9:00–11:00 ET
+- [ ] Watch the thread for the first 2 hours; lobste.rs threads die fast but the early discussion sets the tone
+- [ ] Engage substantively on technical pushback — this audience values long-form replies, not one-liners

--- a/docs/site/launch/reddit-localllama.md
+++ b/docs/site/launch/reddit-localllama.md
@@ -1,0 +1,86 @@
+---
+channel: reddit-localllama
+status: draft
+length: ~140 chars title / ~620 words body
+---
+
+# /r/LocalLLaMA submission draft
+
+> **DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.**
+
+## Submission
+
+**Title** (max 300 chars; this is 138):
+
+```
+Kiln: a single-GPU inference server in Rust that also trains the model it's serving — live LoRA hot-swap, runs Qwen3.5-4B on a 3090
+```
+
+**Flair suggestion:** `Resources` or `New Model / New Tool` (whichever is canonical at post time).
+
+## Body
+
+> Hey r/LocalLLaMA. I built [Kiln](https://github.com/ericflo/kiln) because I got tired of the loop where you ship a local model, find a thing it does badly, collect failure examples, run a separate training job overnight, and redeploy. I wanted that loop to be one HTTP call.
+>
+> **What it is:** one Rust binary that serves a model AND trains it in the same process, on the same GPU, sharing the same weights in VRAM. You POST corrections to `/v1/train/sft` or scored completions to `/v1/train/grpo` and new LoRA weights hot-swap in atomically at the next iteration boundary. No restart, no second copy of the model, no Python sidecar.
+>
+> **What it runs:** [Qwen3.5-4B](https://huggingface.co/Qwen/Qwen3.5-4B) on a single 24 GB consumer GPU. RTX 3090, RTX 4090, A6000 on the CUDA side. M-series Mac with 16 GB+ unified memory on the Metal side.
+>
+> **The 24 GB story is unusually good** because Qwen3.5-4B's hybrid architecture is 24 linear-attention Gated DeltaNet layers + 8 full-attention layers. Only 8 layers need a KV cache at all — the other 24 have O(1) state. So 128K context for one sequence fits in ~13 GB. Even *training* at 128K context fits in ~18 GB. (Actual numbers, not back-of-envelope.)
+>
+> **The killer feature is GRPO, not SFT.** Generate candidates, score them with your own reward function, POST the batch. The model learns what "good" means for *your* use case:
+>
+> ```python
+> import openai, requests
+> client = openai.OpenAI(base_url="http://localhost:8420/v1", api_key="unused")
+>
+> # 1. Generate 8 candidates
+> responses = [
+>     client.chat.completions.create(
+>         model="qwen3.5-4b-kiln",
+>         messages=[{"role": "user", "content": prompt}],
+>         temperature=0.7,
+>     )
+>     for _ in range(8)
+> ]
+>
+> # 2. Score them however you want — regex, unit tests, another model, click-through
+> scored = [{"text": r.choices[0].message.content, "reward": my_score(r)}
+>           for r in responses]
+>
+> # 3. POST — the server trains and hot-swaps immediately
+> requests.post("http://localhost:8420/v1/train/grpo", json={
+>     "groups": [{"prompt": prompt, "completions": scored}]
+> })
+>
+> # 4. Next inference already uses the improved weights
+> ```
+>
+> **What's actually in the repo** (not wrapped Python, not vendored C++ ports): the forward pass, the Sarathi-style chunked-prefill scheduler, the paged KV cache, the LoRA training loop with gradient checkpointing, fused CUDA kernels for flash-attention-2, GDN linear-attention, Marlin W4A16 GEMM, RMSNorm, and Conv1d. Vendored where it made sense, written from scratch where it didn't.
+>
+> **What's the catch?**
+>
+> - **Single model.** Every line of code is tuned for Qwen3.5-4B. Model-agnostic mode is post-1.0 with the honest tradeoff that kernels need re-tuning per architecture.
+> - **Single GPU.** Multi-GPU tensor parallelism is also post-1.0.
+> - **Pre-1.0.** Current production line is kiln-v0.2.8. The phases that got us here closed core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, developer experience, advanced adapter features, v0.1.0 release engineering, and the Liger long-context training pieces. The roadmap from here is deliberately small.
+>
+> **How to try it:**
+>
+> - Linux+CUDA, macOS Apple Silicon (Metal), and Windows+CUDA binaries on the [releases page](https://github.com/ericflo/kiln/releases). Sigstore-signed build provenance on every artifact.
+> - `ghcr.io/ericflo/kiln-server:latest` on GHCR with the same provenance attestation.
+> - [Quickstart](https://github.com/ericflo/kiln/blob/main/QUICKSTART.md) walks through downloading the model weights, the first chat completion, the first SFT POST, and the first GRPO loop.
+> - Embedded `/ui` dashboard for live decode tok/s, p50/p99 ITL, recent requests, and adapter management. No extra service to run.
+> - Full launch post (with the architecture deep-dive and the tradeoffs section): https://ericflo.github.io/kiln/launch.html
+>
+> MIT licensed. Built solo in Rust.
+>
+> Happy to answer questions — particularly interested in what reward functions y'all would want to plug into the GRPO loop. The single-model design is also the thing I most expect pushback on, so fire away.
+
+## Posting checklist
+
+- [ ] Demo asciicast linked from the launch post
+- [ ] Confirm flair against current sub rules (the mods rotate accepted flair)
+- [ ] Eric reviews this draft + the asciicast
+- [ ] Submit Tuesday–Thursday, 9:00–11:00 ET (catches both US morning and EU afternoon)
+- [ ] Reply to every top-level comment in the first 4 hours; this sub rewards founder presence
+- [ ] If the post catches: cross-post to r/MachineLearning Project Announcements (separate weekly thread) — but only after r/LocalLLaMA discussion has settled

--- a/docs/site/launch/twitter.md
+++ b/docs/site/launch/twitter.md
@@ -1,0 +1,103 @@
+---
+channel: x
+status: draft
+length: 8 tweets, each <280 chars
+---
+
+# X / Twitter thread draft
+
+> **DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.**
+
+## Thread
+
+**1/8 — hook (lead with GRPO value prop)**
+
+> Most AI products feel frozen because the model never learns from the people using it.
+>
+> I built Kiln to fix that: a single-GPU inference server that trains the model it's serving. POST a correction over HTTP, the next request already uses the improved weights.
+>
+> 🧵
+
+*(279 chars including 🧵)*
+
+**2/8 — the killer feature**
+
+> The unlock isn't SFT. It's GRPO.
+>
+> Generate 8 candidates → score them with your own reward fn (regex, unit tests, a judge model, click-through) → POST → server trains → next inference already uses the new weights.
+>
+> The model learns what "good" means for your workload, not a benchmark.
+
+*(278 chars)*
+
+**3/8 — hot-swap mechanics**
+
+> No restart. No separate training pipeline. No second copy of the model in VRAM.
+>
+> Training runs on a background thread inside the same process. New LoRA weights swap in atomically at the next iteration boundary. The request that started 1 ms ago finishes on old weights; the next runs on new ones.
+
+*(279 chars — at limit, OK)*
+
+**4/8 — the 4B argument**
+
+> Why 4B? Because a 4B model continuously tuned to your data beats a generic 70B on your task, and it runs on a 24 GB consumer GPU.
+>
+> Qwen3.5-4B's hybrid architecture (24 linear-attention layers + 8 full-attention) puts 128K context in ~13 GB. Training too.
+
+*(254 chars)*
+
+**5/8 — the Rust argument**
+
+> Pure Rust. Single binary. One process.
+>
+> No Python sidecar, no socket-tensor-copy, no second model held in VRAM during training. Vendored CUDA kernels for flash-attn, GDN, Marlin W4A16, RMSNorm, Conv1d. Every layer is accounted for in the source.
+>
+> The specificity is the speed.
+
+*(278 chars)*
+
+**6/8 — anti-Goliath positioning**
+
+> Kiln is not a general-purpose framework. It does not support 47 model families. There is no plugin system. No 800-knob config.
+>
+> It's a scalpel for one model. If you want to get extremely good at one model, that's the loop. If you want to swap between five, vLLM/SGLang are great.
+
+*(279 chars)*
+
+**7/8 — how to try it**
+
+> Linux+CUDA, macOS Apple Silicon (Metal), and Windows+CUDA binaries on the releases page. Sigstore-signed build provenance on every artifact. `ghcr.io/ericflo/kiln-server` on GHCR.
+>
+> Quickstart is single-command. Embedded /ui dashboard for adapters, training, and a chat playground.
+
+*(278 chars)*
+
+**8/8 — call to action + link**
+
+> Repo, releases, and the full launch post:
+>
+> https://ericflo.github.io/kiln/launch.html
+>
+> MIT licensed. v0.2.8 is the production line. Built in Rust by one person; the GRPO loop is what kept me up at night and what I most want feedback on.
+
+*(248 chars — has link headroom for X's t.co)*
+
+## Image / asciicast suggestions
+
+- **Tweet 1 hero:** static screenshot of the GRPO Python snippet from `docs/site/launch.html` (lines 171–193). Alt text: "Python code: 1) generate 8 chat completions; 2) score them; 3) POST to /v1/train/grpo; 4) next request already uses the improved weights."
+- **Tweet 2 GRPO:** the demo asciicast embed (when ready). Alt text: "60-second terminal recording of cold-starting Kiln, sending a chat request, POSTing an SFT correction, and seeing the next request use the improved output."
+- **Tweet 4 4B:** screenshot of the README memory budget table. Alt text: "Memory budget table showing Qwen3.5-4B fits 128K context in ~13 GB on a 24 GB GPU, including training."
+- **Tweet 7 try it:** screenshot of the embedded `/ui` dashboard. Alt text: "Kiln /ui dashboard showing live decode tokens/sec, p50/p99 ITL, recent requests, and adapter management controls."
+
+## Post-thread reply template ("is this a wrapper around X?")
+
+> Not a wrapper — every layer is in the source. The forward pass, the scheduler, the block manager, the LoRA training loop, and the fused CUDA kernels (flash-attn, GDN, Marlin W4A16, RMSNorm, Conv1d) are all in-repo and tuned specifically for Qwen3.5-4B's hybrid architecture. The only "wrap" is being OpenAI-API-compatible on the wire so existing clients work unchanged.
+
+## Posting checklist
+
+- [ ] Demo asciicast finalized and linked from the launch post
+- [ ] Verify the `og:image` and Twitter card on `docs/site/launch.html` render correctly via cards-validator
+- [ ] Eric reviews this draft + the asciicast
+- [ ] Post Tuesday or Wednesday, 9:00–11:00 ET (best Twitter dev-tools traction window)
+- [ ] Pin tweet 1 to the profile for the launch week
+- [ ] Watch replies for the first 2 hours, respond to every substantive question


### PR DESCRIPTION
Stages 5 channel-specific launch post drafts under `docs/site/launch/` for review before public announce. Pages workflow does not render this directory (only top-level `*.html`). Companion to PR #667 (live launch blog) and the upcoming demo asciicast task.

Drafts staged:
- `hackernews.md` — Show HN submission + first comment, anticipates the why-4B / why-Rust / why-one-model objections.
- `twitter.md` — 8-tweet thread under 280 chars each + alt-text and post-thread reply template.
- `lobsters.md` — long-form skeptical-audience comment with explicit tradeoffs.
- `reddit-localllama.md` — consumer-GPU angle with the GRPO Python snippet inline.
- `discord-rust.md` — Rust-systems framing (vendored kernels, in-process training).
- `README.md` — index, recommended posting order/timing, after-posting checklist, cross-channel boundaries, pre-launch ops gate.

All drafts are explicitly marked DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.