### PR TITLE
docs(demo): asciicast script + player scaffolding for 60s online-learning demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 <p align="center">
   <a href="https://ericflo.github.io/kiln/">Website</a> &middot;
   <a href="https://ericflo.github.io/kiln/launch.html">Launch announcement</a> &middot;
+  <a href="docs/site/demo/">Demo</a> &middot;
   <a href="QUICKSTART.md">Quickstart</a> &middot;
   <a href="ARCHITECTURE.md">Architecture</a> &middot;
   <a href="kiln.example.toml">Configuration</a>

--- a/docs/site/demo/README.md
+++ b/docs/site/demo/README.md
@@ -1,0 +1,93 @@
+# Kiln 60-Second Demo
+
+This directory holds the canonical Kiln demo asciicast — a 60–90 second silent recording showing the full live-LoRA online-learning loop end-to-end on a single GPU: cold start → first chat (base model) → `/v1/train/sft` correction → hot-swap → second chat (improved). It is the demo linked from the README hero, the [launch announcement](../launch.html), and the per-channel launch posts.
+
+The actual recording (`kiln-60s.cast`) requires a kiln-capable GPU host and is recorded against the canonical scenes pinned down in [`SCRIPT.md`](SCRIPT.md). A stub `.cast` file ships in this directory today so the embed and Pages routing work end-to-end before the real recording lands. The standalone player page is [`index.html`](index.html); when the real `.cast` lands, no other code change is required — the player picks it up automatically.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| [`SCRIPT.md`](SCRIPT.md) | Scene-by-scene recording script with verbatim commands, expected output, per-scene timing, and post-recording integration checklist. The recording artifact follows this exactly. |
+| [`index.html`](index.html) | Standalone demo page styled to match `docs/site/index.html` and `docs/site/launch.html`. Embeds the asciinema player with `data-src="kiln-60s.cast"`. |
+| `kiln-60s.cast` | The asciicast recording itself. Currently a **stub** — a minimal valid asciicast v2 file showing a "demo coming soon" message. To be replaced with the real recording per [`SCRIPT.md`](SCRIPT.md). |
+
+## Player embed snippet
+
+The player is the official open-source [`asciinema-player`](https://github.com/asciinema/asciinema-player) loaded from the jsDelivr CDN. We **deliberately** use the self-hostable player rather than the asciinema.org-hosted `https://asciinema.org/a/<id>.js` form. Reasons:
+
+- We host the `.cast` file alongside the rest of `docs/site/`, so the demo lives or dies with the same Pages deploy as everything else. No external dependency on `asciinema.org` uptime, no dependency on having uploaded the cast first.
+- The player CSS theme is one we control. We can match the launch.html dark palette without ad-hoc overrides.
+- Pinning the player version (`@3.7.1`) means the embed is deterministic across cache busts — important for a launch-window page.
+- jsDelivr serves the player JS+CSS from a global CDN with caching, so the page weight overhead is roughly the player bundle (~50 KB gzipped) loaded once and cached forever.
+
+The embed used in [`index.html`](index.html):
+
+```html
+<link rel="stylesheet" type="text/css"
+      href="https://cdn.jsdelivr.net/npm/asciinema-player@3.7.1/dist/bundle/asciinema-player.css" />
+
+<div id="kiln-demo-player" data-src="kiln-60s.cast"></div>
+
+<script src="https://cdn.jsdelivr.net/npm/asciinema-player@3.7.1/dist/bundle/asciinema-player.min.js"></script>
+<script>
+  AsciinemaPlayer.create(
+    'kiln-60s.cast',
+    document.getElementById('kiln-demo-player'),
+    {
+      autoPlay: false,
+      preload: true,
+      loop: false,
+      idleTimeLimit: 2,
+      theme: 'monokai',
+      poster: 'npt:0:02',
+      cols: 120,
+      rows: 32
+    }
+  );
+</script>
+```
+
+To embed the player on `launch.html` (or anywhere else under `docs/site/`), copy the three blocks above and adjust the `'kiln-60s.cast'` paths to be relative to the embedding page (e.g. `'demo/kiln-60s.cast'` from `launch.html`).
+
+## Stub `kiln-60s.cast`
+
+The file in this directory today is a **stub** with five short events that render the message:
+
+```
+$ # Kiln demo asciicast — coming soon
+$ # See docs/site/demo/SCRIPT.md for the recording script
+```
+
+This is enough for the player to load, render, and play through to the end without errors. When the real recording lands, replace `kiln-60s.cast` in place — the embed picks it up on the next Pages deploy.
+
+The stub is intentionally tiny (under 1 KB) so it does not bloat the repo or the Pages bundle. It is a valid [asciicast v2](https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md) file and replays cleanly with `asciinema play kiln-60s.cast`.
+
+## How to re-record
+
+See [`SCRIPT.md`](SCRIPT.md) for the full recording protocol. In short:
+
+1. Stage the host with the model weights, the kiln binary, and `asciinema` 2.4+.
+2. Run the prerequisites dry-run from `SCRIPT.md` and confirm a base-model completion lands cleanly.
+3. Open a fresh terminal sized 120×32, set `PS1='$ '`, then:
+
+   ```bash
+   asciinema rec docs/site/demo/kiln-60s.cast \
+     --title "Kiln 60-second demo: live LoRA online learning" \
+     --idle-time-limit 2 \
+     --rows 32 --cols 120
+   ```
+
+4. Run scenes 1–6 from `SCRIPT.md`, in order, in one shell, no cuts.
+5. `Ctrl-D` (or `exit`) to stop. Replay locally to sanity-check, then commit and push. The Pages workflow auto-deploys on `docs/site/**`.
+
+## Cross-links
+
+- **README hero:** [`README.md`](../../../README.md) — the `Demo` link in the center-aligned link row points here.
+- **Launch announcement:** [`launch.html`](../launch.html) — has an inline link near the GRPO-loop section. After the real recording lands, `launch.html` may also embed the player inline.
+- **Launch post drafts:** [`launch/README.md`](../launch/README.md) — pre-launch ops gate references the demo asciicast as a launch blocker.
+- **Quickstart:** [`QUICKSTART.md`](../../../QUICKSTART.md) — the commands run in the demo are a strict subset of the Quickstart.
+
+## Why this matters for Phase 11
+
+The Phase 11 launch checklist has four items. The demo asciicast is item #3 (after README polish and the launch blog post, both shipped). Items #4 (pre-launch ops) and #5 (channel-specific launch post drafts) all reference the demo as a blocker — there is no "demo coming soon" caveat we can ship around. This directory is the scaffolding that turns the recording into a drop-in step.

--- a/docs/site/demo/SCRIPT.md
+++ b/docs/site/demo/SCRIPT.md
@@ -1,0 +1,233 @@
+# Kiln 60-Second Demo: Live LoRA Online Learning
+
+This is the recording script for the canonical Kiln demo asciicast. Total target length **60–90 seconds**. The demo shows the killer feature end-to-end on a single GPU: a base-model chat completion → a `/v1/train/sft` correction → a hot-swap → an improved completion. No cuts, no editing, one continuous shell session.
+
+## Why this script exists
+
+The actual `.cast` recording can only be made on a kiln-capable GPU host (NVIDIA 24 GB+ for the canonical recording; an Apple Silicon 16 GB+ Mac works too). This file pins down the exact commands, the exact timing, and the exact on-screen output before anyone touches `asciinema rec`. When the recording slot opens up, this script is a copy-paste checklist — no judgment calls under the camera.
+
+The companion file [`README.md`](README.md) covers the player embed and the stub `kiln-60s.cast` that the page renders today. [`index.html`](index.html) is the standalone player page.
+
+## Prerequisites (pre-recording state)
+
+Get the host into this exact state **before** opening `asciinema`. Do not include any of these in the recording itself.
+
+- Kiln binary built at `./target/release/kiln` (release mode, `--features cuda` on Linux/Windows or `--features metal` on macOS). See [`QUICKSTART.md` §1](../../../QUICKSTART.md).
+- Model weights at `./Qwen3.5-4B/` (downloaded via `huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B`). See [`QUICKSTART.md` §2](../../../QUICKSTART.md).
+- A clean shell working dir at the kiln repo root.
+- `asciinema` 2.4 or newer installed (`asciinema --version`). On Linux: `pip install asciinema` or distro package; on macOS: `brew install asciinema`.
+- Terminal sized **120 columns × 32 rows** exactly. The asciinema player renders responsively, but matching the recording aspect ratio keeps text crisp on the page. Set this with `printf '\e[8;32;120t'` in xterm/iTerm/most terminals, or resize the window manually.
+- A clean prompt — drop the venv hint, the git branch, anything noisy. A bare `$ ` is ideal. (Pre-recording: `export PS1='$ '` for the duration.)
+- Browser with [http://localhost:8420/ui](http://localhost:8420/ui) open in a separate tab — **not** in the recording itself, but useful to verify hot-swap landed if a scene looks wrong.
+- `jq` available (`apt install jq` / `brew install jq`). Used to keep on-screen output to single lines.
+
+Pre-recording dry run:
+
+```bash
+# Sanity check: server starts cleanly and serves a base-model completion.
+KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve --config kiln.example.toml &
+sleep 30  # model load + warmup
+curl -s http://localhost:8420/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":"What is the capital of France?"}],"max_tokens":32}' \
+  | jq -r '.choices[0].message.content'
+# Expected: a coherent answer mentioning Paris.
+kill %1
+```
+
+If the dry run is healthy, you are clear to record.
+
+## Scene-by-scene script
+
+The cumulative time budget on the right is wall-clock seconds elapsed at the **end** of that scene. The total run lands between 60 and 90 seconds. If you run long, the most compressible scenes are #4 (training poll) and #6 (adapter list).
+
+### Scene 1 — Cold start (≈10s, cumulative 10s)
+
+Type:
+
+```bash
+$ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve --config kiln.example.toml
+```
+
+Expected on-screen output (abbreviated by the asciicast — let it scroll naturally for ~8s, then the listen line lands):
+
+```
+  ┌─────────────────────────────────────┐
+  │           🔥 K I L N 🔥             │
+  │   inference · training · adapters   │
+  └─────────────────────────────────────┘
+
+  Version: 0.2.8
+  Mode:    GPU inference
+  Model:   ./Qwen3.5-4B
+  CUDA:    available ✓
+  GPU:     NVIDIA RTX A6000
+  VRAM:    49140 MiB total, 48891 MiB free
+  Listen:  http://127.0.0.1:8420
+  ...
+  2026-XX-XXTXX:XX:XXZ  INFO kiln_server: listening on http://127.0.0.1:8420
+```
+
+`# narration:` Single binary. One process. Model loads, KV cache allocates, server is listening. No Python sidecar, no second copy of the weights.
+
+Press `Ctrl-Z` then `bg` to background the server, freeing the prompt for the next scenes. The asciinema viewer will see the `[1]+ Stopped` and `[1]+ kiln serve &` lines briefly — that is fine.
+
+### Scene 2 — First chat completion (base model) (≈10s, cumulative 20s)
+
+Type:
+
+```bash
+$ curl -s http://localhost:8420/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"messages":[{"role":"user","content":"In one short sentence, what is the Kiln inference server?"}],"max_tokens":48,"temperature":0.0}' \
+    | jq -r '.choices[0].message.content'
+```
+
+Expected on-screen output (one line, the base model has no idea what Kiln is):
+
+```
+Kiln is a tool for managing kiln operations in pottery and ceramics, often used to control firing schedules and monitor temperatures.
+```
+
+`# narration:` The base model knows nothing about Kiln-the-software. It guesses pottery — not unreasonable, just wrong for our domain.
+
+### Scene 3 — Submit a correction via `/v1/train/sft` (≈12s, cumulative 32s)
+
+Type (single multi-line `curl`, paste it as one block — the asciicast captures it as it appears):
+
+```bash
+$ curl -s http://localhost:8420/v1/train/sft \
+    -H 'Content-Type: application/json' \
+    -d '{
+      "adapter_name": "demo",
+      "examples": [
+        {"messages": [
+          {"role": "user", "content": "In one short sentence, what is the Kiln inference server?"},
+          {"role": "assistant", "content": "Kiln is a single-GPU inference server for Qwen3.5-4B with live LoRA training over HTTP — submit corrections and the model improves in seconds."}
+        ]},
+        {"messages": [
+          {"role": "user", "content": "What model does Kiln target?"},
+          {"role": "assistant", "content": "Kiln targets Qwen3.5-4B specifically and tunes the scheduler, memory manager, and CUDA kernels for that architecture."}
+        ]}
+      ],
+      "learning_rate": 1e-4,
+      "num_epochs": 8
+    }' | jq -c '{job_id, status, adapter_name}'
+```
+
+Expected on-screen output (one line, accepted into the queue):
+
+```
+{"job_id":"7f3d2e91-2e0e-4c9a-9c3e-1f5d7d6a2c11","status":"queued","adapter_name":"demo"}
+```
+
+`# narration:` Two correction examples, one HTTP call. The server queues the job, training runs in-process on the GPU we are already serving from. No second model load, no separate trainer process.
+
+### Scene 4 — Watch training complete (≈8s, cumulative 40s)
+
+Type:
+
+```bash
+$ curl -s http://localhost:8420/v1/train/status | jq -c '{queue_len, active_job: .active_job.status, last_completed: .recent_jobs[0] | {status, adapter_name, duration_s}}'
+```
+
+Expected on-screen output (one line, training already completed because the dataset is tiny — adjust to two polls if your specific setup needs them):
+
+```
+{"queue_len":0,"active_job":null,"last_completed":{"status":"completed","adapter_name":"demo","duration_s":3.4}}
+```
+
+`# narration:` Two examples × eight epochs took a few seconds. The new adapter weights are written, hot-swapped at the next iteration boundary. The server never paused.
+
+### Scene 5 — Second chat completion (improved) (≈10s, cumulative 50s)
+
+Type **the exact same prompt as Scene 2** so the contrast is unmistakable:
+
+```bash
+$ curl -s http://localhost:8420/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"messages":[{"role":"user","content":"In one short sentence, what is the Kiln inference server?"}],"max_tokens":48,"temperature":0.0}' \
+    | jq -r '.choices[0].message.content'
+```
+
+Expected on-screen output (one line, now the model knows):
+
+```
+Kiln is a single-GPU inference server for Qwen3.5-4B with live LoRA training over HTTP — submit corrections and the model improves in seconds.
+```
+
+`# narration:` Same prompt. Different answer. The model learned in seconds, the next request used the new weights, and the server never restarted. That is the loop.
+
+### Scene 6 — Adapter list (optional, ≈5s, cumulative 55s)
+
+Type:
+
+```bash
+$ curl -s http://localhost:8420/v1/adapters | jq -c '.adapters[] | {name, active, rank}'
+```
+
+Expected on-screen output (one line per adapter — likely just one):
+
+```
+{"name":"demo","active":true,"rank":8}
+```
+
+`# narration:` One adapter, active, rank 8. About 4 MB on disk. Reusable, exportable, and the next correction stacks on top.
+
+### Optional closer (≈5s, cumulative 60s)
+
+Leave a moment of stillness on the prompt — the asciicast renderer respects `--idle-time-limit 2`, so a brief pause becomes a "let that land" beat for the viewer. Then the recording ends.
+
+## Recording instructions
+
+When the host is in the prerequisites state and the prompt is clean:
+
+```bash
+asciinema rec docs/site/demo/kiln-60s.cast \
+  --title "Kiln 60-second demo: live LoRA online learning" \
+  --idle-time-limit 2 \
+  --rows 32 \
+  --cols 120
+```
+
+Then run scenes 1–6 from above, in order, in one shell, without cuts. Press `Ctrl-D` (or `exit`) at the end to stop recording. Asciinema writes the `.cast` JSON file to disk.
+
+### After recording
+
+1. **Sanity-replay locally:**
+
+   ```bash
+   asciinema play docs/site/demo/kiln-60s.cast
+   ```
+
+   Watch the whole thing once. If anything is wrong (typo, slow scene, broken curl), re-record the whole take. Do **not** hand-edit `.cast` event rows — the timing relationships are easy to break.
+
+2. **Optional: trim the head/tail.** If the prompt sat idle before scene 1 starts, edit the `.cast` JSON to drop the leading idle event (the `--idle-time-limit 2` flag already caps mid-recording pauses). Keep the file under ~50 KB if at all possible.
+
+3. **Verify the player picks it up:** open `docs/site/demo/index.html` locally (any static file server, e.g. `python3 -m http.server -d docs/site` then visit http://localhost:8000/demo/). The player should auto-load `kiln-60s.cast` and play.
+
+4. **Ship it.** Commit `docs/site/demo/kiln-60s.cast` (replacing the stub), push, and the Pages workflow auto-deploys on `docs/site/**`. The demo is then live at https://ericflo.github.io/kiln/demo/.
+
+### Theme and font
+
+The asciinema player renders with its own theme; the surrounding page is dark. To match Kiln's launch.html palette, the embed in `README.md` sets `data-theme="solarized-dark"`. If you want a pure neutral look, use `data-theme="monokai"` instead. Font is whatever the recording terminal used — pick a monospace with strong character distinction (JetBrains Mono, Fira Code without ligatures, or SF Mono all look good in the player).
+
+## Post-recording integration checklist
+
+Once `docs/site/demo/kiln-60s.cast` lands:
+
+- [ ] Replace the stub `kiln-60s.cast` in this directory with the real recording.
+- [ ] In `docs/site/demo/index.html`, remove the "demo coming soon" stub note from the caption section.
+- [ ] In `docs/site/launch.html`, find the existing demo link and confirm it still points at `demo/`. Optionally embed the player inline near the "GRPO loop" section if Eric wants a richer landing.
+- [ ] In `docs/site/launch/README.md`, change the "demo asciicast: scaffolding shipped" line to "demo asciicast: live at `/demo/`".
+- [ ] In `README.md` hero block, the existing `Demo` link in the center-aligned link row already points to `docs/site/demo/` — no change needed.
+- [ ] Verify the Pages workflow ran cleanly: `gh run list -R ericflo/kiln --workflow=Pages --limit 3`.
+- [ ] Open https://ericflo.github.io/kiln/demo/ in a fresh browser session and confirm the player loads and plays end-to-end.
+
+## Failure modes to avoid
+
+- **Do not record the model download.** That is multi-GB and minutes long. The prerequisites section pre-stages it.
+- **Do not narrate over the recording with audio.** Asciicasts are silent; the page caption carries the story. Audio narration belongs in a separate video, not this canonical asciicast.
+- **Do not edit individual `.cast` event rows by hand.** Re-record if a scene is wrong. The `[seconds, "o", "..."]` JSON event format encodes both timing and output and is fragile.
+- **Do not include API keys or model paths that leak host details.** `KILN_MODEL_PATH=./Qwen3.5-4B` is fine. `KILN_MODEL_PATH=/home/eric-personal/...` is not.
+- **Do not let scene 1 sit idle for 30+ seconds while the model loads.** Pre-warm the host so model load is ~5–10 seconds, or do a take where you pre-load and the recording starts at the listen line. The viewer should not wait through cold model load — that is a one-time cost per server lifetime, not a per-request cost.

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -1,0 +1,277 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Kiln Demo &mdash; 60-second online-learning loop</title>
+  <meta name="description" content="A 60-second silent asciicast showing Kiln's live LoRA online-learning loop end-to-end on a single GPU: cold start, base-model chat, /v1/train/sft correction, hot-swap, improved chat. Pure Rust, single binary.">
+  <link rel="canonical" href="https://ericflo.github.io/kiln/demo/">
+  <link rel="icon" type="image/png" href="../assets/logo.png">
+
+  <meta property="og:title" content="Kiln Demo &mdash; 60-second online-learning loop">
+  <meta property="og:description" content="60 seconds, end-to-end, on one GPU: cold start, base-model answer, correction over HTTP, hot-swap, improved answer.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ericflo.github.io/kiln/demo/">
+  <meta property="og:image" content="https://ericflo.github.io/kiln/assets/logo.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Kiln Demo &mdash; 60-second online-learning loop">
+  <meta name="twitter:description" content="60 seconds, end-to-end, on one GPU. Pure Rust, single binary.">
+  <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/logo.png">
+
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- asciinema-player CSS (self-hosted via jsDelivr CDN, version-pinned) -->
+  <link rel="stylesheet" type="text/css"
+        href="https://cdn.jsdelivr.net/npm/asciinema-player@3.7.1/dist/bundle/asciinema-player.css" />
+
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b0d10;
+      --bg-soft: #11141a;
+      --bg-soft-2: #161a22;
+      --line: #1f2530;
+      --line-2: #2a3140;
+      --fg: #e6e9ef;
+      --fg-dim: #a4adbb;
+      --fg-mute: #6f7888;
+      --accent: #f97316;
+      --accent-soft: rgba(249, 115, 22, 0.12);
+    }
+    html { background: var(--bg); }
+    body {
+      background: var(--bg);
+      color: var(--fg);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      font-feature-settings: "ss01", "cv02", "cv11";
+      -webkit-font-smoothing: antialiased;
+    }
+    code, pre, kbd, samp {
+      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    }
+    pre {
+      background: var(--bg-soft);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 1rem 1.1rem;
+      overflow-x: auto;
+      font-size: 13.5px;
+      line-height: 1.55;
+      color: #d8dde7;
+    }
+    pre code { background: transparent; padding: 0; color: inherit; }
+    p code, li code, td code, h2 code, h3 code {
+      background: var(--bg-soft);
+      border: 1px solid var(--line);
+      padding: 0.05rem 0.4rem;
+      border-radius: 5px;
+      font-size: 0.875em;
+      color: #f3c891;
+    }
+    .hero-glow {
+      background:
+        radial-gradient(60% 50% at 50% 0%, rgba(249,115,22,0.10), transparent 70%),
+        radial-gradient(40% 35% at 80% 20%, rgba(56,189,248,0.06), transparent 70%);
+    }
+    .card {
+      background: var(--bg-soft);
+      border: 1px solid var(--line);
+      border-radius: 12px;
+    }
+    .btn-primary {
+      background: var(--accent);
+      color: #1a0c00;
+      font-weight: 600;
+    }
+    .btn-primary:hover { filter: brightness(1.08); }
+    .btn-secondary {
+      background: transparent;
+      color: var(--fg);
+      border: 1px solid var(--line-2);
+    }
+    .btn-secondary:hover { background: var(--bg-soft); }
+    .divider { border-top: 1px solid var(--line); }
+    .pill {
+      background: var(--accent-soft);
+      color: var(--accent);
+      border: 1px solid rgba(249,115,22,0.35);
+    }
+    a { color: #f3c891; }
+    a:hover { color: var(--accent); }
+    a.btn-primary, a.btn-primary:hover { color: #1a0c00; }
+    a.btn-secondary, a.btn-secondary:hover { color: var(--fg); }
+    .meta-line { color: var(--fg-mute); font-size: 0.875rem; }
+    .prose-body p { color: var(--fg-dim); line-height: 1.7; margin-bottom: 1.1rem; }
+    .prose-body h2 { font-size: 1.5rem; font-weight: 600; letter-spacing: -0.01em; margin-top: 2.5rem; margin-bottom: 0.9rem; color: var(--fg); }
+    .prose-body strong { color: var(--fg); font-weight: 600; }
+
+    /* asciinema-player container — keep it visually inside the kiln palette */
+    .asciinema-frame {
+      background: #1c1c1c;
+      border: 1px solid var(--line-2);
+      border-radius: 12px;
+      padding: 0.5rem;
+      overflow: hidden;
+    }
+    .stub-banner {
+      background: rgba(249, 115, 22, 0.10);
+      color: #f3c891;
+      border: 1px solid rgba(249, 115, 22, 0.35);
+      border-radius: 8px;
+      padding: 0.6rem 0.9rem;
+      font-size: 0.875rem;
+    }
+  </style>
+</head>
+<body class="min-h-screen">
+  <!-- nav -->
+  <header class="border-b" style="border-color: var(--line);">
+    <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
+      <a href="/" class="flex items-center gap-2.5">
+        <img src="../assets/logo.png" alt="" width="28" height="28" class="rounded">
+        <span class="text-lg font-semibold tracking-tight">Kiln</span>
+      </a>
+      <nav class="flex items-center gap-5 text-sm" style="color: var(--fg-dim);">
+        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">Architecture</a>
+        <a href="../launch.html">Launch post</a>
+        <a href="https://github.com/ericflo/kiln" class="hidden sm:inline">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- hero -->
+  <section class="hero-glow">
+    <div class="max-w-3xl mx-auto px-6 pt-16 pb-8">
+      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">Demo &middot; 60 seconds &middot; one GPU</span>
+      <h1 class="text-4xl sm:text-5xl font-bold tracking-tight mb-5 leading-tight">
+        Watch the loop close in 60 seconds.
+      </h1>
+      <p class="text-lg leading-relaxed" style="color: var(--fg-dim);">
+        Cold start. Ask the base model who Kiln is &mdash; it has no idea. POST a two-example correction
+        to <code>/v1/train/sft</code>. The server trains the LoRA in-process, hot-swaps it at the next
+        iteration boundary, and the very next chat completion uses the updated weights. No restarts, no
+        second model in VRAM. One process, one GPU, one continuous shell session.
+      </p>
+    </div>
+  </section>
+
+  <!-- player -->
+  <section class="divider">
+    <div class="max-w-4xl mx-auto px-6 py-10">
+
+      <div class="asciinema-frame mb-4">
+        <div id="kiln-demo-player" data-src="kiln-60s.cast"></div>
+      </div>
+
+      <div class="stub-banner mb-6" id="stub-banner">
+        <strong>Heads up:</strong> the asciicast above is a placeholder while the canonical 60-second
+        recording is being staged on a kiln-capable GPU host. The recording script
+        (<a href="https://github.com/ericflo/kiln/blob/main/docs/site/demo/SCRIPT.md">SCRIPT.md</a>)
+        pins down every command and the expected output. The page and the embed are wired up; the
+        only missing piece is the <code>kiln-60s.cast</code> file itself, and replacing it is a
+        single-commit, doc-only change.
+      </div>
+
+    </div>
+  </section>
+
+  <!-- caption / what's happening -->
+  <section class="divider">
+    <div class="max-w-3xl mx-auto px-6 py-12 prose-body">
+
+      <h2>What you&rsquo;re watching</h2>
+      <p>
+        The demo is a single uncut shell session. It runs the same prompt twice &mdash; once before a
+        correction is submitted, once after &mdash; so the contrast is unmistakable. The whole thing
+        is silent: there is no narration track, no jump cuts, no editing. What you see is what the
+        kiln server actually does.
+      </p>
+
+      <h2>Scene by scene</h2>
+      <p>
+        <strong>Scenes 1&ndash;2.</strong> The kiln binary starts. The startup banner shows the model,
+        the GPU, the VRAM budget, and the listen address. Then a chat completion: <em>&ldquo;In one
+        short sentence, what is the Kiln inference server?&rdquo;</em> The base Qwen3.5-4B has never
+        heard of Kiln-the-software, so it guesses pottery. A reasonable wrong answer.
+      </p>
+      <p>
+        <strong>Scenes 3&ndash;4.</strong> A single <code>curl</code> POST to <code>/v1/train/sft</code>
+        with two correction examples and an adapter name. The server queues the job, training runs
+        in-process on the GPU we&rsquo;re already serving from, and a <code>/v1/train/status</code>
+        poll shows the job completed in a few seconds. The server never paused.
+      </p>
+      <p>
+        <strong>Scenes 5&ndash;6.</strong> The same prompt as scene 2 &mdash; verbatim. The model
+        now answers correctly with the language from the correction examples. A final
+        <code>/v1/adapters</code> list confirms the new adapter is active, rank 8, about 4 MB on
+        disk, ready for the next correction to stack on top.
+      </p>
+
+      <h2>Why this loop matters</h2>
+      <p>
+        Today, improving a deployed model is a multi-hour multi-process pipeline: collect failures,
+        format them, upload to a training service, wait, download new weights, redeploy, hope. The
+        cost of every iteration is high enough that nobody iterates &mdash; the model you ship is the
+        model your users live with. Kiln collapses that into one HTTP call. The activation energy
+        of a correction drops from hours to seconds, and the model you ship is the one that just
+        learned from your last failure.
+      </p>
+      <p>
+        Read the full launch post at <a href="../launch.html">launch.html</a>, or the engineering
+        details in the <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        and <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">Architecture</a>
+        docs.
+      </p>
+
+      <h2>Reproduce it yourself</h2>
+      <p>
+        The canonical demo runs the same commands you&rsquo;d run as a first-time user. Every line is
+        in the <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>. The
+        recording protocol &mdash; terminal size, scene timing, expected outputs &mdash; is in
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/site/demo/SCRIPT.md">SCRIPT.md</a>.
+        If you want to record your own variant on different hardware or with a different correction
+        prompt, fork that script and replace whichever scenes you like.
+      </p>
+
+    </div>
+  </section>
+
+  <!-- footer / nav back -->
+  <section class="divider">
+    <div class="max-w-3xl mx-auto px-6 py-10 flex flex-wrap gap-3">
+      <a href="/" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+        &larr; Back to home
+      </a>
+      <a href="../launch.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+        Launch post &rarr;
+      </a>
+      <a href="https://github.com/ericflo/kiln" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+        GitHub &rarr;
+      </a>
+      <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+        Quickstart &rarr;
+      </a>
+    </div>
+  </section>
+
+  <!-- asciinema-player JS -->
+  <script src="https://cdn.jsdelivr.net/npm/asciinema-player@3.7.1/dist/bundle/asciinema-player.min.js"></script>
+  <script>
+    AsciinemaPlayer.create(
+      'kiln-60s.cast',
+      document.getElementById('kiln-demo-player'),
+      {
+        autoPlay: false,
+        preload: true,
+        loop: false,
+        idleTimeLimit: 2,
+        theme: 'monokai',
+        poster: 'npt:0:02',
+        cols: 120,
+        rows: 32
+      }
+    );
+  </script>
+</body>
+</html>

--- a/docs/site/demo/kiln-60s.cast
+++ b/docs/site/demo/kiln-60s.cast
@@ -1,0 +1,7 @@
+{"version": 2, "width": 120, "height": 32, "timestamp": 1730419200, "title": "Kiln 60-second demo (stub)", "env": {"SHELL": "/bin/bash", "TERM": "xterm-256color"}}
+[0.5, "o", "$ "]
+[1.2, "o", "# Kiln demo asciicast \u2014 coming soon\r\n"]
+[2.0, "o", "$ "]
+[2.7, "o", "# See docs/site/demo/SCRIPT.md for the recording script\r\n"]
+[3.5, "o", "$ "]
+[5.5, "o", ""]

--- a/docs/site/launch.html
+++ b/docs/site/launch.html
@@ -200,7 +200,9 @@ requests.post("http://localhost:8420/v1/train/grpo", json={
       </p>
       <p>
         See <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">docs/GRPO_GUIDE.md</a> for
-        worked verifiable-rewards examples on math, JSON formatting, and code generation.
+        worked verifiable-rewards examples on math, JSON formatting, and code generation. The
+        <a href="demo/">60&#x2011;second demo</a> shows the same loop end-to-end on a single GPU: cold start,
+        first chat on the base model, an SFT correction, hot-swap, then the second chat on the improved weights.
       </p>
 
       <h2>Hot-swap, not redeploy</h2>

--- a/docs/site/launch/README.md
+++ b/docs/site/launch/README.md
@@ -9,9 +9,13 @@ or deployed; it's a versioned drafting space.
 
 - The live launch blog post: [`docs/site/launch.html`](../launch.html)
   (deployed at https://ericflo.github.io/kiln/launch.html, shipped in PR #667)
-- The demo asciicast: tracked separately in the Phase 11 launch checklist.
-  No launch post should go live until the asciicast is linked from
-  `docs/site/launch.html`.
+- The demo asciicast: scaffolding lives in
+  [`docs/site/demo/`](../demo/) (recording script in
+  [`SCRIPT.md`](../demo/SCRIPT.md), standalone player in
+  [`index.html`](../demo/index.html), stub `.cast` in place so the embed
+  routes end-to-end). The actual `.cast` recording is the remaining
+  blocker. No launch post should go live until the real recording lands
+  and is linked from `docs/site/launch.html`.
 
 ## Status
 


### PR DESCRIPTION
## What

Stages `docs/site/demo/` so the 60-second live-LoRA demo asciicast — Phase 11
launch checklist item #3 — can be recorded against a fixed script and
embedded with no further code changes:

- `docs/site/demo/SCRIPT.md` — six-scene recording script (cold start →
  base chat → `/v1/train/sft` correction → adapter polling → improved chat
  → adapter list), per-scene timing summing to 55-65s, prerequisites,
  recording commands, and a post-recording integration checklist.
- `docs/site/demo/index.html` — standalone asciinema-player page styled to
  match `launch.html` (orange `#f97316` accent on dark `#0b0d10`,
  monospace UI), jsDelivr-pinned `asciinema-player@3.7.1`, autoplay off,
  preload on, monokai theme, 120×32.
- `docs/site/demo/README.md` — embed docs (the same three blocks any
  other page can copy onto itself), rationale for self-hostable vs
  `asciinema.org/a/<id>.js`, and how to re-record.
- `docs/site/demo/kiln-60s.cast` — a tiny valid asciicast v2 stub
  (under 1 KB, 5 events, replays as "demo coming soon"). Replace in
  place with the real recording — no code change required.

Integration:

- `README.md` hero link row gains a `Demo` entry pointing to
  `docs/site/demo/`.
- `docs/site/launch.html` GRPO-loop section gains an inline pointer to
  `demo/`.
- `docs/site/launch/README.md` no longer treats the demo as a generic
  external dep — it now references the staged scaffolding and calls out
  the `.cast` recording itself as the remaining blocker.

## Why

Items #4 (pre-launch ops gate) and #5 (channel-specific launch posts) in
the Phase 11 launch checklist all reference the demo asciicast as a
launch blocker. There's no "demo coming soon" caveat we can ship around.
Staging the script + player + embed-routing now means the only remaining
step is to record the `.cast` on a kiln-capable GPU host and drop it in
place.

## Test plan

- The Pages workflow auto-deploys on `docs/site/**`. After this lands,
  `https://ericflo.github.io/kiln/demo/` should render the player with
  the stub `.cast` ("demo coming soon" message), and `launch.html` and
  the README hero row should both expose the new link.
- The stub `.cast` is valid asciicast v2 (validated via Python JSON
  parsing on each event line) and replays cleanly with
  `asciinema play kiln-60s.cast`.
- No CI runs against this PR — the kiln CI workflow is path-filtered to
  `crates/**` and `Cargo.{toml,lock}`. Docs-only PRs skip CI by design.