### PR TITLE
Serialize real inference to avoid workers=2 prefill cascade

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -44,6 +44,20 @@ fn last_user_message_text(req: &ChatCompletionRequest) -> String {
         .unwrap_or_default()
 }
 
+/// Acquire the real-model GPU gate for inference.
+///
+/// This intentionally takes the exclusive side of `GpuCoordinationLock` instead
+/// of a shared read guard: #664 round-6 showed that client-side `workers=2` can
+/// still drive the real long-prefill path into a persistent 5xx cascade after
+/// #666's timeout-drain fix. Holding the write guard makes the server enforce
+/// the known-stable workers=1 behavior until the CUDA/paged-cache/prefix-cache
+/// path has a stronger concurrent-prefill contract.
+fn acquire_real_inference_gpu_guard(
+    gpu_lock: &crate::state::GpuCoordinationLock,
+) -> std::sync::RwLockWriteGuard<'_, ()> {
+    gpu_lock.write().unwrap()
+}
+
 const REASONING_OPEN_TAG: &str = "<think>\n";
 const REASONING_CLOSE_TAG: &str = "</think>";
 
@@ -1213,9 +1227,7 @@ async fn generate_real(
     let cancel = CancelHandle::new();
     let cancel_inner = cancel.clone();
     let generation = tokio::task::spawn_blocking(move || {
-        // Acquire GPU coordination read lock — allows concurrent inference,
-        // but blocks while training holds the write lock.
-        let _gpu_guard = gpu_lock.read().unwrap();
+        let _gpu_guard = acquire_real_inference_gpu_guard(&gpu_lock);
         let runner_guard = runner.read().unwrap();
         match speculative_mode {
             ResolvedSpeculativeMode::Off => {
@@ -1324,7 +1336,10 @@ async fn generate_real(
     let output = match tokio::time::timeout(timeout, &mut generation).await {
         Ok(join_result) => join_result
             .map_err(|e| ApiError::internal(format!("join error: {e}")))?
-            .map_err(ApiError::generation_failed)?,
+            .map_err(|err| {
+                tracing::error!(error = %format!("{err:#}"), "real generation failed");
+                ApiError::generation_failed(err)
+            })?,
         Err(_) => {
             // Signal cooperative cancellation, then await the join handle so
             // the spawn_blocking closure releases `runner.read()` /
@@ -1560,7 +1575,7 @@ async fn generate_real_streaming(
                     // instead of buffering everything until generation is
                     // done.
                     match tokio::task::spawn_blocking(move || {
-                        let _gpu_guard = gpu_lock.read().unwrap();
+                        let _gpu_guard = acquire_real_inference_gpu_guard(&gpu_lock);
                         let prefix_enabled = {
                             let cache = prefix_cache.lock().unwrap();
                             cache.is_enabled()
@@ -1668,7 +1683,7 @@ async fn generate_real_streaming(
                 }
                 ResolvedSpeculativeMode::SkipLayer(spec_config) => {
                     match tokio::task::spawn_blocking(move || {
-                        let _gpu_guard = gpu_lock.read().unwrap();
+                        let _gpu_guard = acquire_real_inference_gpu_guard(&gpu_lock);
                         let runner_guard = runner.read().unwrap();
                         if params.temperature == 0.0 {
                             runner_guard.generate_streaming_paged_speculative_shared_tokens(
@@ -1706,7 +1721,7 @@ async fn generate_real_streaming(
                 }
                 ResolvedSpeculativeMode::Mtp => {
                     match tokio::task::spawn_blocking(move || {
-                        let _gpu_guard = gpu_lock.read().unwrap();
+                        let _gpu_guard = acquire_real_inference_gpu_guard(&gpu_lock);
                         let runner_guard = runner.read().unwrap();
                         runner_guard.generate_streaming_mtp_speculative(&prompt, &params)
                     })
@@ -2459,6 +2474,19 @@ mod tests {
             temperature,
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn real_inference_gpu_guard_is_exclusive() {
+        let gpu_lock = std::sync::Arc::new(std::sync::RwLock::new(()));
+        let guard = acquire_real_inference_gpu_guard(&gpu_lock);
+
+        assert!(
+            gpu_lock.try_read().is_err(),
+            "real inference must serialize instead of allowing a second reader"
+        );
+        drop(guard);
+        assert!(gpu_lock.try_read().is_ok());
     }
 
     #[test]

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -114,9 +114,11 @@ impl GpuMemoryBudget {
 
 /// Coordination lock for GPU memory sharing between inference and training.
 ///
-/// Inference acquires a read lock (multiple concurrent inference requests OK).
-/// Training acquires a write lock (blocks inference during gradient computation).
-/// This prevents combined peak VRAM from exceeding GPU capacity.
+/// Inference currently acquires a write lock, serializing real GPU generation.
+/// This intentionally mirrors the known-stable workers=1 behavior after #664
+/// reproduced a workers=2 long-prefill 5xx cascade. Training also acquires the
+/// write lock, so training and inference remain mutually exclusive during GPU
+/// work.
 ///
 /// Training should acquire this per-segment (for gradient-checkpointed training),
 /// not for the entire job, to minimize inference latency impact.


### PR DESCRIPTION
## Summary

- Serializes the real-model GPU generation path by taking the exclusive side of `GpuCoordinationLock` for non-streaming and streaming completions.
- Keeps PR #666's cancellation drain intact, but prevents a second workers=2 request from entering long prefill/decode while another real request owns CUDA, paged KV cache, prefix cache, and runner state.
- Logs the full anyhow chain for real non-streaming generation failures so the next preserved `kiln-server.log` includes the actual prefill root cause instead of only HTTP 500 spans.

## Round-6 evidence

I pulled and read `b2://clouderic/corrections-experiment/phase2-round6/REPORT.md`, `logs/kiln-server.log`, `logs/collect.log`, and raw rejected shards before touching code.

Key observations:

- Server startup confirms main was post-#666 (`Version: 0.2.8`, 32768 BF16 KV blocks on RTX A6000).
- The preserved server log shows a 300s timeout at `2026-05-01T03:02:20.391744Z` (`status=408`, `duration_ms=300302.6`), even though the later heartbeat summary did not call it out as immediately preceding the cascade.
- The first preserved 500 is at `2026-05-01T03:41:47.528630Z` (`duration_ms=1012.3`), immediately after a long successful/rejected trajectory finished at `03:41:46.5`.
- The first 500 is not itself a 300s timeout. It is a fast prefill/generation error on the next worker, which differs from the original #664 framing of "timeout fires, un-drained blocking task keeps locks forever".
- The server log does not include the full generation error chain today; only the HTTP span is preserved. This PR adds logging so the next run captures the concrete kernel/OOM/assertion cause.

## Root cause / why #666 was insufficient

#666 correctly drains the `spawn_blocking` join handle after timeout, but it still allows multiple real inference requests to hold the GPU coordination lock concurrently via shared `read()` guards. Round-6 shows the known-stable workers=1 workaround was not encoded server-side: with client `workers=2`, a second long request can enter the real GPU prefill path immediately after another long request completes or times out.

This PR treats real GPU generation as not concurrency-safe until proven otherwise. It switches inference from a shared read guard to an exclusive write guard, so server behavior matches the known-stable workers=1 mode regardless of client concurrency.

## Regression coverage

- Adds `real_inference_gpu_guard_is_exclusive`, pinning that real inference takes an exclusive guard and rejects a second concurrent reader while held.

## Validation

- `git diff --check` passes.
- Attempted `cargo nextest run -p kiln-server`, but this local task container has no Rust toolchain (`cargo: command not found`). Per task scope I did not spin up a RunPod pod.

## Confidence

Medium. This is a conservative correctness shim, not a proof of the lower-level CUDA/paged-cache/prefix-cache race. It should close the workers=2 cascade by making real inference effectively workers=1 inside the server, which matches the stable workaround. The remaining risk is throughput regression and the possibility that a single-request long-prefill kernel failure still occurs; the new error logging is intended to make that distinguishable in the next round.
