### PR TITLE
fix(prefix-cache): never return retained blocks in evicted_blocks

### DIFF
--- a/crates/kiln-core/src/block.rs
+++ b/crates/kiln-core/src/block.rs
@@ -74,6 +74,25 @@ impl BlockManager {
 
     /// Free multiple blocks.
     pub fn free_all(&mut self, block_ids: &[u32]) {
+        // #673: A double-free corrupts the free list and lets concurrent
+        // requests get the same physical block twice. The prefix-cache layer
+        // is the canonical source of these IDs and should never hand us a
+        // duplicate or a block that is still on the free list.
+        debug_assert!(
+            {
+                let mut seen = std::collections::HashSet::with_capacity(block_ids.len());
+                block_ids.iter().all(|id| seen.insert(*id))
+            },
+            "BlockManager::free_all called with duplicate block IDs: {block_ids:?}",
+        );
+        debug_assert!(
+            {
+                let free_set: std::collections::HashSet<u32> =
+                    self.free_blocks.iter().copied().collect();
+                block_ids.iter().all(|id| !free_set.contains(id))
+            },
+            "BlockManager::free_all called with block IDs already on the free list: incoming={block_ids:?}",
+        );
         for &id in block_ids {
             self.free_blocks.push_back(id);
         }

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -1295,6 +1295,23 @@ async fn generate_real(
                         .filter(|block_id| !retained_blocks.contains(block_id))
                         .collect();
                     blocks_to_free.extend(evicted_blocks);
+                    // #673: never free a block that the prefix cache has just
+                    // claimed for the new entry, and never queue the same
+                    // block twice in one free call.
+                    debug_assert!(
+                        blocks_to_free
+                            .iter()
+                            .all(|id| !retained_blocks.contains(id)),
+                        "blocks_to_free overlaps retained_blocks: free={blocks_to_free:?} retained={retained_blocks:?}",
+                    );
+                    debug_assert!(
+                        {
+                            let mut seen =
+                                std::collections::HashSet::with_capacity(blocks_to_free.len());
+                            blocks_to_free.iter().all(|id| seen.insert(*id))
+                        },
+                        "blocks_to_free contains duplicate block IDs: {blocks_to_free:?}",
+                    );
                     if !blocks_to_free.is_empty() {
                         let mut bm_guard = bm.lock().unwrap();
                         bm_guard.free_all(&blocks_to_free);
@@ -1642,6 +1659,25 @@ async fn generate_real_streaming(
                                 .filter(|block_id| !retained_blocks.contains(block_id))
                                 .collect();
                             blocks_to_free.extend(evicted_blocks);
+                            // #673: never free a block that the prefix cache
+                            // has just claimed for the new entry, and never
+                            // queue the same block twice in one free call —
+                            // even on the deferred (channel) path.
+                            debug_assert!(
+                                blocks_to_free
+                                    .iter()
+                                    .all(|id| !retained_blocks.contains(id)),
+                                "blocks_to_free overlaps retained_blocks: free={blocks_to_free:?} retained={retained_blocks:?}",
+                            );
+                            debug_assert!(
+                                {
+                                    let mut seen = std::collections::HashSet::with_capacity(
+                                        blocks_to_free.len(),
+                                    );
+                                    blocks_to_free.iter().all(|id| seen.insert(*id))
+                                },
+                                "blocks_to_free contains duplicate block IDs: {blocks_to_free:?}",
+                            );
                             // For the threaded streaming path, NEVER free
                             // here — the spawned decode worker is still
                             // reading these block ids for KV. Hand the

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -319,6 +319,21 @@ impl RealPrefixCache {
         for &block_id in &registration.block_ids {
             *self.block_refcounts.entry(block_id).or_insert(0) += 1;
         }
+        // #673: An entry evicted above may have shared block IDs with the
+        // incoming registration. `release_entry_blocks` would have pushed those
+        // IDs into `evicted_blocks`, but the refcount increments above have now
+        // re-claimed them. Returning them in `evicted_blocks` would cause the
+        // API layer to free live cached blocks back to the BlockManager, where
+        // a concurrent request can re-allocate and overwrite them.
+        let registration_set: HashSet<u32> =
+            registration.block_ids.iter().copied().collect();
+        evicted_blocks.retain(|block_id| !registration_set.contains(block_id));
+        debug_assert!(
+            evicted_blocks
+                .iter()
+                .all(|id| !self.block_refcounts.contains_key(id)),
+            "RealPrefixCache::register: evicted_blocks must not contain any block currently in block_refcounts"
+        );
         let id = self.next_entry_id;
         self.next_entry_id += 1;
         let last_used = self.stats.lookup_hits + self.stats.lookup_misses;
@@ -972,6 +987,166 @@ mod tests {
                 .lookup(&Some("adapter-a".to_string()), &[1, 2, 3, 4, 5])?
                 .is_some()
         );
+        Ok(())
+    }
+
+    // Regression tests for #673: prefix-cache eviction must never return block
+    // IDs that the same `register()` call has just re-retained for the new
+    // entry. If it does, the API layer hands those IDs to BlockManager::free_all,
+    // which under workers=2 can re-allocate them and overwrite live KV that the
+    // prefix cache still serves as valid.
+
+    #[test]
+    fn register_does_not_evict_blocks_retained_by_incoming() -> anyhow::Result<()> {
+        let config = tiny_linear_config();
+        let device = candle_core::Device::Cpu;
+        let mut cache = RealPrefixCache::new(true, 4, 2);
+
+        // Entry A occupies blocks [10, 11], the cache's full capacity.
+        let outcome_a = cache.register(
+            None,
+            PagedPrefixRegistration {
+                prompt_tokens: vec![1, 2, 3, 4, 5, 6, 7, 8],
+                block_ids: vec![10, 11],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+            },
+        );
+        assert_eq!(outcome_a.retained_blocks, vec![10, 11]);
+        assert!(outcome_a.evicted_blocks.is_empty());
+
+        // Entry B is a strict superset of A and reuses A's blocks plus block 12.
+        // To make room (cached_blocks=2 + needed_new=1 > max=2), the cache must
+        // evict A. Pre-fix, evicted_blocks would contain [10, 11] AND those IDs
+        // would be re-retained for B — a double-claim that frees live blocks.
+        let outcome_b = cache.register(
+            None,
+            PagedPrefixRegistration {
+                prompt_tokens: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                block_ids: vec![10, 11, 12],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+            },
+        );
+
+        let retained: HashSet<u32> = outcome_b.retained_blocks.iter().copied().collect();
+        let evicted: HashSet<u32> = outcome_b.evicted_blocks.iter().copied().collect();
+        assert!(
+            retained.is_disjoint(&evicted),
+            "retained_blocks {retained:?} must not overlap evicted_blocks {evicted:?}",
+        );
+        for block_id in &[10u32, 11, 12] {
+            assert!(
+                !evicted.contains(block_id),
+                "block {block_id} re-retained by incoming registration must not appear in evicted_blocks: {evicted:?}",
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn register_outcome_no_duplicate_or_overlap() -> anyhow::Result<()> {
+        let config = tiny_linear_config();
+        let device = candle_core::Device::Cpu;
+        let mut cache = RealPrefixCache::new(true, 4, 3);
+
+        // Three small entries that together fill capacity, two of which share
+        // block 20 with the eventual incoming registration.
+        cache.register(
+            None,
+            PagedPrefixRegistration {
+                prompt_tokens: vec![1, 2, 3, 4],
+                block_ids: vec![20],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+            },
+        );
+        cache.register(
+            Some("a".to_string()),
+            PagedPrefixRegistration {
+                prompt_tokens: vec![5, 6, 7, 8],
+                block_ids: vec![20, 21],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+            },
+        );
+        cache.register(
+            Some("b".to_string()),
+            PagedPrefixRegistration {
+                prompt_tokens: vec![9, 10, 11, 12],
+                block_ids: vec![22],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+            },
+        );
+
+        // Incoming registration shares block 20 with two existing entries and
+        // brings a fresh block 99. Eviction will likely run multiple times.
+        let outcome = cache.register(
+            Some("c".to_string()),
+            PagedPrefixRegistration {
+                prompt_tokens: vec![13, 14, 15, 16, 17, 18, 19, 20],
+                block_ids: vec![20, 99],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+            },
+        );
+
+        let retained_set: HashSet<u32> =
+            outcome.retained_blocks.iter().copied().collect();
+        assert_eq!(
+            retained_set.len(),
+            outcome.retained_blocks.len(),
+            "retained_blocks must not contain duplicates: {:?}",
+            outcome.retained_blocks,
+        );
+
+        let evicted_set: HashSet<u32> =
+            outcome.evicted_blocks.iter().copied().collect();
+        assert_eq!(
+            evicted_set.len(),
+            outcome.evicted_blocks.len(),
+            "evicted_blocks must not contain duplicates: {:?}",
+            outcome.evicted_blocks,
+        );
+
+        assert!(
+            retained_set.is_disjoint(&evicted_set),
+            "retained {retained_set:?} and evicted {evicted_set:?} must be disjoint",
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn register_evicted_blocks_not_in_refcounts_after() -> anyhow::Result<()> {
+        let config = tiny_linear_config();
+        let device = candle_core::Device::Cpu;
+        let mut cache = RealPrefixCache::new(true, 4, 2);
+
+        // Fill capacity with an evictable entry whose blocks the next
+        // registration also wants.
+        cache.register(
+            None,
+            PagedPrefixRegistration {
+                prompt_tokens: vec![1, 2, 3, 4, 5, 6, 7, 8],
+                block_ids: vec![30, 31],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+            },
+        );
+
+        // Register a longer prompt that reuses [30, 31] and adds 32. The bug
+        // would let evicted_blocks contain 30/31 even though they are now
+        // tracked by the new entry's refcounts.
+        let outcome = cache.register(
+            Some("ad".to_string()),
+            PagedPrefixRegistration {
+                prompt_tokens: vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                block_ids: vec![30, 31, 32],
+                linear_state: LinearAttentionState::new(&config, &device)?,
+            },
+        );
+
+        for block_id in &outcome.evicted_blocks {
+            assert!(
+                !cache.block_refcounts.contains_key(block_id),
+                "evicted block {block_id} must not be tracked in block_refcounts after register(); refcounts={:?}",
+                cache.block_refcounts,
+            );
+        }
         Ok(())
     }
 


### PR DESCRIPTION
Closes #673. Unblocks relaxing #672's exclusive `GpuCoordinationLock` serialization shim, which is the path back to real workers=2 throughput per the kiln-excellence-throughput-mandate.

## Root cause

`RealPrefixCache::register()` could return block IDs in `evicted_blocks` that the same call had just re-incremented refcounts for in the new registration. The API layer in `completions.rs` unconditionally appends `evicted_blocks` to `blocks_to_free` and calls `BlockManager::free_all()`, returning live cached blocks to the free list. Under `workers=2`, another request can then allocate from that free list and overwrite KV that the prefix cache still serves as valid.

Concrete reproducer:
- Cache holds entry A with blocks `[10, 11]` at full capacity.
- Incoming registration B has block_ids `[10, 11, 12]`.
- LRU eviction of A calls `release_entry_blocks([10, 11])`, decrementing both to 0 and pushing them into `evicted_blocks`.
- `register()` then increments refcounts for `[10, 11, 12]` for B → all three are live again.
- Pre-fix: returned `retained=[10, 11, 12]`, `evicted=[10, 11]` — blocks 10 and 11 are in BOTH lists.

## Invariant enforced

After this PR, `RealPrefixCacheRegisterOutcome` upholds:

- `retained_blocks ∩ evicted_blocks == ∅`
- No block currently in `block_refcounts` may appear in `evicted_blocks`
- No duplicate block IDs in any returned vec

## Fix

`crates/kiln-server/src/state.rs` — after computing eviction-derived `evicted_blocks` and incrementing refcounts for the incoming registration, drop any block ID that is in `registration.block_ids`. A `debug_assert!` enforces the stronger "no evicted block remains in `block_refcounts`" post-condition.

## Defense in depth

- **`crates/kiln-server/src/api/completions.rs`** — both the non-streaming path (line 1265-ish) and the streaming/channel path (line 1615-ish): `debug_assert!`s that `blocks_to_free` is disjoint from `retained_blocks` and contains no duplicates. Today both paths already filter `allocated_blocks` against `retained_blocks` before extending with `evicted_blocks`; the new state.rs fix makes that extension safe, and the asserts guard against future regressions.
- **`crates/kiln-core/src/block.rs::BlockManager::free_all`** — `debug_assert!`s no duplicate incoming IDs and no IDs already on the free list. Catches double-free regressions cheaply for any future caller.

## Tests

Three new CPU-only regression tests in `crates/kiln-server/src/state.rs`:

- **`register_does_not_evict_blocks_retained_by_incoming`** — direct reproducer of the bug: short prefix occupies full cache; longer superset prefix forces eviction; asserts `evicted_blocks` is disjoint from the new entry's blocks.
- **`register_outcome_no_duplicate_or_overlap`** — generic invariant: `retained_blocks` and `evicted_blocks` are disjoint with no internal duplicates, even across multi-evict scenarios.
- **`register_evicted_blocks_not_in_refcounts_after`** — no block ID in the returned `evicted_blocks` may be present in `block_refcounts`.

### Verified the tests catch the bug

Temporarily removed the new `evicted_blocks.retain(...)` line and re-ran:

```
FAIL register_does_not_evict_blocks_retained_by_incoming
  retained_blocks {10, 12, 11} must not overlap evicted_blocks {11, 10}
FAIL register_evicted_blocks_not_in_refcounts_after
```

Restored, all three pass.

## Test results

```
$ cargo nextest run -p kiln-server -p kiln-core --lib
Summary: 170 tests run: 170 passed, 3 skipped
```

No GPU required for this change — purely CPU-side logic on the `RealPrefixCache` data structure.

## Out of scope

This PR keeps the scope tight to just the prefix-cache bug + tests + defensive asserts. **Does not** relax PR #672's exclusive `GpuCoordinationLock` for real inference — that follow-up will land separately once this CI passes and the planning loop verifies the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)