### PR TITLE
revert: workers=2 serialize shim from #672 now that #673 is fixed

### DIFF
--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -44,20 +44,6 @@ fn last_user_message_text(req: &ChatCompletionRequest) -> String {
         .unwrap_or_default()
 }
 
-/// Acquire the real-model GPU gate for inference.
-///
-/// This intentionally takes the exclusive side of `GpuCoordinationLock` instead
-/// of a shared read guard: #664 round-6 showed that client-side `workers=2` can
-/// still drive the real long-prefill path into a persistent 5xx cascade after
-/// #666's timeout-drain fix. Holding the write guard makes the server enforce
-/// the known-stable workers=1 behavior until the CUDA/paged-cache/prefix-cache
-/// path has a stronger concurrent-prefill contract.
-fn acquire_real_inference_gpu_guard(
-    gpu_lock: &crate::state::GpuCoordinationLock,
-) -> std::sync::RwLockWriteGuard<'_, ()> {
-    gpu_lock.write().unwrap()
-}
-
 const REASONING_OPEN_TAG: &str = "<think>\n";
 const REASONING_CLOSE_TAG: &str = "</think>";
 
@@ -1227,7 +1213,9 @@ async fn generate_real(
     let cancel = CancelHandle::new();
     let cancel_inner = cancel.clone();
     let generation = tokio::task::spawn_blocking(move || {
-        let _gpu_guard = acquire_real_inference_gpu_guard(&gpu_lock);
+        // Acquire GPU coordination read lock — allows concurrent inference,
+        // but blocks while training holds the write lock.
+        let _gpu_guard = gpu_lock.read().unwrap();
         let runner_guard = runner.read().unwrap();
         match speculative_mode {
             ResolvedSpeculativeMode::Off => {
@@ -1592,7 +1580,7 @@ async fn generate_real_streaming(
                     // instead of buffering everything until generation is
                     // done.
                     match tokio::task::spawn_blocking(move || {
-                        let _gpu_guard = acquire_real_inference_gpu_guard(&gpu_lock);
+                        let _gpu_guard = gpu_lock.read().unwrap();
                         let prefix_enabled = {
                             let cache = prefix_cache.lock().unwrap();
                             cache.is_enabled()
@@ -1719,7 +1707,7 @@ async fn generate_real_streaming(
                 }
                 ResolvedSpeculativeMode::SkipLayer(spec_config) => {
                     match tokio::task::spawn_blocking(move || {
-                        let _gpu_guard = acquire_real_inference_gpu_guard(&gpu_lock);
+                        let _gpu_guard = gpu_lock.read().unwrap();
                         let runner_guard = runner.read().unwrap();
                         if params.temperature == 0.0 {
                             runner_guard.generate_streaming_paged_speculative_shared_tokens(
@@ -1757,7 +1745,7 @@ async fn generate_real_streaming(
                 }
                 ResolvedSpeculativeMode::Mtp => {
                     match tokio::task::spawn_blocking(move || {
-                        let _gpu_guard = acquire_real_inference_gpu_guard(&gpu_lock);
+                        let _gpu_guard = gpu_lock.read().unwrap();
                         let runner_guard = runner.read().unwrap();
                         runner_guard.generate_streaming_mtp_speculative(&prompt, &params)
                     })
@@ -2510,19 +2498,6 @@ mod tests {
             temperature,
             ..Default::default()
         }
-    }
-
-    #[test]
-    fn real_inference_gpu_guard_is_exclusive() {
-        let gpu_lock = std::sync::Arc::new(std::sync::RwLock::new(()));
-        let guard = acquire_real_inference_gpu_guard(&gpu_lock);
-
-        assert!(
-            gpu_lock.try_read().is_err(),
-            "real inference must serialize instead of allowing a second reader"
-        );
-        drop(guard);
-        assert!(gpu_lock.try_read().is_ok());
     }
 
     #[test]

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -114,11 +114,9 @@ impl GpuMemoryBudget {
 
 /// Coordination lock for GPU memory sharing between inference and training.
 ///
-/// Inference currently acquires a write lock, serializing real GPU generation.
-/// This intentionally mirrors the known-stable workers=1 behavior after #664
-/// reproduced a workers=2 long-prefill 5xx cascade. Training also acquires the
-/// write lock, so training and inference remain mutually exclusive during GPU
-/// work.
+/// Inference acquires a read lock (multiple concurrent inference requests OK).
+/// Training acquires a write lock (blocks inference during gradient computation).
+/// This prevents combined peak VRAM from exceeding GPU capacity.
 ///
 /// Training should acquire this per-segment (for gradient-checkpointed training),
 /// not for the entire job, to minimize inference latency impact.


### PR DESCRIPTION
## What

Reverts the workers=2 serialization shim from #672 now that #674 has fixed the underlying prefix-cache double-free. Restores `gpu_lock.read()` (shared) at all four `/v1/chat/completions` real-inference call sites and restores the original `GpuCoordinationLock` doc comment.

Keeps the independent `tracing::error!` improvement that #672 also introduced in the `generate_real` timeout path — that's orthogonal to the lock change and remains useful diagnostic surface area.

## Why

PR #672 was an emergency serialization shim: it took the **exclusive write side** of `GpuCoordinationLock` for every real inference request, which made the server enforce known-stable workers=1 behavior while the workers=2 cascade was still being root-caused. Per the `kiln-excellence-throughput-mandate` agent note, serialization shims are emergency-only — kiln must be high-throughput.

PR #674 closed #673, which is the actual root cause. `RealPrefixCache::register()` was returning block IDs in `evicted_blocks` that the same call had just re-incremented refcounts for in the new registration. Under workers=2, a second request would then allocate those blocks from the free list and overwrite KV that the prefix cache still served as valid, surfacing as the persistent 5xx cascade documented in #664.

With the cache double-free fixed, the lock shim is no longer load-bearing and is actively harmful: it collapses concurrent prefill into a single in-flight request and undoes the shared-read concurrency the lock was designed for.

## Validation (RTX A6000, real Qwen3.5-4B inference)

Workers=2 prefix-cache cascade reproduction harness: 2 client threads × 15 tools-bearing chat completion requests with a ~1500-token shared prefix and per-request variant suffix (exercises prefix-cache hits + LRU eviction together). Measures status mix, wall-clock throughput, and per-request latency.

| Build | status_mix | ok_req/s | completion_tok/s | p50/p95/p99 ms | wall_clock_s |
|-------|-----------|----------|------------------|----------------|--------------|
| main with #672 shim still in (d06163a) | `{200: 30}` | 0.777 | 24.86 | 1995 / 9666 / 10656 | 38.61 |
| this revert branch (#674 only) | `{200: 30}` | **0.955** | **30.58** | 2075 / **2328** / **2347** | **31.40** |
| delta | same | **+22.9%** | **+23.0%** | — / **−75.9%** / **−78.0%** | **−18.7%** |

Both runs returned **30/30 status=200** — the workers=2 cascade is closed by #674 alone. The lock revert recovers the throughput / tail-latency the shim was costing: ~+23% on both req/s and tokens/s, and p99 drops from ~10.7s to ~2.3s (4.5× lower) because requests no longer queue serially behind a single in-flight prefill.

## Tests

`cargo nextest run -p kiln-server -p kiln-core --lib`: **169/169 pass** (3 skipped). The `real_inference_gpu_guard_is_exclusive` test from #672 is removed alongside the helper it covered. The new prefix-cache regression tests added in #674 (`register_does_not_evict_blocks_retained_by_incoming`, `register_outcome_no_duplicate_or_overlap`, `register_evicted_blocks_not_in_refcounts_after`) all pass on this branch.

## Files changed

- `crates/kiln-server/src/api/completions.rs`
  - Drops the `acquire_real_inference_gpu_guard` helper.
  - Restores `gpu_lock.read().unwrap()` at all 4 real-inference call sites (non-streaming `generate_real`, and streaming `Off` / `SkipLayer` / `Mtp` modes in `generate_real_streaming`).
  - Drops the `real_inference_gpu_guard_is_exclusive` test.
  - **Keeps** the `tracing::error!` improvement in the `generate_real` timeout-join path.
- `crates/kiln-server/src/state.rs`
  - Restores the original `GpuCoordinationLock` doc comment describing the shared-read (inference) / exclusive-write (training) contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
