### PR TITLE
docs(launch): bump production-line refs from v0.2.8 to v0.2.9

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -105,7 +105,7 @@ You'll see the startup banner:
   │   inference · training · adapters   │
   └─────────────────────────────────────┘
 
-  Version: 0.2.8
+  Version: 0.2.9
   Mode:    GPU inference
   Model:   ./Qwen3.5-4B
   CUDA:    available ✓

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve
   │   inference · training · adapters   │
   └─────────────────────────────────────┘
 
-  Version: 0.2.8
+  Version: 0.2.9
   Model:   ./Qwen3.5-4B
   CUDA:    available ✓
   GPU:     NVIDIA RTX A6000
@@ -306,7 +306,7 @@ Each `kiln-v*` tag publishes a `linux/amd64` CUDA 12.4 image to GHCR:
 ```bash
 docker pull ghcr.io/ericflo/kiln-server:latest
 # or pin a version:
-docker pull ghcr.io/ericflo/kiln-server:0.2.8
+docker pull ghcr.io/ericflo/kiln-server:0.2.9
 ```
 
 Run with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html):

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -123,7 +123,7 @@
   <!-- hero -->
   <section class="hero-glow">
     <div class="max-w-5xl mx-auto px-6 pt-20 pb-16">
-      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">v0.2.8 &middot; pre-1.0 preview</span>
+      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">v0.2.9 &middot; pre-1.0 preview</span>
       <h1 class="text-5xl sm:text-6xl font-bold tracking-tight mb-5">
         Your model gets better<br>every time you use it.
       </h1>
@@ -258,25 +258,25 @@ requests.post("http://localhost:8420/v1/train/grpo",
     <div class="max-w-5xl mx-auto px-6 py-16">
       <h2 class="text-2xl font-semibold tracking-tight mb-2">Install</h2>
       <p class="text-sm mb-8" style="color: var(--fg-mute);">
-        Latest release: <a href="https://github.com/ericflo/kiln/releases/tag/kiln-v0.2.8">kiln-v0.2.8</a>.
+        Latest release: <a href="https://github.com/ericflo/kiln/releases/tag/kiln-v0.2.9">kiln-v0.2.9</a>.
         Prerequisites: NVIDIA GPU with 24 GB+ VRAM and CUDA 12.4 <em>or</em> Apple Silicon Mac with 16 GB+ unified memory.
       </p>
 
       <h3 class="font-semibold mb-2 mt-2">Linux x86_64 &middot; CUDA 12.4</h3>
 <pre><code>curl -L -o kiln.tar.gz \
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.8/kiln-0.2.8-x86_64-unknown-linux-gnu-cuda124.tar.gz
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.9/kiln-0.2.9-x86_64-unknown-linux-gnu-cuda124.tar.gz
 tar -xzf kiln.tar.gz
 KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
 
       <h3 class="font-semibold mb-2 mt-6">macOS &middot; Apple Silicon (Metal)</h3>
 <pre><code>curl -L -o kiln.tar.gz \
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.8/kiln-0.2.8-aarch64-apple-darwin-metal.tar.gz
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.9/kiln-0.2.9-aarch64-apple-darwin-metal.tar.gz
 tar -xzf kiln.tar.gz
 KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
 
       <h3 class="font-semibold mb-2 mt-6">Windows x86_64 &middot; CUDA 12.4</h3>
 <pre><code>Invoke-WebRequest -Uri `
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.8/kiln-0.2.8-x86_64-pc-windows-msvc-cuda124.zip `
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.9/kiln-0.2.9-x86_64-pc-windows-msvc-cuda124.zip `
   -OutFile kiln.zip
 Expand-Archive kiln.zip
 $env:KILN_MODEL_PATH = ".\Qwen3.5-4B"; .\kiln\kiln.exe serve</code></pre>

--- a/docs/site/launch.html
+++ b/docs/site/launch.html
@@ -125,7 +125,7 @@
   <!-- hero -->
   <section class="hero-glow">
     <div class="max-w-3xl mx-auto px-6 pt-20 pb-10">
-      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">Launch announcement &middot; v0.2.8</span>
+      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">Launch announcement &middot; v0.2.9</span>
       <h1 class="text-4xl sm:text-5xl font-bold tracking-tight mb-5 leading-tight">
         Launching Kiln &mdash; your model gets better every time you use it.
       </h1>
@@ -270,7 +270,7 @@ requests.post("http://localhost:8420/v1/train/grpo", json={
         Sigstore build provenance and ships with a SHA-256 sidecar.
       </p>
 <pre><code>curl -L -o kiln.tar.gz \
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.8/kiln-0.2.8-x86_64-unknown-linux-gnu-cuda124.tar.gz
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.9/kiln-0.2.9-x86_64-unknown-linux-gnu-cuda124.tar.gz
 tar -xzf kiln.tar.gz
 KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
       <p>
@@ -285,7 +285,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
 
       <h2>What&rsquo;s next</h2>
       <p>
-        kiln-v0.2.8 is the production line we&rsquo;re launching on, but the project is explicitly pre-1.0.
+        kiln-v0.2.9 is the production line we&rsquo;re launching on, but the project is explicitly pre-1.0.
         The Phases 1&ndash;10 work that got us here closed out core inference, LoRA serving, SFT, GRPO,
         production hardening, decode-perf optimization, developer experience, advanced adapter features, the
         v0.1.0 release engineering, and the Liger long-context training pieces. The roadmap from here is

--- a/docs/site/launch/README.md
+++ b/docs/site/launch/README.md
@@ -87,7 +87,7 @@ For each channel, after going live:
 
 ## Pre-launch ops gate (must be green before any draft goes live)
 
-- `gh release view kiln-v0.2.8 -R ericflo/kiln` — clean
+- `gh release view kiln-v0.2.9 -R ericflo/kiln` — clean
 - `gh attestation verify` against the latest release artifact — clean
 - `gh api repos/ericflo/kiln` — public, README rendered, links work
 - https://ericflo.github.io/kiln/ and https://ericflo.github.io/kiln/launch.html

--- a/docs/site/launch/discord-rust.md
+++ b/docs/site/launch/discord-rust.md
@@ -30,7 +30,7 @@ length: ~250 words
 >
 > **Build matrix is intentionally small** — "has CUDA or doesn't." `cargo build --release --features cuda` on Linux+CUDA, `--features metal` on Apple Silicon, plain `cargo build --release` for the CPU/headless path. macOS Apple Silicon gets the Metal backend via a candle-metal JIT path.
 >
-> Reproducible builds with `--locked`, Sigstore-signed build provenance on every release artifact and the GHCR `kiln-server` image, MIT licensed, pre-1.0 (current production line is kiln-v0.2.8).
+> Reproducible builds with `--locked`, Sigstore-signed build provenance on every release artifact and the GHCR `kiln-server` image, MIT licensed, pre-1.0 (current production line is kiln-v0.2.9).
 >
 > Would love eyes on the kernel crates and the in-process training thread design. Also happy to talk about the tradeoffs of the single-model architectural choice — that's the thing I most expect pushback on.
 

--- a/docs/site/launch/hackernews.md
+++ b/docs/site/launch/hackernews.md
@@ -44,7 +44,7 @@ https://ericflo.github.io/kiln/launch.html
 ## Posting checklist
 
 - [ ] Demo asciicast linked from the launch post (`docs/site/launch.html`)
-- [ ] Confirm `gh release view kiln-v0.2.8 -R ericflo/kiln` is clean
+- [ ] Confirm `gh release view kiln-v0.2.9 -R ericflo/kiln` is clean
 - [ ] Confirm `https://ericflo.github.io/kiln/launch.html` renders on mobile + desktop
 - [ ] Eric reviews this draft and the asciicast
 - [ ] Submit Tuesday–Thursday, 9:00–11:00 ET (US morning peak for HN)

--- a/docs/site/launch/lobsters.md
+++ b/docs/site/launch/lobsters.md
@@ -43,7 +43,7 @@ https://ericflo.github.io/kiln/launch.html
 >
 > - **Single model.** It targets [Qwen3.5-4B](https://huggingface.co/Qwen/Qwen3.5-4B) and the scheduler, block manager, and CUDA kernels are tuned for that one architecture. Model-agnostic mode is on the post-1.0 roadmap with the explicit caveat that kernels need re-tuning per architecture.
 > - **Single GPU.** No tensor parallel, no multi-node. Multi-GPU TP is also on the post-1.0 roadmap.
-> - **Pre-1.0.** The current production line is kiln-v0.2.8. Phases 1–10 (core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, dev experience, advanced adapter features, v0.1.0 release engineering, Liger long-context training) are all closed. The roadmap from here is deliberately small and chosen by what early users actually ask for.
+> - **Pre-1.0.** The current production line is kiln-v0.2.9. Phases 1–10 (core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, dev experience, advanced adapter features, v0.1.0 release engineering, Liger long-context training) are all closed. The roadmap from here is deliberately small and chosen by what early users actually ask for.
 >
 > What's in-tree (not vendored Python or wrapped C++): the forward pass, paged KV cache + block manager, Sarathi-style chunked-prefill scheduler, LoRA training loop, Marlin W4A16 GEMM, fused RMSNorm, GDN linear-attention kernel, vendored flash-attn-2 with our own C-ABI wrapper, fused Conv1d. All in `crates/kiln-*-kernel/` and `crates/kiln-model/src/forward.rs`.
 >

--- a/docs/site/launch/reddit-localllama.md
+++ b/docs/site/launch/reddit-localllama.md
@@ -62,7 +62,7 @@ Kiln: a single-GPU inference server in Rust that also trains the model it's serv
 >
 > - **Single model.** Every line of code is tuned for Qwen3.5-4B. Model-agnostic mode is post-1.0 with the honest tradeoff that kernels need re-tuning per architecture.
 > - **Single GPU.** Multi-GPU tensor parallelism is also post-1.0.
-> - **Pre-1.0.** Current production line is kiln-v0.2.8. The phases that got us here closed core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, developer experience, advanced adapter features, v0.1.0 release engineering, and the Liger long-context training pieces. The roadmap from here is deliberately small.
+> - **Pre-1.0.** Current production line is kiln-v0.2.9. The phases that got us here closed core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, developer experience, advanced adapter features, v0.1.0 release engineering, and the Liger long-context training pieces. The roadmap from here is deliberately small.
 >
 > **How to try it:**
 >

--- a/docs/site/launch/twitter.md
+++ b/docs/site/launch/twitter.md
@@ -78,7 +78,7 @@ length: 8 tweets, each <280 chars
 >
 > https://ericflo.github.io/kiln/launch.html
 >
-> MIT licensed. v0.2.8 is the production line. Built in Rust by one person; the GRPO loop is what kept me up at night and what I most want feedback on.
+> MIT licensed. v0.2.9 is the production line. Built in Rust by one person; the GRPO loop is what kept me up at night and what I most want feedback on.
 
 *(248 chars — has link headroom for X's t.co)*
 


### PR DESCRIPTION
## What

Bumps the kiln-v0.2.8 → kiln-v0.2.9 production-line references on the launch surfaces (README, QUICKSTART, landing page, launch blog post, all 5 per-channel launch post drafts) so the public-launch posts direct users to v0.2.9 instead of v0.2.8.

## Why

v0.2.9 (cut 2026-05-01) restores +23% throughput and −75% p99 ITL relative to v0.2.8, by reverting the workers=2 emergency serialize shim from #672 once #674 fixed the underlying prefix-cache double-decrement (root-caused as #673). Posting the launch with v0.2.8 refs would direct first-100 users to a release with the slower exclusive-GpuCoordinationLock path — the public-facing throughput claim (~50 tok/s decode on Qwen3.5-4B / A6000 / bs=1) holds for v0.2.9 but is muted under the v0.2.8 shim.

The greenlight approval for the launch posts (`3da4a6354ad6c4fddd85ae0a`) is currently pending Eric — landing this bump before he approves keeps the launch surfaces consistent.

## Out of scope

- Asciicast at `docs/site/demo/kiln-60s.cast` literally embeds `Version: 0.2.8` because the session was recorded on the v0.2.8 build. Re-recording is a separate task; the asciicast is a true artifact of the session that produced it, and showing 'recorded one day before launch' is acceptable.
- CHANGELOG.md already has the v0.2.9 entry from #676.

## Verification

- `gh release view kiln-v0.2.9 -R ericflo/kiln` clean (live since 2026-05-01T10:32Z)
- GHCR `ghcr.io/ericflo/kiln-server:0.2.9` and `:latest` live (since 2026-05-01T09:47Z)
- All 3 release artifact URLs return HTTP 200
- Pages workflow auto-deploys `docs/site/**` on push, so landing page + launch post pick up the bump within ~1–2 min of merge