### PR TITLE
docs(site): link 60s demo from landing hero

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -145,6 +145,8 @@
       </div>
       <p class="mt-6 text-sm">
         <a href="launch.html">&rarr; Read the launch announcement</a>
+        <span class="mx-2" style="color: var(--fg-dim);">&middot;</span>
+        <a href="demo/">&rarr; Watch the 60-second demo</a>
       </p>
     </div>
   </section>


### PR DESCRIPTION
## What
Adds a second hero-footer link from the landing page (https://ericflo.github.io/kiln/) to the live asciicast demo at /demo/.

Before: the hero footer links only to launch.html. A first-time visitor has to click in to learn the demo exists.
After: hero footer offers both "Read the launch announcement" and "Watch the 60-second demo" side-by-side.

## Why
Phase 11 launch-prep cold-reader test: the asciicast is the most visceral way to show the GRPO loop and belongs one click away from the landing hero, not two. Closes a real cold-reader gap surfaced in the planning loop on 2026-05-01.

## Test plan
- [x] grep confirms both links present in docs/site/index.html
- [ ] Pages workflow auto-deploys on merge
- [ ] Verify https://ericflo.github.io/kiln/ shows both links after deploy