### PR TITLE
phase10: LoRA Var BF16 storage + FP32-accumulate (null-result A/B)

### DIFF
--- a/crates/kiln-model/src/lora_loader.rs
+++ b/crates/kiln-model/src/lora_loader.rs
@@ -215,15 +215,18 @@ pub fn compute_lora_delta(
     // A: [rank, in_features] -> A^T: [in_features, rank]
     // B: [out_features, rank] -> B^T: [rank, out_features]
     // delta = x @ A^T @ B^T * scale
-    let x_f32 = x.to_dtype(DType::F32)?;
-    let a_f32 = proj.a.to_dtype(DType::F32)?;
-    let b_f32 = proj.b.to_dtype(DType::F32)?;
+    //
+    // Phase 10: cast A/B to x's dtype (BF16 typically; F32 when MTP fp32-head is
+    // armed) and let cuBLAS run BF16-input + FP32-accumulate on tensor cores.
+    // See docs/audits/PHASE10_LORA_PRECISION_STUDY.md §5.
+    let a = proj.a.to_dtype(x.dtype())?;
+    let b = proj.b.to_dtype(x.dtype())?;
 
-    let hidden = x_f32.broadcast_matmul(&a_f32.t()?)?; // [..., rank]
-    let delta = hidden.broadcast_matmul(&b_f32.t()?)?; // [..., out_features]
+    let hidden = x.broadcast_matmul(&a.t()?)?; // [..., rank]
+    let delta = hidden.broadcast_matmul(&b.t()?)?; // [..., out_features]
     let delta = (delta * scale as f64)?;
 
-    // Cast back to input dtype
+    // Final cast to input dtype (no-op when already matching).
     let delta = delta.to_dtype(x.dtype())?;
     Ok(delta)
 }

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -2943,9 +2943,14 @@ mod tests {
             let id = var.as_tensor().id();
             match (grads_mono.get(&id), grads_tiled.get(&id)) {
                 (Some(g_m), Some(g_t)) => {
-                    let diff = (g_m - g_t)?.abs()?.max_all()?.to_scalar::<f32>()?;
+                    let diff = (g_m - g_t)?
+                        .abs()?
+                        .max_all()?
+                        .to_dtype(DType::F32)?
+                        .to_scalar::<f32>()?;
+                    // BF16 LoRA Var storage: 7-bit mantissa, ~1e-3 absolute noise.
                     assert!(
-                        diff < 1e-5,
+                        diff < 1e-3,
                         "tiled grad differs from monolithic for var: max_abs_diff={diff:.2e}",
                     );
                     compared += 1;
@@ -3180,9 +3185,14 @@ mod tests {
         for (var, kind, name) in &classified {
             let g_s = grad_or_zero(&grads_std, var)?;
             let g_p = grad_or_zero(&grads_layer_pair, var)?;
-            let diff = (&g_s - &g_p)?.abs()?.max_all()?.to_scalar::<f32>()?;
+            let diff = (&g_s - &g_p)?
+                .abs()?
+                .max_all()?
+                .to_dtype(DType::F32)?
+                .to_scalar::<f32>()?;
+            // BF16 LoRA Var storage: ~1e-3 absolute noise across kinds.
             let tol: f32 = match *kind {
-                "mlp" => 1e-5,
+                "mlp" => 1e-3,
                 "fa" => 1e-3,
                 _ => 1e-3,
             };
@@ -3353,7 +3363,12 @@ mod tests {
         let mut has_grad_seg1 = false; // layers 2-3
         for var in params.all_vars() {
             if let Some(grad) = grads.get(&var.as_tensor().id()) {
-                let grad_norm = grad.sqr()?.sum_all()?.to_scalar::<f32>()?.sqrt();
+                let grad_norm = grad
+                    .sqr()?
+                    .sum_all()?
+                    .to_dtype(DType::F32)?
+                    .to_scalar::<f32>()?
+                    .sqrt();
                 if grad_norm > 0.0 {
                     // Determine which segment this var belongs to
                     // by checking if it matches layer 0-1 or 2-3 params

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -135,11 +135,13 @@ impl TrainableLoraParams {
                 };
 
                 // A: [rank, in_features] — Kaiming uniform
-                let a = Var::rand_f64(-bound, bound, (rank, in_features), DType::F32, device)
+                // Phase 10: BF16 storage + FP32-accumulate via tensor cores (audit
+                // docs/audits/PHASE10_LORA_PRECISION_STUDY.md §5).
+                let a = Var::rand_f64(-bound, bound, (rank, in_features), DType::BF16, device)
                     .with_context(|| format!("init LoRA A for layer {layer_idx} {module}"))?;
 
                 // B: [out_features, rank] — zeros
-                let b = Var::zeros((out_features, rank), DType::F32, device)
+                let b = Var::zeros((out_features, rank), DType::BF16, device)
                     .with_context(|| format!("init LoRA B for layer {layer_idx} {module}"))?;
 
                 match module {


### PR DESCRIPTION
## Summary

Implements the two-file change from the LoRA precision study audit (PR #680, `docs/audits/PHASE10_LORA_PRECISION_STUDY.md` §5) and reports the empirical A/B result on RTX A6000.

**Result: parity holds, speedup below the 14% perf gate. Per audit §4 decision tree, this is a null-result PR — do not merge.**

## Code change

Two-line change to flip LoRA Var storage from F32 to BF16, and drop the explicit F32 upcast in `compute_lora_delta` so cuBLAS runs the BF16-input + FP32-accumulate path on Ampere tensor cores. The `to_dtype(x.dtype())` pattern preserves the MTP fp32-head TLS branch (when `x` is F32, A/B follow naturally).

- `crates/kiln-train/src/trainer.rs`: `Var::rand_f64`/`Var::zeros` `DType::F32` → `DType::BF16` (LoRA A/B init).
- `crates/kiln-model/src/lora_loader.rs::compute_lora_delta`: drop `to_dtype(DType::F32)` upcast on x, A, B; cast A/B to `x.dtype()` instead.

## A/B validation

| Arm | Branch / commit | Binary md5 |
|---|---|---|
| Control | `main` @ `4a3babd` | `91d0c53a419cc76a0e42eb398121a40d` |
| Treatment | `phase10/lora-precision-study-impl` @ `ec66da0` | `262b0a9f37f85152ecc6e636835075fb` |

Hardware: RunPod RTX A6000 (49 GB VRAM), CUDA 12.4, sccache+B2 build cache, `KILN_CUDA_ARCHS=86`.

Driver: `kiln-bench --model-path /workspace/qwen3.5-4b --training-steps 100 --seed 42 --paged` with `KILN_W4A16=0` (W4A16 stubs out `q_proj_t` and is incompatible with SFT). 100 SFT steps, rank=8, alpha=16, lr=1e-4, SGD, 1 epoch over 100 synthetic examples.

### Parity gates (audit §4)

| Gate | Threshold | Observed | Pass |
|---|---|---|---|
| Final loss \|Δ\| | ≤ 0.5% | **0.052%** (1.663116 → 1.663987) | ✅ |
| Per-step max \|Δ\| | ≤ 1.5% | **0.622%** (worst single step) | ✅ |
| Per-step mean \|Δ\| | — | 0.141% | ℹ️ |
| NaN / Inf in losses | none | 0/100 both arms | ✅ |
| PEFT roundtrip | loadable, dtypes valid | 256 BF16 tensors, 0 NaN/Inf, valid HF `adapter_config.json` (r=8, α=16, 7 target modules, CAUSAL_LM) | ✅ |

Per-step max \|Δ\|/control hit 0.622% on step 5; mean over 100 steps was 0.141%. Loss curves track within tens of basis points throughout.

#### Loss-curve excerpts

First 10 steps (step | control | treatment | Δ):

```
  1  1.604096  1.604096  +0.000000
  2  1.549075  1.548894  -0.000181
  3  1.590777  1.587273  -0.003504
  4  1.509785  1.511436  +0.001651
  5  1.612205  1.608070  -0.004135   ← max |Δ| = 0.622%
  6  1.585075  1.585798  +0.000723
  7  1.572125  1.567952  -0.004173
  8  1.576043  1.574032  -0.002011
  9  1.543071  1.540769  -0.002302
 10  1.593239  1.591835  -0.001404
```

Last 10 steps:

```
 91  1.645475  1.647595  +0.002120
 92  1.603362  1.602802  -0.000560
 93  1.598523  1.598151  -0.000372
 94  1.557549  1.559706  +0.002157
 95  1.602686  1.601110  -0.001576
 96  1.529696  1.531909  +0.002213
 97  1.587118  1.588782  +0.001664
 98  1.580115  1.581834  +0.001719
 99  1.638669  1.634355  -0.004314
100  1.663116  1.663987  +0.000871   ← final |Δ| = 0.052%
```

### Performance gates (audit §4)

| Metric | Gate | Observed | Pass |
|---|---|---|---|
| Step-time reduction | ≥ 14% | **+2.94%** (0.34 s/step → 0.33 s/step, 100-step median per bench harness) | ❌ |
| Peak training VRAM | ≤ +1% | **−0.64%** (24906 → 24746 MB) | ✅ |

The bench harness reports `s/step` rounded to 0.01 s, so the 1 ms delta is at or below measurement precision for a 100-step run on this dataset shape. There is no signal anywhere near the 14% (or even 5%) speedup the audit predicted.

## Why the perf gate failed

The audit hypothesis was that the ~42% FP32 SGEMM bucket attributed in PR #649 (`ampere_sgemm_64x64_nn` + `ampere_sgemm_128x64_nn`) was dominated by LoRA A/B matmuls and their backward, and that flipping Var storage + dropping the F32 upcast would collapse those calls into the `s16816gemm` BF16 tensor-core family. The observed result is inconsistent with that hypothesis. Likely contributors:

1. **The FP32 SGEMM bucket was not LoRA-dominated.** The 42% may include LM-head, embedding, and elementwise reductions in backward that are unaffected by this change. A dedicated nsys re-profile of the SFT step on the treatment branch would tell us which kernels actually moved.
2. **cuBLAS heuristic may not have flipped to `s16816gemm`** for the candle `broadcast_matmul` shapes used here (rank=8, hidden=2560, intermediate=9216). Candle dispatches matmul through cuBLAS with default heuristics; without `cublasLtMatmulPreferenceSetAttribute` tuning, BF16-input + FP32-accum can still land on a non-tensor-core SGEMM path on Ampere.
3. **Bench precision is too coarse.** A 100-step rank-8 SFT on synthetic 1-example batches takes ~33–34 s end-to-end; the harness rounds to 0.01 s/step, which is ±3% of the step time. We cannot resolve a sub-3% speedup with this driver. But even if real, ~3% is still well under the 14% audit floor.

## Decision

Per audit §4: **null-result PR, do not merge**. The parity evidence is strong (well within all thresholds, including PEFT compatibility and NaN-free), so the BF16 storage path is *safe*. It is just not worth the diff: there is no observable training-time speedup at this rank/shape mix on A6000.

Recommendation for follow-up Phase 10 planning:
- Re-profile the SFT step on `main` with the same harness to verify whether the ~42% FP32 SGEMM bucket cited in PR #649 is still present and what kernels currently populate it.
- If a real LoRA-side hotspot remains, target the actual kernel choice (e.g. force a `cublasLtMatmul` with `s16816gemm` selection) rather than the storage dtype.

## Reproducibility

```bash
# Build (both arms)
KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench

# Run (both arms, identical seed)
KILN_W4A16=0 ./target/release/kiln-bench \
  --model-path /workspace/qwen3.5-4b \
  --training-steps 100 --seed 42 --paged
```

Per-step `loss=` lines emit on stderr from `bench_training`'s progress callback (`Step N/100: loss=X.XXXX`).

## Cost

90-min/$40 budget hard cap from task brief; actual spend ≈ 30 min wall-clock and ≈ $0.25 of A6000 time, well under cap.

Refs: PR #680 (audit doc).
