### PR TITLE
Fix long-prefill streaming with prefix cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Kiln Server Changelog
 
+## kiln-v0.2.10 — Unreleased
+
+### Fixed
+- server: route prefix-cache prefill through the tiled/streaming long-prefill dispatcher so first-touch 43k-token prompts no longer bypass the GDN activation-bounded path (#686).
+
+### Observability
+- metrics: add `kiln_request_prefill_tokens_completed` to show live long-prefill progress instead of making operators infer whether a request is wedged from latency alone (#686).
+
+### Configuration
+- server: raise the default `request_timeout_secs` from 300 to 600 seconds so the production default is honest for long-prefill workloads; explicit TOML/env overrides remain unchanged (#686).
+
 ## kiln-v0.2.9 — 2026-05-01
 
 Phase 11 launch-baseline release. Reliability + throughput fixes for the

--- a/crates/kiln-model/src/cancel.rs
+++ b/crates/kiln-model/src/cancel.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 // `kiln-server` wraps blocking generation in `tokio::time::timeout`, but
 // `tokio::task::spawn_blocking` does not honor outer-future cancellation —
@@ -12,11 +12,21 @@ use std::sync::atomic::{AtomicBool, Ordering};
 #[derive(Debug, Clone, Default)]
 pub struct CancelHandle {
     flag: Arc<AtomicBool>,
+    prefill_tokens_completed: Arc<AtomicU64>,
+    prefill_progress_gauge: Option<Arc<AtomicU64>>,
 }
 
 impl CancelHandle {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_prefill_progress_gauge(prefill_progress_gauge: Arc<AtomicU64>) -> Self {
+        Self {
+            flag: Arc::new(AtomicBool::new(false)),
+            prefill_tokens_completed: Arc::new(AtomicU64::new(0)),
+            prefill_progress_gauge: Some(prefill_progress_gauge),
+        }
     }
 
     pub fn cancel(&self) {
@@ -25,6 +35,32 @@ impl CancelHandle {
 
     pub fn is_cancelled(&self) -> bool {
         self.flag.load(Ordering::SeqCst)
+    }
+
+    pub fn report_prefill_tokens_completed(&self, completed: u64) {
+        let previous = self
+            .prefill_tokens_completed
+            .swap(completed, Ordering::SeqCst);
+        if let Some(gauge) = &self.prefill_progress_gauge {
+            if completed >= previous {
+                gauge.fetch_add(completed - previous, Ordering::SeqCst);
+            } else {
+                gauge.fetch_sub(previous - completed, Ordering::SeqCst);
+            }
+        }
+    }
+
+    pub fn prefill_tokens_completed(&self) -> u64 {
+        self.prefill_tokens_completed.load(Ordering::SeqCst)
+    }
+
+    pub fn clear_prefill_progress(&self) {
+        let previous = self.prefill_tokens_completed.swap(0, Ordering::SeqCst);
+        if previous > 0 {
+            if let Some(gauge) = &self.prefill_progress_gauge {
+                gauge.fetch_sub(previous, Ordering::SeqCst);
+            }
+        }
     }
 }
 
@@ -51,5 +87,23 @@ mod tests {
         let h2 = h.clone();
         h.cancel();
         assert!(h2.is_cancelled());
+    }
+
+    #[test]
+    fn prefill_progress_updates_shared_gauge() {
+        let gauge = Arc::new(AtomicU64::new(0));
+        let h = CancelHandle::with_prefill_progress_gauge(gauge.clone());
+        h.report_prefill_tokens_completed(128);
+        assert_eq!(h.prefill_tokens_completed(), 128);
+        assert_eq!(gauge.load(Ordering::SeqCst), 128);
+
+        let h2 = h.clone();
+        h2.report_prefill_tokens_completed(256);
+        assert_eq!(h.prefill_tokens_completed(), 256);
+        assert_eq!(gauge.load(Ordering::SeqCst), 256);
+
+        h.clear_prefill_progress();
+        assert_eq!(h.prefill_tokens_completed(), 0);
+        assert_eq!(gauge.load(Ordering::SeqCst), 0);
     }
 }

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -1311,7 +1311,7 @@ fn marlin_bf16_drop_disabled() -> bool {
 /// `GDN_CHUNK_SIZE` (64) so the chunkwise kernel never sees a partial tail
 /// chunk from a tile boundary.
 pub const STREAMING_PREFILL_DEFAULT_TILE: usize = 8192;
-pub const STREAMING_PREFILL_CUDA_DEFAULT_THRESHOLD: usize = 65533;
+pub const STREAMING_PREFILL_CUDA_DEFAULT_THRESHOLD: usize = 32768;
 pub const STREAMING_PREFILL_METAL_DEFAULT_TILE: usize = 2048;
 pub const STREAMING_PREFILL_METAL_DEFAULT_THRESHOLD: usize = 2048;
 const PAGED_KV_HEAD_MAJOR_READ_MIN_TOKENS: usize = 1024;
@@ -7233,6 +7233,33 @@ pub fn model_forward_paged_streaming(
     linear_state: Option<&mut LinearAttentionState>,
     lora: Option<&LoraWeights>,
 ) -> Result<Tensor> {
+    model_forward_paged_streaming_with_progress(
+        backend,
+        token_ids,
+        weights,
+        config,
+        paged_cache,
+        block_table,
+        start_pos,
+        linear_state,
+        lora,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn model_forward_paged_streaming_with_progress(
+    backend: &dyn BackendRuntime,
+    token_ids: &[u32],
+    weights: &GpuWeights,
+    config: &kiln_core::config::ModelConfig,
+    paged_cache: &mut PagedKvCache,
+    block_table: &BlockTable,
+    start_pos: usize,
+    linear_state: Option<&mut LinearAttentionState>,
+    lora: Option<&LoraWeights>,
+    progress: Option<&crate::cancel::CancelHandle>,
+) -> Result<Tensor> {
     model_forward_paged_streaming_with(
         backend,
         token_ids,
@@ -7245,6 +7272,7 @@ pub fn model_forward_paged_streaming(
         lora,
         streaming_tile_tokens_for(weights.embed_tokens.device()),
         streaming_last_token_lm_head(),
+        progress,
     )
 }
 
@@ -7372,6 +7400,7 @@ pub fn model_forward_paged_streaming_with(
     lora: Option<&LoraWeights>,
     tile_size: usize,
     last_token_only: bool,
+    progress: Option<&crate::cancel::CancelHandle>,
 ) -> Result<Tensor> {
     let total = token_ids.len();
     if total == 0 {
@@ -7428,6 +7457,9 @@ pub fn model_forward_paged_streaming_with(
         }
 
         cursor = end;
+        if let Some(progress) = progress {
+            progress.report_prefill_tokens_completed(cursor as u64);
+        }
     }
 
     last_logits.context("streaming prefill produced no logits (empty token_ids)")
@@ -11060,6 +11092,7 @@ mod tests {
             None,
             tile_size,
             false,
+            None,
         )?;
 
         Ok((mono_logits, stream_logits))
@@ -11259,6 +11292,7 @@ mod tests {
                 None,
                 tile,
                 true, // last_token_only — matches production dispatch
+                None,
             )?;
             assert_eq!(logits.dims(), &[1, 1, config.vocab_size]);
             let last = logits.flatten_all()?.to_vec1::<f32>()?;
@@ -11431,6 +11465,7 @@ mod tests {
             None,
             tile,
             true,
+            None,
         )?;
         let stream_decode = model_forward_paged(
             &backend,
@@ -11788,6 +11823,7 @@ mod tests {
             None,
             tile,
             false,
+            None,
         )?;
 
         assert_eq!(mono_logits.dims(), &[1, total, config.vocab_size]);
@@ -11876,6 +11912,10 @@ mod tests {
         assert!(streaming_prefill_default_for(
             StreamingPrefillDeviceKind::Cuda,
             STREAMING_PREFILL_CUDA_DEFAULT_THRESHOLD
+        ));
+        assert!(streaming_prefill_default_for(
+            StreamingPrefillDeviceKind::Cuda,
+            43_814
         ));
         assert!(!streaming_prefill_default_for(
             StreamingPrefillDeviceKind::Metal,

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -21,6 +21,7 @@ use crate::forward::{
     model_forward_paged_last_token, model_forward_paged_last_token_greedy,
     model_forward_paged_last_token_with_last_hidden, model_forward_paged_next_token_greedy,
     model_forward_paged_streaming, model_forward_paged_streaming_last_token_with_last_hidden,
+    model_forward_paged_streaming_with_progress,
     streaming_prefill_enabled_for,
 };
 use crate::kv_cache::KvCache;
@@ -1043,7 +1044,23 @@ impl ModelRunner {
             && !streaming_prefill_enabled_for(self.backend.device(), prefill_tokens.len());
         let prefill_source = {
             let mut pc_guard = lock_paged_cache(paged_cache)?;
-            if use_greedy_prefill_token {
+            if streaming_prefill_enabled_for(self.backend.device(), prefill_tokens.len()) {
+                PrefillSampleSource::Logits(
+                    model_forward_paged_streaming_with_progress(
+                        &*self.backend,
+                        prefill_tokens,
+                        &self.weights,
+                        &self.config,
+                        &mut pc_guard,
+                        block_table,
+                        cached_tokens,
+                        Some(&mut linear_state),
+                        self.active_lora.as_ref(),
+                        cancel,
+                    )
+                    .context("prefill forward pass (paged prefix cache, streaming) failed")?,
+                )
+            } else if use_greedy_prefill_token {
                 PrefillSampleSource::GreedyToken(
                     model_forward_paged_last_token_greedy(
                         &*self.backend,
@@ -1060,21 +1077,23 @@ impl ModelRunner {
                     .context("greedy prefill forward pass (paged prefix cache) failed")?,
                 )
             } else {
-                PrefillSampleSource::Logits(
-                    model_forward_paged_last_token(
-                        &*self.backend,
-                        prefill_tokens,
-                        &self.weights,
-                        &self.config,
-                        &mut pc_guard,
-                        block_table,
-                        cached_tokens,
-                        Some(&mut linear_state),
-                        self.active_lora.as_ref(),
-                        None,
-                    )
-                    .context("prefill forward pass (paged prefix cache) failed")?,
+                let logits = model_forward_paged_last_token(
+                    &*self.backend,
+                    prefill_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    cached_tokens,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
                 )
+                .context("prefill forward pass (paged prefix cache) failed")?;
+                if let Some(cancel) = cancel {
+                    cancel.report_prefill_tokens_completed(prefill_tokens.len() as u64);
+                }
+                PrefillSampleSource::Logits(logits)
             }
         };
 
@@ -1378,7 +1397,7 @@ impl ModelRunner {
         let logits = {
             let mut pc_guard = lock_paged_cache(paged_cache)?;
             if streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len()) {
-                model_forward_paged_streaming(
+                model_forward_paged_streaming_with_progress(
                     &*self.backend,
                     prompt_tokens,
                     &self.weights,
@@ -1388,10 +1407,11 @@ impl ModelRunner {
                     0,
                     Some(&mut linear_state),
                     self.active_lora.as_ref(),
+                    cancel,
                 )
                 .context("prefill forward pass (paged, streaming) failed")?
             } else {
-                model_forward_paged_last_token(
+                let logits = model_forward_paged_last_token(
                     &*self.backend,
                     prompt_tokens,
                     &self.weights,
@@ -1403,7 +1423,11 @@ impl ModelRunner {
                     self.active_lora.as_ref(),
                     None,
                 )
-                .context("prefill forward pass (paged) failed")?
+                .context("prefill forward pass (paged) failed")?;
+                if let Some(cancel) = cancel {
+                    cancel.report_prefill_tokens_completed(prompt_tokens.len() as u64);
+                }
+                logits
             }
         };
 

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -1210,7 +1210,9 @@ async fn generate_real(
     // races against still-held state and 5xx's. On timeout we signal this
     // handle and `.await` the join handle so locks release before we
     // respond. See issue #664.
-    let cancel = CancelHandle::new();
+    let cancel = CancelHandle::with_prefill_progress_gauge(
+        state.metrics.request_prefill_tokens_completed.clone(),
+    );
     let cancel_inner = cancel.clone();
     let generation = tokio::task::spawn_blocking(move || {
         // Acquire GPU coordination read lock — allows concurrent inference,
@@ -1339,12 +1341,21 @@ async fn generate_real(
 
     tokio::pin!(generation);
     let output = match tokio::time::timeout(timeout, &mut generation).await {
-        Ok(join_result) => join_result
-            .map_err(|e| ApiError::internal(format!("join error: {e}")))?
-            .map_err(|err| {
+        Ok(join_result) => match join_result {
+            Ok(Ok(output)) => {
+                cancel.clear_prefill_progress();
+                output
+            }
+            Ok(Err(err)) => {
+                cancel.clear_prefill_progress();
                 tracing::error!(error = %format!("{err:#}"), "real generation failed");
-                ApiError::generation_failed(err)
-            })?,
+                return Err(ApiError::generation_failed(err));
+            }
+            Err(err) => {
+                cancel.clear_prefill_progress();
+                return Err(ApiError::internal(format!("join error: {err}")));
+            }
+        },
         Err(_) => {
             // Signal cooperative cancellation, then await the join handle so
             // the spawn_blocking closure releases `runner.read()` /
@@ -1355,6 +1366,7 @@ async fn generate_real(
             // typically returns within one decode step after we signal.
             cancel.cancel();
             let _ = generation.await;
+            cancel.clear_prefill_progress();
             return Err(ApiError::request_timeout(timeout.as_secs()));
         }
     };

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -327,7 +327,7 @@ impl Default for ServerConfig {
         Self {
             host: "127.0.0.1".into(),
             port: 8420,
-            request_timeout_secs: 300,
+            request_timeout_secs: 600,
             shutdown_timeout_secs: 30,
         }
     }
@@ -765,7 +765,7 @@ mod tests {
         let config = KilnConfig::default();
         assert_eq!(config.server.host, "127.0.0.1");
         assert_eq!(config.server.port, 8420);
-        assert_eq!(config.server.request_timeout_secs, 300);
+        assert_eq!(config.server.request_timeout_secs, 600);
         assert_eq!(config.server.shutdown_timeout_secs, 30);
         assert_eq!(config.model.model_id, "Qwen/Qwen3.5-4B");
         assert!(config.model.path.is_none());
@@ -911,7 +911,7 @@ port = 3000
         let config: KilnConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.server.port, 3000);
         assert_eq!(config.server.host, "127.0.0.1"); // default (loopback)
-        assert_eq!(config.server.request_timeout_secs, 300); // default
+        assert_eq!(config.server.request_timeout_secs, 600); // default
         assert_eq!(config.model.model_id, "Qwen/Qwen3.5-4B"); // default
         assert_eq!(config.memory.inference_memory_fraction, 0.7); // default
         assert_eq!(config.logging.level, "info"); // default

--- a/crates/kiln-server/src/metrics.rs
+++ b/crates/kiln-server/src/metrics.rs
@@ -4,6 +4,7 @@
 //! The `/metrics` endpoint renders all metrics in Prometheus text exposition format.
 
 use kiln_scheduler::PrefixCacheStats;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Atomically tracked metrics for the kiln server.
@@ -19,6 +20,9 @@ pub struct Metrics {
 
     /// Currently in-flight inference requests.
     pub active_requests: AtomicU64,
+
+    /// Prompt/prefix prefill tokens completed by currently in-flight requests.
+    pub request_prefill_tokens_completed: Arc<AtomicU64>,
 
     /// Request duration tracking (simple: count + sum in microseconds).
     pub request_duration_count: AtomicU64,
@@ -42,6 +46,7 @@ impl Metrics {
             requests_rejected: AtomicU64::new(0),
             tokens_generated: AtomicU64::new(0),
             active_requests: AtomicU64::new(0),
+            request_prefill_tokens_completed: Arc::new(AtomicU64::new(0)),
             request_duration_count: AtomicU64::new(0),
             request_duration_sum_us: AtomicU64::new(0),
             training_sft_completed: AtomicU64::new(0),
@@ -139,6 +144,16 @@ impl Metrics {
         out.push_str("# HELP kiln_active_requests Currently in-flight requests.\n");
         out.push_str("# TYPE kiln_active_requests gauge\n");
         push_line(&mut out, &format!("kiln_active_requests {}", self.active_requests.load(Ordering::Relaxed)));
+
+        out.push_str("# HELP kiln_request_prefill_tokens_completed Prompt/prefix prefill tokens completed by currently in-flight requests.\n");
+        out.push_str("# TYPE kiln_request_prefill_tokens_completed gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_request_prefill_tokens_completed {}",
+                self.request_prefill_tokens_completed.load(Ordering::Relaxed)
+            ),
+        );
 
         // --- Scheduler ---
         out.push_str("# HELP kiln_scheduler_waiting Requests waiting to be scheduled.\n");
@@ -320,6 +335,8 @@ mod tests {
         m.observe_duration(0.5);
         m.add_tokens(100);
         m.inc_active();
+        m.request_prefill_tokens_completed
+            .store(8192, std::sync::atomic::Ordering::Relaxed);
 
         let gauges = SnapshotGauges {
             scheduler_waiting: 3,
@@ -348,6 +365,7 @@ mod tests {
         assert!(output.contains("kiln_requests_total{status=\"error\"} 1"));
         assert!(output.contains("kiln_tokens_generated_total 100"));
         assert!(output.contains("kiln_active_requests 1"));
+        assert!(output.contains("kiln_request_prefill_tokens_completed 8192"));
         assert!(output.contains("kiln_scheduler_waiting 3"));
         assert!(output.contains("kiln_blocks_total 256"));
         assert!(output.contains("kiln_vram_total_bytes 24000000000"));

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -437,7 +437,7 @@ pub struct AppState {
     pub vram_info: kiln_core::vram::GpuVramInfo,
     /// Shutdown flag — set to true when the server is shutting down.
     pub shutdown: ShutdownFlag,
-    /// Per-request timeout duration. Configurable via KILN_REQUEST_TIMEOUT_SECS (default 300).
+    /// Per-request timeout duration. Configurable via KILN_REQUEST_TIMEOUT_SECS (default 600).
     pub request_timeout: std::time::Duration,
     /// Prometheus metrics counters.
     pub metrics: Arc<Metrics>,

--- a/crates/kiln-server/tests/real_model_integration.rs
+++ b/crates/kiln-server/tests/real_model_integration.rs
@@ -402,7 +402,7 @@ async fn test_request_timeout_configurable() {
     assert_eq!(state.request_timeout.as_secs(), 42);
 }
 
-/// Test that default request timeout is 300 seconds.
+/// Test that default request timeout is 600 seconds.
 #[tokio::test]
 async fn test_default_request_timeout() {
     let config = tiny_config();
@@ -425,7 +425,7 @@ async fn test_default_request_timeout() {
         &kiln_server::config::PrefixCacheConfig::default(),
     );
 
-    assert_eq!(state.request_timeout.as_secs(), 300);
+    assert_eq!(state.request_timeout.as_secs(), 600);
 }
 
 #[tokio::test]

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -10,7 +10,7 @@
 [server]
 host = "0.0.0.0"
 port = 8420
-request_timeout_secs = 300
+request_timeout_secs = 600
 shutdown_timeout_secs = 30
 
 [model]


### PR DESCRIPTION
## Summary

Fixes the issue #686 long-prefill production path instead of documenting another workaround.

Root cause: HTTP real generation with prefix cache enabled routed first-touch prefix-cache suffix prefill through `model_forward_paged_last_token`, which bypassed the existing tiled/streaming long-prefill dispatcher. The canonical 43k-token prompt therefore ran monolithic on the prefix-cache path and could time out under tight block caps even though KV occupancy was low.

Changes:
- Route prefix-cache suffix prefill through tiled/streaming prefill whenever `streaming_prefill_enabled_for()` says a long prompt should stream.
- Lower CUDA automatic streaming-prefill threshold from 65,533 to 32,768 tokens so the 43,814-token #686 payload streams by default.
- Add `kiln_request_prefill_tokens_completed` gauge for live in-flight prefill progress.
- Raise default `server.request_timeout_secs` from 300 to 600 and update example config/tests/changelog.

## A6000 validation

RunPod A6000, `ghcr.io/ericflo/kiln-runpod:latest`, CUDA release build with `KILN_CUDA_ARCHS=86`.

Unit/static:
- `cargo test -p kiln-model cancel::tests --lib`
- `cargo test -p kiln-model streaming_prefill_env_helpers --lib`
- `cargo test -p kiln-server test_metrics_render --lib`
- `cargo test -p kiln-server test_defaults --lib`
- `cargo test -p kiln-server test_partial_toml_uses_defaults --lib`
- `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln-bench`
- `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln`

43k paged prefill target:
- Auto/default: `kiln-bench --paged --prompt-tokens 43814 --max-output-tokens 1 --skip-training --latency-only`
  - actual prompt tokens: 43,803
  - prefill: 18,487.8 ms / 2,369 tok/s
- Tight cap: `KILN_NUM_BLOCKS=16384 ... kiln-bench --paged --prompt-tokens 43814 --max-output-tokens 1 --skip-training --latency-only`
  - actual prompt tokens: 43,803
  - prefill: 27,207.7 ms / 1,610 tok/s

HTTP prefix-cache/server path:
- One 43,824-token chat completion with `memory.num_blocks = 16384`, prefix cache enabled, `max_tokens=1` returned HTTP 200; `/metrics` during prefill showed `kiln_request_prefill_tokens_completed 24576`.
- Two concurrent 43,824-token chat completions with the same server config both returned HTTP 200; `/metrics` during prefill showed `kiln_active_requests 2` and `kiln_request_prefill_tokens_completed 32768`.

## Notes

This PR closes the immediate #686 production-grade fix criteria: 43k prefill is under 60s on A6000, tight-block and auto configs both complete, workers=2 does not cascade under concurrent long requests, and the new metric distinguishes slow progress from a wedge.

Refs #686.
