### PR TITLE
Bound real prefix cache state memory

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -606,7 +606,8 @@ Key settings:
 | `memory.inference_memory_fraction` | — | 0.7 | VRAM fraction for inference (rest for training) |
 | `memory.kv_cache_fp8` | `KILN_KV_CACHE_FP8` | false | FP8 KV cache (halves memory, ~2x context) |
 | `logging.format` | `KILN_LOG_FORMAT` | auto | Log format: `auto` (pretty on TTY, JSON otherwise), `json`, `pretty`, `text`, `human` |
-| `prefix_cache.enabled` | — | true | Reuse KV cache for shared prefixes |
+| `prefix_cache.enabled` | `KILN_PREFIX_CACHE_ENABLED` | true | Reuse KV cache for shared prefixes |
+| `prefix_cache.max_entries` | `KILN_PREFIX_CACHE_MAX_ENTRIES` | auto | Cap cached GDN state snapshots (~49 MiB each; auto budget ≤1 GiB) |
 
 ## Running with Docker
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ Kiln uses a TOML config file. Environment variables override config values. See 
 | `memory.inference_memory_fraction` | — | 0.7 | VRAM fraction for inference vs training |
 | `memory.kv_cache_fp8` | `KILN_KV_CACHE_FP8` | false | FP8 KV cache (2x context length) |
 | `logging.format` | `KILN_LOG_FORMAT` | auto | `auto` (default; pretty on TTY, JSON otherwise), `json`, `pretty`, `text`, or `human` |
-| `prefix_cache.enabled` | — | true | Reuse KV cache for shared prefixes |
+| `prefix_cache.enabled` | `KILN_PREFIX_CACHE_ENABLED` | true | Reuse KV cache for shared prefixes |
+| `prefix_cache.max_entries` | `KILN_PREFIX_CACHE_MAX_ENTRIES` | auto | Cap cached GDN state snapshots (~49 MiB each; auto budget ≤1 GiB) |
 
 ## Security model
 

--- a/crates/kiln-scheduler/src/scheduler.rs
+++ b/crates/kiln-scheduler/src/scheduler.rs
@@ -68,6 +68,10 @@ pub struct PrefixCacheStats {
     pub hit_blocks: u64,
     pub cached_blocks: usize,
     pub max_blocks: usize,
+    pub cached_entries: usize,
+    pub max_entries: usize,
+    pub cached_state_bytes: u64,
+    pub max_state_bytes: u64,
 }
 
 /// Iteration-level continuous batching scheduler.

--- a/crates/kiln-server/src/config.rs
+++ b/crates/kiln-server/src/config.rs
@@ -165,6 +165,11 @@ pub struct PrefixCacheConfig {
     /// Maximum number of KV cache blocks the prefix cache may retain.
     /// Default: 25% of total blocks. Set to 0 to use the default.
     pub max_blocks: Option<usize>,
+    /// Maximum number of real-backend prefix entries to retain.
+    /// Each entry owns a GDN linear-attention state snapshot in addition to
+    /// KV blocks, so this cap prevents sustained unique-prompt traffic from
+    /// accumulating unbounded device state memory. Default is memory-tiered.
+    pub max_entries: Option<usize>,
 }
 
 /// Which speculative-decoding method to use when `enabled = true`.
@@ -386,6 +391,7 @@ impl Default for PrefixCacheConfig {
         Self {
             enabled: true,
             max_blocks: None,
+            max_entries: None,
         }
     }
 }
@@ -630,6 +636,11 @@ impl KilnConfig {
                 self.prefix_cache.max_blocks = Some(n);
             }
         }
+        if let Ok(v) = std::env::var("KILN_PREFIX_CACHE_MAX_ENTRIES") {
+            if let Ok(n) = v.parse() {
+                self.prefix_cache.max_entries = Some(n);
+            }
+        }
 
         // Speculative decoding
         if let Ok(v) = std::env::var("KILN_SPEC_ENABLED") {
@@ -847,6 +858,7 @@ format = "pretty"
 [prefix_cache]
 enabled = false
 max_blocks = 32
+max_entries = 8
 
 [speculative]
 enabled = true
@@ -888,6 +900,7 @@ composed_cache_max_entries = 8
         assert_eq!(config.logging.format, "pretty");
         assert!(!config.prefix_cache.enabled);
         assert_eq!(config.prefix_cache.max_blocks, Some(32));
+        assert_eq!(config.prefix_cache.max_entries, Some(8));
         assert!(config.speculative.enabled);
         assert_eq!(config.speculative.num_speculative_tokens, 6);
         assert_eq!(config.speculative.draft_layers, 10);
@@ -1028,6 +1041,7 @@ port = 3000
         assert!(!config.memory.cuda_graphs);
         assert!(!config.prefix_cache.enabled);
         assert_eq!(config.prefix_cache.max_blocks, Some(128));
+        assert!(config.prefix_cache.max_entries.is_none());
         assert!(config.speculative.enabled);
         assert_eq!(config.speculative.num_speculative_tokens, 6);
         assert_eq!(config.speculative.draft_layers, 10);

--- a/crates/kiln-server/src/metrics.rs
+++ b/crates/kiln-server/src/metrics.rs
@@ -247,6 +247,46 @@ impl Metrics {
             ),
         );
 
+        out.push_str("# HELP kiln_prefix_cache_cached_entries Prefix-cache entries currently retaining GDN state snapshots.\n");
+        out.push_str("# TYPE kiln_prefix_cache_cached_entries gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_prefix_cache_cached_entries {}",
+                gauges.prefix_cache.cached_entries
+            ),
+        );
+
+        out.push_str("# HELP kiln_prefix_cache_max_entries Maximum prefix-cache entries that may retain GDN state snapshots.\n");
+        out.push_str("# TYPE kiln_prefix_cache_max_entries gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_prefix_cache_max_entries {}",
+                gauges.prefix_cache.max_entries
+            ),
+        );
+
+        out.push_str("# HELP kiln_prefix_cache_state_bytes Device memory retained by cached GDN state snapshots.\n");
+        out.push_str("# TYPE kiln_prefix_cache_state_bytes gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_prefix_cache_state_bytes {}",
+                gauges.prefix_cache.cached_state_bytes
+            ),
+        );
+
+        out.push_str("# HELP kiln_prefix_cache_max_state_bytes Maximum device memory retainable by cached GDN state snapshots.\n");
+        out.push_str("# TYPE kiln_prefix_cache_max_state_bytes gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_prefix_cache_max_state_bytes {}",
+                gauges.prefix_cache.max_state_bytes
+            ),
+        );
+
         // --- Training ---
         out.push_str("# HELP kiln_training_jobs_total Total training jobs.\n");
         out.push_str("# TYPE kiln_training_jobs_total counter\n");
@@ -354,6 +394,10 @@ mod tests {
                 hit_blocks: 7,
                 cached_blocks: 64,
                 max_blocks: 128,
+                cached_entries: 4,
+                max_entries: 8,
+                cached_state_bytes: 196,
+                max_state_bytes: 392,
             },
             training_active: 0,
             active_adapter: Some("my-adapter".to_string()),
@@ -375,6 +419,10 @@ mod tests {
         assert!(output.contains("kiln_prefix_cache_hit_blocks_total 7"));
         assert!(output.contains("kiln_prefix_cache_cached_blocks 64"));
         assert!(output.contains("kiln_prefix_cache_max_blocks 128"));
+        assert!(output.contains("kiln_prefix_cache_cached_entries 4"));
+        assert!(output.contains("kiln_prefix_cache_max_entries 8"));
+        assert!(output.contains("kiln_prefix_cache_state_bytes 196"));
+        assert!(output.contains("kiln_prefix_cache_max_state_bytes 392"));
         assert!(output.contains("kiln_active_adapter{name=\"my-adapter\"} 1"));
         assert!(output.contains("kiln_request_duration_seconds_count 1"));
         assert!(output.contains("kiln_request_duration_seconds_sum 0.5"));

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -168,9 +168,17 @@ pub struct TrainingJobInfo {
 /// Thread-safe map of tracked training jobs.
 pub type TrainingJobs = Arc<std::sync::RwLock<HashMap<String, TrainingJobInfo>>>;
 
+pub const MIN_PREFIX_CACHE_MAX_ENTRIES: usize = 1;
+const MIN_PREFIX_CACHE_STATE_BYTES: u64 = 256 * 1024 * 1024;
+const MAX_PREFIX_CACHE_STATE_BYTES: u64 = 1024 * 1024 * 1024;
+const PREFIX_CACHE_STATE_FRACTION_DIVISOR: u64 = 40;
+
 pub struct RealPrefixCache {
     enabled: bool,
     max_blocks: usize,
+    max_entries: usize,
+    state_bytes_per_entry: u64,
+    max_state_bytes: u64,
     block_size: usize,
     next_entry_id: u64,
     entries: Vec<RealPrefixCacheEntry>,
@@ -201,10 +209,21 @@ pub struct RealPrefixCacheRegisterOutcome {
 }
 
 impl RealPrefixCache {
-    pub fn new(enabled: bool, block_size: usize, max_blocks: usize) -> Self {
+    pub fn new(
+        enabled: bool,
+        block_size: usize,
+        max_blocks: usize,
+        max_entries: usize,
+        state_bytes_per_entry: u64,
+    ) -> Self {
+        let max_entries = max_entries.max(MIN_PREFIX_CACHE_MAX_ENTRIES);
+        let max_state_bytes = state_bytes_per_entry.saturating_mul(max_entries as u64);
         Self {
             enabled,
             max_blocks,
+            max_entries,
+            state_bytes_per_entry,
+            max_state_bytes,
             block_size,
             next_entry_id: 1,
             entries: Vec::new(),
@@ -217,7 +236,7 @@ impl RealPrefixCache {
     }
 
     pub fn disabled(block_size: usize) -> Self {
-        Self::new(false, block_size, 0)
+        Self::new(false, block_size, 0, MIN_PREFIX_CACHE_MAX_ENTRIES, 0)
     }
 
     pub fn is_enabled(&self) -> bool {
@@ -302,15 +321,10 @@ impl RealPrefixCache {
             .iter()
             .filter(|block_id| !self.block_refcounts.contains_key(block_id))
             .count();
-        while self.cached_blocks() + needed_new_blocks > self.max_blocks {
-            let Some(evict_idx) = self
-                .entries
-                .iter()
-                .enumerate()
-                .filter(|(_, entry)| entry.active_uses == 0)
-                .min_by_key(|(_, entry)| entry.last_used)
-                .map(|(idx, _)| idx)
-            else {
+        while self.cached_blocks() + needed_new_blocks > self.max_blocks
+            || self.entries.len() >= self.max_entries
+        {
+            let Some(evict_idx) = self.oldest_evictable_entry_idx() else {
                 return RealPrefixCacheRegisterOutcome {
                     retained_blocks: Vec::new(),
                     evicted_blocks,
@@ -370,6 +384,15 @@ impl RealPrefixCache {
         blocks
     }
 
+    fn oldest_evictable_entry_idx(&self) -> Option<usize> {
+        self.entries
+            .iter()
+            .enumerate()
+            .filter(|(_, entry)| entry.active_uses == 0)
+            .min_by_key(|(_, entry)| entry.last_used)
+            .map(|(idx, _)| idx)
+    }
+
     fn release_entry_blocks(&mut self, block_ids: &[u32]) -> Vec<u32> {
         let mut freed = Vec::new();
         for &block_id in block_ids {
@@ -388,6 +411,12 @@ impl RealPrefixCache {
         PrefixCacheStats {
             cached_blocks: self.cached_blocks(),
             max_blocks: self.max_blocks,
+            cached_entries: self.entries.len(),
+            max_entries: self.max_entries,
+            cached_state_bytes: self
+                .state_bytes_per_entry
+                .saturating_mul(self.entries.len() as u64),
+            max_state_bytes: self.max_state_bytes,
             ..self.stats
         }
     }
@@ -815,10 +844,29 @@ impl AppState {
         } else {
             0
         };
+        let prefix_cache_state_bytes_per_entry =
+            linear_attention_state_bytes(&model_config, &device);
+        let prefix_cache_max_entries = if prefix_cache_cfg.enabled {
+            prefix_cache_cfg.max_entries.unwrap_or_else(|| {
+                default_prefix_cache_max_entries(total_vram, prefix_cache_state_bytes_per_entry)
+            })
+        } else {
+            MIN_PREFIX_CACHE_MAX_ENTRIES
+        };
+        tracing::info!(
+            max_blocks = prefix_cache_max_blocks,
+            max_entries = prefix_cache_max_entries,
+            state_bytes_per_entry = prefix_cache_state_bytes_per_entry,
+            max_state_bytes = prefix_cache_state_bytes_per_entry
+                .saturating_mul(prefix_cache_max_entries as u64),
+            "prefix cache budget"
+        );
         let prefix_cache = RealPrefixCache::new(
             prefix_cache_cfg.enabled,
             block_size,
             prefix_cache_max_blocks,
+            prefix_cache_max_entries,
+            prefix_cache_state_bytes_per_entry,
         );
 
         Self {
@@ -860,6 +908,42 @@ impl AppState {
             ))),
         }
     }
+}
+
+fn linear_attention_state_bytes(config: &ModelConfig, device: &candle_core::Device) -> u64 {
+    let num_linear_layers = config
+        .num_layers
+        .saturating_sub(config.num_full_attention_layers) as u64;
+    let recurrent_dtype_bytes = match (device, config.dtype) {
+        #[cfg(feature = "metal")]
+        (candle_core::Device::Metal(_), kiln_core::config::DType::BF16) => 2,
+        #[cfg(feature = "metal")]
+        (candle_core::Device::Metal(_), kiln_core::config::DType::FP16) => 2,
+        _ => 4,
+    };
+    let recurrent_elems = (config.linear_num_value_heads
+        * config.linear_key_head_dim
+        * config.linear_value_head_dim) as u64;
+    let conv_elems = (config.linear_qkv_dim()
+        * config.linear_conv_kernel_dim.saturating_sub(1)) as u64;
+    num_linear_layers.saturating_mul(
+        recurrent_elems
+            .saturating_mul(recurrent_dtype_bytes)
+            .saturating_add(conv_elems.saturating_mul(4)),
+    )
+}
+
+fn default_prefix_cache_max_entries(total_vram_bytes: u64, state_bytes_per_entry: u64) -> usize {
+    if state_bytes_per_entry == 0 {
+        return MIN_PREFIX_CACHE_MAX_ENTRIES;
+    }
+    let state_budget = if total_vram_bytes == 0 {
+        MIN_PREFIX_CACHE_STATE_BYTES
+    } else {
+        (total_vram_bytes / PREFIX_CACHE_STATE_FRACTION_DIVISOR)
+            .clamp(MIN_PREFIX_CACHE_STATE_BYTES, MAX_PREFIX_CACHE_STATE_BYTES)
+    };
+    ((state_budget / state_bytes_per_entry) as usize).max(MIN_PREFIX_CACHE_MAX_ENTRIES)
 }
 
 /// Estimate model weight memory in bytes from config.
@@ -1182,7 +1266,7 @@ mod tests {
         let config = tiny_linear_config();
         let device = candle_core::Device::Cpu;
         let state = LinearAttentionState::new(&config, &device)?;
-        let mut cache = RealPrefixCache::new(true, 4, 4);
+        let mut cache = RealPrefixCache::new(true, 4, 4, 1024, 49);
 
         let registration = PagedPrefixRegistration {
             prompt_tokens: vec![1, 2, 3, 4],
@@ -1210,7 +1294,55 @@ mod tests {
         assert_eq!(stats.hit_blocks, 1);
         assert_eq!(stats.cached_blocks, 1);
         assert_eq!(stats.max_blocks, 4);
+        assert_eq!(stats.cached_entries, 1);
+        assert_eq!(stats.max_entries, 1024);
+        assert_eq!(stats.cached_state_bytes, 49);
+        assert_eq!(stats.max_state_bytes, 1024 * 49);
         Ok(())
+    }
+
+    #[test]
+    fn real_prefix_cache_caps_entries_and_state_bytes() -> anyhow::Result<()> {
+        let config = tiny_linear_config();
+        let device = candle_core::Device::Cpu;
+        let mut cache = RealPrefixCache::new(true, 4, 100, 2, 49);
+
+        for i in 0..3u32 {
+            let start = 1 + i * 4;
+            cache.register(
+                None,
+                PagedPrefixRegistration {
+                    prompt_tokens: vec![start, start + 1, start + 2, start + 3],
+                    block_ids: vec![10 + i],
+                    linear_state: LinearAttentionState::new(&config, &device)?,
+                },
+            );
+        }
+
+        let stats = cache.stats();
+        assert_eq!(stats.cached_entries, 2);
+        assert_eq!(stats.max_entries, 2);
+        assert_eq!(stats.cached_state_bytes, 98);
+        assert_eq!(stats.max_state_bytes, 98);
+        assert_eq!(stats.cached_blocks, 2);
+        assert!(cache.lookup(&None, &[1, 2, 3, 4, 99])?.is_none());
+        assert!(cache.lookup(&None, &[5, 6, 7, 8, 99])?.is_some());
+        assert!(cache.lookup(&None, &[9, 10, 11, 12, 99])?.is_some());
+        Ok(())
+    }
+
+    #[test]
+    fn default_prefix_cache_entries_reserves_state_memory_budget() {
+        let entry = 49 * 1024 * 1024;
+        assert_eq!(
+            default_prefix_cache_max_entries(48 * 1024 * 1024 * 1024, entry),
+            20
+        );
+        assert_eq!(
+            default_prefix_cache_max_entries(24 * 1024 * 1024 * 1024, entry),
+            12
+        );
+        assert_eq!(default_prefix_cache_max_entries(0, entry), 5);
     }
 
     #[test]
@@ -1218,7 +1350,7 @@ mod tests {
         let config = tiny_linear_config();
         let device = candle_core::Device::Cpu;
         let state = LinearAttentionState::new(&config, &device)?;
-        let mut cache = RealPrefixCache::new(true, 4, 4);
+        let mut cache = RealPrefixCache::new(true, 4, 4, 1024, 49);
         cache.register(
             Some("adapter-a".to_string()),
             PagedPrefixRegistration {
@@ -1252,7 +1384,7 @@ mod tests {
     fn register_does_not_evict_blocks_retained_by_incoming() -> anyhow::Result<()> {
         let config = tiny_linear_config();
         let device = candle_core::Device::Cpu;
-        let mut cache = RealPrefixCache::new(true, 4, 2);
+        let mut cache = RealPrefixCache::new(true, 4, 2, 1024, 49);
 
         // Entry A occupies blocks [10, 11], the cache's full capacity.
         let outcome_a = cache.register(
@@ -1298,7 +1430,7 @@ mod tests {
     fn register_outcome_no_duplicate_or_overlap() -> anyhow::Result<()> {
         let config = tiny_linear_config();
         let device = candle_core::Device::Cpu;
-        let mut cache = RealPrefixCache::new(true, 4, 3);
+        let mut cache = RealPrefixCache::new(true, 4, 3, 1024, 49);
 
         // Three small entries that together fill capacity, two of which share
         // block 20 with the eventual incoming registration.
@@ -1367,7 +1499,7 @@ mod tests {
     fn register_evicted_blocks_not_in_refcounts_after() -> anyhow::Result<()> {
         let config = tiny_linear_config();
         let device = candle_core::Device::Cpu;
-        let mut cache = RealPrefixCache::new(true, 4, 2);
+        let mut cache = RealPrefixCache::new(true, 4, 2, 1024, 49);
 
         // Fill capacity with an evictable entry whose blocks the next
         // registration also wants.

--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -62,6 +62,9 @@ format = "json"                       # json, pretty, text, human
 [prefix_cache]
 enabled = true                        # Reuse KV cache blocks for shared prompt prefixes
 # max_blocks = 64                     # Max blocks for prefix cache (default: 25% of total)
+# max_entries = 20                    # Max cached prompt snapshots (auto-sized by VRAM if omitted).
+                                      # Each real-backend entry retains ~49 MiB of GDN state
+                                      # on Qwen3.5-4B, separate from KV blocks.
 
 [speculative]
 enabled = false                       # Self-speculative decoding (skip-layer draft)


### PR DESCRIPTION
## Summary

Fixes #696.

Round-8's sustained workers=2 OOM cascade was not KV block exhaustion and not #694's streaming-prefill timeout path. The first 500s in the uploaded server logs fail in GDN layer-0 prefill on the real prefix-cache path:

```text
prefill forward pass (paged prefix cache) failed: gated deltanet layer 0 (linear attention, paged): DriverError(CUDA_ERROR_OUT_OF_MEMORY, "out of memory")
```

Root cause: `RealPrefixCache` bounded retained KV blocks (`max_blocks = num_blocks / 4`) but did not bound retained GDN `LinearAttentionState` snapshots. Every registered real-backend prefix entry owns a fresh device snapshot from `LinearAttentionState::snapshot()` — ~49 MiB for Qwen3.5-4B's 24 GDN layers — separate from the preallocated KV cache. Under round-8's unique tools-bearing prompts, sustained successful/rejected attempts can accumulate hundreds of prompt snapshots even while `kiln_blocks_used` remains healthy. Lowering `inference_memory_fraction` from 0.7 to 0.6 only buys a few GiB, so it delays but does not eliminate the cascade.

## Fix

- Add a real prefix-cache entry/state-memory cap in addition to the existing KV-block cap.
- Auto-size the cap by VRAM with a conservative state budget: 5% of VRAM, clamped to 256 MiB..1 GiB. On A6000/Qwen3.5-4B this is 20 entries / ~1.05 GiB.
- Add `prefix_cache.max_entries` / `KILN_PREFIX_CACHE_MAX_ENTRIES` for explicit tuning.
- Extend prefix-cache Prometheus stats with:
  - `kiln_prefix_cache_cached_entries`
  - `kiln_prefix_cache_max_entries`
  - `kiln_prefix_cache_state_bytes`
  - `kiln_prefix_cache_max_state_bytes`
- Document the new knob in README, QUICKSTART, and `kiln.example.toml`.

## Validation

On RunPod A6000 `y77fs32uhtu9d7`, kiln-runpod image, branch build with `KILN_CUDA_ARCHS=86`:

- `cargo test -p kiln-server prefix_cache -- --nocapture`
  - 4 passed, including `real_prefix_cache_caps_entries_and_state_bytes` and `default_prefix_cache_entries_reserves_state_memory_budget`.
- `cargo test -p kiln-server metrics -- --nocapture`
  - 2 passed, including new metrics rendering.
- `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln`
  - Passed.
- Workers=2 stress, default `KILN_INFERENCE_MEMORY_FRACTION=0.7`, tools-bearing chat completions, 128/128 block-aligned unique prompts:
  - `failures=0`, `kiln_requests_total{status="error"}=0`
  - `kiln_prefix_cache_cached_entries=20`
  - `kiln_prefix_cache_max_entries=20`
  - `kiln_prefix_cache_state_bytes=1053818880`
  - `kiln_blocks_used=480`, `kiln_blocks_total=56570`
- Long-prefill sanity after the stress cache was full:
  - 43,521 prompt tokens, max_tokens=1, `status=200`, elapsed 15.5s.

## Notes

I also tested the initial 2 GiB cap candidate. It passed the 128-request workers=2 stress but then a 52k-token long-prefill request OOMed in a full-attention streaming tile with the cache holding ~2.1 GiB of state snapshots. Tightening the default cap to ≤1 GiB preserved the round-8 stress fix and kept the post-#694 long-prefill path healthy.
