### PR TITLE
Prepare kiln v0.2.11 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Kiln Server Changelog
 
+## kiln-v0.2.11 — 2026-05-02
+
+### Fixed
+- memory: bound retained `RealPrefixCache` GDN `LinearAttentionState` snapshots via `prefix_cache.max_entries` / `KILN_PREFIX_CACHE_MAX_ENTRIES`, and expose new prefix-cache state metrics so sustained workers=2 traffic cannot accumulate hidden ~49 MiB state entries into post-v0.2.10 OOM cascades (#697).
+
 ## kiln-v0.2.10 — 2026-05-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "candle-core",
  "cc",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "candle-core",
  "cc",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "candle-core",
  "cc",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1816,11 +1816,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.10"
+version = "0.2.11"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "candle-core",
  "cc",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "axum",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.10"
+version = "0.2.11"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## Summary
- bump workspace package metadata from `0.2.10` to `0.2.11`
- add `kiln-v0.2.11` changelog entry for #697
- refresh `Cargo.lock` package version metadata only

## Why
PR #697 (`Bound real prefix cache state memory`) merged after `kiln-v0.2.10` and is not yet tagged. This patch release prep ensures the critical prefix-cache state cap fix is included in the public-announce release line.

## Validation
- `gh release list -R ericflo/kiln --limit 5` shows latest release is `kiln-v0.2.10`
- `gh api repos/ericflo/kiln/compare/kiln-v0.2.10...main --jq '{ahead_by, commits: [.commits[].commit.message]}'` shows #697 as the only unreleased commit
- `git diff --check`
- `rg -n 'version = "0\.2\.11"|kiln-v0\.2\.11|prefix_cache.max_entries|KILN_PREFIX_CACHE_MAX_ENTRIES' Cargo.toml CHANGELOG.md README.md QUICKSTART.md kiln.example.toml`
- `gh release view kiln-v0.2.11 -R ericflo/kiln` fails with `release not found`, confirming this is prep and not a duplicate release

## Follow-up
Do not create the `kiln-v0.2.11` tag from this PR. A separate cut-and-verify task should tag v0.2.11 after this PR merges.
