### PR TITLE
Prepare kiln v0.2.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Kiln Server Changelog
 
+## kiln-v0.2.12 — 2026-05-02
+
+### Fixed
+- reliability: complete the production-shaped prefill OOM hardening series from #694/#697/#699. KV auto-sizing now uses post-load CUDA residency instead of only the static model estimate, CUDA streaming prefill starts at 8k tokens for production-shaped prompts below the old 32k threshold, and new VRAM metrics expose the static estimate, post-load snapshot, and observed prefill peak (#701).
+
 ## kiln-v0.2.11 — 2026-05-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "candle-core",
  "cc",
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1748,7 +1748,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "candle-core",
  "cc",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1777,7 +1777,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "candle-core",
  "cc",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1816,11 +1816,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.11"
+version = "0.2.12"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "candle-core",
  "cc",
@@ -1829,7 +1829,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "axum",
@@ -1874,7 +1874,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.11"
+version = "0.2.12"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## Summary
- Bump workspace/package versions to 0.2.12.
- Add release notes for the #694/#697/#699 reliability hardening story, with #701 as the final production-shaped prefill OOM headroom fix.

## Validation
- git diff --check