### PR TITLE
Update launch copy for v0.2.12

### DIFF
--- a/docs/site/launch.html
+++ b/docs/site/launch.html
@@ -125,7 +125,7 @@
   <!-- hero -->
   <section class="hero-glow">
     <div class="max-w-3xl mx-auto px-6 pt-20 pb-10">
-      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">Launch announcement &middot; v0.2.9</span>
+      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">Launch announcement &middot; v0.2.12</span>
       <h1 class="text-4xl sm:text-5xl font-bold tracking-tight mb-5 leading-tight">
         Launching Kiln &mdash; your model gets better every time you use it.
       </h1>
@@ -270,7 +270,7 @@ requests.post("http://localhost:8420/v1/train/grpo", json={
         Sigstore build provenance and ships with a SHA-256 sidecar.
       </p>
 <pre><code>curl -L -o kiln.tar.gz \
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.9/kiln-0.2.9-x86_64-unknown-linux-gnu-cuda124.tar.gz
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.12/kiln-0.2.12-x86_64-unknown-linux-gnu-cuda124.tar.gz
 tar -xzf kiln.tar.gz
 KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
       <p>
@@ -285,7 +285,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
 
       <h2>What&rsquo;s next</h2>
       <p>
-        kiln-v0.2.9 is the production line we&rsquo;re launching on, but the project is explicitly pre-1.0.
+        kiln-v0.2.12 is the production line we&rsquo;re launching on, but the project is explicitly pre-1.0.
         The Phases 1&ndash;10 work that got us here closed out core inference, LoRA serving, SFT, GRPO,
         production hardening, decode-perf optimization, developer experience, advanced adapter features, the
         v0.1.0 release engineering, and the Liger long-context training pieces. The roadmap from here is

--- a/docs/site/launch/README.md
+++ b/docs/site/launch/README.md
@@ -87,7 +87,7 @@ For each channel, after going live:
 
 ## Pre-launch ops gate (must be green before any draft goes live)
 
-- `gh release view kiln-v0.2.9 -R ericflo/kiln` — clean
+- `gh release view kiln-v0.2.12 -R ericflo/kiln` — clean
 - `gh attestation verify` against the latest release artifact — clean
 - `gh api repos/ericflo/kiln` — public, README rendered, links work
 - https://ericflo.github.io/kiln/ and https://ericflo.github.io/kiln/launch.html

--- a/docs/site/launch/discord-rust.md
+++ b/docs/site/launch/discord-rust.md
@@ -30,7 +30,7 @@ length: ~250 words
 >
 > **Build matrix is intentionally small** — "has CUDA or doesn't." `cargo build --release --features cuda` on Linux+CUDA, `--features metal` on Apple Silicon, plain `cargo build --release` for the CPU/headless path. macOS Apple Silicon gets the Metal backend via a candle-metal JIT path.
 >
-> Reproducible builds with `--locked`, Sigstore-signed build provenance on every release artifact and the GHCR `kiln-server` image, MIT licensed, pre-1.0 (current production line is kiln-v0.2.9).
+> Reproducible builds with `--locked`, Sigstore-signed build provenance on every release artifact and the GHCR `kiln-server` image, MIT licensed, pre-1.0 (current production line is kiln-v0.2.12).
 >
 > Would love eyes on the kernel crates and the in-process training thread design. Also happy to talk about the tradeoffs of the single-model architectural choice — that's the thing I most expect pushback on.
 

--- a/docs/site/launch/hackernews.md
+++ b/docs/site/launch/hackernews.md
@@ -44,7 +44,7 @@ https://ericflo.github.io/kiln/launch.html
 ## Posting checklist
 
 - [ ] Demo asciicast linked from the launch post (`docs/site/launch.html`)
-- [ ] Confirm `gh release view kiln-v0.2.9 -R ericflo/kiln` is clean
+- [ ] Confirm `gh release view kiln-v0.2.12 -R ericflo/kiln` is clean
 - [ ] Confirm `https://ericflo.github.io/kiln/launch.html` renders on mobile + desktop
 - [ ] Eric reviews this draft and the asciicast
 - [ ] Submit Tuesday–Thursday, 9:00–11:00 ET (US morning peak for HN)

--- a/docs/site/launch/lobsters.md
+++ b/docs/site/launch/lobsters.md
@@ -43,7 +43,7 @@ https://ericflo.github.io/kiln/launch.html
 >
 > - **Single model.** It targets [Qwen3.5-4B](https://huggingface.co/Qwen/Qwen3.5-4B) and the scheduler, block manager, and CUDA kernels are tuned for that one architecture. Model-agnostic mode is on the post-1.0 roadmap with the explicit caveat that kernels need re-tuning per architecture.
 > - **Single GPU.** No tensor parallel, no multi-node. Multi-GPU TP is also on the post-1.0 roadmap.
-> - **Pre-1.0.** The current production line is kiln-v0.2.9. Phases 1–10 (core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, dev experience, advanced adapter features, v0.1.0 release engineering, Liger long-context training) are all closed. The roadmap from here is deliberately small and chosen by what early users actually ask for.
+> - **Pre-1.0.** The current production line is kiln-v0.2.12. Phases 1–10 (core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, dev experience, advanced adapter features, v0.1.0 release engineering, Liger long-context training) are all closed. The roadmap from here is deliberately small and chosen by what early users actually ask for.
 >
 > What's in-tree (not vendored Python or wrapped C++): the forward pass, paged KV cache + block manager, Sarathi-style chunked-prefill scheduler, LoRA training loop, Marlin W4A16 GEMM, fused RMSNorm, GDN linear-attention kernel, vendored flash-attn-2 with our own C-ABI wrapper, fused Conv1d. All in `crates/kiln-*-kernel/` and `crates/kiln-model/src/forward.rs`.
 >

--- a/docs/site/launch/reddit-localllama.md
+++ b/docs/site/launch/reddit-localllama.md
@@ -62,7 +62,7 @@ Kiln: a single-GPU inference server in Rust that also trains the model it's serv
 >
 > - **Single model.** Every line of code is tuned for Qwen3.5-4B. Model-agnostic mode is post-1.0 with the honest tradeoff that kernels need re-tuning per architecture.
 > - **Single GPU.** Multi-GPU tensor parallelism is also post-1.0.
-> - **Pre-1.0.** Current production line is kiln-v0.2.9. The phases that got us here closed core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, developer experience, advanced adapter features, v0.1.0 release engineering, and the Liger long-context training pieces. The roadmap from here is deliberately small.
+> - **Pre-1.0.** Current production line is kiln-v0.2.12. The phases that got us here closed core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, developer experience, advanced adapter features, v0.1.0 release engineering, and the Liger long-context training pieces. The roadmap from here is deliberately small.
 >
 > **How to try it:**
 >

--- a/docs/site/launch/twitter.md
+++ b/docs/site/launch/twitter.md
@@ -78,7 +78,7 @@ length: 8 tweets, each <280 chars
 >
 > https://ericflo.github.io/kiln/launch.html
 >
-> MIT licensed. v0.2.9 is the production line. Built in Rust by one person; the GRPO loop is what kept me up at night and what I most want feedback on.
+> MIT licensed. v0.2.12 is the production line. Built in Rust by one person; the GRPO loop is what kept me up at night and what I most want feedback on.
 
 *(248 chars — has link headroom for X's t.co)*
 


### PR DESCRIPTION
## Summary
- Update the public launch page release badge, download URL, and production-line wording from kiln-v0.2.9 to kiln-v0.2.12.
- Update staged launch-channel drafts and the adjacent launch README pre-launch gate to reference kiln-v0.2.12.

## Validation
- `rg -n "v0\\.2\\.9|0\\.2\\.9|kiln-v0\\.2\\.10|0\\.2\\.10|kiln-v0\\.2\\.11|0\\.2\\.11" docs/site/launch.html docs/site/launch/*.md` — no stale launch-release refs found.
- `rg -n "v0\\.2\\.12|0\\.2\\.12|kiln-v0\\.2\\.12" docs/site/launch.html docs/site/launch/*.md` — launch page plus staged posts point at v0.2.12.
- `python3 -m http.server 8000 --directory docs/site >/tmp/kiln-docs-http.log 2>&1 & echo $! >/tmp/kiln-docs-http.pid; sleep 1; curl -kfsSL http://127.0.0.1:8000/launch.html | rg "v0.2.12|0.2.12|kiln-v0.2.12"; kill $(cat /tmp/kiln-docs-http.pid)` — local launch page contains v0.2.12 references.

## Historical references
- None intentionally retained for v0.2.9, v0.2.10, or v0.2.11 in the launch surfaces.