### PR TITLE
docs(launch): record v0.2.12 pre-launch ops gate

### DIFF
--- a/docs/site/launch/README.md
+++ b/docs/site/launch/README.md
@@ -20,7 +20,8 @@ or deployed; it's a versioned drafting space.
 ## Status
 
 > **All drafts in this directory are DRAFT status.**
-> **Do not post any of them until Eric reviews them AND the demo asciicast lands.**
+> **Demo has landed. Do not post any draft until Eric reviews it and the
+> v0.2.12 pre-launch ops gate remains green.**
 
 ## Files
 
@@ -94,8 +95,27 @@ For each channel, after going live:
   — render correctly on mobile and desktop
 - The demo asciicast — embedded on `launch.html` and visible in the page
 
+### 2026-05-02 v0.2.12 verification
+
+- [x] `gh release view kiln-v0.2.12 -R ericflo/kiln` reports
+      `isDraft=false`, `isPrerelease=false`, published at
+      `2026-05-02T08:30:14Z`, and 7 release assets.
+- [x] `gh attestation verify kiln-0.2.12-x86_64-unknown-linux-gnu-cuda124.tar.gz -R ericflo/kiln`
+      verifies SLSA provenance from `https://github.com/ericflo/kiln`.
+- [x] `gh api repos/ericflo/kiln` reports `private=false` and public repo URL
+      `https://github.com/ericflo/kiln`.
+- [x] GHCR `kiln-server` package includes tags `0.2.12` and `latest`.
+- [x] `https://ericflo.github.io/kiln/`,
+      `https://ericflo.github.io/kiln/launch.html`, and
+      `https://ericflo.github.io/kiln/demo/` return HTTP 200 and render the
+      expected titles: `Kiln — Your model gets better every time you use it`,
+      `Launching Kiln — Your model gets better every time you use it`, and
+      `Kiln Demo — 60-second online-learning loop`.
+- [x] `docs/site/launch.html` links to `demo/`, and
+      `docs/site/demo/index.html` embeds `kiln-60s.cast`.
+
 ## Where this directory came from
 
-Companion to PR #667 (live launch blog) and the upcoming demo asciicast
-task. Staged so Eric can review the channel-specific framing before any
-public post goes live.
+Companion to PR #667 (live launch blog) and the landed demo asciicast. Staged
+so Eric can review the channel-specific framing before any public post goes
+live.

--- a/docs/site/launch/discord-rust.md
+++ b/docs/site/launch/discord-rust.md
@@ -6,7 +6,7 @@ length: ~250 words
 
 # Rust Discord #showcase post draft
 
-> **DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
 
 ## Post body (paste directly into #showcase)
 
@@ -36,8 +36,8 @@ length: ~250 words
 
 ## Posting checklist
 
-- [ ] Demo asciicast linked from the launch post
+- [x] Demo asciicast landed and linked from the launch post
 - [ ] Verify the post is under the channel's character limit (`#showcase` rules sometimes cap at 2000 chars; trim the kernel bullet list if needed)
-- [ ] Eric reviews this draft + the asciicast
+- [ ] Eric reviews this draft before posting
 - [ ] Post during US working hours, Tue–Thu (Discord is more time-zone-mixed than HN; aim for 12:00–14:00 ET to catch both EU late-afternoon and US lunch)
 - [ ] Stay in the channel for ~1 hour to answer questions; Discord conversations are short-lived

--- a/docs/site/launch/hackernews.md
+++ b/docs/site/launch/hackernews.md
@@ -6,7 +6,7 @@ length: ~80 chars title / ~220 words first comment
 
 # Show HN: Kiln draft
 
-> **DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
 
 ## Submission
 
@@ -43,10 +43,10 @@ https://ericflo.github.io/kiln/launch.html
 
 ## Posting checklist
 
-- [ ] Demo asciicast linked from the launch post (`docs/site/launch.html`)
+- [x] Demo asciicast landed and linked from the launch post (`docs/site/launch.html`)
 - [ ] Confirm `gh release view kiln-v0.2.12 -R ericflo/kiln` is clean
 - [ ] Confirm `https://ericflo.github.io/kiln/launch.html` renders on mobile + desktop
-- [ ] Eric reviews this draft and the asciicast
+- [ ] Eric reviews this draft before posting
 - [ ] Submit Tuesday–Thursday, 9:00–11:00 ET (US morning peak for HN)
 - [ ] Post the first comment within 60 seconds of submission
 - [ ] Watch the thread for the first 90 minutes, answer every top-level question

--- a/docs/site/launch/lobsters.md
+++ b/docs/site/launch/lobsters.md
@@ -6,7 +6,7 @@ length: ~70 chars title / ~330 words comment
 
 # lobste.rs submission draft
 
-> **DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
 
 ## Submission
 
@@ -53,9 +53,9 @@ https://ericflo.github.io/kiln/launch.html
 
 ## Posting checklist
 
-- [ ] Demo asciicast linked from the launch post
+- [x] Demo asciicast landed and linked from the launch post
 - [ ] Confirm tags against current lobste.rs taxonomy (they prune)
-- [ ] Eric reviews this draft and the asciicast
+- [ ] Eric reviews this draft before posting
 - [ ] Submit Tuesday–Thursday, 9:00–11:00 ET
 - [ ] Watch the thread for the first 2 hours; lobste.rs threads die fast but the early discussion sets the tone
 - [ ] Engage substantively on technical pushback — this audience values long-form replies, not one-liners

--- a/docs/site/launch/reddit-localllama.md
+++ b/docs/site/launch/reddit-localllama.md
@@ -6,7 +6,7 @@ length: ~140 chars title / ~620 words body
 
 # /r/LocalLLaMA submission draft
 
-> **DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
 
 ## Submission
 
@@ -78,9 +78,9 @@ Kiln: a single-GPU inference server in Rust that also trains the model it's serv
 
 ## Posting checklist
 
-- [ ] Demo asciicast linked from the launch post
+- [x] Demo asciicast landed and linked from the launch post
 - [ ] Confirm flair against current sub rules (the mods rotate accepted flair)
-- [ ] Eric reviews this draft + the asciicast
+- [ ] Eric reviews this draft before posting
 - [ ] Submit Tuesday–Thursday, 9:00–11:00 ET (catches both US morning and EU afternoon)
 - [ ] Reply to every top-level comment in the first 4 hours; this sub rewards founder presence
 - [ ] If the post catches: cross-post to r/MachineLearning Project Announcements (separate weekly thread) — but only after r/LocalLLaMA discussion has settled

--- a/docs/site/launch/twitter.md
+++ b/docs/site/launch/twitter.md
@@ -6,7 +6,7 @@ length: 8 tweets, each <280 chars
 
 # X / Twitter thread draft
 
-> **DRAFT — do not post until reviewed by Eric AND the demo asciicast lands.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
 
 ## Thread
 
@@ -85,7 +85,7 @@ length: 8 tweets, each <280 chars
 ## Image / asciicast suggestions
 
 - **Tweet 1 hero:** static screenshot of the GRPO Python snippet from `docs/site/launch.html` (lines 171–193). Alt text: "Python code: 1) generate 8 chat completions; 2) score them; 3) POST to /v1/train/grpo; 4) next request already uses the improved weights."
-- **Tweet 2 GRPO:** the demo asciicast embed (when ready). Alt text: "60-second terminal recording of cold-starting Kiln, sending a chat request, POSTing an SFT correction, and seeing the next request use the improved output."
+- **Tweet 2 GRPO:** the landed demo asciicast embed. Alt text: "60-second terminal recording of cold-starting Kiln, sending a chat request, POSTing an SFT correction, and seeing the next request use the improved output."
 - **Tweet 4 4B:** screenshot of the README memory budget table. Alt text: "Memory budget table showing Qwen3.5-4B fits 128K context in ~13 GB on a 24 GB GPU, including training."
 - **Tweet 7 try it:** screenshot of the embedded `/ui` dashboard. Alt text: "Kiln /ui dashboard showing live decode tokens/sec, p50/p99 ITL, recent requests, and adapter management controls."
 
@@ -95,9 +95,9 @@ length: 8 tweets, each <280 chars
 
 ## Posting checklist
 
-- [ ] Demo asciicast finalized and linked from the launch post
+- [x] Demo landed and is linked from the launch post
 - [ ] Verify the `og:image` and Twitter card on `docs/site/launch.html` render correctly via cards-validator
-- [ ] Eric reviews this draft + the asciicast
+- [ ] Eric reviews this draft before posting
 - [ ] Post Tuesday or Wednesday, 9:00–11:00 ET (best Twitter dev-tools traction window)
 - [ ] Pin tweet 1 to the profile for the launch week
 - [ ] Watch replies for the first 2 hours, respond to every substantive question


### PR DESCRIPTION
## Summary
- Record the dated 2026-05-02 v0.2.12 pre-launch ops verification in `docs/site/launch/README.md`.
- Update channel draft gates so the demo is treated as landed/linked while drafts remain unposted pending Eric review and the ops gate.
- Keep all channel drafts in `status: draft`.

## Verification
- `git diff --check`
- `rg -n "demo asciicast lands|Demo asciicast finalized|Demo asciicast linked|status: posted" docs/site/launch docs/site/launch.html docs/site/demo/index.html`
- `gh release view kiln-v0.2.12 -R ericflo/kiln --json tagName,publishedAt,url,isDraft,isPrerelease,assets | jq '{tagName,publishedAt,url,isDraft,isPrerelease,asset_count:(.assets|length)}'`
- `gh attestation verify /tmp/kiln-attest/kiln-0.2.12-x86_64-unknown-linux-gnu-cuda124.tar.gz -R ericflo/kiln`
- `gh api /users/ericflo/packages/container/kiln-server/versions --jq '.[0:5] | map(.metadata.container.tags)'`
- `for u in https://ericflo.github.io/kiln/ https://ericflo.github.io/kiln/launch.html https://ericflo.github.io/kiln/demo/; do curl -L -s -o /tmp/kiln-page.html -w "%{http_code} %{url_effective}\n" "$u"; grep -io '<title>[^<]*' /tmp/kiln-page.html | head -1; done`
