### PR TITLE
[codex] Add Anthropic Discord launch draft

### DIFF
--- a/docs/site/launch/README.md
+++ b/docs/site/launch/README.md
@@ -32,6 +32,7 @@ or deployed; it's a versioned drafting space.
 | [`lobsters.md`](lobsters.md) | lobste.rs | Skeptical technical audience. Long-form comment that front-loads the honest tradeoffs. |
 | [`reddit-localllama.md`](reddit-localllama.md) | /r/LocalLLaMA | Hobbyist + enthusiast audience. Emphasizes the consumer-GPU angle and includes the GRPO Python snippet inline. |
 | [`discord-rust.md`](discord-rust.md) | Rust Discord `#showcase` | Rust-systems framing — vendored CUDA kernels, in-process training thread, build matrix. |
+| [`anthropic-discord.md`](anthropic-discord.md) | Anthropic Discord | Claude / AI-product-builder framing — live online learning, GRPO reward loops, hot-swap LoRA, single-GPU economics. |
 
 ## Recommended posting order and timing
 
@@ -54,10 +55,14 @@ window:
 5. **Rust Discord `#showcase`** — same day, **12:00–14:00 ET** (US
    lunchtime, EU late afternoon). Discord is conversational; stay in the
    channel for ~1 hour to answer questions.
+6. **Anthropic Discord** — same day or next morning as a targeted
+   AI-builder follow-up after Rust Discord. Lead with Claude-in-the-loop
+   evaluation, GRPO reward loops, hot-swap LoRA, and the single-GPU product
+   economics rather than Rust internals.
 
-If HN goes hot (front page), pause channels 3–5 by an hour or two so they
+If HN goes hot (front page), pause channels 3–6 by an hour or two so they
 don't compete with the HN thread for Eric's attention. If HN flops, still
-ship 2–5 — they reach different audiences and recovery from a bad HN day is
+ship 2–6 — they reach different audiences and recovery from a bad HN day is
 boring not fatal.
 
 ## After-posting checklist
@@ -79,9 +84,9 @@ For each channel, after going live:
 
 - **Don't post the same body across channels.** Each draft is rewritten for
   its audience — HN gets crisp tradeoffs, lobste.rs gets long-form honesty,
-  /r/LocalLLaMA gets the consumer-GPU angle, Discord gets the Rust-systems
-  angle, X gets one-line hooks. Reusing a body across channels reads as
-  spam.
+  /r/LocalLLaMA gets the consumer-GPU angle, Rust Discord gets the systems
+  angle, Anthropic Discord gets the Claude / AI-product-builder online-learning
+  angle, X gets one-line hooks. Reusing a body across channels reads as spam.
 - **Don't link channels at each other.** "Saw this on HN, posting here too"
   triggers downvotes on lobste.rs and Reddit.
 - **Don't autopost.** Every submission is manual, by Eric, after review.

--- a/docs/site/launch/anthropic-discord.md
+++ b/docs/site/launch/anthropic-discord.md
@@ -1,0 +1,37 @@
+---
+channel: anthropic-discord
+status: draft
+length: ~220 words
+---
+
+# Anthropic Discord launch post draft
+
+> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
+
+## Post body (paste directly into the appropriate Anthropic Discord channel)
+
+> **Kiln: single-GPU inference server with live online learning**
+>
+> https://ericflo.github.io/kiln/launch.html · https://ericflo.github.io/kiln/demo/ · https://github.com/ericflo/kiln
+>
+> I built Kiln around a workflow I wanted as an AI-product builder: your model should get better from production feedback without a separate training service, a notebook handoff, or a redeploy.
+>
+> Kiln serves one model and trains LoRA adapters in the same process on the same GPU. Send normal OpenAI-compatible chat requests, then POST corrections to `/v1/train/sft` or scored completions to `/v1/train/grpo`. Training runs in the background, writes a new adapter, and hot-swaps it at an iteration boundary — no restart and no second copy of the model in VRAM.
+>
+> The part I think is most relevant here is the feedback loop: Claude can be the evaluator, rubric writer, or product copilot that scores generations, while Kiln is the self-hosted model that absorbs those scores into a domain-specific LoRA. That makes GRPO reward loops feel like an API integration instead of a batch ML project.
+>
+> It is deliberately single-model and single-GPU: Qwen3.5-4B, tuned for 24GB+ cards, with continuous batching, paged KV cache, live SFT/GRPO endpoints, adapter history, and a small enough footprint that the economics work for product teams experimenting outside managed fine-tuning platforms.
+>
+> Launch post: https://ericflo.github.io/kiln/launch.html
+> 60-second demo: https://ericflo.github.io/kiln/demo/
+> GitHub: https://github.com/ericflo/kiln
+>
+> I would especially love feedback from people building Claude-centered workflows: where would you want the reward/scoring boundary to live, and what would make the online-learning loop safe enough to trust in a real product?
+
+## Posting checklist
+
+- [x] Demo asciicast landed and linked from the launch post
+- [ ] Confirm the target channel permits project launch drafts and GitHub links
+- [ ] Eric reviews this draft before posting
+- [ ] Post after Rust Discord as a targeted AI-builder follow-up, ideally while the HN/X threads are still active
+- [ ] Stay in the channel for ~1 hour to answer questions about reward loops, safety boundaries, and Claude-in-the-loop scoring


### PR DESCRIPTION
## What
- Add `docs/site/launch/anthropic-discord.md` as a draft-only Anthropic Discord launch post.
- Wire the new draft into `docs/site/launch/README.md` with the files table, posting order, and channel-specific framing guidance.

## Why
Phase 11 staged-launch docs listed Discord launch channels but were missing the Anthropic Discord draft for Claude / AI-product-builder audiences.

## Validation
- `rg -n "anthropic-discord|Anthropic Discord|Claude|v0.2.12|ops gate" docs/site/launch/README.md docs/site/launch/anthropic-discord.md`
- `python3 - <<'PY'
from pathlib import Path
for path in [Path('docs/site/launch/README.md'), Path('docs/site/launch/anthropic-discord.md')]:
    text = path.read_text()
    assert 'v0.2.12' in text
    assert 'draft' in text.lower()
    assert 'https://ericflo.github.io/kiln/launch.html' in text
print('launch draft checks passed')
PY`