### PR TITLE
[codex] Fix lobsters launch channel metadata

### DIFF
--- a/docs/site/launch/lobsters.md
+++ b/docs/site/launch/lobsters.md
@@ -1,5 +1,5 @@
 ---
-channel: lobste
+channel: lobsters
 status: draft
 length: ~70 chars title / ~330 words comment
 ---


### PR DESCRIPTION
## What
- Fix the `docs/site/launch/lobsters.md` frontmatter channel from `lobste` to `lobsters`.

## Why
- Keeps the launch draft metadata aligned with the intended lobste.rs channel identifier.

## Validation
- `git diff --check`
- `rg -n '^channel: lobste$|^channel: lobsters$' docs/site/launch/lobsters.md docs/site/launch/*.md`
- `sed -n '1,12p' docs/site/launch/lobsters.md`