### PR TITLE
Add round-10 throughput observability

### DIFF
--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -95,6 +95,8 @@ pub struct PrefixCachedGenerationOutput {
     pub output: GenerationOutput,
     pub registration: Option<PagedPrefixRegistration>,
     pub allocated_blocks: Vec<u32>,
+    pub prefill_duration: std::time::Duration,
+    pub decode_duration: std::time::Duration,
 }
 
 enum PrefillSampleSource {
@@ -850,6 +852,8 @@ impl ModelRunner {
             },
             registration: output.registration,
             allocated_blocks: output.allocated_blocks,
+            prefill_duration: output.prefill_duration,
+            decode_duration: output.decode_duration,
         })
     }
 
@@ -1042,6 +1046,7 @@ impl ModelRunner {
         let use_greedy_prefill_token = params.temperature == 0.0
             && matches!(self.backend.device(), candle_core::Device::Metal(_))
             && !streaming_prefill_enabled_for(self.backend.device(), prefill_tokens.len());
+        let prefill_start = std::time::Instant::now();
         let prefill_source = {
             let mut pc_guard = lock_paged_cache(paged_cache)?;
             if streaming_prefill_enabled_for(self.backend.device(), prefill_tokens.len()) {
@@ -1097,6 +1102,7 @@ impl ModelRunner {
             }
         };
 
+        let prefill_duration = prefill_start.elapsed();
         let registration = self.completed_prompt_registration(
             prompt_tokens,
             block_table,
@@ -1104,6 +1110,7 @@ impl ModelRunner {
             block_size,
         )?;
 
+        let decode_start = std::time::Instant::now();
         let output = match prefill_source {
             PrefillSampleSource::Logits(logits) => self.decode_from_prefill_logits(
                 logits,
@@ -1126,10 +1133,14 @@ impl ModelRunner {
             )?,
         };
 
+        let decode_duration = decode_start.elapsed();
+
         Ok(PrefixCachedGenerationOutput {
             output,
             registration,
             allocated_blocks: Vec::new(),
+            prefill_duration,
+            decode_duration,
         })
     }
 

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -1209,6 +1209,7 @@ async fn generate_real(
 
     let gpu_lock = state.gpu_lock.clone();
     let memory_budget = state.memory_budget.clone();
+    let metrics = state.metrics.clone();
     let timeout = state.request_timeout;
     // Cooperative cancellation: `tokio::time::timeout` cancels the outer
     // future, but `spawn_blocking` does not honor that — the closure keeps
@@ -1262,7 +1263,11 @@ async fn generate_real(
                     );
 
                     let mut output = match result {
-                        Ok(output) => output,
+                        Ok(output) => {
+                            metrics.observe_prefill_duration(output.prefill_duration.as_secs_f64());
+                            metrics.observe_decode_duration(output.decode_duration.as_secs_f64());
+                            output
+                        }
                         Err(err) => {
                             if let Some(entry_id) = hit_entry_id {
                                 let mut cache = prefix_cache.lock().unwrap();

--- a/crates/kiln-server/src/metrics.rs
+++ b/crates/kiln-server/src/metrics.rs
@@ -7,6 +7,26 @@ use kiln_scheduler::PrefixCacheStats;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+const LATENCY_BUCKETS_SECONDS: [f64; 13] = [
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+];
+
+const LATENCY_BUCKETS_US: [u64; LATENCY_BUCKETS_SECONDS.len()] = [
+    5_000, 10_000, 25_000, 50_000, 100_000, 250_000, 500_000, 1_000_000, 2_500_000, 5_000_000,
+    10_000_000, 30_000_000, 60_000_000,
+];
+
+const REQUEST_LATENCY_BUCKETS_SECONDS: [f64; 16] = [
+    0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0, 180.0, 240.0, 300.0, 420.0, 600.0,
+    900.0,
+];
+
+const REQUEST_LATENCY_BUCKETS_US: [u64; REQUEST_LATENCY_BUCKETS_SECONDS.len()] = [
+    100_000, 250_000, 500_000, 1_000_000, 2_500_000, 5_000_000, 10_000_000, 30_000_000,
+    60_000_000, 120_000_000, 180_000_000, 240_000_000, 300_000_000, 420_000_000, 600_000_000,
+    900_000_000,
+];
+
 /// Atomically tracked metrics for the kiln server.
 pub struct Metrics {
     // Inference counters
@@ -21,12 +41,26 @@ pub struct Metrics {
     /// Currently in-flight inference requests.
     pub active_requests: AtomicU64,
 
+    /// Peak concurrently in-flight inference requests since process start.
+    pub active_requests_peak: AtomicU64,
+
     /// Prompt/prefix prefill tokens completed by currently in-flight requests.
     pub request_prefill_tokens_completed: Arc<AtomicU64>,
 
     /// Request duration tracking (simple: count + sum in microseconds).
     pub request_duration_count: AtomicU64,
     pub request_duration_sum_us: AtomicU64,
+    pub request_duration_buckets: [AtomicU64; REQUEST_LATENCY_BUCKETS_US.len() + 1],
+
+    /// Time spent in model prefill before decode starts, in microseconds.
+    pub prefill_duration_count: AtomicU64,
+    pub prefill_duration_sum_us: AtomicU64,
+    pub prefill_duration_buckets: [AtomicU64; LATENCY_BUCKETS_US.len() + 1],
+
+    /// Time spent in token decode after prefill, in microseconds.
+    pub decode_duration_count: AtomicU64,
+    pub decode_duration_sum_us: AtomicU64,
+    pub decode_duration_buckets: [AtomicU64; LATENCY_BUCKETS_US.len() + 1],
 
     // Training counters
     pub training_sft_completed: AtomicU64,
@@ -46,9 +80,17 @@ impl Metrics {
             requests_rejected: AtomicU64::new(0),
             tokens_generated: AtomicU64::new(0),
             active_requests: AtomicU64::new(0),
+            active_requests_peak: AtomicU64::new(0),
             request_prefill_tokens_completed: Arc::new(AtomicU64::new(0)),
             request_duration_count: AtomicU64::new(0),
             request_duration_sum_us: AtomicU64::new(0),
+            request_duration_buckets: std::array::from_fn(|_| AtomicU64::new(0)),
+            prefill_duration_count: AtomicU64::new(0),
+            prefill_duration_sum_us: AtomicU64::new(0),
+            prefill_duration_buckets: std::array::from_fn(|_| AtomicU64::new(0)),
+            decode_duration_count: AtomicU64::new(0),
+            decode_duration_sum_us: AtomicU64::new(0),
+            decode_duration_buckets: std::array::from_fn(|_| AtomicU64::new(0)),
             training_sft_completed: AtomicU64::new(0),
             training_sft_failed: AtomicU64::new(0),
             training_sft_cancelled: AtomicU64::new(0),
@@ -73,6 +115,23 @@ impl Metrics {
         self.request_duration_count.fetch_add(1, Ordering::Relaxed);
         let us = (secs * 1_000_000.0) as u64;
         self.request_duration_sum_us.fetch_add(us, Ordering::Relaxed);
+        observe_bucket(&self.request_duration_buckets, &REQUEST_LATENCY_BUCKETS_US, us);
+    }
+
+    /// Record model prefill duration in seconds.
+    pub fn observe_prefill_duration(&self, secs: f64) {
+        self.prefill_duration_count.fetch_add(1, Ordering::Relaxed);
+        let us = (secs * 1_000_000.0) as u64;
+        self.prefill_duration_sum_us.fetch_add(us, Ordering::Relaxed);
+        observe_bucket(&self.prefill_duration_buckets, &LATENCY_BUCKETS_US, us);
+    }
+
+    /// Record model decode duration in seconds.
+    pub fn observe_decode_duration(&self, secs: f64) {
+        self.decode_duration_count.fetch_add(1, Ordering::Relaxed);
+        let us = (secs * 1_000_000.0) as u64;
+        self.decode_duration_sum_us.fetch_add(us, Ordering::Relaxed);
+        observe_bucket(&self.decode_duration_buckets, &LATENCY_BUCKETS_US, us);
     }
 
     /// Add generated token count.
@@ -82,7 +141,8 @@ impl Metrics {
 
     /// Increment active requests (call on request entry).
     pub fn inc_active(&self) {
-        self.active_requests.fetch_add(1, Ordering::Relaxed);
+        let active = self.active_requests.fetch_add(1, Ordering::Relaxed) + 1;
+        update_peak(&self.active_requests_peak, active);
     }
 
     /// Decrement active requests (call on request exit).
@@ -131,11 +191,61 @@ impl Metrics {
         prom_counter(&mut out, "kiln_requests_total", "status", "rejected", self.requests_rejected.load(Ordering::Relaxed));
 
         out.push_str("# HELP kiln_request_duration_seconds Request latency.\n");
-        out.push_str("# TYPE kiln_request_duration_seconds summary\n");
+        out.push_str("# TYPE kiln_request_duration_seconds histogram\n");
         let count = self.request_duration_count.load(Ordering::Relaxed);
         let sum_us = self.request_duration_sum_us.load(Ordering::Relaxed);
+        render_histogram_buckets(
+            &mut out,
+            "kiln_request_duration_seconds",
+            &REQUEST_LATENCY_BUCKETS_SECONDS,
+            &self.request_duration_buckets,
+        );
         push_line(&mut out, &format!("kiln_request_duration_seconds_count {count}"));
         push_line(&mut out, &format!("kiln_request_duration_seconds_sum {:.6}", sum_us as f64 / 1_000_000.0));
+
+        out.push_str("# HELP kiln_request_prefill_duration_seconds Model prefill latency before decode.\n");
+        out.push_str("# TYPE kiln_request_prefill_duration_seconds histogram\n");
+        let prefill_count = self.prefill_duration_count.load(Ordering::Relaxed);
+        let prefill_sum_us = self.prefill_duration_sum_us.load(Ordering::Relaxed);
+        render_histogram_buckets(
+            &mut out,
+            "kiln_request_prefill_duration_seconds",
+            &LATENCY_BUCKETS_SECONDS,
+            &self.prefill_duration_buckets,
+        );
+        push_line(
+            &mut out,
+            &format!("kiln_request_prefill_duration_seconds_count {prefill_count}"),
+        );
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_request_prefill_duration_seconds_sum {:.6}",
+                prefill_sum_us as f64 / 1_000_000.0
+            ),
+        );
+
+        out.push_str("# HELP kiln_request_decode_duration_seconds Model decode latency after prefill.\n");
+        out.push_str("# TYPE kiln_request_decode_duration_seconds histogram\n");
+        let decode_count = self.decode_duration_count.load(Ordering::Relaxed);
+        let decode_sum_us = self.decode_duration_sum_us.load(Ordering::Relaxed);
+        render_histogram_buckets(
+            &mut out,
+            "kiln_request_decode_duration_seconds",
+            &LATENCY_BUCKETS_SECONDS,
+            &self.decode_duration_buckets,
+        );
+        push_line(
+            &mut out,
+            &format!("kiln_request_decode_duration_seconds_count {decode_count}"),
+        );
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_request_decode_duration_seconds_sum {:.6}",
+                decode_sum_us as f64 / 1_000_000.0
+            ),
+        );
 
         out.push_str("# HELP kiln_tokens_generated_total Total tokens generated.\n");
         out.push_str("# TYPE kiln_tokens_generated_total counter\n");
@@ -144,6 +254,16 @@ impl Metrics {
         out.push_str("# HELP kiln_active_requests Currently in-flight requests.\n");
         out.push_str("# TYPE kiln_active_requests gauge\n");
         push_line(&mut out, &format!("kiln_active_requests {}", self.active_requests.load(Ordering::Relaxed)));
+
+        out.push_str("# HELP kiln_active_requests_peak Peak in-flight requests since process start.\n");
+        out.push_str("# TYPE kiln_active_requests_peak gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_active_requests_peak {}",
+                self.active_requests_peak.load(Ordering::Relaxed)
+            ),
+        );
 
         out.push_str("# HELP kiln_request_prefill_tokens_completed Prompt/prefix prefill tokens completed by currently in-flight requests.\n");
         out.push_str("# TYPE kiln_request_prefill_tokens_completed gauge\n");
@@ -369,6 +489,39 @@ fn push_line(out: &mut String, line: &str) {
     out.push('\n');
 }
 
+fn observe_bucket(buckets: &[AtomicU64], bounds_us: &[u64], value_us: u64) {
+    let index = bounds_us
+        .iter()
+        .position(|&bound| value_us <= bound)
+        .unwrap_or(bounds_us.len());
+    buckets[index].fetch_add(1, Ordering::Relaxed);
+}
+
+fn update_peak(peak: &AtomicU64, value: u64) {
+    let mut current = peak.load(Ordering::Relaxed);
+    while value > current {
+        match peak.compare_exchange_weak(current, value, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(next) => current = next,
+        }
+    }
+}
+
+fn render_histogram_buckets(
+    out: &mut String,
+    name: &str,
+    bounds_seconds: &[f64],
+    buckets: &[AtomicU64],
+) {
+    let mut cumulative = 0;
+    for (idx, bound) in bounds_seconds.iter().enumerate() {
+        cumulative += buckets[idx].load(Ordering::Relaxed);
+        push_line(out, &format!("{name}_bucket{{le=\"{bound}\"}} {cumulative}"));
+    }
+    cumulative += buckets[bounds_seconds.len()].load(Ordering::Relaxed);
+    push_line(out, &format!("{name}_bucket{{le=\"+Inf\"}} {cumulative}"));
+}
+
 fn prom_counter(out: &mut String, name: &str, label: &str, value: &str, count: u64) {
     out.push_str(&format!("{name}{{{label}=\"{value}\"}} {count}\n"));
 }
@@ -388,8 +541,12 @@ mod tests {
         m.inc_request(RequestStatus::Ok);
         m.inc_request(RequestStatus::Error);
         m.observe_duration(0.5);
+        m.observe_prefill_duration(0.25);
+        m.observe_decode_duration(0.75);
         m.add_tokens(100);
         m.inc_active();
+        m.inc_active();
+        m.dec_active();
         m.request_prefill_tokens_completed
             .store(8192, std::sync::atomic::Ordering::Relaxed);
 
@@ -427,6 +584,7 @@ mod tests {
         assert!(output.contains("kiln_requests_total{status=\"error\"} 1"));
         assert!(output.contains("kiln_tokens_generated_total 100"));
         assert!(output.contains("kiln_active_requests 1"));
+        assert!(output.contains("kiln_active_requests_peak 2"));
         assert!(output.contains("kiln_request_prefill_tokens_completed 8192"));
         assert!(output.contains("kiln_scheduler_waiting 3"));
         assert!(output.contains("kiln_blocks_total 256"));
@@ -446,8 +604,16 @@ mod tests {
         assert!(output.contains("kiln_prefix_cache_state_bytes 196"));
         assert!(output.contains("kiln_prefix_cache_max_state_bytes 392"));
         assert!(output.contains("kiln_active_adapter{name=\"my-adapter\"} 1"));
+        assert!(output.contains(r#"kiln_request_duration_seconds_bucket{le="0.5"} 1"#));
+        assert!(output.contains(r#"kiln_request_duration_seconds_bucket{le="+Inf"} 1"#));
         assert!(output.contains("kiln_request_duration_seconds_count 1"));
         assert!(output.contains("kiln_request_duration_seconds_sum 0.5"));
+        assert!(output.contains(r#"kiln_request_prefill_duration_seconds_bucket{le="0.25"} 1"#));
+        assert!(output.contains("kiln_request_prefill_duration_seconds_count 1"));
+        assert!(output.contains("kiln_request_prefill_duration_seconds_sum 0.25"));
+        assert!(output.contains(r#"kiln_request_decode_duration_seconds_bucket{le="1"} 1"#));
+        assert!(output.contains("kiln_request_decode_duration_seconds_count 1"));
+        assert!(output.contains("kiln_request_decode_duration_seconds_sum 0.75"));
     }
 
     #[test]

--- a/docs/audits/ROUND10_WORKERS2_THROUGHPUT.md
+++ b/docs/audits/ROUND10_WORKERS2_THROUGHPUT.md
@@ -1,0 +1,112 @@
+# Round-10 workers=2 throughput investigation
+
+Date: 2026-05-02
+
+## Summary
+
+Round-10 did not expose a kiln workers=2 scheduling regression. It exposed a workload/acceptance-rate throughput limit: the server kept two production-shaped requests in flight almost continuously, but each finalized trajectory required many long requests.
+
+The actionable kiln gap was observability. Before this investigation, `/metrics` exposed only whole-request latency and aggregate counters, so the next throughput regression could not be split into prefill, decode, queueing, and concurrency from Prometheus alone. This audit adds the missing server-side metrics.
+
+## Evidence
+
+Round-10 artifacts:
+
+- `b2://clouderic/corrections-experiment/phase2-round10/REPORT.md`
+- `b2://clouderic/corrections-experiment/phase2-round10/preflight-stats.json`
+- `b2://clouderic/corrections-experiment/phase2-round10/logs/round10-kiln-server.log`
+- `b2://clouderic/corrections-experiment/phase2-round10/logs/round10-metrics.prom`
+
+From `REPORT.md` and `preflight-stats.json`:
+
+- Wall clock: 10,087.38 s
+- Finalized trajectories: 20
+- Inference requests: 277 OK, 0 error, 0 timeout
+- Attempt latency: p50 54.86 s, p90 154.66 s, p99 377.87 s
+- Per-trajectory throughput: 8.41 min/trajectory
+
+Parsing `round10-kiln-server.log` response spans gives:
+
+- Response count including smoke: 284
+- Total request service time: 20,194.24 s
+- Mean request latency: 71.11 s
+- Median request latency: 53.04 s
+- Peak overlapping requests: 3 including smoke/metrics timing overlap
+- Mean overlapping requests during collection: 1.96
+- Requests >=120 s: 44
+- Requests >=240 s: 5
+
+The observed throughput is explained by Little's Law:
+
+```text
+13.85 requests/trajectory × 71.11 s/request ÷ 1.96 concurrent requests = 502 s/trajectory
+502 s/trajectory = 8.36 min/trajectory
+```
+
+That matches the report's 8.41 min/trajectory. In other words, the server was already keeping roughly two long requests active; the trajectory-level slowdown came from request count and request length, not idle workers.
+
+## Round-5 comparison caveat
+
+The quoted round-5 `~5.76 min/trajectory` is not an apples-to-apples kiln throughput baseline:
+
+- Round-5 ran workers=1 only after workers=2 had already hit the pre-#672/#694 reliability cascade.
+- Round-5 report records `max_prompt_chars: 32000 (default)` while round-10 explicitly used unbounded production prompts.
+- Round-5 did not preserve the same per-request latency histogram and prefill/decode split needed for direct attribution.
+- Round-10 finalized only 20 trajectories but issued 277 successful requests, i.e. 13.85 requests per trajectory.
+
+## Hypothesis results
+
+1. Streaming-prefill threshold: not supported by round-10 logs. Production-shaped requests are long, but PR #694-class streaming preserved reliability and request latencies are decode-heavy enough that reverting or raising the threshold would risk OOM/timeout regressions without explaining trajectory count.
+2. Prefix-cache hit-rate cap: not supported as a throughput root cause. Round-10 prefix cache remained comfortably below the #697 cap: peak 5/20 cached entries and 263 MB/1.05 GB state bytes.
+3. workers=2 scheduler underlap: not supported. Server logs show mean overlap 1.96 across the run.
+4. #701 KV headroom: not supported. `kiln_blocks_used` final was 9,441/45,914 and no OOM/eviction signal appeared.
+5. metrics overhead: not supported. Round-10 metrics collection was sparse and the hot path used atomic counters.
+6. workload mix / retries: supported. The trajectory-level throughput is explained by 13.85 long successful requests per trajectory.
+
+## Added observability
+
+This change adds:
+
+- `kiln_request_duration_seconds` as a histogram while preserving count/sum names.
+- `kiln_request_prefill_duration_seconds` histogram for prefix-cache production requests.
+- `kiln_request_decode_duration_seconds` histogram for prefix-cache production requests.
+- `kiln_active_requests_peak` gauge for peak in-flight concurrency.
+
+These metrics make future workers=2 regressions immediately attributable from `/metrics`: if workers are idle, `kiln_active_requests_peak` and the live gauge show it; if long-prefill regresses, prefill buckets move; if decode dominates, decode buckets move.
+
+## Validation receipts
+
+On an A6000 RunPod pod (`ghcr.io/ericflo/kiln-runpod:latest`):
+
+```bash
+cargo test -p kiln-server metrics::tests:: -- --nocapture
+KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln
+```
+
+Both passed.
+
+A live A6000 request run against a 53,307-token prompt with `max_tokens=256` produced populated split metrics:
+
+```json
+{
+  "request_sum": 213.538474,
+  "prefill_sum": 78.333799,
+  "prefill_count": 4,
+  "decode_sum": 134.731954,
+  "decode_count": 4,
+  "active_peak": 1,
+  "tokens": 1024
+}
+```
+
+## Recommendation
+
+Do not ship a speculative throughput code change for round-10. Run round-12 with this observability build first. If trajectory throughput is still low, compare:
+
+- `kiln_active_requests` / `kiln_active_requests_peak`
+- `kiln_request_prefill_duration_seconds_*`
+- `kiln_request_decode_duration_seconds_*`
+- prefix-cache hit tokens / entries / state bytes
+- requests per finalized trajectory
+
+The likely next non-kiln lever is prompt/retry shaping in corrections-experiment, not kiln GPU scheduling.


### PR DESCRIPTION
## Summary

- documents the round-10 workers=2 throughput investigation against the B2 evidence
- attributes the 8.41 min/trajectory result to long request service time × 13.85 requests/trajectory with workers already saturated at ~1.96 concurrent requests
- adds Prometheus histograms for request, prefill, and decode latency plus a peak in-flight request gauge so future throughput issues are attributable from `/metrics`

## Root-cause finding

Round-10 did not show a kiln workers=2 scheduling regression. The server processed 277/277 requests successfully and kept roughly two requests active over the run:

```text
13.85 requests/trajectory × 71.11 s/request ÷ 1.96 concurrent requests = 502 s/trajectory
502 s/trajectory = 8.36 min/trajectory
```

That matches the reported 8.41 min/trajectory. Round-5 is not apples-to-apples because it fell back to workers=1 after a reliability cascade and used the older bounded prompt shape.

## Validation

A6000 RunPod (`ghcr.io/ericflo/kiln-runpod:latest`):

```bash
cargo test -p kiln-server metrics::tests:: -- --nocapture
KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln
```

Live metrics smoke with a 53,307-token prompt and `max_tokens=256`:

```json
{
  "request_sum": 213.538474,
  "prefill_sum": 78.333799,
  "prefill_count": 4,
  "decode_sum": 134.731954,
  "decode_count": 4,
  "active_peak": 1,
  "tokens": 1024
}
```

`cargo fmt --check` for the full repo currently reports unrelated pre-existing formatting diffs across many files; I did not apply them to avoid a noisy PR.
