### PR TITLE
[codex] Record v0.2.13 pre-launch ops gate

### DIFF
--- a/docs/site/launch/README.md
+++ b/docs/site/launch/README.md
@@ -102,14 +102,19 @@ For each channel, after going live:
 
 ### 2026-05-02 v0.2.13 verification
 
-- [ ] `gh release view kiln-v0.2.13 -R ericflo/kiln` reports
-      `isDraft=false`, `isPrerelease=false`, and includes the expected release
-      assets.
-- [ ] `gh attestation verify kiln-0.2.13-x86_64-unknown-linux-gnu-cuda124.tar.gz -R ericflo/kiln`
-      verifies SLSA provenance from `https://github.com/ericflo/kiln`.
-- [ ] GHCR `kiln-server` package includes tags `0.2.13` and `latest`; verify
-      with `gh api orgs/ericflo/packages/container/kiln-server/versions` or the
-      package UI before posting.
+- [x] `gh release view kiln-v0.2.13 -R ericflo/kiln` reports
+      `isDraft=false`, `isPrerelease=false`, published at
+      `2026-05-02T19:19:06Z`, and 7 release assets.
+- [x] `kiln-0.2.13-x86_64-unknown-linux-gnu-cuda124.tar.gz` verifies against
+      the release SHA-256 evidence: sidecar, local digest, and GitHub asset
+      digest all match
+      `99053967ef2e8917e2e59ace1c27f732c97c89b786a5a8650d40982f2feb91e1`.
+- [x] `gh attestation verify kiln-0.2.13-x86_64-unknown-linux-gnu-cuda124.tar.gz -R ericflo/kiln --format json`
+      verifies SLSA provenance from `https://github.com/ericflo/kiln` on
+      `refs/tags/kiln-v0.2.13`.
+- [x] GHCR `kiln-server` package includes tags `0.2.13` and `latest`, updated
+      at `2026-05-02T18:44:08Z`; verified with
+      `gh api /users/ericflo/packages/container/kiln-server/versions`.
 
 ### 2026-05-02 v0.2.12 verification
 

--- a/docs/site/launch/anthropic-discord.md
+++ b/docs/site/launch/anthropic-discord.md
@@ -6,7 +6,7 @@ length: ~220 words
 
 # Anthropic Discord launch post draft
 
-> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.13 ops gate stays green.**
 
 ## Post body (paste directly into the appropriate Anthropic Discord channel)
 

--- a/docs/site/launch/discord-rust.md
+++ b/docs/site/launch/discord-rust.md
@@ -6,7 +6,7 @@ length: ~250 words
 
 # Rust Discord #showcase post draft
 
-> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.13 ops gate stays green.**
 
 ## Post body (paste directly into #showcase)
 
@@ -30,7 +30,7 @@ length: ~250 words
 >
 > **Build matrix is intentionally small** — "has CUDA or doesn't." `cargo build --release --features cuda` on Linux+CUDA, `--features metal` on Apple Silicon, plain `cargo build --release` for the CPU/headless path. macOS Apple Silicon gets the Metal backend via a candle-metal JIT path.
 >
-> Reproducible builds with `--locked`, Sigstore-signed build provenance on every release artifact and the GHCR `kiln-server` image, MIT licensed, pre-1.0 (current production line is kiln-v0.2.12).
+> Reproducible builds with `--locked`, Sigstore-signed build provenance on every release artifact and the GHCR `kiln-server` image, MIT licensed, pre-1.0 (current production line is kiln-v0.2.13).
 >
 > Would love eyes on the kernel crates and the in-process training thread design. Also happy to talk about the tradeoffs of the single-model architectural choice — that's the thing I most expect pushback on.
 

--- a/docs/site/launch/hackernews.md
+++ b/docs/site/launch/hackernews.md
@@ -6,7 +6,7 @@ length: ~80 chars title / ~220 words first comment
 
 # Show HN: Kiln draft
 
-> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.13 ops gate stays green.**
 
 ## Submission
 
@@ -44,7 +44,7 @@ https://ericflo.github.io/kiln/launch.html
 ## Posting checklist
 
 - [x] Demo asciicast landed and linked from the launch post (`docs/site/launch.html`)
-- [ ] Confirm `gh release view kiln-v0.2.12 -R ericflo/kiln` is clean
+- [ ] Confirm `gh release view kiln-v0.2.13 -R ericflo/kiln` is clean
 - [ ] Confirm `https://ericflo.github.io/kiln/launch.html` renders on mobile + desktop
 - [ ] Eric reviews this draft before posting
 - [ ] Submit Tuesday–Thursday, 9:00–11:00 ET (US morning peak for HN)

--- a/docs/site/launch/lobsters.md
+++ b/docs/site/launch/lobsters.md
@@ -6,7 +6,7 @@ length: ~70 chars title / ~330 words comment
 
 # lobste.rs submission draft
 
-> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.13 ops gate stays green.**
 
 ## Submission
 
@@ -43,7 +43,7 @@ https://ericflo.github.io/kiln/launch.html
 >
 > - **Single model.** It targets [Qwen3.5-4B](https://huggingface.co/Qwen/Qwen3.5-4B) and the scheduler, block manager, and CUDA kernels are tuned for that one architecture. Model-agnostic mode is on the post-1.0 roadmap with the explicit caveat that kernels need re-tuning per architecture.
 > - **Single GPU.** No tensor parallel, no multi-node. Multi-GPU TP is also on the post-1.0 roadmap.
-> - **Pre-1.0.** The current production line is kiln-v0.2.12. Phases 1–10 (core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, dev experience, advanced adapter features, v0.1.0 release engineering, Liger long-context training) are all closed. The roadmap from here is deliberately small and chosen by what early users actually ask for.
+> - **Pre-1.0.** The current production line is kiln-v0.2.13. Phases 1–10 (core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, dev experience, advanced adapter features, v0.1.0 release engineering, Liger long-context training) are all closed. The roadmap from here is deliberately small and chosen by what early users actually ask for.
 >
 > What's in-tree (not vendored Python or wrapped C++): the forward pass, paged KV cache + block manager, Sarathi-style chunked-prefill scheduler, LoRA training loop, Marlin W4A16 GEMM, fused RMSNorm, GDN linear-attention kernel, vendored flash-attn-2 with our own C-ABI wrapper, fused Conv1d. All in `crates/kiln-*-kernel/` and `crates/kiln-model/src/forward.rs`.
 >

--- a/docs/site/launch/reddit-localllama.md
+++ b/docs/site/launch/reddit-localllama.md
@@ -6,7 +6,7 @@ length: ~140 chars title / ~620 words body
 
 # /r/LocalLLaMA submission draft
 
-> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.13 ops gate stays green.**
 
 ## Submission
 
@@ -62,7 +62,7 @@ Kiln: a single-GPU inference server in Rust that also trains the model it's serv
 >
 > - **Single model.** Every line of code is tuned for Qwen3.5-4B. Model-agnostic mode is post-1.0 with the honest tradeoff that kernels need re-tuning per architecture.
 > - **Single GPU.** Multi-GPU tensor parallelism is also post-1.0.
-> - **Pre-1.0.** Current production line is kiln-v0.2.12. The phases that got us here closed core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, developer experience, advanced adapter features, v0.1.0 release engineering, and the Liger long-context training pieces. The roadmap from here is deliberately small.
+> - **Pre-1.0.** Current production line is kiln-v0.2.13. The phases that got us here closed core inference, LoRA serving, SFT, GRPO, production hardening, decode-perf optimization, developer experience, advanced adapter features, v0.1.0 release engineering, and the Liger long-context training pieces. The roadmap from here is deliberately small.
 >
 > **How to try it:**
 >

--- a/docs/site/launch/twitter.md
+++ b/docs/site/launch/twitter.md
@@ -6,7 +6,7 @@ length: 8 tweets, each <280 chars
 
 # X / Twitter thread draft
 
-> **DRAFT — do not post until reviewed by Eric and the v0.2.12 ops gate stays green.**
+> **DRAFT — do not post until reviewed by Eric and the v0.2.13 ops gate stays green.**
 
 ## Thread
 
@@ -78,7 +78,7 @@ length: 8 tweets, each <280 chars
 >
 > https://ericflo.github.io/kiln/launch.html
 >
-> MIT licensed. v0.2.12 is the production line. Built in Rust by one person; the GRPO loop is what kept me up at night and what I most want feedback on.
+> MIT licensed. v0.2.13 is the production line. Built in Rust by one person; the GRPO loop is what kept me up at night and what I most want feedback on.
 
 *(248 chars — has link headroom for X's t.co)*
 


### PR DESCRIPTION
## Summary
- Mark the v0.2.13 launch ops gate as verified in `docs/site/launch/README.md`.
- Record published release metadata, Linux artifact digest evidence, SLSA provenance source/ref, and GHCR `0.2.13`/`latest` evidence.
- Update staged launch-channel drafts from the v0.2.12 gate/current-production-line text to v0.2.13.

## Verification
- `gh release view kiln-v0.2.13 -R ericflo/kiln --json isDraft,isPrerelease,publishedAt,assets,url`
- `gh run view 25258277525 -R ericflo/kiln --json status,conclusion,url`
- `gh run view 25258277533 -R ericflo/kiln --json status,conclusion,url,jobs`
- Linux tarball digest matched the release sidecar and GitHub asset digest: `99053967ef2e8917e2e59ace1c27f732c97c89b786a5a8650d40982f2feb91e1`
- `gh attestation verify /tmp/kiln-v0.2.13/kiln-0.2.13-x86_64-unknown-linux-gnu-cuda124.tar.gz -R ericflo/kiln --format json`
- `gh api /users/ericflo/packages/container/kiln-server/versions`
- `git diff --check`
- `rg -n "v0\.2\.12|0\.2\.12" docs/site/launch/*.md docs/site/launch/README.md` (only the historical checked v0.2.12 section remains)
- `rg -n "v0\.2\.13|0\.2\.13" docs/site/launch/*.md docs/site/launch/README.md README.md docs/site/index.html docs/site/launch.html`
- `gh api repos/ericflo/kiln --jq '{private, html_url, default_branch}'`
- `curl -fsSL` title checks for `/`, `/launch.html`, and `/demo/`