### PR TITLE
[codex] Embed launch demo player

### DIFF
--- a/docs/site/demo/README.md
+++ b/docs/site/demo/README.md
@@ -50,7 +50,7 @@ The embed used in [`index.html`](index.html):
 </script>
 ```
 
-To embed the player on `launch.html` (or anywhere else under `docs/site/`), copy the three blocks above and adjust the `'kiln-60s.cast'` paths to be relative to the embedding page (e.g. `'demo/kiln-60s.cast'` from `launch.html`).
+`launch.html` embeds this player inline using the same settings and the page-relative source path `'demo/kiln-60s.cast'`. For another page under `docs/site/`, copy the three blocks above and adjust the cast path relative to that page.
 
 ## How to re-record
 
@@ -70,7 +70,7 @@ The `--command` flag scripts the entire take so each run is byte-deterministic i
 ## Cross-links
 
 - **README hero:** [`README.md`](../../../README.md) — the `Demo` link in the center-aligned link row points here.
-- **Launch announcement:** [`launch.html`](../launch.html) — has an inline link near the GRPO-loop section. After the real recording lands, `launch.html` may also embed the player inline.
+- **Launch announcement:** [`launch.html`](../launch.html) — embeds the same `kiln-60s.cast` player inline near the GRPO-loop section.
 - **Launch post drafts:** [`launch/README.md`](../launch/README.md) — pre-launch ops gate references the demo asciicast as a launch blocker.
 - **Quickstart:** [`QUICKSTART.md`](../../../QUICKSTART.md) — the commands run in the demo are a strict subset of the Quickstart.
 

--- a/docs/site/launch.html
+++ b/docs/site/launch.html
@@ -19,6 +19,11 @@
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/logo.png">
 
   <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- asciinema-player CSS (self-hosted via jsDelivr CDN, version-pinned) -->
+  <link rel="stylesheet" type="text/css"
+        href="https://cdn.jsdelivr.net/npm/asciinema-player@3.7.1/dist/bundle/asciinema-player.css" />
+
   <style>
     :root {
       color-scheme: dark;
@@ -104,6 +109,13 @@
     .prose-body ul li { margin-bottom: 0.35rem; }
     .prose-body strong { color: var(--fg); font-weight: 600; }
     .meta-line { color: var(--fg-mute); font-size: 0.875rem; }
+    .asciinema-frame {
+      background: #1c1c1c;
+      border: 1px solid var(--line-2);
+      border-radius: 12px;
+      padding: 0.5rem;
+      overflow: hidden;
+    }
   </style>
 </head>
 <body class="min-h-screen">
@@ -201,9 +213,13 @@ requests.post("http://localhost:8420/v1/train/grpo", json={
       <p>
         See <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">docs/GRPO_GUIDE.md</a> for
         worked verifiable-rewards examples on math, JSON formatting, and code generation. The
-        <a href="demo/">60&#x2011;second demo</a> shows the same loop end-to-end on a single GPU: cold start,
-        first chat on the base model, an SFT correction, hot-swap, then the second chat on the improved weights.
+        <a href="demo/">60&#x2011;second demo</a> below shows the same loop end-to-end on a single GPU:
+        cold start, first chat on the base model, an SFT correction, hot-swap, then the second chat on
+        the improved weights.
       </p>
+      <div class="asciinema-frame mb-8" aria-label="Kiln 60-second online-learning demo">
+        <div id="kiln-demo-player" data-src="demo/kiln-60s.cast"></div>
+      </div>
 
       <h2>Hot-swap, not redeploy</h2>
       <p>
@@ -342,5 +358,24 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
       </nav>
     </div>
   </footer>
+
+  <!-- asciinema-player JS -->
+  <script src="https://cdn.jsdelivr.net/npm/asciinema-player@3.7.1/dist/bundle/asciinema-player.min.js"></script>
+  <script>
+    AsciinemaPlayer.create(
+      'demo/kiln-60s.cast',
+      document.getElementById('kiln-demo-player'),
+      {
+        autoPlay: false,
+        preload: true,
+        loop: false,
+        idleTimeLimit: 2,
+        theme: 'monokai',
+        poster: 'npt:0:02',
+        cols: 120,
+        rows: 32
+      }
+    );
+  </script>
 </body>
 </html>

--- a/docs/site/launch/README.md
+++ b/docs/site/launch/README.md
@@ -15,7 +15,7 @@ or deployed; it's a versioned drafting space.
   [`index.html`](../demo/index.html), canonical recording in
   [`kiln-60s.cast`](../demo/kiln-60s.cast), and the reference shell driver
   in [`demo.sh`](../demo/demo.sh)). Embedded at the standalone demo page
-  and ready to be linked from `docs/site/launch.html`.
+  and inline in `docs/site/launch.html`.
 
 ## Status
 
@@ -132,8 +132,8 @@ For each channel, after going live:
       expected titles: `Kiln — Your model gets better every time you use it`,
       `Launching Kiln — Your model gets better every time you use it`, and
       `Kiln Demo — 60-second online-learning loop`.
-- [x] `docs/site/launch.html` links to `demo/`, and
-      `docs/site/demo/index.html` embeds `kiln-60s.cast`.
+- [x] `docs/site/launch.html` embeds `demo/kiln-60s.cast` inline, and
+      `docs/site/demo/index.html` embeds `kiln-60s.cast` on the standalone demo page.
 
 ## Where this directory came from
 


### PR DESCRIPTION
## Summary

- Embed the canonical `demo/kiln-60s.cast` asciinema player directly in `docs/site/launch.html` near the GRPO-loop demo paragraph.
- Add the pinned asciinema-player CSS/JS and use the same player settings as `docs/site/demo/index.html`.
- Update launch/demo README wording so the pre-launch gate reflects the inline launch-page embed.

## Validation

- `python3 -m http.server 8000 --directory docs/site`
- Puppeteer mobile check against `http://127.0.0.1:8000/launch.html` with `NODE_PATH=/data/.clouderic-internal/repos/apps/webui-next/node_modules`
- `rg -n "kiln-demo-player|demo/kiln-60s.cast|asciinema-player" docs/site/launch.html docs/site/launch/README.md docs/site/demo/README.md`
- `git diff --check`