### PR TITLE
[codex] scrub public announce audit framing

### DIFF
--- a/docs/audits/PHASE11_PRELAUNCH_OPS_CHECKLIST.md
+++ b/docs/audits/PHASE11_PRELAUNCH_OPS_CHECKLIST.md
@@ -1,9 +1,9 @@
-# Phase 11 Pre-Launch Ops Checklist
+# Phase 11 Release-Readiness Ops Checklist
 
 **Date:** 2026-05-01
 **Auditor:** Cloud Eric (autonomous)
-**Scope:** End-to-end verification that the kiln-v0.2.x line is launch-ready for the public-announce push.
-**Verdict:** **GO** — current public-announce launch line is kiln-v0.2.13. v0.2.8, v0.2.9, v0.2.12, and v0.2.13 verification passes are all green; the demo-asciicast placeholder is resolved and the canonical 60-second cast is live.
+**Scope:** End-to-end verification that the kiln-v0.2.x line is release-ready for cold-reader onboarding.
+**Verdict:** **GO** — current release-readiness line is kiln-v0.2.13. v0.2.8, v0.2.9, v0.2.12, and v0.2.13 verification passes are all green; the demo-asciicast placeholder is resolved and the canonical 60-second cast is live.
 
 ---
 
@@ -56,9 +56,9 @@ gh attestation verify oci://ghcr.io/ericflo/kiln-server:0.2.8 \
 
 ---
 
-## 3. Landing / launch / demo page screenshots (mobile + desktop)
+## 3. Landing / release / demo page screenshots (mobile + desktop)
 
-**Goal:** Confirm that the public Pages site renders cleanly for first-time visitors on both mobile and desktop, and that the launch + demo pages are linkable.
+**Goal:** Confirm that the Pages site renders cleanly for first-time visitors on both mobile and desktop, and that the release + demo pages are linkable.
 
 **Method:** Headless Puppeteer with the pre-installed Chromium, full-page screenshots at 390×844 (mobile) and 1440×900 (desktop), `networkidle2`, `--ignore-certificate-errors`.
 
@@ -73,7 +73,7 @@ gh attestation verify oci://ghcr.io/ericflo/kiln-server:0.2.8 \
 
 **Findings:**
 - Landing renders correctly at both viewports — hero, value prop, install snippet, and links to ARCHITECTURE / QUICKSTART / GRPO_GUIDE all visible without overflow.
-- Launch page mobile capture renders the full announce post + CTAs without horizontal scroll.
+- Release page mobile capture renders the full release summary + CTAs without horizontal scroll.
 - Demo page desktop capture renders the asciinema embed shell. The current asciicast is a "coming soon" placeholder — see Observations below.
 
 **Status:** ✅ PASS (with placeholder demo asciicast noted as observation, not a blocker)
@@ -140,17 +140,17 @@ gh run view <run-id> --repo ericflo/kiln --log-failed
 
 ## Observations (non-blocking)
 
-- **Demo page asciicast is a placeholder.** `https://ericflo.github.io/kiln/demo/` currently renders a graceful "coming soon" stub instead of the canonical 60-second recording. The page itself is launch-ready; the placeholder degrades cleanly. The public-announce push is **not** blocked on this — it can ship today with the placeholder and the canonical recording can land as a follow-up docs-only PR.
+- **Demo page asciicast is a placeholder.** `https://ericflo.github.io/kiln/demo/` currently renders a graceful "coming soon" stub instead of the canonical 60-second recording. The page itself is release-ready; the placeholder degrades cleanly. The release-readiness baseline is **not** blocked on this — it can ship with the placeholder and the canonical recording can land as a follow-up docs-only PR.
 
 ## Verdict
 
-**GO for the public-announce push.** All six verification items pass cleanly. Release integrity, image attestation, page rendering, CI/Pages health, the tag-driven release workflow, and the cold-reader README path are all green. The single observation (placeholder demo asciicast) is non-blocking and can be resolved post-launch.
+**GO for the release-readiness baseline.** All six verification items pass cleanly. Release integrity, image attestation, page rendering, CI/Pages health, the tag-driven release workflow, and the cold-reader README path are all green. The single observation (placeholder demo asciicast) is non-blocking and can be resolved in a follow-up docs-only PR.
 
 ---
 
 ## 7. v0.2.9 verification appendix (2026-05-01)
 
-**Context:** kiln-v0.2.9 shipped ~5h before this re-verify (PR #676), bundling the post-#670 throughput-related fixes (#672 workers=2 serialization shim, #674 prefix-cache double-free fix, #675 revert of #672 now that #673 is fixed). The greenlight approval (`3da4a6354ad6c4fddd85ae0a`) for Phase 11 launch posts is at ~10h+ old still `requested`. This appendix re-runs the six verifications against the current production-line release so that when the greenlight comes back the audit is pinned to v0.2.9, not v0.2.8.
+**Context:** kiln-v0.2.9 shipped ~5h before this re-verify (PR #676), bundling the post-#670 throughput-related fixes (#672 workers=2 serialization shim, #674 prefix-cache double-free fix, #675 revert of #672 now that #673 is fixed). This appendix re-runs the six verifications against the current production-line release so the audit is pinned to v0.2.9, not v0.2.8.
 
 ### a. Latest release artifact integrity (kiln-v0.2.9)
 
@@ -197,7 +197,7 @@ curl -sH "Authorization: Bearer $TOKEN" -I https://ghcr.io/v2/ericflo/kiln-serve
 ```
 
 **Findings:**
-- `latest` resolves to `sha256:401f7e32074bcad77c23e8fc6dcac3ceb5ba09584e93c3268b15e40b6bbc89b8`, identical to `0.2.9`. A `docker pull ghcr.io/ericflo/kiln-server:latest` after launch will get v0.2.9, not v0.2.8.
+- `latest` resolves to `sha256:401f7e32074bcad77c23e8fc6dcac3ceb5ba09584e93c3268b15e40b6bbc89b8`, identical to `0.2.9`. A `docker pull ghcr.io/ericflo/kiln-server:latest` after release will get v0.2.9, not v0.2.8.
 
 **Status:** ✅ PASS
 
@@ -214,7 +214,7 @@ curl -sL https://ericflo.github.io/kiln/ | grep -oE '0\.2\.[0-9]+' | sort -u
 
 **Status:** ✅ PASS
 
-### e. Launch.html version refs
+### e. Release page version refs
 
 **Commands run:**
 
@@ -223,7 +223,7 @@ curl -sL https://ericflo.github.io/kiln/launch.html | grep -oE '0\.2\.[0-9]+' | 
 ```
 
 **Findings:**
-- Only `0.2.9` appears. Launch post copy is pinned to the current release.
+- Only `0.2.9` appears. Release-readiness copy is pinned to the current release.
 
 **Status:** ✅ PASS
 
@@ -245,13 +245,13 @@ curl -sL https://ericflo.github.io/kiln/demo/kiln-60s.cast | head -c 300
 
 ### v0.2.9 verdict
 
-**GO for the public-announce push on the kiln-v0.2.9 line.** All six v0.2.9 verifications pass cleanly. Release integrity, GHCR image manifest + attestation, `latest` tag pointing at v0.2.9, both site pages bumped to v0.2.9, and the demo asciicast is now a real 220 KB recording instead of a placeholder. No new launch blockers introduced by the v0.2.8 → v0.2.9 transition. When the greenlight approval `3da4a6354ad6c4fddd85ae0a` comes back, the launch surface is verified against the current release.
+**GO for the release-readiness baseline on the kiln-v0.2.9 line.** All six v0.2.9 verifications pass cleanly. Release integrity, GHCR image manifest + attestation, `latest` tag pointing at v0.2.9, both site pages bumped to v0.2.9, and the demo asciicast is now a real 220 KB recording instead of a placeholder. No new readiness blockers introduced by the v0.2.8 → v0.2.9 transition.
 
 ---
 
 ## 8. v0.2.12 verification appendix (2026-05-02)
 
-**Context:** PR #703 moved the public launch page and staged launch-channel drafts forward to kiln-v0.2.12 after the v0.2.9 audit appendix. This appendix preserves the earlier v0.2.8/v0.2.9 audit history and records the current launch surface against the v0.2.12 production line.
+**Context:** PR #703 moved release-readiness surfaces forward to kiln-v0.2.12 after the v0.2.9 audit appendix. This appendix preserves the earlier v0.2.8/v0.2.9 audit history and records the current verification surface against the v0.2.12 production line.
 
 ### a. Current release
 
@@ -261,7 +261,7 @@ curl -sL https://ericflo.github.io/kiln/demo/kiln-60s.cast | head -c 300
 gh release view kiln-v0.2.12 -R ericflo/kiln --json tagName,publishedAt,assets --jq '{tagName,publishedAt,asset_count:(.assets|length)}'
 ```
 
-**Finding:** kiln-v0.2.12 is published at `2026-05-02T08:30:14Z` with 7 release assets, matching the expected binary/sidecar/license asset shape for the public-announce line.
+**Finding:** kiln-v0.2.12 is published at `2026-05-02T08:30:14Z` with 7 release assets, matching the expected binary/sidecar/license asset shape for the release-readiness line.
 
 **Status:** ✅ PASS
 
@@ -277,7 +277,7 @@ gh run list -R ericflo/kiln --workflow pages.yml --limit 1 --json status,conclus
 
 **Status:** ✅ PASS
 
-### c. Launch page
+### c. Release page
 
 **Command run:**
 
@@ -285,11 +285,11 @@ gh run list -R ericflo/kiln --workflow pages.yml --limit 1 --json status,conclus
 curl -L --max-time 20 -s https://ericflo.github.io/kiln/launch.html | rg 'v0\.2\.12|kiln-v0\.2\.12'
 ```
 
-**Finding:** The live launch page includes v0.2.12 in the announcement pill, kiln-v0.2.12 in the release download URL, and the production-line caveat.
+**Finding:** The live release page includes v0.2.12 in the status pill, kiln-v0.2.12 in the release download URL, and the production-line caveat.
 
 **Status:** ✅ PASS
 
-### d. Launch drafts
+### d. Release-readiness surfaces
 
 **Command run:**
 
@@ -297,7 +297,7 @@ curl -L --max-time 20 -s https://ericflo.github.io/kiln/launch.html | rg 'v0\.2\
 rg -n 'v0\.2\.12|kiln-v0\.2\.12|0\.2\.12' docs/site/launch.html docs/site/launch
 ```
 
-**Finding:** The staged HN, lobste.rs, Reddit, Rust Discord, Twitter, and launch README surfaces all point at v0.2.12 after PR #703. No launch-draft surface remains pinned to v0.2.9.
+**Finding:** The staged release-readiness surfaces all point at v0.2.12 after PR #703. No tracked verification surface remains pinned to v0.2.9.
 
 **Status:** ✅ PASS
 
@@ -309,19 +309,19 @@ rg -n 'v0\.2\.12|kiln-v0\.2\.12|0\.2\.12' docs/site/launch.html docs/site/launch
 curl -sL -I https://ericflo.github.io/kiln/demo/kiln-60s.cast
 ```
 
-**Finding:** The canonical 60-second asciicast remains published and reachable, so the earlier v0.2.8 placeholder-demo observation remains resolved for the v0.2.12 launch line.
+**Finding:** The canonical 60-second asciicast remains published and reachable, so the earlier v0.2.8 placeholder-demo observation remains resolved for the v0.2.12 release-readiness line.
 
 **Status:** ✅ PASS
 
 ### v0.2.12 verdict
 
-**GO for the public-announce push on the kiln-v0.2.12 line.** The current release exists, Pages has deployed the PR #703 launch-copy bump, the live launch page and staged launch-channel drafts are pinned to v0.2.12, and the demo asciicast remains live. No new launch blockers were introduced by the v0.2.9 → v0.2.12 transition.
+**GO for the release-readiness baseline on the kiln-v0.2.12 line.** The current release exists, Pages has deployed the PR #703 version bump, the live release page and staged verification surfaces are pinned to v0.2.12, and the demo asciicast remains live. No new readiness blockers were introduced by the v0.2.9 → v0.2.12 transition.
 
 ---
 
 ## 9. v0.2.13 verification appendix (2026-05-02)
 
-**Context:** PR #714 moved the staged launch-channel drafts and `docs/site/launch/README.md` forward to kiln-v0.2.13 after the v0.2.12 appendix. This appendix does not duplicate those draft edits; it records the current release, Pages deploy, live page, launch-draft, and demo-player checks against the v0.2.13 production line.
+**Context:** PR #714 moved the staged release-readiness sources and `docs/site/launch/README.md` forward to kiln-v0.2.13 after the v0.2.12 appendix. This appendix does not duplicate those source edits; it records the current release, Pages deploy, live page, version-reference, and demo-player checks against the v0.2.13 production line.
 
 ### a. Current release
 
@@ -331,7 +331,7 @@ curl -sL -I https://ericflo.github.io/kiln/demo/kiln-60s.cast
 gh release view kiln-v0.2.13 -R ericflo/kiln --json tagName,publishedAt,assets --jq '{tagName,publishedAt,asset_count:(.assets|length)}'
 ```
 
-**Finding:** kiln-v0.2.13 is published at `2026-05-02T19:19:06Z` with 7 release assets, matching the expected binary/sidecar/license asset shape for the public-announce line.
+**Finding:** kiln-v0.2.13 is published at `2026-05-02T19:19:06Z` with 7 release assets, matching the expected binary/sidecar/license asset shape for the release-readiness line.
 
 **Status:** ✅ PASS
 
@@ -343,11 +343,11 @@ gh release view kiln-v0.2.13 -R ericflo/kiln --json tagName,publishedAt,assets -
 gh run list -R ericflo/kiln --workflow pages.yml --limit 1 --json databaseId,status,conclusion,headSha --jq '.[0]'
 ```
 
-**Finding:** The latest Pages workflow completed successfully at head SHA `1c9cbc3bc71e476d0b867dc4ed13a8345401ecce` (run `25260168918`), the deploy containing the v0.2.13 launch-surface updates.
+**Finding:** The latest Pages workflow completed successfully at head SHA `1c9cbc3bc71e476d0b867dc4ed13a8345401ecce` (run `25260168918`), the deploy containing the v0.2.13 release-surface updates.
 
 **Status:** ✅ PASS
 
-### c. Live landing and launch version refs
+### c. Live landing and release version refs
 
 **Commands run:**
 
@@ -357,11 +357,11 @@ for url in https://ericflo.github.io/kiln/ https://ericflo.github.io/kiln/launch
 done
 ```
 
-**Finding:** The live landing page and launch page only expose `0.2.13` version references. The launch page is pinned to the kiln-v0.2.13 release download URL and no stale v0.2.12 refs remain visible to cold readers.
+**Finding:** The live landing page and release page only expose `0.2.13` version references. The release page is pinned to the kiln-v0.2.13 release download URL and no stale v0.2.12 refs remain visible to cold readers.
 
 **Status:** ✅ PASS
 
-### d. Launch drafts
+### d. Release-readiness surfaces
 
 **Command run:**
 
@@ -369,7 +369,7 @@ done
 rg -n 'v0\.2\.13|kiln-v0\.2\.13|0\.2\.13' docs/site/launch.html docs/site/launch
 ```
 
-**Finding:** The staged HN, lobste.rs, Reddit, Rust Discord, Twitter, and launch README surfaces are pinned to v0.2.13 after PR #714. This audit records that state without changing the draft copy.
+**Finding:** The staged release-readiness surfaces are pinned to v0.2.13 after PR #714. This audit records that state without changing the source copy.
 
 **Status:** ✅ PASS
 
@@ -386,10 +386,10 @@ for url in \
 done
 ```
 
-**Finding:** The demo page, logo asset, and canonical `kiln-60s.cast` all return HTTP 200. The asciinema player and cast remain reachable for the v0.2.13 launch line, so the earlier v0.2.8 placeholder-demo observation remains resolved.
+**Finding:** The demo page, logo asset, and canonical `kiln-60s.cast` all return HTTP 200. The asciinema player and cast remain reachable for the v0.2.13 release-readiness line, so the earlier v0.2.8 placeholder-demo observation remains resolved.
 
 **Status:** ✅ PASS
 
 ### v0.2.13 verdict
 
-**GO for the public-announce push on the kiln-v0.2.13 line.** The current release exists with 7 assets, Pages has deployed the v0.2.13 launch-surface updates, the live landing and launch pages only expose v0.2.13 version refs, staged launch-channel drafts are pinned to v0.2.13, and the demo player/cast assets remain live. No new launch blockers were introduced by the v0.2.12 → v0.2.13 transition.
+**GO for the release-readiness baseline on the kiln-v0.2.13 line.** The current release exists with 7 assets, Pages has deployed the v0.2.13 release-surface updates, the live landing and release pages only expose v0.2.13 version refs, staged verification surfaces are pinned to v0.2.13, and the demo player/cast assets remain live. No new readiness blockers were introduced by the v0.2.12 → v0.2.13 transition.

--- a/docs/audits/PHASE11_SERVER_TIMEOUT_POLICY.md
+++ b/docs/audits/PHASE11_SERVER_TIMEOUT_POLICY.md
@@ -18,14 +18,14 @@ The bisect harness in PR #689 used `KILN_REQUEST_TIMEOUT_SECS=305` — the same 
 
 The concrete failure mode: `workers=2` against a single 43 814-input-token correction request on `Qwen3.5-4B`, A6000, `KILN_NUM_BLOCKS=16384`, `KILN_KV_CACHE_FP8=1`, all four bisect commits (`e6f417f`, `d06163a`, `2318343`, `76281c6`) reproduce identically — the chat-completion span opens, prefill begins, and 305 s later the client gives up. Peak `kiln_blocks_used` is 4 306 / 16 384 (26 % occupancy) so block-pool exhaustion is ruled out. The metrics path stays sub-millisecond throughout. The block of work is inside the prefill engine itself.
 
-The v0.2.9 launch artifact ships a documented workaround at [`QUICKSTART.md:296-326`](../../QUICKSTART.md#L296) (§4.3): either run with `workers=1` (client-side serialize the prompt) **or** raise `server.request_timeout_secs` to ≥600 s. The CHANGELOG.md `kiln-v0.2.9 — 2026-05-01` entry references the same workaround. **There is no committed default-fix direction for v0.2.10.** This audit picks one.
+The v0.2.9 release artifact ships a documented workaround at [`QUICKSTART.md:296-326`](../../QUICKSTART.md#L296) (§4.3): either run with `workers=1` (client-side serialize the prompt) **or** raise `server.request_timeout_secs` to ≥600 s. The CHANGELOG.md `kiln-v0.2.9 — 2026-05-01` entry references the same workaround. **There is no committed default-fix direction for v0.2.10.** This audit picks one.
 
 ## 2. Constraints and goals
 
 - **Doc-only PR.** No code changes in this audit. All design choices need to be implementable from the recommendation alone.
 - **No regressions for in-the-wild configs.** Anything that explicitly sets `server.request_timeout_secs` in TOML (or `KILN_REQUEST_TIMEOUT_SECS` in env) must keep its current behavior bit-for-bit.
 - **The fix must be bounded.** A request that runs forever ties up an engine slot forever; PR #666's cancel-drain is the floor — anything we change must compose with that floor, not erode it.
-- **Phase 11 is the launch-prep phase.** Real prefill-scheduler work (Option E below) is v0.3.x territory; v0.2.10 wants the smallest correct change that closes the public-launch reliability story without committing the project to a multi-week kernel rewrite.
+- **Phase 11 is the onboarding-prep phase.** Real prefill-scheduler work (Option E below) is v0.3.x territory; v0.2.10 wants the smallest correct change that closes the release-readiness reliability story without committing the project to a multi-week kernel rewrite.
 - **The 4-commit bisect rules out a regression in {#666, #672, #674, #675}.** Whatever the right server-side default is, it can be picked without first identifying an offending commit.
 
 ## 3. Options
@@ -36,7 +36,7 @@ Each option lists **What**, **Pros**, **Cons**, **Code shape**, **Migration**, *
 
 - **What.** Keep `request_timeout_secs = 300`. Rely on QUICKSTART §4.3 + the existing `prompt_too_long`-style hint string at `error.rs:88` to teach users.
 - **Pros.** Zero code change. Zero migration. The cancel-drain in PR #666 means the 408 doesn't leak engine state.
-- **Cons.** Every cold-reader who first hits a long-prefill prompt sees a 408 and has to find QUICKSTART §4.3 (or read the error hint, which currently only points at `request_timeout_secs`, not at the workers=1 alternative). The launch story is "by the way, there's a known regression — read this section first." That's a worse first impression than any of B/C/D.
+- **Cons.** Every cold-reader who first hits a long-prefill prompt sees a 408 and has to find QUICKSTART §4.3 (or read the error hint, which currently only points at `request_timeout_secs`, not at the workers=1 alternative). The onboarding story is "by the way, there's a known regression — read this section first." That's a worse first impression than any of B/C/D.
 - **Code shape.** Zero.
 - **Migration.** Zero.
 - **Risk.** Reputational, not technical. The bisect already rules out a fix in the {#666, #672, #674, #675} commit window, so there is no known scoped code change that closes the issue without going to Option E.
@@ -57,7 +57,7 @@ Each option lists **What**, **Pros**, **Cons**, **Code shape**, **Migration**, *
 - **Cons.** API surface widens. Every future client library needs to know about the header. Tests need to cover header parsing edge cases (negative, zero, non-integer, larger-than-cap). The default header-absent path still runs into the 300 s default unless we *also* raise the default (i.e., this is additive to Option B, not a substitute).
 - **Code shape.** ~80–120 lines: header parse in completions handler + bounds check + new config field + validator + integration tests + CHANGELOG.
 - **Migration.** Zero for clients that don't send the header — current behavior is preserved.
-- **Risk.** Medium. New API surface is a launch-eve commitment; once shipped, removing or renaming the header is a breaking change. Better timing is post-launch when first 100 users have actually asked for per-request control.
+- **Risk.** Medium. New API surface is a release-eve commitment; once shipped, removing or renaming the header is a breaking change. Better timing is later, after users have actually asked for per-request control.
 
 ### Option D — API-layer rejection of long-prefill at submission
 
@@ -75,11 +75,11 @@ Each option lists **What**, **Pros**, **Cons**, **Code shape**, **Migration**, *
 - **Cons.** Live scheduler work in [`crates/kiln-scheduler/`](../../crates/kiln-scheduler/) — re-verify the exact module layout and the existing chunk-yield policy before designing the change; do **not** guess line numbers in this audit. Behavior change may regress single-stream throughput if yield granularity is wrong. Needs a GPU bench cycle (NVTX trace + per-yield-policy A/B) plus the `kiln_request_prefill_tokens_completed` gauge from PR #689 item 3 to even know whether the fix is doing what it should. This is the v0.2.x → v0.3.x scheduler line of work.
 - **Code shape.** Requires its own audit doc with GPU bench numbers. This audit explicitly defers detailed design.
 - **Migration.** Behavior change — chunk-yield policy is observable in throughput shape. Needs a migration paragraph in CHANGELOG plus an opt-out env var for the first release that ships it.
-- **Risk.** High. Real scheduler work in launch-prep phase is exactly the kind of v0.3.x commitment Phase 11 is supposed to defer until after the public-announce cut.
+- **Risk.** High. Real scheduler work during release-readiness cleanup is exactly the kind of v0.3.x commitment Phase 11 is supposed to defer until after the onboarding baseline is stable.
 
 ## 4. Recommendation
 
-**Pick Option B + D combined for v0.2.10.** Explicitly defer Option C until a real customer asks for it (YAGNI). Explicitly defer Option E to its own audit doc + GPU bench cycle scheduled after the public-announce milestone.
+**Pick Option B + D combined for v0.2.10.** Explicitly defer Option C until a real customer asks for it (YAGNI). Explicitly defer Option E to its own audit doc + GPU bench cycle scheduled after the release-readiness milestone.
 
 **Why B + D, specifically.**
 
@@ -88,15 +88,15 @@ Each option lists **What**, **Pros**, **Cons**, **Code shape**, **Migration**, *
 - **B + D together** make the default behavior good (long prefills get enough budget) **and** give operators who want to clamp their deployment a single TOML knob to do so.
 - The combined surface is small: one default change + one new optional config field + one new error variant. Total under ~150 lines of code, all in `kiln-server`, no engine or scheduler changes.
 
-**Why defer C.** Per-request override is real flexibility but it widens the public API contract on launch eve. Once shipped it's a breaking change to remove. Better to wait for the first 100 users (Phase 11 adoption milestone) to tell us they want it.
+**Why defer C.** Per-request override is real flexibility but it widens the API contract during release-readiness cleanup. Once shipped it's a breaking change to remove. Better to wait for users to tell us they want it.
 
-**Why defer E.** The real scheduler work is the v0.3.x prefill story. Trying to land it before public-announce risks dragging v0.2.10 into a multi-week debugging arc and pushes the launch out. Ship B + D for v0.2.10, then take Option E up properly with PR #689 items 1–3 as the supporting evidence.
+**Why defer E.** The real scheduler work is the v0.3.x prefill story. Trying to land it during release-readiness cleanup risks dragging v0.2.10 into a multi-week debugging arc and delays onboarding polish. Ship B + D for v0.2.10, then take Option E up properly with PR #689 items 1–3 as the supporting evidence.
 
 **Alternative primary recommendations and what would justify picking them.**
 
 - *Pick D alone* if you believe the production SLA must stay at exactly 5 min and you'd rather reject than wait. B + D collapses to D alone in that case (no default change, just the cap). Trade-off: every long-prefill user has to know about the cap and configure a workaround, reverting to status quo for the on-by-default user.
-- *Pick A* if the public-announce cut should ship with no v0.2.10 reliability changes at all and the workaround docs are deemed sufficient. Cheapest option; worst first impression for cold readers; no engineering investment.
-- *Pick E now* if Eric believes the launch story can absorb the schedule risk. This audit doesn't recommend it but the argument is open: the bisect rules out a fix in the four-commit window, so the only "real" fix path is Option E. If launch slip is acceptable in exchange for shipping v0.2.10 with the actual prefill regression closed, Option E is the technically-correct choice.
+- *Pick A* if the release-readiness baseline should ship with no v0.2.10 reliability changes at all and the workaround docs are deemed sufficient. Cheapest option; worst first impression for cold readers; no engineering investment.
+- *Pick E now* if Eric believes the release-readiness story can absorb the schedule risk. This audit doesn't recommend it but the argument is open: the bisect rules out a fix in the four-commit window, so the only "real" fix path is Option E. If schedule slip is acceptable in exchange for shipping v0.2.10 with the actual prefill regression closed, Option E is the technically-correct choice.
 
 ## 5. Concrete v0.2.10 PR shopping list (post-decision)
 

--- a/docs/audits/PHASE9_V0_1_0_READINESS.md
+++ b/docs/audits/PHASE9_V0_1_0_READINESS.md
@@ -20,12 +20,12 @@ the project description has either landed or is met by an
 already-published artifact.
 
 The single remaining action is a **project-description amendment**:
-either retire the "Phase 9 v0.1.0 release prep" goal entirely, or
-rename it to a forward-looking public-announce milestone (suggested:
-"Phase 9: public-announce cut on the kiln-v0.2.x line"). The Phase 10
-closure doc's claim that "what remains is an audit pass + the v0.1.0
-semver cut" was written without rechecking the release index — the
-v0.1.0 cut happened 10 days before that doc was authored.
+retire the "Phase 9 v0.1.0 release prep" goal as complete and carry
+forward any remaining work as neutral Phase 11 onboarding and
+release-readiness polish. The Phase 10 closure doc's claim that "what
+remains is an audit pass + the v0.1.0 semver cut" was written without
+rechecking the release index — the v0.1.0 cut happened 10 days before
+that doc was authored.
 
 ## Phase 9 checklist status
 
@@ -68,31 +68,30 @@ tag predated that doc by 10 days. This audit is the audit pass; there
 is no remaining v0.1.0 cut to do.
 
 **What "v0.1.0" was probably meant to mean** in the project
-description, charitably: *the public-announce milestone* — the moment
-where kiln stops being an internal project and gets a deliberate
-external-facing announcement (HN post, X/Twitter thread, Discord,
-etc.). That milestone has not happened. The current `0.2.x` line is
-mature enough that it could happen tomorrow.
+description, charitably: *the release-readiness milestone* — the moment
+where kiln's release artifacts, supply-chain metadata, docs, and
+onboarding path are coherent enough for cold-reader developers. That
+milestone is satisfied by the current `0.2.x` line, with Phase 11 left
+to keep the onboarding surfaces polished.
 
 **Recommendation:** Amend the kiln project description's "Phase 9:
 Public Release Preparation" section to:
 
 * Strike the "v0.1.0 release with semantic versioning" bullet (already
   shipped on 2026-04-19; the goal as written cannot be met any more).
-* Add a new explicit goal in its place — suggested:
-  "**Public-announce cut** on the kiln-v0.2.x line: write the launch
-  blog post, post to HN/X/Discord, link the demo, and gate any
-  remaining v0.3.0-ahead changes behind that announcement." This is
-  the *actual* remaining work the original "v0.1.0 cut" goal was
-  reaching toward.
-* Optionally mention that the `0.2.x` line is the public release line
+* Add a new explicit note in its place — suggested:
+  "**Release-readiness baseline** on the kiln-v0.2.x line: release
+  artifacts, provenance, docs, landing page, demo link, and cold-reader
+  onboarding checks are green; keep v0.3.0-ahead changes separate from
+  Phase 11 onboarding polish." This is the *actual* remaining work the
+  original "v0.1.0 cut" goal was reaching toward.
+* Optionally mention that the `0.2.x` line is the current release line
   and `0.1.x` was the early-access run.
 
 Do **not** silently rewrite the project description from this audit
 PR — that decision belongs to Eric (it's a positioning question, not
 a doc-fact correction). This audit's job is to flag the staleness and
-recommend the amendment. Eric's call on whether to take the
-"public-announce" framing or something else.
+recommend a neutral release-readiness amendment.
 
 ## Punch list
 
@@ -101,7 +100,7 @@ punch list of remaining work is:
 
 1. **Project description amendment** (no GPU; Eric-driven; not a code
    PR). Strike the stale `v0.1.0 release with semantic versioning`
-   bullet from the kiln project description, add a public-announce
+   bullet from the kiln project description, add a release-readiness
    milestone in its place per the recommendation above. Effort:
    ~10 minutes of editing in the Cloud Eric project UI.
 
@@ -118,31 +117,32 @@ The single highest-leverage next task — concrete, verifiable,
 no-GPU — is:
 
 > **Title:** `kiln project description: replace stale v0.1.0 cut goal
-> with public-announce milestone`
+> with release-readiness milestone`
 >
 > **Description:** Apply the project-description amendment recommended
 > in `docs/audits/PHASE9_V0_1_0_READINESS.md`: strike the
 > `v0.1.0 release with semantic versioning` Phase 9 checklist bullet
 > (already shipped 2026-04-19; the goal as written is met) and replace
-> it with a forward-looking "Public-announce cut on the kiln-v0.2.x
-> line" goal that names the announcement channels (blog post,
-> HN, X, Discord), the gating relationship to a hypothetical v0.3.0
-> changes, and the verification step (post hits, demo link is live).
+> it with a forward-looking "Release-readiness baseline on the
+> kiln-v0.2.x line" goal that names the shipped artifacts,
+> provenance, docs, demo link, onboarding checks, and the boundary for
+> hypothetical v0.3.0-ahead changes.
 > Doc-only / project-config-only; no PR against ericflo/kiln required.
 >
 > **Effort:** ~10 minutes. **GPU required:** no. **Cycle backoff
 > after:** 30 minutes (steady state, Phase 9 cleared, no v0.1.0 cut to
 > watch).
 
-After that amendment lands, the next Phase 9 cycle should pivot the
-loop to either (a) the public-announce execution itself if Eric wants
-that work in-loop, or (b) the two ranked post-Phase-10 alternatives
-from `PHASE10_CLOSURE.md` §"Pivot recommendations" — GDN training-time
-streaming follow-ups (PR #635/#636/#637 in flight) or a LoRA precision
-study targeting the FP32 SGEMM ~42% hotspot. Per planning-loop policy,
-do **not** end the cycle on "awaiting Eric" without a corresponding
-`ce approval-create` if the choice between (a) and (b) is genuinely
-his call; otherwise pick the higher-leverage option and execute it.
+After that amendment lands, the next Phase 9 cycle should treat Phase
+9 as closed and continue Phase 11 onboarding polish, or take the two
+ranked post-Phase-10 alternatives from `PHASE10_CLOSURE.md` §"Pivot
+recommendations" only if the planning policy has moved beyond Phase
+11: GDN training-time streaming follow-ups (PR #635/#636/#637 in
+flight) or a LoRA precision study targeting the FP32 SGEMM ~42%
+hotspot. Per planning-loop policy, do **not** end the cycle on
+"awaiting Eric" without a corresponding `ce approval-create` if a
+genuine product decision is required; otherwise pick the
+higher-leverage option and execute it.
 
 ## References
 

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -66,9 +66,9 @@ Prefix cache:
   verdict: kiln-v0.1.0 shipped 2026-04-19 and the production line is at
   kiln-v0.2.8.
 
-## Phase 11 (public-announce + sustained-adoption)
+## Phase 11 (onboarding + sustained adoption)
 
-- `PHASE11_PRELAUNCH_OPS_CHECKLIST.md` — pre-launch ops checklist verifying
+- `PHASE11_PRELAUNCH_OPS_CHECKLIST.md` — release-readiness ops checklist verifying
   release artifacts, GHCR image, landing page, and SLOs at the unit and CI
   level.
 - `PHASE11_ISSUE_686_BISECT.md` — four-commit bisect of the v0.2.9


### PR DESCRIPTION
## Summary

- Rewords Phase 11 audit-doc framing from external-publicity/public-announce language to neutral release-readiness and onboarding wording.
- Removes channel-specific launch-draft references from the tracked audit docs while preserving version numbers, dates, PR references, release asset checks, and technical verification history.
- Keeps the change scoped to `docs/audits/README.md`, `docs/audits/PHASE11_SERVER_TIMEOUT_POLICY.md`, `docs/audits/PHASE11_PRELAUNCH_OPS_CHECKLIST.md`, and `docs/audits/PHASE9_V0_1_0_READINESS.md`.

## Validation

- `git diff --check`
- `! rg -n 'public-announce|Launch announcement|launch announcement|launch blog post|Launch post|launch post|per-channel launch posts|HN|Hacker News|X/Twitter|Twitter|lobste\.rs|LocalLLaMA|Rust Discord|launch-window' docs/audits/README.md docs/audits/PHASE11_SERVER_TIMEOUT_POLICY.md docs/audits/PHASE11_PRELAUNCH_OPS_CHECKLIST.md docs/audits/PHASE9_V0_1_0_READINESS.md`
- `rg -n 'v0\.2\.13|Release|readiness|verification|onboarding|PR #717|PR #718|PR #719|#717|#718|#719' docs/audits/README.md docs/audits/PHASE11_SERVER_TIMEOUT_POLICY.md docs/audits/PHASE11_PRELAUNCH_OPS_CHECKLIST.md docs/audits/PHASE9_V0_1_0_READINESS.md`