### PR TITLE
[codex] Neutralize issue 686 audit pre-launch framing

### DIFF
--- a/docs/audits/PHASE11_ISSUE_686_BISECT.md
+++ b/docs/audits/PHASE11_ISSUE_686_BISECT.md
@@ -13,7 +13,7 @@ Bisect SHAs (in order):
 | 3 | `2318343` | After #675 (revert of #672) lands; serialize shim removed but #674 still in | #666, #674 |
 | 4 | `76281c6` | Current `main` / `v0.2.9` (HEAD at audit time) | #666, #674 |
 
-Companion to: [`PHASE11_PRELAUNCH_OPS_CHECKLIST.md`](PHASE11_PRELAUNCH_OPS_CHECKLIST.md). The pre-launch checklist verified release artifacts and SLOs at the unit and CI level. This audit closes the open production-load question raised in issue #686.
+Companion to the Phase 11 operational-readiness checklist, which verified release artifacts and SLOs at the unit and CI level. This audit closes the open production-load question raised in issue #686.
 
 ## TL;DR
 


### PR DESCRIPTION
## Summary
- Rewords the issue #686 bisect audit companion sentence to neutral operational-readiness wording.
- Removes the remaining stale pre-launch framing from the scoped audit file while preserving the issue #686 production-load history.
- Leaves the sentinel/reference prelaunch docs untouched as requested.

## Validation
- `rg -n "PHASE11_PRELAUNCH_OPS_CHECKLIST|pre-launch" docs/audits/PHASE11_ISSUE_686_BISECT.md` exits 1 with no matches.
- `rg -n "issue #686|pre-launch|PHASE11_PRELAUNCH_OPS_CHECKLIST" docs/audits/PHASE11_ISSUE_686_BISECT.md || true` shows issue #686 references only, with no stale pre-launch wording.