### PR TITLE
docs: Fix Pages home links

### DIFF
--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -119,7 +119,7 @@
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-      <a href="/" class="flex items-center gap-2.5">
+      <a href="../" class="flex items-center gap-2.5">
         <img src="../assets/logo.png" alt="" width="28" height="28" class="rounded">
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
@@ -221,7 +221,7 @@
   <!-- footer / nav back -->
   <section class="divider">
     <div class="max-w-3xl mx-auto px-6 py-10 flex flex-wrap gap-3">
-      <a href="/" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+      <a href="../" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
         &larr; Back to home
       </a>
       <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -108,7 +108,7 @@
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="max-w-5xl mx-auto px-6 py-4 flex items-center justify-between">
-      <a href="/" class="flex items-center gap-2.5">
+      <a href="./" class="flex items-center gap-2.5">
         <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>


### PR DESCRIPTION
## Summary

- Change the docs/site landing-page logo link from `/` to `./` so it stays at the Kiln GitHub Pages root.
- Change the docs/site demo logo link and final back-home CTA from `/` to `../` so they resolve from `/kiln/demo/` back to `/kiln/`.
- Leave launch/publicity content untouched.

## Validation

- `git diff --check`
- `rg -n 'href="/"' docs/site/index.html docs/site/demo/index.html` returns no matches
- `/usr/bin/chromium-browser --headless --no-sandbox --disable-gpu --dump-dom file://$PWD/docs/site/index.html >/tmp/kiln-site-home.html`
- `/usr/bin/chromium-browser --headless --no-sandbox --disable-gpu --dump-dom file://$PWD/docs/site/demo/index.html >/tmp/kiln-site-demo.html`
- Parsed browser DOM links confirm `./` from `https://ericflo.github.io/kiln/` and `../` from `https://ericflo.github.io/kiln/demo/` both resolve to `https://ericflo.github.io/kiln/`.