### PR TITLE
[codex] Cross-link architecture and GRPO guides

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,6 +2,14 @@
 
 This document explains how Kiln works internally. It is aimed at contributors and power users who want to understand what happens between an HTTP request arriving and a token being generated — or a model being trained.
 
+## Where to go next
+
+- Use this architecture deep-dive when you want to understand Kiln's scheduler, model runner, LoRA hot-swap, training queue, and CUDA kernel layout.
+- Start with [Quickstart](QUICKSTART.md) when you want to install Kiln, run the server, or try the common API flows before reading internals.
+- Read [docs/GRPO_GUIDE.md](docs/GRPO_GUIDE.md) when you want the generate → score → train loop, reward-shaping examples, and GRPO request shapes.
+- Skim [README.md](README.md) when you want the shorter overview, feature map, install command, and links to the rest of the docs.
+- If setup or API behavior is confusing, use the website [Troubleshooting guide](https://ericflo.github.io/kiln/troubleshooting.html).
+
 ## System Overview
 
 Kiln is a single Rust binary built as a Cargo workspace with twelve crates — seven portable crates plus five CUDA kernel crates that are only compiled when `--features cuda` is enabled:

--- a/docs/GRPO_GUIDE.md
+++ b/docs/GRPO_GUIDE.md
@@ -46,7 +46,7 @@ reward trend up.
 ## Endpoint reference
 
 The full schema for both endpoints lives in
-[QUICKSTART.md §9](../QUICKSTART.md#9-phase-8-api-examples). The fields used in
+[Quickstart §9](../QUICKSTART.md#9-phase-8-api-examples). The fields used in
 this guide are:
 
 **`POST /v1/completions/batch`** — issues `prompts.len() × n` completions in
@@ -337,8 +337,12 @@ Watch live training progress with `GET /v1/train/status`.
 
 ## See also
 
-- [QUICKSTART.md §9](../QUICKSTART.md#9-phase-8-api-examples) — full schema for
-  `/v1/completions/batch` and `/v1/train/grpo`.
+- [Quickstart §9](../QUICKSTART.md#9-phase-8-api-examples) — full schema for
+  `/v1/completions/batch` and `/v1/train/grpo`, plus the fastest path to run
+  Kiln before trying GRPO.
 - [README.md `## The GRPO Loop`](../README.md#the-grpo-loop) — the 30-second
-  pitch.
+  overview of why the generate → score → train loop exists.
+- [Website Troubleshooting guide](https://ericflo.github.io/kiln/troubleshooting.html) — setup,
+  model-loading, adapter, and API recovery steps when a command or request does
+  not behave as expected.
 - [DeepSeekMath](https://arxiv.org/abs/2402.03300) — the algorithm.


### PR DESCRIPTION
## Summary

- Add a compact "Where to go next" section near the top of `ARCHITECTURE.md` for cold readers choosing between the architecture deep-dive, Quickstart, GRPO guide, README, and website troubleshooting guide.
- Strengthen `docs/GRPO_GUIDE.md` cross-links so readers can recover from setup or API confusion via Quickstart, README's GRPO overview, and the website troubleshooting guide.

## Validation

- `rg -n "Quickstart|Troubleshooting|GRPO_GUIDE|README|ericflo.github.io/kiln/troubleshooting" ARCHITECTURE.md docs/GRPO_GUIDE.md`
- `git diff --check`
- Read the resulting diff as a first-time developer and confirmed it answers where to run Kiln, debug setup/API issues, or see the simpler overview after starting with architecture or GRPO docs.