### PR TITLE
fix: device init — use ? operator instead of missing anyhow::Context

### DIFF
--- a/crates/kiln-server/src/device.rs
+++ b/crates/kiln-server/src/device.rs
@@ -5,20 +5,20 @@
 //! Silicon) → CPU. Each branch logs which backend was chosen so the
 //! startup banner and crash dumps make it obvious.
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use candle_core::Device;
 
 pub fn select_device() -> Result<Device> {
     #[cfg(feature = "cuda")]
     if candle_core::utils::cuda_is_available() {
         tracing::info!("CUDA available — using GPU device 0");
-        return Device::new_cuda(0).context("failed to initialize CUDA device");
+        return Ok(Device::new_cuda(0)?);
     }
 
     #[cfg(feature = "metal")]
     if candle_core::utils::metal_is_available() {
         tracing::info!("Metal available — using Apple Silicon GPU");
-        return Device::new_metal(0).context("failed to initialize Metal device");
+        return Ok(Device::new_metal(0)?);
     }
 
     tracing::info!("no GPU feature active — using CPU");


### PR DESCRIPTION
## Problem

macOS / Metal CI builds fail with:

```
error[E0599]: no method named `context` found for enum `Result<T, E>` in the current scope
  --> crates/kiln-server/src/device.rs:32:37
```

## Root cause

The file imports `use anyhow::{Context, Result}` but the `context()` method is ambiguous: `candle_core::Error` has its own `context(self, c) -> Self` method defined directly (not a trait method), and `anyhow::Context` also provides a `context()` method on `Result`. The compiler can't disambiguate.

## Fix

Replace the `Context` import with just `Result`, and use `Ok(Device::new_*(0)?)` instead of `Device::new_*(0).context("...")`. The `?` operator works directly with the function's `Result<Device>` return type via `candle_core::Error`'s `From` impl on `anyhow::Error`.

Two lines changed (3 insertions, 3 deletions).