### PR TITLE
[codex] Add prebuilt Docker path to Quickstart

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -632,6 +632,18 @@ Key settings:
 
 ## Running with Docker
 
+Use the prebuilt GHCR image for the fastest terminal path. You need the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed so Docker can pass your GPU through to kiln.
+
+```bash
+docker pull ghcr.io/ericflo/kiln-server:latest
+
+docker run --gpus all -p 8420:8420 \
+  -v /path/to/Qwen3.5-4B:/models \
+  ghcr.io/ericflo/kiln-server:latest serve
+```
+
+Optional: build from source if you are contributing to kiln or testing local image changes.
+
 ```bash
 # Build the image
 docker build -f deploy/Dockerfile -t kiln .


### PR DESCRIPTION
## Summary
- Makes the Quickstart Docker section lead with the prebuilt GHCR image.
- Adds the NVIDIA Container Toolkit prerequisite and ready-to-copy pull/run commands.
- Keeps the source-build Docker commands as the optional contributor/local-image path.

## Validation
- `git diff --check`
- `python3 - <<'PY' ... PY` section assertion from the task description