### PR TITLE
[codex] Align GRPO landing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,10 @@ scored = [{"text": r.choices[0].message.content, "reward": my_score(r)} for r in
 
 # 3. Submit — the server trains and hot-swaps immediately
 requests.post("http://localhost:8420/v1/train/grpo", json={
-    "groups": [{"prompt": prompt, "completions": scored}]
+    "groups": [{
+        "messages": [{"role": "user", "content": prompt}],
+        "completions": scored,
+    }]
 })
 
 # 4. Next inference already uses the improved weights

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -249,7 +249,10 @@ scored = [{"text": r.choices[0].message.content, "reward": my_score(r)}
 
 <span style="color:#7f8694"># 3. Submit &mdash; server trains and hot-swaps immediately</span>
 requests.post("http://localhost:8420/v1/train/grpo",
-              json={"groups": [{"prompt": prompt, "completions": scored}]})
+              json={"groups": [{
+                  "messages": [{"role": "user", "content": prompt}],
+                  "completions": scored,
+              }]})
 
 <span style="color:#7f8694"># 4. Next inference already uses the improved weights</span></code></pre>
       <p class="text-sm mt-5" style="color: var(--fg-mute);">


### PR DESCRIPTION
## Summary

Aligns the README and landing-page GRPO examples with the accepted `/v1/train/grpo` wire shape. Both snippets now submit groups with `messages` plus `completions`, matching `GrpoGroup { messages, completions }` and the existing `docs/GRPO_GUIDE.md` examples.

## Validation

- `rg -n '"groups"|"prompt"\s*:|messages=|/v1/train/grpo' README.md docs/site/index.html docs/GRPO_GUIDE.md`
- `rg -n 'json=\{"groups": \[\{"prompt"|"groups"\s*:\s*\[\s*\{\s*"prompt"' README.md docs/site/index.html docs/GRPO_GUIDE.md` returns no stale GRPO request examples.

Doc-only change; no GPU/RunPod work needed.