### PR TITLE
[codex] Add demo links to docs site nav

### DIFF
--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -125,6 +125,7 @@
       </a>
       <nav class="flex items-center gap-5 text-sm" style="color: var(--fg-dim);">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="./">Demo</a>
         <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/ericflo/kiln" class="hidden sm:inline">GitHub</a>
       </nav>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -114,6 +114,7 @@
       </a>
       <nav class="flex items-center gap-5 text-sm" style="color: var(--fg-dim);">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/ericflo/kiln" class="hidden sm:inline">GitHub</a>
@@ -316,6 +317,7 @@ docker run --gpus all -p 8420:8420 \
         <a href="https://github.com/ericflo/kiln">Repo</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -115,6 +115,7 @@
       </a>
       <nav class="flex items-center gap-5 text-sm" style="color: var(--fg-dim);">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/ericflo/kiln" class="hidden sm:inline">GitHub</a>
@@ -321,6 +322,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">Architecture</a>
         <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>


### PR DESCRIPTION
## Summary
- Add `Demo` to the docs site top nav on the landing and troubleshooting pages.
- Add `Demo` to the landing and troubleshooting footer nav.
- Add a self-consistent `Demo` item to the demo page top nav.

## Validation
- `rg -n 'href="demo/"|href="../demo/"|>Demo<' docs/site/index.html docs/site/troubleshooting.html docs/site/demo/index.html`
- `python3 -m http.server 8765 -d docs/site`
- `curl -fsS http://127.0.0.1:8765/ | rg -n 'href="demo/"|Watch the 60-second demo'`
- `curl -fsS http://127.0.0.1:8765/troubleshooting.html | rg -n 'href="demo/"|Demo'`
- `curl -fsS http://127.0.0.1:8765/demo/ | rg -n 'Kiln Demo|Quickstart|Troubleshooting'`