### PR TITLE
[codex] Make dashboard forms mobile-friendly

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -371,6 +371,51 @@ textarea { resize: vertical; min-height: 80px; }
 .tab-content { display: none; }
 .tab-content.active { display: block; }
 
+@media (max-width: 640px) {
+  .header {
+    padding: 10px 12px;
+    gap: 10px;
+  }
+  .header-stats {
+    width: 100%;
+    margin-left: 0;
+    gap: 8px 12px;
+  }
+  .main {
+    padding: 12px;
+    gap: 12px;
+  }
+  .main > *, .panel, .form-row > *, .chat-input-row input {
+    min-width: 0;
+  }
+  .panel-head {
+    align-items: flex-start;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+  .tabs {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .tab {
+    flex: 1 0 auto;
+    text-align: center;
+  }
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+  .chat-controls, .chat-input-row, .adapter-actions {
+    flex-wrap: wrap;
+  }
+  .chat-controls select, .chat-input-row input {
+    width: 100%;
+  }
+  .chat-input-row .btn, .form-group .btn {
+    max-width: 100%;
+    white-space: normal;
+  }
+}
+
 /* Empty state */
 .empty {
   text-align: center;


### PR DESCRIPTION
## Summary
- Add a narrow-viewport media query for the dashboard UI so training form rows collapse to one column on mobile.
- Wrap common dashboard controls and prevent chat/sample payload controls from overflowing on small screens while leaving desktop layout unchanged.

## Validation
- `python3 - <<'PY' ... PY && node --check /tmp/kiln-ui.js` — passed
- Provided `npx puppeteer@latest --yes <<'JS' ... JS` invocation exposed Puppeteer's CLI and failed before running the script in this environment.
- Equivalent static mobile smoke check run through Node with a temp `/tmp` Puppeteer install — passed with `{"rowColumns":"1fr","mainColumns":"366px","bodyOverflow":false}`
- Manual diff review confirmed desktop two-column `.form-row` behavior remains unchanged outside `@media (max-width: 640px)`.