### PR TITLE
[codex] Refresh README Docker pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Each `kiln-v*` tag publishes a `linux/amd64` CUDA 12.4 image to GHCR:
 ```bash
 docker pull ghcr.io/ericflo/kiln-server:latest
 # or pin a version:
-docker pull ghcr.io/ericflo/kiln-server:0.2.9
+docker pull ghcr.io/ericflo/kiln-server:0.2.13
 ```
 
 Run with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html):


### PR DESCRIPTION
## Summary
- Refreshes the README pinned GHCR kiln-server Docker example from `0.2.9` to `0.2.13`.
- Leaves the `latest` image example and Docker run instructions unchanged.

## Validation
- `gh release list -R ericflo/kiln --limit 1`
- `rg -n '^version = "0\.2\.13"|ghcr.io/ericflo/kiln-server:(0\.2\.9|0\.2\.13)' Cargo.toml README.md`
- Static README pin assertions from the task prompt
- `git diff -- README.md`