### PR TITLE
[codex] de-phase QUICKSTART advanced examples

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -469,7 +469,10 @@ curl -s http://localhost:8420/v1/train/status | python3 -m json.tool
 ./target/release/kiln adapters delete default
 ```
 
-## 9. Phase 8 API Examples
+## 9. Advanced API Examples
+
+These optional next steps are useful after your first chat and training runs:
+batch generation for GRPO rollouts, adapter import/export/merge/compose, and training-completion webhooks.
 
 ### 9.1 Batch generation (efficient for GRPO rollouts)
 


### PR DESCRIPTION
## Summary

- Rename the QUICKSTART advanced examples heading from internal Phase 8 jargon to a cold-reader-friendly title.
- Add a short bridge sentence framing batch generation, adapter lifecycle APIs, composition, and webhooks as optional next steps after first chat/training.

## Validation

- `rg -n 'Phase 8 API Examples|Advanced API Examples|optional next steps|batch generation|webhooks' QUICKSTART.md`
- `python3 - <<'PY' ... PY` static assertion check
- `git diff -- QUICKSTART.md` manual review: docs-only and small
