### PR TITLE
Fix QUICKSTART server start order

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -76,17 +76,13 @@ This downloads ~8GB of safetensors weights plus the tokenizer.
 
 ## 3. Start the Server
 
-```bash
-./target/release/kiln serve --config kiln.example.toml
-```
-
-But first, tell Kiln where the model is. Set the model path via environment variable:
+Point Kiln at the model directory you downloaded in step 2, then start the server:
 
 ```bash
 KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve
 ```
 
-Or create a `kiln.toml` config file:
+Optionally, create a `kiln.toml` config file instead:
 
 ```toml
 [model]


### PR DESCRIPTION
## Summary
- Rewrites `QUICKSTART.md` section 3 so the first shell command is the runnable `KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve` command.
- Keeps the optional `kiln.toml` config-file path after the direct model-path command.
- Removes the confusing initial `serve --config kiln.example.toml` command and the phrase `But first`.

## Validation
- `rg -n '^## 3\\. Start the Server|KILN_MODEL_PATH=\\./Qwen3\\.5-4B \\./target/release/kiln serve|serve --config kiln.example.toml|But first|serve --config kiln.toml' QUICKSTART.md`
- `python3 - <<'PY' ... PY` → `quickstart section 3 command order ok`
- `git diff --check`