### PR TITLE
[codex] fix demo footer GRPO guide link

### DIFF
--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -268,8 +268,8 @@
       <a href="https://github.com/ericflo/kiln" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
         GitHub &rarr;
       </a>
-      <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
-        Quickstart &rarr;
+      <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+        GRPO Guide &rarr;
       </a>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- Replaces the duplicate Quickstart footer button on the demo page with a GRPO Guide button.
- Keeps the existing Back to home, Quickstart, Troubleshooting, and GitHub footer buttons intact.

## Validation
- `python3 - <<'PYLINK' ...` link/content check
- `chromium-browser --headless --no-sandbox --disable-gpu --window-size=390,844 --screenshot=/tmp/kiln-demo-mobile.png http://127.0.0.1:8765/demo/`
- Tall mobile smoke screenshot at `/tmp/kiln-demo-mobile-tall.png` to inspect footer wrapping
- `git diff --check`