### PR TITLE
[codex] Move legacy prefill notes out of quickstart

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -272,76 +272,19 @@ Francisco.").
 > on Hugging Face. If a tool call format ever looks ambiguous, that file is
 > the source of truth.
 
-### 4.2 Troubleshooting: long tools-bearing prompts on older releases
+### 4.2 Troubleshooting: older-release long-prefill timeouts
 
-For current users, start by upgrading to the latest `kiln-v*` release
-before applying old concurrency workarounds. The current `kiln-v0.2.13`
-release line includes the v0.2.10-v0.2.13 long-prefill
+If long tools-bearing prompts or long-prefill requests time out, first upgrade
+to the latest `kiln-v*` release. Current releases include the long-prefill
 dispatcher, timeout, prefix-cache memory, KV auto-sizing, streaming-prefill,
-and observability fixes that replaced the v0.2.9-era workaround framing.
+and observability fixes that replaced the v0.2.9 workaround guidance.
 
-If you are pinned to kiln-v0.2.9 and see tools-bearing chat completions with
-input prompts longer than roughly 30k tokens degrade after a prefill timeout,
-run your client with **at most one in-flight request at a time**
-(`workers=1`). This is a client-side workaround — there is no kiln-side flag
-to set; you control it by serializing requests in your driver, worker pool,
-or load generator.
+Pinned older-release users should see the
+[troubleshooting page](docs/site/troubleshooting.html) for the historical
+`workers=1` client-side serialization and `request_timeout_secs >= 600`
+details.
 
-If you push two or more concurrent in-flight prefills under that older
-workload, a single 300-second prefill timeout (the v0.2.9 default
-`server.request_timeout_secs` in [`kiln.example.toml`](kiln.example.toml))
-can leave kiln in a degraded prefill state. Subsequent requests then fail
-with HTTP 500:
-
-```
-{"error":{"code":"generation_error","message":"Text generation failed: prefill forward pass (paged) failed: ..."}}
-```
-
-…until the server is restarted. With `workers=1` there is no concurrent
-prefill, no degraded state, and the failure mode does not occur.
-
-The original cascade and symptoms are tracked in
-[issue #664](https://github.com/ericflo/kiln/issues/664); the underlying
-KV-cache-exhaustion / prefill-state-cleanup investigation is in
-[issue #656](https://github.com/ericflo/kiln/issues/656). Current users
-should upgrade to the latest `kiln-v*` release rather than carrying this
-v0.2.9 workaround forward.
-
-### 4.3 Troubleshooting: v0.2.9 long-prefill 408s
-
-On kiln-v0.2.9, long-prefill workloads (input prompts of roughly 20k tokens
-or more) under `workers=2` with a tight KV-cache cap could hit repeated HTTP
-408 prefill timeouts at exactly the old `server.request_timeout_secs`
-boundary (300 seconds). The recommended fix for current users is to upgrade
-to the latest `kiln-v*` release: v0.2.10 routed prefix-cache prefill through
-the tiled/streaming long-prefill dispatcher, raised the default timeout to
-600 seconds, and added progress metrics for
-[issue #686](https://github.com/ericflo/kiln/issues/686); v0.2.11-v0.2.13
-added follow-on prefix-cache memory bounds, post-load KV
-auto-sizing, streaming-prefill hardening, and throughput observability.
-
-If you must stay pinned to kiln-v0.2.9, use one of these mitigations:
-
-- **Workaround A (recommended): run with `workers=1`.** Same client-side
-  serialization pattern as §4.2 — there is no kiln-side flag, you
-  control it by keeping at most one in-flight request in your driver,
-  worker pool, or load generator. With no concurrent prefill the
-  regression does not trigger.
-- **Workaround B: raise `server.request_timeout_secs` to at least 600.**
-  If `workers=2` is required, bump `server.request_timeout_secs` in
-  [`kiln.example.toml`](kiln.example.toml) to `600` or higher. The
-  v0.2.8 round-6 p99 prefill latency on the same workload was at or
-  below 300 seconds under loose KV; budget roughly 2× that headroom
-  (≥600s) for the tighter KV cap on v0.2.9.
-
-The v0.2.9 diagnosis is tracked in
-[issue #686](https://github.com/ericflo/kiln/issues/686) and the bisect
-audit lives at
-[`docs/audits/PHASE11_ISSUE_686_BISECT.md`](docs/audits/PHASE11_ISSUE_686_BISECT.md).
-Those fixes have landed; upgrade to the latest `kiln-v*` release unless you
-are intentionally reproducing v0.2.9 behavior.
-
-### 4.4 Troubleshooting: KV cache OOM auto-recovery
+### 4.3 Troubleshooting: KV cache OOM auto-recovery
 
 At startup, kiln's auto-sizer computes the paged KV cache budget as
 `available_for_kv = (total_vram - model_bytes) * inference_memory_fraction`

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -269,6 +269,41 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
       </article>
 
       <article class="card p-6">
+        <h2 class="text-xl font-semibold mb-4">Older-release long-prefill and tool-call timeouts</h2>
+        <div class="grid md:grid-cols-3 gap-5 check-list" style="color: var(--fg-dim);">
+          <div>
+            <div class="label mb-2">Symptom</div>
+            <p>On kiln-v0.2.9, long tools-bearing chat completions or long-prefill prompts could time out under concurrent load, then leave later requests failing until restart.</p>
+          </div>
+          <div>
+            <div class="label mb-2">Check</div>
+            <ul class="list-disc pl-5">
+              <li>This guidance is only for users intentionally pinned to kiln-v0.2.9.</li>
+              <li>Issue <a href="https://github.com/ericflo/kiln/issues/664">#664</a> tracks the tools-bearing cascade after a prefill timeout.</li>
+              <li>Issue <a href="https://github.com/ericflo/kiln/issues/656">#656</a> tracks the KV-cache-exhaustion and prefill-state-cleanup investigation.</li>
+              <li>Issue <a href="https://github.com/ericflo/kiln/issues/686">#686</a> tracks repeated long-prefill HTTP 408s around the old timeout boundary.</li>
+            </ul>
+          </div>
+          <div>
+            <div class="label mb-2">Fix</div>
+            <p>Upgrade to the latest <code>kiln-v*</code> release. If pinned to v0.2.9, run clients with <code>workers=1</code> so requests are serialized; if concurrent workers are required, set <code>server.request_timeout_secs</code> to at least <code>600</code>.</p>
+          </div>
+        </div>
+        <div class="mt-5 space-y-3" style="color: var(--fg-dim);">
+          <p>
+            The <code>workers=1</code> mitigation is client-side serialization, not a kiln server flag: keep at most one in-flight request in your driver, worker pool, or load generator. It avoids concurrent prefills, which is the condition that exposed the older degraded-state failure mode.
+          </p>
+          <p>
+            The <code>request_timeout_secs &gt;= 600</code> mitigation is also historical. It was useful for pinned kiln-v0.2.9 deployments that had to keep <code>workers=2</code> while running tight KV-cache caps and roughly 20k-token-or-longer prefills. Current releases route prefix-cache prefill through the tiled/streaming dispatcher and include follow-on prefix-cache memory, KV auto-sizing, streaming-prefill, and observability fixes.
+          </p>
+          <p>
+            For the original diagnosis and bisect notes, read
+            <a href="https://github.com/ericflo/kiln/blob/main/docs/audits/PHASE11_ISSUE_686_BISECT.md"><code>docs/audits/PHASE11_ISSUE_686_BISECT.md</code></a>.
+          </p>
+        </div>
+      </article>
+
+      <article class="card p-6">
         <h2 class="text-xl font-semibold mb-4">Mock mode is not real training</h2>
         <div class="grid md:grid-cols-3 gap-5 check-list" style="color: var(--fg-dim);">
           <div>


### PR DESCRIPTION
## Summary

- Replaces the two detailed kiln-v0.2.9 long-prefill troubleshooting sections in `QUICKSTART.md` with one compact upgrade-first note.
- Moves the pinned older-release details into `docs/site/troubleshooting.html`, including `workers=1`, `request_timeout_secs >= 600`, issues #664/#656/#686, and the issue #686 bisect audit link.
- Keeps the wording informational and focused on cold-reader onboarding.

## Validation

- `python3 - <<'PY' ...` content check from the task
- `python3 - <<'PY' ...` docs-site local link check from the task
- `git diff --check`