### PR TITLE
Clarify desktop and server release pins

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -28,6 +28,8 @@ Kiln Desktop ships prebuilt installers for Windows, Linux, and macOS. The instal
 
 **Download — [Kiln Desktop v0.2.2](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2):**
 
+**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.2` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, currently `kiln-v0.2.13`, so this quickstart is not stale.
+
 | Platform | Installer | Size |
 |----------|-----------|------|
 | macOS (Apple Silicon) | [Kiln.Desktop_0.2.2_aarch64.dmg](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_aarch64.dmg) | 8.5 MB |

--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Kiln Desktop is a system-tray app that wraps the `kiln` server for people who do
 
 **Download — [Kiln Desktop v0.2.2](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2):**
 
+**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.2` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, currently `kiln-v0.2.13`, so the version split is intentional.
+
 See **[desktop/CHANGELOG.md](desktop/CHANGELOG.md)** for the full version history.
 
 | Platform | Installer | Size |


### PR DESCRIPTION
## Summary
- Add a concise release note to the README Desktop App download section explaining the separate desktop and server release tags.
- Add the same cold-reader clarification to QUICKSTART so `desktop-v0.2.2` does not look stale beside the `kiln-v0.2.13` server line.

## Validation
- `gh release list -R ericflo/kiln --limit 30 | rg 'Kiln server|Kiln Desktop|kiln-v0\.2\.13|desktop-v0\.2\.2'`
- `rg -n 'desktop-v0.2.2|kiln-v0.2.13|separate release|server binary' README.md QUICKSTART.md`
- `git diff --check`