### PR TITLE
[codex] clarify adapter upload import UX

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -562,6 +562,9 @@ textarea { resize: vertical; min-height: 80px; }
     </div>
     <div class="panel-body" style="border-top:1px solid var(--border);">
       <div style="font-size:11px;color:var(--text2);margin-bottom:6px;text-transform:uppercase;font-weight:600;letter-spacing:0.5px;">Upload Adapter</div>
+      <div style="font-size:12px;color:var(--text2);margin-bottom:8px;line-height:1.4;">
+        Import a PEFT-compatible <code>.tar.gz</code>/<code>.tgz</code> adapter archive, typically one created by Kiln's adapter download/export endpoint. The adapter name becomes the saved adapter directory name.
+      </div>
       <div style="display:grid;grid-template-columns:1fr 1fr auto;gap:6px;align-items:center;">
         <input type="text" id="upload-name" placeholder="adapter name">
         <input type="file" id="upload-archive" accept=".tar.gz,.tgz,application/gzip,application/x-gzip,application/x-tar" style="font-family:var(--sans);font-size:12px;">
@@ -1067,7 +1070,12 @@ window.uploadAdapter = async function() {
   const name = nameEl.value.trim();
   const file = fileEl.files[0];
   if (!name) { toast('Adapter name is required', 'err'); return; }
-  if (!file) { toast('Choose a .tar.gz archive', 'err'); return; }
+  if (!file) { toast('Choose a .tar.gz or .tgz adapter archive', 'err'); return; }
+  const lowerName = file.name.toLowerCase();
+  if (!lowerName.endsWith('.tar.gz') && !lowerName.endsWith('.tgz')) {
+    toast('Adapter upload expects a .tar.gz or .tgz archive', 'err');
+    return;
+  }
   const fd = new FormData();
   fd.append('name', name);
   fd.append('archive', file);


### PR DESCRIPTION
## Summary
- Adds cold-reader helper copy to the `/ui` Adapter upload panel explaining the expected PEFT-compatible `.tar.gz`/`.tgz` archive shape and common source.
- Clarifies that the supplied adapter name becomes the saved adapter directory name.
- Adds browser-side validation for missing archive files and clearly wrong filename extensions before the multipart upload request runs.

## Validation
- `python3 - <<'PY' ... PY` static upload UX checks
- `python3 -m http.server 8765 --directory docs/site` plus `curl -fsS http://127.0.0.1:8765/ >/dev/null`

No cargo/local CUDA build or test was run; this is a focused `ui.html` onboarding copy and browser-validation change.
