### PR TITLE
[codex] Fix quickstart training status command

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -385,8 +385,10 @@ Training runs in the background. The model continues serving requests during tra
 Via CLI:
 
 ```bash
-./target/release/kiln health
+./target/release/kiln train status
 ```
+
+`kiln health` is still useful for server/model diagnostics; `kiln train status` shows the training queue and recent jobs.
 
 Via curl:
 


### PR DESCRIPTION
## Summary
- Update QUICKSTART section 7 to show `./target/release/kiln train status` for training status checks.
- Add a concise note distinguishing `kiln health` diagnostics from `kiln train status` queue/job status.

## Validation
- `git diff --check`
- `rg -n "## 7\\. Check Training Status|kiln train status|kiln health|Training queue" QUICKSTART.md`
- `python3 - <<'PY' ... PY` quickstart section assertion script