### PR TITLE
Add docs-site GDN architecture explainer

### DIFF
--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -213,6 +213,34 @@
       </article>
 
       <article class="card p-6">
+        <div class="label mb-3">Model architecture</div>
+        <h2 class="text-2xl font-semibold mb-4">Why the Gated DeltaNet hybrid matters</h2>
+        <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">
+          Qwen3.5-4B is not a plain all-attention transformer. Its 32 layers are split into
+          24 Gated DeltaNet linear-attention layers and 8 full GQA layers, and Kiln is tuned
+          around that exact shape instead of hiding it behind a generic model-family abstraction.
+        </p>
+        <div class="grid md:grid-cols-3 gap-5 check-list mb-5" style="color: var(--fg-dim);">
+          <div>
+            <h3 class="font-semibold mb-2" style="color: var(--fg);">Fixed GDN state</h3>
+            <p>Gated DeltaNet layers carry fixed-size recurrent state through the sequence instead of storing per-token K/V tensors.</p>
+          </div>
+          <div>
+            <h3 class="font-semibold mb-2" style="color: var(--fg);">Small KV footprint</h3>
+            <p>Only the 8 full-attention GQA layers need KV cache, which is why long context can fit on one GPU.</p>
+          </div>
+          <div>
+            <h3 class="font-semibold mb-2" style="color: var(--fg);">Targeted kernels</h3>
+            <p>GDN handles most layers with recurrent linear attention while GQA handles periodic full-attention checkpoints.</p>
+          </div>
+        </div>
+        <p class="text-sm" style="color: var(--fg-mute);">
+          For the detailed recurrence, paging, and kernel discussion, read the
+          <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">full ARCHITECTURE.md deep dive</a>.
+        </p>
+      </article>
+
+      <article class="card p-6">
         <div class="label mb-3">Live learning</div>
         <h2 class="text-2xl font-semibold mb-4">LoRA hot-swap and training queue</h2>
         <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">


### PR DESCRIPTION
## Summary
- Add a focused docs-site architecture card explaining Qwen3.5-4B's 24 Gated DeltaNet + 8 GQA hybrid layout.
- Clarify why only the full-attention layers need KV cache and why that helps long context fit on one GPU.
- Link cold readers to `ARCHITECTURE.md` for the detailed recurrence, paging, and kernel discussion.

## Validation
- `git diff --check`
- `python3 - <<'PY' ... PY` content assertion for Gated DeltaNet, 24, 8, KV cache, recurrent state, and ARCHITECTURE.md
- Mobile browser smoke via local `python3 -m http.server` and `puppeteer-core` using system Chromium
