### PR TITLE
[codex] Polish offline UI server status

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -784,6 +784,7 @@ async function pollHealth() {
   } catch (e) {
     document.getElementById('status-dot').className = 'status-dot offline';
     document.getElementById('status-text').textContent = 'offline';
+    document.getElementById('server-status').innerHTML = apiFailureHtml('Server status', e);
   }
 }
 


### PR DESCRIPTION
## Summary
- Updates the `/ui` health polling error path so the Server Status card no longer stays on `Loading...` when `/health` is unavailable.
- Reuses the existing `apiFailureHtml` empty-state helper for cold-start/offline guidance about server startup and logs.

## Validation
- `git diff --check`
- `rg -n "pollHealth|server-status|apiFailureHtml|offline|Loading" crates/kiln-server/src/ui.html`
- Static browser spot-check with `python3 -m http.server` returning 404 for `/health`, Puppeteer, and Chromium at `/usr/bin/chromium-browser`.