### PR TITLE
[codex] Add offline UI docs links

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -914,6 +914,7 @@ function apiFailureHtml(action, e) {
     <div style="font-weight:600;color:var(--text);margin-bottom:6px;">Dashboard is waiting for Kiln server APIs.</div>
     <div>${escapeHtml(action)} could not load yet. If this is a cold start, wait for <code>kiln serve</code> to finish model startup, then refresh this panel.</div>
     <div style="margin-top:8px;">If it keeps failing, check the server logs for startup, model-path, or GPU initialization errors.</div>
+    <div style="margin-top:8px;">Need setup help? See the <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" target="_blank" rel="noopener noreferrer">Quickstart</a> or <a href="https://ericflo.github.io/kiln/troubleshooting.html" target="_blank" rel="noopener noreferrer">Troubleshooting</a>.</div>
     <div style="margin-top:8px;font-family:var(--mono);font-size:12px;">Details: ${escapeHtml(e.message)}</div>
   </div>`;
 }


### PR DESCRIPTION
## Summary
- Add Quickstart and Troubleshooting links to the shared `/ui` API-failure empty state.
- Keep the existing offline status behavior and informational cold-start copy intact.

## Validation
- `git diff --check`
- `rg -n "apiFailureHtml|Quickstart|Troubleshooting|troubleshooting.html|github.com/ericflo/kiln/blob/main/QUICKSTART.md" crates/kiln-server/src/ui.html`
- Static `/ui.html` browser spot-check with `/health` and other APIs returning 404, verifying offline status and both help links.