### PR TITLE
[codex] Add API copy-paste examples

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -184,6 +184,41 @@
   <main class="max-w-4xl mx-auto px-6 py-12">
     <div class="grid gap-6">
       <article class="card p-6">
+        <div class="label mb-3">First requests</div>
+        <h2 class="text-2xl font-semibold mb-4">Copy-paste first requests</h2>
+        <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">
+          Once Kiln is serving on <code>localhost:8420</code>, these are the smallest useful
+          requests to chat, submit one SFT correction, and watch the training queue.
+        </p>
+        <div class="grid gap-4">
+          <section class="endpoint">
+            <h3 class="font-semibold mb-2">First chat completion</h3>
+            <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>curl -s http://localhost:8420/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"messages": [{"role": "user", "content": "Hello!"}], "max_tokens": 64}' \
+  | python3 -m json.tool</code></pre>
+          </section>
+          <section class="endpoint">
+            <h3 class="font-semibold mb-2">First SFT correction submission</h3>
+            <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>curl -s http://localhost:8420/v1/train/sft \
+  -H "Content-Type: application/json" \
+  -d '{
+    "examples": [{"messages": [
+      {"role": "user", "content": "Hi"},
+      {"role": "assistant", "content": "Hey there!"}
+    ]}],
+    "config": {"output_name": "default", "learning_rate": 1e-4, "epochs": 3}
+  }' \
+  | python3 -m json.tool</code></pre>
+          </section>
+          <section class="endpoint">
+            <h3 class="font-semibold mb-2">Training status check</h3>
+            <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>curl -s http://localhost:8420/v1/train/status | python3 -m json.tool</code></pre>
+          </section>
+        </div>
+      </article>
+
+      <article class="card p-6">
         <div class="label mb-3">Run and observe</div>
         <h2 class="text-2xl font-semibold mb-4">Server status, metrics, UI, and config</h2>
         <div class="endpoint-list" style="color: var(--fg-dim);">


### PR DESCRIPTION
## Summary

Adds a compact `Copy-paste first requests` section to `docs/site/api.html` so cold-reader developers can run a first chat completion, submit a first SFT correction, and check training status without leaving the API reference.

## Validation

- `git diff --check`
- `rg -n "Copy-paste first requests|/v1/chat/completions|/v1/train/sft|/v1/train/status|curl" docs/site/api.html`

Doc-only change; no GPU or cargo build required.