### PR TITLE
[codex] Add README API reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://ericflo.github.io/kiln/">Website</a> &middot;
   <a href="docs/site/demo/">Demo</a> &middot;
   <a href="QUICKSTART.md">Quickstart</a> &middot;
+  <a href="https://ericflo.github.io/kiln/api.html">API Reference</a> &middot;
   <a href="https://ericflo.github.io/kiln/troubleshooting.html">Troubleshooting</a> &middot;
   <a href="ARCHITECTURE.md">Architecture</a> &middot;
   <a href="kiln.example.toml">Configuration</a> &middot;


### PR DESCRIPTION
## Summary
- Add a top-row README link to the hosted API reference page.
- Keep the Phase 11 onboarding change scoped to README navigation only.

## Validation
- `git diff --check`
- `rg -n 'api.html|API Reference|API' README.md`