### PR TITLE
[codex] Surface docs demo asciicast

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -167,6 +167,9 @@
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
           Quickstart &rarr;
         </a>
+        <a href="demo/" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+          Watch 60-second demo &rarr;
+        </a>
         <a href="architecture.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
           Architecture &rarr;
         </a>
@@ -184,6 +187,18 @@
         <span class="mx-2" style="color: var(--fg-dim);">&middot;</span>
         <a href="demo/">&rarr; Watch the 60-second demo</a>
       </p>
+      <a href="demo/" class="card block p-5 mt-8 max-w-3xl">
+        <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <div>
+            <p class="text-xs uppercase tracking-wide mb-2" style="color: var(--accent);">60-second asciicast</p>
+            <h2 class="text-lg font-semibold mb-2">See the live LoRA loop end to end.</h2>
+            <p class="text-sm leading-relaxed" style="color: var(--fg-dim);">
+              Watch a cold start, first chat, SFT correction, adapter hot-swap, and improved chat in one quick terminal demo.
+            </p>
+          </div>
+          <span class="text-sm whitespace-nowrap">Watch demo &rarr;</span>
+        </div>
+      </a>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Adds a hero CTA for the 60-second demo/asciicast on the docs landing page.
- Adds a visible landing-page card explaining the demo covers cold start, first chat, SFT correction, adapter hot-swap, and improved chat.

## Validation
- `rg -n "demo/|asciicast|60-second|hot-swap" docs/site/index.html`
- `python3 -m http.server 8765 --directory docs/site` plus a Python `urlopen` assertion that the landing page links the demo.