### PR TITLE
Add homepage API reference CTA

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -167,6 +167,9 @@
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
           Quickstart &rarr;
         </a>
+        <a href="api.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+          API Reference &rarr;
+        </a>
         <a href="demo/" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
           Watch 60-second demo &rarr;
         </a>


### PR DESCRIPTION
## Summary
- Adds an `API Reference` button to the homepage hero CTA row.
- Surfaces `docs/site/api.html` alongside Quickstart, Demo, Architecture, and Troubleshooting for cold-reader onboarding.

## Validation
- Confirmed `docs/site/index.html` is the only changed file.
- Parsed `docs/site/index.html` with Python `HTMLParser`.
- Grepped the homepage for the new `API Reference` hero link to `api.html`.
