### PR TITLE
Add demo page footer navigation

### DIFF
--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -278,6 +278,28 @@
     </div>
   </section>
 
+  <!-- footer -->
+  <footer class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">
+      <div class="flex items-center gap-2.5">
+        <img src="../assets/logo.png" alt="" width="20" height="20" class="rounded">
+        <span>Kiln &middot; MIT licensed</span>
+      </div>
+      <nav class="flex flex-wrap gap-x-5 gap-y-1">
+        <a href="../">Home</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="../api.html">API</a>
+        <a href="./">Demo</a>
+        <a href="../troubleshooting.html">Troubleshooting</a>
+        <a href="../architecture.html">Architecture</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/SECURITY.md">Security</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/LICENSE">License</a>
+      </nav>
+    </div>
+  </footer>
+
   <!-- asciinema-player JS -->
   <script src="https://cdn.jsdelivr.net/npm/asciinema-player@3.7.1/dist/bundle/asciinema-player.min.js"></script>
   <script>


### PR DESCRIPTION
## Summary
- Add the shared docs-site footer navigation to `docs/site/demo/index.html`
- Use demo-relative links for Home, API, Demo, Troubleshooting, and Architecture
- Keep external repository doc links aligned with the other docs pages

## Validation
```bash
python3 - <<'PY'
from pathlib import Path
s = Path('docs/site/demo/index.html').read_text()
required = [
    '<footer',
    'Kiln &middot; MIT licensed',
    'href="../"',
    'href="../api.html"',
    'href="./">Demo</a>',
    'href="../troubleshooting.html"',
    'href="../architecture.html"',
    'href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md"',
    'href="https://github.com/ericflo/kiln/blob/main/SECURITY.md"',
    'href="https://github.com/ericflo/kiln/blob/main/LICENSE"',
]
missing = [x for x in required if x not in s]
if missing:
    raise SystemExit(f'missing expected demo footer strings: {missing}')
footer_pos = s.index('<footer')
script_pos = s.index('<!-- asciinema-player JS -->')
if footer_pos > script_pos:
    raise SystemExit('footer must appear before asciinema-player JS')
print('demo footer ok')
PY
git diff --check
```