### PR TITLE
Clarify advanced adapter CLI docs

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -547,7 +547,11 @@ kiln adapters load support-bot
 kiln adapters unload support-bot
 kiln adapters delete support-bot
     List, load, unload the active adapter, or delete a saved adapter on the running server.
+```
 
+The CLI currently covers the basic adapter lifecycle: `list`, `load`, `unload`, and `delete`. For advanced adapter download, upload, merge, and composition flows — plus training-completion webhooks — use the dashboard or the HTTP API examples in [9. Advanced API Examples](#9-advanced-api-examples).
+
+```
 Global options:
   --config, -c <file>   Path to TOML config file
 ```


### PR DESCRIPTION
## Summary

- Clarifies the CLI Reference in `QUICKSTART.md` for cold-reader developers.
- Notes that the CLI handles basic adapter lifecycle commands: list, load, unload, and delete.
- Points advanced adapter download/upload/merge/composition and training webhook flows to the dashboard and Advanced API Examples.

## Validation

- `git diff --check`
- `python3 - <<'PY'
from pathlib import Path
text = Path('QUICKSTART.md').read_text()
cli = text[text.index('## CLI Reference'):]
for needle in ['advanced', 'download', 'upload', 'merge', 'composition', 'webhooks']:
    assert needle in cli.lower(), f'missing CLI-scope note for {needle}'
assert '## API Endpoints' in cli, 'CLI Reference section should still flow into API Endpoints'
PY`