### PR TITLE
[codex] Add API Reference to docs-site nav

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -147,7 +147,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="api.html">API</a>
+        <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
@@ -405,7 +405,7 @@ kiln serve --config kiln.toml</code></pre>
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="api.html">API</a>
+        <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -140,7 +140,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="api.html">API</a>
+        <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
@@ -319,7 +319,7 @@
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="api.html">API</a>
+        <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -150,7 +150,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="../api.html">API</a>
+        <a href="../api.html">API Reference</a>
         <a href="./">Demo</a>
         <a href="../troubleshooting.html">Troubleshooting</a>
         <a href="../architecture.html">Architecture</a>
@@ -289,7 +289,7 @@
         <a href="../">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="../api.html">API</a>
+        <a href="../api.html">API Reference</a>
         <a href="./">Demo</a>
         <a href="../troubleshooting.html">Troubleshooting</a>
         <a href="../architecture.html">Architecture</a>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -139,7 +139,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="api.html">API</a>
+        <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
@@ -378,7 +378,7 @@ docker run --gpus all -p 8420:8420 \
         <a href="https://github.com/ericflo/kiln">Repo</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="api.html">API</a>
+        <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -140,7 +140,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="api.html">API</a>
+        <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
@@ -407,7 +407,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="api.html">API</a>
+        <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>


### PR DESCRIPTION
## Summary

- Rename docs-site header/footer API nav labels to `API Reference`.
- Keep existing relative links: `api.html` for top-level docs-site pages and `../api.html` from `docs/site/demo/index.html`.
- Preserve existing nav ordering and styling.

## Validation

- `rg -n '<a href="(\.\./)?api\.html">API Reference</a>' docs/site/index.html docs/site/architecture.html docs/site/api.html docs/site/troubleshooting.html docs/site/demo/index.html`
- `rg -o '<a href="api\.html">API Reference</a>' docs/site/index.html docs/site/architecture.html docs/site/api.html docs/site/troubleshooting.html | wc -l` → `8`
- `rg -o '<a href="\.\./api\.html">API Reference</a>' docs/site/demo/index.html | wc -l` → `2`
- `rg -n '<a href="(\.\./)?api\.html">API</a>' docs/site/index.html docs/site/architecture.html docs/site/api.html docs/site/troubleshooting.html docs/site/demo/index.html` → no matches