### PR TITLE
[codex] Associate UI training and chat labels

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -586,11 +586,11 @@ textarea { resize: vertical; min-height: 80px; }
       </div>
       <div class="form-row" style="margin-bottom:8px;">
         <div class="form-group" style="margin-bottom:0;">
-          <label>Output Name</label>
+          <label for="merge-output-name">Output Name</label>
           <input type="text" id="merge-output-name" placeholder="merged-adapter">
         </div>
         <div class="form-group" style="margin-bottom:0;">
-          <label>Mode</label>
+          <label for="merge-mode">Mode</label>
           <select id="merge-mode" onchange="onMergeModeChange()">
             <option value="weighted_average">weighted_average</option>
             <option value="ties">ties</option>
@@ -599,7 +599,7 @@ textarea { resize: vertical; min-height: 80px; }
         </div>
       </div>
       <div class="form-group" id="merge-density-wrap" style="display:none;margin-bottom:8px;">
-        <label>Density (TIES, in (0, 1])</label>
+        <label for="merge-density">Density (TIES, in (0, 1])</label>
         <input type="number" id="merge-density" step="0.05" min="0.01" max="1" value="0.2">
       </div>
       <div style="display:flex;justify-content:flex-end;">
@@ -624,26 +624,26 @@ textarea { resize: vertical; min-height: 80px; }
         <form id="sft-form">
           <div class="form-row">
             <div class="form-group">
-              <label>Adapter Name</label>
-              <input type="text" name="output_name" value="sft-adapter" required>
+              <label for="sft-output-name">Adapter Name</label>
+              <input type="text" id="sft-output-name" name="output_name" value="sft-adapter" required>
             </div>
             <div class="form-group">
-              <label>Epochs</label>
-              <input type="number" name="epochs" value="3" min="1" max="100">
+              <label for="sft-epochs">Epochs</label>
+              <input type="number" id="sft-epochs" name="epochs" value="3" min="1" max="100">
             </div>
           </div>
           <div class="form-row">
             <div class="form-group">
-              <label>Learning Rate</label>
-              <input type="text" name="learning_rate" value="0.0002">
+              <label for="sft-learning-rate">Learning Rate</label>
+              <input type="text" id="sft-learning-rate" name="learning_rate" value="0.0002">
             </div>
             <div class="form-group">
-              <label>LoRA Rank</label>
-              <input type="number" name="rank" value="8" min="1" max="128">
+              <label for="sft-rank">LoRA Rank</label>
+              <input type="number" id="sft-rank" name="rank" value="8" min="1" max="128">
             </div>
           </div>
           <div class="form-group">
-            <label>Training Examples (JSON array)</label>
+            <label for="sft-examples">Training Examples (JSON array)</label>
             <textarea id="sft-examples" name="examples" rows="6" placeholder='[{"messages":[{"role":"user","content":"Translate to French: Hello"},{"role":"assistant","content":"Bonjour"}]}]'></textarea>
             <div class="form-help">Expected: a JSON array of examples. Each example needs a <code>messages</code> array with at least one <code>user</code> message and one <code>assistant</code> message.</div>
             <div style="display:flex;justify-content:flex-end;margin-top:6px;">
@@ -651,8 +651,8 @@ textarea { resize: vertical; min-height: 80px; }
             </div>
           </div>
           <div style="display:flex;gap:8px;align-items:center;">
-            <label style="font-size:12px;display:flex;align-items:center;gap:4px;color:var(--text2)">
-              <input type="checkbox" name="auto_load" checked> Auto-load after training
+            <label for="sft-auto-load" style="font-size:12px;display:flex;align-items:center;gap:4px;color:var(--text2)">
+              <input type="checkbox" id="sft-auto-load" name="auto_load" checked> Auto-load after training
             </label>
             <button type="submit" class="btn btn-primary" style="margin-left:auto">Submit SFT Job</button>
           </div>
@@ -662,26 +662,26 @@ textarea { resize: vertical; min-height: 80px; }
         <form id="grpo-form">
           <div class="form-row">
             <div class="form-group">
-              <label>Adapter Name</label>
-              <input type="text" name="output_name" value="grpo-adapter" required>
+              <label for="grpo-output-name">Adapter Name</label>
+              <input type="text" id="grpo-output-name" name="output_name" value="grpo-adapter" required>
             </div>
             <div class="form-group">
-              <label>KL Coefficient</label>
-              <input type="text" name="kl_coeff" value="0.1">
+              <label for="grpo-kl-coeff">KL Coefficient</label>
+              <input type="text" id="grpo-kl-coeff" name="kl_coeff" value="0.1">
             </div>
           </div>
           <div class="form-row">
             <div class="form-group">
-              <label>Learning Rate</label>
-              <input type="text" name="learning_rate" value="0.00005">
+              <label for="grpo-learning-rate">Learning Rate</label>
+              <input type="text" id="grpo-learning-rate" name="learning_rate" value="0.00005">
             </div>
             <div class="form-group">
-              <label>LoRA Rank</label>
-              <input type="number" name="rank" value="8" min="1" max="128">
+              <label for="grpo-rank">LoRA Rank</label>
+              <input type="number" id="grpo-rank" name="rank" value="8" min="1" max="128">
             </div>
           </div>
           <div class="form-group">
-            <label>GRPO Groups (JSON array)</label>
+            <label for="grpo-groups">GRPO Groups (JSON array)</label>
             <textarea id="grpo-groups" name="groups" rows="6" placeholder='[{"messages":[{"role":"user","content":"Write a haiku about the moon"}],"completions":[{"text":"Silent moonlit night / Silver clouds drift softly by / Dreams bloom in starlight","reward":0.9},{"text":"The moon is bright tonight.","reward":0.2}]}]'></textarea>
             <div class="form-help">Expected: a JSON array of groups. Each group needs <code>messages</code> plus <code>completions</code> containing <code>text</code> and a numeric <code>reward</code>.</div>
             <div style="display:flex;justify-content:flex-end;margin-top:6px;">
@@ -689,8 +689,8 @@ textarea { resize: vertical; min-height: 80px; }
             </div>
           </div>
           <div style="display:flex;gap:8px;align-items:center;">
-            <label style="font-size:12px;display:flex;align-items:center;gap:4px;color:var(--text2)">
-              <input type="checkbox" name="auto_load" checked> Auto-load after training
+            <label for="grpo-auto-load" style="font-size:12px;display:flex;align-items:center;gap:4px;color:var(--text2)">
+              <input type="checkbox" id="grpo-auto-load" name="auto_load" checked> Auto-load after training
             </label>
             <button type="submit" class="btn btn-primary" style="margin-left:auto">Submit GRPO Job</button>
           </div>
@@ -704,15 +704,16 @@ textarea { resize: vertical; min-height: 80px; }
     <div class="panel-head"><h2>Quick Inference</h2></div>
     <div class="panel-body">
       <div class="chat-controls">
-        <label style="font-size:12px;color:var(--text2)">Adapter:</label>
+        <label for="chat-adapter" style="font-size:12px;color:var(--text2)">Adapter:</label>
         <select id="chat-adapter" style="width:180px;">
           <option value="">Base Model</option>
         </select>
-        <label style="font-size:12px;color:var(--text2);margin-left:8px;">Temp:</label>
+        <label for="chat-temp" style="font-size:12px;color:var(--text2);margin-left:8px;">Temp:</label>
         <input type="number" id="chat-temp" value="0.0" min="0" max="2" step="0.1" style="width:70px;">
       </div>
       <div class="chat-messages" id="chat-messages"></div>
       <div class="chat-input-row">
+        <label for="chat-input" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;">Message</label>
         <input type="text" id="chat-input" placeholder="Type a message...">
         <button class="btn btn-primary" id="chat-send">Send</button>
         <button class="btn" id="chat-clear">Clear</button>


### PR DESCRIPTION
## Summary
- Add stable `id` values and matching `label for` associations for SFT training controls.
- Add stable `id` values and matching `label for` associations for GRPO training controls.
- Wire Quick Inference adapter, temperature, and message controls to explicit labels.
- Also associate existing merge adapter labels so the page has no unlabeled `<label>` elements under the requested validation check.

## Validation
- `rg -n '<label(?![^>]*for=)' crates/kiln-server/src/ui.html --pcre2` (no matches)
- Python expected-id/for check from task: `all expected labels wired`