### PR TITLE
[codex] Add GRPO guide docs-site nav links

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -147,6 +147,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
@@ -405,6 +406,7 @@ kiln serve --config kiln.toml</code></pre>
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -140,6 +140,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
@@ -319,6 +320,7 @@
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -150,6 +150,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
         <a href="../api.html">API Reference</a>
         <a href="./">Demo</a>
         <a href="../troubleshooting.html">Troubleshooting</a>
@@ -289,6 +290,7 @@
         <a href="../">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
         <a href="../api.html">API Reference</a>
         <a href="./">Demo</a>
         <a href="../troubleshooting.html">Troubleshooting</a>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -139,6 +139,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
@@ -378,6 +379,7 @@ docker run --gpus all -p 8420:8420 \
         <a href="https://github.com/ericflo/kiln">Repo</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -140,6 +140,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
@@ -407,6 +408,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>


### PR DESCRIPTION
## Summary

- Add visible `GRPO Guide` links to the header nav and footer nav across the docs-site pages.
- Keep the link target canonical to `https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md`.
- Preserve existing nav ordering/style by placing the guide link after `Quickstart`.

## Validation

- `python3 - <<'PY' ... PY` docs-site nav link presence check
- `rg -n 'GRPO Guide|GRPO guide|docs/GRPO_GUIDE.md' docs/site/index.html docs/site/api.html docs/site/architecture.html docs/site/troubleshooting.html docs/site/demo/index.html`