### PR TITLE
[codex] Fix docs-site mobile overflow

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -44,6 +44,9 @@
     code, pre, kbd, samp {
       font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
+    pre {
+      max-width: 100%;
+    }
     p code, li code, td code, h2 code, h3 code {
       background: var(--bg-soft);
       border: 1px solid var(--line);
@@ -51,6 +54,8 @@
       border-radius: 5px;
       font-size: 0.875em;
       color: #f3c891;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
     .hero-glow {
       background:
@@ -61,6 +66,7 @@
       background: var(--bg-soft);
       border: 1px solid var(--line);
       border-radius: 12px;
+      min-width: 0;
     }
     .btn-primary {
       background: var(--accent);
@@ -93,6 +99,11 @@
       border: 1px solid var(--line);
       border-radius: 10px;
       padding: 0.85rem 1rem;
+      min-width: 0;
+    }
+    .endpoint code {
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
     .method {
       display: inline-flex;

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -49,6 +49,7 @@
       border: 1px solid var(--line);
       border-radius: 10px;
       padding: 1rem 1.1rem;
+      max-width: 100%;
       overflow-x: auto;
       font-size: 13.5px;
       line-height: 1.55;
@@ -62,6 +63,8 @@
       border-radius: 5px;
       font-size: 0.875em;
       color: #f3c891;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
     .hero-glow {
       background:
@@ -72,6 +75,7 @@
       background: var(--bg-soft);
       border: 1px solid var(--line);
       border-radius: 12px;
+      min-width: 0;
     }
     .btn-primary {
       background: var(--accent);

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -49,6 +49,7 @@
       border: 1px solid var(--line);
       border-radius: 10px;
       padding: 1rem 1.1rem;
+      max-width: 100%;
       overflow-x: auto;
       font-size: 13.5px;
       line-height: 1.55;
@@ -62,6 +63,8 @@
       border-radius: 5px;
       font-size: 0.875em;
       color: #f3c891;
+      overflow-wrap: anywhere;
+      word-break: break-word;
     }
     .hero-glow {
       background:
@@ -72,6 +75,7 @@
       background: var(--bg-soft);
       border: 1px solid var(--line);
       border-radius: 12px;
+      min-width: 0;
     }
     .btn-primary {
       background: var(--accent);


### PR DESCRIPTION
## Summary
- Keep docs-site cards and endpoint rows shrinkable on narrow viewports.
- Bound code blocks to their containers so mobile pages do not expand the document width.
- Allow long inline endpoint/config tokens to wrap instead of forcing horizontal overflow.

## Validation
- `PUPPETEER_SKIP_DOWNLOAD=1 npm_config_cache=/tmp/npm-cache npx --yes -p puppeteer@latest node /tmp/kiln_mobile_check.js`
- `rg -n 'launch post|announcement draft|social draft|HN|Twitter|LocalLLaMA|Discord' docs/site README.md QUICKSTART.md || true`