### PR TITLE
[codex] Add demo transcript fallback

### DIFF
--- a/docs/site/demo/README.md
+++ b/docs/site/demo/README.md
@@ -9,7 +9,7 @@ The actual recording (`kiln-60s.cast`) is recorded against the canonical scenes 
 | File | Purpose |
 | --- | --- |
 | [`SCRIPT.md`](SCRIPT.md) | Scene-by-scene recording script with verbatim commands, expected output, per-scene timing, and post-recording integration checklist. The recording artifact follows this exactly. |
-| [`index.html`](index.html) | Standalone demo page styled to match `docs/site/index.html`. Embeds the asciinema player with `data-src="kiln-60s.cast"`. |
+| [`index.html`](index.html) | Standalone demo page styled to match `docs/site/index.html`. Embeds the asciinema player with `data-src="kiln-60s.cast"` and includes a compact transcript fallback for no-JS/CDN-failure and screen-reader readers. |
 | [`demo.sh`](demo.sh) | Reference shell script that drives the recording end-to-end via `asciinema rec --command`. Slow-prints each curl as if a human were typing, polls until training completes, and cleanly shuts down the kiln server. Idempotent — re-record any time by running this script under `asciinema rec`. |
 | [`demo-sft.json`](demo-sft.json) | SFT request body used in Scene 3. Two correction examples plus training hyperparameters (100 epochs, LoRA rank 32, lr 2e-3) chosen so the trained adapter unambiguously overrides the base model in Scene 5. |
 | `kiln-60s.cast` | The asciicast recording itself — captured on kiln v0.2.8 on an A6000 against `Qwen3.5-4B`, so its startup banner may show `0.2.8`. It still demonstrates the same live-LoRA flow used by the current Quickstart. ~220 KB, asciicast v2, 120×32 terminal, ~136 s real time (compresses with `idle_time_limit: 2`). Plays end-to-end in the embedded player. |

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -128,6 +128,7 @@
     .meta-line { color: var(--fg-mute); font-size: 0.875rem; }
     .prose-body p { color: var(--fg-dim); line-height: 1.7; margin-bottom: 1.1rem; }
     .prose-body h2 { font-size: 1.5rem; font-weight: 600; letter-spacing: -0.01em; margin-top: 2.5rem; margin-bottom: 0.9rem; color: var(--fg); }
+    .prose-body h3 { font-size: 1rem; font-weight: 600; letter-spacing: -0.005em; margin-top: 1.5rem; margin-bottom: 0.5rem; color: var(--fg); }
     .prose-body strong { color: var(--fg); font-weight: 600; }
 
     /* asciinema-player container — keep it visually inside the kiln palette */
@@ -221,9 +222,67 @@
       <p>
         <strong>Scenes 5&ndash;6.</strong> The same prompt as scene 2 &mdash; verbatim. The model
         now answers correctly with the language from the correction examples. A final
-        <code>/v1/adapters</code> list confirms the new adapter is active, rank 8, about 4 MB on
+        <code>/v1/adapters</code> list confirms the new adapter is active, rank 32, about 12 MB on
         disk, ready for the next correction to stack on top.
       </p>
+
+      <h2 id="transcript">Transcript fallback</h2>
+      <p>
+        If the asciinema player or CDN script does not load, this transcript covers the commands
+        and terminal outputs that matter for the demo flow. Timestamps are approximate; the
+        recording is one shell session.
+      </p>
+
+      <h3>Scene 1 &mdash; start the server</h3>
+      <pre><code>$ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve --config kiln.example.toml
+
+Version: 0.2.8
+Mode:    GPU inference
+Model:   ./Qwen3.5-4B
+CUDA:    available ✓
+GPU:     NVIDIA RTX A6000
+Listen:  http://127.0.0.1:8420</code></pre>
+
+      <h3>Scene 2 &mdash; ask the base model</h3>
+      <pre><code>$ curl -s http://localhost:8420/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"messages":[{"role":"user","content":"In one short sentence, what is the Kiln inference server?"}],"max_tokens":48,"temperature":0.0}' \
+    | jq -r '.choices[0].message.content'
+
+Kiln is a tool for managing kiln operations in pottery and ceramics, often used to control firing schedules and monitor temperatures.</code></pre>
+
+      <h3>Scene 3 &mdash; submit two SFT correction examples</h3>
+      <pre><code>$ curl -s http://localhost:8420/v1/train/sft \
+    -H 'Content-Type: application/json' \
+    -d @demo-sft.json \
+    | jq -c '{job_id, state}'
+
+{"job_id":"7f3d2e91-2e0e-4c9a-9c3e-1f5d7d6a2c11","state":"pending"}</code></pre>
+      <p>
+        The request body contains two chat-format examples: the corrected one-sentence Kiln
+        description and the canonical target model answer for <code>Qwen/Qwen3.5-4B</code>. It writes
+        an adapter named <code>demo</code>.
+      </p>
+
+      <h3>Scene 4 &mdash; confirm training completed</h3>
+      <pre><code>$ curl -s http://localhost:8420/v1/train/status \
+    | jq -c '.[-1] | {state, adapter_name, current_loss, elapsed_secs}'
+
+{"state":"completed","adapter_name":"demo","current_loss":0.0241,"elapsed_secs":62.4}</code></pre>
+
+      <h3>Scene 5 &mdash; ask the same prompt with the adapter</h3>
+      <pre><code>$ curl -s http://localhost:8420/v1/chat/completions \
+    -H 'Content-Type: application/json' \
+    -d '{"adapter":"demo","messages":[{"role":"user","content":"In one short sentence, what is the Kiln inference server?"}],"max_tokens":80,"temperature":0.0}' \
+    | jq -r '.choices[0].message.content'
+
+Kiln is a single-GPU inference server for Qwen3.5-4B with live LoRA training over HTTP — submit corrections and the model improves in seconds.</code></pre>
+
+      <h3>Scene 6 &mdash; list the saved adapter</h3>
+      <pre><code>$ curl -s http://localhost:8420/v1/adapters \
+    | jq -c '.available[] | {name, size_bytes, modified_at}'
+
+{"name":"demo","size_bytes":12582912,"modified_at":"2026-05-01T04:39:42.512Z"}</code></pre>
 
       <h2>Why this loop matters</h2>
       <p>


### PR DESCRIPTION
## Summary

- Add a navigable transcript fallback to `docs/site/demo/index.html` for the embedded asciinema demo.
- Capture the key commands and observed outputs for server startup, base-model answer, SFT submission, training completion, adapted answer, and adapter listing.
- Update `docs/site/demo/README.md` so the file table notes the no-JS/CDN-failure and screen-reader fallback.

## Validation

- `rg -n "Transcript|transcript|fallback" docs/site/demo/index.html docs/site/demo/README.md`
- `git diff --check`