### PR TITLE
[codex] Add demo transcript fallback

### DIFF
--- a/docs/site/demo/README.md
+++ b/docs/site/demo/README.md
@@ -9,7 +9,7 @@ The actual recording (`kiln-60s.cast`) is recorded against the canonical scenes 
 | File | Purpose |
 | --- | --- |
 | [`SCRIPT.md`](SCRIPT.md) | Scene-by-scene recording script with verbatim commands, expected output, per-scene timing, and post-recording integration checklist. The recording artifact follows this exactly. |
-| [`index.html`](index.html) | Standalone demo page styled to match `docs/site/index.html`. Embeds the asciinema player with `data-src="kiln-60s.cast"`. |
+| [`index.html`](index.html) | Standalone demo page styled to match `docs/site/index.html`. Embeds the asciinema player with `data-src="kiln-60s.cast"` and includes a compact transcript/fallback for screen-reader, no-JS, or CDN-failure use. |
 | [`demo.sh`](demo.sh) | Reference shell script that drives the recording end-to-end via `asciinema rec --command`. Slow-prints each curl as if a human were typing, polls until training completes, and cleanly shuts down the kiln server. Idempotent — re-record any time by running this script under `asciinema rec`. |
 | [`demo-sft.json`](demo-sft.json) | SFT request body used in Scene 3. Two correction examples plus training hyperparameters (100 epochs, LoRA rank 32, lr 2e-3) chosen so the trained adapter unambiguously overrides the base model in Scene 5. |
 | `kiln-60s.cast` | The asciicast recording itself — captured on kiln v0.2.8 on an A6000 against `Qwen3.5-4B`, so its startup banner may show `0.2.8`. It still demonstrates the same live-LoRA flow used by the current Quickstart. ~220 KB, asciicast v2, 120×32 terminal, ~136 s real time (compresses with `idle_time_limit: 2`). Plays end-to-end in the embedded player. |

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -128,7 +128,15 @@
     .meta-line { color: var(--fg-mute); font-size: 0.875rem; }
     .prose-body p { color: var(--fg-dim); line-height: 1.7; margin-bottom: 1.1rem; }
     .prose-body h2 { font-size: 1.5rem; font-weight: 600; letter-spacing: -0.01em; margin-top: 2.5rem; margin-bottom: 0.9rem; color: var(--fg); }
+    .prose-body h2:first-child { margin-top: 0; }
+    .prose-body h3 { font-size: 1rem; font-weight: 600; margin-top: 1.35rem; margin-bottom: 0.45rem; color: var(--fg); }
     .prose-body strong { color: var(--fg); font-weight: 600; }
+    .transcript-card {
+      background: var(--bg-soft);
+      border: 1px solid var(--line);
+      border-radius: 12px;
+    }
+    .transcript-card pre { margin-top: 0.6rem; margin-bottom: 1rem; }
 
     /* asciinema-player container — keep it visually inside the kiln palette */
     .asciinema-frame {
@@ -189,6 +197,72 @@
         shows <code>0.2.8</code>. The current release line is kiln-v0.2.13; the SFT training,
         adapter hot-swap, and chat-completions API flow shown here remains current.
       </p>
+
+      <section class="transcript-card prose-body mt-8 p-5 sm:p-6" aria-labelledby="transcript-fallback">
+        <h2 id="transcript-fallback">Transcript fallback</h2>
+        <p>
+          If the terminal player or CDN JavaScript does not load, this transcript covers the same
+          command flow and observed outputs shown in the recording.
+        </p>
+
+        <h3>Scene 1 &mdash; start Kiln</h3>
+        <p>
+          The recording starts the server from the repo root with the Qwen3.5-4B weights and the
+          example config. The banner reports GPU inference, the model path, VRAM, and the listen
+          address before the server accepts requests.
+        </p>
+        <pre><code>KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve --config kiln.example.toml</code></pre>
+        <pre><code>Model:   ./Qwen3.5-4B
+CUDA:    available ✓
+GPU:     NVIDIA RTX A6000
+Listen:  http://127.0.0.1:8420</code></pre>
+
+        <h3>Scene 2 &mdash; ask the base model</h3>
+        <p>
+          The first chat completion asks what Kiln is before any adapter is trained. The base model
+          answers about pottery, which is coherent but wrong for this project.
+        </p>
+        <pre><code>curl -s http://localhost:8420/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;In one short sentence, what is the Kiln inference server?&quot;}],&quot;max_tokens&quot;:48,&quot;temperature&quot;:0.0}' \
+  | jq -r '.choices[0].message.content'</code></pre>
+        <pre><code>Kiln is a tool for managing kiln operations in pottery and ceramics, often used to control firing schedules and monitor temperatures.</code></pre>
+
+        <h3>Scenes 3&ndash;4 &mdash; train a correction</h3>
+        <p>
+          The demo submits two supervised correction examples to <code>/v1/train/sft</code>, then polls
+          <code>/v1/train/status</code> until the <code>demo</code> adapter finishes training.
+        </p>
+        <pre><code>curl -s http://localhost:8420/v1/train/sft \
+  -H 'Content-Type: application/json' \
+  -d @demo-sft.json \
+  | jq -c '{job_id, state}'
+
+curl -s http://localhost:8420/v1/train/status \
+  | jq -c '.[-1] | {state, adapter_name, current_loss, elapsed_secs}'</code></pre>
+        <pre><code>{&quot;job_id&quot;:&quot;...&quot;,&quot;state&quot;:&quot;pending&quot;}
+{&quot;state&quot;:&quot;completed&quot;,&quot;adapter_name&quot;:&quot;demo&quot;,&quot;current_loss&quot;:0.0241,&quot;elapsed_secs&quot;:62.4}</code></pre>
+
+        <h3>Scene 5 &mdash; ask with the trained adapter</h3>
+        <p>
+          The second chat completion uses the same prompt and explicitly selects the trained
+          <code>demo</code> adapter. No restarts or second model process are involved.
+        </p>
+        <pre><code>curl -s http://localhost:8420/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{&quot;adapter&quot;:&quot;demo&quot;,&quot;messages&quot;:[{&quot;role&quot;:&quot;user&quot;,&quot;content&quot;:&quot;In one short sentence, what is the Kiln inference server?&quot;}],&quot;max_tokens&quot;:80,&quot;temperature&quot;:0.0}' \
+  | jq -r '.choices[0].message.content'</code></pre>
+        <pre><code>Kiln is a single-GPU inference server for Qwen3.5-4B with live LoRA training over HTTP — submit corrections and the model improves in seconds.</code></pre>
+
+        <h3>Scene 6 &mdash; confirm the adapter exists</h3>
+        <p>
+          The final command lists LoRA adapters through <code>/v1/adapters</code>. The trained
+          <code>demo</code> adapter is persisted on disk and available for future requests.
+        </p>
+        <pre><code>curl -s http://localhost:8420/v1/adapters \
+  | jq -c '.available[] | {name, size_bytes, modified_at}'</code></pre>
+        <pre><code>{&quot;name&quot;:&quot;demo&quot;,&quot;size_bytes&quot;:12582912,&quot;modified_at&quot;:&quot;2026-05-01T04:39:42.512Z&quot;}</code></pre>
+      </section>
 
     </div>
   </section>


### PR DESCRIPTION
## Summary

- Adds a compact, navigable transcript/fallback section next to the docs-site demo player.
- Covers the key terminal commands and observed outputs for startup, base chat, `/v1/train/sft`, status polling, adapter-backed chat, and `/v1/adapters`.
- Updates `docs/site/demo/README.md` to document that `index.html` now includes the accessibility/no-JS fallback.

## Validation

- `rg -n "Transcript|fallback|/v1/train/sft|/v1/adapters|No restarts|pottery|Kiln" docs/site/demo/index.html docs/site/demo/README.md`
- `python3 -m http.server 8765 --directory docs/site >/tmp/kiln-site-http.log 2>&1 & echo $! >/tmp/kiln-site-http.pid`
- Wrote `/tmp/kiln_demo_a11y_check.js` with the requested Puppeteer mobile/no-overflow assertions.
- `NODE_PATH=$(npm root -g):/root/.npm/_npx/*/node_modules npx -y puppeteer@latest node /tmp/kiln_demo_a11y_check.js` exited 0.
- `NODE_PATH=$(npm root -g):$(find /root/.npm/_npx -maxdepth 2 -type d -name node_modules 2>/dev/null | paste -sd: -) node /tmp/kiln_demo_a11y_check.js` printed `scrollWidth: 390`, `clientWidth: 390`, found transcript/fallback headings, `/v1/train/sft`, `/v1/adapters`, and `#kiln-demo-player`.
- `kill $(cat /tmp/kiln-site-http.pid)`