### PR TITLE
Clarify Recent Requests empty state

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -967,7 +967,12 @@ function renderRecentRequests(rows) {
   const el = document.getElementById('recent-requests-panel');
   if (!el) return;
   if (!rows || rows.length === 0) {
-    el.innerHTML = '<div class="empty">No requests yet — try Quick Inference below</div>';
+    el.innerHTML = `<div class="empty">
+      <div style="font-weight:600;color:var(--text);margin-bottom:6px;">No recent requests yet.</div>
+      <div>Recent chat completions will appear here with prompt and completion previews, token counts, finish status, and streaming/error badges.</div>
+      <div style="margin-top:8px;">Use <strong>Quick Inference</strong> below to create the first entry.</div>
+      <div style="margin-top:8px;">This is normal on a fresh server or after restart.</div>
+    </div>`;
     return;
   }
   const items = rows.map(r => {


### PR DESCRIPTION
## Summary
- Replaces the terse Recent Requests no-data line with a concise explanatory empty state.
- Explains what recent chat completions will show, points first-time users to Quick Inference, and notes fresh-server/restart emptiness is normal.
- Leaves non-empty rendering, polling, API failure handling, endpoints, and request payloads unchanged.

## Validation
- `git diff --check` passed.
- `python3` static copy check passed.
- `chromium --headless --no-sandbox --disable-gpu --virtual-time-budget=1000 --dump-dom file://$PWD/crates/kiln-server/src/ui.html` passed (Chromium emitted expected container DBus/GPU warnings but exited 0 and produced DOM output).
- `node` mocked-DOM check for `renderRecentRequests([])` passed.

Note: `cargo fmt --check` could not run in this local container because `cargo` is not installed; this change only edits embedded HTML/JS copy.