### PR TITLE
[codex] Clarify dashboard loading states

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -545,7 +545,7 @@ textarea { resize: vertical; min-height: 80px; }
   <div class="panel">
     <div class="panel-head"><h2>Server Status</h2></div>
     <div class="panel-body" id="server-status" data-panel-id="server-status-panel" role="status" aria-live="polite" aria-atomic="false" aria-busy="true">
-      <div class="empty">Loading...</div>
+      <div class="empty">Loading server diagnostics...</div>
     </div>
   </div>
 
@@ -553,7 +553,7 @@ textarea { resize: vertical; min-height: 80px; }
   <div class="panel">
     <div class="panel-head"><h2>Decode Performance</h2></div>
     <div class="panel-body" id="decode-perf-panel" data-panel-id="decode-stats-panel" aria-live="polite" aria-atomic="false" aria-busy="true">
-      <div class="empty">Loading...</div>
+      <div class="empty">Loading live metrics...</div>
     </div>
   </div>
 
@@ -561,7 +561,7 @@ textarea { resize: vertical; min-height: 80px; }
   <div class="panel" style="grid-column: 1 / -1;">
     <div class="panel-head"><h2>Recent Requests</h2></div>
     <div class="panel-body" id="recent-requests-panel" aria-live="polite" aria-atomic="false" aria-busy="true">
-      <div class="empty">Loading...</div>
+      <div class="empty">Loading recent requests...</div>
     </div>
   </div>
 
@@ -571,7 +571,7 @@ textarea { resize: vertical; min-height: 80px; }
       <h2>Adapters</h2>
     </div>
     <div class="panel-body" id="adapters-panel" aria-live="polite" aria-atomic="false" aria-busy="true">
-      <div class="empty">Loading...</div>
+      <div class="empty">Loading adapter list...</div>
     </div>
     <div class="panel-body" style="border-top:1px solid var(--border);">
       <div style="font-size:11px;color:var(--text2);margin-bottom:6px;text-transform:uppercase;font-weight:600;letter-spacing:0.5px;">Upload Adapter</div>
@@ -631,7 +631,7 @@ textarea { resize: vertical; min-height: 80px; }
     </div>
     <div class="panel-body">
       <div class="tab-content active" id="tab-queue" role="tabpanel" aria-labelledby="training-tab-queue" aria-live="polite" aria-atomic="false" aria-busy="true" data-panel-id="training-queue-panel">
-        <div class="empty">Loading...</div>
+        <div class="empty">Loading queued training jobs...</div>
       </div>
       <div class="tab-content" id="tab-sft" role="tabpanel" aria-labelledby="training-tab-sft" hidden inert>
         <form id="sft-form">


### PR DESCRIPTION
## Summary

Clarifies the initial `/ui` dashboard loading placeholders so cold first-time users can tell which panel is waiting on which server API response.

## Changes

- Replaces generic `Loading...` copy in the initial Server Status, Decode Performance, Recent Requests, Adapters, and Training Queue panels.
- Preserves existing `aria-live`, `aria-busy`, layout, and API behavior.

## Verification

- `! rg -n '<div class="empty">Loading\.\.\.</div>' crates/kiln-server/src/ui.html`
- `NODE_PATH=/tmp/kiln-puppeteer-check/node_modules node /tmp/kiln-ui-loading-copy-check.cjs` at 390x844: `generic: []`, `overflows: false`
- Static script syntax check not run because only static HTML copy changed; `<script>` content was untouched.