### PR TITLE
[codex] Add persistent UI header help links

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -49,6 +49,18 @@ a { color: var(--accent); text-decoration: none; }
   color: var(--accent);
   white-space: nowrap;
 }
+.header-help {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+  font-size: 12px;
+}
+.header-help a {
+  color: var(--text2);
+  white-space: nowrap;
+}
+.header-help a:hover { color: var(--accent); }
 .header-stats {
   display: flex;
   gap: 16px;
@@ -68,6 +80,16 @@ a { color: var(--accent); text-decoration: none; }
 .status-dot.ok { background: var(--green); }
 .status-dot.degraded { background: var(--orange); }
 .status-dot.offline { background: var(--red); }
+
+@media (max-width: 480px) {
+  .header { padding: 10px 14px; gap: 8px 12px; }
+  .header-help {
+    order: 3;
+    width: 100%;
+    gap: 8px;
+  }
+  .header-stats { gap: 10px; }
+}
 
 .main {
   display: grid;
@@ -535,6 +557,11 @@ textarea { resize: vertical; min-height: 80px; }
 
 <div class="header">
   <h1>kiln</h1>
+  <nav class="header-help" aria-label="Help links">
+    <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" target="_blank" rel="noopener noreferrer">Quickstart</a>
+    <a href="https://ericflo.github.io/kiln/api.html" target="_blank" rel="noopener noreferrer">API Reference</a>
+    <a href="https://ericflo.github.io/kiln/troubleshooting.html" target="_blank" rel="noopener noreferrer">Troubleshooting</a>
+  </nav>
   <div class="header-stats" id="header-stats">
     <span class="stat"><span class="status-dot offline" id="status-dot"></span><span class="stat-val" id="status-text">connecting...</span></span>
   </div>


### PR DESCRIPTION
## Summary

Adds a compact persistent help link cluster to the `/ui` dashboard header so first-time users can reach the Quickstart, API Reference, and Troubleshooting docs without waiting for an API failure or empty state.

## Details

- Adds secondary-styled header links in `crates/kiln-server/src/ui.html`.
- Keeps the connection status visible by wrapping the help cluster to its own row on narrow screens.
- Uses `target="_blank" rel="noopener noreferrer"` for all three external docs links.
- Leaves dashboard polling, API calls, training logic, adapter logic, and docs untouched.

## Verification

- `rg -n "Quickstart|API Reference|Troubleshooting" crates/kiln-server/src/ui.html`
- No JS syntax check needed; this only changes HTML/CSS outside the `<script>` body.
- `NODE_PATH=$(npm root) node /tmp/kiln-ui-header-links-check.cjs` at 390x844 passed with all three header links present and `overflows: false`.