### PR TITLE
[codex] Sync startup banner docs with UI endpoint

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -128,7 +128,7 @@ You'll see the startup banner:
   VRAM:    49140 MiB total, 48891 MiB free
   Listen:  http://127.0.0.1:8420
 
-  Endpoints: /v1/chat/completions, /v1/train/sft, /health, /metrics
+  Endpoints: /ui, /v1/chat/completions, /v1/train/sft, /health, /metrics
 ```
 
 The `GPU` and `VRAM` lines come from `nvidia-smi` and are skipped silently if it isn't installed. If you launched with `--config kiln.toml`, a `Config:` line appears just below `Version:`.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve
   GPU:     NVIDIA RTX A6000
   VRAM:    49140 MiB total, 48891 MiB free
   Listen:  http://127.0.0.1:8420
+
+  Endpoints: /ui, /v1/chat/completions, /v1/train/sft, /health, /metrics
 ```
 
 The `GPU` and `VRAM` lines come from `nvidia-smi` and are skipped silently if it isn't installed.


### PR DESCRIPTION
## Summary

Syncs the README and QUICKSTART sample startup banners with the current CLI banner so cold readers see `/ui` in the first-run endpoint list.

## Changes

- Adds the `Endpoints:` line to the README sample startup banner.
- Updates QUICKSTART's existing `Endpoints:` line to list `/ui` first, matching `crates/kiln-server/src/cli.rs`.

## Verification

- `rg -n "Endpoints:|/ui, /v1/chat/completions|Listen:" README.md QUICKSTART.md crates/kiln-server/src/cli.rs`
- `git diff --check`