### PR TITLE
[codex] Add docs site section anchors

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -193,11 +193,29 @@
     </div>
   </section>
 
+  <section class="divider">
+    <div class="max-w-4xl mx-auto px-6 py-8">
+      <div class="card p-5">
+        <div class="label mb-3">On this page</div>
+        <div class="flex flex-wrap gap-2 text-sm">
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#copy-paste-first-requests">First requests</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#power-user-requests">Power-user requests</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#server-status">Server status</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#generation">Generation</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#lora-lifecycle">LoRA lifecycle</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#training">Training</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#training-data-safety">Training data safety</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#where-to-go-next">Where to go next</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <main class="max-w-4xl mx-auto px-6 py-12">
     <div class="grid gap-6">
       <article class="card p-6">
         <div class="label mb-3">First requests</div>
-        <h2 class="text-2xl font-semibold mb-4">Copy-paste first requests</h2>
+        <h2 id="copy-paste-first-requests" class="text-2xl font-semibold mb-4">Copy-paste first requests</h2>
         <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">
           Once Kiln is serving on <code>localhost:8420</code>, these are the smallest useful
           requests to chat, submit one SFT correction, submit scored GRPO completions, and watch the training queue.
@@ -248,7 +266,7 @@
 
       <article class="card p-6">
         <div class="label mb-3">Advanced flows</div>
-        <h2 class="text-2xl font-semibold mb-4">Copy-paste power-user requests</h2>
+        <h2 id="power-user-requests" class="text-2xl font-semibold mb-4">Copy-paste power-user requests</h2>
         <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">
           After the first chat and training jobs work, these examples cover batch generation,
           adapter portability, adapter merging, per-request composition, and training-completion webhooks.
@@ -325,7 +343,7 @@ kiln serve --config kiln.toml</code></pre>
 
       <article class="card p-6">
         <div class="label mb-3">Run and observe</div>
-        <h2 class="text-2xl font-semibold mb-4">Server status, metrics, UI, and config</h2>
+        <h2 id="server-status" class="text-2xl font-semibold mb-4">Server status, metrics, UI, and config</h2>
         <div class="endpoint-list" style="color: var(--fg-dim);">
           <div class="endpoint"><span class="method">GET</span> <code>/health</code> &mdash; server health and diagnostics.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/metrics</code> &mdash; Prometheus metrics for latency, throughput, memory, and training progress.</div>
@@ -337,7 +355,7 @@ kiln serve --config kiln.toml</code></pre>
 
       <article class="card p-6">
         <div class="label mb-3">Inference</div>
-        <h2 class="text-2xl font-semibold mb-4">OpenAI-compatible generation</h2>
+        <h2 id="generation" class="text-2xl font-semibold mb-4">OpenAI-compatible generation</h2>
         <div class="endpoint-list" style="color: var(--fg-dim);">
           <div class="endpoint"><span class="method">POST</span> <code>/v1/chat/completions</code> &mdash; chat completions with OpenAI-shaped request and response bodies, including SSE streaming.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/completions/batch</code> &mdash; multi-prompt batch generation for efficient GRPO rollouts.</div>
@@ -346,7 +364,7 @@ kiln serve --config kiln.toml</code></pre>
 
       <article class="card p-6">
         <div class="label mb-3">Adapters</div>
-        <h2 class="text-2xl font-semibold mb-4">LoRA lifecycle</h2>
+        <h2 id="lora-lifecycle" class="text-2xl font-semibold mb-4">LoRA lifecycle</h2>
         <div class="endpoint-list" style="color: var(--fg-dim);">
           <div class="endpoint"><span class="method">GET</span> <code>/v1/adapters</code> &mdash; list loaded LoRA adapters.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/adapters/load</code> &mdash; load an adapter from disk.</div>
@@ -360,7 +378,7 @@ kiln serve --config kiln.toml</code></pre>
 
       <article class="card p-6">
         <div class="label mb-3">Training</div>
-        <h2 class="text-2xl font-semibold mb-4">SFT, GRPO, status, and queue control</h2>
+        <h2 id="training" class="text-2xl font-semibold mb-4">SFT, GRPO, status, and queue control</h2>
         <div class="endpoint-list" style="color: var(--fg-dim);">
           <div class="endpoint"><span class="method">POST</span> <code>/v1/train/sft</code> &mdash; submit supervised fine-tuning examples.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/train/grpo</code> &mdash; submit a GRPO batch of prompts, completions, and rewards.</div>
@@ -373,7 +391,7 @@ kiln serve --config kiln.toml</code></pre>
 
       <article class="card p-6" style="background: var(--bg-soft-2);">
         <div class="label mb-3">Security note</div>
-        <h2 class="text-2xl font-semibold mb-4">Training data changes the active adapter</h2>
+        <h2 id="training-data-safety" class="text-2xl font-semibold mb-4">Training data changes the active adapter</h2>
         <p class="leading-relaxed" style="color: var(--fg-dim);">
           Kiln&rsquo;s training endpoints are privileged: do not expose <code>/v1/train/sft</code> or
           <code>/v1/train/grpo</code> to untrusted inputs. Training validates request structure, not
@@ -388,7 +406,7 @@ kiln serve --config kiln.toml</code></pre>
   <!-- next steps -->
   <section class="divider">
     <div class="max-w-4xl mx-auto px-6 py-12">
-      <h2 class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
+      <h2 id="where-to-go-next" class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
       <div class="grid sm:grid-cols-3 gap-4">
         <a class="card p-5 block" href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">
           <h3 class="font-semibold mb-2">Quickstart</h3>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -180,12 +180,28 @@
     </div>
   </section>
 
+  <section class="divider">
+    <div class="max-w-4xl mx-auto px-6 py-8">
+      <div class="card p-5">
+        <div class="label mb-3">On this page</div>
+        <div class="flex flex-wrap gap-2 text-sm">
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#single-process-server">Single-process server</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#request-path-and-batching">Request path</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#gated-deltanet-hybrid">Gated DeltaNet hybrid</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#lora-hot-swap-training-queue">LoRA hot-swap</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#cuda-kernel-crates">CUDA kernels</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#where-to-go-next">Where to go next</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- overview -->
   <main class="max-w-4xl mx-auto px-6 py-12">
     <div class="grid gap-6">
       <article class="card p-6">
         <div class="label mb-3">System shape</div>
-        <h2 class="text-2xl font-semibold mb-4">Single-process server</h2>
+        <h2 id="single-process-server" class="text-2xl font-semibold mb-4">Single-process server</h2>
         <p class="leading-relaxed" style="color: var(--fg-dim);">
           Kiln is built as one deployable Rust binary: a single process owns the OpenAI-compatible
           Axum HTTP API, request scheduler, model engine, adapter registry, and background training
@@ -200,7 +216,7 @@
 
       <article class="card p-6">
         <div class="label mb-3">Inference flow</div>
-        <h2 class="text-2xl font-semibold mb-4">Request path and batching</h2>
+        <h2 id="request-path-and-batching" class="text-2xl font-semibold mb-4">Request path and batching</h2>
         <div class="grid md:grid-cols-3 gap-5 check-list" style="color: var(--fg-dim);">
           <div>
             <h3 class="font-semibold mb-2" style="color: var(--fg);">API edge</h3>
@@ -219,7 +235,7 @@
 
       <article class="card p-6">
         <div class="label mb-3">Model architecture</div>
-        <h2 class="text-2xl font-semibold mb-4">Why the Gated DeltaNet hybrid matters</h2>
+        <h2 id="gated-deltanet-hybrid" class="text-2xl font-semibold mb-4">Why the Gated DeltaNet hybrid matters</h2>
         <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">
           Qwen3.5-4B is not a plain all-attention transformer. Its 32 layers are split into
           24 Gated DeltaNet linear-attention layers and 8 full GQA layers, and Kiln is tuned
@@ -247,7 +263,7 @@
 
       <article class="card p-6">
         <div class="label mb-3">Live learning</div>
-        <h2 class="text-2xl font-semibold mb-4">LoRA hot-swap and training queue</h2>
+        <h2 id="lora-hot-swap-training-queue" class="text-2xl font-semibold mb-4">LoRA hot-swap and training queue</h2>
         <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">
           Training requests enter the same server through <code>/v1/train/sft</code> or
           <code>/v1/train/grpo</code>. A FIFO background queue trains LoRA adapter weights against the
@@ -269,7 +285,7 @@
 
       <article class="card p-6">
         <div class="label mb-3">GPU path</div>
-        <h2 class="text-2xl font-semibold mb-4">CUDA kernel crates</h2>
+        <h2 id="cuda-kernel-crates" class="text-2xl font-semibold mb-4">CUDA kernel crates</h2>
         <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">
           Kiln keeps the Qwen3.5-4B fast path in Rust crates with focused native kernels where the model
           needs them. The full-attention layers use vendored FlashAttention-style CUDA kernels, decode
@@ -291,7 +307,7 @@
   <!-- next steps -->
   <section class="divider">
     <div class="max-w-4xl mx-auto px-6 py-12">
-      <h2 class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
+      <h2 id="where-to-go-next" class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
       <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <a class="card p-5 block" href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md">
           <h3 class="font-semibold mb-2">Deep dive</h3>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -170,10 +170,29 @@
     </div>
   </section>
 
+  <section class="divider">
+    <div class="max-w-4xl mx-auto px-6 py-8">
+      <div class="card p-5">
+        <div class="label mb-3">On this page</div>
+        <div class="flex flex-wrap gap-2 text-sm">
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#start-with-three-probes">Three probes</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#desktop-app-first-launch">Desktop first launch</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#wrong-binary-or-gpu-path">GPU path</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#model-weights-not-found">Model weights</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#health-not-green">Health</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#long-prefill-timeouts">Long-prefill timeouts</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#mock-mode">Mock mode</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#adapter-directory">Adapter directory</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#where-to-go-next">Where to go next</a>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- quick checks -->
   <section class="divider">
     <div class="max-w-4xl mx-auto px-6 py-12">
-      <h2 class="text-2xl font-semibold tracking-tight mb-6">Start with three probes</h2>
+      <h2 id="start-with-three-probes" class="text-2xl font-semibold tracking-tight mb-6">Start with three probes</h2>
       <div class="grid md:grid-cols-3 gap-4">
         <div class="card p-5">
           <div class="label mb-2">Binary</div>
@@ -201,7 +220,7 @@
 curl -s http://localhost:8420/v1/models | jq .</code></pre>
       <div class="card p-6 mt-6">
         <div class="label mb-2">Desktop App first launch</div>
-        <h2 class="text-xl font-semibold mb-3">If the Desktop App does not finish first launch</h2>
+        <h2 id="desktop-app-first-launch" class="text-xl font-semibold mb-3">If the Desktop App does not finish first launch</h2>
         <p class="mb-4" style="color: var(--fg-dim);">
           The Desktop App wraps the same Kiln server, model path, CUDA driver, and local port checks. If setup stalls,
           open the app's <strong>Logs</strong> view first, then compare the message with these common recovery paths.
@@ -227,7 +246,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
     <div class="max-w-4xl mx-auto px-6 py-12 space-y-5">
 
       <article class="card p-6">
-        <h2 class="text-xl font-semibold mb-4">Wrong binary or GPU path</h2>
+        <h2 id="wrong-binary-or-gpu-path" class="text-xl font-semibold mb-4">Wrong binary or GPU path</h2>
         <div class="grid md:grid-cols-3 gap-5 check-list" style="color: var(--fg-dim);">
           <div>
             <div class="label mb-2">Symptom</div>
@@ -249,7 +268,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
       </article>
 
       <article class="card p-6">
-        <h2 class="text-xl font-semibold mb-4">Model weights are not found</h2>
+        <h2 id="model-weights-not-found" class="text-xl font-semibold mb-4">Model weights are not found</h2>
         <div class="grid md:grid-cols-3 gap-5 check-list" style="color: var(--fg-dim);">
           <div>
             <div class="label mb-2">Symptom</div>
@@ -273,7 +292,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
       </article>
 
       <article class="card p-6">
-        <h2 class="text-xl font-semibold mb-4"><code>/health</code> is not green</h2>
+        <h2 id="health-not-green" class="text-xl font-semibold mb-4"><code>/health</code> is not green</h2>
         <div class="grid md:grid-cols-3 gap-5 check-list" style="color: var(--fg-dim);">
           <div>
             <div class="label mb-2">Symptom</div>
@@ -295,7 +314,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
       </article>
 
       <article class="card p-6">
-        <h2 class="text-xl font-semibold mb-4">Older-release long-prefill and tool-call timeouts</h2>
+        <h2 id="long-prefill-timeouts" class="text-xl font-semibold mb-4">Older-release long-prefill and tool-call timeouts</h2>
         <div class="grid md:grid-cols-3 gap-5 check-list" style="color: var(--fg-dim);">
           <div>
             <div class="label mb-2">Symptom</div>
@@ -330,7 +349,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
       </article>
 
       <article class="card p-6">
-        <h2 class="text-xl font-semibold mb-4">Mock mode is not real training</h2>
+        <h2 id="mock-mode" class="text-xl font-semibold mb-4">Mock mode is not real training</h2>
         <div class="grid md:grid-cols-3 gap-5 check-list" style="color: var(--fg-dim);">
           <div>
             <div class="label mb-2">Symptom</div>
@@ -352,7 +371,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
       </article>
 
       <article class="card p-6">
-        <h2 class="text-xl font-semibold mb-4">Adapters are in a different directory than expected</h2>
+        <h2 id="adapter-directory" class="text-xl font-semibold mb-4">Adapters are in a different directory than expected</h2>
         <div class="grid md:grid-cols-3 gap-5 check-list" style="color: var(--fg-dim);">
           <div>
             <div class="label mb-2">Symptom</div>
@@ -379,7 +398,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
   <!-- next steps -->
   <section class="divider">
     <div class="max-w-4xl mx-auto px-6 py-12">
-      <h2 class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
+      <h2 id="where-to-go-next" class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
       <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <a class="card p-5 block" href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">
           <h3 class="font-semibold mb-2">Quickstart</h3>


### PR DESCRIPTION
## Summary

- Add compact `On this page` jump-link cards near the hero copy on `docs/site/api.html`, `docs/site/architecture.html`, and `docs/site/troubleshooting.html`.
- Add stable, human-readable ids to the major section headings on those long reference pages.
- Keep the existing static HTML/Tailwind styling pattern; no JS or shared build step added.

## Verification

- `git diff --check`
- `rg -n 'id="(copy-paste-first-requests|single-process-server|start-with-three-probes)|On this page|href="#' docs/site/api.html docs/site/architecture.html docs/site/troubleshooting.html`
- Python `HTMLParser` check that every local `href="#..."` has a matching id
- Optional mobile Chromium spot-check at `390x844` for `api.html`, `architecture.html`, and `troubleshooting.html`: `On this page` visible with no horizontal overflow