### PR TITLE
[codex] Clarify mock-mode startup banner

### DIFF
--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -369,6 +369,22 @@ pub fn print_banner(host: &str, port: u16, model_path: Option<&str>, config_path
     };
     let _ = writeln!(stderr, "  {} {}", style("Mode:").dim(), mode);
 
+    if model_path.is_none() {
+        let _ = writeln!(stderr);
+        let _ = writeln!(
+            stderr,
+            "  {} set {} or {} in TOML for real inference/training.",
+            style("Next:").dim(),
+            style("KILN_MODEL_PATH=./Qwen3.5-4B").yellow().bold(),
+            style("model.path").yellow().bold()
+        );
+        let _ = writeln!(
+            stderr,
+            "  {} training endpoints return 503 in mock mode.",
+            style("Note:").dim()
+        );
+    }
+
     if let Some(mp) = model_path {
         let _ = writeln!(
             stderr,


### PR DESCRIPTION
## Summary
- Adds a short mock-mode next step to the `kiln serve` startup banner when no model path is configured.
- Points first-run users to `KILN_MODEL_PATH=./Qwen3.5-4B` or `model.path` for real inference/training.
- Notes that training endpoints return 503 while running in mock mode.

## Verification
- `git diff --check` ✅
- `cargo fmt --check` ⚠️ not run: `cargo` is not installed in this Cloud Eric session
- `rg -n 'mock \\(no model loaded\\)|KILN_MODEL_PATH|training endpoints.*503|model\\.path' crates/kiln-server/src/cli.rs README.md QUICKSTART.md` ✅