### PR TITLE
[codex] make dashboard toast errors accessible

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -762,7 +762,7 @@ textarea { resize: vertical; min-height: 80px; }
   </div>
 </div>
 
-<div class="toast-container" id="toasts"></div>
+<div class="toast-container" id="toasts" role="status" aria-live="polite" aria-atomic="true"></div>
 
 <script>
 (function() {
@@ -773,6 +773,11 @@ function toast(msg, type) {
   const c = document.getElementById('toasts');
   const el = document.createElement('div');
   el.className = 'toast ' + (type || 'ok');
+  if (type === 'err') {
+    el.setAttribute('role', 'alert');
+    el.setAttribute('aria-live', 'assertive');
+    el.setAttribute('aria-atomic', 'true');
+  }
   el.textContent = msg;
   c.appendChild(el);
   setTimeout(() => el.remove(), 4000);


### PR DESCRIPTION
## Summary
- Adds polite live-region semantics to the dashboard toast container.
- Marks error toasts as assertive alerts while preserving existing visual behavior and timeout.

## Verification
- `python3 - <<'PY'\nfrom pathlib import Path\nhtml = Path('crates/kiln-server/src/ui.html').read_text()\nassert 'id="toasts"' in html\nassert 'aria-live' in html and ('role="status"' in html or 'role="alert"' in html)\nassert 'toast(msg, type)' in html\nPY`
- `node --check /tmp/kiln-ui.js`
- Chromium/Puppeteer smoke at mobile viewport `390x844` loading `crates/kiln-server/src/ui.html` as a static file; confirmed `#toasts` exposes `role="status" aria-live="polite" aria-atomic="true"` and a validation error toast exposes `role="alert" aria-live="assertive" aria-atomic="true"`.