### PR TITLE
[codex] Link GRPO guide from UI training

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -559,6 +559,7 @@ textarea { resize: vertical; min-height: 80px; }
   <h1>kiln</h1>
   <nav class="header-help" aria-label="Help links">
     <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" target="_blank" rel="noopener noreferrer">Quickstart</a>
+    <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md" target="_blank" rel="noopener noreferrer">GRPO Guide</a>
     <a href="https://ericflo.github.io/kiln/api.html" target="_blank" rel="noopener noreferrer">API Reference</a>
     <a href="https://ericflo.github.io/kiln/troubleshooting.html" target="_blank" rel="noopener noreferrer">Troubleshooting</a>
   </nav>
@@ -1385,6 +1386,7 @@ function renderTrainingQueue(data) {
     html = `<div class="empty">
       <div style="font-weight:600;color:var(--text);margin-bottom:6px;">No training jobs yet.</div>
       <div>Submit SFT examples to teach the model a correction, or use Submit GRPO for scored completions and reward-driven updates.</div>
+      <div style="margin-top:8px;">New to reward-driven training? Read the <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md" target="_blank" rel="noopener noreferrer">GRPO Guide</a>.</div>
       <div style="margin-top:8px;">Until then, Quick Inference uses the Base Model or whichever adapter you load.</div>
     </div>`;
   }


### PR DESCRIPTION
## Summary
- Adds a visible GRPO Guide link to the dashboard help navigation.
- Adds the same guide link to the Training empty state near the Submit GRPO guidance.

## Verification
- `python3 - <<'PY' ... PY && node --check /tmp/kiln-ui.js`
- `NODE_PATH=/tmp/kiln-puppeteer/node_modules node - <<'NODE' ... NODE` mobile Chromium check at 390px wide

Note: `puppeteer` was not installed in the checkout, so I installed `puppeteer` under `/tmp/kiln-puppeteer` with `PUPPETEER_SKIP_DOWNLOAD=true` and used the system `/usr/bin/chromium-browser`.