### PR TITLE
[codex] Add Docker verification notes to QUICKSTART

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -616,6 +616,8 @@ docker run --gpus all -p 8420:8420 \
   ghcr.io/ericflo/kiln-server:latest serve
 ```
 
+Replace `/path/to/Qwen3.5-4B` with your local model directory. After the server starts, verify it with `curl http://localhost:8420/health`, then open [http://localhost:8420/ui](http://localhost:8420/ui).
+
 Optional: build from source if you are contributing to kiln or testing local image changes.
 
 ```bash
@@ -628,6 +630,8 @@ docker run --gpus all \
   -p 8420:8420 \
   kiln serve
 ```
+
+Use the same local model path replacement and post-run check: `curl http://localhost:8420/health`, then open [http://localhost:8420/ui](http://localhost:8420/ui).
 
 ## Running with systemd
 


### PR DESCRIPTION
## Summary
- Add post-run guidance after the prebuilt GHCR Docker snippet in `QUICKSTART.md`
- Add equivalent verification guidance after the source-built Docker snippet

## Validation
- `rg -n "Running with Docker|docker run --gpus|/path/to/Qwen3.5-4B|localhost:8420/health|localhost:8420/ui" QUICKSTART.md`
- `git diff --check`