### PR TITLE
Redirect server root to UI dashboard

### DIFF
--- a/crates/kiln-server/src/api/ui.rs
+++ b/crates/kiln-server/src/api/ui.rs
@@ -1,4 +1,8 @@
-use axum::{response::Html, routing::get, Router};
+use axum::{
+    response::{Html, Redirect},
+    routing::get,
+    Router,
+};
 
 const UI_HTML: &str = include_str!("../ui.html");
 
@@ -6,6 +10,12 @@ async fn serve_ui() -> Html<&'static str> {
     Html(UI_HTML)
 }
 
+async fn redirect_to_ui() -> Redirect {
+    Redirect::to("/ui")
+}
+
 pub fn routes() -> Router<crate::state::AppState> {
-    Router::new().route("/ui", get(serve_ui))
+    Router::new()
+        .route("/", get(redirect_to_ui))
+        .route("/ui", get(serve_ui))
 }


### PR DESCRIPTION
## Summary
- add `GET /` to the embedded UI router
- redirect root browser visits to `/ui` while preserving the existing `/ui` dashboard route

## Validation
- `git diff --check`
- `rg -n 'Redirect::to\\("/ui"\\)|route\\("/"' crates/kiln-server/src/api/ui.rs crates/kiln-server/src/api/mod.rs`\n\nNo local cargo build/check/test run; local CUDA builds are forbidden for kiln.