### PR TITLE
Fix landing hero H1 spacing

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -154,7 +154,7 @@
     <div class="max-w-5xl mx-auto px-6 pt-20 pb-16">
       <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">v0.2.13 &middot; pre-1.0 preview</span>
       <h1 class="text-5xl sm:text-6xl font-bold tracking-tight mb-5">
-        Your model gets better<br>every time you use it.
+        Your model gets better <br>every time you use it.
       </h1>
       <p class="text-xl max-w-2xl leading-relaxed mb-8" style="color: var(--fg-dim);">
         Kiln is a single-GPU inference server with live LoRA training. Pure Rust. Single binary.


### PR DESCRIPTION
## Summary
- Preserve the landing page hero's two-line visual break while ensuring extracted H1 text includes the missing space between "better" and "every".

## Validation
- `git diff --check`
- `python3 - <<'PY' ...` H1 extraction check prints `Your model gets better every time you use it.`