### PR TITLE
Keep demo GRPO links site-local

### DIFF
--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -158,7 +158,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
+        <a href="../grpo.html">GRPO Guide</a>
         <a href="../api.html">API Reference</a>
         <a href="./">Demo</a>
         <a href="../troubleshooting.html">Troubleshooting</a>
@@ -347,7 +347,7 @@ curl -s http://localhost:8420/v1/train/status \
       <a href="https://github.com/ericflo/kiln" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
         GitHub &rarr;
       </a>
-      <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+      <a href="../grpo.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
         GRPO Guide &rarr;
       </a>
     </div>
@@ -364,7 +364,7 @@ curl -s http://localhost:8420/v1/train/status \
         <a href="../">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
         <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
-        <a href="https://github.com/ericflo/kiln/blob/main/docs/GRPO_GUIDE.md">GRPO Guide</a>
+        <a href="../grpo.html">GRPO Guide</a>
         <a href="../api.html">API Reference</a>
         <a href="./">Demo</a>
         <a href="../troubleshooting.html">Troubleshooting</a>


### PR DESCRIPTION
## Summary
- Update demo-page GRPO Guide links to stay within the docs site via `../grpo.html`
- Preserve existing link text, classes, and surrounding markup

## Validation
- `git diff --check`
- `python3 - <<'PY' ...` link assertion script

Verification for next planning cycle: read the diff as a cold visitor and confirm every GRPO Guide link on `docs/site/demo/index.html` stays within `docs/site/` instead of opening GitHub.