### PR TITLE
[codex] Add site-local quickstart page

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -157,7 +157,7 @@
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
@@ -180,7 +180,7 @@
         monitoring, and configuration endpoints before walking through the full Quickstart.
       </p>
       <div class="flex flex-wrap gap-3 mt-8">
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+        <a href="quickstart.html" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
           Quickstart &rarr;
         </a>
         <a href="grpo.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
@@ -408,7 +408,7 @@ kiln serve --config kiln.toml</code></pre>
     <div class="max-w-4xl mx-auto px-6 py-12">
       <h2 id="where-to-go-next" class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
       <div class="grid sm:grid-cols-3 gap-4">
-        <a class="card p-5 block" href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">
+        <a class="card p-5 block" href="quickstart.html">
           <h3 class="font-semibold mb-2">Quickstart</h3>
           <p style="color: var(--fg-dim);">Run the server, send the first chat request, and post the first SFT job.</p>
         </a>
@@ -434,7 +434,7 @@ kiln serve --config kiln.toml</code></pre>
       <nav class="flex flex-wrap gap-x-5 gap-y-1">
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -143,7 +143,7 @@
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
@@ -170,7 +170,7 @@
         <a href="https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
           Full architecture doc &rarr;
         </a>
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+        <a href="quickstart.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
           Quickstart &rarr;
         </a>
         <a href="troubleshooting.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
@@ -317,7 +317,7 @@
           <h3 class="font-semibold mb-2">GRPO guide</h3>
           <p style="color: var(--fg-dim);">See the reward-scored training payloads and generate &rarr; score &rarr; train loop.</p>
         </a>
-        <a class="card p-5 block" href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">
+        <a class="card p-5 block" href="quickstart.html">
           <h3 class="font-semibold mb-2">Quickstart</h3>
           <p style="color: var(--fg-dim);">Run the server, send the first chat request, and post the first training example.</p>
         </a>
@@ -339,7 +339,7 @@
       <nav class="flex flex-wrap gap-x-5 gap-y-1">
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -157,7 +157,7 @@
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="../quickstart.html">Quickstart</a>
         <a href="../grpo.html">GRPO Guide</a>
         <a href="../api.html">API Reference</a>
         <a href="./">Demo</a>
@@ -309,7 +309,7 @@ curl -s http://localhost:8420/v1/train/status \
         learned from your last failure.
       </p>
       <p>
-        Read the setup path in the <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        Read the setup path in the <a href="../quickstart.html">Quickstart</a>
         and <a href="../architecture.html">Architecture</a>
         docs. If your local run differs from the recording, use the
         <a href="../troubleshooting.html">Troubleshooting</a> page to check the binary, model path,
@@ -319,7 +319,7 @@ curl -s http://localhost:8420/v1/train/status \
       <h2>Reproduce it yourself</h2>
       <p>
         The canonical demo runs the same commands you&rsquo;d run as a first-time user. Every line is
-        in the <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>. The
+        in the <a href="../quickstart.html">Quickstart</a>. The
         recording protocol &mdash; terminal size, scene timing, expected outputs &mdash; is in
         <a href="https://github.com/ericflo/kiln/blob/main/docs/site/demo/SCRIPT.md">SCRIPT.md</a>.
         If you want to record your own variant on different hardware or with a different correction
@@ -335,7 +335,7 @@ curl -s http://localhost:8420/v1/train/status \
       <a href="../" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
         &larr; Back to home
       </a>
-      <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+      <a href="../quickstart.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
         Quickstart &rarr;
       </a>
       <a href="../api.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
@@ -363,7 +363,7 @@ curl -s http://localhost:8420/v1/train/status \
       <nav class="flex flex-wrap gap-x-5 gap-y-1">
         <a href="../">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="../quickstart.html">Quickstart</a>
         <a href="../grpo.html">GRPO Guide</a>
         <a href="../api.html">API Reference</a>
         <a href="./">Demo</a>

--- a/docs/site/grpo.html
+++ b/docs/site/grpo.html
@@ -155,7 +155,7 @@
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
@@ -352,7 +352,7 @@
       <nav class="flex flex-wrap gap-x-5 gap-y-1">
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -138,7 +138,7 @@
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
@@ -165,7 +165,7 @@
         <a href="https://github.com/ericflo/kiln" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
           GitHub &rarr;
         </a>
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+        <a href="quickstart.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
           Quickstart &rarr;
         </a>
         <a href="api.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
@@ -185,7 +185,7 @@
         </a>
       </div>
       <p class="mt-6 text-sm">
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">&rarr; Start with the Quickstart</a>
+        <a href="quickstart.html">&rarr; Start with the Quickstart</a>
         <span class="mx-2" style="color: var(--fg-dim);">&middot;</span>
         <a href="architecture.html">&rarr; Read the architecture guide</a>
         <span class="mx-2" style="color: var(--fg-dim);">&middot;</span>
@@ -362,7 +362,7 @@ docker run --gpus all -p 8420:8420 \
       <p class="text-sm mt-6" style="color: var(--fg-mute);">
         Each release is signed and SHA-256 checksums are published as <code>.sha256</code> sidecars on the
         <a href="https://github.com/ericflo/kiln/releases">releases page</a>. The
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a> walks through
+        <a href="quickstart.html">Quickstart</a> walks through
         downloading model weights, the first chat completion, the first SFT POST, and the first GRPO loop.
       </p>
     </div>
@@ -378,7 +378,7 @@ docker run --gpus all -p 8420:8420 \
       <nav class="flex flex-wrap gap-x-5 gap-y-1">
         <a href="https://github.com/ericflo/kiln">Repo</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -1,0 +1,337 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Kiln Quickstart &mdash; Run Qwen3.5-4B in 5 minutes</title>
+  <meta name="description" content="A concise site-local quickstart for Kiln: choose Desktop, a server binary, or Docker; point KILN_MODEL_PATH at Qwen3.5-4B; start the server; open /ui; verify /health; and send one chat request.">
+  <link rel="canonical" href="https://ericflo.github.io/kiln/quickstart.html">
+  <link rel="icon" type="image/png" href="assets/logo.png">
+
+  <meta property="og:title" content="Kiln Quickstart &mdash; Run Qwen3.5-4B in 5 minutes">
+  <meta property="og:description" content="Choose Desktop, a server binary, or Docker; start Kiln with Qwen3.5-4B; open /ui; verify /health; and send one chat request.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://ericflo.github.io/kiln/quickstart.html">
+  <meta property="og:image" content="https://ericflo.github.io/kiln/assets/logo.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Kiln Quickstart &mdash; Run Qwen3.5-4B in 5 minutes">
+  <meta name="twitter:description" content="Start Kiln, open the UI, verify health, and send one OpenAI-compatible chat request.">
+  <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/logo.png">
+
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0b0d10;
+      --bg-soft: #11141a;
+      --bg-soft-2: #161a22;
+      --line: #1f2530;
+      --line-2: #2a3140;
+      --fg: #e6e9ef;
+      --fg-dim: #a4adbb;
+      --fg-mute: #6f7888;
+      --accent: #f97316;
+      --accent-soft: rgba(249, 115, 22, 0.12);
+    }
+    html { background: var(--bg); }
+    body {
+      background: var(--bg);
+      color: var(--fg);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      font-feature-settings: "ss01", "cv02", "cv11";
+      -webkit-font-smoothing: antialiased;
+    }
+    code, pre, kbd, samp {
+      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    }
+    pre { max-width: 100%; overflow-x: auto; }
+    p code, li code, td code, h2 code, h3 code {
+      background: var(--bg-soft);
+      border: 1px solid var(--line);
+      padding: 0.05rem 0.4rem;
+      border-radius: 5px;
+      font-size: 0.875em;
+      color: #f3c891;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+    .hero-glow {
+      background:
+        radial-gradient(60% 50% at 50% 0%, rgba(249,115,22,0.10), transparent 70%),
+        radial-gradient(40% 35% at 80% 20%, rgba(56,189,248,0.06), transparent 70%);
+    }
+    .card {
+      background: var(--bg-soft);
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      min-width: 0;
+    }
+    .btn-primary {
+      background: var(--accent);
+      color: #1a0c00;
+      font-weight: 600;
+    }
+    .btn-primary:hover { filter: brightness(1.08); }
+    .btn-secondary {
+      background: transparent;
+      color: var(--fg);
+      border: 1px solid var(--line-2);
+    }
+    .btn-secondary:hover { background: var(--bg-soft); }
+    .divider { border-top: 1px solid var(--line); }
+    .pill {
+      background: var(--accent-soft);
+      color: var(--accent);
+      border: 1px solid rgba(249,115,22,0.35);
+    }
+    .label {
+      color: var(--accent);
+      font-size: 0.74rem;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+    .step {
+      display: inline-flex;
+      width: 1.75rem;
+      height: 1.75rem;
+      align-items: center;
+      justify-content: center;
+      border-radius: 999px;
+      background: var(--accent-soft);
+      border: 1px solid rgba(249,115,22,0.35);
+      color: var(--accent);
+      font-size: 0.8rem;
+      font-weight: 700;
+      flex: 0 0 auto;
+    }
+    .install-grid { display: grid; gap: 1rem; }
+    .install-card {
+      background: var(--bg-soft-2);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 1rem;
+      min-width: 0;
+    }
+    a { color: #f3c891; }
+    a:hover { color: var(--accent); }
+    a.btn-primary, a.btn-primary:hover { color: #1a0c00; }
+    a.btn-secondary, a.btn-secondary:hover { color: var(--fg); }
+    .site-nav-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1rem;
+    }
+    .site-nav {
+      display: flex;
+      align-items: center;
+      gap: 1.25rem;
+      color: var(--fg-dim);
+    }
+    @media (max-width: 640px) {
+      .site-nav-bar {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 0.75rem;
+      }
+      .site-nav {
+        flex-wrap: wrap;
+        gap: 0.35rem 1rem;
+        line-height: 1.35;
+        width: 100%;
+      }
+    }
+  </style>
+</head>
+<body class="min-h-screen">
+  <!-- nav -->
+  <header class="border-b" style="border-color: var(--line);">
+    <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
+      <a href="./" class="flex items-center gap-2.5">
+        <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
+        <span class="text-lg font-semibold tracking-tight">Kiln</span>
+      </a>
+      <nav class="site-nav text-sm">
+        <a href="quickstart.html">Quickstart</a>
+        <a href="grpo.html">GRPO Guide</a>
+        <a href="api.html">API Reference</a>
+        <a href="demo/">Demo</a>
+        <a href="troubleshooting.html">Troubleshooting</a>
+        <a href="architecture.html">Architecture</a>
+        <a href="https://github.com/ericflo/kiln" class="hidden sm:inline">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- hero -->
+  <section class="hero-glow">
+    <div class="max-w-4xl mx-auto px-6 pt-16 pb-10">
+      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">Quickstart &middot; 5-minute path &middot; Qwen3.5-4B</span>
+      <h1 class="text-4xl sm:text-5xl font-bold tracking-tight mb-5 leading-tight">
+        Run Kiln, open the UI, and send one chat request.
+      </h1>
+      <p class="text-lg leading-relaxed max-w-3xl" style="color: var(--fg-dim);">
+        Start with the Desktop App if you want the shortest path. Use a server binary or Docker when you want a terminal-first setup. Every path serves the same single target model: <code>Qwen/Qwen3.5-4B</code>.
+      </p>
+      <div class="mt-8 flex flex-wrap gap-3">
+        <a href="#install" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Choose an install path</a>
+        <a href="#verify" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Verify the server</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- install -->
+  <section id="install" class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-12">
+      <div class="flex items-start gap-3 mb-6">
+        <span class="step">1</span>
+        <div>
+          <p class="label mb-2">Choose one path</p>
+          <h2 class="text-2xl font-semibold tracking-tight">Install Kiln</h2>
+        </div>
+      </div>
+      <div class="install-grid lg:grid-cols-2">
+        <div class="install-card">
+          <h3 class="font-semibold mb-2">Desktop App &middot; recommended</h3>
+          <p class="mb-3" style="color: var(--fg-dim);">
+            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2">Kiln Desktop desktop-v0.2.2</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
+          </p>
+          <p class="text-sm" style="color: var(--fg-mute);">The app downloads and verifies the matching server binary for you.</p>
+        </div>
+        <div class="install-card">
+          <h3 class="font-semibold mb-2">Linux x86_64 &middot; CUDA 12.4</h3>
+<pre class="text-sm"><code>curl -L -o kiln-linux.tar.gz \
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-unknown-linux-gnu-cuda124.tar.gz
+tar -xzf kiln-linux.tar.gz</code></pre>
+        </div>
+        <div class="install-card">
+          <h3 class="font-semibold mb-2">macOS Apple Silicon &middot; Metal</h3>
+<pre class="text-sm"><code>curl -L -o kiln-macos.tar.gz \
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-aarch64-apple-darwin-metal.tar.gz
+tar -xzf kiln-macos.tar.gz</code></pre>
+        </div>
+        <div class="install-card">
+          <h3 class="font-semibold mb-2">Windows x86_64 &middot; CUDA 12.4</h3>
+<pre class="text-sm"><code>curl.exe -L -o kiln-windows.zip `
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-pc-windows-msvc-cuda124.zip
+Expand-Archive .\kiln-windows.zip -DestinationPath .\kiln</code></pre>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- model and serve -->
+  <section class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-12 grid lg:grid-cols-2 gap-6">
+      <div class="card p-6">
+        <div class="flex items-start gap-3 mb-4">
+          <span class="step">2</span>
+          <div>
+            <p class="label mb-2">Model path</p>
+            <h2 class="text-2xl font-semibold tracking-tight">Download Qwen3.5-4B</h2>
+          </div>
+        </div>
+        <p class="mb-4" style="color: var(--fg-dim);">Point <code>KILN_MODEL_PATH</code> at a local checkout of <code>Qwen/Qwen3.5-4B</code>.</p>
+<pre class="text-sm"><code>pip install huggingface-hub
+huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
+export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
+      </div>
+      <div class="card p-6">
+        <div class="flex items-start gap-3 mb-4">
+          <span class="step">3</span>
+          <div>
+            <p class="label mb-2">Start</p>
+            <h2 class="text-2xl font-semibold tracking-tight">Run the server</h2>
+          </div>
+        </div>
+        <p class="mb-4" style="color: var(--fg-dim);">Server binaries bind to <code>127.0.0.1:8420</code> by default.</p>
+<pre class="text-sm"><code>KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
+        <h3 class="font-semibold mt-6 mb-2">Docker (Linux + NVIDIA Container Toolkit)</h3>
+<pre class="text-sm"><code>docker run --gpus all -p 8420:8420 \
+  -e KILN_MODEL_PATH=/models/Qwen3.5-4B \
+  -v "$PWD/Qwen3.5-4B:/models/Qwen3.5-4B:ro" \
+  ghcr.io/ericflo/kiln-server:0.2.13</code></pre>
+      </div>
+    </div>
+  </section>
+
+  <!-- verify -->
+  <section id="verify" class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-12">
+      <div class="flex items-start gap-3 mb-6">
+        <span class="step">4</span>
+        <div>
+          <p class="label mb-2">Verify</p>
+          <h2 class="text-2xl font-semibold tracking-tight">Open the UI, check health, send chat</h2>
+        </div>
+      </div>
+      <div class="grid lg:grid-cols-3 gap-4">
+        <div class="card p-5">
+          <h3 class="font-semibold mb-2">Open the dashboard</h3>
+          <p style="color: var(--fg-dim);">Visit <a href="http://127.0.0.1:8420/ui">http://127.0.0.1:8420/ui</a> to inspect requests, adapters, and training jobs.</p>
+        </div>
+        <div class="card p-5">
+          <h3 class="font-semibold mb-2">Check <code>/health</code></h3>
+<pre class="text-sm"><code>curl -s http://127.0.0.1:8420/health \
+  | python3 -m json.tool</code></pre>
+        </div>
+        <div class="card p-5">
+          <h3 class="font-semibold mb-2">Send chat</h3>
+<pre class="text-sm"><code>curl -s http://127.0.0.1:8420/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "messages": [{"role": "user", "content": "What is 2+2?"}],
+    "max_tokens": 64,
+    "temperature": 0.7
+  }' | python3 -m json.tool</code></pre>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- next -->
+  <section class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-12">
+      <h2 class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
+      <div class="grid sm:grid-cols-3 gap-4">
+        <a class="card p-5 block" href="grpo.html">
+          <h3 class="font-semibold mb-2">GRPO Guide</h3>
+          <p style="color: var(--fg-dim);">Run the generate &rarr; score &rarr; train loop against the same server.</p>
+        </a>
+        <a class="card p-5 block" href="api.html">
+          <h3 class="font-semibold mb-2">API Reference</h3>
+          <p style="color: var(--fg-dim);">See inference, adapter, training, metrics, and configuration endpoints.</p>
+        </a>
+        <a class="card p-5 block" href="troubleshooting.html">
+          <h3 class="font-semibold mb-2">Troubleshooting</h3>
+          <p style="color: var(--fg-dim);">Fix model paths, binary downloads, CUDA/Metal setup, Docker, and health checks.</p>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- footer -->
+  <footer class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">
+      <div class="flex items-center gap-2.5">
+        <img src="assets/logo.png" alt="" width="20" height="20" class="rounded">
+        <span>Kiln &middot; MIT licensed</span>
+      </div>
+      <nav class="flex flex-wrap gap-x-5 gap-y-1">
+        <a href="./">Home</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
+        <a href="quickstart.html">Quickstart</a>
+        <a href="grpo.html">GRPO Guide</a>
+        <a href="api.html">API Reference</a>
+        <a href="demo/">Demo</a>
+        <a href="troubleshooting.html">Troubleshooting</a>
+        <a href="architecture.html">Architecture</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/SECURITY.md">Security</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/LICENSE">License</a>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -143,7 +143,7 @@
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>
@@ -163,7 +163,7 @@
       </h1>
       <p class="text-lg leading-relaxed max-w-3xl" style="color: var(--fg-dim);">
         This page is a compact diagnosis guide for cold-reader setup issues. It does not replace the
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>; use it when
+        <a href="quickstart.html">Quickstart</a>; use it when
         a command fails, <code>/health</code> is not green, or the server is running but not using the
         model or adapter you expected.
       </p>
@@ -400,7 +400,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
     <div class="max-w-4xl mx-auto px-6 py-12">
       <h2 id="where-to-go-next" class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
       <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <a class="card p-5 block" href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">
+        <a class="card p-5 block" href="quickstart.html">
           <h3 class="font-semibold mb-2">Quickstart</h3>
           <p style="color: var(--fg-dim);">Full zero-to-running flow, first chat completion, first SFT job, and first GRPO loop.</p>
         </a>
@@ -430,7 +430,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
       <nav class="flex flex-wrap gap-x-5 gap-y-1">
         <a href="./">Home</a>
         <a href="https://github.com/ericflo/kiln/blob/main/README.md">README</a>
-        <a href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md">Quickstart</a>
+        <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="demo/">Demo</a>


### PR DESCRIPTION
## Summary
- Adds a concise `docs/site/quickstart.html` page that keeps the 5-minute setup flow inside the docs site.
- Covers Desktop, Linux CUDA, macOS Metal, Windows CUDA, and Docker paths; setting `KILN_MODEL_PATH` to `Qwen/Qwen3.5-4B`; starting Kiln; opening `/ui`; checking `/health`; and sending one `/v1/chat/completions` request.
- Repoints Quickstart links in the landing page, docs pages, and demo page to the site-local quickstart.

## Validation
- `git diff --check`
- Python wiring/content assertion from the task description (`site-local quickstart wired`)