### PR TITLE
[codex] Add Vulkan docs and detection diagnostics

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -15,7 +15,7 @@ Choose the path that matches how you want to run Kiln.
 **Desktop App path (recommended for most users):**
 
 - **Platform**: Windows, Linux, or macOS on Apple Silicon.
-- **GPU**: NVIDIA GPU or Apple Silicon Mac. NVIDIA systems should have 24GB+ VRAM (RTX 3090, RTX 4090, A6000, etc.); Apple Silicon systems should have 16GB+ unified memory.
+- **GPU**: NVIDIA GPU, AMD/Intel Vulkan-capable Linux GPU, or Apple Silicon Mac. NVIDIA systems should have 24GB+ VRAM (RTX 3090, RTX 4090, A6000, etc.); Apple Silicon systems should have 16GB+ unified memory.
 - **Disk**: ~20GB free for the server binary, model weights, and adapters.
 - **Build tooling**: No Rust toolchain, CUDA toolkit, or Xcode install is required for the GUI path. The app downloads the matching prebuilt `kiln` server binary for your platform.
 
@@ -68,7 +68,7 @@ The first build takes 15-30 minutes (CUDA kernel compilation). Subsequent builds
 cargo build --release --features vulkan
 ```
 
-Kiln auto-detects Vulkan at startup and logs `Vulkan available — using Vulkan GPU (AMD/Intel)`. `KILN_VULKAN_DEVICE=0` or `GGML_VK_VISIBLE_DEVICES=0` can pin a specific Vulkan physical device.
+Kiln auto-detects Vulkan at startup and logs `Vulkan available — using Vulkan GPU (AMD/Intel)`. `KILN_VULKAN_DEVICE=0` pins a zero-based Vulkan physical device; `GGML_VK_VISIBLE_DEVICES=0,1` is also honored for llama.cpp compatibility. Invalid values produce a warning and Kiln falls back to automatic discrete-GPU selection, then CPU if Vulkan is not usable.
 
 **macOS + Apple Silicon:**
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ cd kiln
 cargo build --release --features cuda     # ~15-30 min first build (CUDA kernels)
 
 # Linux + AMD / Intel
+# Requires Vulkan 1.2+ runtime plus glslc or glslangValidator for shader embedding.
 cargo build --release --features vulkan   # Vulkan compute kernels via ash + SPIR-V
 
 # macOS + Apple Silicon
@@ -152,6 +153,8 @@ Start the source-built server:
 ```bash
 KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve
 ```
+
+Vulkan builds auto-select a Vulkan physical device at startup. Use `KILN_VULKAN_DEVICE=0` to pin a zero-based Vulkan device index, or `GGML_VK_VISIBLE_DEVICES=0,1` to reuse llama.cpp-style visibility; invalid values are ignored with a warning and Kiln falls back to automatic selection or CPU if no Vulkan device is usable.
 
 ```
   ┌─────────────────────────────────────┐

--- a/crates/kiln-server/src/device.rs
+++ b/crates/kiln-server/src/device.rs
@@ -14,6 +14,9 @@ pub fn select_device() -> Result<Device> {
 }
 
 pub fn select_device_with_options(cuda_graphs: bool) -> Result<Device> {
+    #[cfg(not(feature = "cuda"))]
+    let _ = cuda_graphs;
+
     #[cfg(feature = "cuda")]
     if candle_core::utils::cuda_is_available() {
         if cuda_graphs {
@@ -44,6 +47,10 @@ pub fn select_device_with_options(cuda_graphs: bool) -> Result<Device> {
         return Ok(Device::new_metal(0)?);
     }
 
+    #[cfg(any(feature = "cuda", feature = "vulkan", feature = "metal"))]
+    tracing::info!("no compiled GPU backend found an available device — using CPU");
+
+    #[cfg(not(any(feature = "cuda", feature = "vulkan", feature = "metal")))]
     tracing::info!("no GPU feature active — using CPU");
     Ok(Device::Cpu)
 }

--- a/crates/kiln-vulkan-kernel/src/device.rs
+++ b/crates/kiln-vulkan-kernel/src/device.rs
@@ -72,6 +72,41 @@ impl std::fmt::Debug for VulkanDevice {
 }
 
 impl VulkanDevice {
+    /// Select an explicit Vulkan physical-device index from environment-style
+    /// values without touching Vulkan. `KILN_VULKAN_DEVICE` wins over the
+    /// llama.cpp-compatible `GGML_VK_VISIBLE_DEVICES`; the latter may contain a
+    /// comma-separated list, so pick the first visible index that exists.
+    pub fn explicit_device_index_from_env_values(
+        device_count: usize,
+        kiln_vulkan_device: Option<&str>,
+        ggml_vk_visible_devices: Option<&str>,
+    ) -> Option<(usize, &'static str)> {
+        if device_count == 0 {
+            return None;
+        }
+
+        if let Some(dev_str) = kiln_vulkan_device {
+            if let Ok(idx) = dev_str.trim().parse::<usize>() {
+                if idx < device_count {
+                    return Some((idx, "KILN_VULKAN_DEVICE"));
+                }
+            }
+        }
+
+        if let Some(visible) = ggml_vk_visible_devices {
+            for idx in visible
+                .split(',')
+                .filter_map(|s| s.trim().parse::<usize>().ok())
+            {
+                if idx < device_count {
+                    return Some((idx, "GGML_VK_VISIBLE_DEVICES"));
+                }
+            }
+        }
+
+        None
+    }
+
     /// Cheap probe: check if Vulkan is available without creating a logical device.
     ///
     /// Creates a minimal Vulkan instance and enumerates physical devices.
@@ -248,28 +283,29 @@ impl VulkanDevice {
         instance: &ash::Instance,
         physical_devices: &[vk::PhysicalDevice],
     ) -> Result<vk::PhysicalDevice> {
-        // Respect KILN_VULKAN_DEVICE env var
-        if let Ok(dev_str) = std::env::var("KILN_VULKAN_DEVICE") {
-            if let Ok(idx) = dev_str.parse::<usize>() {
-                if idx < physical_devices.len() {
-                    tracing::info!(device_index = idx, "using KILN_VULKAN_DEVICE");
-                    return Ok(physical_devices[idx]);
-                }
-            }
+        let kiln_vulkan_device = std::env::var("KILN_VULKAN_DEVICE").ok();
+        let ggml_vk_visible_devices = std::env::var("GGML_VK_VISIBLE_DEVICES").ok();
+        if let Some((idx, source)) = Self::explicit_device_index_from_env_values(
+            physical_devices.len(),
+            kiln_vulkan_device.as_deref(),
+            ggml_vk_visible_devices.as_deref(),
+        ) {
+            tracing::info!(device_index = idx, source, "using explicit Vulkan device selection");
+            return Ok(physical_devices[idx]);
         }
 
-        // Respect GGML_VK_VISIBLE_DEVICES (llama.cpp compatibility)
-        if let Ok(visible) = std::env::var("GGML_VK_VISIBLE_DEVICES") {
-            let indices: Vec<usize> = visible
-                .split(',')
-                .filter_map(|s| s.trim().parse().ok())
-                .collect();
-            if let Some(&idx) = indices.first() {
-                if idx < physical_devices.len() {
-                    tracing::info!(device_index = idx, "using GGML_VK_VISIBLE_DEVICES");
-                    return Ok(physical_devices[idx]);
-                }
-            }
+        if let Some(value) = kiln_vulkan_device.as_deref() {
+            tracing::warn!(
+                value,
+                device_count = physical_devices.len(),
+                "ignoring invalid KILN_VULKAN_DEVICE; expected a zero-based Vulkan physical-device index"
+            );
+        } else if let Some(value) = ggml_vk_visible_devices.as_deref() {
+            tracing::warn!(
+                value,
+                device_count = physical_devices.len(),
+                "ignoring GGML_VK_VISIBLE_DEVICES; no listed Vulkan physical-device index is available"
+            );
         }
 
         // Prefer discrete GPU
@@ -512,6 +548,34 @@ impl Drop for VulkanDevice {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn explicit_vulkan_device_prefers_kiln_env() {
+        assert_eq!(
+            VulkanDevice::explicit_device_index_from_env_values(4, Some("2"), Some("1,3")),
+            Some((2, "KILN_VULKAN_DEVICE"))
+        );
+    }
+
+    #[test]
+    fn explicit_vulkan_device_uses_first_valid_ggml_visible_device() {
+        assert_eq!(
+            VulkanDevice::explicit_device_index_from_env_values(4, None, Some("99, 3, 1")),
+            Some((3, "GGML_VK_VISIBLE_DEVICES"))
+        );
+    }
+
+    #[test]
+    fn explicit_vulkan_device_ignores_invalid_or_missing_values() {
+        assert_eq!(
+            VulkanDevice::explicit_device_index_from_env_values(2, Some("amd"), Some("4")),
+            None
+        );
+        assert_eq!(
+            VulkanDevice::explicit_device_index_from_env_values(0, Some("0"), Some("0")),
+            None
+        );
+    }
 
     #[test]
     fn test_vulkan_device_init_fails_gracefully_without_gpu() {

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -4,18 +4,18 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Kiln Architecture &mdash; Single-process inference and training</title>
-  <meta name="description" content="A docs-site architecture guide for Kiln: single-process serving, request flow, LoRA hot-swap training, and CUDA kernel crates.">
+  <meta name="description" content="A docs-site architecture guide for Kiln: single-process serving, request flow, LoRA hot-swap training, and CUDA, Vulkan, and Metal backend kernels.">
   <link rel="canonical" href="https://ericflo.github.io/kiln/architecture.html">
   <link rel="icon" type="image/png" href="assets/logo.png">
 
   <meta property="og:title" content="Kiln Architecture &mdash; Single-process inference and training">
-  <meta property="og:description" content="A compact architecture guide for Kiln internals: server, scheduler, model engine, live LoRA training, and CUDA kernels.">
+  <meta property="og:description" content="A compact architecture guide for Kiln internals: server, scheduler, model engine, live LoRA training, and GPU backend kernels.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ericflo.github.io/kiln/architecture.html">
   <meta property="og:image" content="https://ericflo.github.io/kiln/assets/logo.png">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Kiln Architecture &mdash; Single-process inference and training">
-  <meta name="twitter:description" content="A compact architecture guide for Kiln internals: server, scheduler, model engine, live LoRA training, and CUDA kernels.">
+  <meta name="twitter:description" content="A compact architecture guide for Kiln internals: server, scheduler, model engine, live LoRA training, and GPU backend kernels.">
   <meta name="twitter:image" content="https://ericflo.github.io/kiln/assets/logo.png">
 
   <script src="https://cdn.tailwindcss.com"></script>
@@ -164,7 +164,7 @@
       </h1>
       <p class="text-lg leading-relaxed max-w-3xl" style="color: var(--fg-dim);">
         This page is the website-level map of Kiln internals. It explains how the HTTP server,
-        scheduler, model engine, LoRA training queue, and CUDA kernel crates fit together before
+        scheduler, model engine, LoRA training queue, and GPU backend crates fit together before
         you dive into the full GitHub architecture document.
       </p>
       <div class="flex flex-wrap gap-3 mt-8">
@@ -190,7 +190,7 @@
           <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#request-path-and-batching">Request path</a>
           <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#gated-deltanet-hybrid">Gated DeltaNet hybrid</a>
           <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#lora-hot-swap-training-queue">LoRA hot-swap</a>
-          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#cuda-kernel-crates">CUDA kernels</a>
+          <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#gpu-backend-crates">GPU backends</a>
           <a class="btn-secondary inline-flex px-3 py-1.5 rounded-md" href="#where-to-go-next">Where to go next</a>
         </div>
       </div>
@@ -286,19 +286,19 @@
 
       <article class="card p-6">
         <div class="label mb-3">GPU path</div>
-        <h2 id="cuda-kernel-crates" class="text-2xl font-semibold mb-4">CUDA kernel crates</h2>
+        <h2 id="gpu-backend-crates" class="text-2xl font-semibold mb-4">GPU backend crates</h2>
         <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">
           Kiln keeps the Qwen3.5-4B fast path in Rust crates with focused native kernels where the model
-          needs them. The full-attention layers use vendored FlashAttention-style CUDA kernels, decode
-          uses paged GQA paths, and the hybrid architecture includes Gated DeltaNet support for the
-          linear-attention layers. The result is a small codebase that is tuned for one model instead of
-          abstracting over many model families.
+          needs them. CUDA builds use vendored FlashAttention-style kernels and paged GQA decode paths,
+          Vulkan builds use ash plus embedded SPIR-V shaders for AMD/Intel Linux GDN hot paths, and
+          Metal builds use candle-metal plus Kiln's Apple Silicon shader family. The result is a small
+          codebase tuned for one model instead of abstracting over many model families.
         </p>
         <ul class="list-disc pl-5 check-list" style="color: var(--fg-dim);">
           <li><code>kiln-server</code> owns HTTP routing, configuration, metrics, and API surfaces.</li>
           <li><code>kiln-scheduler</code> and <code>kiln-core</code> coordinate batching, requests, and KV blocks.</li>
           <li><code>kiln-model</code> loads Qwen3.5-4B weights, applies adapters, and drives the forward pass.</li>
-          <li><code>kiln-flash-attn</code> and CUDA-backed crates provide the tuned GPU kernels.</li>
+          <li><code>kiln-flash-attn</code>, CUDA-backed crates, <code>kiln-vulkan-kernel</code>, and Metal shaders provide backend-specific GPU kernels.</li>
           <li><code>kiln-training</code> defines the SFT and GRPO training APIs and job state.</li>
         </ul>
       </article>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -346,6 +346,12 @@ requests.post("http://localhost:8420/v1/train/grpo",
 tar -xzf kiln.tar.gz
 KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
 
+      <h3 class="font-semibold mb-2 mt-6">Linux x86_64 &middot; Vulkan 1.2</h3>
+<pre><code>curl -L -o kiln.tar.gz \
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-unknown-linux-gnu-vulkan.tar.gz
+tar -xzf kiln.tar.gz
+KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
+
       <h3 class="font-semibold mb-2 mt-6">macOS &middot; Apple Silicon (Metal)</h3>
 <pre><code>curl -L -o kiln.tar.gz \
   https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-aarch64-apple-darwin-metal.tar.gz

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -202,9 +202,16 @@
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">Linux x86_64 &middot; CUDA 12.4</h3>
-<pre class="text-sm"><code>curl -L -o kiln-linux.tar.gz \
+<pre class="text-sm"><code>curl -L -o kiln-linux-cuda.tar.gz \
   https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-unknown-linux-gnu-cuda124.tar.gz
-tar -xzf kiln-linux.tar.gz</code></pre>
+tar -xzf kiln-linux-cuda.tar.gz</code></pre>
+        </div>
+        <div class="install-card">
+          <h3 class="font-semibold mb-2">Linux x86_64 &middot; Vulkan 1.2</h3>
+<pre class="text-sm"><code>curl -L -o kiln-linux-vulkan.tar.gz \
+  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-unknown-linux-gnu-vulkan.tar.gz
+tar -xzf kiln-linux-vulkan.tar.gz</code></pre>
+          <p class="text-sm mt-3" style="color: var(--fg-mute);">Use this on AMD/Intel Linux systems where <code>vulkaninfo --summary</code> lists the GPU.</p>
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">macOS Apple Silicon &middot; Metal</h3>
@@ -309,7 +316,7 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
         </a>
         <a class="card p-5 block" href="troubleshooting.html">
           <h3 class="font-semibold mb-2">Troubleshooting</h3>
-          <p style="color: var(--fg-dim);">Fix model paths, binary downloads, CUDA/Metal setup, Docker, and health checks.</p>
+          <p style="color: var(--fg-dim);">Fix model paths, binary downloads, CUDA/Vulkan/Metal setup, Docker, and health checks.</p>
         </a>
       </div>
     </div>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Kiln Troubleshooting &mdash; First-run checks</title>
-  <meta name="description" content="Compact troubleshooting notes for first-time Kiln setup: binaries, CUDA, Apple Silicon, model paths, health checks, training endpoints, and adapters.">
+  <meta name="description" content="Compact troubleshooting notes for first-time Kiln setup: binaries, CUDA, Vulkan, Apple Silicon, model paths, health checks, training endpoints, and adapters.">
   <link rel="canonical" href="https://ericflo.github.io/kiln/troubleshooting.html">
   <link rel="icon" type="image/png" href="assets/logo.png">
 
@@ -199,7 +199,7 @@
           <div class="label mb-2">Binary</div>
           <p style="color: var(--fg-dim);">
             Pick the release artifact for your OS and accelerator: Linux/Windows CUDA builds for NVIDIA GPUs,
-            or the Apple Silicon Metal build on macOS arm64.
+            the Linux Vulkan build for AMD/Intel GPUs, or the Apple Silicon Metal build on macOS arm64.
           </p>
         </div>
         <div class="card p-5">
@@ -223,7 +223,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
         <div class="label mb-2">Desktop App first launch</div>
         <h2 id="desktop-app-first-launch" class="text-xl font-semibold mb-3">If the Desktop App does not finish first launch</h2>
         <p class="mb-4" style="color: var(--fg-dim);">
-          The Desktop App wraps the same Kiln server, model path, CUDA driver, and local port checks. If setup stalls,
+          The Desktop App wraps the same Kiln server, model path, GPU driver, and local port checks. If setup stalls,
           open the app's <strong>Logs</strong> view first, then compare the message with these common recovery paths.
         </p>
         <div class="grid md:grid-cols-2 gap-5 check-list" style="color: var(--fg-dim);">
@@ -231,6 +231,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
             <li>If the server binary failed to download or verify, retry the download and confirm the app can write to its data directory.</li>
             <li>If the model path is unset or missing weights, choose the local Qwen3.5-4B directory that contains safetensors, config, and tokenizer files.</li>
             <li>If the CUDA driver is too old or an update is blocked on Linux or Windows, update the NVIDIA driver before launching the CUDA server.</li>
+            <li>If a Vulkan build falls back to CPU, run <code>vulkaninfo --summary</code> and confirm the AMD/Intel GPU is listed before launching the Vulkan server.</li>
           </ul>
           <ul class="list-disc pl-5">
             <li>If the port is already in use, stop the other Kiln/server process or change the Desktop App server port before restarting.</li>
@@ -257,13 +258,14 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
             <div class="label mb-2">Check</div>
             <ul class="list-disc pl-5">
               <li>Linux and Windows CUDA builds require an NVIDIA GPU.</li>
+              <li>Linux Vulkan builds require a Vulkan 1.2+ AMD/Intel driver; <code>vulkaninfo --summary</code> should list the target GPU.</li>
               <li>CUDA release builds target CUDA 12.4-era systems.</li>
-              <li>macOS uses the Apple Silicon Metal artifact, not a CUDA artifact.</li>
+              <li>macOS uses the Apple Silicon Metal artifact, not a CUDA or Vulkan artifact.</li>
             </ul>
           </div>
           <div>
             <div class="label mb-2">Fix</div>
-            <p>Download the matching artifact from <a href="https://github.com/ericflo/kiln/releases">GitHub releases</a>. On Linux with Docker, install NVIDIA Container Toolkit before using <code>--gpus all</code>.</p>
+            <p>Download the matching artifact from <a href="https://github.com/ericflo/kiln/releases">GitHub releases</a>. On Linux Vulkan hosts, use <code>KILN_VULKAN_DEVICE=0</code> or <code>GGML_VK_VISIBLE_DEVICES=0</code> to pin a device. On Linux with Docker, install NVIDIA Container Toolkit before using <code>--gpus all</code>.</p>
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Summary
- Document Vulkan build/runtime selection across README, QUICKSTART, and docs site pages that still described CUDA/Metal-only paths.
- Improve Vulkan device selection diagnostics for invalid `KILN_VULKAN_DEVICE` / `GGML_VK_VISIBLE_DEVICES` values while preserving graceful fallback.
- Add pure unit coverage for Vulkan device-index selection without requiring a Vulkan host.

## Validation
- `cargo check --locked -p kiln-server --features vulkan`
- `cargo test --locked -p kiln-vulkan-kernel explicit_vulkan_device -- --nocapture`
- `git diff --check`

Note: `cargo fmt --all` could not be run locally because this container's `stable-x86_64-unknown-linux-musl` toolchain is missing `rustfmt`, and `rustup component add rustfmt` failed while cleaning cached downloads.