### PR TITLE
Make release examples track latest Kiln version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: actions/configure-pages@v5
+      - name: Check release version drift
+        run: python3 scripts/check_release_versions.py
       - name: Assemble site
         run: |
           mkdir -p _site

--- a/.github/workflows/release-version-drift.yml
+++ b/.github/workflows/release-version-drift.yml
@@ -1,0 +1,35 @@
+name: Release Version Drift
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Cargo.toml'
+      - 'desktop/Cargo.toml'
+      - 'README.md'
+      - 'QUICKSTART.md'
+      - 'desktop/README.md'
+      - 'docs/site/**'
+      - 'docs/release-version-policy.md'
+      - 'scripts/check_release_versions.py'
+      - '.github/workflows/release-version-drift.yml'
+  pull_request:
+    paths:
+      - 'Cargo.toml'
+      - 'desktop/Cargo.toml'
+      - 'README.md'
+      - 'QUICKSTART.md'
+      - 'desktop/README.md'
+      - 'docs/site/**'
+      - 'docs/release-version-policy.md'
+      - 'scripts/check_release_versions.py'
+      - '.github/workflows/release-version-drift.yml'
+  workflow_dispatch:
+
+jobs:
+  check:
+    name: Check user-facing release examples
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+      - run: python3 scripts/check_release_versions.py

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -35,7 +35,7 @@ Kiln Desktop ships prebuilt installers for Windows, Linux, and macOS. The instal
 
 **Download — [Kiln Desktop v0.2.2](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2):**
 
-**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.2` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, currently `kiln-v0.2.13`, so this quickstart is not stale.
+**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.2` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, so this quickstart is not stale.
 
 | Platform | Installer | Size |
 |----------|-----------|------|
@@ -129,7 +129,7 @@ You'll see the startup banner:
   │   inference · training · adapters   │
   └─────────────────────────────────────┘
 
-  Version: 0.2.13
+  Version: <workspace version>
   Mode:    GPU inference
   Model:   ./Qwen3.5-4B
   CUDA:    available ✓

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Vulkan builds auto-select a Vulkan physical device at startup. Use `KILN_VULKAN_
   │   inference · training · adapters   │
   └─────────────────────────────────────┘
 
-  Version: 0.2.13
+  Version: <workspace version>
   Model:   ./Qwen3.5-4B
   CUDA:    available ✓
   GPU:     NVIDIA RTX A6000
@@ -319,7 +319,7 @@ Kiln Desktop is a system-tray app that wraps the `kiln` server for people who do
 
 **Download — [Kiln Desktop v0.2.2](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2):**
 
-**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.2` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, currently `kiln-v0.2.13`, so the version split is intentional.
+**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.2` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, so the version split is intentional.
 
 See **[desktop/CHANGELOG.md](desktop/CHANGELOG.md)** for the full version history.
 
@@ -355,8 +355,9 @@ Each `kiln-v*` tag publishes a `linux/amd64` CUDA 12.4 image to GHCR:
 
 ```bash
 docker pull ghcr.io/ericflo/kiln-server:latest
-# or pin a version:
-docker pull ghcr.io/ericflo/kiln-server:0.2.13
+# or pin the current latest version programmatically:
+KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest | sed -n 's/.*"tag_name": "kiln-v\([^"]*\)".*/\1/p')
+docker pull ghcr.io/ericflo/kiln-server:${KILN_VERSION}
 ```
 
 Run with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html):
@@ -384,7 +385,7 @@ sudo systemctl enable --now kiln
 
 ## Status
 
-Kiln v0.1.0 shipped on 2026-04-19 and the current release line is **kiln-v0.2.13** (released 2026-05-02). Phases 1–10 are shipped or chapter-closed: core inference, LoRA serving, SFT and GRPO training over HTTP, production hardening, the Phase 6 performance sprint (FP8 KV cache, CUDA graphs, GPTQ + Marlin W4A16 quantization, fused decode kernels, SGLang-style radix prefix cache), Phase 7 developer experience, Phase 8 advanced features (adapter upload/download, TIES + concatenation merge modes, per-request adapter composition, batch completions for GRPO, training webhooks), Phase 9 public-release prep (Sigstore-signed provenance, GHCR image, signed binaries for Linux/macOS/Windows), and Phase 10 Liger-style long-context training kernels (closed by [`docs/audits/PHASE10_CLOSURE.md`](docs/audits/PHASE10_CLOSURE.md)). Inference on macOS / Apple Silicon runs via the candle-metal backend, with a fused Metal kernel family landed in v0.2.0. Active phase is Phase 11 — onboarding and polish for cold-reader developers. See [`CHANGELOG.md`](CHANGELOG.md) for what landed in the most recent release and [`BENCHMARKS.md`](BENCHMARKS.md) for current decode numbers.
+Kiln v0.1.0 shipped on 2026-04-19 and the current release line follows the latest `kiln-v*` GitHub release. Phases 1–10 are shipped or chapter-closed: core inference, LoRA serving, SFT and GRPO training over HTTP, production hardening, the Phase 6 performance sprint (FP8 KV cache, CUDA graphs, GPTQ + Marlin W4A16 quantization, fused decode kernels, SGLang-style radix prefix cache), Phase 7 developer experience, Phase 8 advanced features (adapter upload/download, TIES + concatenation merge modes, per-request adapter composition, batch completions for GRPO, training webhooks), Phase 9 public-release prep (Sigstore-signed provenance, GHCR image, signed binaries for Linux/macOS/Windows), and Phase 10 Liger-style long-context training kernels (closed by [`docs/audits/PHASE10_CLOSURE.md`](docs/audits/PHASE10_CLOSURE.md)). Inference on macOS / Apple Silicon runs via the candle-metal backend, with a fused Metal kernel family landed in v0.2.0. Active phase is Phase 11 — onboarding and polish for cold-reader developers. See [`CHANGELOG.md`](CHANGELOG.md) for what landed in the most recent release and [`BENCHMARKS.md`](BENCHMARKS.md) for current decode numbers.
 
 Not yet production-hardened for multi-tenant use. Designed for single-user, single-GPU deployments — your home server, your dev box, your dedicated cloud instance.
 

--- a/docs/release-version-policy.md
+++ b/docs/release-version-policy.md
@@ -1,0 +1,12 @@
+# Release Version Policy
+
+Kiln has two release lines with different sources of truth:
+
+- **Server releases** use the root workspace version in `Cargo.toml` and publish GitHub releases named `kiln-vX.Y.Z` plus `ghcr.io/ericflo/kiln-server:{X.Y.Z}` / `latest`.
+- **Desktop releases** use `desktop/Cargo.toml` and publish GitHub releases named `desktop-vX.Y.Z`.
+
+User-facing server install snippets should avoid checked-in `kiln-vX.Y.Z`, `kiln-X.Y.Z-...`, or `ghcr.io/ericflo/kiln-server:X.Y.Z` literals. Prefer `/releases/latest`, `ghcr.io/ericflo/kiln-server:latest`, or a short `KILN_VERSION=$(curl ... /releases/latest ...)` lookup before constructing asset URLs. GitHub release asset filenames include the version, so binary download commands need the computed `KILN_VERSION` variable.
+
+Desktop download links are intentionally pinned because GitHub only has one repository-wide `latest` release, and the server release line moves independently of `desktop-v*`. Keep desktop user-facing links aligned with `desktop/Cargo.toml`; `scripts/check_release_versions.py` enforces that pin.
+
+Historical changelogs, audit reports, troubleshooting notes for old releases, and release workflow examples may mention specific versions when the version is part of the historical record or a test fixture.

--- a/docs/site/demo/SCRIPT.md
+++ b/docs/site/demo/SCRIPT.md
@@ -57,7 +57,7 @@ Expected on-screen output (abbreviated by the asciicast — let it scroll natura
   │   inference · training · adapters   │
   └─────────────────────────────────────┘
 
-  Version: 0.2.13
+  Version: <workspace version>
   Mode:    GPU inference
   Model:   ./Qwen3.5-4B
   CUDA:    available ✓

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -194,8 +194,8 @@
 
       <p class="meta-line">
         Recording note: this embedded asciicast was captured on kiln v0.2.8, so the startup banner
-        shows <code>0.2.8</code>. The current release line is kiln-v0.2.13; the SFT training,
-        adapter hot-swap, and chat-completions API flow shown here remains current.
+        shows <code>0.2.8</code>. The SFT training, adapter hot-swap, and
+        chat-completions API flow shown here remains current even as the latest release moves forward.
       </p>
 
       <section class="transcript-card prose-body mt-8 p-5 sm:p-6" aria-labelledby="transcript-fallback">

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -153,7 +153,7 @@
   <!-- hero -->
   <section class="hero-glow">
     <div class="max-w-5xl mx-auto px-6 pt-20 pb-16">
-      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">v0.2.13 &middot; pre-1.0 preview</span>
+      <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">latest kiln-v* &middot; pre-1.0 preview</span>
       <h1 class="text-5xl sm:text-6xl font-bold tracking-tight mb-5">
         Your model gets better <br>every time you use it.
       </h1>
@@ -324,7 +324,7 @@ requests.post("http://localhost:8420/v1/train/grpo",
     <div class="max-w-5xl mx-auto px-6 py-16">
       <h2 class="text-2xl font-semibold tracking-tight mb-2">Install</h2>
       <p class="text-sm mb-8" style="color: var(--fg-mute);">
-        Latest release: <a href="https://github.com/ericflo/kiln/releases/tag/kiln-v0.2.13">kiln-v0.2.13</a>.
+        Latest release: <a href="https://github.com/ericflo/kiln/releases/latest">GitHub's latest kiln-v* release</a>.
         Prerequisites: NVIDIA GPU with 24 GB+ VRAM and CUDA 12.4 <em>or</em> Apple Silicon Mac with 16 GB+ unified memory.
       </p>
 
@@ -341,26 +341,30 @@ requests.post("http://localhost:8420/v1/train/grpo",
       </div>
 
       <h3 class="font-semibold mb-2 mt-2">Linux x86_64 &middot; CUDA 12.4</h3>
-<pre><code>curl -L -o kiln.tar.gz \
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-unknown-linux-gnu-cuda124.tar.gz
+<pre><code>KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest | sed -n 's/.*&quot;tag_name&quot;: &quot;kiln-v\([^&quot;]*\)&quot;.*/\1/p')
+curl -L -o kiln.tar.gz \
+  "https://github.com/ericflo/kiln/releases/download/kiln-v${KILN_VERSION}/kiln-${KILN_VERSION}-x86_64-unknown-linux-gnu-cuda124.tar.gz"
 tar -xzf kiln.tar.gz
 KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
 
       <h3 class="font-semibold mb-2 mt-6">Linux x86_64 &middot; Vulkan 1.2</h3>
-<pre><code>curl -L -o kiln.tar.gz \
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-unknown-linux-gnu-vulkan.tar.gz
+<pre><code>KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest | sed -n 's/.*&quot;tag_name&quot;: &quot;kiln-v\([^&quot;]*\)&quot;.*/\1/p')
+curl -L -o kiln.tar.gz \
+  "https://github.com/ericflo/kiln/releases/download/kiln-v${KILN_VERSION}/kiln-${KILN_VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz"
 tar -xzf kiln.tar.gz
 KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
 
       <h3 class="font-semibold mb-2 mt-6">macOS &middot; Apple Silicon (Metal)</h3>
-<pre><code>curl -L -o kiln.tar.gz \
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-aarch64-apple-darwin-metal.tar.gz
+<pre><code>KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest | sed -n 's/.*&quot;tag_name&quot;: &quot;kiln-v\([^&quot;]*\)&quot;.*/\1/p')
+curl -L -o kiln.tar.gz \
+  "https://github.com/ericflo/kiln/releases/download/kiln-v${KILN_VERSION}/kiln-${KILN_VERSION}-aarch64-apple-darwin-metal.tar.gz"
 tar -xzf kiln.tar.gz
 KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve</code></pre>
 
       <h3 class="font-semibold mb-2 mt-6">Windows x86_64 &middot; CUDA 12.4</h3>
-<pre><code>Invoke-WebRequest -Uri `
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-pc-windows-msvc-cuda124.zip `
+<pre><code>$KilnVersion = ((Invoke-RestMethod https://api.github.com/repos/ericflo/kiln/releases/latest).tag_name -replace '^kiln-v', '')
+Invoke-WebRequest -Uri `
+  "https://github.com/ericflo/kiln/releases/download/kiln-v$KilnVersion/kiln-$KilnVersion-x86_64-pc-windows-msvc-cuda124.zip" `
   -OutFile kiln.zip
 Expand-Archive kiln.zip
 $env:KILN_MODEL_PATH = ".\Qwen3.5-4B"; .\kiln\kiln.exe serve</code></pre>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -202,27 +202,31 @@
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">Linux x86_64 &middot; CUDA 12.4</h3>
-<pre class="text-sm"><code>curl -L -o kiln-linux-cuda.tar.gz \
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-unknown-linux-gnu-cuda124.tar.gz
+<pre class="text-sm"><code>KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest | sed -n 's/.*&quot;tag_name&quot;: &quot;kiln-v\([^&quot;]*\)&quot;.*/\1/p')
+curl -L -o kiln-linux-cuda.tar.gz \
+  "https://github.com/ericflo/kiln/releases/download/kiln-v${KILN_VERSION}/kiln-${KILN_VERSION}-x86_64-unknown-linux-gnu-cuda124.tar.gz"
 tar -xzf kiln-linux-cuda.tar.gz</code></pre>
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">Linux x86_64 &middot; Vulkan 1.2</h3>
-<pre class="text-sm"><code>curl -L -o kiln-linux-vulkan.tar.gz \
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-unknown-linux-gnu-vulkan.tar.gz
+<pre class="text-sm"><code>KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest | sed -n 's/.*&quot;tag_name&quot;: &quot;kiln-v\([^&quot;]*\)&quot;.*/\1/p')
+curl -L -o kiln-linux-vulkan.tar.gz \
+  "https://github.com/ericflo/kiln/releases/download/kiln-v${KILN_VERSION}/kiln-${KILN_VERSION}-x86_64-unknown-linux-gnu-vulkan.tar.gz"
 tar -xzf kiln-linux-vulkan.tar.gz</code></pre>
           <p class="text-sm mt-3" style="color: var(--fg-mute);">Use this on AMD/Intel Linux systems where <code>vulkaninfo --summary</code> lists the GPU.</p>
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">macOS Apple Silicon &middot; Metal</h3>
-<pre class="text-sm"><code>curl -L -o kiln-macos.tar.gz \
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-aarch64-apple-darwin-metal.tar.gz
+<pre class="text-sm"><code>KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest | sed -n 's/.*&quot;tag_name&quot;: &quot;kiln-v\([^&quot;]*\)&quot;.*/\1/p')
+curl -L -o kiln-macos.tar.gz \
+  "https://github.com/ericflo/kiln/releases/download/kiln-v${KILN_VERSION}/kiln-${KILN_VERSION}-aarch64-apple-darwin-metal.tar.gz"
 tar -xzf kiln-macos.tar.gz</code></pre>
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">Windows x86_64 &middot; CUDA 12.4</h3>
-<pre class="text-sm"><code>curl.exe -L -o kiln-windows.zip `
-  https://github.com/ericflo/kiln/releases/download/kiln-v0.2.13/kiln-0.2.13-x86_64-pc-windows-msvc-cuda124.zip
+<pre class="text-sm"><code>$KilnVersion = ((Invoke-RestMethod https://api.github.com/repos/ericflo/kiln/releases/latest).tag_name -replace '^kiln-v', '')
+curl.exe -L -o kiln-windows.zip `
+  "https://github.com/ericflo/kiln/releases/download/kiln-v$KilnVersion/kiln-$KilnVersion-x86_64-pc-windows-msvc-cuda124.zip"
 Expand-Archive .\kiln-windows.zip -DestinationPath .\kiln</code></pre>
         </div>
       </div>
@@ -259,7 +263,7 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
 <pre class="text-sm"><code>docker run --gpus all -p 8420:8420 \
   -e KILN_MODEL_PATH=/models/Qwen3.5-4B \
   -v "$PWD/Qwen3.5-4B:/models/Qwen3.5-4B:ro" \
-  ghcr.io/ericflo/kiln-server:0.2.13</code></pre>
+  ghcr.io/ericflo/kiln-server:latest</code></pre>
       </div>
     </div>
   </section>

--- a/scripts/check_release_versions.py
+++ b/scripts/check_release_versions.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Guard user-facing Kiln release examples against stale version literals."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER_VERSION_RE = re.compile(r'^version\s*=\s*"([0-9]+\.[0-9]+\.[0-9]+)"\s*$', re.MULTILINE)
+
+
+def package_version(path: Path) -> str:
+    text = path.read_text()
+    match = SERVER_VERSION_RE.search(text)
+    if not match:
+        raise SystemExit(f"could not find package version in {path}")
+    return match.group(1)
+
+
+SERVER_VERSION = package_version(ROOT / "Cargo.toml")
+DESKTOP_VERSION = package_version(ROOT / "desktop" / "Cargo.toml")
+
+CURRENT_SERVER_SURFACES = [
+    ROOT / "README.md",
+    ROOT / "QUICKSTART.md",
+    ROOT / "docs/site/index.html",
+    ROOT / "docs/site/quickstart.html",
+    ROOT / "docs/site/demo/SCRIPT.md",
+    ROOT / "docs/site/demo/index.html",
+]
+
+DISALLOWED_CURRENT_SERVER_PATTERNS = [
+    (re.compile(r"kiln-v[0-9]+\.[0-9]+\.[0-9]+"), "server release tags should use /releases/latest or a latest-release lookup"),
+    (re.compile(r"kiln-[0-9]+\.[0-9]+\.[0-9]+-(?:x86_64|aarch64)"), "server release asset names should derive from KILN_VERSION"),
+    (re.compile(r"ghcr\.io/ericflo/kiln-server:[0-9]+\.[0-9]+\.[0-9]+"), "Docker examples should use :latest or a computed KILN_VERSION"),
+    (re.compile(rf"Version:\s*{re.escape(SERVER_VERSION)}"), "sample startup banners should use <workspace version>"),
+]
+
+DESKTOP_SURFACES = [
+    ROOT / "README.md",
+    ROOT / "QUICKSTART.md",
+    ROOT / "desktop/README.md",
+    ROOT / "docs/site/index.html",
+    ROOT / "docs/site/quickstart.html",
+]
+
+
+def rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    for path in CURRENT_SERVER_SURFACES:
+        text = path.read_text()
+        for pattern, reason in DISALLOWED_CURRENT_SERVER_PATTERNS:
+            for match in pattern.finditer(text):
+                line = text.count("\n", 0, match.start()) + 1
+                line_text = text.splitlines()[line - 1]
+                if "Since kiln-v" in line_text:
+                    continue
+                errors.append(f"{rel(path)}:{line}: {reason}: {match.group(0)!r}")
+
+    expected_desktop_tag = f"desktop-v{DESKTOP_VERSION}"
+    expected_desktop_asset = f"Kiln.Desktop_{DESKTOP_VERSION}_"
+    for path in DESKTOP_SURFACES:
+        text = path.read_text()
+        for match in re.finditer(r"desktop-v[0-9]+\.[0-9]+\.[0-9]+", text):
+            if match.group(0) != expected_desktop_tag:
+                line = text.count("\n", 0, match.start()) + 1
+                errors.append(
+                    f"{rel(path)}:{line}: desktop release tag should match "
+                    f"desktop/Cargo.toml ({expected_desktop_tag}), got {match.group(0)!r}"
+                )
+        for match in re.finditer(r"Kiln\.Desktop_[0-9]+\.[0-9]+\.[0-9]+_", text):
+            if match.group(0) != expected_desktop_asset:
+                line = text.count("\n", 0, match.start()) + 1
+                errors.append(
+                    f"{rel(path)}:{line}: desktop installer asset should match "
+                    f"desktop/Cargo.toml ({expected_desktop_asset}*), got {match.group(0)!r}"
+                )
+
+    required_latest_snippets = {
+        ROOT / "docs/site/index.html": ["releases/latest", "KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest"],
+        ROOT / "docs/site/quickstart.html": ["KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest", "ghcr.io/ericflo/kiln-server:latest"],
+        ROOT / "README.md": ["ghcr.io/ericflo/kiln-server:latest", "KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest"],
+    }
+    for path, snippets in required_latest_snippets.items():
+        text = path.read_text()
+        for snippet in snippets:
+            if snippet not in text:
+                errors.append(f"{rel(path)}: missing latest-version snippet {snippet!r}")
+
+    if errors:
+        print("release version drift check failed:", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        return 1
+
+    print(
+        "release version drift check passed: "
+        f"server examples avoid pinned {SERVER_VERSION}; desktop pins match {expected_desktop_tag}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Audited user-facing release/version references across README, QUICKSTART, docs/site, desktop docs, workflows, changelogs/audits, and desktop installer tests.
- Replaced current server release literals in README and the published `docs/site` install paths with `/releases/latest`, `ghcr.io/ericflo/kiln-server:latest`, or a computed `KILN_VERSION` from the GitHub latest-release API before constructing versioned asset URLs.
- Updated sample startup banners to use `<workspace version>` instead of a checked-in current version number.
- Added `docs/release-version-policy.md` documenting the two sources of truth: root `Cargo.toml` for server releases and `desktop/Cargo.toml` for the separate desktop release line.
- Added `scripts/check_release_versions.py` plus a lightweight `Release Version Drift` workflow and a Pages pre-deploy check.

## Audit Findings

- **Server install/download examples**: README, `docs/site/index.html`, and `docs/site/quickstart.html` had `kiln-v0.2.13`, `kiln-0.2.13-*`, and `ghcr.io/ericflo/kiln-server:0.2.13` literals. These now resolve latest dynamically.
- **Current-status prose and sample banners**: README/QUICKSTART/demo copy carried the current package version as example output. These now use neutral/current-moving wording.
- **Desktop downloads**: README, QUICKSTART, `desktop/README.md`, and site desktop links intentionally remain pinned to `desktop-v0.2.2` because GitHub only has one repo-wide latest release and the server line moves independently. The new guard checks those pins against `desktop/Cargo.toml`.
- **Historical records/tests**: CHANGELOG, audits, troubleshooting notes for pinned old releases, and Rust installer test fixtures keep literal versions because they are historical records or behavior fixtures rather than current install guidance.

## Validation

- `python3 scripts/check_release_versions.py`
- `git diff --check`
- Verified `https://api.github.com/repos/ericflo/kiln/releases/latest` resolves to workspace version `0.2.13` today.