### PR TITLE
Quiet kiln serve startup and add --verbose/--quiet flags

### DIFF
--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -144,6 +144,34 @@ pub struct Cli {
     /// Path to TOML config file
     #[arg(long, short, global = true)]
     pub config: Option<String>,
+
+    /// Increase verbosity. `-v` shows debug logs (the legacy startup firehose),
+    /// `-vv` adds trace-level kernel detail. Wins over `KILN_LOG_LEVEL` and the
+    /// TOML `[logging] level`, but loses to `RUST_LOG` if set explicitly.
+    #[arg(long, short, global = true, action = clap::ArgAction::Count)]
+    pub verbose: u8,
+
+    /// Quiet mode — only warnings and errors. Mutually exclusive with `--verbose`.
+    #[arg(long, short, global = true, conflicts_with = "verbose")]
+    pub quiet: bool,
+}
+
+impl Cli {
+    /// Resolve the effective tracing-subscriber filter directive based on
+    /// `--verbose`/`--quiet` flags and a fallback (typically the TOML
+    /// `[logging] level`). `RUST_LOG` is *not* consulted here; it's checked
+    /// inside `logging::init` and wins regardless of CLI flags.
+    pub fn effective_log_level<'a>(&'a self, fallback: &'a str) -> &'a str {
+        if self.quiet {
+            "warn"
+        } else {
+            match self.verbose {
+                0 => fallback,
+                1 => "debug",
+                _ => "trace",
+            }
+        }
+    }
 }
 
 #[derive(Subcommand)]
@@ -429,6 +457,45 @@ pub fn print_banner(host: &str, port: u16, model_path: Option<&str>, config_path
         stderr,
         "  {} /ui, /v1/chat/completions, /v1/train/sft, /health, /metrics",
         style("Endpoints:").dim()
+    );
+    let _ = writeln!(stderr);
+}
+
+/// Build a spinner-style indicatif bar for long-running startup phases (model
+/// load, weight upload, KV cache allocation). Returns `None` when stderr isn't
+/// attended (CI, systemd, docker) so the JSON log path stays clean.
+///
+/// The returned `ProgressBar` ticks every 80ms; callers should `set_message`
+/// between phases and `finish_and_clear` once done so the line goes away
+/// before [`print_ready_line`] writes the final status.
+pub fn make_startup_spinner(initial_message: impl Into<std::borrow::Cow<'static, str>>) -> Option<indicatif::ProgressBar> {
+    if !console::Term::stderr().features().is_attended() {
+        return None;
+    }
+    let pb = indicatif::ProgressBar::new_spinner();
+    pb.set_style(
+        indicatif::ProgressStyle::with_template("  {spinner:.cyan} {msg} {elapsed:.dim}")
+            .expect("static spinner template is valid")
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+    );
+    pb.enable_steady_tick(std::time::Duration::from_millis(80));
+    pb.set_message(initial_message);
+    Some(pb)
+}
+
+/// Emit the single human-readable "ready" line at INFO level. Called once after
+/// the listener binds and after any model-load progress finishes. Stays terse on
+/// purpose — the banner already covered version/GPU/model details, and we want
+/// silence-until-requests after this line.
+pub fn print_ready_line(host: &str, port: u16) {
+    let mut stderr = std::io::stderr();
+    let addr = format!("http://{host}:{port}");
+    let _ = writeln!(
+        stderr,
+        "  {} {} {}",
+        style("✓").green().bold(),
+        style("Ready on").dim(),
+        style(addr).cyan().bold()
     );
     let _ = writeln!(stderr);
 }
@@ -1229,6 +1296,42 @@ mod tests {
     use super::*;
     use reqwest::StatusCode;
     use serde_json::json;
+
+    fn cli_with(verbose: u8, quiet: bool) -> Cli {
+        Cli {
+            command: None,
+            config: None,
+            verbose,
+            quiet,
+        }
+    }
+
+    #[test]
+    fn effective_log_level_returns_fallback_with_no_flags() {
+        assert_eq!(cli_with(0, false).effective_log_level("info"), "info");
+        assert_eq!(
+            cli_with(0, false).effective_log_level("kiln=info,tower_http=warn"),
+            "kiln=info,tower_http=warn"
+        );
+    }
+
+    #[test]
+    fn effective_log_level_v_promotes_to_debug() {
+        assert_eq!(cli_with(1, false).effective_log_level("info"), "debug");
+    }
+
+    #[test]
+    fn effective_log_level_vv_promotes_to_trace() {
+        assert_eq!(cli_with(2, false).effective_log_level("info"), "trace");
+        assert_eq!(cli_with(3, false).effective_log_level("info"), "trace");
+    }
+
+    #[test]
+    fn effective_log_level_quiet_overrides_verbose_fallback() {
+        assert_eq!(cli_with(0, true).effective_log_level("info"), "warn");
+        // quiet wins regardless of fallback severity
+        assert_eq!(cli_with(0, true).effective_log_level("trace"), "warn");
+    }
 
     #[test]
     fn build_sft_training_payload_uses_nested_config() {

--- a/crates/kiln-server/src/main.rs
+++ b/crates/kiln-server/src/main.rs
@@ -88,7 +88,8 @@ async fn main() -> Result<()> {
     // --- Server startup ---
     let config = KilnConfig::load(args.config.as_deref())?;
 
-    kiln_server::logging::init(&config.logging.level, &config.logging.format)?;
+    let level = args.effective_log_level(&config.logging.level);
+    kiln_server::logging::init(level, &config.logging.format)?;
 
     let host = &config.server.host;
     let port = config.server.port;
@@ -96,7 +97,7 @@ async fn main() -> Result<()> {
     let model_config = ModelConfig::qwen3_5_4b();
     let model_path = config.model.path.as_deref();
     let served_model_id = config.model.effective_served_model_id();
-    tracing::info!(served_model_id = %served_model_id, "served model identifier");
+    tracing::debug!(served_model_id = %served_model_id, "served model identifier");
 
     // Print startup banner to stderr (doesn't interfere with structured logs)
     cli::print_banner(host, port, model_path, args.config.as_deref());
@@ -106,7 +107,7 @@ async fn main() -> Result<()> {
     let tokenizer_path = config.model.tokenizer_path.as_deref();
 
     let (tokenizer, chat_template_dir) = if let Some(path) = tokenizer_path {
-        tracing::info!("loading tokenizer from {path}");
+        tracing::debug!("loading tokenizer from {path}");
         let tok = KilnTokenizer::from_file(path)?;
         let dir = Path::new(path).parent().map(|p| p.to_path_buf());
         (tok, dir)
@@ -114,7 +115,7 @@ async fn main() -> Result<()> {
         // Try loading tokenizer from the model directory first
         let tok_file = Path::new(mp).join("tokenizer.json");
         if tok_file.exists() {
-            tracing::info!(
+            tracing::debug!(
                 "loading tokenizer from model directory: {}",
                 tok_file.display()
             );
@@ -123,11 +124,11 @@ async fn main() -> Result<()> {
                 Some(PathBuf::from(mp)),
             )
         } else {
-            tracing::info!("loading tokenizer from HuggingFace Hub: {model_id}");
+            tracing::debug!("loading tokenizer from HuggingFace Hub: {model_id}");
             (KilnTokenizer::from_pretrained(model_id)?, None)
         }
     } else {
-        tracing::info!("loading tokenizer from HuggingFace Hub: {model_id}");
+        tracing::debug!("loading tokenizer from HuggingFace Hub: {model_id}");
         (KilnTokenizer::from_pretrained(model_id)?, None)
     };
 
@@ -140,7 +141,7 @@ async fn main() -> Result<()> {
     let tokenizer = if let Some(dir) = chat_template_dir.as_deref() {
         match load_chat_template_from_model_dir(dir) {
             Ok(Some((source, template))) => {
-                tracing::info!(
+                tracing::debug!(
                     source = source,
                     bytes = template.len(),
                     "loaded chat template from model directory"
@@ -168,28 +169,41 @@ async fn main() -> Result<()> {
         tokenizer
     };
 
-    tracing::info!(
+    tracing::debug!(
         vocab_size = tokenizer.vocab_size(),
         "tokenizer loaded successfully"
     );
 
     let mut state = if let Some(mp) = model_path {
         // Real inference mode: load model weights and create ModelRunner.
-        tracing::info!("loading model weights from {mp}");
+        tracing::debug!("loading model weights from {mp}");
+        let load_spinner = cli::make_startup_spinner("selecting device");
         let device = select_device_with_options(config.memory.cuda_graphs)?;
+        if let Some(pb) = load_spinner.as_ref() {
+            pb.set_message(format!("loading model weights from {mp}"));
+        }
         let model_weights = kiln_model::load_model_with_options(
             Path::new(mp),
             &model_config,
             kiln_model::LoadModelOptions { load_mtp: false },
         )?;
+        if let Some(pb) = load_spinner.as_ref() {
+            pb.set_message("uploading weights to GPU");
+        }
         let gpu_weights = GpuWeights::from_model_weights(&model_weights, &model_config, &device)?;
 
+        if let Some(pb) = load_spinner.as_ref() {
+            pb.set_message("initializing inference runtime");
+        }
         let runner = ModelRunner::new_with_options(
             gpu_weights,
             tokenizer.clone(),
             model_config.clone(),
             config.memory.cuda_graphs,
         );
+        if let Some(pb) = load_spinner.as_ref() {
+            pb.finish_and_clear();
+        }
 
         let adapter_dir = config
             .model
@@ -199,18 +213,18 @@ async fn main() -> Result<()> {
             .unwrap_or_else(|| PathBuf::from(mp).join("adapters"));
 
         if !adapter_dir.exists() {
-            tracing::info!(path = %adapter_dir.display(), "creating adapter directory");
+            tracing::debug!(path = %adapter_dir.display(), "creating adapter directory");
             std::fs::create_dir_all(&adapter_dir)?;
         }
 
-        tracing::info!(adapter_dir = %adapter_dir.display(), "model loaded — real inference mode");
+        tracing::debug!(adapter_dir = %adapter_dir.display(), "model loaded — real inference mode");
         if matches!(
             std::env::var("KILN_BATCHING_ENGINE").as_deref(),
             Ok("1") | Ok("true") | Ok("TRUE")
         ) {
-            tracing::info!("real non-streaming batching actor requested via KILN_BATCHING_ENGINE");
+            tracing::debug!("real non-streaming batching actor requested via KILN_BATCHING_ENGINE");
         }
-        tracing::info!(
+        tracing::debug!(
             "training endpoints available — in-process LoRA training (no sidecar needed)"
         );
         AppState::new_real(
@@ -226,8 +240,8 @@ async fn main() -> Result<()> {
         )
     } else {
         // Mock mode: use scheduler + mock engine.
-        tracing::info!("no model path set — running in mock mode");
-        tracing::info!("training endpoints will return 503 in mock mode (no real weights)");
+        tracing::debug!("no model path set — running in mock mode");
+        tracing::debug!("training endpoints will return 503 in mock mode (no real weights)");
         let scheduler_config = SchedulerConfig {
             max_batch_tokens: 8192,
             max_batch_size: 64,
@@ -258,33 +272,33 @@ async fn main() -> Result<()> {
     state.composed_cache_max_bytes = config.adapters.composed_cache_max_bytes;
     state.composed_cache_max_entries = config.adapters.composed_cache_max_entries;
     if let Some(ref url) = state.training_webhook_url {
-        tracing::info!(url = %url, "training completion webhook configured");
+        tracing::debug!(url = %url, "training completion webhook configured");
     }
-    tracing::info!(
+    tracing::debug!(
         cap = state.max_queued_training_jobs,
         "training queue cap configured"
     );
-    tracing::info!(
+    tracing::debug!(
         cap = state.max_tracked_jobs,
         ttl_secs = config.training.tracked_job_ttl_secs,
         "training tracked-jobs cap and TTL configured"
     );
     match state.adapter_max_disk_bytes {
-        Some(cap) => tracing::info!(
+        Some(cap) => tracing::debug!(
             cap_bytes = cap,
             cap_gib = cap as f64 / 1024.0 / 1024.0 / 1024.0,
             "adapter_dir disk cap configured"
         ),
-        None => tracing::info!("adapter_dir disk cap disabled (operator opt-out)"),
+        None => tracing::debug!("adapter_dir disk cap disabled (operator opt-out)"),
     }
     match (
         state.composed_cache_max_bytes,
         state.composed_cache_max_entries,
     ) {
         (None, None) => {
-            tracing::info!("composed-adapter cache LRU eviction disabled (operator opt-out)")
+            tracing::debug!("composed-adapter cache LRU eviction disabled (operator opt-out)")
         }
-        (bytes, entries) => tracing::info!(
+        (bytes, entries) => tracing::debug!(
             cap_bytes = ?bytes,
             cap_gib = ?bytes.map(|b| b as f64 / 1024.0 / 1024.0 / 1024.0),
             cap_entries = ?entries,
@@ -302,12 +316,13 @@ async fn main() -> Result<()> {
 
     let addr = format!("{host}:{port}");
     let listener = tokio::net::TcpListener::bind(&addr).await?;
-    tracing::info!(
+    tracing::debug!(
         host = %host,
         port = port,
         model_path = model_path.unwrap_or("none (mock mode)"),
         "kiln listening"
     );
+    cli::print_ready_line(host, port);
     spawn_tokenizer_warmup(tokenizer_prewarm);
     spawn_backend_prewarm(prewarm_state);
     // Graceful shutdown: listen for SIGTERM/SIGINT, drain in-flight requests,
@@ -318,7 +333,7 @@ async fn main() -> Result<()> {
         .with_graceful_shutdown(shutdown_signal(shutdown_flag))
         .await?;
 
-    tracing::info!(
+    tracing::debug!(
         timeout_secs = shutdown_timeout_secs,
         "server stopped accepting connections — waiting for in-flight requests to drain"
     );


### PR DESCRIPTION
## Summary

Make `kiln serve` quiet on the happy path and add CLI flags to scale verbosity up or down.

**Before:** the default startup emitted a 12-line JSON firehose at INFO before the listener was even bound — config caps, queue caps, cache caps, "kiln listening". Operator trivia, not load-bearing for an interactive run.

**After:** banner → optional model-load spinner → one green `✓ Ready on http://host:port` line → silence until requests arrive.

```
  ┌─────────────────────────────────────┐
  │           🔥 K I L N 🔥             │
  │   inference · training · adapters   │
  └─────────────────────────────────────┘

  Version: 0.2.13
  Mode: GPU inference
  Model: ./Qwen3.5-4B
  CUDA: available ✓
  GPU:  NVIDIA RTX A6000
  VRAM: 49140 MiB total, 47912 MiB free
  Listen: http://0.0.0.0:8420

  Endpoints: /ui, /v1/chat/completions, /v1/train/sft, /health, /metrics

  ✓ Ready on http://0.0.0.0:8420
```

## Changes

- **Verbosity flags** (global, on every subcommand):
  - `-v` / `--verbose` (count): `-v` → debug, `-vv` → trace.
  - `-q` / `--quiet`: warn-level only. Mutually exclusive with `--verbose`.
  - Wins over `KILN_LOG_LEVEL` and TOML `[logging] level`, but `RUST_LOG` still wins (precedence preserved inside `logging::init`).

- **Demote ~15 startup `tracing::info!` to `debug!`** in `main.rs`: served-model id, tokenizer-loading messages, chat-template loaded, model-load progress, training-cap config, adapter-dir cap, composed-cache cap, "kiln listening", drain-on-shutdown.

- **One-line ready signal**: `cli::print_ready_line(host, port)` writes `✓ Ready on http://...` (green checkmark, dim "Ready on", cyan address) — the single human-readable INFO of the serve path.

- **Model-load spinner** (TTY-only, `console::Term::stderr().features().is_attended()` gated): `cli::make_startup_spinner` mirrors the kiln-train indicatif pattern. Phases: "selecting device" → "loading model weights from …" → "uploading weights to GPU" → "initializing inference runtime" → `finish_and_clear`. On non-TTY (systemd, docker, CI) the spinner is suppressed so structured JSON logs stay clean.

## Test plan

- [x] 4 new unit tests for `Cli::effective_log_level` — default fallback, `-v` → debug, `-vv` → trace, `--quiet` → warn precedence.
- [x] All 261 existing `kiln-server` tests pass (`cargo nextest run -p kiln-server --lib`).
- [x] `cargo check -p kiln-server` clean.
- [x] Smoke-tested all three modes locally:
  - default: banner + ready line, no DEBUG noise
  - `--quiet`: banner + ready line, no DEBUG/INFO noise
  - `--verbose`: banner + DEBUG firehose + ready line
- [x] `kiln --help` shows new `--verbose` / `--quiet` entries.

## Notes

- This is PR-A in a two-PR sequence (see `DESIGN.md` in the demo session). PR-B will give `kiln-bench` the same treatment: progress bars, styled summary table, median-of-N row.
- No behavior change for `RUST_LOG`-driven logging; `logging::init` still gives `RUST_LOG` final precedence.