### PR TITLE
Add docs site code copy buttons

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -146,6 +146,40 @@
         width: 100%;
       }
     }
+
+    .copy-code-shell {
+      position: relative;
+    }
+    .copy-code-shell pre {
+      padding-right: 4.75rem;
+    }
+    .copy-code-button {
+      position: absolute;
+      top: 0.65rem;
+      right: 0.65rem;
+      z-index: 1;
+      border: 1px solid var(--line-2);
+      border-radius: 999px;
+      background: rgba(11, 13, 16, 0.88);
+      color: var(--fg-dim);
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 700;
+      line-height: 1;
+      padding: 0.45rem 0.65rem;
+      transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    }
+    .copy-code-button:hover,
+    .copy-code-button:focus-visible {
+      background: var(--bg-soft-2);
+      border-color: rgba(249, 115, 22, 0.55);
+      color: var(--fg);
+      outline: none;
+    }
+    .copy-code-button.is-copied {
+      border-color: rgba(34, 197, 94, 0.55);
+      color: #86efac;
+    }
   </style>
 </head>
 <body class="min-h-screen">
@@ -448,5 +482,69 @@ kiln serve --config kiln.toml</code></pre>
       </nav>
     </div>
   </footer>
+
+  <script>
+    (() => {
+      const resetDelay = 1800;
+
+      function selectCode(code) {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(code);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      async function copyCode(code) {
+        const text = code.innerText.replace(/\n$/, "");
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text);
+          return true;
+        }
+
+        selectCode(code);
+        const copied = document.execCommand && document.execCommand("copy");
+        if (!copied) {
+          console.info("Kiln docs: clipboard unavailable; selected the code block for manual copy.");
+        }
+        return copied;
+      }
+
+      document.querySelectorAll("pre > code").forEach((code) => {
+        const pre = code.parentElement;
+        if (!pre || pre.parentElement.classList.contains("copy-code-shell")) return;
+
+        const shell = document.createElement("div");
+        shell.className = "copy-code-shell";
+        pre.parentNode.insertBefore(shell, pre);
+        shell.appendChild(pre);
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "copy-code-button";
+        button.textContent = "Copy";
+        button.setAttribute("aria-label", "Copy code block");
+        shell.appendChild(button);
+
+        button.addEventListener("click", async () => {
+          try {
+            const copied = await copyCode(code);
+            button.textContent = copied ? "Copied" : "Selected";
+            button.classList.toggle("is-copied", copied);
+          } catch (error) {
+            selectCode(code);
+            console.info("Kiln docs: clipboard copy failed; selected the code block for manual copy.", error);
+            button.textContent = "Selected";
+            button.classList.remove("is-copied");
+          }
+
+          window.setTimeout(() => {
+            button.textContent = "Copy";
+            button.classList.remove("is-copied");
+          }, resetDelay);
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -132,6 +132,40 @@
         width: 100%;
       }
     }
+
+    .copy-code-shell {
+      position: relative;
+    }
+    .copy-code-shell pre {
+      padding-right: 4.75rem;
+    }
+    .copy-code-button {
+      position: absolute;
+      top: 0.65rem;
+      right: 0.65rem;
+      z-index: 1;
+      border: 1px solid var(--line-2);
+      border-radius: 999px;
+      background: rgba(11, 13, 16, 0.88);
+      color: var(--fg-dim);
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 700;
+      line-height: 1;
+      padding: 0.45rem 0.65rem;
+      transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    }
+    .copy-code-button:hover,
+    .copy-code-button:focus-visible {
+      background: var(--bg-soft-2);
+      border-color: rgba(249, 115, 22, 0.55);
+      color: var(--fg);
+      outline: none;
+    }
+    .copy-code-button.is-copied {
+      border-color: rgba(34, 197, 94, 0.55);
+      color: #86efac;
+    }
   </style>
 </head>
 <body class="min-h-screen">
@@ -353,5 +387,69 @@
       </nav>
     </div>
   </footer>
+
+  <script>
+    (() => {
+      const resetDelay = 1800;
+
+      function selectCode(code) {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(code);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      async function copyCode(code) {
+        const text = code.innerText.replace(/\n$/, "");
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text);
+          return true;
+        }
+
+        selectCode(code);
+        const copied = document.execCommand && document.execCommand("copy");
+        if (!copied) {
+          console.info("Kiln docs: clipboard unavailable; selected the code block for manual copy.");
+        }
+        return copied;
+      }
+
+      document.querySelectorAll("pre > code").forEach((code) => {
+        const pre = code.parentElement;
+        if (!pre || pre.parentElement.classList.contains("copy-code-shell")) return;
+
+        const shell = document.createElement("div");
+        shell.className = "copy-code-shell";
+        pre.parentNode.insertBefore(shell, pre);
+        shell.appendChild(pre);
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "copy-code-button";
+        button.textContent = "Copy";
+        button.setAttribute("aria-label", "Copy code block");
+        shell.appendChild(button);
+
+        button.addEventListener("click", async () => {
+          try {
+            const copied = await copyCode(code);
+            button.textContent = copied ? "Copied" : "Selected";
+            button.classList.toggle("is-copied", copied);
+          } catch (error) {
+            selectCode(code);
+            console.info("Kiln docs: clipboard copy failed; selected the code block for manual copy.", error);
+            button.textContent = "Selected";
+            button.classList.remove("is-copied");
+          }
+
+          window.setTimeout(() => {
+            button.textContent = "Copy";
+            button.classList.remove("is-copied");
+          }, resetDelay);
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -101,6 +101,40 @@
         width: 100%;
       }
     }
+
+    .copy-code-shell {
+      position: relative;
+    }
+    .copy-code-shell pre {
+      padding-right: 4.75rem;
+    }
+    .copy-code-button {
+      position: absolute;
+      top: 0.65rem;
+      right: 0.65rem;
+      z-index: 1;
+      border: 1px solid var(--line-2);
+      border-radius: 999px;
+      background: rgba(11, 13, 16, 0.88);
+      color: var(--fg-dim);
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 700;
+      line-height: 1;
+      padding: 0.45rem 0.65rem;
+      transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    }
+    .copy-code-button:hover,
+    .copy-code-button:focus-visible {
+      background: var(--bg-soft-2);
+      border-color: rgba(249, 115, 22, 0.55);
+      color: var(--fg);
+      outline: none;
+    }
+    .copy-code-button.is-copied {
+      border-color: rgba(34, 197, 94, 0.55);
+      color: #86efac;
+    }
   </style>
 </head>
 <body class="min-h-screen">
@@ -278,5 +312,69 @@ kiln adapters unload support-bot</code></pre>
       </nav>
     </div>
   </footer>
+
+  <script>
+    (() => {
+      const resetDelay = 1800;
+
+      function selectCode(code) {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(code);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      async function copyCode(code) {
+        const text = code.innerText.replace(/\n$/, "");
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text);
+          return true;
+        }
+
+        selectCode(code);
+        const copied = document.execCommand && document.execCommand("copy");
+        if (!copied) {
+          console.info("Kiln docs: clipboard unavailable; selected the code block for manual copy.");
+        }
+        return copied;
+      }
+
+      document.querySelectorAll("pre > code").forEach((code) => {
+        const pre = code.parentElement;
+        if (!pre || pre.parentElement.classList.contains("copy-code-shell")) return;
+
+        const shell = document.createElement("div");
+        shell.className = "copy-code-shell";
+        pre.parentNode.insertBefore(shell, pre);
+        shell.appendChild(pre);
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "copy-code-button";
+        button.textContent = "Copy";
+        button.setAttribute("aria-label", "Copy code block");
+        shell.appendChild(button);
+
+        button.addEventListener("click", async () => {
+          try {
+            const copied = await copyCode(code);
+            button.textContent = copied ? "Copied" : "Selected";
+            button.classList.toggle("is-copied", copied);
+          } catch (error) {
+            selectCode(code);
+            console.info("Kiln docs: clipboard copy failed; selected the code block for manual copy.", error);
+            button.textContent = "Selected";
+            button.classList.remove("is-copied");
+          }
+
+          window.setTimeout(() => {
+            button.textContent = "Copy";
+            button.classList.remove("is-copied");
+          }, resetDelay);
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/docs/site/grpo.html
+++ b/docs/site/grpo.html
@@ -144,6 +144,40 @@
         width: 100%;
       }
     }
+
+    .copy-code-shell {
+      position: relative;
+    }
+    .copy-code-shell pre {
+      padding-right: 4.75rem;
+    }
+    .copy-code-button {
+      position: absolute;
+      top: 0.65rem;
+      right: 0.65rem;
+      z-index: 1;
+      border: 1px solid var(--line-2);
+      border-radius: 999px;
+      background: rgba(11, 13, 16, 0.88);
+      color: var(--fg-dim);
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 700;
+      line-height: 1;
+      padding: 0.45rem 0.65rem;
+      transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    }
+    .copy-code-button:hover,
+    .copy-code-button:focus-visible {
+      background: var(--bg-soft-2);
+      border-color: rgba(249, 115, 22, 0.55);
+      color: var(--fg);
+      outline: none;
+    }
+    .copy-code-button.is-copied {
+      border-color: rgba(34, 197, 94, 0.55);
+      color: #86efac;
+    }
   </style>
 </head>
 <body class="min-h-screen">
@@ -366,5 +400,69 @@
       </nav>
     </div>
   </footer>
+
+  <script>
+    (() => {
+      const resetDelay = 1800;
+
+      function selectCode(code) {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(code);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      async function copyCode(code) {
+        const text = code.innerText.replace(/\n$/, "");
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text);
+          return true;
+        }
+
+        selectCode(code);
+        const copied = document.execCommand && document.execCommand("copy");
+        if (!copied) {
+          console.info("Kiln docs: clipboard unavailable; selected the code block for manual copy.");
+        }
+        return copied;
+      }
+
+      document.querySelectorAll("pre > code").forEach((code) => {
+        const pre = code.parentElement;
+        if (!pre || pre.parentElement.classList.contains("copy-code-shell")) return;
+
+        const shell = document.createElement("div");
+        shell.className = "copy-code-shell";
+        pre.parentNode.insertBefore(shell, pre);
+        shell.appendChild(pre);
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "copy-code-button";
+        button.textContent = "Copy";
+        button.setAttribute("aria-label", "Copy code block");
+        shell.appendChild(button);
+
+        button.addEventListener("click", async () => {
+          try {
+            const copied = await copyCode(code);
+            button.textContent = copied ? "Copied" : "Selected";
+            button.classList.toggle("is-copied", copied);
+          } catch (error) {
+            selectCode(code);
+            console.info("Kiln docs: clipboard copy failed; selected the code block for manual copy.", error);
+            button.textContent = "Selected";
+            button.classList.remove("is-copied");
+          }
+
+          window.setTimeout(() => {
+            button.textContent = "Copy";
+            button.classList.remove("is-copied");
+          }, resetDelay);
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -127,6 +127,40 @@
     .num {
       font-variant-numeric: tabular-nums;
     }
+
+    .copy-code-shell {
+      position: relative;
+    }
+    .copy-code-shell pre {
+      padding-right: 4.75rem;
+    }
+    .copy-code-button {
+      position: absolute;
+      top: 0.65rem;
+      right: 0.65rem;
+      z-index: 1;
+      border: 1px solid var(--line-2);
+      border-radius: 999px;
+      background: rgba(11, 13, 16, 0.88);
+      color: var(--fg-dim);
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 700;
+      line-height: 1;
+      padding: 0.45rem 0.65rem;
+      transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    }
+    .copy-code-button:hover,
+    .copy-code-button:focus-visible {
+      background: var(--bg-soft-2);
+      border-color: rgba(249, 115, 22, 0.55);
+      color: var(--fg);
+      outline: none;
+    }
+    .copy-code-button.is-copied {
+      border-color: rgba(34, 197, 94, 0.55);
+      color: #86efac;
+    }
   </style>
 </head>
 <body class="min-h-screen">
@@ -408,5 +442,69 @@ docker run --gpus all -p 8420:8420 \
       </nav>
     </div>
   </footer>
+
+  <script>
+    (() => {
+      const resetDelay = 1800;
+
+      function selectCode(code) {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(code);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      async function copyCode(code) {
+        const text = code.innerText.replace(/\n$/, "");
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text);
+          return true;
+        }
+
+        selectCode(code);
+        const copied = document.execCommand && document.execCommand("copy");
+        if (!copied) {
+          console.info("Kiln docs: clipboard unavailable; selected the code block for manual copy.");
+        }
+        return copied;
+      }
+
+      document.querySelectorAll("pre > code").forEach((code) => {
+        const pre = code.parentElement;
+        if (!pre || pre.parentElement.classList.contains("copy-code-shell")) return;
+
+        const shell = document.createElement("div");
+        shell.className = "copy-code-shell";
+        pre.parentNode.insertBefore(shell, pre);
+        shell.appendChild(pre);
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "copy-code-button";
+        button.textContent = "Copy";
+        button.setAttribute("aria-label", "Copy code block");
+        shell.appendChild(button);
+
+        button.addEventListener("click", async () => {
+          try {
+            const copied = await copyCode(code);
+            button.textContent = copied ? "Copied" : "Selected";
+            button.classList.toggle("is-copied", copied);
+          } catch (error) {
+            selectCode(code);
+            console.info("Kiln docs: clipboard copy failed; selected the code block for manual copy.", error);
+            button.textContent = "Selected";
+            button.classList.remove("is-copied");
+          }
+
+          window.setTimeout(() => {
+            button.textContent = "Copy";
+            button.classList.remove("is-copied");
+          }, resetDelay);
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -142,6 +142,40 @@
         width: 100%;
       }
     }
+
+    .copy-code-shell {
+      position: relative;
+    }
+    .copy-code-shell pre {
+      padding-right: 4.75rem;
+    }
+    .copy-code-button {
+      position: absolute;
+      top: 0.65rem;
+      right: 0.65rem;
+      z-index: 1;
+      border: 1px solid var(--line-2);
+      border-radius: 999px;
+      background: rgba(11, 13, 16, 0.88);
+      color: var(--fg-dim);
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 700;
+      line-height: 1;
+      padding: 0.45rem 0.65rem;
+      transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    }
+    .copy-code-button:hover,
+    .copy-code-button:focus-visible {
+      background: var(--bg-soft-2);
+      border-color: rgba(249, 115, 22, 0.55);
+      color: var(--fg);
+      outline: none;
+    }
+    .copy-code-button.is-copied {
+      border-color: rgba(34, 197, 94, 0.55);
+      color: #86efac;
+    }
   </style>
 </head>
 <body class="min-h-screen">
@@ -353,5 +387,69 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
       </nav>
     </div>
   </footer>
+
+  <script>
+    (() => {
+      const resetDelay = 1800;
+
+      function selectCode(code) {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(code);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      async function copyCode(code) {
+        const text = code.innerText.replace(/\n$/, "");
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text);
+          return true;
+        }
+
+        selectCode(code);
+        const copied = document.execCommand && document.execCommand("copy");
+        if (!copied) {
+          console.info("Kiln docs: clipboard unavailable; selected the code block for manual copy.");
+        }
+        return copied;
+      }
+
+      document.querySelectorAll("pre > code").forEach((code) => {
+        const pre = code.parentElement;
+        if (!pre || pre.parentElement.classList.contains("copy-code-shell")) return;
+
+        const shell = document.createElement("div");
+        shell.className = "copy-code-shell";
+        pre.parentNode.insertBefore(shell, pre);
+        shell.appendChild(pre);
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "copy-code-button";
+        button.textContent = "Copy";
+        button.setAttribute("aria-label", "Copy code block");
+        shell.appendChild(button);
+
+        button.addEventListener("click", async () => {
+          try {
+            const copied = await copyCode(code);
+            button.textContent = copied ? "Copied" : "Selected";
+            button.classList.toggle("is-copied", copied);
+          } catch (error) {
+            selectCode(code);
+            console.info("Kiln docs: clipboard copy failed; selected the code block for manual copy.", error);
+            button.textContent = "Selected";
+            button.classList.remove("is-copied");
+          }
+
+          window.setTimeout(() => {
+            button.textContent = "Copy";
+            button.classList.remove("is-copied");
+          }, resetDelay);
+        });
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -132,6 +132,40 @@
         width: 100%;
       }
     }
+
+    .copy-code-shell {
+      position: relative;
+    }
+    .copy-code-shell pre {
+      padding-right: 4.75rem;
+    }
+    .copy-code-button {
+      position: absolute;
+      top: 0.65rem;
+      right: 0.65rem;
+      z-index: 1;
+      border: 1px solid var(--line-2);
+      border-radius: 999px;
+      background: rgba(11, 13, 16, 0.88);
+      color: var(--fg-dim);
+      cursor: pointer;
+      font-size: 0.72rem;
+      font-weight: 700;
+      line-height: 1;
+      padding: 0.45rem 0.65rem;
+      transition: background 0.15s ease, border-color 0.15s ease, color 0.15s ease;
+    }
+    .copy-code-button:hover,
+    .copy-code-button:focus-visible {
+      background: var(--bg-soft-2);
+      border-color: rgba(249, 115, 22, 0.55);
+      color: var(--fg);
+      outline: none;
+    }
+    .copy-code-button.is-copied {
+      border-color: rgba(34, 197, 94, 0.55);
+      color: #86efac;
+    }
   </style>
 </head>
 <body class="min-h-screen">
@@ -446,5 +480,69 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
       </nav>
     </div>
   </footer>
+
+  <script>
+    (() => {
+      const resetDelay = 1800;
+
+      function selectCode(code) {
+        const selection = window.getSelection();
+        const range = document.createRange();
+        range.selectNodeContents(code);
+        selection.removeAllRanges();
+        selection.addRange(range);
+      }
+
+      async function copyCode(code) {
+        const text = code.innerText.replace(/\n$/, "");
+        if (navigator.clipboard && window.isSecureContext) {
+          await navigator.clipboard.writeText(text);
+          return true;
+        }
+
+        selectCode(code);
+        const copied = document.execCommand && document.execCommand("copy");
+        if (!copied) {
+          console.info("Kiln docs: clipboard unavailable; selected the code block for manual copy.");
+        }
+        return copied;
+      }
+
+      document.querySelectorAll("pre > code").forEach((code) => {
+        const pre = code.parentElement;
+        if (!pre || pre.parentElement.classList.contains("copy-code-shell")) return;
+
+        const shell = document.createElement("div");
+        shell.className = "copy-code-shell";
+        pre.parentNode.insertBefore(shell, pre);
+        shell.appendChild(pre);
+
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = "copy-code-button";
+        button.textContent = "Copy";
+        button.setAttribute("aria-label", "Copy code block");
+        shell.appendChild(button);
+
+        button.addEventListener("click", async () => {
+          try {
+            const copied = await copyCode(code);
+            button.textContent = copied ? "Copied" : "Selected";
+            button.classList.toggle("is-copied", copied);
+          } catch (error) {
+            selectCode(code);
+            console.info("Kiln docs: clipboard copy failed; selected the code block for manual copy.", error);
+            button.textContent = "Selected";
+            button.classList.remove("is-copied");
+          }
+
+          window.setTimeout(() => {
+            button.textContent = "Copy";
+            button.classList.remove("is-copied");
+          }, resetDelay);
+        });
+      });
+    })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds small accessible copy-to-clipboard controls to every `<pre><code>` block on the static docs site pages:

- `docs/site/index.html`
- `docs/site/quickstart.html`
- `docs/site/cli.html`
- `docs/site/api.html`
- `docs/site/grpo.html`
- `docs/site/troubleshooting.html`
- `docs/site/architecture.html`

The controls are lightweight vanilla JS plus local CSS on each page. Buttons start as `Copy`, switch to `Copied` after successful clipboard writes, and select the code block with a console hint if clipboard access is unavailable.

## Validation

- `git diff --check`
- Extracted each page's inline script and ran `node --check`
- `python3 -m http.server 8765 --directory docs/site`
- `for p in / /quickstart.html /cli.html /api.html /grpo.html /troubleshooting.html /architecture.html; do curl -fsS "http://127.0.0.1:8765$p" >/dev/null; done`
- Headless Chromium/Puppeteer mobile viewport `390x844` against `/quickstart.html`: found copy buttons, clicked one, and confirmed text changed to `Copied`