### PR TITLE
docs: Add CLI links to demo navigation

### DIFF
--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -262,6 +262,7 @@
         <a href="../quickstart.html">Quickstart</a>
         <a href="../grpo.html">GRPO Guide</a>
         <a href="../api.html">API Reference</a>
+        <a href="../cli.html">CLI Reference</a>
         <a href="./">Demo</a>
         <a href="../troubleshooting.html">Troubleshooting</a>
         <a href="../architecture.html">Architecture</a>
@@ -385,6 +386,9 @@
       <a href="../api.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
         API &rarr;
       </a>
+      <a href="../cli.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
+        CLI &rarr;
+      </a>
       <a href="../troubleshooting.html" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">
         Troubleshooting &rarr;
       </a>
@@ -410,6 +414,7 @@
         <a href="../quickstart.html">Quickstart</a>
         <a href="../grpo.html">GRPO Guide</a>
         <a href="../api.html">API Reference</a>
+        <a href="../cli.html">CLI Reference</a>
         <a href="./">Demo</a>
         <a href="../troubleshooting.html">Troubleshooting</a>
         <a href="../architecture.html">Architecture</a>


### PR DESCRIPTION
## Summary
- Add the CLI Reference link to the demo page top navigation between API Reference and Demo.
- Add a CLI button to the demo page footer/nav-back button group.
- Add the CLI Reference link to the demo page footer navigation between API Reference and Demo.

## Validation
- Ran a nav-scoped check confirming the demo page CLI links are present and ordered between API Reference and Demo.
- Ran the provided local docs link checker: `local docs links ok`.

Note: the first provided raw substring ordering assertion is over-broad on this page because `html.index('./')` matches the pre-existing `../assets/logo.png` favicon before the nav. The nav-scoped assertion checks the intended ordering directly.