### PR TITLE
docs: add README CLI and GRPO guide links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
   <a href="https://ericflo.github.io/kiln/">Website</a> &middot;
   <a href="docs/site/demo/">Demo</a> &middot;
   <a href="QUICKSTART.md">Quickstart</a> &middot;
+  <a href="https://ericflo.github.io/kiln/cli.html">CLI Guide</a> &middot;
+  <a href="https://ericflo.github.io/kiln/grpo.html">GRPO Guide</a> &middot;
   <a href="https://ericflo.github.io/kiln/api.html">API Reference</a> &middot;
   <a href="https://ericflo.github.io/kiln/troubleshooting.html">Troubleshooting</a> &middot;
   <a href="ARCHITECTURE.md">Architecture</a> &middot;


### PR DESCRIPTION
## Summary
- Add README top navigation links to the hosted CLI guide and GRPO guide.
- Keep the change informational-only and adjacent to the existing Quickstart/API/Troubleshooting links.

## Validation
- `rg -n "CLI Guide|GRPO Guide|Quickstart|API Reference|Troubleshooting" README.md`

## Planner verification
Read the README top navigation diff as a cold reader and confirm terminal users can find the CLI guide and training users can find the hosted GRPO guide.
