### PR TITLE
[codex] Add site quickstart reader map

### DIFF
--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -216,6 +216,31 @@
     </div>
   </section>
 
+  <!-- reader map -->
+  <section id="reader-map" class="divider">
+    <div class="max-w-5xl mx-auto px-6 py-10">
+      <p class="label mb-2">Reader map</p>
+      <h2 class="text-2xl font-semibold tracking-tight mb-4">Know where to stop</h2>
+      <div class="grid md:grid-cols-3 gap-4">
+        <div class="card p-5">
+          <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-4">Basic path</span>
+          <h3 class="font-semibold mb-2">Get Kiln running first</h3>
+          <p style="color: var(--fg-dim);">Follow install, model download, server start, <code>/health</code>, and <code>/ui</code>. If chat works, the first-run path is complete.</p>
+        </div>
+        <div class="card p-5">
+          <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-4">Optional learning</span>
+          <h3 class="font-semibold mb-2">Train after verification</h3>
+          <p style="color: var(--fg-dim);">Use SFT, <a href="grpo.html">GRPO</a>, and adapter workflows only after the server is healthy and you have sent one chat request.</p>
+        </div>
+        <div class="card p-5">
+          <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-4">Advanced reference</span>
+          <h3 class="font-semibold mb-2">Return when integrating</h3>
+          <p style="color: var(--fg-dim);">Use the <a href="api.html">API Reference</a> and <a href="cli.html">CLI Reference</a> for tools, batch generation, adapter import/export, merge, composition, and webhooks.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- install -->
   <section id="install" class="divider">
     <div class="max-w-5xl mx-auto px-6 py-12">


### PR DESCRIPTION
## Summary
- Add a compact reader-map section near the top of `docs/site/quickstart.html`.
- Clarify the basic stop point: install, model path, server start, `/health`, `/ui`, and one chat request.
- Point optional next steps to SFT, GRPO, adapters, and advanced API/CLI references without launch or publicity language.

## Validation
- `git diff --check`
- `python3` HTML parser smoke check for `docs/site/quickstart.html`
- Served `docs/site` locally with `python3 -m http.server` and verified reader-map copy via `curl`
- Served `docs/site` locally and verified `quickstart.html` reader-map copy via headless `chromium --dump-dom`