### PR TITLE
[codex] Clarify demo script link labels

### DIFF
--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -368,7 +368,7 @@
         <a href="https://github.com/ericflo/kiln/blob/main/docs/site/demo/SCRIPTS.md">SCRIPTS.md</a>.
         Each cast also has a thin shell driver in
         <a href="https://github.com/ericflo/kiln/tree/main/docs/site/demo">docs/site/demo/</a>;
-        click <em>copy script</em> below the player on any cast to jump straight to its driver.
+        click <em>view script</em> below the player on any cast to jump straight to its driver.
       </p>
 
     </div>
@@ -581,7 +581,7 @@
       const castUrl = repoBase + c.cast;
       return `
         <span><strong style="color: var(--fg-dim);">Duration:</strong> ${c.duration}</span>
-        <a href="${c.script}" target="_blank" rel="noopener">copy script</a>
+        <a href="${c.script}" target="_blank" rel="noopener">view script</a>
         <a href="${castUrl}" target="_blank" rel="noopener">view .cast</a>
       `;
     }


### PR DESCRIPTION
## Summary
- Rename demo driver links from “copy script” to “view script” because they navigate to GitHub blob URLs.
- Update the nearby explanatory copy to match the new link label.

## Validation
- `rg -n "copy script" docs/site/demo/index.html` produced no matches.
- `rg -n "view script" docs/site/demo/index.html` showed the updated explainer and link template.
- Served `docs/site` locally and checked `/demo/` via `curl`.
- Dumped the rendered `/demo/` DOM with Chromium and confirmed `view script` appears and `copy script` does not.