### PR TITLE
docs: clarify Desktop version copy

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -365,7 +365,7 @@ requests.post("http://localhost:8420/v1/train/grpo",
       <div class="rounded-xl border px-5 py-4 mb-8" style="border-color: var(--border); background: var(--bg-card);">
         <h3 class="font-semibold mb-2">Desktop App &middot; recommended quick path</h3>
         <p class="text-sm mb-3" style="color: var(--fg-mute);">
-          Prefer the GUI? Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2">Kiln Desktop desktop-v0.2.2</a>.
+          Prefer the GUI? Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2">Kiln Desktop v0.2.2</a>.
           On first launch, the Desktop App downloads and verifies the matching <code>kiln</code> server binary for you.
           No Rust toolchain, CUDA toolkit, or Xcode install is required for the GUI path.
         </p>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -255,9 +255,9 @@
         <div class="install-card">
           <h3 class="font-semibold mb-2">Desktop App &middot; recommended</h3>
           <p class="mb-3" style="color: var(--fg-dim);">
-            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2">Kiln Desktop desktop-v0.2.2</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
+            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2">Kiln Desktop v0.2.2</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
           </p>
-          <p class="text-sm" style="color: var(--fg-mute);">The app downloads and verifies the matching server binary for you.</p>
+          <p class="text-sm" style="color: var(--fg-mute);">Desktop and server release lines intentionally differ: <code>desktop-v0.2.2</code> is the latest Desktop app release, and the app downloads and verifies the latest <code>kiln-v*</code> server binary for you.</p>
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">Linux x86_64 &middot; CUDA 12.4</h3>


### PR DESCRIPTION
## Summary
- Replaces the awkward `Kiln Desktop desktop-v0.2.2` rendered link text on the docs landing page with `Kiln Desktop v0.2.2`.
- Updates the docs-site quickstart Desktop card to explain that the Desktop and server release lines intentionally differ.

## Validation
- `rg -n "Kiln Desktop desktop|Kiln Desktop v0.2.2|Desktop and server|version split|latest kiln-v" docs/site/index.html docs/site/quickstart.html README.md QUICKSTART.md`
- `git diff --check`
- `cd docs/site && python3 -m http.server 8765`
- `/usr/bin/chromium-browser --headless --no-sandbox --disable-gpu --dump-dom http://127.0.0.1:8765/index.html | rg -n "Kiln Desktop v0.2.2|Kiln Desktop desktop"`
- `/usr/bin/chromium-browser --headless --no-sandbox --disable-gpu --dump-dom http://127.0.0.1:8765/quickstart.html | rg -n "Desktop and server|version split|latest kiln-v"`