### PR TITLE
[codex] Add docs site current nav state

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -133,6 +133,7 @@
       gap: 1.25rem;
       color: var(--fg-dim);
     }
+    .site-nav a[aria-current="page"] { color: var(--fg); }
     @media (max-width: 640px) {
       .site-nav-bar {
         align-items: flex-start;
@@ -193,7 +194,7 @@
       <nav class="site-nav text-sm">
         <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
-        <a href="api.html">API Reference</a>
+        <a href="api.html" aria-current=page>API Reference</a>
         <a href="cli.html">CLI Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -119,6 +119,7 @@
       gap: 1.25rem;
       color: var(--fg-dim);
     }
+    .site-nav a[aria-current="page"] { color: var(--fg); }
     @media (max-width: 640px) {
       .site-nav-bar {
         align-items: flex-start;
@@ -183,7 +184,7 @@
         <a href="cli.html">CLI Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
-        <a href="architecture.html">Architecture</a>
+        <a href="architecture.html" aria-current=page>Architecture</a>
         <a href="https://github.com/ericflo/kiln" class="hidden sm:inline">GitHub</a>
       </nav>
     </div>

--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -84,6 +84,7 @@
       gap: 1.25rem;
       color: var(--fg-dim);
     }
+    .site-nav a[aria-current="page"] { color: var(--fg); }
     a { color: #f3c891; }
     a:hover { color: var(--accent); }
     a.btn-primary, a.btn-primary:hover { color: #1a0c00; }
@@ -148,7 +149,7 @@
         <a href="quickstart.html">Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
-        <a href="cli.html">CLI Reference</a>
+        <a href="cli.html" aria-current=page>CLI Reference</a>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -112,6 +112,7 @@
       gap: 1.25rem;
       color: var(--fg-dim);
     }
+    .site-nav a[aria-current="page"] { color: var(--fg); }
     @media (max-width: 640px) {
       .site-nav-bar {
         align-items: flex-start;
@@ -263,7 +264,7 @@
         <a href="../grpo.html">GRPO Guide</a>
         <a href="../api.html">API Reference</a>
         <a href="../cli.html">CLI Reference</a>
-        <a href="./">Demo</a>
+        <a href="./" aria-current=page>Demo</a>
         <a href="../troubleshooting.html">Troubleshooting</a>
         <a href="../architecture.html">Architecture</a>
         <a href="https://github.com/ericflo/kiln" class="hidden sm:inline">GitHub</a>

--- a/docs/site/grpo.html
+++ b/docs/site/grpo.html
@@ -131,6 +131,7 @@
       gap: 1.25rem;
       color: var(--fg-dim);
     }
+    .site-nav a[aria-current="page"] { color: var(--fg); }
     @media (max-width: 640px) {
       .site-nav-bar {
         align-items: flex-start;
@@ -190,7 +191,7 @@
       </a>
       <nav class="site-nav text-sm">
         <a href="quickstart.html">Quickstart</a>
-        <a href="grpo.html">GRPO Guide</a>
+        <a href="grpo.html" aria-current=page>GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="cli.html">CLI Reference</a>
         <a href="demo/">Demo</a>

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -111,6 +111,7 @@
       gap: 1.25rem;
       color: var(--fg-dim);
     }
+    .site-nav a[aria-current="page"] { color: var(--fg); }
     @media (max-width: 640px) {
       .site-nav-bar {
         align-items: flex-start;
@@ -167,7 +168,7 @@
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
-      <a href="./" class="flex items-center gap-2.5">
+      <a href="./" class="flex items-center gap-2.5" aria-current=page>
         <img src="assets/logo.png" alt="" width="28" height="28" class="rounded">
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -129,6 +129,7 @@
       gap: 1.25rem;
       color: var(--fg-dim);
     }
+    .site-nav a[aria-current="page"] { color: var(--fg); }
     @media (max-width: 640px) {
       .site-nav-bar {
         align-items: flex-start;
@@ -187,7 +188,7 @@
         <span class="text-lg font-semibold tracking-tight">Kiln</span>
       </a>
       <nav class="site-nav text-sm">
-        <a href="quickstart.html">Quickstart</a>
+        <a href="quickstart.html" aria-current=page>Quickstart</a>
         <a href="grpo.html">GRPO Guide</a>
         <a href="api.html">API Reference</a>
         <a href="cli.html">CLI Reference</a>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -119,6 +119,7 @@
       gap: 1.25rem;
       color: var(--fg-dim);
     }
+    .site-nav a[aria-current="page"] { color: var(--fg); }
     @media (max-width: 640px) {
       .site-nav-bar {
         align-items: flex-start;
@@ -182,7 +183,7 @@
         <a href="api.html">API Reference</a>
         <a href="cli.html">CLI Reference</a>
         <a href="demo/">Demo</a>
-        <a href="troubleshooting.html">Troubleshooting</a>
+        <a href="troubleshooting.html" aria-current=page>Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
         <a href="https://github.com/ericflo/kiln" class="hidden sm:inline">GitHub</a>
       </nav>


### PR DESCRIPTION
## Summary
- Adds current-page state to each static docs-site top nav surface.
- Styles active nav links with the existing per-page inline CSS pattern.
- Keeps the change scoped to the requested docs/site HTML files.

## Validation
- `gh pr list -R ericflo/kiln --state open --search "aria-current docs/site"`
- `python3 - <<'PY' ... PY`
- `git diff --check`