### PR TITLE
[codex] Add docs site main landmarks

### DIFF
--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -158,6 +158,8 @@
     </div>
   </header>
 
+  <main>
+
   <section>
     <div class="max-w-4xl mx-auto px-6 pt-16 pb-10">
       <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">CLI Reference &middot; serve &middot; train &middot; adapters</span>
@@ -334,6 +336,8 @@ kiln adapters unload support-bot</code></pre>
       </div>
     </div>
   </section>
+
+  </main>
 
   <footer class="divider">
     <div class="max-w-5xl mx-auto px-6 py-10 flex flex-wrap gap-x-6 gap-y-2 items-center justify-between text-sm" style="color: var(--fg-mute);">

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -272,6 +272,8 @@
     </div>
   </header>
 
+  <main>
+
   <!-- hero -->
   <section class="hero-glow">
     <div class="max-w-3xl mx-auto px-6 pt-16 pb-8">
@@ -401,6 +403,8 @@
       </a>
     </div>
   </section>
+
+  </main>
 
   <!-- footer -->
   <footer class="divider">

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -185,6 +185,8 @@
     </div>
   </header>
 
+  <main>
+
   <!-- hero -->
   <section class="hero-glow">
     <div class="max-w-5xl mx-auto px-6 pt-20 pb-16">
@@ -419,6 +421,8 @@ docker run --gpus all -p 8420:8420 \
       </p>
     </div>
   </section>
+
+  </main>
 
   <!-- footer -->
   <footer class="divider">

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -200,6 +200,8 @@
     </div>
   </header>
 
+  <main>
+
   <!-- hero -->
   <section class="hero-glow">
     <div class="max-w-4xl mx-auto px-6 pt-16 pb-10">
@@ -389,6 +391,8 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
       </div>
     </div>
   </section>
+
+  </main>
 
   <!-- footer -->
   <footer class="divider">


### PR DESCRIPTION
## Summary
- Wrap the primary content on the docs landing, quickstart, CLI reference, and demo pages in a single semantic `<main>` landmark.
- Preserve existing header/nav, footer, scripts, layout classes, and page copy.

## Validation
- `rg -n '<main|</main>|<header|<footer' docs/site/index.html docs/site/quickstart.html docs/site/cli.html docs/site/demo/index.html`
- `python3 -m http.server 8421 --directory docs/site >/tmp/kiln-site.log 2>&1 & echo $! >/tmp/kiln-site.pid; for path in / /quickstart.html /cli.html /demo/; do /usr/bin/chromium-browser --headless --no-sandbox --disable-gpu --dump-dom http://127.0.0.1:8421$path 2>/tmp/chromium.err | python3 -c 'import sys; html=sys.stdin.read(); assert html.count("<main") == 1, "expected one main landmark"; assert "aria-current" in html; print("ok")'; done; kill $(cat /tmp/kiln-site.pid)`