### PR TITLE
[codex] Add docs site skip links

### DIFF
--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -25,6 +25,25 @@
       color: var(--fg);
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     }
+    .skip-link {
+      position: absolute;
+      left: 1rem;
+      top: 0;
+      transform: translateY(-120%);
+      z-index: 50;
+      background: var(--accent);
+      color: #1a0c00;
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.65rem 0.9rem;
+      font-weight: 700;
+      text-decoration: none;
+      transition: transform 0.15s ease;
+    }
+    .skip-link:focus {
+      transform: translateY(0);
+      outline: 2px solid #fed7aa;
+      outline-offset: 2px;
+    }
     code, pre { font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace; }
     pre {
       background: #070605;
@@ -139,6 +158,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+  <a class="skip-link" href="#content">Skip to content</a>
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
       <a href="./" class="flex items-center gap-2.5">
@@ -158,7 +178,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="content" tabindex="-1">
 
   <section>
     <div class="max-w-4xl mx-auto px-6 pt-16 pb-10">

--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -46,6 +46,25 @@
       font-feature-settings: "ss01", "cv02", "cv11";
       -webkit-font-smoothing: antialiased;
     }
+    .skip-link {
+      position: absolute;
+      left: 1rem;
+      top: 0;
+      transform: translateY(-120%);
+      z-index: 50;
+      background: var(--accent);
+      color: #1a0c00;
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.65rem 0.9rem;
+      font-weight: 700;
+      text-decoration: none;
+      transition: transform 0.15s ease;
+    }
+    .skip-link:focus {
+      transform: translateY(0);
+      outline: 2px solid #fed7aa;
+      outline-offset: 2px;
+    }
     code, pre, kbd, samp {
       font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
@@ -252,6 +271,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+  <a class="skip-link" href="#content">Skip to content</a>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
@@ -272,7 +292,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="content" tabindex="-1">
 
   <!-- hero -->
   <section class="hero-glow">

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -41,6 +41,25 @@
       font-feature-settings: "ss01", "cv02", "cv11";
       -webkit-font-smoothing: antialiased;
     }
+    .skip-link {
+      position: absolute;
+      left: 1rem;
+      top: 0;
+      transform: translateY(-120%);
+      z-index: 50;
+      background: var(--accent);
+      color: #1a0c00;
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.65rem 0.9rem;
+      font-weight: 700;
+      text-decoration: none;
+      transition: transform 0.15s ease;
+    }
+    .skip-link:focus {
+      transform: translateY(0);
+      outline: 2px solid #fed7aa;
+      outline-offset: 2px;
+    }
     code, pre, kbd, samp {
       font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
@@ -165,6 +184,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+  <a class="skip-link" href="#content">Skip to content</a>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
@@ -185,7 +205,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="content" tabindex="-1">
 
   <!-- hero -->
   <section class="hero-glow">

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -41,6 +41,25 @@
       font-feature-settings: "ss01", "cv02", "cv11";
       -webkit-font-smoothing: antialiased;
     }
+    .skip-link {
+      position: absolute;
+      left: 1rem;
+      top: 0;
+      transform: translateY(-120%);
+      z-index: 50;
+      background: var(--accent);
+      color: #1a0c00;
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.65rem 0.9rem;
+      font-weight: 700;
+      text-decoration: none;
+      transition: transform 0.15s ease;
+    }
+    .skip-link:focus {
+      transform: translateY(0);
+      outline: 2px solid #fed7aa;
+      outline-offset: 2px;
+    }
     code, pre, kbd, samp {
       font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
@@ -180,6 +199,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+  <a class="skip-link" href="#content">Skip to content</a>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
@@ -200,7 +220,7 @@
     </div>
   </header>
 
-  <main>
+  <main id="content" tabindex="-1">
 
   <!-- hero -->
   <section class="hero-glow">


### PR DESCRIPTION
## Summary

Adds keyboard-accessible skip-to-content links to the static docs site pages that already have main landmarks.

- Adds a visually hidden `Skip to content` link before the header on each scoped page
- Updates each page's single `<main>` to `id="content" tabindex="-1"`
- Adds minimal focus-visible styling in each page's existing style block without changing normal layout

## Validation

- `rg -n 'skip-link|id="content"|<main' docs/site/index.html docs/site/quickstart.html docs/site/cli.html docs/site/demo/index.html`
- `python3 -m http.server 8421 --directory docs/site >/tmp/kiln-site.log 2>&1 & echo $! >/tmp/kiln-site.pid; for path in / /quickstart.html /cli.html /demo/; do /usr/bin/chromium-browser --headless --no-sandbox --disable-gpu --dump-dom http://127.0.0.1:8421$path 2>/tmp/chromium.err | python3 -c 'import sys; html=sys.stdin.read(); assert html.count("<main") == 1, "expected one main"; assert "id=\"content\"" in html, "missing content id"; assert "skip-link" in html and "Skip to content" in html, "missing skip link"; assert "aria-current" in html, "missing current nav"; print("ok")'; done; kill $(cat /tmp/kiln-site.pid)`