### PR TITLE
[codex] Complete docs site skip link coverage

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -41,6 +41,25 @@
       font-feature-settings: "ss01", "cv02", "cv11";
       -webkit-font-smoothing: antialiased;
     }
+    .skip-link {
+      position: absolute;
+      left: 1rem;
+      top: 0;
+      transform: translateY(-120%);
+      z-index: 50;
+      background: var(--accent);
+      color: #1a0c00;
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.65rem 0.9rem;
+      font-weight: 700;
+      text-decoration: none;
+      transition: transform 0.15s ease;
+    }
+    .skip-link:focus {
+      transform: translateY(0);
+      outline: 2px solid #fed7aa;
+      outline-offset: 2px;
+    }
     code, pre, kbd, samp {
       font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
@@ -184,6 +203,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+  <a class="skip-link" href="#content">Skip to content</a>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
@@ -247,7 +267,7 @@
     </div>
   </section>
 
-  <main class="max-w-4xl mx-auto px-6 py-12">
+  <main id="content" tabindex="-1" class="max-w-4xl mx-auto px-6 py-12">
     <div class="grid gap-6">
       <article class="card p-6">
         <div class="label mb-3">First requests</div>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -41,6 +41,25 @@
       font-feature-settings: "ss01", "cv02", "cv11";
       -webkit-font-smoothing: antialiased;
     }
+    .skip-link {
+      position: absolute;
+      left: 1rem;
+      top: 0;
+      transform: translateY(-120%);
+      z-index: 50;
+      background: var(--accent);
+      color: #1a0c00;
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.65rem 0.9rem;
+      font-weight: 700;
+      text-decoration: none;
+      transition: transform 0.15s ease;
+    }
+    .skip-link:focus {
+      transform: translateY(0);
+      outline: 2px solid #fed7aa;
+      outline-offset: 2px;
+    }
     code, pre, kbd, samp {
       font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
@@ -170,6 +189,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+  <a class="skip-link" href="#content">Skip to content</a>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
@@ -233,7 +253,7 @@
   </section>
 
   <!-- overview -->
-  <main class="max-w-4xl mx-auto px-6 py-12">
+  <main id="content" tabindex="-1" class="max-w-4xl mx-auto px-6 py-12">
     <div class="grid gap-6">
       <article class="card p-6">
         <div class="label mb-3">System shape</div>

--- a/docs/site/grpo.html
+++ b/docs/site/grpo.html
@@ -41,6 +41,25 @@
       font-feature-settings: "ss01", "cv02", "cv11";
       -webkit-font-smoothing: antialiased;
     }
+    .skip-link {
+      position: absolute;
+      left: 1rem;
+      top: 0;
+      transform: translateY(-120%);
+      z-index: 50;
+      background: var(--accent);
+      color: #1a0c00;
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.65rem 0.9rem;
+      font-weight: 700;
+      text-decoration: none;
+      transition: transform 0.15s ease;
+    }
+    .skip-link:focus {
+      transform: translateY(0);
+      outline: 2px solid #fed7aa;
+      outline-offset: 2px;
+    }
     code, pre, kbd, samp {
       font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
@@ -182,6 +201,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+  <a class="skip-link" href="#content">Skip to content</a>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
@@ -242,7 +262,7 @@
     </div>
   </section>
 
-  <main class="max-w-4xl mx-auto px-6 py-12">
+  <main id="content" tabindex="-1" class="max-w-4xl mx-auto px-6 py-12">
     <div class="grid gap-6">
       <article class="card p-6">
         <div class="label mb-3">Concept</div>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -41,6 +41,25 @@
       font-feature-settings: "ss01", "cv02", "cv11";
       -webkit-font-smoothing: antialiased;
     }
+    .skip-link {
+      position: absolute;
+      left: 1rem;
+      top: 0;
+      transform: translateY(-120%);
+      z-index: 50;
+      background: var(--accent);
+      color: #1a0c00;
+      border-radius: 0 0 0.5rem 0.5rem;
+      padding: 0.65rem 0.9rem;
+      font-weight: 700;
+      text-decoration: none;
+      transition: transform 0.15s ease;
+    }
+    .skip-link:focus {
+      transform: translateY(0);
+      outline: 2px solid #fed7aa;
+      outline-offset: 2px;
+    }
     code, pre, kbd, samp {
       font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", monospace;
     }
@@ -170,6 +189,7 @@
   </style>
 </head>
 <body class="min-h-screen">
+  <a class="skip-link" href="#content">Skip to content</a>
   <!-- nav -->
   <header class="border-b" style="border-color: var(--line);">
     <div class="site-nav-bar max-w-5xl mx-auto px-6 py-4">
@@ -279,7 +299,7 @@ curl -s http://localhost:8420/v1/models | jq .</code></pre>
   </section>
 
   <!-- symptom cards -->
-  <main class="divider">
+  <main id="content" tabindex="-1" class="divider">
     <div class="max-w-4xl mx-auto px-6 py-12 space-y-5">
 
       <article class="card p-6">


### PR DESCRIPTION
## Summary

- Add the existing docs-site `.skip-link` focus pattern to the remaining first-level docs pages.
- Add `Skip to content` anchors immediately after `<body>`.
- Add `id="content"` and `tabindex="-1"` to each primary `<main>` element while preserving classes.

## Validation

```bash
python3 - <<'PY'
from pathlib import Path
from html.parser import HTMLParser
files = [Path(p) for p in [
    'docs/site/api.html',
    'docs/site/architecture.html',
    'docs/site/grpo.html',
    'docs/site/troubleshooting.html',
]]
class Parser(HTMLParser):
    def __init__(self):
        super().__init__(); self.skip=False; self.main_id=False
    def handle_starttag(self, tag, attrs):
        attrs=dict(attrs); classes=attrs.get('class','').split()
        if tag == 'a' and 'skip-link' in classes and attrs.get('href') in ('#content', '#main'):
            self.skip=True
        if tag == 'main' and attrs.get('id') in ('content', 'main') and attrs.get('tabindex') == '-1':
            self.main_id=True
for path in files:
    parser=Parser(); parser.feed(path.read_text())
    print(f'{path}: skip={parser.skip} main_id={parser.main_id}')
    assert parser.skip and parser.main_id, path
PY
```

```text
docs/site/api.html: skip=True main_id=True
docs/site/architecture.html: skip=True main_id=True
docs/site/grpo.html: skip=True main_id=True
docs/site/troubleshooting.html: skip=True main_id=True
```