### PR TITLE
Fix workspace rustfmt drift blocking PR 853

### DIFF
--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -1514,7 +1514,10 @@ mod tests {
             adapter_unload_url("http://localhost:8420"),
             "http://localhost:8420/v1/adapters/unload"
         );
-        assert_eq!(build_adapter_load_payload("support-bot"), json!({ "name": "support-bot" }));
+        assert_eq!(
+            build_adapter_load_payload("support-bot"),
+            json!({ "name": "support-bot" })
+        );
     }
 
     #[test]

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -1125,7 +1125,9 @@ fn analytic_sft_tail_grad_pre_final_norm(
     let hidden_2d = hidden.squeeze(0)?;
     let shift_hidden = hidden_2d.narrow(0, 0, seq_len - 1)?;
     let active_indices = Tensor::new(active_positions.as_slice(), device)?;
-    let active_hidden = shift_hidden.index_select(&active_indices, 0)?.to_dtype(DType::F32)?;
+    let active_hidden = shift_hidden
+        .index_select(&active_indices, 0)?
+        .to_dtype(DType::F32)?;
 
     let variance = active_hidden.sqr()?.mean_keepdim(candle_core::D::Minus1)?;
     let rms_inv = (variance + rms_norm_eps)?.sqrt()?.recip()?;


### PR DESCRIPTION
## Summary
- Apply the rustfmt multiline formatting drift currently blocking PR #853 validation.
- Keep the change scoped to the two files reported by the PR #853 `cargo fmt --check` failure.
- Avoid touching PR #853 implementation files.

## Validation
- Not run locally: `cargo` is unavailable in this workspace (`cargo: command not found`).
