### PR TITLE
Fix current rustfmt drift blocking PR 853 validation

### DIFF
--- a/crates/kiln-flash-attn/src/lib.rs
+++ b/crates/kiln-flash-attn/src/lib.rs
@@ -785,7 +785,6 @@ mod tests {
     }
 }
 
-
 /// Flash-attention paged decode with graph-stable dynamic sequence lengths.
 ///
 /// `max_seqlen_k` fixes the captured kernel launch shape. `seqused_k` is a
@@ -813,22 +812,34 @@ pub fn flash_attn_paged_decode_dyn_seqlen(
         candle_core::bail!("paged decode dyn seqlen head_dim mismatch");
     }
     if num_heads % num_heads_k != 0 {
-        candle_core::bail!("num_heads ({num_heads}) must be divisible by num_heads_k ({num_heads_k})");
+        candle_core::bail!(
+            "num_heads ({num_heads}) must be divisible by num_heads_k ({num_heads_k})"
+        );
     }
     if q.dtype() != DType::BF16 || k_pool.dtype() != DType::BF16 || v_pool.dtype() != DType::BF16 {
         candle_core::bail!("flash_attn_paged_decode_dyn_seqlen requires bf16 q/k/v");
     }
     if head_dim != 128 && head_dim != 256 {
-        candle_core::bail!("flash_attn_paged_decode_dyn_seqlen only supports head_dim=128,256, got {head_dim}");
+        candle_core::bail!(
+            "flash_attn_paged_decode_dyn_seqlen only supports head_dim=128,256, got {head_dim}"
+        );
     }
     if page_block_size == 0 || 128 % page_block_size != 0 {
-        candle_core::bail!("flash_attn_paged_decode_dyn_seqlen requires page_block_size to divide 128, got {page_block_size}");
+        candle_core::bail!(
+            "flash_attn_paged_decode_dyn_seqlen requires page_block_size to divide 128, got {page_block_size}"
+        );
     }
     if block_table.dtype() != DType::U32 {
-        candle_core::bail!("flash_attn_paged_decode_dyn_seqlen requires block_table dtype=u32, got {:?}", block_table.dtype());
+        candle_core::bail!(
+            "flash_attn_paged_decode_dyn_seqlen requires block_table dtype=u32, got {:?}",
+            block_table.dtype()
+        );
     }
     if seqused_k.dtype() != DType::I32 {
-        candle_core::bail!("flash_attn_paged_decode_dyn_seqlen requires seqused_k dtype=i32, got {:?}", seqused_k.dtype());
+        candle_core::bail!(
+            "flash_attn_paged_decode_dyn_seqlen requires seqused_k dtype=i32, got {:?}",
+            seqused_k.dtype()
+        );
     }
     let (bt_batch, max_blocks_per_seq) = block_table.dims2()?;
     if bt_batch != b {
@@ -895,13 +906,27 @@ pub fn flash_attn_paged_decode_dyn_seqlen(
         let stream = q_cuda.device().cuda_stream();
         let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
 
-        let q_slice = q_cuda.as_cuda_slice::<bf16>()?.slice(q_layout.start_offset()..);
-        let k_slice = k_cuda.as_cuda_slice::<bf16>()?.slice(k_layout.start_offset()..);
-        let v_slice = v_cuda.as_cuda_slice::<bf16>()?.slice(v_layout.start_offset()..);
-        let bt_slice = bt_cuda.as_cuda_slice::<u32>()?.slice(bt_layout.start_offset()..);
-        let seq_slice = seq_cuda.as_cuda_slice::<i32>()?.slice(seq_layout.start_offset()..);
-        let out_slice = out_cuda.as_cuda_slice::<bf16>()?.slice(out_layout.start_offset()..);
-        let lse_slice = lse_cuda.as_cuda_slice::<f32>()?.slice(lse_layout.start_offset()..);
+        let q_slice = q_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(q_layout.start_offset()..);
+        let k_slice = k_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(k_layout.start_offset()..);
+        let v_slice = v_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(v_layout.start_offset()..);
+        let bt_slice = bt_cuda
+            .as_cuda_slice::<u32>()?
+            .slice(bt_layout.start_offset()..);
+        let seq_slice = seq_cuda
+            .as_cuda_slice::<i32>()?
+            .slice(seq_layout.start_offset()..);
+        let out_slice = out_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(out_layout.start_offset()..);
+        let lse_slice = lse_cuda
+            .as_cuda_slice::<f32>()?
+            .slice(lse_layout.start_offset()..);
 
         unsafe {
             let (q_ptr, _g1) = q_slice.device_ptr(&stream);
@@ -931,7 +956,9 @@ pub fn flash_attn_paged_decode_dyn_seqlen(
                 raw_stream,
             );
             if status != 0 {
-                candle_core::bail!("kiln_flash_attn_fwd_paged_decode_dyn_seqlen failed with status {status}");
+                candle_core::bail!(
+                    "kiln_flash_attn_fwd_paged_decode_dyn_seqlen failed with status {status}"
+                );
             }
         }
     }
@@ -952,11 +979,19 @@ pub fn paged_kv_write_token_major_bf16_slot(
     if v_pool.dims3()? != k_pool.dims3()? {
         candle_core::bail!("paged_kv_write_token_major_bf16_slot k/v pool dims mismatch");
     }
-    if k.dtype() != DType::BF16 || v.dtype() != DType::BF16 || k_pool.dtype() != DType::BF16 || v_pool.dtype() != DType::BF16 {
+    if k.dtype() != DType::BF16
+        || v.dtype() != DType::BF16
+        || k_pool.dtype() != DType::BF16
+        || v_pool.dtype() != DType::BF16
+    {
         candle_core::bail!("paged_kv_write_token_major_bf16_slot requires bf16 tensors");
     }
     if slot.dtype() != DType::U32 || slot.dims() != [1] {
-        candle_core::bail!("paged_kv_write_token_major_bf16_slot requires u32 slot shape [1], got {:?} {:?}", slot.dtype(), slot.dims());
+        candle_core::bail!(
+            "paged_kv_write_token_major_bf16_slot requires u32 slot shape [1], got {:?} {:?}",
+            slot.dtype(),
+            slot.dims()
+        );
     }
     let k = k.contiguous()?;
     let v = v.contiguous()?;
@@ -982,11 +1017,21 @@ pub fn paged_kv_write_token_major_bf16_slot(
     let slot_cuda = cuda!(slot_storage, "slot");
     let stream = k_cuda.device().cuda_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
-    let k_slice = k_cuda.as_cuda_slice::<bf16>()?.slice(k_layout.start_offset()..);
-    let v_slice = v_cuda.as_cuda_slice::<bf16>()?.slice(v_layout.start_offset()..);
-    let kp_slice = kp_cuda.as_cuda_slice::<bf16>()?.slice(kp_layout.start_offset()..);
-    let vp_slice = vp_cuda.as_cuda_slice::<bf16>()?.slice(vp_layout.start_offset()..);
-    let slot_slice = slot_cuda.as_cuda_slice::<u32>()?.slice(slot_layout.start_offset()..);
+    let k_slice = k_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(k_layout.start_offset()..);
+    let v_slice = v_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(v_layout.start_offset()..);
+    let kp_slice = kp_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(kp_layout.start_offset()..);
+    let vp_slice = vp_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(vp_layout.start_offset()..);
+    let slot_slice = slot_cuda
+        .as_cuda_slice::<u32>()?
+        .slice(slot_layout.start_offset()..);
     unsafe {
         let (k_ptr, _g1) = k_slice.device_ptr(&stream);
         let (v_ptr, _g2) = v_slice.device_ptr(&stream);
@@ -1004,7 +1049,9 @@ pub fn paged_kv_write_token_major_bf16_slot(
             raw_stream,
         );
         if status != 0 {
-            candle_core::bail!("kiln_paged_kv_write_token_major_bf16_slot failed with status {status}");
+            candle_core::bail!(
+                "kiln_paged_kv_write_token_major_bf16_slot failed with status {status}"
+            );
         }
     }
     Ok(())

--- a/crates/kiln-gdn-kernel/src/lib.rs
+++ b/crates/kiln-gdn-kernel/src/lib.rs
@@ -59,7 +59,8 @@
 //! chunkwise recurrence and are *not* covered by this crate.
 
 use candle_core::{
-    CustomOp1, CustomOp3, DType, Layout, Result, Shape, Tensor, backend::BackendStorage,
+    CustomOp1, CustomOp3, DType, Layout, Result, Shape, Tensor,
+    backend::BackendStorage,
     cuda_backend::{CudaStorage, cudarc::driver::DevicePtr},
 };
 use half::bf16;
@@ -577,14 +578,9 @@ thread_local! {
     static DECODE_GATES_RECURRENT_OUTPUTS: RefCell<Option<DecodeGatesRecurrentOutputs>> = const { RefCell::new(None) };
 }
 
-pub fn with_decode_gates_recurrent_outputs<R>(
-    outputs: Vec<Tensor>,
-    f: impl FnOnce() -> R,
-) -> R {
-    let previous = DECODE_GATES_RECURRENT_OUTPUTS.replace(Some(DecodeGatesRecurrentOutputs {
-        outputs,
-        next: 0,
-    }));
+pub fn with_decode_gates_recurrent_outputs<R>(outputs: Vec<Tensor>, f: impl FnOnce() -> R) -> R {
+    let previous = DECODE_GATES_RECURRENT_OUTPUTS
+        .replace(Some(DecodeGatesRecurrentOutputs { outputs, next: 0 }));
     let result = f();
     DECODE_GATES_RECURRENT_OUTPUTS.replace(previous);
     result
@@ -652,8 +648,14 @@ pub fn gdn_decode_gates_recurrent(
     let v = gdn_gates_ctx(v.contiguous(), "gdn_decode_gates_recurrent v contiguous")?;
     let a = gdn_gates_ctx(a.contiguous(), "gdn_decode_gates_recurrent a contiguous")?;
     let b = gdn_gates_ctx(b.contiguous(), "gdn_decode_gates_recurrent b contiguous")?;
-    let a_log = gdn_gates_ctx(a_log.contiguous(), "gdn_decode_gates_recurrent a_log contiguous")?;
-    let dt_bias = gdn_gates_ctx(dt_bias.contiguous(), "gdn_decode_gates_recurrent dt_bias contiguous")?;
+    let a_log = gdn_gates_ctx(
+        a_log.contiguous(),
+        "gdn_decode_gates_recurrent a_log contiguous",
+    )?;
+    let dt_bias = gdn_gates_ctx(
+        dt_bias.contiguous(),
+        "gdn_decode_gates_recurrent dt_bias contiguous",
+    )?;
     let out = match next_decode_gates_recurrent_output((batch, 1, value_heads, dv), device)? {
         Some(out) => out,
         None => gdn_gates_ctx(
@@ -801,7 +803,9 @@ pub fn gdn_decode_gates_recurrent(
                         raw_stream,
                     )
                 }
-                other => candle_core::bail!("kiln-gdn-kernel: unsupported fused decode v dtype {other:?}"),
+                other => candle_core::bail!(
+                    "kiln-gdn-kernel: unsupported fused decode v dtype {other:?}"
+                ),
             };
             if status != 0 {
                 candle_core::bail!(
@@ -911,17 +915,29 @@ unsafe extern "C" {
 struct GdnGateBetaOp;
 
 impl CustomOp1 for GdnGateBetaOp {
-    fn name(&self) -> &'static str { "gdn-gate-beta" }
+    fn name(&self) -> &'static str {
+        "gdn-gate-beta"
+    }
 
-    fn cpu_fwd(&self, _s: &candle_core::CpuStorage, _l: &Layout) -> Result<(candle_core::CpuStorage, Shape)> {
+    fn cpu_fwd(
+        &self,
+        _s: &candle_core::CpuStorage,
+        _l: &Layout,
+    ) -> Result<(candle_core::CpuStorage, Shape)> {
         candle_core::bail!("GdnGateBetaOp CPU fallback is not implemented")
     }
 
     fn cuda_fwd(&self, s_b: &CudaStorage, l_b: &Layout) -> Result<(CudaStorage, Shape)> {
         let dims = l_b.shape().dims().to_vec();
-        let nv = *dims.last().ok_or_else(|| candle_core::Error::Msg("GdnGateBetaOp: b must have rank >= 1".to_string()))?;
-        if nv == 0 || nv > 256 { candle_core::bail!("GdnGateBetaOp: nv {nv} outside 1..=256"); }
-        if !l_b.is_contiguous() { candle_core::bail!("GdnGateBetaOp requires contiguous b"); }
+        let nv = *dims.last().ok_or_else(|| {
+            candle_core::Error::Msg("GdnGateBetaOp: b must have rank >= 1".to_string())
+        })?;
+        if nv == 0 || nv > 256 {
+            candle_core::bail!("GdnGateBetaOp: nv {nv} outside 1..=256");
+        }
+        if !l_b.is_contiguous() {
+            candle_core::bail!("GdnGateBetaOp requires contiguous b");
+        }
         let rows: usize = dims[..dims.len() - 1].iter().product();
         let device = s_b.device();
         let stream = device.cuda_stream();
@@ -932,28 +948,65 @@ impl CustomOp1 for GdnGateBetaOp {
         unsafe {
             let (b_ptr, _g1) = b_slice.device_ptr(&stream);
             let (out_ptr, _g2) = out_slice.device_ptr(&stream);
-            let status = kiln_gdn_gate_beta_bf16(b_ptr as *const _, out_ptr as *mut _, rows as i32, nv as i32, raw_stream);
-            if status != 0 { candle_core::bail!("GdnGateBetaOp: kernel failed with status {status}"); }
+            let status = kiln_gdn_gate_beta_bf16(
+                b_ptr as *const _,
+                out_ptr as *mut _,
+                rows as i32,
+                nv as i32,
+                raw_stream,
+            );
+            if status != 0 {
+                candle_core::bail!("GdnGateBetaOp: kernel failed with status {status}");
+            }
         }
-        Ok((CudaStorage::wrap_cuda_slice(out_slice, device.clone()), Shape::from(dims.as_slice())))
+        Ok((
+            CudaStorage::wrap_cuda_slice(out_slice, device.clone()),
+            Shape::from(dims.as_slice()),
+        ))
     }
 }
 
 struct GdnGateGOp;
 
 impl CustomOp3 for GdnGateGOp {
-    fn name(&self) -> &'static str { "gdn-gate-g" }
+    fn name(&self) -> &'static str {
+        "gdn-gate-g"
+    }
 
-    fn cpu_fwd(&self, _s1: &candle_core::CpuStorage, _l1: &Layout, _s2: &candle_core::CpuStorage, _l2: &Layout, _s3: &candle_core::CpuStorage, _l3: &Layout) -> Result<(candle_core::CpuStorage, Shape)> {
+    fn cpu_fwd(
+        &self,
+        _s1: &candle_core::CpuStorage,
+        _l1: &Layout,
+        _s2: &candle_core::CpuStorage,
+        _l2: &Layout,
+        _s3: &candle_core::CpuStorage,
+        _l3: &Layout,
+    ) -> Result<(candle_core::CpuStorage, Shape)> {
         candle_core::bail!("GdnGateGOp CPU fallback is not implemented")
     }
 
-    fn cuda_fwd(&self, s_a: &CudaStorage, l_a: &Layout, s_al: &CudaStorage, l_al: &Layout, s_dt: &CudaStorage, l_dt: &Layout) -> Result<(CudaStorage, Shape)> {
+    fn cuda_fwd(
+        &self,
+        s_a: &CudaStorage,
+        l_a: &Layout,
+        s_al: &CudaStorage,
+        l_al: &Layout,
+        s_dt: &CudaStorage,
+        l_dt: &Layout,
+    ) -> Result<(CudaStorage, Shape)> {
         let dims = l_a.shape().dims().to_vec();
-        let nv = *dims.last().ok_or_else(|| candle_core::Error::Msg("GdnGateGOp: a must have rank >= 1".to_string()))?;
-        if nv == 0 || nv > 256 { candle_core::bail!("GdnGateGOp: nv {nv} outside 1..=256"); }
-        if l_al.shape().dims() != [nv] || l_dt.shape().dims() != [nv] { candle_core::bail!("GdnGateGOp: params must have shape [nv]"); }
-        if !l_a.is_contiguous() || !l_al.is_contiguous() || !l_dt.is_contiguous() { candle_core::bail!("GdnGateGOp requires contiguous inputs"); }
+        let nv = *dims.last().ok_or_else(|| {
+            candle_core::Error::Msg("GdnGateGOp: a must have rank >= 1".to_string())
+        })?;
+        if nv == 0 || nv > 256 {
+            candle_core::bail!("GdnGateGOp: nv {nv} outside 1..=256");
+        }
+        if l_al.shape().dims() != [nv] || l_dt.shape().dims() != [nv] {
+            candle_core::bail!("GdnGateGOp: params must have shape [nv]");
+        }
+        if !l_a.is_contiguous() || !l_al.is_contiguous() || !l_dt.is_contiguous() {
+            candle_core::bail!("GdnGateGOp requires contiguous inputs");
+        }
         let rows: usize = dims[..dims.len() - 1].iter().product();
         let device = s_a.device();
         let stream = device.cuda_stream();
@@ -968,10 +1021,23 @@ impl CustomOp3 for GdnGateGOp {
             let (al_ptr, _g2) = al_slice.device_ptr(&stream);
             let (dt_ptr, _g3) = dt_slice.device_ptr(&stream);
             let (out_ptr, _g4) = out_slice.device_ptr(&stream);
-            let status = kiln_gdn_gate_g_bf16(a_ptr as *const _, al_ptr as *const _, dt_ptr as *const _, out_ptr as *mut _, rows as i32, nv as i32, raw_stream);
-            if status != 0 { candle_core::bail!("GdnGateGOp: kernel failed with status {status}"); }
+            let status = kiln_gdn_gate_g_bf16(
+                a_ptr as *const _,
+                al_ptr as *const _,
+                dt_ptr as *const _,
+                out_ptr as *mut _,
+                rows as i32,
+                nv as i32,
+                raw_stream,
+            );
+            if status != 0 {
+                candle_core::bail!("GdnGateGOp: kernel failed with status {status}");
+            }
         }
-        Ok((CudaStorage::wrap_cuda_slice(out_slice, device.clone()), Shape::from(dims.as_slice())))
+        Ok((
+            CudaStorage::wrap_cuda_slice(out_slice, device.clone()),
+            Shape::from(dims.as_slice()),
+        ))
     }
 }
 
@@ -1068,8 +1134,14 @@ pub fn gdn_gates(
     let a_log = gdn_gates_ctx(a_log.contiguous(), "gdn_gates a_log contiguous")?;
     let dt_bias = gdn_gates_ctx(dt_bias.contiguous(), "gdn_gates dt_bias contiguous")?;
 
-    let beta = gdn_gates_ctx(Tensor::zeros(shape.clone(), DType::BF16, device), "gdn_gates beta zeros")?;
-    let g = gdn_gates_ctx(Tensor::zeros(shape, DType::BF16, device), "gdn_gates g zeros")?;
+    let beta = gdn_gates_ctx(
+        Tensor::zeros(shape.clone(), DType::BF16, device),
+        "gdn_gates beta zeros",
+    )?;
+    let g = gdn_gates_ctx(
+        Tensor::zeros(shape, DType::BF16, device),
+        "gdn_gates g zeros",
+    )?;
 
     {
         let (a_storage, a_layout) = a.storage_and_layout();
@@ -1134,11 +1206,15 @@ pub fn gdn_gates(
                 (DType::BF16, DType::BF16) => {
                     let al_slice = al_cuda
                         .as_cuda_slice::<bf16>()
-            .map_err(|err| candle_core::Error::Msg(format!("gdn_gates bf16 as_cuda_slice: {err}")))?
+                        .map_err(|err| {
+                            candle_core::Error::Msg(format!("gdn_gates bf16 as_cuda_slice: {err}"))
+                        })?
                         .slice(al_layout.start_offset()..);
                     let dt_slice = dt_cuda
                         .as_cuda_slice::<bf16>()
-            .map_err(|err| candle_core::Error::Msg(format!("gdn_gates bf16 as_cuda_slice: {err}")))?
+                        .map_err(|err| {
+                            candle_core::Error::Msg(format!("gdn_gates bf16 as_cuda_slice: {err}"))
+                        })?
                         .slice(dt_layout.start_offset()..);
                     let (al_ptr, _g3) = al_slice.device_ptr(&stream);
                     let (dt_ptr, _g4) = dt_slice.device_ptr(&stream);
@@ -1157,11 +1233,15 @@ pub fn gdn_gates(
                 (DType::F32, DType::F32) => {
                     let al_slice = al_cuda
                         .as_cuda_slice::<f32>()
-                        .map_err(|err| candle_core::Error::Msg(format!("gdn_gates f32 as_cuda_slice: {err}")))?
+                        .map_err(|err| {
+                            candle_core::Error::Msg(format!("gdn_gates f32 as_cuda_slice: {err}"))
+                        })?
                         .slice(al_layout.start_offset()..);
                     let dt_slice = dt_cuda
                         .as_cuda_slice::<f32>()
-                        .map_err(|err| candle_core::Error::Msg(format!("gdn_gates f32 as_cuda_slice: {err}")))?
+                        .map_err(|err| {
+                            candle_core::Error::Msg(format!("gdn_gates f32 as_cuda_slice: {err}"))
+                        })?
                         .slice(dt_layout.start_offset()..);
                     let (al_ptr, _g3) = al_slice.device_ptr(&stream);
                     let (dt_ptr, _g4) = dt_slice.device_ptr(&stream);
@@ -1180,11 +1260,15 @@ pub fn gdn_gates(
                 (DType::F32, DType::BF16) => {
                     let al_slice = al_cuda
                         .as_cuda_slice::<f32>()
-                        .map_err(|err| candle_core::Error::Msg(format!("gdn_gates f32 as_cuda_slice: {err}")))?
+                        .map_err(|err| {
+                            candle_core::Error::Msg(format!("gdn_gates f32 as_cuda_slice: {err}"))
+                        })?
                         .slice(al_layout.start_offset()..);
                     let dt_slice = dt_cuda
                         .as_cuda_slice::<bf16>()
-            .map_err(|err| candle_core::Error::Msg(format!("gdn_gates bf16 as_cuda_slice: {err}")))?
+                        .map_err(|err| {
+                            candle_core::Error::Msg(format!("gdn_gates bf16 as_cuda_slice: {err}"))
+                        })?
                         .slice(dt_layout.start_offset()..);
                     let (al_ptr, _g3) = al_slice.device_ptr(&stream);
                     let (dt_ptr, _g4) = dt_slice.device_ptr(&stream);

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -41,11 +41,11 @@ use tracing;
 use kiln_core::config::ModelConfig;
 
 use crate::backend::BackendRuntime;
-use crate::forward::{
-    model_forward_paged, model_forward_paged_with_graph_inputs, GpuWeights, LinearAttentionState,
-};
 #[cfg(feature = "cuda")]
 use crate::forward::PagedDecodeGraphInputs;
+use crate::forward::{
+    GpuWeights, LinearAttentionState, model_forward_paged, model_forward_paged_with_graph_inputs,
+};
 use crate::lora_loader::LoraWeights;
 use crate::paged_kv_cache::PagedKvCache;
 
@@ -73,7 +73,11 @@ impl CudaGraphKey {
         Self {
             stable_metadata,
             seq_len: if stable_metadata { 0 } else { seq_len },
-            block_table: if stable_metadata { Vec::new() } else { block_table.blocks.clone() },
+            block_table: if stable_metadata {
+                Vec::new()
+            } else {
+                block_table.blocks.clone()
+            },
             max_seqlen_k,
             max_blocks_per_seq,
         }
@@ -203,8 +207,15 @@ impl CudaGraphRunner {
     ) -> Result<candle_core::Tensor> {
         if !self.enabled {
             return Self::eager_forward(
-                backend, token_id, weights, config, paged_cache, block_table, seq_len,
-                linear_state, lora,
+                backend,
+                token_id,
+                weights,
+                config,
+                paged_cache,
+                block_table,
+                seq_len,
+                linear_state,
+                lora,
             );
         }
 
@@ -215,8 +226,15 @@ impl CudaGraphRunner {
             #[cfg(feature = "cuda")]
             {
                 match Self::eager_forward_with_position_buffer(
-                    backend, token_id, weights, config, paged_cache, block_table, seq_len,
-                    linear_state, lora,
+                    backend,
+                    token_id,
+                    weights,
+                    config,
+                    paged_cache,
+                    block_table,
+                    seq_len,
+                    linear_state,
+                    lora,
                 ) {
                     Ok(logits) => return Ok(logits),
                     Err(e) => {
@@ -227,8 +245,15 @@ impl CudaGraphRunner {
                 }
             }
             return Self::eager_forward(
-                backend, token_id, weights, config, paged_cache, block_table, seq_len,
-                linear_state, lora,
+                backend,
+                token_id,
+                weights,
+                config,
+                paged_cache,
+                block_table,
+                seq_len,
+                linear_state,
+                lora,
             );
         }
 
@@ -246,16 +271,33 @@ impl CudaGraphRunner {
                         tracing::warn!("Failed to update token buffer: {e}, falling back to eager");
                         self.captured.remove(&requested_key);
                         return Self::eager_forward(
-                            backend, token_id, weights, config, paged_cache, block_table, seq_len,
-                            linear_state, lora,
+                            backend,
+                            token_id,
+                            weights,
+                            config,
+                            paged_cache,
+                            block_table,
+                            seq_len,
+                            linear_state,
+                            lora,
                         );
                     }
-                    if let Err(e) = Self::update_position_buffer(&captured.position_buffer, seq_len) {
-                        tracing::warn!("Failed to update position buffer: {e}, falling back to eager");
+                    if let Err(e) = Self::update_position_buffer(&captured.position_buffer, seq_len)
+                    {
+                        tracing::warn!(
+                            "Failed to update position buffer: {e}, falling back to eager"
+                        );
                         self.captured.remove(&requested_key);
                         return Self::eager_forward(
-                            backend, token_id, weights, config, paged_cache, block_table, seq_len,
-                            linear_state, lora,
+                            backend,
+                            token_id,
+                            weights,
+                            config,
+                            paged_cache,
+                            block_table,
+                            seq_len,
+                            linear_state,
+                            lora,
                         );
                     }
                     if let Err(e) = Self::update_rotary_buffers(
@@ -264,14 +306,27 @@ impl CudaGraphRunner {
                         config,
                         seq_len,
                     ) {
-                        tracing::warn!("Failed to update rotary graph buffers: {e}, falling back to eager");
+                        tracing::warn!(
+                            "Failed to update rotary graph buffers: {e}, falling back to eager"
+                        );
                         self.captured.remove(&requested_key);
                         return Self::eager_forward(
-                            backend, token_id, weights, config, paged_cache, block_table, seq_len,
-                            linear_state, lora,
+                            backend,
+                            token_id,
+                            weights,
+                            config,
+                            paged_cache,
+                            block_table,
+                            seq_len,
+                            linear_state,
+                            lora,
                         );
                     }
-                    if let (Some(block_table_buffer), Some(seqused_k_buffer), Some(kv_slot_buffer)) = (
+                    if let (
+                        Some(block_table_buffer),
+                        Some(seqused_k_buffer),
+                        Some(kv_slot_buffer),
+                    ) = (
                         captured.block_table_buffer.as_ref(),
                         captured.seqused_k_buffer.as_ref(),
                         captured.kv_slot_buffer.as_ref(),
@@ -285,11 +340,20 @@ impl CudaGraphRunner {
                             seq_len,
                             captured.max_seqlen_k,
                         ) {
-                            tracing::warn!("Failed to update paged graph metadata buffers: {e}, falling back to eager");
+                            tracing::warn!(
+                                "Failed to update paged graph metadata buffers: {e}, falling back to eager"
+                            );
                             self.captured.remove(&requested_key);
                             return Self::eager_forward(
-                                backend, token_id, weights, config, paged_cache, block_table, seq_len,
-                                linear_state, lora,
+                                backend,
+                                token_id,
+                                weights,
+                                config,
+                                paged_cache,
+                                block_table,
+                                seq_len,
+                                linear_state,
+                                lora,
                             );
                         }
                     }
@@ -307,8 +371,15 @@ impl CudaGraphRunner {
                             tracing::warn!("CUDA graph replay failed: {e}, falling back to eager");
                             self.captured.remove(&requested_key);
                             return Self::eager_forward(
-                                backend, token_id, weights, config, paged_cache, block_table,
-                                seq_len, linear_state, lora,
+                                backend,
+                                token_id,
+                                weights,
+                                config,
+                                paged_cache,
+                                block_table,
+                                seq_len,
+                                linear_state,
+                                lora,
                             );
                         }
                     }
@@ -333,23 +404,44 @@ impl CudaGraphRunner {
                     "CUDA graph capture skipped: paged metadata shape cache is full"
                 );
                 return Self::eager_forward(
-                    backend, token_id, weights, config, paged_cache, block_table, seq_len,
-                    linear_state, lora,
+                    backend,
+                    token_id,
+                    weights,
+                    config,
+                    paged_cache,
+                    block_table,
+                    seq_len,
+                    linear_state,
+                    lora,
                 );
             }
 
             // Phase 2: capture
             match self.try_capture(
-                backend, token_id, weights, config, paged_cache, block_table, seq_len,
-                linear_state, lora,
+                backend,
+                token_id,
+                weights,
+                config,
+                paged_cache,
+                block_table,
+                seq_len,
+                linear_state,
+                lora,
             ) {
                 Ok(logits) => return Ok(logits),
                 Err(e) => {
                     tracing::warn!("CUDA graph capture failed: {e:#}, using eager decode");
                     self.enabled = false;
                     return Self::eager_forward(
-                        backend, token_id, weights, config, paged_cache, block_table, seq_len,
-                        linear_state, lora,
+                        backend,
+                        token_id,
+                        weights,
+                        config,
+                        paged_cache,
+                        block_table,
+                        seq_len,
+                        linear_state,
+                        lora,
                     );
                 }
             }
@@ -357,7 +449,14 @@ impl CudaGraphRunner {
 
         #[cfg(not(feature = "cuda"))]
         Self::eager_forward(
-            backend, token_id, weights, config, paged_cache, block_table, seq_len, linear_state,
+            backend,
+            token_id,
+            weights,
+            config,
+            paged_cache,
+            block_table,
+            seq_len,
+            linear_state,
             lora,
         )
     }
@@ -385,7 +484,9 @@ impl CudaGraphRunner {
         let mut sin = Vec::with_capacity(half_rotary);
         for i in 0..half_rotary {
             let inv_freq = 1.0f32
-                / (config.rope_theta.powf(2.0 * i as f64 / config.rotary_dim() as f64) as f32);
+                / (config
+                    .rope_theta
+                    .powf(2.0 * i as f64 / config.rotary_dim() as f64) as f32);
             let freq = position as f32 * inv_freq;
             cos.push(freq.cos());
             sin.push(freq.sin());
@@ -422,7 +523,8 @@ impl CudaGraphRunner {
         Self::update_cuda_scalar(seqused_k_buffer, &attention_len, "seqused_k buffer")?;
         let slot = [block_table
             .slot_for(seq_len, paged_cache.block_size())
-            .with_context(|| format!("no slot for decode position {seq_len}"))? as u32];
+            .with_context(|| format!("no slot for decode position {seq_len}"))?
+            as u32];
         Self::update_cuda_scalar(kv_slot_buffer, &slot, "KV slot buffer")?;
         Ok(())
     }
@@ -452,9 +554,7 @@ impl CudaGraphRunner {
         unsafe {
             let (dev_ptr, _guard) = slice.device_ptr(&stream);
             candle_core::cuda_backend::cudarc::driver::result::memcpy_htod_async(
-                dev_ptr,
-                value,
-                raw_stream,
+                dev_ptr, value, raw_stream,
             )
             .map_err(|e| anyhow::anyhow!("memcpy_htod_async for {label}: {e:?}"))?;
         }
@@ -495,17 +595,26 @@ impl CudaGraphRunner {
         // device pointers get baked into the captured graph.
         let token_buffer = Self::new_token_buffer(device, token_id)?;
         let position_buffer = Self::new_position_buffer(device, seq_len)?;
-        let output_logits =
-            Self::new_output_logits(config, device, weights.embed_tokens.dtype())?;
+        let output_logits = Self::new_output_logits(config, device, weights.embed_tokens.dtype())?;
         let output_logits_for_capture = output_logits.clone();
         let rotary_cos_buffer = Self::new_rotary_cos_buffer(config, device, seq_len)?;
         let rotary_sin_buffer = Self::new_rotary_sin_buffer(config, device, seq_len)?;
         let key = CudaGraphKey::new(block_table, paged_cache, seq_len);
         let (block_table_buffer, seqused_k_buffer, kv_slot_buffer) = if key.stable_metadata {
             (
-                Some(Self::new_block_table_buffer(block_table, paged_cache, key.max_seqlen_k, device)?),
+                Some(Self::new_block_table_buffer(
+                    block_table,
+                    paged_cache,
+                    key.max_seqlen_k,
+                    device,
+                )?),
                 Some(Self::new_seqused_k_buffer(device, seq_len + 1)?),
-                Some(Self::new_kv_slot_buffer(block_table, paged_cache, seq_len, device)?),
+                Some(Self::new_kv_slot_buffer(
+                    block_table,
+                    paged_cache,
+                    seq_len,
+                    device,
+                )?),
             )
         } else {
             (None, None, None)
@@ -593,22 +702,25 @@ impl CudaGraphRunner {
                     config.num_layers,
                 );
                 let max_seqlen_k = key.max_seqlen_k;
-                self.captured.insert(key, CapturedDecodeGraph {
-                    graph,
-                    output_logits,
-                    adapter_gen: self.adapter_generation,
-                    token_buffer,
-                    position_buffer,
-                    block_table_buffer,
-                    seqused_k_buffer,
-                    kv_slot_buffer,
-                    rotary_cos_buffer,
-                    rotary_sin_buffer,
-                    _paged_decode_outputs: paged_decode_outputs,
-                    _paged_decode_lse: paged_decode_lse,
-                    max_seqlen_k,
-                    _gdn_decode_outputs: gdn_decode_outputs,
-                });
+                self.captured.insert(
+                    key,
+                    CapturedDecodeGraph {
+                        graph,
+                        output_logits,
+                        adapter_gen: self.adapter_generation,
+                        token_buffer,
+                        position_buffer,
+                        block_table_buffer,
+                        seqused_k_buffer,
+                        kv_slot_buffer,
+                        rotary_cos_buffer,
+                        rotary_sin_buffer,
+                        _paged_decode_outputs: paged_decode_outputs,
+                        _paged_decode_lse: paged_decode_lse,
+                        max_seqlen_k,
+                        _gdn_decode_outputs: gdn_decode_outputs,
+                    },
+                );
                 Ok(logits)
             }
             Ok(None) => {
@@ -716,7 +828,8 @@ impl CudaGraphRunner {
     ) -> Result<Tensor> {
         let slot = block_table
             .slot_for(seq_len, paged_cache.block_size())
-            .with_context(|| format!("no slot for decode position {seq_len}"))? as u32;
+            .with_context(|| format!("no slot for decode position {seq_len}"))?
+            as u32;
         Tensor::new(&[slot], device).context("create CUDA graph KV slot buffer")
     }
 
@@ -772,8 +885,12 @@ impl CudaGraphRunner {
                 .context("create CUDA graph paged decode output")?,
             );
             lse.push(
-                Tensor::zeros((1, config.num_attention_heads, 1), candle_core::DType::F32, device)
-                    .context("create CUDA graph paged decode LSE")?,
+                Tensor::zeros(
+                    (1, config.num_attention_heads, 1),
+                    candle_core::DType::F32,
+                    device,
+                )
+                .context("create CUDA graph paged decode LSE")?,
             );
         }
         Ok((outputs, lse))

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -953,7 +953,11 @@ impl LinearAttentionState {
 
         for _ in 0..num_linear_layers {
             recurrent_states.push(Tensor::zeros((batch, nv, dk, dv), recurrent_dtype, device)?);
-            conv_states.push(Tensor::zeros((batch, conv_dim, k_minus_1), DType::F32, device)?);
+            conv_states.push(Tensor::zeros(
+                (batch, conv_dim, k_minus_1),
+                DType::F32,
+                device,
+            )?);
         }
 
         Ok(Self {
@@ -2153,10 +2157,7 @@ fn embedding_lookup_from_weights_with_index(
     embedding_lookup_with_index(index, &weights.embed_tokens)
 }
 
-fn embedding_lookup_from_transposed(
-    token_ids: &[u32],
-    embed_tokens_t: &Tensor,
-) -> Result<Tensor> {
+fn embedding_lookup_from_transposed(token_ids: &[u32], embed_tokens_t: &Tensor) -> Result<Tensor> {
     let index = Tensor::new(token_ids, embed_tokens_t.device())?;
     embedding_lookup_from_transposed_index(&index, embed_tokens_t)
 }
@@ -3805,7 +3806,9 @@ fn gated_deltanet_gates_fallback(
     input_dtype: DType,
 ) -> Result<(Tensor, Tensor)> {
     let beta = cuda_sigmoid(b).context("gdn gates fallback beta cuda_sigmoid")?; // [B, T, nv], bf16
-    let a_f32 = a.to_dtype(DType::F32).context("gdn gates fallback a to f32")?;
+    let a_f32 = a
+        .to_dtype(DType::F32)
+        .context("gdn gates fallback a to f32")?;
     let a_log_f32 = weights
         .a_log
         .to_dtype(DType::F32)
@@ -4569,10 +4572,9 @@ fn gated_deltanet_forward_decode_if(
         let (beta, g) = {
             kiln_nvtx::range!(c"kiln/gdn/gates");
             if use_fused_gdn_gates && backend.supports_gdn_gates() {
-                if let Some((beta, g)) =
-                    backend
-                        .gdn_gates(&a, &b, &weights.a_log_gates, &weights.dt_bias)
-                        .context("gdn decode gates fused backend")?
+                if let Some((beta, g)) = backend
+                    .gdn_gates(&a, &b, &weights.a_log_gates, &weights.dt_bias)
+                    .context("gdn decode gates fused backend")?
                 {
                     (beta, g)
                 } else {
@@ -5278,8 +5280,7 @@ fn try_flash_attn_paged_decode(
         let n_chunks = total_seq_len.div_ceil(K_BLOCK_N);
         let blocks = &block_table.blocks;
         let allocated = blocks.len();
-        if allocated < n_chunks * pages_per_chunk
-            && allocated < total_seq_len.div_ceil(block_size)
+        if allocated < n_chunks * pages_per_chunk && allocated < total_seq_len.div_ceil(block_size)
         {
             return Ok(None);
         }
@@ -5335,8 +5336,8 @@ fn try_flash_attn_paged_decode(
             if let Some(inputs) = graph_inputs {
                 inputs.block_table
             } else {
-                bt_tensor_owned = Tensor::new(padded.as_slice(), device)?
-                    .reshape((batch, max_blocks_per_seq))?;
+                bt_tensor_owned =
+                    Tensor::new(padded.as_slice(), device)?.reshape((batch, max_blocks_per_seq))?;
                 &bt_tensor_owned
             }
         }
@@ -5367,7 +5368,7 @@ fn try_flash_attn_paged_decode(
         q_fa
     };
 
-let stage_profile = start_full_attn_stage_profile(q.device(), profile_context)?;
+    let stage_profile = start_full_attn_stage_profile(q.device(), profile_context)?;
     let attn_out = {
         #[cfg(feature = "cuda")]
         {
@@ -5413,7 +5414,8 @@ let stage_profile = start_full_attn_stage_profile(q.device(), profile_context)?;
                     .iter()
                     .map(|&len| i32::try_from(len).context("paged decode seqlen exceeds i32"))
                     .collect::<Result<_>>()?;
-                let seqused = Tensor::from_slice(seqused.as_slice(), batch, device)?.contiguous()?;
+                let seqused =
+                    Tensor::from_slice(seqused.as_slice(), batch, device)?.contiguous()?;
                 kiln_flash_attn::flash_attn_paged_decode_dyn_seqlen(
                     &q_fa,
                     k_pool,
@@ -5602,7 +5604,9 @@ pub fn gqa_attention_paged_decode_batch(
     };
     let (q, k) = {
         let stage_profile = start_full_attn_stage_profile(profile_device, profile_context)?;
-        let out = rotary_embedding_batched_decode_from_tensor(&q, &k, positions, head_dim, rotary_dim, inv_freq)?;
+        let out = rotary_embedding_batched_decode_from_tensor(
+            &q, &k, positions, head_dim, rotary_dim, inv_freq,
+        )?;
         finish_full_attn_stage_profile(
             profile_device,
             profile_context,
@@ -5971,7 +5975,8 @@ pub fn gqa_attention_paged(
         full_attn_layer_idx,
         attn_output_gate,
         lora,
-        #[cfg(feature = "cuda")] None,
+        #[cfg(feature = "cuda")]
+        None,
     )
 }
 
@@ -6371,13 +6376,15 @@ fn gqa_attention_paged_with_rope_tables(
                 false
             }
         };
-        if !graph_write_done && !paged_cache.write_token_major_native(
-            full_attn_layer_idx,
-            block_table,
-            start_pos,
-            &k_cache_token_major,
-            &v_cache_token_major,
-        )? {
+        if !graph_write_done
+            && !paged_cache.write_token_major_native(
+                full_attn_layer_idx,
+                block_table,
+                start_pos,
+                &k_cache_token_major,
+                &v_cache_token_major,
+            )?
+        {
             let k_head = k_cache_token_major.transpose(1, 2)?.contiguous()?;
             let v_head = v_cache_token_major.transpose(1, 2)?.contiguous()?;
             paged_cache
@@ -6442,7 +6449,8 @@ fn gqa_attention_paged_with_rope_tables(
                 attn_weights,
                 lora_layer,
                 lora_scale,
-                #[cfg(feature = "cuda")] graph_inputs,
+                #[cfg(feature = "cuda")]
+                graph_inputs,
                 profile_context,
             )?
         };
@@ -6995,7 +7003,8 @@ pub fn transformer_block_paged(
         block_table,
         full_attn_layer_idx,
         lora,
-        #[cfg(feature = "cuda")] None,
+        #[cfg(feature = "cuda")]
+        None,
         None,
     )
 }
@@ -7072,7 +7081,8 @@ fn transformer_block_paged_with_rope_tables(
         full_attn_layer_idx,
         config.attn_output_gate,
         lora,
-        #[cfg(feature = "cuda")] graph_inputs,
+        #[cfg(feature = "cuda")]
+        graph_inputs,
     )?;
     if subop_armed {
         let _ = crate::mtp_debug::capture_subop("post_attn_block", &attn_out);
@@ -7703,10 +7713,7 @@ pub fn model_forward_segment(
 ///
 /// Returns `([1, seq_len, hidden_size], positions)` — the initial hidden state
 /// and position indices for RoPE (starting from position 0, no KV cache offset).
-pub fn model_forward_embed(
-    token_ids: &[u32],
-    weights: &GpuWeights,
-) -> Result<(Tensor, Vec<u32>)> {
+pub fn model_forward_embed(token_ids: &[u32], weights: &GpuWeights) -> Result<(Tensor, Vec<u32>)> {
     let seq_len = token_ids.len();
     let mut hidden = embedding_lookup_from_weights(token_ids, weights)?;
     hidden = hidden.unsqueeze(0)?;
@@ -7817,7 +7824,8 @@ pub fn model_forward_paged(
         lora,
         None,
         positions_gpu,
-        #[cfg(feature = "cuda")] None,
+        #[cfg(feature = "cuda")]
+        None,
         LmHeadMode::Full,
     )?;
     // `LmHeadMode::Full` always returns Some.
@@ -7854,7 +7862,8 @@ pub fn model_forward_paged_last_token(
         lora,
         None,
         positions_gpu,
-        #[cfg(feature = "cuda")] None,
+        #[cfg(feature = "cuda")]
+        None,
         LmHeadMode::LastRowOnly,
     )?;
     Ok(logits.expect("LmHeadMode::LastRowOnly always produces logits"))
@@ -7890,7 +7899,8 @@ pub fn model_forward_paged_last_token_greedy(
         lora,
         None,
         positions_gpu,
-        #[cfg(feature = "cuda")] None,
+        #[cfg(feature = "cuda")]
+        None,
         LmHeadMode::LastRowArgmaxOnly,
     )?;
     token.context("LmHeadMode::LastRowArgmaxOnly always produces a token")
@@ -7954,7 +7964,8 @@ pub(crate) fn model_forward_paged_with_graph_inputs(
         lora,
         Some(token_ids_gpu),
         Some(positions_gpu),
-        #[cfg(feature = "cuda")] graph_inputs,
+        #[cfg(feature = "cuda")]
+        graph_inputs,
         LmHeadMode::Full,
     )?;
     Ok(logits.expect("LmHeadMode::Full always produces logits"))
@@ -8127,7 +8138,11 @@ pub fn model_forward_paged_batched_decode_hidden(
                 };
                 let normed_post = {
                     kiln_nvtx::range!(c"kiln/batched_decode/norm/pre_mlp");
-                    rms_norm(&hidden, &layer.post_attention_layernorm, config.rms_norm_eps)?
+                    rms_norm(
+                        &hidden,
+                        &layer.post_attention_layernorm,
+                        config.rms_norm_eps,
+                    )?
                 };
                 let ffn_out = swiglu_ffn(&normed_post, &layer.mlp, layer_lora)?;
                 hidden = {
@@ -8173,7 +8188,11 @@ pub fn model_forward_paged_batched_decode_hidden(
                 };
                 let normed_post = {
                     kiln_nvtx::range!(c"kiln/batched_decode/norm/pre_mlp_full");
-                    rms_norm(&hidden, &layer.post_attention_layernorm, config.rms_norm_eps)?
+                    rms_norm(
+                        &hidden,
+                        &layer.post_attention_layernorm,
+                        config.rms_norm_eps,
+                    )?
                 };
                 let ffn_out = swiglu_ffn(&normed_post, &layer.mlp, layer_lora)?;
                 hidden = {
@@ -8260,7 +8279,8 @@ pub fn model_forward_paged_with_last_hidden(
         lora,
         None,
         positions_gpu,
-        #[cfg(feature = "cuda")] None,
+        #[cfg(feature = "cuda")]
+        None,
         LmHeadMode::FullWithLastHidden,
     )?;
     Ok((
@@ -8307,7 +8327,8 @@ pub fn model_forward_paged_last_token_with_last_hidden(
         lora,
         None,
         positions_gpu,
-        #[cfg(feature = "cuda")] None,
+        #[cfg(feature = "cuda")]
+        None,
         LmHeadMode::LastRowWithLastHidden,
     )?;
     Ok((
@@ -8942,7 +8963,10 @@ fn model_forward_paged_inner(
         }
     };
     let rope_tables_owned = if positions_gpu.is_none() && graph_rope_tables.is_none() {
-        Some(rotary_tables_from_tensor(positions, &weights.rotary_inv_freq)?)
+        Some(rotary_tables_from_tensor(
+            positions,
+            &weights.rotary_inv_freq,
+        )?)
     } else {
         None
     };
@@ -8995,7 +9019,8 @@ fn model_forward_paged_inner(
                     block_table,
                     full_attn_idx,
                     layer_lora,
-                    #[cfg(feature = "cuda")] graph_inputs,
+                    #[cfg(feature = "cuda")]
+                    graph_inputs,
                     profile_mlp_stages.then_some((i, start_pos)),
                 );
                 crate::mtp_debug::exit_b12_layer_scope();
@@ -9391,7 +9416,8 @@ pub fn model_forward_paged_streaming_last_token_with_last_hidden_with(
             lora,
             None,
             None,
-            #[cfg(feature = "cuda")] None,
+            #[cfg(feature = "cuda")]
+            None,
             mode,
         )
         .with_context(|| {
@@ -9476,7 +9502,8 @@ pub fn model_forward_paged_streaming_with(
             lora,
             None,
             None,
-            #[cfg(feature = "cuda")] None,
+            #[cfg(feature = "cuda")]
+            None,
             mode,
         )
         .with_context(|| {
@@ -9705,9 +9732,15 @@ mod tests {
         let elems = batch * seq_len * heads * hidden;
 
         let mut rng = StdRng::seed_from_u64(0xC0DA_6A7E);
-        let x_data: Vec<f32> = (0..elems).map(|_| rng.random_range(-1.0f32..1.0f32)).collect();
-        let z_data: Vec<f32> = (0..elems).map(|_| rng.random_range(-2.0f32..2.0f32)).collect();
-        let w_data: Vec<f32> = (0..hidden).map(|_| rng.random_range(0.5f32..1.5f32)).collect();
+        let x_data: Vec<f32> = (0..elems)
+            .map(|_| rng.random_range(-1.0f32..1.0f32))
+            .collect();
+        let z_data: Vec<f32> = (0..elems)
+            .map(|_| rng.random_range(-2.0f32..2.0f32))
+            .collect();
+        let w_data: Vec<f32> = (0..hidden)
+            .map(|_| rng.random_range(0.5f32..1.5f32))
+            .collect();
 
         let x = Tensor::from_slice(&x_data, (batch, seq_len, heads, hidden), &device)?
             .to_dtype(DType::BF16)?;
@@ -9764,9 +9797,15 @@ mod tests {
         let elems = batch * seq_len * heads * hidden;
 
         let mut rng = StdRng::seed_from_u64(0x6A7E_DA75);
-        let x_data: Vec<f32> = (0..elems).map(|_| rng.random_range(-1.0f32..1.0f32)).collect();
-        let z_data: Vec<f32> = (0..elems).map(|_| rng.random_range(-2.0f32..2.0f32)).collect();
-        let w_data: Vec<f32> = (0..hidden).map(|_| rng.random_range(0.5f32..1.5f32)).collect();
+        let x_data: Vec<f32> = (0..elems)
+            .map(|_| rng.random_range(-1.0f32..1.0f32))
+            .collect();
+        let z_data: Vec<f32> = (0..elems)
+            .map(|_| rng.random_range(-2.0f32..2.0f32))
+            .collect();
+        let w_data: Vec<f32> = (0..hidden)
+            .map(|_| rng.random_range(0.5f32..1.5f32))
+            .collect();
 
         let x = Tensor::from_slice(&x_data, (batch, seq_len, heads, hidden), &device)?
             .to_dtype(DType::BF16)?;
@@ -9817,7 +9856,9 @@ mod tests {
         let elems = batch * seq_len * hidden;
 
         let mut rng = StdRng::seed_from_u64(0xA11CE);
-        let x_data: Vec<f32> = (0..elems).map(|_| rng.random_range(-1.0f32..1.0f32)).collect();
+        let x_data: Vec<f32> = (0..elems)
+            .map(|_| rng.random_range(-1.0f32..1.0f32))
+            .collect();
         let w_data: Vec<f32> = (0..hidden)
             .map(|_| rng.random_range(-0.2f32..0.2f32))
             .collect();
@@ -12566,10 +12607,16 @@ mod tests {
         let recurrent_values1: Vec<f32> = (0..64).map(|i| 1000.0 + i as f32).collect();
         let conv_values0: Vec<f32> = (0..96).map(|i| 2000.0 + i as f32).collect();
         let conv_values1: Vec<f32> = (0..96).map(|i| 3000.0 + i as f32).collect();
-        row0.recurrent_states[0] =
-            Tensor::from_slice(&recurrent_values0, (1usize, 4usize, 4usize, 4usize), &device)?;
-        row1.recurrent_states[0] =
-            Tensor::from_slice(&recurrent_values1, (1usize, 4usize, 4usize, 4usize), &device)?;
+        row0.recurrent_states[0] = Tensor::from_slice(
+            &recurrent_values0,
+            (1usize, 4usize, 4usize, 4usize),
+            &device,
+        )?;
+        row1.recurrent_states[0] = Tensor::from_slice(
+            &recurrent_values1,
+            (1usize, 4usize, 4usize, 4usize),
+            &device,
+        )?;
         row0.conv_states[0] =
             Tensor::from_slice(&conv_values0, (1usize, 32usize, 3usize), &device)?;
         row1.conv_states[0] =
@@ -12584,11 +12631,15 @@ mod tests {
         let split = batched.split_batch_rows()?;
         assert_eq!(split.len(), 2);
         assert_eq!(
-            split[0].recurrent_states[0].flatten_all()?.to_vec1::<f32>()?,
+            split[0].recurrent_states[0]
+                .flatten_all()?
+                .to_vec1::<f32>()?,
             row0.recurrent_states[0].flatten_all()?.to_vec1::<f32>()?
         );
         assert_eq!(
-            split[1].recurrent_states[0].flatten_all()?.to_vec1::<f32>()?,
+            split[1].recurrent_states[0]
+                .flatten_all()?
+                .to_vec1::<f32>()?,
             row1.recurrent_states[0].flatten_all()?.to_vec1::<f32>()?
         );
         assert_eq!(
@@ -12666,7 +12717,10 @@ mod tests {
         let batched = LinearAttentionState::new_with_batch(&config, 3, &device)?;
         assert_eq!(batched.recurrent_states[0].dims(), &[3, 4, 4, 4]);
         assert_eq!(batched.recurrent_states[0].dtype(), DType::BF16);
-        assert_eq!(batched.conv_states[0].dims(), &[3, config.linear_qkv_dim(), 3]);
+        assert_eq!(
+            batched.conv_states[0].dims(),
+            &[3, config.linear_qkv_dim(), 3]
+        );
         assert_eq!(batched.conv_states[0].dtype(), DType::F32);
 
         let row0 = LinearAttentionState::new(&config, &device)?;
@@ -12675,13 +12729,19 @@ mod tests {
         assert_eq!(assembled.batch_size()?, 2);
         assert_eq!(assembled.recurrent_states[0].dims(), &[2, 4, 4, 4]);
         assert_eq!(assembled.recurrent_states[0].dtype(), DType::BF16);
-        assert_eq!(assembled.conv_states[0].dims(), &[2, config.linear_qkv_dim(), 3]);
+        assert_eq!(
+            assembled.conv_states[0].dims(),
+            &[2, config.linear_qkv_dim(), 3]
+        );
         assert_eq!(assembled.conv_states[0].dtype(), DType::F32);
         let split = assembled.split_batch_rows()?;
         assert_eq!(split.len(), 2);
         assert_eq!(split[0].recurrent_states[0].dims(), &[1, 4, 4, 4]);
         assert_eq!(split[0].recurrent_states[0].dtype(), DType::BF16);
-        assert_eq!(split[0].conv_states[0].dims(), &[1, config.linear_qkv_dim(), 3]);
+        assert_eq!(
+            split[0].conv_states[0].dims(),
+            &[1, config.linear_qkv_dim(), 3]
+        );
         assert_eq!(split[0].conv_states[0].dtype(), DType::F32);
 
         Ok(())
@@ -12967,8 +13027,12 @@ mod tests {
         let n_v = b * nv * c * dv;
         let n_b = b * nv * c;
 
-        let a_data: Vec<f32> = (0..n_a).map(|_| rng.random_range(-0.05f32..0.05f32)).collect();
-        let v_data: Vec<f32> = (0..n_v).map(|_| rng.random_range(-1.0f32..1.0f32)).collect();
+        let a_data: Vec<f32> = (0..n_a)
+            .map(|_| rng.random_range(-0.05f32..0.05f32))
+            .collect();
+        let v_data: Vec<f32> = (0..n_v)
+            .map(|_| rng.random_range(-1.0f32..1.0f32))
+            .collect();
         let beta_data: Vec<f32> = (0..n_b).map(|_| rng.random_range(0.5f32..1.5f32)).collect();
 
         let a_f32 = Tensor::from_slice(&a_data, (b, nv, c, c), &device)?;
@@ -13032,8 +13096,12 @@ mod tests {
         let n_v = b * nv * c * dv;
         let n_b = b * nv * c;
 
-        let a_data: Vec<f32> = (0..n_a).map(|_| rng.random_range(-0.05f32..0.05f32)).collect();
-        let v_data: Vec<f32> = (0..n_v).map(|_| rng.random_range(-1.0f32..1.0f32)).collect();
+        let a_data: Vec<f32> = (0..n_a)
+            .map(|_| rng.random_range(-0.05f32..0.05f32))
+            .collect();
+        let v_data: Vec<f32> = (0..n_v)
+            .map(|_| rng.random_range(-1.0f32..1.0f32))
+            .collect();
         let beta_data: Vec<f32> = (0..n_b).map(|_| rng.random_range(0.5f32..1.5f32)).collect();
 
         let a_f32 = Tensor::from_slice(&a_data, (b, nv, c, c), &device)?;
@@ -13107,13 +13175,23 @@ mod tests {
         let n_b = b * nv * t;
         let n_s = b * nv * dk * dv;
 
-        let q_data: Vec<f32> = (0..n_qk).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let k_data: Vec<f32> = (0..n_qk).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let v_data: Vec<f32> = (0..n_v).map(|_| rng.random_range(-1.0f32..1.0f32)).collect();
+        let q_data: Vec<f32> = (0..n_qk)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let k_data: Vec<f32> = (0..n_qk)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let v_data: Vec<f32> = (0..n_v)
+            .map(|_| rng.random_range(-1.0f32..1.0f32))
+            .collect();
         let beta_data: Vec<f32> = (0..n_b).map(|_| rng.random_range(0.3f32..1.2f32)).collect();
         // Small negative gates so exp(g) stays in (~0.8, 1.0).
-        let g_data: Vec<f32> = (0..n_b).map(|_| rng.random_range(-0.2f32..0.0f32)).collect();
-        let s_data: Vec<f32> = (0..n_s).map(|_| rng.random_range(-0.1f32..0.1f32)).collect();
+        let g_data: Vec<f32> = (0..n_b)
+            .map(|_| rng.random_range(-0.2f32..0.0f32))
+            .collect();
+        let s_data: Vec<f32> = (0..n_s)
+            .map(|_| rng.random_range(-0.1f32..0.1f32))
+            .collect();
 
         let q_f32 = Tensor::from_slice(&q_data, (b, nv, t, dk), &device)?;
         let k_f32 = Tensor::from_slice(&k_data, (b, nv, t, dk), &device)?;
@@ -13216,12 +13294,22 @@ mod tests {
         let n_b = b * nv * t;
         let n_s = b * nv * dk * dv;
 
-        let q_data: Vec<f32> = (0..n_qk).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let k_data: Vec<f32> = (0..n_qk).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let v_data: Vec<f32> = (0..n_v).map(|_| rng.random_range(-1.0f32..1.0f32)).collect();
+        let q_data: Vec<f32> = (0..n_qk)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let k_data: Vec<f32> = (0..n_qk)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let v_data: Vec<f32> = (0..n_v)
+            .map(|_| rng.random_range(-1.0f32..1.0f32))
+            .collect();
         let beta_data: Vec<f32> = (0..n_b).map(|_| rng.random_range(0.3f32..1.2f32)).collect();
-        let g_data: Vec<f32> = (0..n_b).map(|_| rng.random_range(-0.2f32..0.0f32)).collect();
-        let s_data: Vec<f32> = (0..n_s).map(|_| rng.random_range(-0.1f32..0.1f32)).collect();
+        let g_data: Vec<f32> = (0..n_b)
+            .map(|_| rng.random_range(-0.2f32..0.0f32))
+            .collect();
+        let s_data: Vec<f32> = (0..n_s)
+            .map(|_| rng.random_range(-0.1f32..0.1f32))
+            .collect();
 
         let q = Tensor::from_slice(&q_data, (b, nv, t, dk), &device)?.to_dtype(DType::BF16)?;
         let k = Tensor::from_slice(&k_data, (b, nv, t, dk), &device)?.to_dtype(DType::BF16)?;
@@ -13316,12 +13404,24 @@ mod tests {
         // Small negative gates so big_g stays in a reasonable range — the
         // recurrence produces g_t near zero so the cumulative sum caps
         // around -10 at most.
-        let g_data: Vec<f32> = (0..n_g).map(|_| rng.random_range(-0.15f32..0.0f32)).collect();
-        let v_data: Vec<f32> = (0..n_v).map(|_| rng.random_range(-1.0f32..1.0f32)).collect();
-        let kkt_data: Vec<f32> = (0..n_cc).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let qkt_data: Vec<f32> = (0..n_cc).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let ks_data: Vec<f32> = (0..n_v).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let qs_data: Vec<f32> = (0..n_v).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
+        let g_data: Vec<f32> = (0..n_g)
+            .map(|_| rng.random_range(-0.15f32..0.0f32))
+            .collect();
+        let v_data: Vec<f32> = (0..n_v)
+            .map(|_| rng.random_range(-1.0f32..1.0f32))
+            .collect();
+        let kkt_data: Vec<f32> = (0..n_cc)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let qkt_data: Vec<f32> = (0..n_cc)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let ks_data: Vec<f32> = (0..n_v)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let qs_data: Vec<f32> = (0..n_v)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
 
         let g = Tensor::from_slice(&g_data, (b, nv, c), &device)?.to_dtype(DType::BF16)?;
         let v = Tensor::from_slice(&v_data, (b, nv, c, dv), &device)?.to_dtype(DType::BF16)?;
@@ -13427,9 +13527,15 @@ mod tests {
                 }
             })
             .collect();
-        let b_data: Vec<f32> = (0..n_cc).map(|_| rng.random_range(-0.2f32..0.2f32)).collect();
-        let v_data: Vec<f32> = (0..n_cdv).map(|_| rng.random_range(-1.0f32..1.0f32)).collect();
-        let qss_data: Vec<f32> = (0..n_cdv).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
+        let b_data: Vec<f32> = (0..n_cc)
+            .map(|_| rng.random_range(-0.2f32..0.2f32))
+            .collect();
+        let v_data: Vec<f32> = (0..n_cdv)
+            .map(|_| rng.random_range(-1.0f32..1.0f32))
+            .collect();
+        let qss_data: Vec<f32> = (0..n_cdv)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
         let beta_data: Vec<f32> = (0..n_c).map(|_| rng.random_range(0.3f32..1.1f32)).collect();
         let decay_data: Vec<f32> = (0..n_c).map(|_| rng.random_range(0.6f32..1.0f32)).collect();
 
@@ -13514,14 +13620,28 @@ mod tests {
         let n_dkc = b * nv * dk * c;
         let n_dkdv = b * nv * dk * dv;
 
-        let g_data: Vec<f32> = (0..n_c).map(|_| rng.random_range(-0.15f32..0.0f32)).collect();
-        let v_data: Vec<f32> = (0..n_cdv).map(|_| rng.random_range(-1.0f32..1.0f32)).collect();
-        let kkt_data: Vec<f32> = (0..n_cc).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let qkt_data: Vec<f32> = (0..n_cc).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let ks_data: Vec<f32> = (0..n_cdv).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let qs_data: Vec<f32> = (0..n_cdv).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
+        let g_data: Vec<f32> = (0..n_c)
+            .map(|_| rng.random_range(-0.15f32..0.0f32))
+            .collect();
+        let v_data: Vec<f32> = (0..n_cdv)
+            .map(|_| rng.random_range(-1.0f32..1.0f32))
+            .collect();
+        let kkt_data: Vec<f32> = (0..n_cc)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let qkt_data: Vec<f32> = (0..n_cc)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let ks_data: Vec<f32> = (0..n_cdv)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let qs_data: Vec<f32> = (0..n_cdv)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
         let beta_data: Vec<f32> = (0..n_c).map(|_| rng.random_range(0.3f32..1.1f32)).collect();
-        let kt_data: Vec<f32> = (0..n_dkc).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
+        let kt_data: Vec<f32> = (0..n_dkc)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
         let state_data: Vec<f32> = (0..n_dkdv)
             .map(|_| rng.random_range(-0.25f32..0.25f32))
             .collect();
@@ -13620,9 +13740,15 @@ mod tests {
         let n_w = channels * kernel_size;
         let n_s = batch * channels * (kernel_size - 1);
 
-        let x_data: Vec<f32> = (0..n_x).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let w_data: Vec<f32> = (0..n_w).map(|_| rng.random_range(-0.1f32..0.1f32)).collect();
-        let s_data: Vec<f32> = (0..n_s).map(|_| rng.random_range(-0.3f32..0.3f32)).collect();
+        let x_data: Vec<f32> = (0..n_x)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let w_data: Vec<f32> = (0..n_w)
+            .map(|_| rng.random_range(-0.1f32..0.1f32))
+            .collect();
+        let s_data: Vec<f32> = (0..n_s)
+            .map(|_| rng.random_range(-0.3f32..0.3f32))
+            .collect();
 
         let x_f32 = Tensor::from_slice(&x_data, (batch, channels, 1), &device)?;
         let w_f32 = Tensor::from_slice(&w_data, (channels, 1, kernel_size), &device)?;
@@ -13709,9 +13835,15 @@ mod tests {
         let n_w = channels * kernel_size;
         let n_s = batch * channels * (kernel_size - 1);
 
-        let x_data: Vec<f32> = (0..n_x).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let w_data: Vec<f32> = (0..n_w).map(|_| rng.random_range(-0.1f32..0.1f32)).collect();
-        let s_data: Vec<f32> = (0..n_s).map(|_| rng.random_range(-0.3f32..0.3f32)).collect();
+        let x_data: Vec<f32> = (0..n_x)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let w_data: Vec<f32> = (0..n_w)
+            .map(|_| rng.random_range(-0.1f32..0.1f32))
+            .collect();
+        let s_data: Vec<f32> = (0..n_s)
+            .map(|_| rng.random_range(-0.3f32..0.3f32))
+            .collect();
 
         let x = Tensor::from_slice(&x_data, (batch, channels, seq_len), &device)?
             .to_dtype(DType::BF16)?;
@@ -13788,9 +13920,15 @@ mod tests {
         let n_w = channels * kernel_size;
         let n_s = batch * channels * (kernel_size - 1);
 
-        let x_data: Vec<f32> = (0..n_x).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let w_data: Vec<f32> = (0..n_w).map(|_| rng.random_range(-0.1f32..0.1f32)).collect();
-        let s_data: Vec<f32> = (0..n_s).map(|_| rng.random_range(-0.3f32..0.3f32)).collect();
+        let x_data: Vec<f32> = (0..n_x)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let w_data: Vec<f32> = (0..n_w)
+            .map(|_| rng.random_range(-0.1f32..0.1f32))
+            .collect();
+        let s_data: Vec<f32> = (0..n_s)
+            .map(|_| rng.random_range(-0.3f32..0.3f32))
+            .collect();
 
         let x_f32 = Tensor::from_slice(&x_data, (batch, channels, 1), &device)?;
         let w_f32 = Tensor::from_slice(&w_data, (channels, 1, kernel_size), &device)?;
@@ -13867,9 +14005,15 @@ mod tests {
         let n_w = channels * kernel_size;
         let n_s = batch * channels * (kernel_size - 1);
 
-        let x_data: Vec<f32> = (0..n_x).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let w_data: Vec<f32> = (0..n_w).map(|_| rng.random_range(-0.1f32..0.1f32)).collect();
-        let s_data: Vec<f32> = (0..n_s).map(|_| rng.random_range(-0.3f32..0.3f32)).collect();
+        let x_data: Vec<f32> = (0..n_x)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let w_data: Vec<f32> = (0..n_w)
+            .map(|_| rng.random_range(-0.1f32..0.1f32))
+            .collect();
+        let s_data: Vec<f32> = (0..n_s)
+            .map(|_| rng.random_range(-0.3f32..0.3f32))
+            .collect();
 
         let x = Tensor::from_slice(&x_data, (batch, channels, seq_len), &device)?
             .to_dtype(DType::BF16)?;
@@ -13940,9 +14084,15 @@ mod tests {
         let n_w = channels * kernel_size;
         let n_s = batch * channels * (kernel_size - 1);
 
-        let x_data: Vec<f32> = (0..n_x).map(|_| rng.random_range(-0.5f32..0.5f32)).collect();
-        let w_data: Vec<f32> = (0..n_w).map(|_| rng.random_range(-0.1f32..0.1f32)).collect();
-        let s_data: Vec<f32> = (0..n_s).map(|_| rng.random_range(-0.3f32..0.3f32)).collect();
+        let x_data: Vec<f32> = (0..n_x)
+            .map(|_| rng.random_range(-0.5f32..0.5f32))
+            .collect();
+        let w_data: Vec<f32> = (0..n_w)
+            .map(|_| rng.random_range(-0.1f32..0.1f32))
+            .collect();
+        let s_data: Vec<f32> = (0..n_s)
+            .map(|_| rng.random_range(-0.3f32..0.3f32))
+            .collect();
 
         let x = Tensor::from_slice(&x_data, (batch, channels, seq_len), &device)?
             .to_dtype(DType::BF16)?;
@@ -14660,7 +14810,9 @@ mod tests {
 
         // Final recurrent state must match (the load-bearing invariant for
         // training-time streaming — autograd flows through this state thread).
-        let mr = mono_state.recurrent_states[0].flatten_all()?.to_vec1::<f32>()?;
+        let mr = mono_state.recurrent_states[0]
+            .flatten_all()?
+            .to_vec1::<f32>()?;
         let sr = stream_state.recurrent_states[0]
             .flatten_all()?
             .to_vec1::<f32>()?;

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -22,12 +22,11 @@ use crate::backend::{self, BackendRuntime};
 use crate::cancel::CancelHandle;
 use crate::cuda_graph::CudaGraphRunner;
 use crate::forward::{
-    GpuWeights, LinearAttentionState, model_forward, model_forward_paged, model_forward_head,
+    GpuWeights, LinearAttentionState, model_forward, model_forward_head, model_forward_paged,
     model_forward_paged_batched_decode_hidden, model_forward_paged_decode_contiguous_batch_greedy,
-    model_forward_paged_last_token,
-    model_forward_paged_last_token_greedy, model_forward_paged_last_token_with_last_hidden,
-    model_forward_paged_next_token_greedy, model_forward_paged_streaming,
-    model_forward_paged_streaming_last_token_with_last_hidden,
+    model_forward_paged_last_token, model_forward_paged_last_token_greedy,
+    model_forward_paged_last_token_with_last_hidden, model_forward_paged_next_token_greedy,
+    model_forward_paged_streaming, model_forward_paged_streaming_last_token_with_last_hidden,
     model_forward_paged_streaming_with_progress, streaming_prefill_enabled_for,
 };
 use crate::kv_cache::KvCache;
@@ -1916,7 +1915,12 @@ impl ModelRunner {
                     .iter()
                     .zip(states.iter())
                     .map(|(params, state)| {
-                        (params.temperature, params.top_p, params.top_k, state.step_seed)
+                        (
+                            params.temperature,
+                            params.top_p,
+                            params.top_k,
+                            state.step_seed,
+                        )
                     })
                     .collect();
                 sample_rows_with_params(&logits, &sampling_params)

--- a/crates/kiln-model/src/sampling.rs
+++ b/crates/kiln-model/src/sampling.rs
@@ -69,7 +69,6 @@ pub fn greedy_sample_rows(logits: &Tensor) -> Result<Vec<u32>> {
     Ok(ids.to_vec1::<u32>()?)
 }
 
-
 /// Sample one token for every batch row in a logits tensor.
 ///
 /// Fast paths cover the hot serving cases without per-row synchronization:

--- a/crates/kiln-server/src/api/completions.rs
+++ b/crates/kiln-server/src/api/completions.rs
@@ -1828,8 +1828,7 @@ fn completion_usage_tokens(
     visible_token_count: usize,
     finish_reason: &kiln_model::FinishReason,
 ) -> usize {
-    visible_token_count
-        + usize::from(matches!(finish_reason, kiln_model::FinishReason::Eos))
+    visible_token_count + usize::from(matches!(finish_reason, kiln_model::FinishReason::Eos))
 }
 
 /// OpenAI-compatible streaming chunk.
@@ -3003,7 +3002,6 @@ async fn generate_real_batched(
         },
     })
 }
-
 
 async fn generate_real_batched_streaming(
     state: &AppState,
@@ -6022,8 +6020,14 @@ mod tests {
 
     #[test]
     fn completion_usage_counts_terminal_eos_token() {
-        assert_eq!(completion_usage_tokens(0, &kiln_model::FinishReason::Eos), 1);
-        assert_eq!(completion_usage_tokens(3, &kiln_model::FinishReason::Eos), 4);
+        assert_eq!(
+            completion_usage_tokens(0, &kiln_model::FinishReason::Eos),
+            1
+        );
+        assert_eq!(
+            completion_usage_tokens(3, &kiln_model::FinishReason::Eos),
+            4
+        );
         assert_eq!(
             completion_usage_tokens(3, &kiln_model::FinishReason::MaxTokens),
             3

--- a/crates/kiln-server/src/api/ui.rs
+++ b/crates/kiln-server/src/api/ui.rs
@@ -1,7 +1,7 @@
 use axum::{
+    Router,
     response::{Html, Redirect},
     routing::get,
-    Router,
 };
 
 const UI_HTML: &str = include_str!("../ui.html");

--- a/crates/kiln-server/src/batching_engine.rs
+++ b/crates/kiln-server/src/batching_engine.rs
@@ -299,7 +299,9 @@ impl DecodeForward for RealDecodeForward {
                     DecodeSlot::Real { .. } => {
                         anyhow::bail!("decode row {idx} became first-token pending")
                     }
-                    DecodeSlot::Mock { .. } => anyhow::bail!("mock slot sent to real decode forward"),
+                    DecodeSlot::Mock { .. } => {
+                        anyhow::bail!("mock slot sent to real decode forward")
+                    }
                 }
             }
             anyhow::ensure!(
@@ -969,8 +971,20 @@ mod tests {
         assert_eq!(decode_params[0].max_tokens, 22);
         assert_eq!(decode_params[1].max_tokens, 44);
         drop(slots);
-        assert!(matches!(pending_a, DecodeSlot::Real { first_token_pending: false, .. }));
-        assert!(matches!(pending_b, DecodeSlot::Real { first_token_pending: false, .. }));
+        assert!(matches!(
+            pending_a,
+            DecodeSlot::Real {
+                first_token_pending: false,
+                ..
+            }
+        ));
+        assert!(matches!(
+            pending_b,
+            DecodeSlot::Real {
+                first_token_pending: false,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -375,7 +375,9 @@ fn parse_args() -> Result<BenchArgs> {
                 eprintln!(
                     "                            (Phase C40b — tests greedy-is-uniquely-harmful hypothesis on code MTP α)"
                 );
-                eprintln!("  -v, --verbose             Show per-site tracing logs (repeat for trace)");
+                eprintln!(
+                    "  -v, --verbose             Show per-site tracing logs (repeat for trace)"
+                );
                 eprintln!("  -q, --quiet               Drop tracing to warnings and errors only");
                 std::process::exit(0);
             }
@@ -446,11 +448,9 @@ fn make_run_progress(total: u64, label: &str) -> Option<ProgressBar> {
     }
     let pb = ProgressBar::new(total);
     pb.set_style(
-        ProgressStyle::with_template(
-            "  {prefix:.dim} [{bar:24.cyan/blue}] {pos}/{len} {msg:.dim}",
-        )
-        .expect("static progress template is valid")
-        .progress_chars("=>-"),
+        ProgressStyle::with_template("  {prefix:.dim} [{bar:24.cyan/blue}] {pos}/{len} {msg:.dim}")
+            .expect("static progress template is valid")
+            .progress_chars("=>-"),
     );
     pb.set_prefix(label.to_string());
     Some(pb)
@@ -655,10 +655,7 @@ fn bench_inference(
 
         let run_tps = gen_tokens as f64 / run_time.as_secs_f64();
         if let Some(pb) = pb.as_ref() {
-            pb.set_message(format!(
-                "{} tok @ {:.0} tok/s",
-                gen_tokens, run_tps
-            ));
+            pb.set_message(format!("{} tok @ {:.0} tok/s", gen_tokens, run_tps));
             pb.inc(1);
         } else {
             tracing::info!(
@@ -2352,7 +2349,11 @@ fn print_summary(results: &BenchmarkResults) {
         format!("{:.1}", results.latency.p99_inter_token_ms),
         Some("ms"),
     );
-    metric("Tokens generated", results.latency.num_tokens_generated, None);
+    metric(
+        "Tokens generated",
+        results.latency.num_tokens_generated,
+        None,
+    );
     metric("Spec method", &results.latency.spec_method, None);
     if let Some(alpha) = results.latency.acceptance_rate {
         metric("Draft acceptance α", format!("{alpha:.3}"), None);
@@ -2362,7 +2363,11 @@ fn print_summary(results: &BenchmarkResults) {
         section_header("SFT training");
         metric("Steps", t.num_steps, None);
         metric("Total time", format!("{:.2}", t.total_time_secs), Some("s"));
-        metric("Time per step", format!("{:.2}", t.secs_per_step), Some("s"));
+        metric(
+            "Time per step",
+            format!("{:.2}", t.secs_per_step),
+            Some("s"),
+        );
         metric("Peak VRAM", t.peak_vram_mb, Some("MB"));
     }
 
@@ -2666,7 +2671,11 @@ fn main() -> Result<()> {
             stderr,
             "  {} {}",
             style("→").cyan(),
-            style(format!("{n} sequential run{}", if n == 1 { "" } else { "s" })).white()
+            style(format!(
+                "{n} sequential run{}",
+                if n == 1 { "" } else { "s" }
+            ))
+            .white()
         );
         match bench_inference(
             &runner,
@@ -2682,16 +2691,14 @@ fn main() -> Result<()> {
                     stderr,
                     "    {} {} tok/s aggregate",
                     style("✓").green().bold(),
-                    style(format!("{:.1}", result.tokens_per_sec)).white().bold()
+                    style(format!("{:.1}", result.tokens_per_sec))
+                        .white()
+                        .bold()
                 );
                 inference_results.push(result);
             }
             Err(e) => {
-                let _ = writeln!(
-                    stderr,
-                    "    {} {e}",
-                    style("✗ FAILED:").red().bold()
-                );
+                let _ = writeln!(stderr, "    {} {e}", style("✗ FAILED:").red().bold());
             }
         }
     }

--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -360,7 +360,9 @@ pub fn print_banner(host: &str, port: u16, model_path: Option<&str>, config_path
     let _ = writeln!(
         stderr,
         "  {}",
-        style("│           🔥 K I L N 🔥             │").cyan().bold()
+        style("│           🔥 K I L N 🔥             │")
+            .cyan()
+            .bold()
     );
     let _ = writeln!(
         stderr,
@@ -382,12 +384,7 @@ pub fn print_banner(host: &str, port: u16, model_path: Option<&str>, config_path
     );
 
     if let Some(cp) = config_path {
-        let _ = writeln!(
-            stderr,
-            "  {} {}",
-            style("Config:").dim(),
-            style(cp).white()
-        );
+        let _ = writeln!(stderr, "  {} {}", style("Config:").dim(), style(cp).white());
     }
 
     let mode = if model_path.is_some() {
@@ -414,12 +411,7 @@ pub fn print_banner(host: &str, port: u16, model_path: Option<&str>, config_path
     }
 
     if let Some(mp) = model_path {
-        let _ = writeln!(
-            stderr,
-            "  {} {}",
-            style("Model:").dim(),
-            style(mp).white()
-        );
+        let _ = writeln!(stderr, "  {} {}", style("Model:").dim(), style(mp).white());
     }
 
     let cuda_status = if candle_core::utils::cuda_is_available() {
@@ -468,7 +460,9 @@ pub fn print_banner(host: &str, port: u16, model_path: Option<&str>, config_path
 /// The returned `ProgressBar` ticks every 80ms; callers should `set_message`
 /// between phases and `finish_and_clear` once done so the line goes away
 /// before [`print_ready_line`] writes the final status.
-pub fn make_startup_spinner(initial_message: impl Into<std::borrow::Cow<'static, str>>) -> Option<indicatif::ProgressBar> {
+pub fn make_startup_spinner(
+    initial_message: impl Into<std::borrow::Cow<'static, str>>,
+) -> Option<indicatif::ProgressBar> {
     if !console::Term::stderr().features().is_attended() {
         return None;
     }
@@ -541,15 +535,30 @@ pub fn format_health_pretty(body: &serde_json::Value) -> String {
         .and_then(|v| v.as_u64())
         .unwrap_or(0);
 
-    let _ = writeln!(out, "  {} {}", style("Version:").dim(), style(version).white().bold());
+    let _ = writeln!(
+        out,
+        "  {} {}",
+        style("Version:").dim(),
+        style(version).white().bold()
+    );
     let _ = writeln!(
         out,
         "  {}  {}",
         style("Uptime:").dim(),
         style(format_uptime_secs(uptime_secs)).white().bold()
     );
-    let _ = writeln!(out, "  {}   {}", style("Model:").dim(), style(model).white().bold());
-    let _ = writeln!(out, "  {} {}", style("Backend:").dim(), style(backend).white().bold());
+    let _ = writeln!(
+        out,
+        "  {}   {}",
+        style("Model:").dim(),
+        style(model).white().bold()
+    );
+    let _ = writeln!(
+        out,
+        "  {} {}",
+        style("Backend:").dim(),
+        style(backend).white().bold()
+    );
     let _ = writeln!(
         out,
         "  {} {}",
@@ -566,9 +575,18 @@ pub fn format_health_pretty(body: &serde_json::Value) -> String {
     if let Some(sched) = body.get("scheduler").and_then(|v| v.as_object()) {
         let waiting = sched.get("waiting").and_then(|v| v.as_u64()).unwrap_or(0);
         let running = sched.get("running").and_then(|v| v.as_u64()).unwrap_or(0);
-        let blocks_used = sched.get("blocks_used").and_then(|v| v.as_u64()).unwrap_or(0);
-        let blocks_free = sched.get("blocks_free").and_then(|v| v.as_u64()).unwrap_or(0);
-        let blocks_total = sched.get("blocks_total").and_then(|v| v.as_u64()).unwrap_or(0);
+        let blocks_used = sched
+            .get("blocks_used")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let blocks_free = sched
+            .get("blocks_free")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let blocks_total = sched
+            .get("blocks_total")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
         let _ = writeln!(
             out,
             "  {} waiting={} running={}  blocks={}/{} ({} free)",
@@ -582,9 +600,15 @@ pub fn format_health_pretty(body: &serde_json::Value) -> String {
     }
 
     if let Some(gpu) = body.get("gpu_memory").and_then(|v| v.as_object()) {
-        let total = gpu.get("total_vram_gb").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let total = gpu
+            .get("total_vram_gb")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
         let model_gb = gpu.get("model_gb").and_then(|v| v.as_f64()).unwrap_or(0.0);
-        let kv = gpu.get("kv_cache_gb").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let kv = gpu
+            .get("kv_cache_gb")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
         let train = gpu
             .get("training_budget_gb")
             .and_then(|v| v.as_f64())
@@ -662,10 +686,7 @@ pub async fn run_health(url: &str, json: bool) -> anyhow::Result<()> {
     let body: serde_json::Value = resp.json().await?;
 
     if status.is_success() {
-        println!(
-            "{} Server is healthy",
-            style("✓").green().bold()
-        );
+        println!("{} Server is healthy", style("✓").green().bold());
         if json {
             println!("{}", serde_json::to_string_pretty(&body)?);
         } else {
@@ -690,10 +711,7 @@ pub fn run_config_check(file: Option<&str>) -> anyhow::Result<()> {
 
     match KilnConfig::load(file) {
         Ok(config) => {
-            println!(
-                "{} Configuration is valid",
-                style("✓").green().bold()
-            );
+            println!("{} Configuration is valid", style("✓").green().bold());
             println!();
             println!(
                 "  {} {}:{}",
@@ -701,11 +719,7 @@ pub fn run_config_check(file: Option<&str>) -> anyhow::Result<()> {
                 config.server.host,
                 config.server.port
             );
-            println!(
-                "  {} {}",
-                style("Model ID:").dim(),
-                config.model.model_id
-            );
+            println!("  {} {}", style("Model ID:").dim(), config.model.model_id);
             println!(
                 "  {} {}",
                 style("Served as:").dim(),
@@ -714,16 +728,8 @@ pub fn run_config_check(file: Option<&str>) -> anyhow::Result<()> {
             if let Some(ref p) = config.model.path {
                 println!("  {} {}", style("Model path:").dim(), p);
             }
-            println!(
-                "  {} {}",
-                style("Log level:").dim(),
-                config.logging.level
-            );
-            println!(
-                "  {} {}",
-                style("Log format:").dim(),
-                config.logging.format
-            );
+            println!("  {} {}", style("Log level:").dim(), config.logging.level);
+            println!("  {} {}", style("Log format:").dim(), config.logging.format);
             println!(
                 "  {} {}",
                 style("KV cache FP8:").dim(),
@@ -747,10 +753,7 @@ pub fn run_config_check(file: Option<&str>) -> anyhow::Result<()> {
             Ok(())
         }
         Err(e) => {
-            eprintln!(
-                "{} Configuration error: {e}",
-                style("✗").red().bold()
-            );
+            eprintln!("{} Configuration error: {e}", style("✗").red().bold());
             std::process::exit(1);
         }
     }
@@ -895,10 +898,7 @@ pub async fn run_adapters_load(url: &str, name: &str) -> anyhow::Result<()> {
 /// Run the `adapters unload` CLI subcommand.
 pub async fn run_adapters_unload(url: &str, name: Option<&str>) -> anyhow::Result<()> {
     let client = reqwest::Client::new();
-    let resp = client
-        .post(adapter_unload_url(url))
-        .send()
-        .await?;
+    let resp = client.post(adapter_unload_url(url)).send().await?;
     let status = resp.status();
     let body: serde_json::Value = resp.json().await?;
 
@@ -963,8 +963,8 @@ pub async fn run_train_sft(
     epochs: u32,
     lora_rank: Option<usize>,
 ) -> anyhow::Result<()> {
-    let content = std::fs::read_to_string(file)
-        .map_err(|e| anyhow::anyhow!("Failed to read {file}: {e}"))?;
+    let content =
+        std::fs::read_to_string(file).map_err(|e| anyhow::anyhow!("Failed to read {file}: {e}"))?;
 
     let mut examples = Vec::new();
     for (i, line) in content.lines().enumerate() {
@@ -997,10 +997,7 @@ pub async fn run_train_sft(
     let resp_body: serde_json::Value = resp.json().await?;
 
     if status.is_success() {
-        println!(
-            "{} Training job submitted",
-            style("✓").green().bold()
-        );
+        println!("{} Training job submitted", style("✓").green().bold());
         let job_id = resp_body.get("job_id").and_then(|j| j.as_str());
         if let Some(id) = job_id {
             println!("  {} {}", style("Job ID:").dim(), id);
@@ -1033,8 +1030,8 @@ pub async fn run_train_grpo(
     adapter: &str,
     lora_rank: Option<usize>,
 ) -> anyhow::Result<()> {
-    let content = std::fs::read_to_string(file)
-        .map_err(|e| anyhow::anyhow!("Failed to read {file}: {e}"))?;
+    let content =
+        std::fs::read_to_string(file).map_err(|e| anyhow::anyhow!("Failed to read {file}: {e}"))?;
 
     let body: serde_json::Value = serde_json::from_str(&content)
         .map_err(|e| anyhow::anyhow!("Invalid JSON in {file}: {e}"))?;
@@ -1058,10 +1055,7 @@ pub async fn run_train_grpo(
     let resp_body: serde_json::Value = resp.json().await?;
 
     if status.is_success() {
-        println!(
-            "{} GRPO training job submitted",
-            style("✓").green().bold()
-        );
+        println!("{} GRPO training job submitted", style("✓").green().bold());
         let job_id = resp_body.get("job_id").and_then(|j| j.as_str());
         if let Some(id) = job_id {
             println!("  {} {}", style("Job ID:").dim(), id);
@@ -1114,14 +1108,12 @@ fn build_grpo_training_payload(
     adapter: &str,
     lora_rank: Option<usize>,
 ) -> anyhow::Result<serde_json::Value> {
-    let obj = body
-        .as_object_mut()
-        .ok_or_else(|| anyhow::anyhow!("GRPO request must be a JSON object with groups and config"))?;
+    let obj = body.as_object_mut().ok_or_else(|| {
+        anyhow::anyhow!("GRPO request must be a JSON object with groups and config")
+    })?;
     obj.remove("adapter_name");
 
-    let config = obj
-        .entry("config")
-        .or_insert_with(|| serde_json::json!({}));
+    let config = obj.entry("config").or_insert_with(|| serde_json::json!({}));
     let config_obj = config
         .as_object_mut()
         .ok_or_else(|| anyhow::anyhow!("GRPO request config must be a JSON object"))?;
@@ -1207,16 +1199,18 @@ async fn print_all_job_statuses(url: &str) -> anyhow::Result<()> {
     }
     // Sort terminal by elapsed_secs ascending (most recent submissions last).
     terminal.sort_by(|a, b| {
-        let ea = a.get("elapsed_secs").and_then(|v| v.as_f64()).unwrap_or(0.0);
-        let eb = b.get("elapsed_secs").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let ea = a
+            .get("elapsed_secs")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
+        let eb = b
+            .get("elapsed_secs")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(0.0);
         ea.partial_cmp(&eb).unwrap_or(std::cmp::Ordering::Equal)
     });
 
-    println!(
-        "{} {} job(s):",
-        style("✓").green().bold(),
-        jobs.len()
-    );
+    println!("{} {} job(s):", style("✓").green().bold(), jobs.len());
     for job in running.iter().chain(queued.iter()).chain(terminal.iter()) {
         print_job_line(job);
     }
@@ -1241,19 +1235,19 @@ fn print_job_summary(job: &serde_json::Value) {
         .get("adapter_name")
         .and_then(|v| v.as_str())
         .unwrap_or("?");
-    let progress_pct = (job
-        .get("progress")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.0)
-        * 100.0)
-        .round() as i64;
+    let progress_pct =
+        (job.get("progress").and_then(|v| v.as_f64()).unwrap_or(0.0) * 100.0).round() as i64;
     let elapsed = job
         .get("elapsed_secs")
         .and_then(|v| v.as_f64())
         .unwrap_or(0.0)
         .round() as i64;
 
-    println!("{} Job {}", style("✓").green().bold(), style(id).white().bold());
+    println!(
+        "{} Job {}",
+        style("✓").green().bold(),
+        style(id).white().bold()
+    );
     println!("  {} {}", style("State:").dim(), style_state(state));
     println!("  {} {}", style("Adapter:").dim(), style(adapter).white());
     println!("  {} {}%", style("Progress:").dim(), progress_pct);
@@ -1270,12 +1264,8 @@ fn print_job_line(job: &serde_json::Value) {
         .get("adapter_name")
         .and_then(|v| v.as_str())
         .unwrap_or("?");
-    let progress_pct = (job
-        .get("progress")
-        .and_then(|v| v.as_f64())
-        .unwrap_or(0.0)
-        * 100.0)
-        .round() as i64;
+    let progress_pct =
+        (job.get("progress").and_then(|v| v.as_f64()).unwrap_or(0.0) * 100.0).round() as i64;
     let elapsed = job
         .get("elapsed_secs")
         .and_then(|v| v.as_f64())
@@ -1684,7 +1674,10 @@ mod tests {
         assert!(out.contains("model_loaded"), "got: {out}");
         assert!(out.contains("scheduler_responsive"), "got: {out}");
         // ✓ glyph appears at least twice (once per check, plus the runtime header is rendered separately)
-        assert!(out.contains("✓"), "expected at least one ✓ glyph, got: {out}");
+        assert!(
+            out.contains("✓"),
+            "expected at least one ✓ glyph, got: {out}"
+        );
     }
 
     #[test]

--- a/crates/kiln-vulkan-kernel/build.rs
+++ b/crates/kiln-vulkan-kernel/build.rs
@@ -69,7 +69,10 @@ const SHADERS: &[(&str, &str)] = &[
     ("flash_attn", "SPIR_V_FLASH_ATTN"),
 ];
 
-fn compile_shader_command(glsl_path: &std::path::Path, spv_path: &std::path::Path) -> std::io::Result<std::process::Output> {
+fn compile_shader_command(
+    glsl_path: &std::path::Path,
+    spv_path: &std::path::Path,
+) -> std::io::Result<std::process::Output> {
     let glslc = std::process::Command::new("glslc")
         .arg(glsl_path)
         .arg("-o")

--- a/crates/kiln-vulkan-kernel/src/device.rs
+++ b/crates/kiln-vulkan-kernel/src/device.rs
@@ -290,7 +290,11 @@ impl VulkanDevice {
             kiln_vulkan_device.as_deref(),
             ggml_vk_visible_devices.as_deref(),
         ) {
-            tracing::info!(device_index = idx, source, "using explicit Vulkan device selection");
+            tracing::info!(
+                device_index = idx,
+                source,
+                "using explicit Vulkan device selection"
+            );
             return Ok(physical_devices[idx]);
         }
 

--- a/crates/kiln-vulkan-kernel/src/pipeline.rs
+++ b/crates/kiln-vulkan-kernel/src/pipeline.rs
@@ -3,7 +3,10 @@ use ash::vk;
 use std::collections::HashMap;
 use std::sync::Arc;
 
-fn compile_shader_command(glsl_path: &str, spv_path: &std::path::Path) -> std::io::Result<std::process::Output> {
+fn compile_shader_command(
+    glsl_path: &str,
+    spv_path: &std::path::Path,
+) -> std::io::Result<std::process::Output> {
     let glslc = std::process::Command::new("glslc")
         .arg(glsl_path)
         .arg("-o")


### PR DESCRIPTION
## Summary
- Apply workspace rustfmt output so PR #853 validation can get past its formatting gate.
- Keep the patch formatting-only; no PR #853 implementation logic was changed.
- Include the newly reported Vulkan rustfmt drift plus the additional current workspace drift reproduced by `cargo fmt --check` on `main`.

## Validation
- `cargo +1.94.0-x86_64-unknown-linux-musl fmt --check`
- `cargo +stable-x86_64-unknown-linux-musl fmt --check`
