### PR TITLE
[codex] Align Docker model path docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,12 @@ If you prefer a terminal, run the prebuilt container instead:
 ```bash
 docker pull ghcr.io/ericflo/kiln-server:latest
 docker run --gpus all -p 8420:8420 \
-  -v /path/to/Qwen3.5-4B:/models \
+  -e KILN_MODEL_PATH=/models/Qwen3.5-4B \
+  -v /path/to/Qwen3.5-4B:/models/Qwen3.5-4B:ro \
   ghcr.io/ericflo/kiln-server:latest serve
 ```
 
-Replace `/path/to/Qwen3.5-4B` with your local model directory, then open http://127.0.0.1:8420/ui after the container starts.
+Replace `/path/to/Qwen3.5-4B` with your local `Qwen3.5-4B` model directory, then open http://127.0.0.1:8420/ui after the container starts.
 
 **Path 2 — Source / CLI, for contributors and direct CLI users:** Install Rust stable, then build the CLI from source for your platform.
 
@@ -366,7 +367,8 @@ Run with the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud
 
 ```bash
 docker run --gpus all -p 8420:8420 \
-  -v /path/to/Qwen3.5-4B:/models \
+  -e KILN_MODEL_PATH=/models/Qwen3.5-4B \
+  -v /path/to/Qwen3.5-4B:/models/Qwen3.5-4B:ro \
   ghcr.io/ericflo/kiln-server:latest serve
 ```
 
@@ -374,7 +376,10 @@ docker run --gpus all -p 8420:8420 \
 
 ```bash
 docker build -f deploy/Dockerfile -t kiln .
-docker run --gpus all -v /path/to/Qwen3.5-4B:/models -p 8420:8420 kiln serve
+docker run --gpus all -p 8420:8420 \
+  -e KILN_MODEL_PATH=/models/Qwen3.5-4B \
+  -v /path/to/Qwen3.5-4B:/models/Qwen3.5-4B:ro \
+  kiln serve
 ```
 
 ### systemd

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -429,7 +429,8 @@ $env:KILN_MODEL_PATH = ".\Qwen3.5-4B"; .\kiln\kiln.exe serve</code></pre>
       <h3 class="font-semibold mb-2 mt-6">Docker (Linux + NVIDIA Container Toolkit)</h3>
 <pre><code>docker pull ghcr.io/ericflo/kiln-server:latest
 docker run --gpus all -p 8420:8420 \
-  -v /path/to/Qwen3.5-4B:/models \
+  -e KILN_MODEL_PATH=/models/Qwen3.5-4B \
+  -v /path/to/Qwen3.5-4B:/models/Qwen3.5-4B:ro \
   ghcr.io/ericflo/kiln-server:latest serve</code></pre>
 
       <p class="text-sm mt-6" style="color: var(--fg-mute);">


### PR DESCRIPTION
## Summary
- Align README Docker first-run snippets with the site quickstart's explicit `KILN_MODEL_PATH=/models/Qwen3.5-4B` pattern.
- Mount local Qwen3.5-4B weights at `/models/Qwen3.5-4B:ro` in README and homepage Docker examples.
- Clarify that readers should replace `/path/to/Qwen3.5-4B` with their local model directory.

## Validation
- `rg -n 'KILN_MODEL_PATH=/models/Qwen3.5-4B|/models/Qwen3.5-4B:ro|docker run --gpus all' README.md docs/site/index.html docs/site/quickstart.html`
- `git diff --check`