### PR TITLE
[codex] Align QUICKSTART adapter unload examples

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -264,8 +264,8 @@ curl -s http://localhost:8420/v1/train/status | python3 -m json.tool
 # List loaded adapters
 ./target/release/kiln adapters list
 
-# Unload an adapter (revert to base model)
-./target/release/kiln adapters unload default
+# Unload the active adapter (revert to base model)
+./target/release/kiln adapters unload
 
 # Reload it
 ./target/release/kiln adapters load default
@@ -582,9 +582,9 @@ kiln train status --job-id train_123
 
 kiln adapters list
 kiln adapters load support-bot
-kiln adapters unload support-bot
+kiln adapters unload
 kiln adapters delete support-bot
-    List, load, unload the active adapter, or delete a saved adapter on the running server.
+    List, load, unload the active adapter to revert to the base model, or delete a saved adapter on the running server.
 ```
 
 The CLI currently covers the basic adapter lifecycle: `list`, `load`, `unload`, and `delete`. For advanced adapter download, upload, merge, and composition flows — plus training-completion webhooks — use the dashboard or the HTTP API examples in [9. Advanced API Examples](#9-advanced-api-examples).


### PR DESCRIPTION
## Summary

- Updates QUICKSTART adapter unload examples to use the canonical no-argument form.
- Keeps the surrounding copy focused on unloading the active adapter and reverting to the base model.

## Validation

- `rg -n 'adapters unload|legacy adapter name|active adapter|Unload an adapter' QUICKSTART.md docs/site/cli.html crates/kiln-server/src/cli.rs`
- `git diff --check`