### PR TITLE
[codex] Align docs site Docker quickstart command

### DIFF
--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -345,7 +345,7 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
 <pre class="text-sm"><code>docker run --gpus all -p 8420:8420 \
   -e KILN_MODEL_PATH=/models/Qwen3.5-4B \
   -v "$PWD/Qwen3.5-4B:/models/Qwen3.5-4B:ro" \
-  ghcr.io/ericflo/kiln-server:latest</code></pre>
+  ghcr.io/ericflo/kiln-server:latest serve</code></pre>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary

- Updates the docs site quickstart Docker run example to explicitly pass the `serve` subcommand.
- Keeps `docs/site/quickstart.html` aligned with the Docker examples in `README.md`, `QUICKSTART.md`, and `docs/site/index.html`.

## Validation

- `rg -n "ghcr\.io/ericflo/kiln-server:latest( serve)?" README.md QUICKSTART.md docs/site/index.html docs/site/quickstart.html`
- `! rg -n "ghcr\.io/ericflo/kiln-server:latest</code>" docs/site/quickstart.html`