### PR TITLE
[codex] Add quickstart CLI reference card

### DIFF
--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -391,7 +391,7 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
   <section class="divider">
     <div class="max-w-5xl mx-auto px-6 py-12">
       <h2 class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
-      <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <div class="grid sm:grid-cols-2 lg:grid-cols-5 gap-4">
         <a class="card p-5 block" href="api.html#training">
           <h3 class="font-semibold mb-2">SFT corrections</h3>
           <p style="color: var(--fg-dim);">Post simple fixes to <code>/v1/train/sft</code> or use <code>kiln train sft</code> after first inference.</p>
@@ -403,6 +403,10 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
         <a class="card p-5 block" href="api.html">
           <h3 class="font-semibold mb-2">API Reference</h3>
           <p style="color: var(--fg-dim);">See inference, adapter, training, metrics, and configuration endpoints.</p>
+        </a>
+        <a class="card p-5 block" href="cli.html">
+          <h3 class="font-semibold mb-2">CLI Reference</h3>
+          <p style="color: var(--fg-dim);">Keep going from the terminal with health, training, and adapter commands.</p>
         </a>
         <a class="card p-5 block" href="troubleshooting.html">
           <h3 class="font-semibold mb-2">Troubleshooting</h3>


### PR DESCRIPTION
## Summary
- add a first-class CLI Reference card to the docs-site quickstart `Where to go next` grid
- adjust the large-screen grid from four to five columns so the added card fits cleanly with the existing cards

## Validation
- `rg -n 'Where to go next|CLI Reference|cli.html|grid .*cols' docs/site/quickstart.html docs/site/cli.html README.md QUICKSTART.md`