### PR TITLE
[codex] Point README demo link to live player

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center">
   <a href="https://ericflo.github.io/kiln/">Website</a> &middot;
-  <a href="docs/site/demo/">Demo</a> &middot;
+  <a href="https://ericflo.github.io/kiln/demo/">Demo</a> &middot;
   <a href="QUICKSTART.md">Quickstart</a> &middot;
   <a href="https://ericflo.github.io/kiln/cli.html">CLI Guide</a> &middot;
   <a href="https://ericflo.github.io/kiln/grpo.html">GRPO Guide</a> &middot;


### PR DESCRIPTION
## Summary
- Update the centered README hero `Demo` link to point at the live GitHub Pages demo player.
- Keep the separate source-directory link in the "See it in action" section unchanged.

## Validation
- `rg -n '<a href="https://ericflo.github.io/kiln/demo/">Demo</a>|docs/site/demo/|See it in action' README.md docs/site/demo/SCRIPT.md`