### PR TITLE
[codex] Add CLI and demo links to UI help nav

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -651,6 +651,8 @@ textarea { resize: vertical; min-height: 80px; }
     <a href="https://ericflo.github.io/kiln/quickstart.html" target="_blank" rel="noopener noreferrer">Quickstart</a>
     <a href="https://ericflo.github.io/kiln/grpo.html" target="_blank" rel="noopener noreferrer">GRPO Guide</a>
     <a href="https://ericflo.github.io/kiln/api.html" target="_blank" rel="noopener noreferrer">API Reference</a>
+    <a href="https://ericflo.github.io/kiln/cli.html" target="_blank" rel="noopener noreferrer">CLI Reference</a>
+    <a href="https://ericflo.github.io/kiln/demo/" target="_blank" rel="noopener noreferrer">Demo</a>
     <a href="https://ericflo.github.io/kiln/troubleshooting.html" target="_blank" rel="noopener noreferrer">Troubleshooting</a>
   </nav>
   <div class="header-stats" id="header-stats">


### PR DESCRIPTION
## Summary
- Add CLI Reference and Demo links to the embedded `/ui` header help navigation.
- Keep the existing external-link convention with `target="_blank"` and `rel="noopener noreferrer"`.

## Validation
- Ran the requested Python source inspection to confirm the UI help nav contains Quickstart, GRPO Guide, API Reference, CLI Reference, Demo, and Troubleshooting links.
- Did not run Rust build/check/test; this is a `ui.html`-only Phase 11 polish change and no GPU work is required.
