### PR TITLE
[codex] Document CLI verbosity flags

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -592,7 +592,11 @@ The CLI currently covers the basic adapter lifecycle: `list`, `load`, `unload`, 
 ```
 Global options:
   --config, -c <file>   Path to TOML config file
+  --verbose, -v         Show debug startup/model-load diagnostics; repeat as -vv for trace detail
+  --quiet, -q           Print only warnings and errors for script-friendly output
 ```
+
+Use `kiln -v serve` when first-run startup or model-load diagnostics are needed. Use `kiln -q ...` for quieter scripted commands, for example `kiln -q health`.
 
 ## API Endpoints
 

--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -258,6 +258,15 @@ kiln serve --config kiln.toml
 kiln serve --served-model-id qwen3.5-4b-local</code></pre>
         <p class="text-sm mt-4" style="color: var(--fg-mute);">Use <code>kiln config</code> to validate built-in defaults plus <code>KILN_*</code> environment overrides, or <code>kiln config --file</code> / <code>kiln config -f</code> to validate a TOML file before starting the server.</p>
       </div>
+      <div class="card p-6 lg:col-span-2">
+        <p class="label mb-2">Logging</p>
+        <h2 class="text-2xl font-semibold tracking-tight mb-4">Tune startup output</h2>
+        <p class="mb-4" style="color: var(--fg-dim);">Kiln uses the configured log level by default. Add global <code>-v</code> / <code>--verbose</code> for debug startup detail, repeat it as <code>-vv</code> for trace-level kernel and scheduler detail, or use <code>-q</code> / <code>--quiet</code> when you only want warnings and errors.</p>
+<pre class="text-sm"><code>kiln -v serve
+kiln -vv serve
+kiln -q health</code></pre>
+        <p class="text-sm mt-4" style="color: var(--fg-mute);">Put these flags before or after the subcommand; they are global CLI options and are mutually exclusive between verbose and quiet modes.</p>
+      </div>
     </div>
   </section>
 


### PR DESCRIPTION
## Summary
- Document global `-v` / `--verbose`, `-vv`, and `-q` / `--quiet` logging controls in the CLI reference page.
- Add a short QUICKSTART note for startup/model-load diagnostics and quiet scripted commands.

## Validation
- `python3 - <<'PY' ... PY` requested CLI verbosity docs assertion
- `git diff --check -- docs/site/cli.html QUICKSTART.md`

No GPU pod or local cargo build/check/test was used; this is docs-only Phase 11 onboarding polish.