### PR TITLE
[codex] Align docs-site crate map

### DIFF
--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -354,7 +354,7 @@
           <li><code>kiln-scheduler</code> and <code>kiln-core</code> coordinate batching, requests, and KV blocks.</li>
           <li><code>kiln-model</code> loads Qwen3.5-4B weights, applies adapters, and drives the forward pass.</li>
           <li><code>kiln-flash-attn</code>, CUDA-backed crates, <code>kiln-vulkan-kernel</code>, and Metal shaders provide backend-specific GPU kernels.</li>
-          <li><code>kiln-training</code> defines the SFT and GRPO training APIs and job state.</li>
+          <li><code>kiln-train</code> defines the SFT and GRPO training APIs and job state.</li>
         </ul>
       </article>
     </div>


### PR DESCRIPTION
## Summary
- Update the docs-site architecture crate map to use the real workspace crate name `kiln-train`.
- Keep the existing SFT/GRPO job-state description unchanged and concise.

## Validation
- `python3 - <<'PY' ... PY` crate-name assertion
- `git diff --check -- docs/site/architecture.html`

Docs-only Phase 11 onboarding polish; no GPU pod, cargo build, cargo check, or tests run.