### PR TITLE
[codex] document v1 health alias

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -274,6 +274,7 @@
         <h2 id="server-status" class="text-2xl font-semibold mb-4">Server status, metrics, UI, and config</h2>
         <div class="endpoint-list" style="color: var(--fg-dim);">
           <div class="endpoint"><span class="method">GET</span> <code>/health</code> &mdash; server health and diagnostics.</div>
+          <div class="endpoint"><span class="method">GET</span> <code>/v1/health</code> &mdash; /v1 compatibility alias for the same health and diagnostics response.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/metrics</code> &mdash; Prometheus metrics for latency, throughput, memory, and training progress.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/ui</code> &mdash; embedded dashboard for status, adapters, training, and chat.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/stats/decode</code> &mdash; live decode tokens/sec and inter-token latency stats used by the dashboard.</div>


### PR DESCRIPTION
## Summary
- Add `GET /v1/health` to the API reference server-status endpoint map.
- Clarify that it is the `/v1` compatibility alias for the same health and diagnostics response as `GET /health`.

## Validation
- `grep -n '/v1/health\|/health' docs/site/api.html`
- `python3 - <<'PY' ... PY`
- `git diff --check -- docs/site/api.html`