### PR TITLE
[codex] document config endpoint example

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -282,6 +282,13 @@
           <div class="endpoint"><span class="method">GET</span> <code>/v1/models</code> &mdash; list the served model.</div>
           <div class="endpoint"><span class="method">GET</span> <code>/v1/config</code> &mdash; return the current server configuration.</div>
         </div>
+        <div class="endpoint mt-4">
+          <h3 class="font-semibold mb-2">Check runtime configuration</h3>
+          <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>curl -s http://localhost:8420/v1/config | python3 -m json.tool</code></pre>
+          <p class="mt-2 text-sm leading-relaxed" style="color: var(--fg-dim);">
+            Reports detected VRAM, KV-cache sizing and FP8 state, checkpointing, and memory budget.
+          </p>
+        </div>
       </article>
 
       <article class="card p-6">


### PR DESCRIPTION
## Summary

Adds a concise copy-paste `GET /v1/config` example to the API reference's Server status / Run and observe section.

## Why

Cold-reader operators could see `/v1/config` in the endpoint map, but did not have a small command showing how to inspect runtime configuration. The new snippet highlights detected VRAM, KV-cache sizing and FP8 state, checkpointing, and memory budget without expanding into broader config-file docs.

## Validation

- `grep -n '/v1/config\|detected VRAM\|memory budget' docs/site/api.html`
- `python3 - <<'PY' ... PY`
- `git diff --check -- docs/site/api.html`