### PR TITLE
[codex] Add stats APIs to root endpoint maps

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -603,6 +603,8 @@ Use `kiln -v serve` when first-run startup or model-load diagnostics are needed.
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/ui` | Embedded web dashboard (status, adapters, training, chat) |
+| GET | `/v1/stats/decode` | Live decode tokens/sec and inter-token latency stats used by the dashboard |
+| GET | `/v1/stats/recent-requests` | Bounded recent chat-completion history for the dashboard's request panel |
 | GET | `/health` | Server health and diagnostics |
 | GET | `/metrics` | Prometheus metrics |
 | GET | `/v1/models` | List available models |

--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ On Apple Silicon, model weights, KV cache, and training state all live in unifie
 | POST | `/v1/adapters/merge` | Merge adapters (weighted_average, TIES, or concatenation modes) |
 | GET | `/v1/models` | List available models |
 | GET | `/ui` | Embedded web dashboard (status, adapters, training, chat) |
+| GET | `/v1/stats/decode` | Live decode tokens/sec and inter-token latency stats used by the dashboard |
+| GET | `/v1/stats/recent-requests` | Bounded recent chat-completion history for the dashboard's request panel |
 | GET | `/health` | Server health and diagnostics |
 | GET | `/metrics` | Prometheus metrics |
 


### PR DESCRIPTION
## Summary
- Add `/v1/stats/decode` to the README and QUICKSTART endpoint tables.
- Add `/v1/stats/recent-requests` beside the dashboard/metrics entries.
- Match the dashboard-observability terminology already used in `docs/site/api.html`.

## Validation
- `rg -n '/v1/stats/decode|/v1/stats/recent-requests' README.md QUICKSTART.md docs/site/api.html crates/kiln-server/src/api/stats.rs`
- `git diff -- README.md QUICKSTART.md`