### PR TITLE
[codex] Fix docs mobile overflow

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -65,6 +65,13 @@
     }
     pre {
       max-width: 100%;
+      min-width: 0;
+      overflow-x: auto;
+    }
+    pre code {
+      display: block;
+      width: max-content;
+      min-width: 100%;
     }
     p code, li code, td code, h2 code, h3 code {
       background: var(--bg-soft);
@@ -87,6 +94,7 @@
       border-radius: 12px;
       min-width: 0;
     }
+    .grid > * { min-width: 0; }
     .btn-primary {
       background: var(--accent);
       color: #1a0c00;

--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -50,6 +50,8 @@
       border: 1px solid var(--line);
       border-radius: 10px;
       padding: 1rem;
+      max-width: 100%;
+      min-width: 0;
       overflow-x: auto;
       color: #ffe9c9;
     }
@@ -59,13 +61,21 @@
       border-radius: 0.35rem;
       padding: 0.08rem 0.28rem;
     }
-    pre code { background: transparent; border: 0; padding: 0; }
+    pre code {
+      background: transparent;
+      border: 0;
+      display: block;
+      min-width: 100%;
+      padding: 0;
+      width: max-content;
+    }
     .card {
       background: var(--bg-soft);
       border: 1px solid var(--line);
       border-radius: 12px;
       min-width: 0;
     }
+    .grid > * { min-width: 0; }
     .btn-primary {
       background: var(--accent);
       color: #1a0c00;

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -69,12 +69,20 @@
       border-radius: 10px;
       padding: 1rem 1.1rem;
       max-width: 100%;
+      min-width: 0;
       overflow-x: auto;
       font-size: 13.5px;
       line-height: 1.55;
       color: #d8dde7;
     }
-    pre code { background: transparent; padding: 0; color: inherit; }
+    pre code {
+      background: transparent;
+      color: inherit;
+      display: block;
+      min-width: 100%;
+      padding: 0;
+      width: max-content;
+    }
     p code, li code, td code, h2 code, h3 code {
       background: var(--bg-soft);
       border: 1px solid var(--line);
@@ -96,6 +104,7 @@
       border-radius: 12px;
       min-width: 0;
     }
+    .grid > * { min-width: 0; }
     .btn-primary {
       background: var(--accent);
       color: #1a0c00;


### PR DESCRIPTION
## Summary

Fixes mobile horizontal overflow on the docs site target pages by tightening CSS containment for grid children and code blocks:

- `docs/site/api.html`
- `docs/site/cli.html`
- `docs/site/troubleshooting.html`

The content remains unchanged. Wide code examples now scroll inside their own blocks, and grid children can shrink below min-content width on narrow screens without forcing page-level horizontal scroll.

## Validation

- Served docs locally with `python3 -m http.server 8123 --directory docs/site`
- Installed Puppeteer under `/tmp/kiln-pupp` with `PUPPETEER_SKIP_DOWNLOAD=1 npm install puppeteer@latest`
- Ran the requested 390x844 mobile overflow smoke check; the literal selector `a[href=]` is invalid in Chromium, so I reran the same check with `a[href=""]`
- Results:
  - `/api.html {"overflow":0,"brokenImages":[],"emptyLinks":0}`
  - `/cli.html {"overflow":0,"brokenImages":[],"emptyLinks":0}`
  - `/troubleshooting.html {"overflow":0,"brokenImages":[],"emptyLinks":0}`
- Ran `git diff -- docs/site/api.html docs/site/cli.html docs/site/troubleshooting.html`