### PR TITLE
Add desktop installer links to landing page

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -113,6 +113,33 @@
       color: var(--accent);
       border: 1px solid rgba(249,115,22,0.35);
     }
+    .installer-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.875rem;
+      color: var(--fg-dim);
+      table-layout: fixed;
+    }
+    .installer-table th,
+    .installer-table td {
+      border-top: 1px solid var(--line);
+      padding: 0.55rem 0.45rem;
+      text-align: left;
+      vertical-align: top;
+      overflow-wrap: anywhere;
+    }
+    .installer-table th {
+      color: var(--fg);
+      font-size: 0.75rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+    .installer-table th:last-child,
+    .installer-table td:last-child {
+      width: 5.5rem;
+      text-align: right;
+      white-space: nowrap;
+    }
     a { color: #f3c891; }
     a:hover { color: var(--accent); }
     /* the orange link color reads poorly on the buttons; reset there */
@@ -392,6 +419,42 @@ requests.post("http://localhost:8420/v1/train/grpo",
           On first launch, the Desktop App downloads and verifies the matching <code>kiln</code> server binary for you.
           No Rust toolchain, CUDA toolkit, or Xcode install is required for the GUI path.
         </p>
+        <table class="installer-table mb-3" aria-label="Kiln Desktop installer downloads">
+          <thead>
+            <tr>
+              <th scope="col">Platform</th>
+              <th scope="col">Installer</th>
+              <th scope="col">Size</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>macOS Apple Silicon</td>
+              <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_aarch64.dmg">Kiln.Desktop_0.2.2_aarch64.dmg</a></td>
+              <td>8.5 MB</td>
+            </tr>
+            <tr>
+              <td>Windows</td>
+              <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_x64-setup.exe">Kiln.Desktop_0.2.2_x64-setup.exe</a> (NSIS)</td>
+              <td>4.5 MB</td>
+            </tr>
+            <tr>
+              <td>Windows</td>
+              <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_x64_en-US.msi">Kiln.Desktop_0.2.2_x64_en-US.msi</a> (MSI)</td>
+              <td>6.8 MB</td>
+            </tr>
+            <tr>
+              <td>Linux</td>
+              <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_amd64.deb">Kiln.Desktop_0.2.2_amd64.deb</a></td>
+              <td>8.8 MB</td>
+            </tr>
+            <tr>
+              <td>Linux</td>
+              <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_amd64.AppImage">Kiln.Desktop_0.2.2_amd64.AppImage</a></td>
+              <td>85.7 MB</td>
+            </tr>
+          </tbody>
+        </table>
         <p class="text-sm" style="color: var(--fg-mute);">
           Use the server binary commands below when you want to run <code>kiln serve</code> directly or automate a headless host.
         </p>


### PR DESCRIPTION
## Summary
- Add direct Kiln Desktop v0.2.2 installer links to the landing page Desktop App quick path card.
- Mirror the platform, installer, and size details from the site quickstart so first-time visitors do not need to choose from the generic release assets page.
- Add compact table styling that wraps long asset names on mobile.

## Validation
- `git diff --check`
- Headless Chromium mobile overflow smoke at 375px: `{'innerWidth': 375, 'scrollWidth': 360, 'bodyScrollWidth': 360, 'tableScrollWidth': 270, 'ok': True}`