### PR TITLE
[codex] Add demo player CDN fallback

### DIFF
--- a/docs/site/demo/index.html
+++ b/docs/site/demo/index.html
@@ -165,6 +165,40 @@
       padding: 0.5rem;
       overflow: hidden;
     }
+    .player-fallback {
+      background:
+        radial-gradient(60% 80% at 50% 0%, rgba(249,115,22,0.10), transparent 70%),
+        var(--bg-soft);
+      border: 1px dashed var(--line-2);
+      border-radius: 10px;
+      min-height: 16rem;
+      padding: 1.35rem;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      gap: 0.9rem;
+    }
+    .player-fallback h2 {
+      color: var(--fg);
+      font-size: 1.1rem;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+    .player-fallback p {
+      color: var(--fg-dim);
+      line-height: 1.6;
+      max-width: 42rem;
+    }
+    .player-fallback__actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.7rem;
+    }
+    .player-fallback__actions a {
+      border-radius: 8px;
+      padding: 0.62rem 0.8rem;
+      text-decoration: none;
+    }
 
     /* Multi-cast picker */
     .cast-grid {
@@ -611,6 +645,47 @@
       `;
     }
 
+    function renderPlayerFallback(c) {
+      const playerEl = document.getElementById("kiln-demo-player");
+      playerEl.innerHTML = `
+        <section class="player-fallback" role="status" aria-live="polite">
+          <h2>${c.title} recording</h2>
+          <p>
+            The embedded player could not load, usually because the asciinema-player CDN was blocked,
+            unavailable, or failed certificate validation. You can still download the local recording
+            and view the exact script used to capture it from source.
+          </p>
+          <div class="player-fallback__actions">
+            <a class="btn-primary" href="${c.cast}">view .cast</a>
+            <a class="btn-secondary" href="${c.script}" target="_blank" rel="noopener">view script</a>
+          </div>
+        </section>
+      `;
+    }
+
+    function createPlayer(c, playerEl) {
+      if (!window.AsciinemaPlayer || typeof window.AsciinemaPlayer.create !== "function") {
+        renderPlayerFallback(c);
+        return null;
+      }
+
+      try {
+        return window.AsciinemaPlayer.create(c.cast, playerEl, {
+          autoPlay: false,
+          preload: true,
+          loop: false,
+          idleTimeLimit: 2,
+          theme: "monokai",
+          poster: "npt:0:02",
+          cols: 120,
+          rows: 32,
+        });
+      } catch (e) {
+        renderPlayerFallback(c);
+        return null;
+      }
+    }
+
     function renderTiles() {
       const grid = document.getElementById("cast-picker");
       grid.innerHTML = CASTS.map((c, i) => `
@@ -647,16 +722,7 @@
 
       const playerEl = document.getElementById("kiln-demo-player");
       playerEl.innerHTML = "";
-      player = AsciinemaPlayer.create(c.cast, playerEl, {
-        autoPlay: false,
-        preload: true,
-        loop: false,
-        idleTimeLimit: 2,
-        theme: "monokai",
-        poster: "npt:0:02",
-        cols: 120,
-        rows: 32,
-      });
+      player = createPlayer(c, playerEl);
 
       if (updateHash) {
         history.replaceState(null, "", "#" + slug);


### PR DESCRIPTION
## Summary
- Add a guarded `window.AsciinemaPlayer` creation path on the docs demo page.
- Render an in-page fallback when the embedded asciinema player or CDN fails to load.
- Preserve selected cast context with local `.cast` and matching GitHub script links while keeping the picker, hash behavior, metadata, and captions intact.

## Validation
- `git diff --check`
- CDN-blocked headless Chromium smoke: `{'buttons': 7, 'fallback': True}`