### PR TITLE
[codex] Add Quick Inference starter prompts

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -398,6 +398,22 @@ textarea { resize: vertical; min-height: 80px; }
 .chat-input-row input {
   flex: 1;
 }
+.chat-starter-prompts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  margin-bottom: 8px;
+  color: var(--text2);
+  font-size: 12px;
+}
+.chat-starter-prompts span {
+  flex: 0 0 auto;
+}
+.chat-starter-prompts .btn {
+  white-space: normal;
+  text-align: left;
+}
 .chat-controls {
   display: flex;
   gap: 8px;
@@ -471,6 +487,13 @@ textarea { resize: vertical; min-height: 80px; }
   }
   .chat-controls, .chat-input-row, .adapter-actions {
     flex-wrap: wrap;
+  }
+  .chat-starter-prompts {
+    align-items: stretch;
+  }
+  .chat-starter-prompts span,
+  .chat-starter-prompts .btn {
+    flex: 1 1 100%;
   }
   .chat-controls select, .chat-input-row input {
     width: 100%;
@@ -853,12 +876,18 @@ textarea { resize: vertical; min-height: 80px; }
         <input type="number" id="chat-temp" value="0.0" min="0" max="2" step="0.1">
       </div>
       <div class="chat-messages" id="chat-messages"></div>
+      <div class="chat-starter-prompts" aria-label="Starter prompts for Quick Inference">
+        <span>Try a starter:</span>
+        <button type="button" class="btn btn-sm" data-chat-starter-prompt="Summarize Kiln in two sentences for a new developer.">Summarize Kiln</button>
+        <button type="button" class="btn btn-sm" data-chat-starter-prompt="Write a Rust function that computes a moving average.">Code example</button>
+        <button type="button" class="btn btn-sm" data-chat-starter-prompt="Suggest a reward function for grading concise JSON answers.">Reward loop</button>
+      </div>
       <div class="chat-input-row">
         <label for="chat-input" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;">Message</label>
         <input type="text" id="chat-input" placeholder="Type a message...">
-        <button class="btn btn-primary" id="chat-send">Send</button>
-        <button class="btn" id="chat-stop" disabled hidden>Stop</button>
-        <button class="btn" id="chat-clear">Clear</button>
+        <button type="button" class="btn btn-primary" id="chat-send">Send</button>
+        <button type="button" class="btn" id="chat-stop" disabled hidden>Stop</button>
+        <button type="button" class="btn" id="chat-clear">Clear</button>
       </div>
     </div>
   </div>
@@ -1970,6 +1999,13 @@ async function sendChat() {
 document.getElementById('chat-send').addEventListener('click', sendChat);
 document.getElementById('chat-input').addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendChat(); }
+});
+document.querySelectorAll('[data-chat-starter-prompt]').forEach((button) => {
+  button.addEventListener('click', () => {
+    const input = document.getElementById('chat-input');
+    input.value = button.dataset.chatStarterPrompt || '';
+    input.focus();
+  });
 });
 document.getElementById('chat-stop').addEventListener('click', () => {
   if (chatAbort) chatAbort.abort();


### PR DESCRIPTION
## Summary
- Adds three accessible starter prompt chips to the Quick Inference panel.
- Starter prompts fill `#chat-input` and focus it without auto-sending.
- Keeps Send/Stop/Clear behavior intact and makes starter chips stack cleanly on mobile.

## Precondition
- Checked recent PRs after #881 with `gh pr list --repo ericflo/kiln --state all --limit 30`; #881 is still the newest PR.
- Searched starter prompt scope with `gh pr list --repo ericflo/kiln --state all --search 'starter prompt Quick Inference ui.html sort:created-desc'`; only older #794 appeared, and it did not add starter prompt chips/buttons.

## Validation
```text
$ rg -n "starter|sample|chat-input|Quick Inference" crates/kiln-server/src/ui.html
394:.chat-input-row {
398:.chat-input-row input {
401:.chat-starter-prompts {
410:.chat-starter-prompts span {
413:.chat-starter-prompts .btn {
469:  .main > *, .panel, .form-row > *, .chat-input-row input {
488:  .chat-controls, .chat-input-row, .adapter-actions {
491:  .chat-starter-prompts {
494:  .chat-starter-prompts span,
495:  .chat-starter-prompts .btn {
498:  .chat-controls select, .chat-input-row input {
501:  .chat-input-row .btn, .form-group .btn {
576:  .chat-input-row input {
580:  .chat-input-row .btn {
813:              <button type="button" class="btn btn-sm" id="use-sft-sample">Use sample SFT payload</button>
852:              <button type="button" class="btn btn-sm" id="use-grpo-sample">Use sample GRPO payload</button>
866:  <!-- Quick Inference -->
868:    <div class="panel-head"><h2>Quick Inference</h2></div>
879:      <div class="chat-starter-prompts" aria-label="Starter prompts for Quick Inference">
880:        <span>Try a starter:</span>
881:        <button type="button" class="btn btn-sm" data-chat-starter-prompt="Summarize Kiln in two sentences for a new developer.">Summarize Kiln</button>
882:        <button type="button" class="btn btn-sm" data-chat-starter-prompt="Write a Rust function that computes a moving average.">Code example</button>
883:        <button type="button" class="btn btn-sm" data-chat-starter-prompt="Suggest a reward function for grading concise JSON answers.">Reward loop</button>
885:      <div class="chat-input-row">
886:        <label for="chat-input" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;">Message</label>
887:        <input type="text" id="chat-input" placeholder="Type a message...">
1086:    if (!data.sample_count || data.sample_count < 1) {
1091:        <div class="sched-stat"><div class="num">0</div><div class="lbl">samples (last ${window}s)</div></div>
1104:        <div class="sched-stat"><div class="num">${data.sample_count}</div><div class="lbl">samples (last ${window}s)</div></div>
1159:      <div style="margin-top:8px;">Use <strong>Quick Inference</strong> below to create the first entry.</div>
1596:      <div style="margin-top:8px;">Until then, Quick Inference uses the Base Model or whichever adapter you load.</div>
1654:  const sample = [
1662:  document.getElementById('sft-examples').value = JSON.stringify(sample, null, 2);
1666:  const sample = [
1680:  document.getElementById('grpo-groups').value = JSON.stringify(sample, null, 2);
1683:document.getElementById('use-sft-sample').addEventListener('click', fillSftSamplePayload);
1684:document.getElementById('use-grpo-sample').addEventListener('click', fillGrpoSamplePayload);
1689:    throw new Error(`${label} cannot be empty. Paste a JSON array or use the sample payload.`);
1867:      <div>Quick Inference sends a chat completion to the currently selected adapter, or the <strong>Base Model</strong>, using the temperature above.</div>
1904:    'Quick Inference could not complete this request.',
1917:  const input = document.getElementById('chat-input');
2000:document.getElementById('chat-input').addEventListener('keydown', (e) => {
2003:document.querySelectorAll('[data-chat-starter-prompt]').forEach((button) => {
2005:    const input = document.getElementById('chat-input');

$ python3 extract inline JS; node --check /tmp/kiln-ui.js
node --check passed

$ NODE_PATH=/tmp/kiln-ui-smoke/node_modules npm exec --yes --package puppeteer -- node /tmp/kiln-ui-starter-smoke.js
puppeteer smoke passed
```

Note: Puppeteer was installed under `/tmp/kiln-ui-smoke` with `PUPPETEER_SKIP_DOWNLOAD=1`; no repo files were changed for test tooling.
