### PR TITLE
[codex] Guard training sample payload overwrites

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -1667,7 +1667,14 @@ function fillSftSamplePayload() {
       ],
     },
   ];
-  document.getElementById('sft-examples').value = JSON.stringify(sample, null, 2);
+  const textarea = document.getElementById('sft-examples');
+  const samplePayload = JSON.stringify(sample, null, 2);
+  if (textarea.value.trim() && textarea.value !== samplePayload && !confirm('Replace the current SFT examples with the sample payload?')) {
+    return;
+  }
+  textarea.value = samplePayload;
+  textarea.focus();
+  toast('Sample SFT payload inserted');
 }
 
 function fillGrpoSamplePayload() {
@@ -1685,7 +1692,14 @@ function fillGrpoSamplePayload() {
       ],
     },
   ];
-  document.getElementById('grpo-groups').value = JSON.stringify(sample, null, 2);
+  const textarea = document.getElementById('grpo-groups');
+  const samplePayload = JSON.stringify(sample, null, 2);
+  if (textarea.value.trim() && textarea.value !== samplePayload && !confirm('Replace the current GRPO groups with the sample payload?')) {
+    return;
+  }
+  textarea.value = samplePayload;
+  textarea.focus();
+  toast('Sample GRPO payload inserted');
 }
 
 document.getElementById('use-sft-sample').addEventListener('click', fillSftSamplePayload);


### PR DESCRIPTION
## Summary
- Add confirmation guards before replacing non-empty SFT or GRPO training textareas with sample payloads.
- Focus the updated textarea and show success toasts after inserting either sample.
- Preserve existing sample content, validation, training behavior, tab behavior, and Quick Inference copy/starter-prompt UI.

## Validation
- `rg -n "fillSftSamplePayload|fillGrpoSamplePayload|confirm\(|Sample SFT payload inserted|Sample GRPO payload inserted|copy-chat-response|chat-starter-prompts" crates/kiln-server/src/ui.html`
- Extracted inline script and ran `node --check /tmp/kiln-ui.js`
- `git diff --check`
- Ran a tab-aware Puppeteer smoke test covering SFT cancel/confirm, SFT focus, GRPO insertion, and GRPO focus.

Note: the exact provided Puppeteer smoke command fails before exercising this change because `#use-sft-sample` starts inside the hidden `Submit SFT` tab (`Node is either not clickable or not an Element`). The tab-aware version first opens the SFT/GRPO tabs, then verifies the same guard behavior.