### PR TITLE
Autofill adapter upload names

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -1342,6 +1342,52 @@ window.downloadAdapter = function(name) {
 };
 
 let uploadAdapterBusy = false;
+let uploadNameWasAutofilled = false;
+let lastAutofilledUploadName = '';
+
+function pathSafeAdapterStemFromArchiveName(fileName) {
+  const baseName = String(fileName || '').split(/[\\/]/).pop() || '';
+  const stem = baseName.replace(/\.tar\.gz$/i, '').replace(/\.tgz$/i, '');
+  return stem
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[\\/]+/g, '-')
+    .replace(/[^a-z0-9._-]+/gi, '-')
+    .replace(/\.\.+/g, '.')
+    .replace(/-+/g, '-')
+    .replace(/^[.-]+|[.-]+$/g, '');
+}
+
+function maybeAutofillUploadName() {
+  const nameEl = document.getElementById('upload-name');
+  const fileEl = document.getElementById('upload-archive');
+  if (!nameEl || !fileEl || fileEl.files.length === 0) return;
+
+  const currentName = nameEl.value.trim();
+  if (currentName && (!uploadNameWasAutofilled || currentName !== lastAutofilledUploadName)) return;
+
+  const autoName = pathSafeAdapterStemFromArchiveName(fileEl.files[0].name);
+  if (!autoName) return;
+  nameEl.value = autoName;
+  uploadNameWasAutofilled = true;
+  lastAutofilledUploadName = autoName;
+}
+
+function handleUploadNameInput() {
+  const nameEl = document.getElementById('upload-name');
+  if (!nameEl) return;
+  if (uploadNameWasAutofilled && nameEl.value.trim() === lastAutofilledUploadName) {
+    updateUploadAdapterState();
+    return;
+  }
+  uploadNameWasAutofilled = false;
+  updateUploadAdapterState();
+}
+
+function handleUploadArchiveChange() {
+  maybeAutofillUploadName();
+  updateUploadAdapterState();
+}
 
 function updateUploadAdapterState() {
   const nameEl = document.getElementById('upload-name');
@@ -1361,6 +1407,7 @@ function updateUploadAdapterState() {
     if (!hasName && !hasFile) state.textContent = 'Enter a name and choose an archive to enable upload.';
     else if (!hasName) state.textContent = 'Enter an adapter name to enable upload.';
     else if (!hasFile) state.textContent = 'Choose a .tar.gz or .tgz archive to enable upload.';
+    else if (uploadNameWasAutofilled && nameEl.value.trim() === lastAutofilledUploadName) state.textContent = 'Ready to upload with the auto-filled adapter name.';
     else state.textContent = 'Ready to upload.';
   }
 }
@@ -1404,6 +1451,8 @@ window.uploadAdapter = async function() {
     toast(`Uploaded ${data.name} (${fmtBytes(data.size_bytes)}, ${data.files} files)`);
     nameEl.value = '';
     fileEl.value = '';
+    uploadNameWasAutofilled = false;
+    lastAutofilledUploadName = '';
     updateUploadAdapterState();
     pollAdapters();
   } catch (e) { toast(e.message, 'err'); }
@@ -2103,8 +2152,8 @@ document.getElementById('chat-clear').addEventListener('click', () => {
 });
 document.getElementById('copy-chat-response').addEventListener('click', copyLatestAssistantResponse);
 
-document.getElementById('upload-name').addEventListener('input', updateUploadAdapterState);
-document.getElementById('upload-archive').addEventListener('change', updateUploadAdapterState);
+document.getElementById('upload-name').addEventListener('input', handleUploadNameInput);
+document.getElementById('upload-archive').addEventListener('change', handleUploadArchiveChange);
 updateUploadAdapterState();
 
 // --- Init ---


### PR DESCRIPTION
## Summary
- Auto-fill the /ui adapter upload name from selected .tar.gz/.tgz archive stems.
- Preserve manually edited adapter names when users choose another archive.
- Normalize generated names into path-safe single-segment stems before filling the field.

## Validation
- `rg -n "upload-name|upload-archive|uploadAdapter|auto" crates/kiln-server/src/ui.html`
- Extracted inline script to `/tmp/kiln-ui.js`
- `node --check /tmp/kiln-ui.js`
- `git diff --check`
- Browser smoke with Puppeteer against `crates/kiln-server/src/ui.html` verifying auto-fill and manual-name preservation

Note: the requested `npx puppeteer@latest --no-install` invocation exposed Puppeteer's CLI in this environment and `puppeteer` was not locally installed as a module, so I ran the same script with a temporary `puppeteer@latest` install using the system Chromium browser.