### PR TITLE
Validate Quick Inference temperature

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -1804,6 +1804,15 @@ function parsePositiveIntegerField(value, label) {
   return parsed;
 }
 
+function parseQuickInferenceTemperature(input) {
+  const text = input.value.trim();
+  const parsed = Number(text);
+  if (!text || !Number.isFinite(parsed) || parsed < 0 || parsed > 2) {
+    throw new Error('Temperature must be between 0 and 2.');
+  }
+  return parsed;
+}
+
 function validateMessages(messages, label) {
   if (!Array.isArray(messages) || messages.length === 0) {
     throw new Error(`${label} needs a non-empty messages array.`);
@@ -2057,8 +2066,19 @@ function formatQuickInferenceError(error) {
 async function sendChat() {
   if (chatAbort) return;
   const input = document.getElementById('chat-input');
+  const tempInput = document.getElementById('chat-temp');
   const msg = input.value.trim();
   if (!msg) return;
+
+  let temp;
+  try {
+    temp = parseQuickInferenceTemperature(tempInput);
+  } catch (error) {
+    tempInput.focus();
+    toast(error.message, 'err');
+    return;
+  }
+
   input.value = '';
 
   chatMessages.push({ role: 'user', content: msg });
@@ -2067,8 +2087,6 @@ async function sendChat() {
   setChatGenerating(true);
 
   const adapter = document.getElementById('chat-adapter').value || undefined;
-  const parsedTemp = parseFloat(document.getElementById('chat-temp').value);
-  const temp = Number.isFinite(parsedTemp) ? parsedTemp : 0.0;
 
   const body = {
     messages: chatMessages.filter(m => m.content).map(m => ({ role: m.role, content: m.content })),


### PR DESCRIPTION
## Summary
- validate `/ui` Quick Inference temperature before submitting chat completions
- reject blank, non-numeric, and out-of-range values with a clear toast
- preserve the typed prompt and focus the temperature input on validation failure

## Validation
- `rg -n "chat-temp|Quick Inference|temperature|sendChat|parseQuickInferenceTemperature" crates/kiln-server/src/ui.html`
- extracted UI script and ran `node --check /tmp/kiln-ui.js`
- `git diff --check`
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install --silent puppeteer@latest >/tmp/kiln-puppeteer-install.log 2>&1`
- Puppeteer smoke for invalid `-1` blocking fetch/preserving prompt and valid `0.7` submitting once
