### PR TITLE
[codex] Validate Quick Inference temperature

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -1796,6 +1796,15 @@ function parseFiniteNumberField(value, label) {
   return parsed;
 }
 
+function parseQuickInferenceTemperature(input) {
+  const text = input.value.trim();
+  const parsed = Number(text);
+  if (!text || !Number.isFinite(parsed) || parsed < 0 || parsed > 2) {
+    throw new Error('Temperature must be between 0 and 2.');
+  }
+  return parsed;
+}
+
 function parsePositiveIntegerField(value, label) {
   const parsed = parseFiniteNumberField(value, label);
   if (!Number.isInteger(parsed) || parsed <= 0) {
@@ -2057,8 +2066,19 @@ function formatQuickInferenceError(error) {
 async function sendChat() {
   if (chatAbort) return;
   const input = document.getElementById('chat-input');
+  const tempInput = document.getElementById('chat-temp');
   const msg = input.value.trim();
   if (!msg) return;
+
+  let temp;
+  try {
+    temp = parseQuickInferenceTemperature(tempInput);
+  } catch (error) {
+    toast(error.message || 'Temperature must be between 0 and 2.');
+    tempInput.focus();
+    return;
+  }
+
   input.value = '';
 
   chatMessages.push({ role: 'user', content: msg });
@@ -2067,8 +2087,6 @@ async function sendChat() {
   setChatGenerating(true);
 
   const adapter = document.getElementById('chat-adapter').value || undefined;
-  const parsedTemp = parseFloat(document.getElementById('chat-temp').value);
-  const temp = Number.isFinite(parsedTemp) ? parsedTemp : 0.0;
 
   const body = {
     messages: chatMessages.filter(m => m.content).map(m => ({ role: m.role, content: m.content })),


### PR DESCRIPTION
## Summary
- Add strict client-side validation for the `/ui` Quick Inference temperature field.
- Reject blank, non-numeric, and out-of-range values before mutating chat state or submitting `/v1/chat/completions`.
- Focus the temperature input and show a clear toast when validation fails, while preserving the typed prompt.

## Validation
- `rg -n "chat-temp|Quick Inference|temperature|sendChat|parseQuickInferenceTemperature" crates/kiln-server/src/ui.html`
- Extracted the inline script to `/tmp/kiln-ui.js`
- `node --check /tmp/kiln-ui.js`
- `git diff --check`
- `PUPPETEER_SKIP_DOWNLOAD=1 npm install --silent puppeteer@latest >/tmp/kiln-puppeteer-install.log 2>&1`
- Puppeteer smoke: invalid `-1` temperature does not fetch and preserves prompt; valid `0.7` temperature submits once