### PR TITLE
Disable empty Quick Inference send

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -1935,6 +1935,7 @@ document.getElementById('grpo-form').addEventListener('submit', async (e) => {
 // --- Chat ---
 const chatMessages = [];
 let chatAbort = null;
+let chatGenerating = false;
 let servedModelId = null;
 
 async function loadServedModelId() {
@@ -1993,6 +1994,13 @@ function updateCopyChatResponseState() {
 }
 window.updateCopyChatResponseState = updateCopyChatResponseState;
 
+function updateChatSendState() {
+  const input = document.getElementById('chat-input');
+  const send = document.getElementById('chat-send');
+  if (!input || !send) return;
+  send.disabled = chatGenerating || !input.value.trim();
+}
+
 function fallbackCopyText(text) {
   const textarea = document.createElement('textarea');
   textarea.value = text;
@@ -2031,10 +2039,11 @@ async function copyLatestAssistantResponse() {
 }
 
 function setChatGenerating(isGenerating) {
+  chatGenerating = isGenerating;
   const send = document.getElementById('chat-send');
   const stop = document.getElementById('chat-stop');
-  send.disabled = isGenerating;
   send.textContent = isGenerating ? 'Generating…' : 'Send';
+  updateChatSendState();
   stop.hidden = !isGenerating;
   stop.disabled = !isGenerating;
 }
@@ -2080,6 +2089,7 @@ async function sendChat() {
   }
 
   input.value = '';
+  updateChatSendState();
 
   chatMessages.push({ role: 'user', content: msg });
   chatMessages.push({ role: 'assistant', content: '', pending: true });
@@ -2157,6 +2167,7 @@ async function sendChat() {
 }
 
 document.getElementById('chat-send').addEventListener('click', sendChat);
+document.getElementById('chat-input').addEventListener('input', updateChatSendState);
 document.getElementById('chat-input').addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); sendChat(); }
 });
@@ -2164,16 +2175,19 @@ document.querySelectorAll('[data-chat-starter-prompt]').forEach((button) => {
   button.addEventListener('click', () => {
     const input = document.getElementById('chat-input');
     input.value = button.dataset.chatStarterPrompt || '';
+    updateChatSendState();
     input.focus();
   });
 });
 document.getElementById('chat-stop').addEventListener('click', () => {
   if (chatAbort) chatAbort.abort();
+  updateChatSendState();
 });
 document.getElementById('chat-clear').addEventListener('click', () => {
   if (chatAbort) { chatAbort.abort(); chatAbort = null; }
   chatMessages.length = 0;
   setChatGenerating(false);
+  updateChatSendState();
   renderChat();
 });
 document.getElementById('copy-chat-response').addEventListener('click', copyLatestAssistantResponse);
@@ -2184,6 +2198,7 @@ updateUploadAdapterState();
 
 // --- Init ---
 renderChat();
+updateChatSendState();
 pollHealth();
 pollAdapters();
 pollTraining();


### PR DESCRIPTION
## Summary
- Disables the Quick Inference Send button while the prompt input is empty or whitespace-only.
- Adds a small `updateChatSendState()` helper and wires it to input changes, starter prompts, send clearing, stop/clear actions, and initial setup.
- Preserves streaming behavior: Send shows `Generating…` and stays disabled while Stop is shown/enabled.

## Precondition
- Checked PRs newer than #888 with `gh pr list -R ericflo/kiln --state all --limit 40 --json number,title,state,mergedAt,createdAt,url --jq '.[] | select(.number > 888)'`.
- Only #889 appeared, and it covers Quick Inference temperature validation rather than empty Send no-op behavior.

## Validation
```text
$ rg -n "updateChatSendState|chat-send|chat-input|data-chat-starter-prompt|setChatGenerating" crates/kiln-server/src/ui.html
$ python3 - <<'PY'
from pathlib import Path
html = Path('crates/kiln-server/src/ui.html').read_text()
start = html.index('<script>') + len('<script>')
end = html.index('</script>', start)
Path('/tmp/kiln-ui.js').write_text(html[start:end])
PY
$ node --check /tmp/kiln-ui.js
$ PUPPETEER_SKIP_DOWNLOAD=1 npm install --silent puppeteer@latest >/tmp/kiln-puppeteer-install.log 2>&1
$ node - <<'NODE'
const path = require('path');
const puppeteer = require('puppeteer');
(async () => {
  const browser = await puppeteer.launch({headless: 'new', executablePath: process.env.CHROME_BIN || '/usr/bin/chromium-browser', args: ['--no-sandbox']});
  const page = await browser.newPage();
  await page.setViewport({width: 390, height: 844});
  await page.goto('file://' + path.resolve('crates/kiln-server/src/ui.html'));
  const state = async () => page.evaluate(() => ({disabled: document.getElementById('chat-send').disabled, label: document.getElementById('chat-send').textContent}));
  let s = await state();
  if (!s.disabled) throw new Error('empty Quick Inference input should disable Send');
  await page.type('#chat-input', 'Explain Kiln in one sentence.');
  s = await state();
  if (s.disabled) throw new Error('non-empty Quick Inference input should enable Send');
  await page.$eval('#chat-input', el => { el.value = '   '; el.dispatchEvent(new Event('input', {bubbles: true})); });
  s = await state();
  if (!s.disabled) throw new Error('whitespace-only Quick Inference input should disable Send');
  await page.click('[data-chat-starter-prompt]');
  s = await state();
  if (s.disabled) throw new Error('starter prompt should enable Send');
  await browser.close();
})();
NODE
$ git diff --check
```

Note: Puppeteer install artifacts were removed before commit; only `crates/kiln-server/src/ui.html` changed.