### PR TITLE
[codex] Restore path-safe adapter validation in UI

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -1482,12 +1482,14 @@ let mergeSourceCount = 2;
 let mergeAdaptersBusy = false;
 
 function isPathSafeAdapterDirectoryName(name) {
-  return name
+  return Boolean(name)
     && name !== '.'
     && name !== '..'
     && !name.includes('/')
     && !name.includes('\\');
 }
+
+window.isPathSafeAdapterDirectoryName = isPathSafeAdapterDirectoryName;
 
 function pathSafeAdapterDirectoryNameMessage() {
   return 'Name must be a single adapter directory name with no / or \\, and not . or ..';


### PR DESCRIPTION
## Summary
- make `isPathSafeAdapterDirectoryName` return an explicit boolean while preserving the existing path-safety checks
- expose the helper on `window` so the UI smoke check can directly assert path-safe adapter-name behavior

## Validation
- `git diff --check`
- Chromium + Puppeteer browser smoke check at 390x844 for unsafe adapter names and SFT submit readiness

No local cargo build/check/test was run; this is Phase 11 static UI work and local CUDA builds are forbidden by the project guardrails.