### PR TITLE
[codex] Fix README quickstart timeout anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ curl http://localhost:8420/v1/train/sft \
 curl http://localhost:8420/v1/train/status
 ```
 
-See [QUICKSTART.md](QUICKSTART.md) for the full walkthrough including Desktop App setup, source builds, GRPO, adapter management, Docker, and systemd setup. If setup stalls on binary downloads, CUDA/Metal, model paths, `/health`, mock mode, training endpoints, or adapter directories, start with the [Troubleshooting guide](https://ericflo.github.io/kiln/troubleshooting.html). For tools-bearing workloads on older pinned releases, see [QUICKSTART.md §4.2](QUICKSTART.md#42-troubleshooting-older-release-long-prefill-timeouts) for the legacy `workers=1` / request-timeout troubleshooting note ([#664](https://github.com/ericflo/kiln/issues/664)).
+See [QUICKSTART.md](QUICKSTART.md) for the full walkthrough including Desktop App setup, source builds, GRPO, adapter management, Docker, and systemd setup. If setup stalls on binary downloads, CUDA/Metal, model paths, `/health`, mock mode, training endpoints, or adapter directories, start with the [Troubleshooting guide](https://ericflo.github.io/kiln/troubleshooting.html). For tools-bearing workloads on older pinned releases, see [QUICKSTART.md §9.2](QUICKSTART.md#92-troubleshooting-older-release-long-prefill-timeouts) for the legacy `workers=1` / request-timeout troubleshooting note ([#664](https://github.com/ericflo/kiln/issues/664)).
 
 ## See it in action
 


### PR DESCRIPTION
## Summary
- Update the README older-release long-prefill timeout link from QUICKSTART §4.2 to the current QUICKSTART §9.2 heading anchor.
- Keep the surrounding Quick Start paragraph unchanged.

## Validation
- `gh pr list -R ericflo/kiln --state all --limit 20 --json number,title,state,mergedAt,createdAt,url --jq '.[] | select(.number > 895)'`
- `rg -n 'QUICKSTART\.md §9\.2|QUICKSTART\.md#92-troubleshooting-older-release-long-prefill-timeouts' README.md`
- `! rg -n 'QUICKSTART\.md §4\.2|QUICKSTART\.md#42-troubleshooting-older-release-long-prefill-timeouts' README.md`
- Python anchor check confirming `QUICKSTART.md#92-troubleshooting-older-release-long-prefill-timeouts` resolves from the QUICKSTART heading
- `git diff --check`

No local cargo build/check/test was run; this is README-only Phase 11 documentation work and local CUDA builds are forbidden by the project guardrails.