### PR TITLE
[codex] Add site quickstart verify troubleshooting fallback

### DIFF
--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -444,6 +444,9 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
   }' | python3 -m json.tool</code></pre>
         </div>
       </div>
+      <p class="text-sm mt-4" style="color: var(--fg-mute);">
+        If <code>/ui</code>, <code>/health</code>, or the chat request fails, use <a href="troubleshooting.html">Troubleshooting</a> to check the model path, binary download, CUDA/Vulkan/Metal setup, Docker, and health checks before retrying.
+      </p>
       <p class="text-sm mt-6" style="color: var(--fg-mute);">
         Prefer terminal-first checks? See the <a href="cli.html">CLI Reference</a> for <code>kiln health</code>, training, and adapter commands.
       </p>


### PR DESCRIPTION
## Summary
- Add a verify-step troubleshooting fallback to `docs/site/quickstart.html` immediately after the UI/health/chat verification cards.
- Link cold readers to `troubleshooting.html` and name the likely failure areas: model path, binary download, CUDA/Vulkan/Metal setup, Docker, and health checks.

## Validation
- `git diff --check`
- `rg -n 'Open the UI, check health, send chat|troubleshooting\.html|model path|binary download|CUDA|Vulkan|Metal|Docker|health checks' docs/site/quickstart.html`
- Static placement check confirming the troubleshooting fallback appears before the terminal-first CLI note.