### PR TITLE
[codex] Add QUICKSTART dashboard screenshot

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -192,6 +192,8 @@ Kiln ships with an embedded web dashboard. Open [http://localhost:8420/ui](http:
 - **Training** — submit SFT or GRPO jobs from a form, watch the queue, and review recently completed runs
 - **Quick Inference** — chat with the model directly (per-request adapter and temperature pickers) without writing curl
 
+![Kiln embedded server dashboard](docs/site/assets/server-ui-dashboard.png)
+
 It's a single HTML page served by the `kiln` binary itself — no extra process, no build step, no JS bundle to deploy.
 
 


### PR DESCRIPTION
## Summary
- Add the existing embedded dashboard screenshot to `QUICKSTART.md` section 5.
- Place it immediately after the dashboard feature bullets and before the implementation note.

## Validation
- `git diff --check`
- `test -f docs/site/assets/server-ui-dashboard.png`
- `rg -n 'Open the Browser Dashboard|server-ui-dashboard\.png|First Inference Checkpoint|single HTML page' QUICKSTART.md`
- Placement check confirms the screenshot appears in section 5 before the single-page implementation note.