### PR TITLE
[codex] Add docs site mobile smoke guard

### DIFF
--- a/.github/workflows/release-version-drift.yml
+++ b/.github/workflows/release-version-drift.yml
@@ -12,6 +12,7 @@ on:
       - 'docs/site/**'
       - 'docs/release-version-policy.md'
       - 'scripts/check_release_versions.py'
+      - 'scripts/check_docs_site_smoke.mjs'
       - 'scripts/check_server_ui_smoke.mjs'
       - 'crates/kiln-server/src/ui.html'
       - '.github/workflows/release-version-drift.yml'
@@ -25,6 +26,7 @@ on:
       - 'docs/site/**'
       - 'docs/release-version-policy.md'
       - 'scripts/check_release_versions.py'
+      - 'scripts/check_docs_site_smoke.mjs'
       - 'scripts/check_server_ui_smoke.mjs'
       - 'crates/kiln-server/src/ui.html'
       - '.github/workflows/release-version-drift.yml'
@@ -41,11 +43,15 @@ jobs:
         run: |
           CHROME_BIN=$(command -v chromium-browser || command -v chromium || command -v google-chrome || command -v google-chrome-stable || true)
           if [ -z "$CHROME_BIN" ]; then
-            echo "Could not find Chromium/Chrome for scripts/check_server_ui_smoke.mjs" >&2
+            echo "Could not find Chromium/Chrome for docs/server UI smoke checks" >&2
             exit 1
           fi
           echo "CHROME_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
           echo "PUPPETEER_EXECUTABLE_PATH=$CHROME_BIN" >> "$GITHUB_ENV"
+      - name: Check docs site mobile smoke
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+        run: npx --yes --package puppeteer@latest node scripts/check_docs_site_smoke.mjs
       - name: Check server UI smoke
         env:
           PUPPETEER_SKIP_DOWNLOAD: "true"

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import process from 'node:process';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+
+const pages = [
+  { label: 'Home', path: 'docs/site/index.html', currentLabel: null },
+  { label: 'Quickstart', path: 'docs/site/quickstart.html', currentLabel: 'Quickstart' },
+  { label: 'GRPO Guide', path: 'docs/site/grpo.html', currentLabel: 'GRPO Guide' },
+  { label: 'API Reference', path: 'docs/site/api.html', currentLabel: 'API Reference' },
+  { label: 'CLI Reference', path: 'docs/site/cli.html', currentLabel: 'CLI Reference' },
+  { label: 'Troubleshooting', path: 'docs/site/troubleshooting.html', currentLabel: 'Troubleshooting' },
+  { label: 'Architecture', path: 'docs/site/architecture.html', currentLabel: 'Architecture' },
+  { label: 'Demo', path: 'docs/site/demo/index.html', currentLabel: 'Demo' },
+];
+
+const expectedNavLabels = [
+  'Quickstart',
+  'GRPO Guide',
+  'API Reference',
+  'CLI Reference',
+  'Demo',
+  'Troubleshooting',
+  'Architecture',
+];
+
+function fail(message) {
+  throw new Error(message);
+}
+
+async function loadPuppeteer() {
+  try {
+    const module = await import('puppeteer');
+    return module.default || module;
+  } catch (error) {
+    if (error?.code !== 'ERR_MODULE_NOT_FOUND') throw error;
+  }
+
+  const installDir = '/tmp/kiln-docs-site-smoke-puppeteer';
+  const packageJson = join(installDir, 'package.json');
+  const puppeteerPackageJson = join(installDir, 'node_modules/puppeteer/package.json');
+  await mkdir(installDir, { recursive: true });
+  if (!existsSync(packageJson)) {
+    await writeFile(packageJson, '{"private":true,"type":"commonjs"}\n');
+  }
+  if (!existsSync(puppeteerPackageJson)) {
+    execFileSync('npm', ['install', '--silent', '--no-save', 'puppeteer@latest'], {
+      cwd: installDir,
+      stdio: 'inherit',
+      env: { ...process.env, PUPPETEER_SKIP_DOWNLOAD: 'true' },
+    });
+  }
+  const require = createRequire(packageJson);
+  return require('puppeteer');
+}
+
+function chromiumPath() {
+  const path = process.env.CHROME_BIN
+    || process.env.PUPPETEER_EXECUTABLE_PATH
+    || process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+  if (!path) {
+    fail('Set CHROME_BIN, PUPPETEER_EXECUTABLE_PATH, or PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH to an installed Chromium/Chrome binary.');
+  }
+  return path;
+}
+
+async function runSmoke() {
+  const puppeteer = await loadPuppeteer();
+  const browser = await puppeteer.launch({
+    executablePath: chromiumPath(),
+    headless: true,
+    args: ['--no-sandbox', '--disable-setuid-sandbox'],
+  });
+
+  try {
+    const page = await browser.newPage();
+    await page.setViewport({ width: 390, height: 844, deviceScaleFactor: 2, isMobile: true });
+
+    for (const sitePage of pages) {
+      const filePath = resolve(repoRoot, sitePage.path);
+      await page.goto(pathToFileURL(filePath).href, { waitUntil: 'domcontentloaded', timeout: 10000 });
+
+      const result = await page.evaluate((expectedLabels, currentLabel) => {
+        const normalize = (value) => (value || '').replace(/\s+/g, ' ').trim();
+        const h1 = document.querySelector('h1');
+        const nav = document.querySelector('nav.site-nav');
+        const navLinks = Array.from(nav?.querySelectorAll('a') || []);
+        const navLabels = navLinks.map((link) => normalize(link.textContent));
+        const missingLabels = expectedLabels.filter((label) => !navLabels.includes(label));
+        const current = navLinks.find((link) => link.getAttribute('aria-current') === 'page');
+        const homeCurrent = document.querySelector('[aria-current="page"]');
+
+        return {
+          h1Text: normalize(h1?.textContent),
+          hasNav: Boolean(nav),
+          missingLabels,
+          currentLabel: normalize(current?.textContent),
+          hasHomeCurrent: Boolean(homeCurrent),
+          scrollWidth: document.documentElement.scrollWidth,
+          clientWidth: document.documentElement.clientWidth,
+          currentMatches: currentLabel ? normalize(current?.textContent) === currentLabel : Boolean(homeCurrent),
+        };
+      }, expectedNavLabels, sitePage.currentLabel);
+
+      if (!result.h1Text) fail(`${sitePage.path}: missing h1`);
+      if (!result.hasNav) fail(`${sitePage.path}: missing nav.site-nav`);
+      if (result.missingLabels.length > 0) {
+        fail(`${sitePage.path}: nav.site-nav missing labels: ${result.missingLabels.join(', ')}`);
+      }
+      if (!result.currentMatches) {
+        const expected = sitePage.currentLabel || 'an aria-current="page" marker';
+        fail(`${sitePage.path}: expected current marker for ${expected}, got ${result.currentLabel || 'none'}`);
+      }
+      if (result.scrollWidth > result.clientWidth) {
+        fail(`${sitePage.path}: mobile horizontal overflow: scrollWidth ${result.scrollWidth} > clientWidth ${result.clientWidth}`);
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+runSmoke().catch((error) => {
+  console.error(error.message || error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a Puppeteer-based mobile smoke guard for the docs site cold-reader pages. The check opens the core `docs/site` pages through `file://`, verifies the shared nav labels, checks current-page markers, requires an `h1`, and fails on mobile horizontal overflow at a 390x844 viewport.

Wires the guard into the existing release-version/user-facing docs workflow beside the server UI smoke check, reusing the installed Chromium path through `CHROME_BIN` and `PUPPETEER_EXECUTABLE_PATH`.

## Validation

- `python3 scripts/check_release_versions.py`
- `CHROME_BIN=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser npx --yes --package puppeteer@latest node scripts/check_docs_site_smoke.mjs`
- `CHROME_BIN=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser npx --yes --package puppeteer@latest node scripts/check_server_ui_smoke.mjs`