### PR TITLE
[codex] Run docs smoke before Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,19 @@ jobs:
       - uses: actions/configure-pages@v5
       - name: Check release version drift
         run: python3 scripts/check_release_versions.py
+      - name: Locate Chromium
+        run: |
+          CHROME_BIN=$(command -v chromium-browser || command -v chromium || command -v google-chrome || command -v google-chrome-stable || true)
+          if [ -z "$CHROME_BIN" ]; then
+            echo "Could not find Chromium/Chrome for docs site smoke check" >&2
+            exit 1
+          fi
+          echo "CHROME_BIN=$CHROME_BIN" >> "$GITHUB_ENV"
+          echo "PUPPETEER_EXECUTABLE_PATH=$CHROME_BIN" >> "$GITHUB_ENV"
+      - name: Check docs site mobile smoke
+        env:
+          PUPPETEER_SKIP_DOWNLOAD: "true"
+        run: npx --yes --package puppeteer@latest node scripts/check_docs_site_smoke.mjs
       - name: Assemble site
         run: |
           mkdir -p _site


### PR DESCRIPTION
## Summary
- Add the existing Chromium locator/env pattern to the Pages workflow.
- Run `scripts/check_docs_site_smoke.mjs` before assembling and deploying `docs/site`.
- Keep the existing release version drift check in the Pages build job.

## Validation
- `python3 scripts/check_release_versions.py`
- `CHROME_BIN=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser PUPPETEER_SKIP_DOWNLOAD=true npx --yes --package puppeteer@latest node scripts/check_docs_site_smoke.mjs`
- `actionlint .github/workflows/pages.yml` not run: `actionlint` is unavailable locally.