### PR TITLE
[codex] Add architecture page smoke coverage

### DIFF
--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -264,10 +264,15 @@
           workers. There is no Python sidecar and no second model load for the normal SFT or GRPO path.
         </p>
         <pre class="mt-5"><code>client request
-  -> axum API
+  -> axum HTTP/API
   -> scheduler + block manager
   -> Qwen/Qwen3.5-4B engine
-  -> sampler or streaming SSE response</code></pre>
+  -> sampler or streaming SSE response
+
+training request
+  -> axum HTTP/API
+  -> LoRA training queue
+  -> hot-swapped adapter path</code></pre>
       </article>
 
       <article class="card p-6">

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -32,6 +32,7 @@ const expectedNavLabels = [
 
 const demoPagePath = 'docs/site/demo/index.html';
 const apiPagePath = 'docs/site/api.html';
+const architecturePagePath = 'docs/site/architecture.html';
 
 const expectedDemoSections = [
   { label: 'first token', terms: ['first token'] },
@@ -92,6 +93,35 @@ const expectedApiCodeExamples = [
   { label: 'merge', terms: ['/v1/adapters/merge', 'mode', 'ties'] },
   { label: 'composition', terms: ['/v1/chat/completions', 'adapters', 'scale'] },
   { label: 'webhook', terms: ['kiln.toml', 'webhook_url', 'kiln_training_webhook_url'] },
+];
+
+const expectedArchitectureSections = [
+  { label: 'single-process server', terms: ['single process', 'rust binary', 'axum http api'] },
+  { label: 'request path and batching', terms: ['request path and batching', 'iteration-level scheduler', 'continuous batching'] },
+  { label: 'Gated DeltaNet/GDN hybrid', terms: ['gated deltanet', 'gdn', 'hybrid'] },
+  { label: 'paged KV/block manager', terms: ['paged kv', 'block manager'] },
+  { label: 'Qwen3.5-4B', terms: ['qwen3.5-4b'] },
+  { label: 'LoRA hot-swap', terms: ['lora hot-swap', 'iteration boundary'] },
+  { label: 'training queue', terms: ['training queue', 'fifo background queue'] },
+  { label: 'GPU backend crates', terms: ['gpu backend crates', 'kiln-flash-attn', 'kiln-vulkan-kernel'] },
+  { label: 'where-to-go-next links', terms: ['where to go next', 'deep dive', 'grpo guide', 'quickstart', 'troubleshooting'] },
+];
+
+const expectedArchitectureFlowTerms = [
+  'http/api',
+  'scheduler',
+  'block manager',
+  'qwen/qwen3.5-4b engine',
+  'lora training queue',
+  'hot-swapped adapter',
+];
+
+const expectedArchitectureLinks = [
+  { label: 'full ARCHITECTURE.md', href: 'https://github.com/ericflo/kiln/blob/main/ARCHITECTURE.md' },
+  { label: 'quickstart', href: 'quickstart.html' },
+  { label: 'troubleshooting', href: 'troubleshooting.html' },
+  { label: 'API reference', href: 'api.html' },
+  { label: 'GRPO guide', href: 'grpo.html' },
 ];
 
 function fail(message) {
@@ -283,6 +313,54 @@ async function runSmoke() {
 
         if (apiResult.copyButtonCount < apiResult.copyableCodeBlocks.length) {
           fail(`${sitePage.path}: expected each API code block to have a copy button; got ${apiResult.copyButtonCount} for ${apiResult.copyableCodeBlocks.length} code blocks`);
+        }
+      }
+
+      if (sitePage.path === architecturePagePath) {
+        const architectureResult = await page.evaluate(() => {
+          const normalize = (value) => (value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+          const bodyText = normalize(document.body.innerText);
+          const headings = normalize(Array.from(document.querySelectorAll('h2, h3'))
+            .map((heading) => heading.textContent || '')
+            .join('\n'));
+          const copyableCodeBlocks = Array.from(document.querySelectorAll('pre > code'))
+            .map((code) => normalize(code.innerText || code.textContent));
+          const links = Array.from(document.querySelectorAll('a[href]')).map((link) => ({
+            href: link.getAttribute('href'),
+            text: normalize(link.textContent),
+          }));
+
+          return {
+            bodyText,
+            headings,
+            copyableCodeBlocks,
+            links,
+          };
+        });
+
+        const missingSections = expectedArchitectureSections
+          .filter((section) => !section.terms.every((term) => {
+            const normalizedTerm = term.toLowerCase();
+            return architectureResult.headings.includes(normalizedTerm)
+              || architectureResult.bodyText.includes(normalizedTerm);
+          }))
+          .map((section) => section.label);
+        if (missingSections.length > 0) {
+          fail(`${sitePage.path}: missing architecture cold-reader coverage: ${missingSections.join(', ')}`);
+        }
+
+        const hasRequestFlow = architectureResult.copyableCodeBlocks.some((codeBlock) => (
+          expectedArchitectureFlowTerms.every((term) => codeBlock.includes(term.toLowerCase()))
+        ));
+        if (!hasRequestFlow) {
+          fail(`${sitePage.path}: missing copy-paste architecture/request-flow block covering HTTP/API, scheduler, block manager, Qwen engine, and adapter/training path`);
+        }
+
+        const missingLinks = expectedArchitectureLinks
+          .filter((expectedLink) => !architectureResult.links.some((link) => link.href === expectedLink.href))
+          .map((link) => link.label);
+        if (missingLinks.length > 0) {
+          fail(`${sitePage.path}: missing architecture next-step links: ${missingLinks.join(', ')}`);
         }
       }
     }


### PR DESCRIPTION
## Summary
- Add architecture-page-specific smoke assertions for cold-reader concepts, request flow, and next-step links.
- Extend the visible architecture flow block to include the HTTP/API training path through the LoRA queue and hot-swapped adapter path.

## Validation
- `python3 scripts/check_release_versions.py`
- `CHROME_BIN=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser PUPPETEER_SKIP_DOWNLOAD=true npx --yes --package puppeteer@latest node scripts/check_docs_site_smoke.mjs`