### PR TITLE
[codex] Clarify CLI target model

### DIFF
--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -195,7 +195,7 @@
       <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-6">CLI Reference &middot; serve &middot; train &middot; adapters</span>
       <h1 class="text-4xl sm:text-5xl font-bold tracking-tight mb-5 leading-tight">Run Kiln from the terminal.</h1>
       <p class="text-lg leading-relaxed max-w-3xl" style="color: var(--fg-dim);">
-        Use the CLI when you want a headless server, repeatable scripts, or quick diagnostics against a running Kiln instance. If you want visual status, adapter controls, or training monitoring, open <code>http://127.0.0.1:8420/ui</code> instead.
+        Use the CLI when you want a headless server, repeatable scripts, or quick diagnostics against a running Kiln instance. These examples assume a running Kiln server backed by <code>Qwen/Qwen3.5-4B</code>; see <a href="quickstart.html">Quickstart</a> for setup and model download details. If you want visual status, adapter controls, or training monitoring, open <code>http://127.0.0.1:8420/ui</code> instead.
       </p>
       <div class="mt-8 flex flex-wrap gap-3">
         <a href="#serve" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Start the server</a>

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -173,6 +173,12 @@ const expectedCliLinks = [
   { label: 'Architecture', href: 'architecture.html' },
 ];
 
+const expectedCliModelSetupCue = {
+  label: 'Qwen/Qwen3.5-4B setup cue',
+  terms: ['qwen/qwen3.5-4b', 'quickstart', 'setup', 'model download'],
+  href: 'quickstart.html',
+};
+
 const expectedArchitectureSections = [
   { label: 'single-process server', terms: ['single process', 'rust binary', 'axum http api'] },
   { label: 'request path and batching', terms: ['request path and batching', 'iteration-level scheduler', 'continuous batching'] },
@@ -559,6 +565,12 @@ async function runSmoke() {
             href: link.getAttribute('href'),
             text: normalize(link.textContent),
           }));
+          const hero = document.querySelector('main > section:first-of-type');
+          const heroText = normalize(hero?.innerText || '');
+          const heroLinks = Array.from(hero?.querySelectorAll('a[href]') || []).map((link) => ({
+            href: link.getAttribute('href'),
+            text: normalize(link.textContent),
+          }));
 
           return {
             bodyText,
@@ -566,8 +578,19 @@ async function runSmoke() {
             copyableCodeBlocks,
             copyButtonCount: copyButtons.length,
             links,
+            heroText,
+            heroLinks,
           };
         });
+
+        const missingModelSetupCueTerms = expectedCliModelSetupCue.terms
+          .filter((term) => !cliResult.heroText.includes(term));
+        if (missingModelSetupCueTerms.length > 0) {
+          fail(`${sitePage.path}: missing ${expectedCliModelSetupCue.label}: ${missingModelSetupCueTerms.join(', ')}`);
+        }
+        if (!cliResult.heroLinks.some((link) => link.href === expectedCliModelSetupCue.href)) {
+          fail(`${sitePage.path}: ${expectedCliModelSetupCue.label} must link to Quickstart`);
+        }
 
         const missingSections = expectedCliSections
           .filter((section) => !section.terms.every((term) => {


### PR DESCRIPTION
## Summary
- Add a CLI Reference intro sentence naming `Qwen/Qwen3.5-4B` as the assumed target model for examples.
- Link that intro cue to `quickstart.html` for setup and model download details.
- Add a focused docs-site smoke assertion that the CLI hero includes the model/setup cue and Quickstart link.

## Validation
- `CHROME_BIN=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser node scripts/check_docs_site_smoke.mjs`