### PR TITLE
Guard QUICKSTART dashboard alt text

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -192,7 +192,7 @@ Kiln ships with an embedded web dashboard. Open [http://localhost:8420/ui](http:
 - **Training** — submit SFT or GRPO jobs from a form, watch the queue, and review recently completed runs
 - **Quick Inference** — chat with the model directly (per-request adapter and temperature pickers) without writing curl
 
-![Kiln embedded server dashboard](docs/site/assets/server-ui-dashboard.png)
+![Kiln dashboard showing server status, adapters, training controls, and quick inference chat panels](docs/site/assets/server-ui-dashboard.png)
 
 It's a single HTML page served by the `kiln` binary itself — no extra process, no build step, no JS bundle to deploy.
 

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -322,6 +322,35 @@ function validateReadmeMedia() {
   }
 }
 
+function validateQuickstartMarkdownMedia() {
+  const quickstartPath = resolve(repoRoot, 'QUICKSTART.md');
+  const quickstart = readFileSync(quickstartPath, 'utf8');
+  const dashboardImagePath = 'docs/site/assets/server-ui-dashboard.png';
+
+  if (!quickstart.includes(dashboardImagePath)) {
+    fail(`QUICKSTART.md: missing dashboard screenshot reference ${dashboardImagePath}`);
+  }
+  if (!existsSync(resolve(repoRoot, dashboardImagePath))) {
+    fail(`QUICKSTART.md: referenced dashboard screenshot does not exist: ${dashboardImagePath}`);
+  }
+
+  const dashboardImagePattern = new RegExp(`!\\[([^\\]]+)\\]\\(${dashboardImagePath.replaceAll('/', '\\/')}\\)`);
+  const dashboardImageMatch = quickstart.match(dashboardImagePattern);
+  if (!dashboardImageMatch) {
+    fail(`QUICKSTART.md: dashboard screenshot reference must include alt text for ${dashboardImagePath}`);
+  }
+
+  const altText = dashboardImageMatch[1].toLowerCase().replace(/[-_]+/g, ' ').replace(/\s+/g, ' ').trim();
+  const requiredAltTerms = ['dashboard', 'status', 'adapters', 'training'];
+  const missingAltTerms = requiredAltTerms.filter((term) => !altText.includes(term));
+  if (!altText.includes('chat') && !altText.includes('quick inference')) {
+    missingAltTerms.push('chat or quick inference');
+  }
+  if (missingAltTerms.length > 0) {
+    fail(`QUICKSTART.md: dashboard screenshot alt text missing terms: ${missingAltTerms.join(', ')}`);
+  }
+}
+
 function validateLaunchSentinel() {
   const launchDir = resolve(repoRoot, 'docs/site/launch');
   const sentinelPath = resolve(launchDir, 'README.md');
@@ -443,6 +472,7 @@ function chromiumPath() {
 async function runSmoke() {
   validateReadmeStartupBanner();
   validateReadmeMedia();
+  validateQuickstartMarkdownMedia();
   validateLaunchSentinel();
   validateDemoReadmeInventory();
 


### PR DESCRIPTION
## Summary
- Improve the QUICKSTART dashboard screenshot alt text for screen-reader and cold-reader context.
- Add smoke coverage that validates the QUICKSTART markdown dashboard image path, asset existence, and required alt-text terms.

## Validation
- node scripts/check_docs_site_smoke.mjs