### PR TITLE
Split README quick start paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,24 @@ See [docs/GRPO_GUIDE.md](docs/GRPO_GUIDE.md) for worked verifiable-rewards examp
 
 **Supported hardware:** NVIDIA GPU with 24GB+ VRAM and CUDA 12+, AMD/Intel GPU with Vulkan 1.2+ on Linux, **or** Apple Silicon Mac with 16GB+ unified memory. Kiln targets `Qwen/Qwen3.5-4B` and needs about 20GB of free disk for the server, model weights, and adapters.
 
-**Path 1 — Desktop App / prebuilt binary, recommended for most users:** Install [Kiln Desktop](#desktop-app) on Windows, Linux, or macOS. The app downloads and verifies the matching prebuilt `kiln` server binary on first launch, then walks you through choosing or downloading the model weights. No Rust toolchain, CUDA toolkit, or source build is required for this path.
+**Path 1 — Desktop App (recommended):** Install [Kiln Desktop](#desktop-app) on Windows, Linux, or macOS. The app downloads and verifies the matching prebuilt `kiln` server binary on first launch, then walks you through choosing or downloading `Qwen/Qwen3.5-4B`. No Rust toolchain, CUDA toolkit, or source build is required for this path.
 
-If you prefer a terminal, run the prebuilt container instead:
+**Path 2 — Server binary (terminal-first, no source build):** Download the latest `kiln-v*` server artifact when you want the `kiln` server in your terminal with no source build, Desktop App, or Docker. Linux x86_64 + NVIDIA CUDA 12.4 is the compact path:
+
+```bash
+KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest | sed -n 's/.*"tag_name": "kiln-v\([^"]*\)".*/\1/p')
+curl -L -o kiln-linux-cuda.tar.gz \
+  "https://github.com/ericflo/kiln/releases/download/kiln-v${KILN_VERSION}/kiln-${KILN_VERSION}-x86_64-unknown-linux-gnu-cuda124.tar.gz"
+tar -xzf kiln-linux-cuda.tar.gz
+
+pip install huggingface-hub
+huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
+KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve
+```
+
+For Linux Vulkan, macOS Metal, Windows CUDA, and SHA-256 sidecar checks, use the full release artifact matrix in [QUICKSTART.md](QUICKSTART.md#quick-path-server-binary-terminal-first-no-source-build).
+
+**Path 3 — Container:** Run the prebuilt GHCR image when you prefer containerized deployment. This path requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
 
 ```bash
 docker pull ghcr.io/ericflo/kiln-server:latest
@@ -127,7 +142,7 @@ docker run --gpus all -p 8420:8420 \
 
 Replace `/path/to/Qwen3.5-4B` with your local `Qwen3.5-4B` model directory, then open http://127.0.0.1:8420/ui after the container starts.
 
-**Path 2 — Source / CLI, for contributors and direct CLI users:** Install Rust stable, then build the CLI from source for your platform.
+**Path 4 — Source / CLI:** Install Rust stable, then build the CLI from source when you are contributing, scripting against a local checkout, or need to test unreleased changes.
 
 ```bash
 git clone https://github.com/ericflo/kiln.git

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -394,6 +394,46 @@ function validateQuickstartServerBinaryPath() {
   }
 }
 
+function validateReadmeQuickStartPaths() {
+  const readme = readFileSync(resolve(repoRoot, 'README.md'), 'utf8');
+  const quickStartSection = extractMarkdownSection(readme, 'Quick Start');
+  if (!quickStartSection) {
+    fail('README.md: missing ## Quick Start section');
+  }
+
+  const requiredPaths = [
+    ['Desktop App path', 'Desktop App (recommended)'],
+    ['Server binary path', 'Server binary (terminal-first, no source build)'],
+    ['Container path', 'Container'],
+    ['Source / CLI path', 'Source / CLI'],
+  ];
+  for (const [label, term] of requiredPaths) {
+    assertIncludes(quickStartSection, term, `README.md: Quick Start ${label}`);
+  }
+
+  const serverBinaryMatch = quickStartSection.match(/\*\*Path 2 — Server binary \(terminal-first, no source build\):\*\*([\s\S]*?)(?=\n\*\*Path 3 — Container:\*\*)/);
+  if (!serverBinaryMatch) {
+    fail('README.md: Quick Start missing distinct Server binary path before Container path');
+  }
+  const serverBinaryPath = serverBinaryMatch[1];
+  const requiredServerTerms = [
+    'terminal-first',
+    'no source build',
+    'Qwen/Qwen3.5-4B',
+    'kiln-v${KILN_VERSION}',
+    'x86_64-unknown-linux-gnu-cuda124.tar.gz',
+  ];
+  for (const term of requiredServerTerms) {
+    assertIncludes(serverBinaryPath, term, 'README.md: Server binary path');
+  }
+  if (!/https:\/\/github\.com\/ericflo\/kiln\/releases\/download\/kiln-v/.test(serverBinaryPath)) {
+    fail('README.md: Server binary path must include at least one kiln-v release download command');
+  }
+  if (!/QUICKSTART\.md#quick-path-server-binary-terminal-first-no-source-build/.test(serverBinaryPath)) {
+    fail('README.md: Server binary path must link to QUICKSTART.md full artifact matrix');
+  }
+}
+
 function extractMarkdownSection(markdown, heading) {
   const headingPattern = new RegExp(`^## ${heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'm');
   const headingMatch = markdown.match(headingPattern);
@@ -940,6 +980,7 @@ function chromiumPath() {
 async function runSmoke() {
   validateReadmeStartupBanner();
   validateReadmeMedia();
+  validateReadmeQuickStartPaths();
   validateQuickstartMarkdownMedia();
   validateQuickstartServerBinaryPath();
   validateQuickstartCliReference();


### PR DESCRIPTION
## Summary

- Splits `README.md` Quick Start into Desktop App, Server binary, Container, and Source / CLI paths.
- Adds a compact Linux CUDA release-artifact flow for terminal-first users while keeping `Qwen/Qwen3.5-4B` as the only model.
- Adds a README smoke guard in `scripts/check_docs_site_smoke.mjs` so the path split, release download command, and QUICKSTART artifact-matrix link do not drift.

## Validation

- `npx --yes --package puppeteer@latest node scripts/check_docs_site_smoke.mjs`
- `python3 scripts/check_release_versions.py`