### PR TITLE
Add Desktop first-run help links

### DIFF
--- a/desktop/ui/dashboard.html
+++ b/desktop/ui/dashboard.html
@@ -45,6 +45,15 @@
         font-size: 14px;
         max-width: 440px;
       }
+      #status p.help-links {
+        margin-top: 14px;
+        font-size: 12px;
+      }
+      #status a.doc-link {
+        color: #5f9bff;
+        text-decoration: none;
+      }
+      #status a.doc-link:hover { text-decoration: underline; }
       #status code {
         background: #1b1e24;
         padding: 2px 6px;
@@ -571,6 +580,15 @@
         <button id="retry" class="hidden">Retry</button>
         <button id="open-settings-btn" class="hidden">Open Settings</button>
       </div>
+      <p class="help-links">
+        First run? Set your model path and kiln server binary in Settings, then follow the
+        <a class="doc-link" href="https://ericflo.github.io/kiln/quickstart.html"
+           target="_blank" rel="noopener noreferrer">Quickstart</a>
+        or
+        <a class="doc-link" href="https://ericflo.github.io/kiln/troubleshooting.html"
+           target="_blank" rel="noopener noreferrer">Troubleshooting</a>
+        guide.
+      </p>
     </div>
     <div id="install" class="phase-ready hidden">
       <h1 id="install-title">Kiln server isn't installed yet</h1>
@@ -587,8 +605,13 @@
         <button id="install-browse-btn" class="secondary">Use a local build…</button>
       </div>
       <p id="install-footnote">
+        Need setup help? Read the
+        <a class="doc-link" href="https://ericflo.github.io/kiln/quickstart.html"
+           target="_blank" rel="noopener noreferrer">Quickstart</a>, check
+        <a class="doc-link" href="https://ericflo.github.io/kiln/troubleshooting.html"
+           target="_blank" rel="noopener noreferrer">Troubleshooting</a>, or
         <a class="doc-link" href="https://github.com/ericflo/kiln/blob/main/QUICKSTART.md"
-           target="_blank" rel="noopener noreferrer">Prefer to build from source?</a>
+           target="_blank" rel="noopener noreferrer">build from source</a>.
       </p>
     </div>
     <div id="shortcuts-modal" class="modal-overlay hidden" role="dialog" aria-modal="true" aria-labelledby="shortcuts-title">

--- a/desktop/ui/settings.html
+++ b/desktop/ui/settings.html
@@ -139,6 +139,17 @@
       }
       .update-download-line.error { color: #f08080; }
       .update-download-line.success { color: #7fbf7f; }
+      .help-row {
+        color: #6c7280;
+        font-size: 12px;
+        line-height: 1.4;
+        margin: 2px 0 10px 0;
+      }
+      .help-row a {
+        color: #5f9bff;
+        text-decoration: none;
+      }
+      .help-row a:hover { text-decoration: underline; }
       .actions {
         display: flex;
         gap: 8px;
@@ -347,6 +358,13 @@
           <span class="hint">Directory containing the Qwen3.5-4B weights.</span>
           <span class="path-warning" id="warn_model_path"></span>
         </label>
+        <p class="help-row">
+          Setting up Desktop for the first time? Use the hosted
+          <a href="https://ericflo.github.io/kiln/quickstart.html" target="_blank" rel="noopener noreferrer">Quickstart</a>
+          for model path and kiln server binary setup, or open
+          <a href="https://ericflo.github.io/kiln/troubleshooting.html" target="_blank" rel="noopener noreferrer">Troubleshooting</a>
+          if a path check or server start fails.
+        </p>
         <label class="row"><span class="name">Host</span>
           <input type="text" id="host" />
           <span class="hint">IP address to bind on. 127.0.0.1 for local only, 0.0.0.0 for LAN.</span>

--- a/scripts/check_desktop_ui_smoke.mjs
+++ b/scripts/check_desktop_ui_smoke.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const files = {
+  dashboard: 'desktop/ui/dashboard.html',
+  settings: 'desktop/ui/settings.html',
+};
+
+const quickstartHref = 'https://ericflo.github.io/kiln/quickstart.html';
+const troubleshootingHref = 'https://ericflo.github.io/kiln/troubleshooting.html';
+const forbiddenPublicityTerms = [
+  'launch post',
+  'announcement',
+  'press release',
+  'twitter',
+  'x-twitter',
+  'lobste.rs',
+  'localLLaMA',
+  'discord',
+  'hacker news',
+  'hn launch',
+];
+
+function read(path) {
+  return fs.readFileSync(path, 'utf8');
+}
+
+function stripHtml(html) {
+  return html
+    .replace(/<script\b[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style\b[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function assertContains(source, needle, label) {
+  if (!source.includes(needle)) {
+    throw new Error(`${label} is missing ${needle}`);
+  }
+}
+
+function assertAny(source, needles, label) {
+  if (!needles.some((needle) => source.includes(needle))) {
+    throw new Error(`${label} is missing one of: ${needles.join(', ')}`);
+  }
+}
+
+function assertNoForbiddenPublicityCopy(text, label) {
+  for (const term of forbiddenPublicityTerms) {
+    if (text.includes(term.toLowerCase())) {
+      throw new Error(`${label} should not use external publicity wording: ${term}`);
+    }
+  }
+}
+
+function checkDashboard(html) {
+  const text = stripHtml(html);
+  assertContains(html, quickstartHref, 'dashboard first-run help');
+  assertContains(html, troubleshootingHref, 'dashboard first-run help');
+  assertContains(text, 'quickstart', 'dashboard first-run help text');
+  assertContains(text, 'troubleshooting', 'dashboard first-run help text');
+  assertAny(text, ['model path', 'server binary', 'kiln server binary'], 'dashboard first-run setup copy');
+  assertContains(text, 'build from source', 'dashboard source-build link copy');
+  assertNoForbiddenPublicityCopy(text, 'dashboard first-run help');
+}
+
+function checkSettings(html) {
+  const text = stripHtml(html);
+  assertContains(html, quickstartHref, 'settings setup help');
+  assertContains(html, troubleshootingHref, 'settings setup help');
+  assertContains(text, 'quickstart', 'settings setup help text');
+  assertContains(text, 'troubleshooting', 'settings setup help text');
+  assertContains(text, 'model path', 'settings setup help copy');
+  assertAny(text, ['server binary', 'kiln binary'], 'settings binary setup copy');
+  assertNoForbiddenPublicityCopy(text, 'settings setup help');
+}
+
+checkDashboard(read(files.dashboard));
+checkSettings(read(files.settings));
+console.log('Desktop UI smoke checks passed');


### PR DESCRIPTION
## Summary
- Add hosted Quickstart and Troubleshooting links to the Desktop dashboard first-run/status and install-needed panels.
- Add a settings help row near the kiln binary/model path fields for first-run setup recovery.
- Add a dependency-free Desktop UI smoke script that guards the links, setup wording, source-build link, and absence of publicity wording.

## Validation
- `node scripts/check_desktop_ui_smoke.mjs`
- `npx --yes --package puppeteer@latest node scripts/check_server_ui_smoke.mjs`
- `npx --yes --package puppeteer@latest node scripts/check_docs_site_smoke.mjs`
- `python3 scripts/check_release_versions.py`