### PR TITLE
[codex] Add health help onboarding copy

### DIFF
--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -61,6 +61,29 @@ const SERVE_EXAMPLES: &str = r#"Examples:
   See QUICKSTART.md and Troubleshooting if the server cannot find weights, CUDA is unavailable, or config validation fails.
 "#;
 
+const HEALTH_OVERVIEW: &str = r#"Check readiness and setup diagnostics for a running Kiln server at http://localhost:8420 by default.
+
+`kiln health` calls the server's /health endpoint and prints a terminal-friendly tree with model, adapter, scheduler, GPU memory, and training status. Use it after `kiln serve` starts, or point --url at a remote server when debugging another host.
+
+If readiness fails, check the /health response first, then follow QUICKSTART.md and Troubleshooting for model path, CUDA, config, and server-start diagnostics.
+"#;
+
+const HEALTH_EXAMPLES: &str = r#"Examples:
+  kiln health
+      Check whether the local server at http://localhost:8420 is ready.
+
+  kiln health --url http://localhost:8420
+      Check a specific Kiln server URL when the default is not the target.
+
+  kiln health --json
+      Print the raw /health JSON response for scripts or bug reports.
+
+  curl http://localhost:8420/health
+      Call the same readiness endpoint directly if you are narrowing down CLI vs server setup.
+
+  See Troubleshooting if /health is not ready, the model path is wrong, CUDA is unavailable, or the server is not reachable.
+"#;
+
 const TRAIN_OVERVIEW: &str = r#"Submit SFT or GRPO training jobs to the running Kiln server at http://localhost:8420 by default.
 
 SFT reads newline-delimited chat correction examples from JSONL. GRPO reads one JSON request/batch with scored completions.
@@ -225,6 +248,7 @@ pub enum Commands {
     Adapters(AdapterCommands),
 
     /// Check health of a running server
+    #[command(long_about = HEALTH_OVERVIEW, after_help = HEALTH_EXAMPLES)]
     Health {
         /// Server URL
         #[arg(long, default_value = "http://localhost:8420")]

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -524,6 +524,8 @@ function validateCliHelpOnboardingCopy() {
       'TOP_LEVEL_EXAMPLES',
       'SERVE_OVERVIEW',
       'SERVE_EXAMPLES',
+      'HEALTH_OVERVIEW',
+      'HEALTH_EXAMPLES',
       'TRAIN_EXAMPLES',
       'ADAPTERS_EXAMPLES',
       'CONFIG_EXAMPLES',
@@ -565,6 +567,24 @@ function validateCliHelpOnboardingCopy() {
       'kiln health',
       'Troubleshooting',
     ]],
+    ['HEALTH_OVERVIEW', [
+      'kiln health',
+      'http://localhost:8420',
+      '/health',
+      '--url',
+      'QUICKSTART.md',
+      'Troubleshooting',
+    ]],
+    ['HEALTH_EXAMPLES', [
+      'kiln health',
+      'kiln health --url http://localhost:8420',
+      'kiln health --json',
+      'curl http://localhost:8420/health',
+      '/health',
+      '--url',
+      '--json',
+      'Troubleshooting',
+    ]],
     ['TRAIN_EXAMPLES', [
       'kiln train status',
       'kiln train status --job-id train_123',
@@ -591,6 +611,11 @@ function validateCliHelpOnboardingCopy() {
     cliParser,
     /pub enum Commands[\s\S]*?\n\s+#\[command\(long_about = SERVE_OVERVIEW, after_help = SERVE_EXAMPLES\)\]\n\s+Serve\s*\{/,
     'crates/kiln-server/src/cli.rs: Commands::Serve onboarding help wiring',
+  );
+  assertMatches(
+    cliParser,
+    /pub enum Commands[\s\S]*?\n\s+#\[command\(long_about = HEALTH_OVERVIEW, after_help = HEALTH_EXAMPLES\)\]\n\s+Health\s*\{/,
+    'crates/kiln-server/src/cli.rs: Commands::Health onboarding help wiring',
   );
 }
 


### PR DESCRIPTION
## Summary
- Add dedicated `kiln health --help` long help covering readiness, `--url`, `--json`, `/health`, and troubleshooting diagnostics.
- Extend the docs/site smoke guard to assert the new health help constants and `Commands::Health` wiring stay in sync.

## Validation
- `npx --yes --package puppeteer@latest node scripts/check_docs_site_smoke.mjs` — passed
- `PATH=/usr/local/cargo/bin:$PATH cargo test -p kiln-server parses_health --lib` — passed (2 tests; `cli_help_constants` test target did not exist)

## Scope
Phase 11 onboarding/polish only. No GPU pod used.