### PR TITLE
[codex] Mirror train payload cues in QUICKSTART CLI reference

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -636,10 +636,10 @@ kiln config -f kiln.toml
     Validate a TOML config file without starting the server.
 
 kiln train sft --file corrections.jsonl --adapter support-bot
-    Submit JSONL SFT correction examples to the running server.
+    Submit SFT JSONL: each line is one chat correction with a messages array.
 
 kiln train grpo --file grpo-batch.json --adapter support-bot
-    Submit one JSON GRPO request/batch to the running server.
+    Submit one GRPO JSON request/batch with groups, candidate completions, and reward scores.
 
 kiln train status --job-id train_123
     Check a specific training job; omit --job-id to show the queue.

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -688,6 +688,19 @@ function validateQuickstartCliReference() {
     fail(`QUICKSTART.md: CLI Reference command block missing commands: ${missingCommands.join(', ')}`);
   }
 
+  const expectedTrainingPayloadTerms = [
+    'SFT JSONL',
+    'messages array',
+    'GRPO JSON request/batch',
+    'groups',
+    'completions',
+    'reward scores',
+  ];
+  const missingTrainingPayloadTerms = expectedTrainingPayloadTerms.filter((term) => !cliReferenceCodeBlock.includes(term));
+  if (missingTrainingPayloadTerms.length > 0) {
+    fail(`QUICKSTART.md: CLI Reference command block missing training payload cues: ${missingTrainingPayloadTerms.join(', ')}`);
+  }
+
   const cliParser = readFileSync(resolve(repoRoot, 'crates/kiln-server/src/cli.rs'), 'utf8');
   const parserChecks = [
     ['Commands::Serve', /pub enum Commands[\s\S]*?\n\s+Serve\s*\{[\s\S]*?served_model_id:\s*Option<String>/],


### PR DESCRIPTION
## Summary
- Clarify the QUICKSTART CLI reference training commands with concise payload-shape cues.
- Preserve SFT JSONL/messages-array wording and GRPO groups/completions/reward-scores wording in the docs smoke test.

## Validation
- `node scripts/check_docs_site_smoke.mjs`

## Notes
- No GPU pod used; this is Phase 11 docs-only onboarding polish.