### PR TITLE
[codex] Add requests import to GRPO snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ This is the killer feature. Generate completions, score them with your own rewar
 
 ```python
 import openai
+import requests
 
 client = openai.OpenAI(base_url="http://localhost:8420/v1", api_key="unused")
 

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -380,6 +380,8 @@ curl http://localhost:8420/v1/chat/completions \
         regex, unit tests, another model, human eval.
       </p>
 <pre><code><span style="color:#7f8694"># 1. Generate candidates</span>
+import requests
+
 responses = [client.chat.completions.create(
     model="qwen3.5-4b-kiln", messages=[...], temperature=0.7
 ) for _ in range(8)]

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -480,6 +480,36 @@ function validateReadmeQuickStartPaths() {
   }
 }
 
+function validateGrpoOverviewRequestsImports() {
+  const readme = readFileSync(resolve(repoRoot, 'README.md'), 'utf8');
+  const readmeSection = extractMarkdownSection(readme, 'The GRPO Loop');
+  if (!readmeSection) {
+    fail('README.md: missing ## The GRPO Loop section');
+  }
+  assertRequestsImportNearPost(readmeSection, 'README.md: The GRPO Loop');
+
+  const index = readFileSync(resolve(repoRoot, 'docs/site/index.html'), 'utf8');
+  const indexSection = index.match(/<!-- the GRPO loop -->[\s\S]*?<\/section>/);
+  if (!indexSection) {
+    fail('docs/site/index.html: missing The GRPO loop section');
+  }
+  assertRequestsImportNearPost(indexSection[0], 'docs/site/index.html: The GRPO loop');
+}
+
+function assertRequestsImportNearPost(section, context) {
+  const requestPosts = Array.from(section.matchAll(/requests\.post/g));
+  if (requestPosts.length === 0) {
+    fail(`${context}: missing requests.post GRPO submit call`);
+  }
+
+  for (const requestPost of requestPosts) {
+    const nearbyPrefix = section.slice(Math.max(0, requestPost.index - 800), requestPost.index);
+    if (!nearbyPrefix.includes('import requests')) {
+      fail(`${context}: requests.post must have import requests nearby before use`);
+    }
+  }
+}
+
 function extractMarkdownSection(markdown, heading) {
   const headingPattern = new RegExp(`^## ${heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*$`, 'm');
   const headingMatch = markdown.match(headingPattern);
@@ -1131,6 +1161,7 @@ async function runSmoke() {
   validateReadmeStartupBanner();
   validateReadmeMedia();
   validateReadmeQuickStartPaths();
+  validateGrpoOverviewRequestsImports();
   validateQuickstartMarkdownMedia();
   validateQuickstartServerBinaryPath();
   validateQuickstartCliReference();


### PR DESCRIPTION
## Summary
- Add `import requests` to the README GRPO Loop snippet and the docs/site homepage GRPO overview snippet.
- Extend the docs-site smoke check so GRPO overview snippets with `requests.post` must include a nearby `import requests` first.

## Validation
- `node scripts/check_docs_site_smoke.mjs`
- `rg -n "import requests|requests\\.post|The GRPO Loop|The GRPO loop" README.md docs/site/index.html scripts/check_docs_site_smoke.mjs`

No RunPod/GPU validation was run because this is docs-only onboarding polish.