### PR TITLE
[codex] Clarify GRPO CLI docs groups payload

### DIFF
--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -304,7 +304,7 @@ kiln health --url http://localhost:8420</code></pre>
     <div class="max-w-5xl mx-auto px-6 py-12">
       <p class="label mb-2">Training</p>
       <h2 class="text-2xl font-semibold tracking-tight mb-4">Submit SFT and GRPO jobs</h2>
-      <p class="max-w-3xl mb-6" style="color: var(--fg-dim);">Training commands talk to an already-running server. SFT reads JSONL with one chat correction example per line, each with a <code>messages</code> array. GRPO reads one JSON request/batch with <code>prompts</code>/<code>groups</code>, completions, and reward scores.</p>
+      <p class="max-w-3xl mb-6" style="color: var(--fg-dim);">Training commands talk to an already-running server. SFT reads JSONL with one chat correction example per line, each with a <code>messages</code> array. GRPO reads one JSON request/batch with <code>groups</code>; each group has prompt <code>messages</code> plus candidate <code>completions</code> containing <code>text</code> and <code>reward</code> scores.</p>
       <div class="grid lg:grid-cols-3 gap-4">
         <div class="card p-5">
           <h3 class="font-semibold mb-2">SFT corrections</h3>
@@ -319,7 +319,7 @@ kiln train sft --file corrections.jsonl --adapter support-bot --url http://gpu-b
 <pre class="text-sm"><code>kiln train grpo \
   --file grpo-batch.json \
   --adapter support-bot</code></pre>
-          <p class="text-sm mt-4" style="color: var(--fg-mute);">Use this for generate &rarr; score &rarr; train loops: send prompts/groups, candidate completions, and reward scores. See the <a href="grpo.html" class="link">GRPO Guide</a> for reward-loop examples.</p>
+          <p class="text-sm mt-4" style="color: var(--fg-mute);">Use <code>/v1/completions/batch</code> or another generator to create prompts and candidate completions first, score them, then submit the scored <code>groups</code> to <code>kiln train grpo</code>. See the <a href="grpo.html" class="link">GRPO Guide</a> for reward-loop examples.</p>
         </div>
         <div class="card p-5">
           <h3 class="font-semibold mb-2">Queue status</h3>

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -169,7 +169,7 @@ const expectedCliSections = [
   { label: 'health/readiness path', terms: ['check server readiness', 'kiln health'] },
   { label: 'SFT/GRPO training path', terms: ['submit sft and grpo jobs', 'kiln train sft', 'kiln train grpo'] },
   { label: 'SFT payload shape', terms: ['sft reads jsonl', 'one chat correction example per line', 'messages array'] },
-  { label: 'GRPO payload shape', terms: ['grpo reads one json request/batch', 'prompts/groups', 'completions', 'reward scores'] },
+  { label: 'GRPO payload shape', terms: ['grpo reads one json request/batch', 'groups', 'messages', 'candidate completions', 'text', 'reward scores'] },
   { label: 'adapter lifecycle path', terms: ['manage lora adapters', 'kiln adapters list', 'kiln adapters load', 'kiln adapters unload'] },
   { label: 'config validation path', terms: ['validate config', 'kiln config --file'] },
   { label: 'help and verbosity flags', terms: ['--help', '--verbose', '--quiet', '-vv'] },
@@ -1465,6 +1465,10 @@ async function runSmoke() {
           .map((example) => example.label);
         if (missingCodeExamples.length > 0) {
           fail(`${sitePage.path}: missing copy-paste CLI examples: ${missingCodeExamples.join(', ')}`);
+        }
+
+        if (cliResult.bodyText.includes('prompts/groups') || cliResult.copyableCodeBlocks.some((codeBlock) => codeBlock.includes('prompts/groups'))) {
+          fail(`${sitePage.path}: kiln train grpo docs must describe scored groups, not prompts/groups; prompts belong to /v1/completions/batch`);
         }
 
         if (cliResult.copyButtonCount < cliResult.copyableCodeBlocks.length) {


### PR DESCRIPTION
## Summary
- Clarifies the CLI reference training section so SFT is JSONL `messages` and GRPO training consumes scored `groups` with prompt `messages` plus `completions` containing `text` and `reward`.
- Adds a docs-site smoke assertion that `docs/site/cli.html` does not describe `kiln train grpo` as reading `prompts/groups`, while preserving `/v1/completions/batch` as the prompt/candidate generation step.

## Validation
- `node scripts/check_docs_site_smoke.mjs`
- `rg -n "prompts/groups|kiln train grpo|/v1/completions/batch|groups.*completions|GrpoRequest" docs/site/cli.html scripts/check_docs_site_smoke.mjs crates/kiln-train/src/lib.rs`