### PR TITLE
[codex] Fix GRPO CLI help payload wording

### DIFF
--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -86,7 +86,7 @@ const HEALTH_EXAMPLES: &str = r#"Examples:
 
 const TRAIN_OVERVIEW: &str = r#"Submit SFT or GRPO training jobs to the running Kiln server at http://localhost:8420 by default.
 
-SFT reads JSONL: one chat correction example per line with a messages array. GRPO reads one JSON request/batch: prompts/groups with completions and reward scores.
+SFT reads JSONL: one chat correction example per line with a messages array. GRPO reads one JSON request/batch with groups; each group has prompt messages plus candidate completions containing text and reward scores.
 
 Prefer http://127.0.0.1:8420/ui for guided submission and status. See docs/GRPO_GUIDE.md or docs/site/grpo.html for reward-loop examples.
 "#;
@@ -96,7 +96,7 @@ const TRAIN_SFT_OVERVIEW: &str = r#"Train from SFT JSONL: one chat correction ex
 Open http://127.0.0.1:8420/ui for guided submission and training status.
 "#;
 
-const TRAIN_GRPO_OVERVIEW: &str = r#"Train from one GRPO JSON request/batch: prompts/groups with completions and reward scores.
+const TRAIN_GRPO_OVERVIEW: &str = r#"Train from one GRPO JSON request/batch with groups; each group has prompt messages plus candidate completions containing text and reward scores.
 
 Open http://127.0.0.1:8420/ui for guided submission and training status. See docs/GRPO_GUIDE.md or docs/site/grpo.html for reward-loop examples.
 "#;
@@ -106,7 +106,7 @@ const TRAIN_EXAMPLES: &str = r#"Examples:
       Train from SFT JSONL: one chat correction example per line with a messages array.
 
   kiln train grpo --file grpo-batch.json --adapter support-bot
-      Train from GRPO JSON containing prompts/groups, completions, and reward scores.
+      Train from one GRPO JSON request/batch with groups; each group has prompt messages plus candidate completions containing text and reward scores.
 
   kiln train status
       Show the training queue and recent jobs on the running server.
@@ -316,7 +316,7 @@ pub enum TrainCommands {
     /// Train a LoRA adapter from scored GRPO completions
     #[command(long_about = TRAIN_GRPO_OVERVIEW)]
     Grpo {
-        /// Path to GRPO JSON with prompts/groups, completions, and reward scores
+        /// Path to one GRPO JSON request/batch with groups, prompt messages, candidate completions, text, and reward scores
         #[arg(long, short)]
         file: String,
 

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -625,7 +625,10 @@ function validateCliHelpOnboardingCopy() {
       'SFT reads JSONL',
       'messages array',
       'GRPO reads one JSON request/batch',
-      'prompts/groups',
+      'groups',
+      'prompt messages',
+      'candidate completions',
+      'text',
       'completions',
       'reward scores',
       'http://127.0.0.1:8420/ui',
@@ -642,7 +645,10 @@ function validateCliHelpOnboardingCopy() {
     ]],
     ['TRAIN_GRPO_OVERVIEW', [
       'GRPO JSON',
-      'prompts/groups',
+      'groups',
+      'prompt messages',
+      'candidate completions',
+      'text',
       'completions',
       'reward scores',
       'http://127.0.0.1:8420/ui',
@@ -653,6 +659,10 @@ function validateCliHelpOnboardingCopy() {
       'SFT JSONL',
       'messages array',
       'GRPO JSON',
+      'groups',
+      'prompt messages',
+      'candidate completions',
+      'text',
       'completions',
       'reward scores',
       'kiln train status',
@@ -675,6 +685,16 @@ function validateCliHelpOnboardingCopy() {
       assertHelpCopyIncludes(helpCopy, constantName, term);
     }
   }
+
+  if (cliParser.includes('prompts/groups')) {
+    fail('crates/kiln-server/src/cli.rs: kiln train grpo CLI help must describe scored groups, not prompts/groups; prompts belong to /v1/completions/batch');
+  }
+
+  assertMatches(
+    cliParser,
+    /Path to one GRPO JSON request\/batch with groups, prompt messages, candidate completions, text, and reward scores/,
+    'crates/kiln-server/src/cli.rs: TrainCommands::Grpo file arg payload help',
+  );
 
   assertMatches(
     cliParser,


### PR DESCRIPTION
## Summary
- Updates `kiln train` and `kiln train grpo` help copy so GRPO input is described as one JSON request/batch with scored `groups`.
- Adds a smoke-test regression guard so stale `prompts/groups` wording cannot return to CLI help.

## Validation
- `node scripts/check_docs_site_smoke.mjs`
- `rg -n "prompts/groups|TRAIN_OVERVIEW|TRAIN_GRPO_OVERVIEW|Path to GRPO JSON|GRPO request must be a JSON object|GrpoRequest" crates/kiln-server/src/cli.rs scripts/check_docs_site_smoke.mjs crates/kiln-train/src/lib.rs docs/site/cli.html`