### PR TITLE
[codex] Fix adapter API docs examples

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -372,7 +372,7 @@
   -o default-adapter.tar.gz
 
 curl -s http://localhost:8420/v1/adapters/upload \
-  -F "file=@default-adapter.tar.gz" \
+  -F "archive=@default-adapter.tar.gz" \
   -F "name=default-copy" \
   | python3 -m json.tool</code></pre>
           </section>
@@ -383,7 +383,7 @@ curl -s http://localhost:8420/v1/adapters/upload \
   -d '{
     "output_name": "merged-ties",
     "mode": "ties",
-    "adapters": [
+    "sources": [
       {"name": "default", "weight": 0.7},
       {"name": "grpo-demo", "weight": 0.3}
     ]
@@ -397,7 +397,7 @@ curl -s http://localhost:8420/v1/adapters/upload \
   -d '{
     "output_name": "merged-concat",
     "mode": "concat",
-    "adapters": [
+    "sources": [
       {"name": "default", "weight": 1.0},
       {"name": "format-fixes", "weight": 1.0}
     ]

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -1419,6 +1419,30 @@ async function runSmoke() {
           fail(`${sitePage.path}: missing copy-paste API examples: ${missingCodeExamples.join(', ')}`);
         }
 
+        const adapterUploadCode = apiResult.copyableCodeBlocks.find((codeBlock) => codeBlock.includes('/v1/adapters/upload'));
+        if (!adapterUploadCode) {
+          fail(`${sitePage.path}: missing /v1/adapters/upload copy-paste example`);
+        }
+        if (!adapterUploadCode.includes('-f "archive=@default-adapter.tar.gz"')) {
+          fail(`${sitePage.path}: adapter upload example must use multipart field archive for default-adapter.tar.gz`);
+        }
+        if (adapterUploadCode.includes('-f "file=@')) {
+          fail(`${sitePage.path}: adapter upload example uses stale multipart field file; use archive`);
+        }
+
+        const adapterMergeCodeBlocks = apiResult.copyableCodeBlocks.filter((codeBlock) => codeBlock.includes('/v1/adapters/merge'));
+        if (adapterMergeCodeBlocks.length < 2) {
+          fail(`${sitePage.path}: expected TIES and concat /v1/adapters/merge copy-paste examples`);
+        }
+        for (const [index, codeBlock] of adapterMergeCodeBlocks.entries()) {
+          if (!codeBlock.includes('"sources"')) {
+            fail(`${sitePage.path}: adapter merge example ${index + 1} must use sources array`);
+          }
+          if (codeBlock.includes('"adapters"')) {
+            fail(`${sitePage.path}: adapter merge example ${index + 1} uses stale adapters array; use sources`);
+          }
+        }
+
         if (apiResult.copyButtonCount < apiResult.copyableCodeBlocks.length) {
           fail(`${sitePage.path}: expected each API code block to have a copy button; got ${apiResult.copyButtonCount} for ${apiResult.copyableCodeBlocks.length} code blocks`);
         }


### PR DESCRIPTION
## Summary
- Updates the docs-site adapter upload example to use the server's `archive` multipart field while keeping `name=default-copy`.
- Updates the TIES and concat adapter merge examples to use the `sources` request array expected by the server.
- Adds docs-site smoke coverage for stale adapter upload and merge example field names.

## Validation
- `node scripts/check_docs_site_smoke.mjs`