### PR TITLE
[codex] Fix GRPO demo payload path cue

### DIFF
--- a/docs/site/demo/demo-grpo.sh
+++ b/docs/site/demo/demo-grpo.sh
@@ -70,7 +70,7 @@ beat 2.0
 # ------------------------------------------------------------------
 typecmd 'curl -s http://localhost:8420/v1/train/grpo \'
 typecmd '    -H "Content-Type: application/json" \'
-typecmd '    -d @demo-grpo.json \'
+typecmd '    -d @docs/site/demo/demo-grpo.json \'
 typecmd '    | jq -c "{job_id, state}"'
 
 curl -s http://localhost:8420/v1/train/grpo \

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -496,6 +496,19 @@ function validateGrpoOverviewRequestsImports() {
   assertRequestsImportNearPost(indexSection[0], 'docs/site/index.html: The GRPO loop');
 }
 
+function validateGrpoDemoPayloadCue() {
+  const driverPath = 'docs/site/demo/demo-grpo.sh';
+  const driver = readFileSync(resolve(repoRoot, driverPath), 'utf8');
+
+  if (driver.includes('-d @demo-grpo.json')) {
+    fail(`${driverPath}: displayed GRPO curl command must use a repo-root path, not -d @demo-grpo.json`);
+  }
+
+  if (!driver.includes('-d @docs/site/demo/demo-grpo.json')) {
+    fail(`${driverPath}: displayed GRPO curl command must cue docs/site/demo/demo-grpo.json for repo-root copy/paste`);
+  }
+}
+
 function assertRequestsImportNearPost(section, context) {
   const requestPosts = Array.from(section.matchAll(/requests\.post/g));
   if (requestPosts.length === 0) {
@@ -1182,6 +1195,7 @@ async function runSmoke() {
   validateReadmeMedia();
   validateReadmeQuickStartPaths();
   validateGrpoOverviewRequestsImports();
+  validateGrpoDemoPayloadCue();
   validateQuickstartMarkdownMedia();
   validateQuickstartServerBinaryPath();
   validateQuickstartCliReference();


### PR DESCRIPTION
## Summary

- Updates the typed GRPO demo curl scene to use the repo-root-valid `docs/site/demo/demo-grpo.json` payload path.
- Keeps the runtime `GRPO_JSON` execution path unchanged and robust.
- Adds docs-site smoke coverage so the demo driver fails if it regresses to `-d @demo-grpo.json` or drops the repo-root payload cue.

## Validation

- `bash -n docs/site/demo/demo-grpo.sh`
- `node scripts/check_docs_site_smoke.mjs`