### PR TITLE
[codex] Make landing GRPO snippet self-contained

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -380,7 +380,10 @@ curl http://localhost:8420/v1/chat/completions \
         regex, unit tests, another model, human eval.
       </p>
 <pre><code><span style="color:#7f8694"># 1. Generate candidates</span>
+import openai
 import requests
+
+client = openai.OpenAI(base_url="http://localhost:8420/v1", api_key="unused")
 
 responses = [client.chat.completions.create(
     model="qwen3.5-4b-kiln", messages=[...], temperature=0.7

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -494,6 +494,7 @@ function validateGrpoOverviewRequestsImports() {
     fail('docs/site/index.html: missing The GRPO loop section');
   }
   assertRequestsImportNearPost(indexSection[0], 'docs/site/index.html: The GRPO loop');
+  assertOpenAIClientSetupNearChatCreate(indexSection[0], 'docs/site/index.html: The GRPO loop');
 }
 
 function validateGrpoDemoPayloadCue() {
@@ -519,6 +520,23 @@ function assertRequestsImportNearPost(section, context) {
     const nearbyPrefix = section.slice(Math.max(0, requestPost.index - 800), requestPost.index);
     if (!nearbyPrefix.includes('import requests')) {
       fail(`${context}: requests.post must have import requests nearby before use`);
+    }
+  }
+}
+
+function assertOpenAIClientSetupNearChatCreate(section, context) {
+  const chatCreates = Array.from(section.matchAll(/client\.chat\.completions\.create/g));
+  if (chatCreates.length === 0) {
+    fail(`${context}: missing client.chat.completions.create generate call`);
+  }
+
+  for (const chatCreate of chatCreates) {
+    const nearbyPrefix = section.slice(Math.max(0, chatCreate.index - 800), chatCreate.index);
+    if (!nearbyPrefix.includes('import openai')) {
+      fail(`${context}: client.chat.completions.create must have import openai nearby before use`);
+    }
+    if (!nearbyPrefix.includes('openai.OpenAI(base_url="http://localhost:8420/v1", api_key="unused")')) {
+      fail(`${context}: client.chat.completions.create must set OpenAI base_url and api_key nearby before use`);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Adds the OpenAI-compatible client import and setup to the landing page GRPO loop snippet before `client.chat.completions.create`.
- Adds docs-site smoke coverage so the landing GRPO snippet must define an OpenAI client with `base_url="http://localhost:8420/v1"` and `api_key="unused"` before using the client.

## Validation

- `node scripts/check_docs_site_smoke.mjs`