### PR TITLE
[codex] Explain landing desktop version split

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -422,6 +422,7 @@ requests.post("http://localhost:8420/v1/train/grpo",
         <p class="text-sm mb-3" style="color: var(--fg-mute);">
           Prefer the GUI? Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2">Kiln Desktop v0.2.2</a>.
           On first launch, the Desktop App downloads and verifies the matching <code>kiln</code> server binary for you.
+          Desktop and server binaries use separate GitHub release tags/version numbers: <code>desktop-v0.2.2</code> is the latest Desktop release, and it downloads/verifies the latest <code>kiln-v*</code> server binary.
           No Rust toolchain, CUDA toolkit, or Xcode install is required for the GUI path.
         </p>
         <table class="installer-table mb-3" aria-label="Kiln Desktop installer downloads">

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -510,6 +510,24 @@ function validateGrpoDemoPayloadCue() {
   }
 }
 
+function validateLandingDesktopVersionSplitCue() {
+  const index = readFileSync(resolve(repoRoot, 'docs/site/index.html'), 'utf8');
+  const desktopInstallMatch = index.match(/<h3[^>]*>Desktop App[\s\S]*?<\/h3>([\s\S]*?)<table class="installer-table/);
+  if (!desktopInstallMatch) {
+    fail('docs/site/index.html: missing Desktop App install copy');
+  }
+
+  const desktopInstallCopy = desktopInstallMatch[1];
+  const requiredTerms = [
+    'separate GitHub release tags/version numbers',
+    'desktop-v0.2.2',
+    'latest <code>kiln-v*</code>',
+  ];
+  for (const term of requiredTerms) {
+    assertIncludes(desktopInstallCopy, term, 'docs/site/index.html: Desktop App version-split cue');
+  }
+}
+
 function assertRequestsImportNearPost(section, context) {
   const requestPosts = Array.from(section.matchAll(/requests\.post/g));
   if (requestPosts.length === 0) {
@@ -1214,6 +1232,7 @@ async function runSmoke() {
   validateReadmeQuickStartPaths();
   validateGrpoOverviewRequestsImports();
   validateGrpoDemoPayloadCue();
+  validateLandingDesktopVersionSplitCue();
   validateQuickstartMarkdownMedia();
   validateQuickstartServerBinaryPath();
   validateQuickstartCliReference();


### PR DESCRIPTION
## Summary
- Add a compact landing-page note that Desktop and server binaries intentionally use separate release tags/version numbers.
- Add docs-site smoke coverage for the Desktop App install copy so the version-split cue stays near the installer recommendation.

## Validation
- `node scripts/check_docs_site_smoke.mjs`