### PR TITLE
[codex] Clarify adapters list API semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ On Apple Silicon, model weights, KV cache, and training state all live in unifie
 | GET | `/v1/train/status/{job_id}` | Inspect one training job |
 | GET | `/v1/train/queue` | List queued training jobs |
 | DELETE | `/v1/train/queue/{job_id}` | Cancel a queued job |
-| GET | `/v1/adapters` | List loaded LoRA adapters |
+| GET | `/v1/adapters` | List saved/available LoRA adapters and identify the active adapter |
 | POST | `/v1/adapters/load` | Load adapter from disk |
 | POST | `/v1/adapters/unload` | Unload active adapter |
 | DELETE | `/v1/adapters/{name}` | Delete an adapter |

--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -441,7 +441,7 @@ kiln serve --config kiln.toml</code></pre>
         <div class="label mb-3">Adapters</div>
         <h2 id="lora-lifecycle" class="text-2xl font-semibold mb-4">LoRA lifecycle</h2>
         <div class="endpoint-list" style="color: var(--fg-dim);">
-          <div class="endpoint"><span class="method">GET</span> <code>/v1/adapters</code> &mdash; list loaded LoRA adapters.</div>
+          <div class="endpoint"><span class="method">GET</span> <code>/v1/adapters</code> &mdash; list saved/available LoRA adapters and identify the active adapter.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/adapters/load</code> &mdash; load an adapter from disk.</div>
           <div class="endpoint"><span class="method">POST</span> <code>/v1/adapters/unload</code> &mdash; unload the active adapter.</div>
           <div class="endpoint"><span class="method">DELETE</span> <code>/v1/adapters/{name}</code> &mdash; delete an adapter.</div>

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -148,6 +148,15 @@ const expectedApiEndpoints = [
 ];
 
 const staleTrainingJobEndpoint = '/v1/train/jobs/{job_id}';
+const staleAdapterListPhrases = [
+  'List loaded LoRA adapters',
+  'list loaded LoRA adapters',
+  'loaded LoRA adapters',
+];
+const expectedAdapterListSemantics = [
+  'saved/available LoRA adapters',
+  'active adapter',
+];
 
 const expectedApiSections = [
   { label: 'server status', terms: ['server status'] },
@@ -506,6 +515,24 @@ function validateReadmeQuickStartPaths() {
   }
   if (!/QUICKSTART\.md#quick-path-server-binary-terminal-first-no-source-build/.test(serverBinaryPath)) {
     fail('README.md: Server binary path must link to QUICKSTART.md full artifact matrix');
+  }
+}
+
+function validateReadmeAdapterListSemantics() {
+  const readme = readFileSync(resolve(repoRoot, 'README.md'), 'utf8');
+  const adaptersRow = readme
+    .split('\n')
+    .find((line) => line.includes('`/v1/adapters`'));
+  if (!adaptersRow) {
+    fail('README.md: missing GET /v1/adapters API table row');
+  }
+  for (const phrase of staleAdapterListPhrases) {
+    if (readme.includes(phrase)) {
+      fail(`README.md: GET /v1/adapters wording must not say "${phrase}"`);
+    }
+  }
+  for (const term of expectedAdapterListSemantics) {
+    assertIncludes(adaptersRow, term, 'README.md: GET /v1/adapters saved/active semantics');
   }
 }
 
@@ -1281,6 +1308,7 @@ async function runSmoke() {
   validateReadmeStartupBanner();
   validateReadmeMedia();
   validateReadmeQuickStartPaths();
+  validateReadmeAdapterListSemantics();
   validateGrpoOverviewRequestsImports();
   validateGrpoDemoPayloadCue();
   validateLandingDesktopVersionSplitCue();
@@ -1465,8 +1493,11 @@ async function runSmoke() {
           const endpointText = normalize(Array.from(document.querySelectorAll('.endpoint, code'))
             .map((element) => element.textContent || '')
             .join('\n'));
-          const endpointRoutes = Array.from(document.querySelectorAll('.endpoint'))
+          const endpointElements = Array.from(document.querySelectorAll('.endpoint'));
+          const endpointRoutes = endpointElements
             .map((element) => normalize(element.querySelector('code')?.textContent || ''));
+          const endpointDescriptions = endpointElements
+            .map((element) => normalize(element.textContent || ''));
           const headings = normalize(Array.from(document.querySelectorAll('h2, h3'))
             .map((heading) => heading.textContent || '')
             .join('\n'));
@@ -1478,6 +1509,7 @@ async function runSmoke() {
             bodyText,
             endpointText,
             endpointRoutes,
+            endpointDescriptions,
             headings,
             copyableCodeBlocks,
             copyButtonCount: copyButtons.length,
@@ -1502,6 +1534,22 @@ async function runSmoke() {
           && !apiResult.bodyText.includes(`no separate ${normalizedStaleEndpoint} route`)
         ) {
           fail(`${sitePage.path}: stale route ${staleTrainingJobEndpoint} must appear only in explicit negative wording`);
+        }
+
+        for (const phrase of staleAdapterListPhrases) {
+          if (apiResult.bodyText.includes(phrase.toLowerCase())) {
+            fail(`${sitePage.path}: GET /v1/adapters wording must not say "${phrase}"`);
+          }
+        }
+        const adaptersEndpoint = apiResult.endpointDescriptions
+          .find((line) => line.startsWith('get /v1/adapters ')) || '';
+        if (!adaptersEndpoint) {
+          fail(`${sitePage.path}: missing GET /v1/adapters endpoint wording`);
+        }
+        for (const term of expectedAdapterListSemantics) {
+          if (!adaptersEndpoint.includes(term.toLowerCase())) {
+            fail(`${sitePage.path}: GET /v1/adapters wording missing ${term}`);
+          }
         }
 
         const missingSections = expectedApiSections


### PR DESCRIPTION
## Summary
- Clarifies `GET /v1/adapters` in `README.md` and `docs/site/api.html` as listing saved/available adapters and identifying the active adapter.
- Adds docs-site smoke coverage to prevent regressing that endpoint wording back to loaded-only semantics.

## Validation
- `node scripts/check_docs_site_smoke.mjs`
- `rg -n "List loaded LoRA adapters|list loaded LoRA adapters|loaded LoRA adapters" README.md docs/site/api.html` returned no matches