### PR TITLE
[codex] Align adapter list wording

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -325,7 +325,7 @@ curl -s http://localhost:8420/v1/train/status | python3 -m json.tool
 ## 8. Manage Adapters
 
 ```bash
-# List loaded adapters
+# List saved/available adapters and show active adapter status
 ./target/release/kiln adapters list
 
 # Unload the active adapter (revert to base model)

--- a/crates/kiln-server/src/api/adapters.rs
+++ b/crates/kiln-server/src/api/adapters.rs
@@ -73,7 +73,7 @@ struct DeleteAdapterResponse {
     name: String,
 }
 
-/// List loaded and available adapters.
+/// List saved/available adapters and identify the active adapter.
 async fn list_adapters(State(state): State<AppState>) -> Json<AdaptersResponse> {
     // Read the active adapter name from shared state.
     let active = state.active_adapter_name.read().unwrap().clone();

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -149,9 +149,17 @@ const expectedApiEndpoints = [
 
 const staleTrainingJobEndpoint = '/v1/train/jobs/{job_id}';
 const staleAdapterListPhrases = [
+  'List loaded adapters',
+  'List loaded and available adapters',
   'List loaded LoRA adapters',
   'list loaded LoRA adapters',
   'loaded LoRA adapters',
+];
+const adapterListStaleWordingSurfaces = [
+  'README.md',
+  'QUICKSTART.md',
+  'docs/site/api.html',
+  'crates/kiln-server/src/api/adapters.rs',
 ];
 const expectedAdapterListSemantics = [
   'saved/available LoRA adapters',
@@ -533,6 +541,17 @@ function validateReadmeAdapterListSemantics() {
   }
   for (const term of expectedAdapterListSemantics) {
     assertIncludes(adaptersRow, term, 'README.md: GET /v1/adapters saved/active semantics');
+  }
+}
+
+function validateAdapterListStaleWordingSurfaces() {
+  for (const filePath of adapterListStaleWordingSurfaces) {
+    const contents = readFileSync(resolve(repoRoot, filePath), 'utf8');
+    for (const phrase of staleAdapterListPhrases) {
+      if (contents.includes(phrase)) {
+        fail(`${filePath}: adapter-list wording must not say \"${phrase}\"`);
+      }
+    }
   }
 }
 
@@ -1308,6 +1327,7 @@ async function runSmoke() {
   validateReadmeStartupBanner();
   validateReadmeMedia();
   validateReadmeQuickStartPaths();
+  validateAdapterListStaleWordingSurfaces();
   validateReadmeAdapterListSemantics();
   validateGrpoOverviewRequestsImports();
   validateGrpoDemoPayloadCue();


### PR DESCRIPTION
## Summary
- Updates the Quickstart adapter-list comment to describe saved/available adapters and active adapter status.
- Updates the `list_adapters` handler doc comment to match the actual response semantics.
- Extends the docs smoke guard to catch stale loaded-only adapter-list wording in onboarding/API surfaces.

## Validation
- `node scripts/check_docs_site_smoke.mjs`
- `rg -n "List loaded adapters|List loaded and available adapters" QUICKSTART.md crates/kiln-server/src/api/adapters.rs README.md docs/site/api.html` (no matches)