### PR TITLE
[codex] Let demo scripts use release binary paths

### DIFF
--- a/docs/site/demo/SCRIPT.md
+++ b/docs/site/demo/SCRIPT.md
@@ -17,7 +17,7 @@ The companion file [`README.md`](README.md) inventories the full six-cast demo s
 
 Get the host into this exact state **before** opening `asciinema`. Do not include any of these in the recording itself.
 
-- Kiln binary built at `./target/release/kiln` (release mode, `--features cuda` on Linux/Windows or `--features metal` on macOS). See [`QUICKSTART.md` §1](../../../QUICKSTART.md).
+- Kiln binary available through `KILN_BIN`. It defaults to `./target/release/kiln`, but can point at an extracted release artifact or a source-built release binary (`--features cuda` on Linux/Windows or `--features metal` on macOS). See [`QUICKSTART.md` §1](../../../QUICKSTART.md).
 - Model weights at `./Qwen3.5-4B/` (downloaded via `huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B`). See [`QUICKSTART.md` §2](../../../QUICKSTART.md).
 - A clean shell working dir at the kiln repo root.
 - `asciinema` 2.4 or newer installed (`asciinema --version`). On Linux: `pip install asciinema` or distro package; on macOS: `brew install asciinema`.
@@ -30,7 +30,8 @@ Pre-recording dry run:
 
 ```bash
 # Sanity check: server starts cleanly and serves a base-model completion.
-KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve --config kiln.example.toml &
+KILN_BIN=${KILN_BIN:-./target/release/kiln}
+KILN_MODEL_PATH=./Qwen3.5-4B "$KILN_BIN" serve --config kiln.example.toml &
 sleep 30  # model load + warmup
 curl -s http://localhost:8420/v1/chat/completions \
   -H 'Content-Type: application/json' \
@@ -51,7 +52,8 @@ The cumulative time budget on the right is wall-clock seconds elapsed at the **e
 Type:
 
 ```bash
-$ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve --config kiln.example.toml
+$ KILN_BIN=${KILN_BIN:-./target/release/kiln}
+$ KILN_MODEL_PATH=./Qwen3.5-4B "$KILN_BIN" serve --config kiln.example.toml
 ```
 
 Expected on-screen output (abbreviated by the asciicast — let it scroll naturally for ~8s, then the listen line lands):

--- a/docs/site/demo/SCRIPTS.md
+++ b/docs/site/demo/SCRIPTS.md
@@ -7,8 +7,9 @@ original 60-second online-learning loop in detail; this file covers the
 full six-cast recording matrix as a single playlist.
 
 Recording target for every cast: **120 columns × 32 rows**, `xterm-256color`,
-`asciinema rec --idle-time-limit 2`, captured on a RunPod A6000 with the
-release-mode CUDA build of `kiln`.
+`asciinema rec --idle-time-limit 2`, captured on a RunPod A6000 with a
+release-mode CUDA build of `kiln`, either from `./target/release` or an
+extracted release artifact selected via the binary path overrides below.
 
 | File | Driver | Runtime | Story |
 |---|---|---|---|
@@ -27,8 +28,12 @@ play them in sequence.
 
 Same baseline as the canonical 60-second cast:
 
-- `./target/release/kiln` and `./target/release/kiln-bench` built with
-  `--features cuda`.
+- `KILN_BIN` points at the server binary. It defaults to
+  `./target/release/kiln`, but can also point at an extracted release
+  artifact, for example `KILN_BIN=./kiln-release/kiln`.
+- `KILN_BENCH_BIN` points at the benchmark binary. It defaults to
+  `./target/release/kiln-bench`, but can likewise point at an extracted
+  release artifact or a source-built `target/release/kiln-bench`.
 - Model weights at `./Qwen3.5-4B/` (override with `KILN_MODEL_PATH`).
 - `kiln.example.toml` at the repo root, with `inference_memory_fraction`
   ≈ 0.4 so the trainer can grab scratch space alongside the inference

--- a/docs/site/demo/demo-bench.sh
+++ b/docs/site/demo/demo-bench.sh
@@ -11,13 +11,16 @@
 #     --command ./docs/site/demo/demo-bench.sh
 #
 # Prerequisites:
-#   - ./target/release/kiln-bench built with --features cuda
+#   - kiln-bench at ./target/release/kiln-bench by default; override
+#     KILN_BENCH_BIN to use an extracted release artifact or another
+#     source-built binary.
 #   - ./Qwen3.5-4B/ weights (override with KILN_MODEL_PATH)
 #   - kiln.example.toml exists at the repo root
 
 set -e
 
 export KILN_MODEL_PATH="${KILN_MODEL_PATH:-./Qwen3.5-4B}"
+KILN_BENCH_BIN="${KILN_BENCH_BIN:-./target/release/kiln-bench}"
 
 typecmd() {
     local cmd="$1"
@@ -36,10 +39,10 @@ beat() { sleep "$1"; }
 # ------------------------------------------------------------------
 # Scene 1 — Defaults: clean output, structured headers, summary table
 # ------------------------------------------------------------------
-typecmd './target/release/kiln-bench --model-path ./Qwen3.5-4B --paged --skip-training \'
+typecmd "${KILN_BENCH_BIN} --model-path ${KILN_MODEL_PATH} --paged --skip-training \\"
 typecmd '    --prompt-tokens 256 --max-output-tokens 64'
 
-./target/release/kiln-bench --model-path ./Qwen3.5-4B --paged --skip-training \
+"${KILN_BENCH_BIN}" --model-path "${KILN_MODEL_PATH}" --paged --skip-training \
     --prompt-tokens 256 --max-output-tokens 64
 
 beat 2.0
@@ -48,10 +51,10 @@ beat 2.0
 # Scene 2 — Same run with -v: structured tracing for CI / log aggregators
 # ------------------------------------------------------------------
 typecmd '# Same flags, with -v: structured tracing for CI + log scrapers.'
-typecmd './target/release/kiln-bench -v --model-path ./Qwen3.5-4B --paged --skip-training \'
+typecmd "${KILN_BENCH_BIN} -v --model-path ${KILN_MODEL_PATH} --paged --skip-training \\"
 typecmd '    --prompt-tokens 256 --max-output-tokens 32 2>&1 | head -20'
 
-./target/release/kiln-bench -v --model-path ./Qwen3.5-4B --paged --skip-training \
+"${KILN_BENCH_BIN}" -v --model-path "${KILN_MODEL_PATH}" --paged --skip-training \
     --prompt-tokens 256 --max-output-tokens 32 2>&1 | head -20
 
 beat 2.0

--- a/docs/site/demo/demo-first-token.sh
+++ b/docs/site/demo/demo-first-token.sh
@@ -11,13 +11,15 @@
 #     --command ./docs/site/demo/demo-first-token.sh
 #
 # Prerequisites:
-#   - ./target/release/kiln binary (--features cuda)
+#   - Kiln binary at ./target/release/kiln by default; override KILN_BIN to use
+#     an extracted release artifact or another source-built binary.
 #   - ./Qwen3.5-4B/ weights
 #   - kiln.example.toml at the repo root
 
 set -e
 
 export KILN_MODEL_PATH="${KILN_MODEL_PATH:-./Qwen3.5-4B}"
+KILN_BIN="${KILN_BIN:-./target/release/kiln}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 STREAM_PARSER="${SCRIPT_DIR}/demo-stream-parser.py"
@@ -39,10 +41,10 @@ beat() { sleep "$1"; }
 # ------------------------------------------------------------------
 # Scene 1 — Boot. The new structured banner + spinner + ready line.
 # ------------------------------------------------------------------
-typecmd './target/release/kiln serve --config kiln.example.toml &'
+typecmd "${KILN_BIN} serve --config kiln.example.toml &"
 
 # Server logs redirected to a file so they don't bleed into the asciinema TTY.
-./target/release/kiln serve --config kiln.example.toml >/tmp/kiln-first-token.log 2>&1 &
+"${KILN_BIN}" serve --config kiln.example.toml >/tmp/kiln-first-token.log 2>&1 &
 SRV_PID=$!
 
 for i in $(seq 1 180); do

--- a/docs/site/demo/demo-grpo.sh
+++ b/docs/site/demo/demo-grpo.sh
@@ -12,13 +12,16 @@
 #     --command ./docs/site/demo/demo-grpo.sh
 #
 # Prerequisites:
-#   - ./target/release/kiln (--features cuda) + ./Qwen3.5-4B/
+#   - Kiln binary at ./target/release/kiln by default; override KILN_BIN to use
+#     an extracted release artifact or another source-built binary.
+#   - ./Qwen3.5-4B/ weights (override with KILN_MODEL_PATH)
 #   - kiln.example.toml with `inference_memory_fraction` ~0.4 so the trainer
 #     can grab scratch space alongside the inference KV cache.
 
 set -e
 
 export KILN_MODEL_PATH="${KILN_MODEL_PATH:-./Qwen3.5-4B}"
+KILN_BIN="${KILN_BIN:-./target/release/kiln}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 GRPO_JSON="${SCRIPT_DIR}/demo-grpo.json"
@@ -40,10 +43,10 @@ beat() { sleep "$1"; }
 # ------------------------------------------------------------------
 # Scene 1 — Boot kiln. Banner + spinner + ready.
 # ------------------------------------------------------------------
-typecmd './target/release/kiln serve --config kiln.example.toml &'
+typecmd "${KILN_BIN} serve --config kiln.example.toml &"
 
 # Server logs redirected to a file so they don't bleed into the asciinema TTY.
-./target/release/kiln serve --config kiln.example.toml >/tmp/kiln-grpo.log 2>&1 &
+"${KILN_BIN}" serve --config kiln.example.toml >/tmp/kiln-grpo.log 2>&1 &
 SRV_PID=$!
 
 for i in $(seq 1 180); do

--- a/docs/site/demo/demo-hot-swap.sh
+++ b/docs/site/demo/demo-hot-swap.sh
@@ -11,7 +11,9 @@
 #     --command ./docs/site/demo/demo-hot-swap.sh
 #
 # Prerequisites:
-#   - ./target/release/kiln (--features cuda) + ./Qwen3.5-4B/
+#   - Kiln binary at ./target/release/kiln by default; override KILN_BIN to use
+#     an extracted release artifact or another source-built binary.
+#   - ./Qwen3.5-4B/ weights (override with KILN_MODEL_PATH)
 #   - kiln.example.toml at the repo root
 #   - Two adapters PRE-STAGED on disk under ./adapters/:
 #         ./adapters/demo/      — kiln-as-software answer (from demo-sft.json)
@@ -22,6 +24,7 @@
 set -e
 
 export KILN_MODEL_PATH="${KILN_MODEL_PATH:-./Qwen3.5-4B}"
+KILN_BIN="${KILN_BIN:-./target/release/kiln}"
 
 typecmd() {
     local cmd="$1"
@@ -40,10 +43,10 @@ beat() { sleep "$1"; }
 # ------------------------------------------------------------------
 # Scene 1 — Boot kiln. The new structured banner + ready line.
 # ------------------------------------------------------------------
-typecmd './target/release/kiln serve --config kiln.example.toml &'
+typecmd "${KILN_BIN} serve --config kiln.example.toml &"
 
 # Server logs redirected to a file so they don't bleed into the asciinema TTY.
-./target/release/kiln serve --config kiln.example.toml >/tmp/kiln-hotswap.log 2>&1 &
+"${KILN_BIN}" serve --config kiln.example.toml >/tmp/kiln-hotswap.log 2>&1 &
 SRV_PID=$!
 
 for i in $(seq 1 180); do

--- a/docs/site/demo/demo-openai.sh
+++ b/docs/site/demo/demo-openai.sh
@@ -12,13 +12,16 @@
 #     --command ./docs/site/demo/demo-openai.sh
 #
 # Prerequisites:
-#   - ./target/release/kiln (--features cuda) + ./Qwen3.5-4B/
+#   - Kiln binary at ./target/release/kiln by default; override KILN_BIN to use
+#     an extracted release artifact or another source-built binary.
+#   - ./Qwen3.5-4B/ weights (override with KILN_MODEL_PATH)
 #   - kiln.example.toml at the repo root
 #   - Python 3.10+ with `openai` installed: `pip install openai`
 
 set -e
 
 export KILN_MODEL_PATH="${KILN_MODEL_PATH:-./Qwen3.5-4B}"
+KILN_BIN="${KILN_BIN:-./target/release/kiln}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OPENAI_SCRIPT="${SCRIPT_DIR}/demo-openai.py"
@@ -40,10 +43,10 @@ beat() { sleep "$1"; }
 # ------------------------------------------------------------------
 # Scene 1 — Boot kiln. Standard new banner.
 # ------------------------------------------------------------------
-typecmd './target/release/kiln serve --config kiln.example.toml &'
+typecmd "${KILN_BIN} serve --config kiln.example.toml &"
 
 # Server logs redirected to a file so they don't bleed into the asciinema TTY.
-./target/release/kiln serve --config kiln.example.toml >/tmp/kiln-openai.log 2>&1 &
+"${KILN_BIN}" serve --config kiln.example.toml >/tmp/kiln-openai.log 2>&1 &
 SRV_PID=$!
 
 for i in $(seq 1 180); do

--- a/docs/site/demo/demo.sh
+++ b/docs/site/demo/demo.sh
@@ -10,7 +10,8 @@
 #     --command ./docs/site/demo/demo.sh
 #
 # Prerequisites:
-#   - Kiln binary built at ./target/release/kiln (release mode, --features cuda).
+#   - Kiln binary at ./target/release/kiln by default; override KILN_BIN to use
+#     an extracted release artifact or another source-built binary.
 #   - Model weights at ./Qwen3.5-4B/ (override with KILN_MODEL_PATH if elsewhere).
 #   - The chat template disables thinking-mode by default — Qwen3.5-4B will otherwise
 #     emit reasoning into a separate `reasoning_content` field and Scene 2/5 read empty.
@@ -35,6 +36,7 @@ set -e
 
 # Default to ./Qwen3.5-4B but allow override.
 export KILN_MODEL_PATH="${KILN_MODEL_PATH:-./Qwen3.5-4B}"
+KILN_BIN="${KILN_BIN:-./target/release/kiln}"
 
 # Resolve the directory this script lives in so we can find demo-sft.json next to it.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -59,10 +61,10 @@ beat() { sleep "$1"; }
 # ------------------------------------------------------------------
 # Scene 1 — Cold start
 # ------------------------------------------------------------------
-typecmd 'KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve --config kiln.example.toml &'
+typecmd "KILN_MODEL_PATH=${KILN_MODEL_PATH} ${KILN_BIN} serve --config kiln.example.toml &"
 
 # Server logs redirected to a file so they don't bleed into the asciinema TTY.
-./target/release/kiln serve --config kiln.example.toml >/tmp/kiln-demo.log 2>&1 &
+"${KILN_BIN}" serve --config kiln.example.toml >/tmp/kiln-demo.log 2>&1 &
 SRV_PID=$!
 
 # Wait for /health, capped so the recording cannot hang on a broken build.

--- a/docs/site/demo/prep-hot-swap.sh
+++ b/docs/site/demo/prep-hot-swap.sh
@@ -10,12 +10,13 @@
 set -e
 
 export KILN_MODEL_PATH="${KILN_MODEL_PATH:-./Qwen3.5-4B}"
+KILN_BIN="${KILN_BIN:-./target/release/kiln}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DEMO_SFT="${SCRIPT_DIR}/demo-sft.json"
 FORMAL_SFT="${SCRIPT_DIR}/demo-sft-formal.json"
 
-./target/release/kiln serve --config kiln.example.toml >/tmp/kiln-prep.log 2>&1 &
+"${KILN_BIN}" serve --config kiln.example.toml >/tmp/kiln-prep.log 2>&1 &
 SRV_PID=$!
 trap 'kill -TERM "$SRV_PID" 2>/dev/null || true; wait "$SRV_PID" 2>/dev/null || true' EXIT
 


### PR DESCRIPTION
## Summary
- Add `KILN_BIN` defaults to demo server drivers so maintainers can run recordings from source-built or extracted release binaries.
- Add `KILN_BENCH_BIN` to the benchmark demo driver.
- Update demo recording notes, including the legacy 60-second script, to describe release-artifact binary overrides.

## Validation
- `bash -n docs/site/demo/demo.sh docs/site/demo/demo-first-token.sh docs/site/demo/demo-openai.sh docs/site/demo/demo-hot-swap.sh docs/site/demo/demo-grpo.sh docs/site/demo/prep-hot-swap.sh docs/site/demo/demo-bench.sh`
- `node scripts/check_docs_site_smoke.mjs`
- `rg -n ./target/release/kiln docs/site/demo/*.sh docs/site/demo/*.md`