### PR TITLE
[codex] Add CLI canonical smoke guard

### DIFF
--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Kiln CLI Reference &mdash; Server, training, and adapters</title>
   <meta name="description" content="A concise command-line reference for running Kiln, checking health, submitting SFT or GRPO jobs, and managing LoRA adapters.">
+  <link rel="canonical" href="https://ericflo.github.io/kiln/cli.html">
   <link rel="icon" href="assets/logo.png">
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -1006,6 +1006,33 @@ function resolveLocalHref(sourceHtmlPath, href) {
   return resolvedPath;
 }
 
+function expectedCanonicalHref(localPath) {
+  const siteRelativePath = localPath.replace(/^docs\/site\//, '');
+  if (siteRelativePath === 'index.html') return 'https://ericflo.github.io/kiln/';
+  if (siteRelativePath === 'demo/index.html') return 'https://ericflo.github.io/kiln/demo/';
+  return `https://ericflo.github.io/kiln/${siteRelativePath}`;
+}
+
+function validateDocsSiteCanonicalLinks() {
+  for (const sitePage of pages) {
+    const pagePath = resolve(repoRoot, sitePage.path);
+    const html = readFileSync(pagePath, 'utf8');
+    const canonicalMatches = Array.from(html.matchAll(/<link\b[^>]*\brel\s*=\s*(?:"canonical"|'canonical'|canonical)[^>]*>/gi));
+
+    if (canonicalMatches.length !== 1) {
+      fail(`${sitePage.path}: expected exactly one canonical link, found ${canonicalMatches.length}`);
+    }
+
+    const canonicalTag = canonicalMatches[0][0];
+    const hrefMatch = canonicalTag.match(/\bhref\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/i);
+    const href = decodeHtmlAttribute(hrefMatch?.[1] ?? hrefMatch?.[2] ?? hrefMatch?.[3] ?? '').trim();
+    const expectedHref = expectedCanonicalHref(sitePage.path);
+    if (href !== expectedHref) {
+      fail(`${sitePage.path}: canonical href must be ${expectedHref}, found ${href || '(missing)'}`);
+    }
+  }
+}
+
 function validateDocsSiteLocalLinks() {
   for (const sitePage of pages) {
     const pagePath = resolve(repoRoot, sitePage.path);
@@ -1340,6 +1367,7 @@ async function runSmoke() {
   validateCliHelpOnboardingCopy();
   validateLaunchSentinel();
   validateDemoReadmeInventory();
+  validateDocsSiteCanonicalLinks();
   validateDocsSiteLocalLinks();
   validateMarkdownLocalLinks();
 


### PR DESCRIPTION
## Summary
- Add the missing canonical link for `docs/site/cli.html`.
- Extend the docs-site smoke script to require exactly one canonical link per enumerated docs page.
- Derive expected public URLs for standard pages, the landing page, and `demo/`.

## Validation
- `node scripts/check_docs_site_smoke.mjs`
- `rg -n 'rel="canonical"|canonical' docs/site/cli.html scripts/check_docs_site_smoke.mjs`
- `gh pr list -R ericflo/kiln --limit 10 --state all`