### PR TITLE
[codex] Guard embedded UI accessible controls

### DIFF
--- a/crates/kiln-server/src/ui.html
+++ b/crates/kiln-server/src/ui.html
@@ -897,11 +897,12 @@ textarea { resize: vertical; min-height: 80px; }
       </div>
       <div class="chat-input-row">
         <label for="chat-input" style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;">Message</label>
-        <input type="text" id="chat-input" placeholder="Type a message...">
+        <input type="text" id="chat-input" placeholder="Type a message..." aria-describedby="chat-input-help">
         <button type="button" class="btn btn-primary" id="chat-send">Send</button>
         <button type="button" class="btn" id="chat-stop" disabled hidden>Stop</button>
         <button type="button" class="btn" id="chat-clear">Clear</button>
       </div>
+      <div class="form-help" id="chat-input-help">Type a quick prompt to test the selected adapter or base model.</div>
     </div>
   </div>
 </main>

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -52,6 +52,18 @@ const expectedEmbeddedUiHelpLinks = [
   { label: 'Architecture', href: 'https://ericflo.github.io/kiln/architecture.html' },
 ];
 
+const expectedEmbeddedUiAccessibleControls = [
+  { selector: '#chat-input', labelTerms: ['message'], descriptionTerms: ['quick prompt', 'selected adapter', 'base model'] },
+  { selector: '#chat-send', labelTerms: ['send'] },
+  { selector: '#chat-stop', labelTerms: ['stop'] },
+  { selector: '#chat-clear', labelTerms: ['clear'] },
+  { selector: '#sft-examples', labelTerms: ['training examples'], descriptionTerms: ['json array', 'messages'] },
+  { selector: '#grpo-groups', labelTerms: ['grpo groups'], descriptionTerms: ['json array', 'completions', 'reward'] },
+  { selector: '#upload-name', labelTerms: ['adapter name'], descriptionTerms: ['adapter archive', 'saved adapter directory'] },
+  { selector: '#upload-archive', labelTerms: ['adapter archive'], descriptionTerms: ['adapter archive', '.tar.gz'] },
+  { selector: '#merge-output-name', labelTerms: ['output name'], descriptionTerms: ['saved adapter name', 'path-safe'] },
+];
+
 const demoPagePath = 'docs/site/demo/index.html';
 const quickstartPagePath = 'docs/site/quickstart.html';
 const apiPagePath = 'docs/site/api.html';
@@ -399,6 +411,82 @@ function validateEmbeddedUiHelpLinks() {
   });
   if (missingLinks.length > 0) {
     fail(`crates/kiln-server/src/ui.html: embedded UI help nav missing links: ${missingLinks.map(({ label }) => label).join(', ')}`);
+  }
+}
+
+async function validateEmbeddedUiControlAccessibleNames(browser) {
+  const uiPath = resolve(repoRoot, 'crates/kiln-server/src/ui.html');
+  const page = await browser.newPage();
+  await page.goto(pathToFileURL(uiPath).href, { waitUntil: 'domcontentloaded', timeout: 10000 });
+
+  try {
+    const result = await page.evaluate((expectedControls) => {
+      const normalize = (value) => (value || '').replace(/\s+/g, ' ').trim().toLowerCase();
+      const byIdText = (id) => normalize(document.getElementById(id)?.textContent || '');
+      const labelTextFor = (element) => {
+        const explicitLabels = element.id
+          ? Array.from(document.querySelectorAll(`label[for="${CSS.escape(element.id)}"]`))
+          : [];
+        const implicitLabel = element.closest('label');
+        return normalize([
+          ...explicitLabels.map((label) => label.textContent || ''),
+          implicitLabel?.textContent || '',
+        ].join(' '));
+      };
+      const referencedText = (element, attribute) => normalize(
+        (element.getAttribute(attribute) || '')
+          .split(/\s+/)
+          .filter(Boolean)
+          .map(byIdText)
+          .join(' '),
+      );
+      const accessibleName = (element) => normalize([
+        element.getAttribute('aria-label') || '',
+        referencedText(element, 'aria-labelledby'),
+        labelTextFor(element),
+        element.tagName === 'BUTTON' ? element.textContent || '' : '',
+      ].join(' '));
+      const accessibleDescription = (element) => referencedText(element, 'aria-describedby');
+
+      return expectedControls.map((control) => {
+        const element = document.querySelector(control.selector);
+        if (!element) {
+          return { selector: control.selector, missing: true };
+        }
+
+        const name = accessibleName(element);
+        const description = accessibleDescription(element);
+        return {
+          selector: control.selector,
+          name,
+          description,
+          missingLabelTerms: control.labelTerms.filter((term) => !name.includes(term)),
+          missingDescriptionTerms: (control.descriptionTerms || [])
+            .filter((term) => !description.includes(term)),
+        };
+      });
+    }, expectedEmbeddedUiAccessibleControls);
+
+    const missingControls = result.filter((control) => control.missing).map((control) => control.selector);
+    if (missingControls.length > 0) {
+      fail(`crates/kiln-server/src/ui.html: missing embedded UI controls: ${missingControls.join(', ')}`);
+    }
+
+    const unnamedControls = result
+      .filter((control) => control.missingLabelTerms?.length > 0)
+      .map((control) => `${control.selector} missing label terms ${control.missingLabelTerms.join(', ')}`);
+    if (unnamedControls.length > 0) {
+      fail(`crates/kiln-server/src/ui.html: embedded UI controls need accessible names: ${unnamedControls.join('; ')}`);
+    }
+
+    const undescribedControls = result
+      .filter((control) => control.missingDescriptionTerms?.length > 0)
+      .map((control) => `${control.selector} missing description terms ${control.missingDescriptionTerms.join(', ')}`);
+    if (undescribedControls.length > 0) {
+      fail(`crates/kiln-server/src/ui.html: embedded UI controls need aria-describedby help text: ${undescribedControls.join('; ')}`);
+    }
+  } finally {
+    await page.close();
   }
 }
 
@@ -1379,6 +1467,8 @@ async function runSmoke() {
   });
 
   try {
+    await validateEmbeddedUiControlAccessibleNames(browser);
+
     const page = await browser.newPage();
     await page.setViewport({ width: 390, height: 844, deviceScaleFactor: 2, isMobile: true });
 


### PR DESCRIPTION
## Summary
- Add a Puppeteer-backed smoke guard for accessible names and `aria-describedby` help text on first-touch embedded `/ui` controls.
- Cover Quick Inference, SFT, GRPO, adapter upload, and adapter merge controls by selector.
- Add a minimal `chat-input` description so the Quick Inference message field has explicit help text.

## Validation
- `node scripts/check_docs_site_smoke.mjs`
- `rg -n 'validate.*Ui|chat-input|sft-examples|grpo-groups|upload-archive|merge-output-name' scripts/check_docs_site_smoke.mjs crates/kiln-server/src/ui.html`
- `gh pr list -R ericflo/kiln --limit 10 --state all`