### PR TITLE
[codex] Guard demo cast JSONL smoke

### DIFF
--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -1434,6 +1434,66 @@ function validateDemoCasts(sitePagePath, referencedCasts) {
       fail(`${sitePagePath}: referenced demo cast does not exist: ${cast}`);
     }
   }
+
+  for (const cast of expectedDemoCastFiles) {
+    validateDemoCastContent(demoDir, cast);
+  }
+}
+
+function parseDemoCastJsonLine(castPath, line, lineNumber) {
+  try {
+    return JSON.parse(line);
+  } catch (error) {
+    fail(`${castPath}: line ${lineNumber} is not valid JSON: ${error.message}`);
+  }
+}
+
+function validateDemoCastContent(demoDir, cast) {
+  const castPath = resolve(demoDir, cast);
+  const castDisplayPath = relative(repoRoot, castPath).split(sep).join('/');
+  const lines = readFileSync(castPath, 'utf8').trimEnd().split(/\r?\n/);
+
+  if (lines.length === 0 || lines[0].trim() === '') {
+    fail(`${castDisplayPath}: missing asciinema v2 header row`);
+  }
+
+  const header = parseDemoCastJsonLine(castDisplayPath, lines[0], 1);
+  if (!header || Array.isArray(header) || typeof header !== 'object') {
+    fail(`${castDisplayPath}: header row must be a JSON object`);
+  }
+  if (header.version !== 2) {
+    fail(`${castDisplayPath}: header version must be 2, got ${JSON.stringify(header.version)}`);
+  }
+  if (header.width !== 120) {
+    fail(`${castDisplayPath}: header width must be 120, got ${JSON.stringify(header.width)}`);
+  }
+  if (header.height !== 32) {
+    fail(`${castDisplayPath}: header height must be 32, got ${JSON.stringify(header.height)}`);
+  }
+  if (typeof header.title !== 'string' || header.title.trim() === '') {
+    fail(`${castDisplayPath}: header title must be a non-empty string`);
+  }
+
+  const eventLines = lines.slice(1).filter((line) => line.trim() !== '');
+  if (eventLines.length === 0) {
+    fail(`${castDisplayPath}: missing asciinema JSONL event rows`);
+  }
+
+  let hasOutputEvent = false;
+  for (const [eventIndex, eventLine] of eventLines.entries()) {
+    const lineNumber = eventIndex + 2;
+    const event = parseDemoCastJsonLine(castDisplayPath, eventLine, lineNumber);
+    if (!Array.isArray(event) || typeof event[0] !== 'number' || typeof event[1] !== 'string' || typeof event[2] !== 'string') {
+      fail(`${castDisplayPath}: line ${lineNumber} must be an event row shaped like [number, string, string]`);
+    }
+    if (event[1] === 'o') {
+      hasOutputEvent = true;
+    }
+  }
+
+  if (!hasOutputEvent) {
+    fail(`${castDisplayPath}: missing output event shaped like [number, "o", string]`);
+  }
 }
 
 function validateDemoReadmeInventory() {


### PR DESCRIPTION
## Summary
- Extend the docs-site smoke script's existing demo cast validation to parse every expected checked-in `.cast` file.
- Assert asciinema v2 metadata (`version`, `width`, `height`, non-empty `title`) and JSONL event rows.
- Fail with the cast path and specific missing/invalid header field or event row shape.

## Validation
- `CHROME_BIN=/usr/bin/chromium-browser PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium-browser node scripts/check_docs_site_smoke.mjs`
- `node -e 'const fs=require("fs"); for (const f of fs.readdirSync("docs/site/demo").filter(f=>f.endsWith(".cast"))) { const lines=fs.readFileSync(`docs/site/demo/${f}`, "utf8").trim().split(/\n/); const header=JSON.parse(lines[0]); if (header.version !== 2 || header.width !== 120 || header.height !== 32) throw new Error(`${f} bad header`); if (!lines.slice(1).some((line)=>{ const row=JSON.parse(line); return Array.isArray(row) && typeof row[0] === "number" && row[1] === "o" && typeof row[2] === "string"; })) throw new Error(`${f} missing output event`); }'`
- `rg -n 'asciinema|expectedDemoCastFiles|version === 2|width === 120|height === 32|output event|\.cast' scripts/check_docs_site_smoke.mjs`
- `gh pr list -R ericflo/kiln --limit 10 --state all`