### PR TITLE
Polish CLI docs deep links

### DIFF
--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -200,6 +200,7 @@
       </p>
       <div class="mt-8 flex flex-wrap gap-3">
         <a href="#serve" class="btn-primary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Start the server</a>
+        <a href="#health" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Check health</a>
         <a href="#training" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Submit training</a>
         <a href="#adapters" class="btn-secondary inline-flex items-center px-5 py-2.5 rounded-md text-sm">Manage adapters</a>
       </div>
@@ -357,7 +358,7 @@ kiln adapters unload support-bot</code></pre>
     </div>
   </section>
 
-  <section class="divider">
+  <section id="where-to-go-next" class="divider">
     <div class="max-w-5xl mx-auto px-6 py-12">
       <h2 class="text-2xl font-semibold tracking-tight mb-4">Related docs</h2>
       <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -237,6 +237,21 @@ const expectedCliLinks = [
   { label: 'Architecture', href: 'architecture.html' },
 ];
 
+const expectedCliHeroFragments = [
+  { label: 'Start the server', href: '#serve' },
+  { label: 'Check health', href: '#health' },
+  { label: 'Submit training', href: '#training' },
+  { label: 'Manage adapters', href: '#adapters' },
+];
+
+const expectedCliPageFragments = [
+  '#serve',
+  '#health',
+  '#training',
+  '#adapters',
+  '#where-to-go-next',
+];
+
 const expectedCliModelSetupCue = {
   label: 'Qwen/Qwen3.5-4B setup cue',
   terms: ['qwen/qwen3.5-4b', 'quickstart', 'setup', 'model download'],
@@ -1989,6 +2004,8 @@ async function runSmoke() {
             href: link.getAttribute('href'),
             text: normalize(link.textContent),
           }));
+          const fragmentIds = Array.from(document.querySelectorAll('[id]'))
+            .map((element) => element.getAttribute('id'));
 
           return {
             bodyText,
@@ -1998,6 +2015,7 @@ async function runSmoke() {
             links,
             heroText,
             heroLinks,
+            fragmentIds,
           };
         });
 
@@ -2044,6 +2062,19 @@ async function runSmoke() {
           .map((link) => link.label);
         if (missingLinks.length > 0) {
           fail(`${sitePage.path}: missing CLI next-step links: ${missingLinks.join(', ')}`);
+        }
+
+        const missingHeroFragments = expectedCliHeroFragments
+          .filter((expectedLink) => !cliResult.heroLinks.some((link) => link.href === expectedLink.href))
+          .map((link) => `${link.label} -> ${link.href}`);
+        if (missingHeroFragments.length > 0) {
+          fail(`${sitePage.path}: missing CLI hero deep links: ${missingHeroFragments.join(', ')}`);
+        }
+
+        const missingPageFragments = expectedCliPageFragments
+          .filter((fragment) => !cliResult.fragmentIds.includes(fragment.slice(1)));
+        if (missingPageFragments.length > 0) {
+          fail(`${sitePage.path}: missing CLI page fragments: ${missingPageFragments.join(', ')}`);
         }
       }
 


### PR DESCRIPTION
## Summary
- add a hero deep link from the CLI docs to the health/readiness section
- give the related-docs section a stable `#where-to-go-next` fragment
- extend the docs-site smoke test to guard CLI hero links and page fragments

## Validation
- `node scripts/check_docs_site_smoke.mjs`
- manually read `docs/site/cli.html` as a cold first-time CLI user and confirmed the top-page links cover start, health check, training, and adapters
