### PR TITLE
Revert PR #823: restore post-#762 batching baseline

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -2609,23 +2609,6 @@ fn rotary_tables_from_tensor(
     Ok((freqs.cos()?, freqs.sin()?))
 }
 
-fn rotary_embedding_batched_decode_from_tensor(
-    q: &Tensor,
-    k: &Tensor,
-    positions_tensor: &Tensor,
-    head_dim: usize,
-    rotary_dim: usize,
-    inv_freq: &Tensor,
-) -> Result<(Tensor, Tensor)> {
-    let pos = positions_tensor.unsqueeze(1)?;
-    let freqs = pos.broadcast_mul(&inv_freq.unsqueeze(0)?)?;
-    let cos = freqs.cos()?.unsqueeze(1)?;
-    let sin = freqs.sin()?.unsqueeze(1)?;
-    let rotated_q = apply_rope_with_decode_batch_tables(q, &cos, &sin, head_dim, rotary_dim)?;
-    let rotated_k = apply_rope_with_decode_batch_tables(k, &cos, &sin, head_dim, rotary_dim)?;
-    Ok((rotated_q, rotated_k))
-}
-
 fn rotary_embedding_from_tables(
     q: &Tensor,
     k: &Tensor,
@@ -2656,35 +2639,6 @@ fn rotary_embedding_from_tables(
 /// `head_dim`: total dimension per head
 /// `rotary_dim`: number of dimensions to rotate (must be even). The first `rotary_dim` dims
 ///   are rotated; the remaining `head_dim - rotary_dim` dims pass through unchanged.
-fn apply_rope_with_decode_batch_tables(
-    x: &Tensor,
-    cos: &Tensor,
-    sin: &Tensor,
-    head_dim: usize,
-    rotary_dim: usize,
-) -> Result<Tensor> {
-    let half_rotary = rotary_dim / 2;
-    let x_dtype = x.dtype();
-    let x = x.to_dtype(DType::F32)?;
-    let x_rot = x.narrow(candle_core::D::Minus1, 0, rotary_dim)?;
-    let x_pass = if rotary_dim < head_dim {
-        Some(x.narrow(candle_core::D::Minus1, rotary_dim, head_dim - rotary_dim)?)
-    } else {
-        None
-    };
-    let x1 = x_rot.narrow(candle_core::D::Minus1, 0, half_rotary)?;
-    let x2 = x_rot.narrow(candle_core::D::Minus1, half_rotary, half_rotary)?;
-    let cos = cos.to_dtype(DType::F32)?.unsqueeze(2)?;
-    let sin = sin.to_dtype(DType::F32)?.unsqueeze(2)?;
-    let r1 = (x1.broadcast_mul(&cos)? - x2.broadcast_mul(&sin)?)?;
-    let r2 = (x1.broadcast_mul(&sin)? + x2.broadcast_mul(&cos)?)?;
-    let out = match x_pass {
-        Some(pass) => Tensor::cat(&[&r1, &r2, &pass], candle_core::D::Minus1)?,
-        None => Tensor::cat(&[&r1, &r2], candle_core::D::Minus1)?,
-    };
-    Ok(out.to_dtype(x_dtype)?)
-}
-
 fn apply_rope(
     x: &Tensor,
     cos: &Tensor,
@@ -5054,9 +5008,9 @@ fn try_flash_attn_paged_decode(
     backend: &dyn BackendRuntime,
     q: &Tensor,
     paged_cache: &PagedKvCache,
-    block_tables: &[&BlockTable],
+    block_table: &BlockTable,
     full_attn_layer_idx: usize,
-    total_seq_lens: &[usize],
+    total_seq_len: usize,
     num_heads: usize,
     num_kv_heads: usize,
     head_dim: usize,
@@ -5082,11 +5036,9 @@ fn try_flash_attn_paged_decode(
     if q_len != 1 || q_heads != num_heads || q_hd != head_dim {
         return Ok(None);
     }
-    if block_tables.len() != batch || total_seq_lens.len() != batch {
-        return Ok(None);
-    }
-    let max_total_seq_len = total_seq_lens.iter().copied().max().unwrap_or(0);
-    if max_total_seq_len == 0 {
+    if batch != 1 {
+        // Multi-sequence dispatch needs a per-sequence block_table tensor.
+        // Defer to the slow path until the scheduler exercises it.
         return Ok(None);
     }
 
@@ -5100,9 +5052,7 @@ fn try_flash_attn_paged_decode(
     // pool. In that case we can bypass the paged gather path entirely and feed
     // the fused prefill kernel a direct `[1, total_seq_len, kv_heads, head_dim]`
     // narrow of the live K/V window.
-    if batch == 1 && !paged_cache.is_fp8() {
-        let block_table = block_tables[0];
-        let total_seq_len = total_seq_lens[0];
+    if !paged_cache.is_fp8() {
         if let Some(start_slot) =
             contiguous_slot_run_start(block_table, block_size, 0, total_seq_len)
         {
@@ -5270,34 +5220,26 @@ fn try_flash_attn_paged_decode(
     // sequentially from a free list, so a single freshly-allocated sequence
     // satisfies this trivially. After eviction or interleaved allocation the
     // condition may not hold, in which case we fall back.
-    let max_n_chunks = max_total_seq_len.div_ceil(K_BLOCK_N);
-    let max_blocks_per_seq = max_n_chunks * pages_per_chunk;
-    if max_blocks_per_seq == 0 {
+    let n_chunks = total_seq_len.div_ceil(K_BLOCK_N);
+    let blocks = &block_table.blocks;
+    let allocated = blocks.len();
+    if allocated < n_chunks * pages_per_chunk && allocated < total_seq_len.div_ceil(block_size) {
+        // Block table too short for the requested seqlen.
         return Ok(None);
     }
-
-    for (&block_table, &total_seq_len) in block_tables.iter().zip(total_seq_lens) {
-        let n_chunks = total_seq_len.div_ceil(K_BLOCK_N);
-        let blocks = &block_table.blocks;
-        let allocated = blocks.len();
-        if allocated < n_chunks * pages_per_chunk && allocated < total_seq_len.div_ceil(block_size)
-        {
-            return Ok(None);
+    for c in 0..n_chunks {
+        let base_idx = c * pages_per_chunk;
+        if base_idx >= allocated {
+            break;
         }
-        for c in 0..n_chunks {
-            let base_idx = c * pages_per_chunk;
-            if base_idx >= allocated {
+        let base_phys = blocks[base_idx];
+        for i in 1..pages_per_chunk {
+            let idx = base_idx + i;
+            if idx >= allocated {
                 break;
             }
-            let base_phys = blocks[base_idx];
-            for i in 1..pages_per_chunk {
-                let idx = base_idx + i;
-                if idx >= allocated {
-                    break;
-                }
-                if blocks[idx] != base_phys + i as u32 {
-                    return Ok(None);
-                }
+            if blocks[idx] != base_phys + i as u32 {
+                return Ok(None);
             }
         }
     }
@@ -5314,18 +5256,16 @@ fn try_flash_attn_paged_decode(
     // so we truncate to max_blocks_per_seq before copying. Without this,
     // `reshape((1, max_blocks_per_seq))` crashes when allocated > max
     // (observed: 40 blocks vs max 32 at block 3 of full-attention layers).
-    let mut padded: Vec<u32> = Vec::with_capacity(batch * max_blocks_per_seq);
-    for block_table in block_tables {
-        let row_start = padded.len();
-        let take = max_blocks_per_seq.min(block_table.blocks.len());
-        padded.extend_from_slice(&block_table.blocks[..take]);
-        if padded.len() == row_start {
-            return Ok(None);
-        }
-        while padded.len() < row_start + max_blocks_per_seq {
-            let next = padded.last().copied().unwrap_or(0).wrapping_add(1);
-            padded.push(next);
-        }
+    let max_blocks_per_seq = n_chunks * pages_per_chunk;
+    let take = max_blocks_per_seq.min(blocks.len());
+    let mut padded: Vec<u32> = Vec::with_capacity(max_blocks_per_seq);
+    padded.extend_from_slice(&blocks[..take]);
+    if padded.is_empty() {
+        return Ok(None);
+    }
+    while padded.len() < max_blocks_per_seq {
+        let next = padded.last().copied().unwrap_or(0).wrapping_add(1);
+        padded.push(next);
     }
 
     let device = q.device();
@@ -5336,15 +5276,15 @@ fn try_flash_attn_paged_decode(
             if let Some(inputs) = graph_inputs {
                 inputs.block_table
             } else {
-                bt_tensor_owned =
-                    Tensor::new(padded.as_slice(), device)?.reshape((batch, max_blocks_per_seq))?;
+                bt_tensor_owned = Tensor::new(padded.as_slice(), device)?
+                    .reshape((1usize, max_blocks_per_seq))?;
                 &bt_tensor_owned
             }
         }
         #[cfg(not(feature = "cuda"))]
         {
             bt_tensor_owned =
-                Tensor::new(padded.as_slice(), device)?.reshape((batch, max_blocks_per_seq))?;
+                Tensor::new(padded.as_slice(), device)?.reshape((1usize, max_blocks_per_seq))?;
             &bt_tensor_owned
         }
     };
@@ -5372,7 +5312,7 @@ fn try_flash_attn_paged_decode(
     let attn_out = {
         #[cfg(feature = "cuda")]
         {
-            if let Some(inputs) = graph_inputs.filter(|_| batch == 1) {
+            if let Some(inputs) = graph_inputs {
                 let attn_out = inputs.attn_out.get(full_attn_layer_idx).ok_or_else(|| {
                     anyhow::anyhow!(
                         "missing CUDA graph paged decode output buffer for full-attention layer {full_attn_layer_idx}"
@@ -5395,13 +5335,13 @@ fn try_flash_attn_paged_decode(
                     softmax_scale,
                     true,
                 )?
-            } else if total_seq_lens.iter().all(|&len| len == max_total_seq_len) {
+            } else {
                 match backend.flash_attn_paged_decode(
                     &q_fa,
                     k_pool,
                     v_pool,
                     bt_tensor,
-                    max_total_seq_len,
+                    total_seq_len,
                     block_size,
                     softmax_scale,
                     true,
@@ -5409,38 +5349,16 @@ fn try_flash_attn_paged_decode(
                     Some(t) => t,
                     None => return Ok(None),
                 }
-            } else {
-                let seqused: Vec<i32> = total_seq_lens
-                    .iter()
-                    .map(|&len| i32::try_from(len).context("paged decode seqlen exceeds i32"))
-                    .collect::<Result<_>>()?;
-                let seqused =
-                    Tensor::from_slice(seqused.as_slice(), batch, device)?.contiguous()?;
-                kiln_flash_attn::flash_attn_paged_decode_dyn_seqlen(
-                    &q_fa,
-                    k_pool,
-                    v_pool,
-                    bt_tensor,
-                    &seqused,
-                    None,
-                    max_total_seq_len,
-                    block_size,
-                    softmax_scale,
-                    true,
-                )?
             }
         }
         #[cfg(not(feature = "cuda"))]
         {
-            if !total_seq_lens.iter().all(|&len| len == max_total_seq_len) {
-                return Ok(None);
-            }
             match backend.flash_attn_paged_decode(
                 &q_fa,
                 k_pool,
                 v_pool,
                 bt_tensor,
-                max_total_seq_len,
+                total_seq_len,
                 block_size,
                 softmax_scale,
                 true,
@@ -5488,200 +5406,6 @@ fn try_flash_attn_paged_decode(
     finish_full_attn_stage_profile(q.device(), profile_context, "o_proj", q_len, stage_profile)?;
     let _ = crate::mtp_debug::capture_subop("post_o_proj", &out);
     Ok(Some(out))
-}
-
-/// Batched full-attention decode for arbitrary decode rows backed by paged KV.
-///
-/// Projects Q/K/V for `[batch, 1, hidden]`, writes one K/V token per row, builds
-/// one `[batch, max_blocks_per_seq]` block table, and dispatches the paged decode
-/// kernel once for the whole batch. Sequence lengths may differ across rows; the
-/// CUDA path uses the dynamic-seqlen wrapper in that case.
-#[allow(clippy::too_many_arguments)]
-pub fn gqa_attention_paged_decode_batch(
-    backend: &dyn BackendRuntime,
-    x: &Tensor,
-    attn_weights: &GpuFullAttentionWeights,
-    positions: &Tensor,
-    start_positions: &[usize],
-    num_heads: usize,
-    num_kv_heads: usize,
-    head_dim: usize,
-    rotary_dim: usize,
-    inv_freq: &Tensor,
-    rms_norm_eps: f64,
-    paged_cache: &mut PagedKvCache,
-    block_tables: &[&BlockTable],
-    full_attn_layer_idx: usize,
-    attn_output_gate: bool,
-    lora: Option<(&LoraLayerWeights, f32)>,
-    profile_context: Option<(usize, usize)>,
-) -> Result<Tensor> {
-    let (batch, seq_len, _hidden) = x.dims3()?;
-    let profile_device = x.device();
-    anyhow::ensure!(batch > 0, "batched paged decode requires a non-empty batch");
-    anyhow::ensure!(
-        seq_len == 1,
-        "batched paged attention requires one decode token per row"
-    );
-    anyhow::ensure!(
-        block_tables.len() == batch && start_positions.len() == batch,
-        "batched paged attention metadata length mismatch"
-    );
-    anyhow::ensure!(
-        positions.elem_count() == batch,
-        "batched paged attention positions length must match batch"
-    );
-    anyhow::ensure!(
-        full_attn_layer_idx < paged_cache.num_layers(),
-        "batched paged attention layer index out of range"
-    );
-
-    let use_metal_decode_gemv = batch == 1
-        && start_positions[0] > 0
-        && !crate::mtp_debug::is_mtp_single_token_self_attn_armed();
-    let (lora_layer, lora_scale) = match lora {
-        Some((l, s)) => (Some(l), s),
-        None => (None, 0.0),
-    };
-
-    let (q_raw, k, v) = {
-        let stage_profile = start_full_attn_stage_profile(profile_device, profile_context)?;
-        kiln_nvtx::range!(c"kiln/proj/qkv_batch_decode");
-        let out = full_attn_qkv_proj_decode_if(
-            use_metal_decode_gemv,
-            x,
-            attn_weights,
-            lora_layer,
-            lora_scale,
-        )?;
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "qkv_proj_batch",
-            seq_len,
-            stage_profile,
-        )?;
-        out
-    };
-
-    let (q, gate) = {
-        let stage_profile = start_full_attn_stage_profile(profile_device, profile_context)?;
-        let out = if attn_output_gate {
-            let q_raw = q_raw.reshape(((), seq_len, num_heads, head_dim * 2))?;
-            let q = q_raw.narrow(3, 0, head_dim)?;
-            let gate = q_raw
-                .narrow(3, head_dim, head_dim)?
-                .contiguous()?
-                .reshape(((), seq_len, num_heads * head_dim))?;
-            (q.contiguous()?, Some(gate))
-        } else {
-            (q_raw.reshape(((), seq_len, num_heads, head_dim))?, None)
-        };
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "qkv_split_batch",
-            seq_len,
-            stage_profile,
-        )?;
-        out
-    };
-    let k = k.reshape(((), seq_len, num_kv_heads, head_dim))?;
-    let v = v.reshape(((), seq_len, num_kv_heads, head_dim))?;
-
-    let (q, k) = {
-        let stage_profile = start_full_attn_stage_profile(profile_device, profile_context)?;
-        let q = rms_norm(&q, &attn_weights.q_norm, rms_norm_eps)?;
-        let k = rms_norm(&k, &attn_weights.k_norm, rms_norm_eps)?;
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "qk_norm_batch",
-            seq_len,
-            stage_profile,
-        )?;
-        (q, k)
-    };
-    let (q, k) = {
-        let stage_profile = start_full_attn_stage_profile(profile_device, profile_context)?;
-        let out = rotary_embedding_batched_decode_from_tensor(
-            &q, &k, positions, head_dim, rotary_dim, inv_freq,
-        )?;
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "rope_batch",
-            seq_len,
-            stage_profile,
-        )?;
-        out
-    };
-    let q = {
-        let stage_profile = start_full_attn_stage_profile(profile_device, profile_context)?;
-        let q = q.transpose(1, 2)?.contiguous()?;
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "q_transpose_batch",
-            seq_len,
-            stage_profile,
-        )?;
-        q
-    };
-
-    {
-        let stage_profile = start_full_attn_stage_profile(profile_device, profile_context)?;
-        if !paged_cache.write_token_major_native_batch(
-            full_attn_layer_idx,
-            block_tables,
-            start_positions,
-            &k,
-            &v,
-        )? {
-            anyhow::bail!("batched paged attention KV write declined");
-        }
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "kv_write_batch",
-            seq_len,
-            stage_profile,
-        )?;
-    }
-
-    let total_seq_lens: Vec<usize> = start_positions.iter().map(|&pos| pos + 1).collect();
-    let attn_output = {
-        let stage_profile = start_full_attn_stage_profile(profile_device, profile_context)?;
-        let out = try_flash_attn_paged_decode(
-            backend,
-            &q,
-            paged_cache,
-            block_tables,
-            full_attn_layer_idx,
-            &total_seq_lens,
-            num_heads,
-            num_kv_heads,
-            head_dim,
-            gate.as_ref(),
-            use_metal_decode_gemv,
-            attn_weights,
-            lora_layer,
-            lora_scale,
-            #[cfg(feature = "cuda")]
-            None,
-            profile_context,
-        )?;
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "decode_attn_paged_batch",
-            seq_len,
-            stage_profile,
-        )?;
-        out.context("backend declined batched paged attention")?
-    };
-
-    Ok(attn_output)
 }
 
 /// Batched full-attention decode for rows whose live paged-KV windows are
@@ -6438,9 +6162,9 @@ fn gqa_attention_paged_with_rope_tables(
                 backend,
                 &q,
                 paged_cache,
-                &[block_table],
+                block_table,
                 full_attn_layer_idx,
-                &[total_seq_len],
+                total_seq_len,
                 num_heads,
                 num_kv_heads,
                 head_dim,
@@ -8151,54 +7875,45 @@ pub fn model_forward_paged_batched_decode_hidden(
                 };
                 linear_attn_idx += 1;
             }
-            GpuAttentionWeights::Full(attn_weights) => {
-                let positions: Vec<f32> = sequence_lengths.iter().map(|&pos| pos as f32).collect();
-                let positions = Tensor::new(positions.as_slice(), device)?;
-                let block_table_refs: Vec<&BlockTable> = block_tables.iter().collect();
-                let start_positions: Vec<usize> = sequence_lengths.to_vec();
-
-                let normed = {
-                    kiln_nvtx::range!(c"kiln/batched_decode/norm/pre_attn_full");
-                    rms_norm(&hidden, &layer.input_layernorm, config.rms_norm_eps)?
-                };
-                let attn_out = gqa_attention_paged_decode_batch(
-                    backend,
-                    &normed,
-                    attn_weights,
-                    &positions,
-                    &start_positions,
-                    config.num_attention_heads,
-                    config.num_kv_heads,
-                    config.head_dim,
-                    config.rotary_dim(),
-                    &weights.rotary_inv_freq,
-                    config.rms_norm_eps,
-                    paged_cache,
-                    &block_table_refs,
-                    full_attn_idx,
-                    config.attn_output_gate,
-                    layer_lora,
-                    None,
-                )
-                .with_context(|| format!("batched transformer block {layer_idx} full attention"))?;
-
-                hidden = {
-                    kiln_nvtx::range!(c"kiln/batched_decode/residual/attn_full");
-                    (hidden + attn_out)?
-                };
-                let normed_post = {
-                    kiln_nvtx::range!(c"kiln/batched_decode/norm/pre_mlp_full");
-                    rms_norm(
-                        &hidden,
-                        &layer.post_attention_layernorm,
-                        config.rms_norm_eps,
-                    )?
-                };
-                let ffn_out = swiglu_ffn(&normed_post, &layer.mlp, layer_lora)?;
-                hidden = {
-                    kiln_nvtx::range!(c"kiln/batched_decode/residual/mlp_full");
-                    (hidden + ffn_out)?
-                };
+            GpuAttentionWeights::Full(_) => {
+                let mut rows = Vec::with_capacity(batch_size);
+                for row_idx in 0..batch_size {
+                    let row_hidden = hidden.narrow(0, row_idx, 1)?;
+                    let pos = Tensor::new(&[sequence_lengths[row_idx] as f32], device)?;
+                    let rope_tables = rotary_tables_from_tensor(&pos, &weights.rotary_inv_freq)?;
+                    rows.push(
+                        transformer_block_paged_with_rope_tables(
+                            backend,
+                            &row_hidden,
+                            layer,
+                            config,
+                            &pos,
+                            sequence_lengths[row_idx],
+                            config.num_attention_heads,
+                            config.num_kv_heads,
+                            config.head_dim,
+                            config.rotary_dim(),
+                            &weights.rotary_inv_freq,
+                            Some((&rope_tables.0, &rope_tables.1)),
+                            config.rms_norm_eps,
+                            paged_cache,
+                            &block_tables[row_idx],
+                            full_attn_idx,
+                            layer_lora,
+                            #[cfg(feature = "cuda")]
+                            None,
+                            None,
+                        )
+                        .with_context(|| {
+                            format!(
+                                "batched decode row {row_idx} transformer block {layer_idx} (full attention, paged)"
+                            )
+                        })?,
+                    );
+                }
+                let row_refs: Vec<&Tensor> = rows.iter().collect();
+                hidden = Tensor::cat(&row_refs, 0)
+                    .with_context(|| format!("cat full-attention rows after layer {layer_idx}"))?;
                 full_attn_idx += 1;
             }
         }

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -32,7 +32,7 @@ use crate::forward::{
 use crate::kv_cache::KvCache;
 use crate::lora_loader::LoraWeights;
 use crate::paged_kv_cache::PagedKvCache;
-use crate::sampling::{greedy_sample, sample_rows_with_params, sample_with_params};
+use crate::sampling::{greedy_sample, sample_with_params};
 use crate::speculative::{
     SpeculativeConfig, speculative_decode_step, speculative_decode_step_paged_greedy,
     speculative_mtp_decode_step,
@@ -1909,22 +1909,26 @@ impl ModelRunner {
                     self.active_lora.as_ref(),
                 )
                 .context("batched decode forward pass failed")?;
-                let logits = model_forward_head(&hidden, &self.weights, &self.config)
-                    .context("batched decode lm head")?;
-                let sampling_params: Vec<(f32, f32, u32, Option<u64>)> = params
-                    .iter()
-                    .zip(states.iter())
-                    .map(|(params, state)| {
-                        (
+
+                let mut sampled = Vec::with_capacity(states.len());
+                for (idx, params) in params.iter().enumerate() {
+                    let row_hidden = hidden.narrow(0, idx, 1)?;
+                    let row = model_forward_head(&row_hidden, &self.weights, &self.config)
+                        .with_context(|| format!("batched decode lm head row {idx}"))?;
+                    let token = if params.temperature == 0.0 {
+                        greedy_sample(&row)?
+                    } else {
+                        sample_with_params(
+                            &row,
                             params.temperature,
                             params.top_p,
                             params.top_k,
-                            state.step_seed,
-                        )
-                    })
-                    .collect();
-                sample_rows_with_params(&logits, &sampling_params)
-                    .context("batched decode sampling")?
+                            states[idx].step_seed,
+                        )?
+                    };
+                    sampled.push(token);
+                }
+                sampled
             }
         };
         let decode_duration = started.elapsed();

--- a/crates/kiln-model/src/sampling.rs
+++ b/crates/kiln-model/src/sampling.rs
@@ -69,67 +69,6 @@ pub fn greedy_sample_rows(logits: &Tensor) -> Result<Vec<u32>> {
     Ok(ids.to_vec1::<u32>()?)
 }
 
-/// Sample one token for every batch row in a logits tensor.
-///
-/// Fast paths cover the hot serving cases without per-row synchronization:
-/// greedy rows use one argmax over the vocab dimension, while identical
-/// unseeded full-distribution sampling uses one batched Gumbel-softmax over the
-/// vocab dimension. More specialized top-k/top-p/seeded rows fall back to the
-/// scalar sampler for correctness.
-pub fn sample_rows_with_params(
-    logits: &Tensor,
-    params: &[(f32, f32, u32, Option<u64>)],
-) -> Result<Vec<u32>> {
-    if params.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let dims = logits.dims();
-    anyhow::ensure!(!dims.is_empty(), "logits tensor must have at least one dim");
-    let vocab_dim = dims.len() - 1;
-    let vocab_size = dims[vocab_dim];
-    let row_count = logits.elem_count() / vocab_size;
-    anyhow::ensure!(
-        row_count == params.len(),
-        "batched sampler row count {row_count} != params length {}",
-        params.len()
-    );
-
-    if params.iter().all(|&(temperature, _top_p, top_k, _seed)| {
-        kiln_core::sampling::SamplingParams::values_are_effectively_greedy(temperature, top_k)
-    }) {
-        return greedy_sample_rows(logits);
-    }
-
-    let (temperature, top_p, top_k, seed) = params[0];
-    if seed.is_none()
-        && params.iter().all(|&candidate| candidate == params[0])
-        && !kiln_core::sampling::SamplingParams::values_are_effectively_greedy(temperature, top_k)
-        && kiln_core::sampling::SamplingParams::top_p_disables_nucleus_filter(top_p)
-        && (top_k == 0 || top_k as usize >= vocab_size)
-        && matches!(logits.device(), Device::Cuda(_) | Device::Metal(_))
-    {
-        let scaled = logits
-            .to_dtype(DType::F32)?
-            .affine(1.0 / temperature as f64, 0.0)?;
-        let sampled = gumbel_softmax(&scaled, 1.0, vocab_dim)?.flatten_all()?;
-        return Ok(sampled.to_vec1::<u32>()?);
-    }
-
-    let mut sampled = Vec::with_capacity(params.len());
-    for (row, &(temperature, top_p, top_k, seed)) in params.iter().enumerate() {
-        let row_logits = logits.narrow(0, row, 1)?;
-        sampled.push(sample_with_params(
-            &row_logits,
-            temperature,
-            top_p,
-            top_k,
-            seed,
-        )?);
-    }
-    Ok(sampled)
-}
-
 /// Parameterized sampling with temperature, top-k, and top-p (nucleus) filtering.
 ///
 /// `logits`: tensor of shape `[..., vocab_size]`. Only the last position is sampled.


### PR DESCRIPTION
## Why

PR #823 ("Batch hybrid decode attention and lm head") merged on 2026-05-04 and introduced a c=8 OOM regression. Validation found 3016 `CUDA_ERROR_OUT_OF_MEMORY` log entries from "batched decode lm head" — c=8+ requests returned HTTP 200 but produced only 0-2 tokens before silently dying without `finish_reason=length`. c=1 was unaffected; c=4+ broken for any non-trivial output.

PR #853 (still draft) attempted to fix the regression by bounding the batched LM-head workspace. Subsequent measurement on a fresh A6000 found PR #853's branch is *strictly worse* than the post-PR #762 baseline at every concurrency point:

| Stage | c=1 agg | c=8 agg | scaling |
|---|---|---|---|
| Post-PR #762 (target) | 54.76 | 62.45 | 1.14x |
| PR #853 branch (`62b5c17`) | 42.97 | 19.13 | 0.45x |

Source dive at `b2://clouderic/diagnostics/kiln-hybrid-decode-investigation-2026-05-04/REPORT.md` and follow-up dive at `b2://clouderic/diagnostics/kiln-ucopy-bf16-investigation-2026-05-05/REPORT.md` showed PR #823 was working on the wrong layer. The actual remaining bottleneck for c=8 throughput is at `crates/kiln-gdn-kernel/src/lib.rs:646` where the fused GDN decode wrapper materializes `q/k/v/a/b` with `contiguous()`. PR #823 did not touch that code path.

## What's restored

The post-PR #762 working baseline:
- c=1 ~54.76 tok/s
- c=8 ~62.45 tok/s
- scaling ~1.14x
- zero LM-head OOMs
- `finish_reason=length` for all concurrencies

PR #762's actor wiring + streaming route fix are preserved (this only reverts PR #823).

## What's lost

Nothing useful. PR #823's contributions (batched full-attention dispatch, `try_flash_attn_paged_decode` batch>1 lift, batched LM-head dispatch, batched sampler) only materialized in conjunction with the OOM regression — every measured combination of these changes performed worse than post-PR #762.

## Conflict resolution

`git revert bed4b0313b28b9ac76bada66e280a329ea0c0e0f` produced 7 conflict regions across 3 files (forward.rs / generate.rs / sampling.rs). Only one post-#823 commit touched these files: PR #855 ("Fix current rustfmt drift blocking PR #853 validation") — pure formatting, no logic. Conflicts resolved by taking the pre-#823 side; rustfmt re-applied.

## Forward path

Phase 3 fix targeting the actual GDN wrapper bottleneck (`crates/kiln-gdn-kernel/src/lib.rs:646`, replace `contiguous()` materialization with strided-input or fused-pack CUDA path, ~180-250 LOC) will be queued next.

PR #853 will be closed as obsolete once this revert lands — its target was PR #823's regression; with #823 reverted there's nothing to fix.

Tracks issue #816.