### PR TITLE
QUICKSTART: cold-reader pass — collapse Reader map, prerequisites, and KV-cache OOM section

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -23,10 +23,10 @@ All paths share these requirements:
 
 Build-tooling deltas by path:
 
-- **Desktop App** (Windows / Linux / Apple Silicon macOS): no Rust toolchain, CUDA toolkit, or Xcode install. The app downloads and SHA-256-verifies the matching prebuilt `kiln` server binary on first launch.
-- **Server binary** (Linux x86_64 / Windows x86_64 / Apple Silicon macOS): no Rust toolchain. Download a prebuilt `kiln-v*` release artifact, then continue at [Download Model Weights](#2-download-model-weights).
-- **Container** (Linux x86_64 + Docker + [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)): no Rust toolchain or source checkout. Continue at [Running with Docker](#running-with-docker).
-- **Source / CLI** (contributors): stable Rust (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`). NVIDIA builds need `nvcc` (CUDA 12.4+); AMD/Intel builds need `glslc` or `glslangValidator` for shader embedding (`vulkaninfo --summary` should list your GPU); Apple Silicon builds need Xcode Command Line Tools (`xcode-select --install`). Full Xcode is **not** required — `candle-metal-kernels` JIT-compiles MSL shaders at runtime.
+- **Desktop App path** (Windows / Linux / Apple Silicon macOS): No Rust toolchain, CUDA toolkit, or Xcode install. The app downloads and SHA-256-verifies the matching prebuilt `kiln` server binary on first launch.
+- **Server binary path** (Linux x86_64 / Windows x86_64 / Apple Silicon macOS): No Rust toolchain. Download a prebuilt `kiln-v*` release artifact, then continue at [Download Model Weights](#2-download-model-weights).
+- **Container path** (Docker/GHCR, Linux x86_64 + Docker + [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)): No Rust toolchain or source checkout — uses the prebuilt `ghcr.io/ericflo/kiln-server:latest` image. Continue at [Running with Docker](#running-with-docker).
+- **Source / CLI path** (contributors): stable Rust (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`). NVIDIA builds need `nvcc` (CUDA 12.4+); AMD/Intel builds need `glslc` or `glslangValidator` for shader embedding (`vulkaninfo --summary` should list your GPU); Apple Silicon builds need Xcode Command Line Tools (`xcode-select --install`). Full Xcode is **not** required — `candle-metal-kernels` JIT-compiles MSL shaders at runtime.
 
 If setup stalls on binary downloads, CUDA/Vulkan/Metal, model paths, `/health`, mock mode, training endpoints, or adapter directories, see the website [Troubleshooting guide](https://ericflo.github.io/kiln/troubleshooting.html) first.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -11,46 +11,22 @@ This guide gets you from a fresh machine to your first Kiln inference. Stop afte
 | **Container** | You prefer the prebuilt GHCR image and already run NVIDIA GPU workloads with Docker. | Pull `ghcr.io/ericflo/kiln-server:latest`, mount your local `Qwen/Qwen3.5-4B` directory, then follow [Running with Docker](#running-with-docker). |
 | **Source / CLI** | You are contributing, scripting, or want to build the binary yourself. | Optionally build `kiln` from source, then download `Qwen/Qwen3.5-4B`, start `kiln serve`, and continue through steps 2-5. |
 
-## Reader map
-
-- **5-minute path:** choose Desktop, Server binary, Container, or the optional Source / CLI branch, then continue through model download, first inference, and dashboard checkpoint. Stop there if you only need to confirm Kiln is serving.
-- **Optional learning:** sections 6-8 cover live-learning and adapter workflows after the server is working: SFT, training status, and adapter activation.
-- **Advanced API:** section 9 is reference material for direct HTTP usage once the basic path is clear.
-
 After first inference, continue to [SFT training](#6-submit-sft-training), the [GRPO guide](docs/GRPO_GUIDE.md), [advanced API examples](#9-advanced-api-examples), or [Troubleshooting](https://ericflo.github.io/kiln/troubleshooting.html).
 
 ## Prerequisites
 
-Choose the path that matches how you want to run Kiln. The Desktop App is the shortest GUI path, Server binary is the terminal-first path with no Rust build, Container is the prebuilt Docker/GHCR path, and Source / CLI is for contributors or users who want to compile the binary themselves.
+All paths share these requirements:
 
-**Desktop App path (recommended for most users):**
+- **GPU + memory**: NVIDIA with 24GB+ VRAM and CUDA 12.4+ driver/runtime (RTX 3090, 4090, A6000, etc.), AMD/Intel Linux GPU with Vulkan 1.2+ runtime, or Apple Silicon Mac with 16GB+ unified memory. Intel Macs are not supported.
+- **Disk**: ~20GB free for the server binary, model weights, and adapters (Source / CLI builds also share this with build artifacts).
+- **Model**: `Qwen/Qwen3.5-4B` weights — downloaded by the Desktop App, by `huggingface-cli` for the Server binary path, or mounted into the container.
 
-- **Platform**: Windows, Linux, or macOS on Apple Silicon. Intel Macs are not supported.
-- **GPU**: NVIDIA GPU, AMD/Intel Vulkan-capable Linux GPU, or Apple Silicon Mac. NVIDIA systems should have 24GB+ VRAM (RTX 3090, RTX 4090, A6000, etc.); Apple Silicon systems should have 16GB+ unified memory.
-- **Disk**: ~20GB free for the server binary, model weights, and adapters.
-- **Build tooling**: No Rust toolchain, CUDA toolkit, or Xcode install is required for the GUI path. The app downloads the matching prebuilt `kiln` server binary for your platform.
+Build-tooling deltas by path:
 
-**Server binary path (terminal-first, no source build):**
-
-- **Platform**: Linux x86_64, Windows x86_64, or macOS on Apple Silicon. Intel Macs are not supported.
-- **GPU**: NVIDIA systems need CUDA 12.4+ driver/runtime support and 24GB+ VRAM. AMD/Intel Linux systems use Vulkan 1.2+. Apple Silicon Macs use Metal with 16GB+ unified memory.
-- **Disk**: ~20GB free for the server binary, model weights, and adapters.
-- **Build tooling**: No Rust toolchain is required. Download a prebuilt `kiln-v*` release artifact, then continue at [Download Model Weights](#2-download-model-weights).
-
-**Container path (Docker/GHCR, no source build):**
-
-- **Platform**: Linux x86_64 host with Docker and the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) installed for NVIDIA GPU deployment.
-- **GPU**: NVIDIA GPU with 24GB+ VRAM and CUDA 12.4+ driver/runtime support.
-- **Model**: Local `Qwen/Qwen3.5-4B` model directory to mount read-only into the container.
-- **Build tooling**: No Rust toolchain or source checkout is required when using the prebuilt `ghcr.io/ericflo/kiln-server:latest` image. Continue at [Running with Docker](#running-with-docker).
-
-**Source / CLI path (for contributors and direct CLI users):**
-
-- **Rust**: Stable toolchain (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`).
-- **Linux / Windows + NVIDIA builds**: GPU with 24GB+ VRAM and CUDA 12.4+ (`nvcc --version` to check).
-- **Linux + AMD / Intel builds**: Vulkan 1.2+ runtime plus `glslc` or `glslangValidator` for shader embedding. `vulkaninfo --summary` should list your GPU.
-- **macOS + Apple Silicon builds**: M-series Mac with 16GB+ unified memory and Xcode Command Line Tools installed (`xcode-select --install`). Full Xcode is **not** required — `candle-metal-kernels` JIT-compiles MSL shaders at runtime.
-- **Disk**: ~20GB free for model weights and build artifacts.
+- **Desktop App** (Windows / Linux / Apple Silicon macOS): no Rust toolchain, CUDA toolkit, or Xcode install. The app downloads and SHA-256-verifies the matching prebuilt `kiln` server binary on first launch.
+- **Server binary** (Linux x86_64 / Windows x86_64 / Apple Silicon macOS): no Rust toolchain. Download a prebuilt `kiln-v*` release artifact, then continue at [Download Model Weights](#2-download-model-weights).
+- **Container** (Linux x86_64 + Docker + [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)): no Rust toolchain or source checkout. Continue at [Running with Docker](#running-with-docker).
+- **Source / CLI** (contributors): stable Rust (`curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh`). NVIDIA builds need `nvcc` (CUDA 12.4+); AMD/Intel builds need `glslc` or `glslangValidator` for shader embedding (`vulkaninfo --summary` should list your GPU); Apple Silicon builds need Xcode Command Line Tools (`xcode-select --install`). Full Xcode is **not** required — `candle-metal-kernels` JIT-compiles MSL shaders at runtime.
 
 If setup stalls on binary downloads, CUDA/Vulkan/Metal, model paths, `/health`, mock mode, training endpoints, or adapter directories, see the website [Troubleshooting guide](https://ericflo.github.io/kiln/troubleshooting.html) first.
 
@@ -457,8 +433,6 @@ Francisco.").
 > on Hugging Face. If a tool call format ever looks ambiguous, that file is
 > the source of truth.
 
-<a id="42-troubleshooting-older-release-long-prefill-timeouts"></a>
-
 ### 9.2 Troubleshooting: older-release long-prefill timeouts
 
 If long tools-bearing prompts or long-prefill requests time out, first upgrade
@@ -473,50 +447,22 @@ details.
 
 ### 9.3 Troubleshooting: KV cache OOM auto-recovery
 
-At startup, kiln's auto-sizer computes the paged KV cache budget as
-`available_for_kv = (total_vram - model_bytes) * inference_memory_fraction`
-(default `inference_memory_fraction = 0.7`). On A40 / A6000 / RTX 6000 Ada /
-L40S running Qwen3.5-4B in BF16, the configured fraction occasionally OOMs at
-allocation time even though the math says it should fit — driver overhead,
-fragmentation, and other allocations on the device can shrink the actual free
-pool below the auto-sizer's estimate.
+Since kiln-v0.2.9 (PR #687), the KV-cache auto-sizer automatically retries
+allocation with a shrinking `inference_memory_fraction` from the list
+`[0.75, 0.65, 0.55, 0.45]` if the configured value OOMs at startup. On
+recovery it logs a `WARN` naming the `actual_fraction` it landed on; pin
+that value in `[memory] inference_memory_fraction` (or
+`KILN_INFERENCE_MEMORY_FRACTION`) to silence the warning on the next restart.
 
-Since kiln-v0.2.9 (PR #687), the auto-sizer **automatically retries with a
-shrinking fraction** from the fallback list `[0.75, 0.65, 0.55, 0.45]` (only
-values strictly below the configured fraction are attempted). On success after
-a fallback, kiln logs a `WARN` line naming the actual fraction it landed on:
+If every fallback also OOMs, startup aborts with a structured panic and
+recommends:
 
-```
-WARN kiln_server::state: KV cache auto-sizer fell back to a smaller
-inference_memory_fraction because the configured value OOM'd; set
-memory.inference_memory_fraction (or KILN_INFERENCE_MEMORY_FRACTION) to
-this value to silence the warning configured_fraction=0.99
-actual_fraction=0.45 num_blocks=56652 attempts=5
-```
-
-**What to do on the next restart:** pin the `actual_fraction` value so the
-auto-sizer doesn't have to retry. Either set `memory.inference_memory_fraction`
-in [`kiln.example.toml`](kiln.example.toml), or export
-`KILN_INFERENCE_MEMORY_FRACTION=<value>` in your environment. Subsequent
-restarts will hit the configured fraction on the first attempt and the WARN
-line goes away.
-
-If **every** fraction in the fallback list also OOMs, kiln aborts startup with
-a structured panic message that lists each attempted fraction → `num_blocks` →
-exact OOM error, names the detected GPU and model size, and recommends two
-concrete remediations:
-
-- **(a) `KILN_NUM_BLOCKS=N`** (or `[memory] num_blocks = N` in
-  `kiln.example.toml`) — preferred. This bypasses the auto-sizer entirely and
-  pins an exact block count, which is the canonical workaround documented in
-  [issue #685](https://github.com/ericflo/kiln/issues/685). The panic message
-  prints a concrete `N` value sized at ~30% of remaining VRAM (well below the
-  retry floor, with headroom for driver overhead).
-- **(b) `KILN_INFERENCE_MEMORY_FRACTION=X`** (or
-  `[memory] inference_memory_fraction = X`) — equivalent fraction-based knob,
-  if you'd rather size by ratio than by absolute block count.
-
-Use (a) on first-run failures and you are unlikely to see this codepath again.
+- **`KILN_NUM_BLOCKS=N`** (or `[memory] num_blocks = N` in
+  [`kiln.example.toml`](kiln.example.toml)) — preferred; bypasses the
+  auto-sizer with an exact block count. This is the canonical workaround in
+  [issue #685](https://github.com/ericflo/kiln/issues/685). The panic prints
+  a concrete `N`.
+- **`KILN_INFERENCE_MEMORY_FRACTION=X`** — fraction-based equivalent.
 
 
 ### 9.4 Batch generation (efficient for GRPO rollouts)


### PR DESCRIPTION
## What

Cold-reader audit of `QUICKSTART.md` per Phase 11 onboarding/polish work. 4 focused tightening edits, doc-only, no scope creep.

**Diff: 25 insertions, 79 deletions (54 net lines removed).**

## Edits

1. **Delete "Reader map" block** (~7 lines). Pure redundancy with the "Choose your path" table immediately above. Both explained the same navigation flow; cold-reader skips the second pass.
2. **Compress "Prerequisites"** (~33 lines → ~10). Four path-specific lists each repeated `~20GB disk`, `24GB+ VRAM`, `Qwen3.5-4B`. Replaced with a shared "All paths share these requirements" block plus a single per-path build-tooling delta list.
3. **Trim section 9.3 "KV cache OOM auto-recovery"** (~46 lines → ~17). Kept the WARN→pin remediation, the panic→`KILN_NUM_BLOCKS=N` remediation, and the issue #685 reference. Dropped the formula derivation, sample WARN log block, and prose around what driver overhead is — operational detail that does not belong in a first-run quickstart.
4. **Remove dead `<a id="42-troubleshooting-older-release-long-prefill-timeouts">` anchor**. Stale relic from when the section was numbered 4.2; current section is 9.2. `README.md:212` correctly links to GitHub's auto-generated `#92-...` anchor — confirmed.

## Anchor / inbound-link safety

Verified no inbound anchors broken:
- `README.md:132` → `#quick-path-server-binary-terminal-first-no-source-build` — preserved.
- `README.md:212` → `#92-troubleshooting-older-release-long-prefill-timeouts` — preserved (auto-generated from `### 9.2` header text; the explicit `<a id="42-...">` was always dead).
- `docs/GRPO_GUIDE.md` → `#9-advanced-api-examples`, `#94-batch-generation-...` — preserved.
- All numbered section H2/H3 headers untouched.

## Friction log (full audit, in source order)

[FIX] Lines 14-20 "Reader map" duplicates the "Choose your path" table immediately above it. Both sections explain how to navigate the doc. The table on line 5 already tells me which path to take and what to do first; the Reader map then re-explains the same flow as prose. A cold-reader's eyes skip the second pass — pure noise. **(Fixed in this PR.)**

[FIX] Lines 22-55 "Prerequisites" repeats the same disk/GPU/model facts four times — once per path. The Server-binary, Container, and Source/CLI sub-lists each restate "~20GB free", "24GB+ VRAM", "Qwen3.5-4B" with minor variations. A cold-reader who already saw README's hardware line is reading this for the third time. Compresses cleanly to one shared list + per-path build-tooling deltas. **(Fixed in this PR.)**

[FIX] Section 9.3 is 46 lines of operational troubleshooting buried under "Quickstart". It explains the auto-sizer formula, fallback fraction list, the WARN log, the panic message, two remediation knobs, and pointers to issue #685 and PR #687. This is great content but a first-time reader doesn't need any of it before they've sent their first chat completion. **(Trimmed in place to ~17 lines in this PR — chose to trim rather than move because `docs/site/troubleshooting.html` does not currently cover KV-cache OOM, and adding new HTML content is scope creep beyond a "QUICKSTART tightening" PR.)**

[FIX] Line 460 `<a id="42-troubleshooting-older-release-long-prefill-timeouts">` is a stale anchor from a previous section-numbering scheme. The current section is "9.2", not "4.2". GitHub auto-generates the `#92-...` anchor from the H3 header text, and `README.md:212` already links to `#92-...` (works correctly). The explicit `<a id="42-...">` is dead code. **(Removed in this PR.)**

[DEFER] Step "1. Optional Source / CLI Branch: Build Kiln" — the "1." prefix is awkward (it's the only "optional" step in the linear 1-2-3-4-5 first-run sequence). But renaming it would break the visual cadence of subsequent numbered steps, and there are no inbound anchor links to break. Cosmetic; defer.

[DEFER] Lines 57-73 (Desktop App download table) duplicates README lines 342-362 nearly verbatim. Maintenance issue across two docs, not a cold-reader friction issue.

[DEFER] Lines 189-193 explain log-format auto/json/pretty in the middle of "Start the Server". Not first-run-critical but minor.

[DEFER] "Container" path users are forward-referenced to "Running with Docker" — a lot of doc to scroll past. Could inline higher up. Real fix but bigger restructure than this PR allows.

## Test plan

- [x] `git diff --stat` shows ~104 lines changed, well under the 200-line cap.
- [x] All H2/H3 section headers unchanged → all auto-generated anchors preserved.
- [x] Inbound anchor links from `README.md` and `docs/GRPO_GUIDE.md` verified intact.
- [x] No code, no config, no CI changes — doc-only.