### PR TITLE
docs: deduplicate Desktop App install table between README and QUICKSTART

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -34,17 +34,7 @@ If setup stalls on binary downloads, CUDA/Vulkan/Metal, model paths, `/health`, 
 
 Kiln Desktop ships prebuilt installers for Windows, Linux, and macOS on Apple Silicon. The installer bundles only the GUI wrapper — on first launch it auto-downloads the matching prebuilt `kiln` server binary for your platform and verifies it against the published SHA-256. Linux chooses CUDA for NVIDIA systems and Vulkan for AMD/Intel systems; macOS uses the Apple Silicon Metal backend. **No Rust toolchain, CUDA toolkit, or source build is required for this path.**
 
-**Download — [Kiln Desktop v0.2.2](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2):**
-
-**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.2` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, so this quickstart is not stale.
-
-| Platform | Installer | Size |
-|----------|-----------|------|
-| macOS (Apple Silicon) | [Kiln.Desktop_0.2.2_aarch64.dmg](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_aarch64.dmg) | 8.5 MB |
-| Windows | [Kiln.Desktop_0.2.2_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_x64-setup.exe) (NSIS) | 4.5 MB |
-| Windows | [Kiln.Desktop_0.2.2_x64_en-US.msi](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_x64_en-US.msi) (MSI) | 6.8 MB |
-| Linux | [Kiln.Desktop_0.2.2_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_amd64.deb) | 8.8 MB |
-| Linux | [Kiln.Desktop_0.2.2_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_amd64.AppImage) | 85.7 MB |
+**Download:** the full installer matrix (macOS `.dmg`, Windows NSIS `.exe` and MSI, Linux `.deb` and `.AppImage`) lives in the [Desktop App section of the README](README.md#desktop-app), alongside dashboard, settings, and logs screenshots.
 
 Install the desktop app, choose or download the Qwen3.5-4B model weights, start the server from the app, then skip ahead to [Test Inference](#4-test-inference). Continue with the Server binary path if you want a prebuilt terminal-first server, or section 1 if you want to build from source.
 


### PR DESCRIPTION
## Why

Phase 11 onboarding/polish — flagged as `[DEFER]` in PR #969's friction log.

`README.md` (`## Desktop App`, lines 342-360) and `QUICKSTART.md` (`## Quick path: Desktop App`, lines 33-49) both maintained near-identical Desktop App install tables: same `desktop-v0.2.2` URLs, same file sizes, same version-split release note. Every desktop release bump previously required two edits and risked sync drift between the two locations.

## What

Pick `README.md` as the canonical home for the full install table — it already serves as the rich Desktop App section with dashboard, settings, and logs screenshots. README's `## Quick Start` and other surfaces already cross-link to `#desktop-app`.

QUICKSTART's `## Quick path: Desktop App` section now keeps:
- The intro paragraph explaining what Desktop ships and that no Rust toolchain is needed
- A 1-sentence pointer to the README install table that names the available installer formats
- The closing navigation sentence (skip ahead to Test Inference, or continue to Server binary / source paths)

A cold reader following QUICKSTART still finds the download path on the first jump, and the `desktop-v0.2.2` version string now lives in exactly one place.

## Diff

`1 file changed, 1 insertion(+), 11 deletions(-)` — well under the 150-line cap.

## Verification

- `node scripts/check_docs_site_smoke.mjs` exits 0 (this was the same test that caught literal-string requirements in PR #969). The smoke test asserts QUICKSTART's `## Choose your path` section and `## Quick path: Server binary ...` section explicitly, but does not assert the Desktop App install table contents in QUICKSTART (those literal-string checks live against `docs/site/index.html` and `docs/site/quickstart.html`, which are unaffected).
- `grep -nE 'desktop-v0\.[0-9]+\.[0-9]+' README.md QUICKSTART.md` — version string now only appears in `README.md`.
- No external doc references the QUICKSTART desktop section by anchor (`grep -r quick-path-desktop-app .` returns nothing).