### PR TITLE
cli: friendly error when Kiln server is unreachable

### DIFF
--- a/crates/kiln-server/src/cli.rs
+++ b/crates/kiln-server/src/cli.rs
@@ -186,6 +186,64 @@ fn render_api_error(body: &serde_json::Value, status: reqwest::StatusCode) -> St
     }
 }
 
+/// True if a `reqwest::Error` indicates the Kiln server is unreachable
+/// (connect refused, DNS failure, or transport timeout).
+///
+/// Walks the error chain so I/O errors wrapped under hyper/h2/rustls are still
+/// classified — `reqwest::Error::is_connect()` alone misses some cases.
+fn is_connection_error(err: &reqwest::Error) -> bool {
+    use std::error::Error as _;
+    if err.is_connect() || err.is_timeout() {
+        return true;
+    }
+    let mut source: Option<&(dyn std::error::Error + 'static)> = err.source();
+    while let Some(e) = source {
+        if let Some(io_err) = e.downcast_ref::<std::io::Error>() {
+            use std::io::ErrorKind;
+            if matches!(
+                io_err.kind(),
+                ErrorKind::ConnectionRefused
+                    | ErrorKind::ConnectionReset
+                    | ErrorKind::ConnectionAborted
+                    | ErrorKind::TimedOut
+                    | ErrorKind::AddrNotAvailable
+                    | ErrorKind::NotConnected
+            ) {
+                return true;
+            }
+        }
+        source = e.source();
+    }
+    false
+}
+
+/// Map a `reqwest::Error` to a friendly Kiln CLI diagnostic.
+///
+/// On connect / DNS / timeout errors (the "is the server even running?" class),
+/// print a tip pointing at `kiln serve` + QUICKSTART and `exit(1)` so the user
+/// is not buried under raw `reqwest`/`hyper` chain text. For any other transport
+/// error, return it wrapped in `anyhow::Error` so today's `?` propagation keeps
+/// working unchanged. HTTP-error responses (`status.is_success() == false`)
+/// still flow through `render_api_error` since they are reached only after the
+/// response body has been read successfully.
+fn handle_request_error(url: &str, err: reqwest::Error) -> anyhow::Error {
+    if is_connection_error(&err) {
+        eprintln!(
+            "{} Could not reach Kiln server at {}.",
+            style("✗").red().bold(),
+            style(url).cyan()
+        );
+        eprintln!(
+            "  Is the server running? Try {} first, or pass {} to point at another host.",
+            style("kiln serve").white().bold(),
+            style("--url <addr>").white().bold()
+        );
+        eprintln!("  See QUICKSTART.md for setup help.");
+        std::process::exit(1);
+    }
+    anyhow::Error::new(err)
+}
+
 /// Kiln — single-model inference server with live online learning
 #[derive(Parser)]
 #[command(
@@ -743,7 +801,9 @@ pub fn format_health_pretty(body: &serde_json::Value) -> String {
 /// the raw JSON error body is always printed regardless of `json` so failure
 /// diagnostics are never lossy.
 pub async fn run_health(url: &str, json: bool) -> anyhow::Result<()> {
-    let resp = reqwest::get(format!("{url}/health")).await?;
+    let resp = reqwest::get(format!("{url}/health"))
+        .await
+        .map_err(|e| handle_request_error(url, e))?;
     let status = resp.status();
     let body: serde_json::Value = resp.json().await?;
 
@@ -823,7 +883,9 @@ pub fn run_config_check(file: Option<&str>) -> anyhow::Result<()> {
 
 /// Run the `adapters list` CLI subcommand.
 pub async fn run_adapters_list(url: &str) -> anyhow::Result<()> {
-    let resp = reqwest::get(format!("{url}/v1/adapters")).await?;
+    let resp = reqwest::get(format!("{url}/v1/adapters"))
+        .await
+        .map_err(|e| handle_request_error(url, e))?;
     let status = resp.status();
     let body: serde_json::Value = resp.json().await?;
 
@@ -935,7 +997,8 @@ pub async fn run_adapters_load(url: &str, name: &str) -> anyhow::Result<()> {
         .post(adapter_load_url(url))
         .json(&build_adapter_load_payload(name))
         .send()
-        .await?;
+        .await
+        .map_err(|e| handle_request_error(url, e))?;
     let status = resp.status();
     let body: serde_json::Value = resp.json().await?;
 
@@ -960,7 +1023,11 @@ pub async fn run_adapters_load(url: &str, name: &str) -> anyhow::Result<()> {
 /// Run the `adapters unload` CLI subcommand.
 pub async fn run_adapters_unload(url: &str, name: Option<&str>) -> anyhow::Result<()> {
     let client = reqwest::Client::new();
-    let resp = client.post(adapter_unload_url(url)).send().await?;
+    let resp = client
+        .post(adapter_unload_url(url))
+        .send()
+        .await
+        .map_err(|e| handle_request_error(url, e))?;
     let status = resp.status();
     let body: serde_json::Value = resp.json().await?;
 
@@ -994,7 +1061,8 @@ pub async fn run_adapters_delete(url: &str, name: &str) -> anyhow::Result<()> {
     let resp = client
         .delete(format!("{url}/v1/adapters/{name}"))
         .send()
-        .await?;
+        .await
+        .map_err(|e| handle_request_error(url, e))?;
     let status = resp.status();
 
     if status.is_success() {
@@ -1053,7 +1121,8 @@ pub async fn run_train_sft(
         .post(format!("{url}/v1/train/sft"))
         .json(&body)
         .send()
-        .await?;
+        .await
+        .map_err(|e| handle_request_error(url, e))?;
 
     let status = resp.status();
     let resp_body: serde_json::Value = resp.json().await?;
@@ -1111,7 +1180,8 @@ pub async fn run_train_grpo(
         .post(format!("{url}/v1/train/grpo"))
         .json(&body)
         .send()
-        .await?;
+        .await
+        .map_err(|e| handle_request_error(url, e))?;
 
     let status = resp.status();
     let resp_body: serde_json::Value = resp.json().await?;
@@ -1202,7 +1272,9 @@ pub async fn run_train_status(url: &str, job_id: Option<&str>) -> anyhow::Result
 }
 
 async fn print_single_job_status(url: &str, id: &str) -> anyhow::Result<()> {
-    let resp = reqwest::get(format!("{url}/v1/train/status/{id}")).await?;
+    let resp = reqwest::get(format!("{url}/v1/train/status/{id}"))
+        .await
+        .map_err(|e| handle_request_error(url, e))?;
     let status = resp.status();
     let body: serde_json::Value = resp.json().await?;
 
@@ -1221,7 +1293,9 @@ async fn print_single_job_status(url: &str, id: &str) -> anyhow::Result<()> {
 }
 
 async fn print_all_job_statuses(url: &str) -> anyhow::Result<()> {
-    let resp = reqwest::get(format!("{url}/v1/train/status")).await?;
+    let resp = reqwest::get(format!("{url}/v1/train/status"))
+        .await
+        .map_err(|e| handle_request_error(url, e))?;
     let status = resp.status();
     let body: serde_json::Value = resp.json().await?;
 
@@ -1597,6 +1671,35 @@ mod tests {
             }
             other => panic!("expected adapters unload, got {:?}", other.is_some()),
         }
+    }
+
+    #[tokio::test]
+    async fn handle_request_error_classifies_unreachable_server() {
+        // Bind a TCP listener on an OS-assigned port, capture the port, then
+        // drop the listener so that subsequent connects to the same port get
+        // ECONNREFUSED. This is more reliable than picking a "probably closed"
+        // high port.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind 127.0.0.1:0");
+        let port = listener.local_addr().expect("local_addr").port();
+        drop(listener);
+        let url = format!("http://127.0.0.1:{port}");
+
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .expect("build reqwest client");
+        let err = client
+            .get(format!("{url}/health"))
+            .send()
+            .await
+            .expect_err("expected connect error against closed loopback port");
+
+        assert!(
+            is_connection_error(&err),
+            "expected is_connection_error=true (is_connect={}, is_timeout={}); err={err:?}",
+            err.is_connect(),
+            err.is_timeout(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

When a user runs \`kiln health\` (or any other client subcommand) before starting the server, today they get a wall of raw \`reqwest\`/\`hyper\` error chain text:

\`\`\`
Error: error sending request for url (http://127.0.0.1:8420/health): client error (Connect): tcp connect error: Connection refused (os error 111)

Caused by:
    0: client error (Connect)
    1: tcp connect error: Connection refused (os error 111)
    2: Connection refused (os error 111)
\`\`\`

Cold readers can't tell whether they hit a bug or just need to start the server.

## After

\`\`\`
✗ Could not reach Kiln server at http://127.0.0.1:8420.
  Is the server running? Try kiln serve first, or pass --url <addr> to point at another host.
  See QUICKSTART.md for setup help.
\`\`\`

Exit code is still 1, so scripts that check the exit status keep working.

## How

- New \`handle_request_error(url, err) -> anyhow::Error\` helper. Connect / DNS / timeout failures (the "is the server even running?" class) print the friendly diagnostic and \`exit(1)\`. Anything else is wrapped in \`anyhow::Error\` so existing \`?\` propagation is unchanged.
- New \`is_connection_error(&reqwest::Error)\` walks the error chain so wrapped \`std::io::Error\`s under hyper/h2/rustls are still caught — \`reqwest::Error::is_connect()\` alone misses some cases.
- Wired into the 9 \`reqwest::get(...)?\` / \`client...send()?\` sites in \`cli.rs\` via \`.map_err(|e| handle_request_error(url, e))?\`: \`run_health\`, \`run_adapters_list\`/\`_load\`/\`_unload\`/\`_delete\`, \`run_train_sft\`/\`run_train_grpo\`, \`print_single_job_status\`/\`print_all_job_statuses\`.
- HTTP-status response handling (\`status.is_success() == false\`) still flows through \`render_api_error\` since that path is reached only after the body is read successfully.

## Scope

\`crates/kiln-server/src/cli.rs\` only. No behavior change for happy-path requests, HTTP-error responses, or non-connection transport errors.

## Test plan

- New \`#[tokio::test]\` that binds \`127.0.0.1:0\`, drops the listener to free the port, then asserts \`is_connection_error\` is true on the resulting connect failure: \`cargo test -p kiln-server --lib cli::tests::handle_request_error_classifies_unreachable_server\` ✅
- \`cargo build --release -p kiln-server --bin kiln\` ✅
- \`cargo fmt --check\` ✅
- Manual smoke: \`./target/release/kiln health --url http://127.0.0.1:65500\` against a closed port — friendly message printed, exit 1.