### PR TITLE
config: minimum-required preamble in kiln.example.toml

### DIFF
--- a/kiln.example.toml
+++ b/kiln.example.toml
@@ -6,6 +6,15 @@
 #   2. KILN_CONFIG environment variable
 #   3. ./kiln.toml in the current working directory
 #   4. No file — built-in defaults
+#
+# Minimum required for real (non-mock) inference: set `model.path` —
+# everything else has a working default. Paste this:
+#
+#   [model]
+#   path = "/path/to/qwen3.5-4b"
+#
+# Omitting `model.path` boots mock mode (handy for trying the CLI without
+# weights). See QUICKSTART.md or https://ericflo.github.io/kiln/quickstart.html.
 
 [server]
 host = "0.0.0.0"


### PR DESCRIPTION
## What

Adds a brief, all-comment preamble near the top of `kiln.example.toml` (between the existing 7-line file-resolution header and the `[server]` section) that tells a cold first-time user the one thing they actually have to set to get a real (non-mock) server running:

- The minimum required setting is `model.path` — everything else has a working default.
- Shows the exact 2-line snippet to paste.
- Explains that omitting `model.path` boots mock mode (handy for trying the CLI without weights).
- Cross-links to both `QUICKSTART.md` (local) and the canonical docs URL `https://ericflo.github.io/kiln/quickstart.html` (matches the canonical-URL pattern landed in PR #973).

## Why

A first-time user runs `cp kiln.example.toml kiln.toml && kiln serve --config kiln.toml` and is greeted by 100+ lines of `# commented = \"default\"` options. The current required-setting hint (`# path = \"/path/to/model\"            # Required for real inference (omit for mock mode)`) is buried mid-`[model]` block, mixed in with all the other commented optional settings.

This is a Phase 11 (onboarding + polish) item: cold-reader friction on the example config file. It lifts the answer to \"what's the minimum I have to set?\" into the first ~17 lines so users don't have to scan the whole file.

## Verification

- `git diff kiln.example.toml` shows exactly one additive hunk (9 inserted lines, 0 deletions, no other edits).
- `python3 -c \"import tomllib; tomllib.loads(open('kiln.example.toml').read())\"` confirms the file still parses cleanly (the new block is 100% comment-prefixed, so the TOML grammar is unaffected).
- `head -20 kiln.example.toml` confirms the minimum-required callout lands obviously, before the `[server]` block.

## Out of scope

- Did not rename, regroup, or rewrite any existing comments.
- Did not change defaults or add new config keys.
- Did not touch `docs/site/`, `README.md`, or `QUICKSTART.md` — this PR is config-only.