### PR TITLE
CONTRIBUTING.md: drop stale test skip, document cargo-deny CI check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,10 +46,10 @@ CUDA builds compile a fair amount of `nvcc` per architecture. To target only an 
 KILN_CUDA_ARCHS=86 cargo build --release --features cuda
 ```
 
-Run the test suite. The two skipped tests are pre-existing flakes documented in `.github/workflows/ci.yml` (env-var races and a `Device::new_metal(0)` race in `candle-metal`):
+Run the test suite. The skipped `test_health_with_real_backend` depends on a live network backend and is intentionally excluded from CI. Env-mutating tests are now serialized via an internal `ENV_LOCK` mutex and run safely in parallel. CI on macOS additionally pins the Metal feature tests to `--test-threads=1` because of a known race in `candle-metal`'s `MetalDevice::new`:
 
 ```bash
-cargo test --locked -- --skip test_env_var_overrides --skip test_health_with_real_backend
+cargo test --locked -- --skip test_health_with_real_backend
 ```
 
 If you have `cargo-nextest` installed, it runs the same tests in parallel and is noticeably faster:
@@ -57,6 +57,15 @@ If you have `cargo-nextest` installed, it runs the same tests in parallel and is
 ```bash
 cargo nextest run --locked
 ```
+
+Run the license / source / bans policy check that CI runs:
+
+```bash
+cargo install --locked cargo-deny  # if not already installed
+cargo deny check --all-features
+```
+
+This validates that any new dependency satisfies the workspace's MIT/Apache-compatible license allowlist and other policy rules in `deny.toml`. CI pins cargo-deny to a specific action SHA (see `.github/workflows/ci.yml`); local runs with the latest version are fine for catching gross violations before pushing.
 
 ## Running the server locally
 


### PR DESCRIPTION
## What

Two cold-reader fixes to CONTRIBUTING.md:

1. **Drop stale `--skip test_env_var_overrides`** from the documented `cargo test` command. Env-mutating tests are now serialized via an internal `ENV_LOCK` mutex (see ci.yml:43-47). CI itself only skips `test_health_with_real_backend` — the live-network test that's intentionally excluded.
2. **Add a cargo-deny note** so new contributors can run the same license / source / bans policy check that CI runs (`cargo-deny check --all-features`, ci.yml:100-130) before pushing, instead of finding out via a CI failure.

## Why

A new contributor following CONTRIBUTING.md literally:

- Runs an outdated test command with an unnecessary skip flag
- Has no idea cargo-deny is part of CI until their PR fails the deny job

Both are small but fixable cold-reader friction points.

## Verification

- `grep -n test_env_var_overrides .github/workflows/ci.yml` returns nothing — only the test definition (crates/kiln-server/src/config.rs:995) and (before this PR) CONTRIBUTING.md reference it.
- ci.yml line 43-47 explicitly comments that env-mutating tests are now serialized via ENV_LOCK and no longer need the skip.
- ci.yml lines 100-130 run the cargo-deny check that this PR documents.

Doc-only — no behavior change.