### PR TITLE
docs(readme): surface model weights download step before Docker block

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
 
 This downloads `Qwen/Qwen3.5-4B` into `./Qwen3.5-4B`, which the commands below reference directly.
 
-**Path 2 — Server binary (terminal-first, no source build):** Download the latest `kiln-v*` server artifact when you want the `kiln` server in your terminal with no source build, Desktop App, or Docker. Linux x86_64 + NVIDIA CUDA 12.4 is the compact path:
+**Path 2 — Server binary (terminal-first, no source build):** Download the latest `kiln-v*` server artifact when you want the `kiln` server in your terminal with no source build, Desktop App, or Docker. Linux x86_64 + NVIDIA CUDA 12.4 is the compact path (run the `Qwen/Qwen3.5-4B` weights step above first):
 
 ```bash
 KILN_VERSION=$(curl -fsSL https://api.github.com/repos/ericflo/kiln/releases/latest | sed -n 's/.*"tag_name": "kiln-v\([^"]*\)".*/\1/p')

--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ See [docs/GRPO_GUIDE.md](docs/GRPO_GUIDE.md) for worked verifiable-rewards examp
 
 **Path 1 — Desktop App (recommended):** Install [Kiln Desktop](#desktop-app) on Windows, Linux, or macOS. The app downloads and verifies the matching prebuilt `kiln` server binary on first launch, then walks you through choosing or downloading `Qwen/Qwen3.5-4B`. No Rust toolchain, CUDA toolkit, or source build is required for this path.
 
+**Get the model weights** (Paths 2–4 share this step; the Desktop App handles it automatically):
+
+```bash
+pip install huggingface-hub
+huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
+```
+
+This downloads `Qwen/Qwen3.5-4B` into `./Qwen3.5-4B`, which the commands below reference directly.
+
 **Path 2 — Server binary (terminal-first, no source build):** Download the latest `kiln-v*` server artifact when you want the `kiln` server in your terminal with no source build, Desktop App, or Docker. Linux x86_64 + NVIDIA CUDA 12.4 is the compact path:
 
 ```bash
@@ -124,24 +133,22 @@ curl -L -o kiln-linux-cuda.tar.gz \
   "https://github.com/ericflo/kiln/releases/download/kiln-v${KILN_VERSION}/kiln-${KILN_VERSION}-x86_64-unknown-linux-gnu-cuda124.tar.gz"
 tar -xzf kiln-linux-cuda.tar.gz
 
-pip install huggingface-hub
-huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
 KILN_MODEL_PATH=./Qwen3.5-4B ./kiln serve
 ```
 
 For Linux Vulkan, macOS Metal, Windows CUDA, and SHA-256 sidecar checks, use the full release artifact matrix in [QUICKSTART.md](QUICKSTART.md#quick-path-server-binary-terminal-first-no-source-build).
 
-**Path 3 — Container:** Run the prebuilt GHCR image when you prefer containerized deployment. This path requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html).
+**Path 3 — Container:** Run the prebuilt GHCR image when you prefer containerized deployment. This path requires the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html). Make sure the weights step above has placed the model under `./Qwen3.5-4B` (or substitute your own absolute path), then mount that directory into the container:
 
 ```bash
 docker pull ghcr.io/ericflo/kiln-server:latest
 docker run --gpus all -p 8420:8420 \
   -e KILN_MODEL_PATH=/models/Qwen3.5-4B \
-  -v /path/to/Qwen3.5-4B:/models/Qwen3.5-4B:ro \
+  -v "$(pwd)/Qwen3.5-4B:/models/Qwen3.5-4B:ro" \
   ghcr.io/ericflo/kiln-server:latest serve
 ```
 
-Replace `/path/to/Qwen3.5-4B` with your local `Qwen3.5-4B` model directory, then open http://127.0.0.1:8420/ui after the container starts.
+Open http://127.0.0.1:8420/ui after the container starts.
 
 **Path 4 — Source / CLI:** Install Rust stable, then build the CLI from source when you are contributing, scripting against a local checkout, or need to test unreleased changes.
 
@@ -160,14 +167,7 @@ cargo build --release --features vulkan   # Vulkan compute kernels via ash + SPI
 cargo build --release --features metal    # Metal backend via candle
 ```
 
-Download the model weights:
-
-```bash
-pip install huggingface-hub
-huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B
-```
-
-Start the source-built server:
+Start the source-built server (using the weights downloaded above):
 
 ```bash
 KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve


### PR DESCRIPTION
## What

Extract the `huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B` step into a single shared **Get the model weights** subsection that appears before Path 2, so a cold reader trying any of Paths 2–4 (server binary, container, source build) sees the weights step before the run command. Removes the duplicate copies that previously lived inside Path 2 and Path 4. Path 3 (Docker) now references the resulting `./Qwen3.5-4B` directory directly via `-v "$(pwd)/Qwen3.5-4B:/models/Qwen3.5-4B:ro"` instead of the placeholder `/path/to/Qwen3.5-4B`.

## Why

Cold-reader friction in Path 3 (Container): the `docker run` block told users to "Replace `/path/to/Qwen3.5-4B` with your local `Qwen3.5-4B` model directory" but never explained how to obtain those weights — the download command only appeared inside Path 2's code block and again in Path 4. A user who skipped to Docker first had to scan two other paths to figure out where the weights came from. Path 1 (Desktop App) is unaffected — the app still handles weights automatically.

## Verification

- README diff reads cleanly cold: weights-download command now visible before the docker run example.
- `huggingface-cli download Qwen/Qwen3.5-4B --local-dir ./Qwen3.5-4B` appears exactly once in the README (`grep -c` returns `1`).
- 13 insertions, 13 deletions — well under the 25-line cap.
- No Rust changes; no other files touched.