### PR TITLE
docs: surface BENCHMARKS.md from README nav and architecture page

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <a href="https://ericflo.github.io/kiln/api.html">API Reference</a> &middot;
   <a href="https://ericflo.github.io/kiln/troubleshooting.html">Troubleshooting</a> &middot;
   <a href="ARCHITECTURE.md">Architecture</a> &middot;
+  <a href="BENCHMARKS.md">Benchmarks</a> &middot;
   <a href="kiln.example.toml">Configuration</a> &middot;
   <a href="CHANGELOG.md">Changelog</a> &middot;
   <a href="CONTRIBUTING.md">Contributing</a> &middot;

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -386,6 +386,10 @@ training request
           <h3 class="font-semibold mb-2">Troubleshooting</h3>
           <p style="color: var(--fg-dim);">Check binary, CUDA or Metal setup, model path, health output, and adapter storage.</p>
         </a>
+        <a class="card p-5 block" href="https://github.com/ericflo/kiln/blob/main/BENCHMARKS.md">
+          <h3 class="font-semibold mb-2">Benchmarks</h3>
+          <p style="color: var(--fg-dim);">Decode tok/s, mean and p99 ITL on Qwen3.5-4B against external references on the same single-GPU class.</p>
+        </a>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Why

Phase 11 onboarding/polish — cold-reader gap.

A first-time visitor browsing the docs site cannot find Kiln's benchmark numbers: `grep -rn 'BENCHMARKS\|benchmark' docs/site/*.html` returns zero hits across all seven pages. `BENCHMARKS.md` is a 290-line canonical doc (decode tok/s, mean/p99 ITL, single-stream protocol, A6000 setup, per-PR perf history) that is currently only referenced from README's body and ARCHITECTURE.md.

## What

- `README.md`: add a `Benchmarks` entry to the top nav between `Architecture` and `Configuration` (deep-dive cluster).
- `docs/site/architecture.html`: add a 5th `Benchmarks` card to the `Where to go next` grid, linking to the GitHub-hosted `BENCHMARKS.md`. Architecture readers asking "is this fast?" now have a one-click path to the numbers.

## Out of scope (deliberately deferred)

- docs/site nav/footer integration would require touching all 8 pages plus `scripts/check_docs_site_smoke.mjs` — separate follow-up if needed.
- `docs/site/index.html` body card — different design surface.