### PR TITLE
docs(site): surface BENCHMARKS.md on landing page nav and footer

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -227,6 +227,7 @@
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/BENCHMARKS.md">Benchmarks</a>
         <a href="https://github.com/ericflo/kiln" class="hidden sm:inline">GitHub</a>
       </nav>
     </div>
@@ -531,6 +532,7 @@ docker run --gpus all -p 8420:8420 \
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/BENCHMARKS.md">Benchmarks</a>
         <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>
         <a href="https://github.com/ericflo/kiln/blob/main/SECURITY.md">Security</a>
         <a href="https://github.com/ericflo/kiln/blob/main/LICENSE">License</a>


### PR DESCRIPTION
## What
Adds a Benchmarks link to the docs/site/index.html top nav and footer, pointing at BENCHMARKS.md on GitHub.

## Why
PR #978 surfaced BENCHMARKS.md from README nav and docs/site/architecture.html, but the landing page itself (https://ericflo.github.io/kiln/) had no path to performance numbers. A cold reader visiting the landing page wanting to know is-it-fast had no link to BENCHMARKS.md.

## Test plan
- [x] grep finds exactly 2 BENCHMARKS.md references in docs/site/index.html
- [x] No other files changed