### PR TITLE
docs(site): surface kiln health CLI as first probe in troubleshooting

### DIFF
--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -281,6 +281,12 @@
           </p>
         </div>
       </div>
+      <p class="mt-6" style="color: var(--fg-dim);">
+        If the <code>kiln</code> CLI is on your <code>PATH</code>, run <code>kiln health</code> for the same
+        info as a readable tree (use <code>--json</code> for scripts and
+        <code>--url http://host:8420</code> for remote servers). The curl commands below are the
+        equivalent HTTP probes &mdash; handy for CI, scripts, or any environment without the CLI.
+      </p>
 <pre class="mt-6"><code>curl -s http://localhost:8420/health | jq .
 curl -s http://localhost:8420/v1/models | jq .
 curl -s http://localhost:8420/v1/chat/completions \


### PR DESCRIPTION
Add a one-paragraph callout pointing cold readers at the kiln health CLI command before the existing curl probes in the Start-with-three-probes section. CLI ships with the server and kiln health is the simplest one-command probe; the curl commands stay as the remote/CI fallback path.