### PR TITLE
docs(site): surface kiln train status CLI as first GRPO status probe

### DIFF
--- a/docs/site/grpo.html
+++ b/docs/site/grpo.html
@@ -363,7 +363,14 @@
         <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">
           <code>/v1/train/grpo</code> returns a queued job immediately. Poll <code>/v1/train/status</code> to see pending, running, completed, or failed jobs, then confirm the trained adapter through the adapter APIs or the web UI.
         </p>
+        <p class="leading-relaxed mb-5" style="color: var(--fg-dim);">
+          If the <code>kiln</code> CLI is on your <code>PATH</code>, run <code>kiln train status</code> for the same info as a readable summary (use <code>--url http://host:8420</code> for remote servers). The curl command below is the equivalent HTTP probe &mdash; handy for CI, scripts, or any environment without the CLI.
+        </p>
         <section class="endpoint">
+          <h3 class="font-semibold mb-2">Training status from the CLI</h3>
+          <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>kiln train status</code></pre>
+        </section>
+        <section class="endpoint mt-4">
           <h3 class="font-semibold mb-2">Training status</h3>
           <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>curl -s http://localhost:8420/v1/train/status | python3 -m json.tool</code></pre>
         </section>


### PR DESCRIPTION
## What
In docs/site/grpo.html, surface 'kiln train status' as the canonical CLI probe in the Watch-the-background-training-job section. The existing curl /v1/train/status block stays as the JSON fallback.

## Why
Cold-reader gap mirroring PR #980 (kiln health in troubleshooting Start-with-three-probes). The GRPO guide is one of the highest-traffic onboarding pages — readers following it should discover the canonical CLI command without bouncing to cli.html.

## Test plan
- [x] HTML parse smoke check
- [x] scripts/check_docs_site_smoke.mjs passes
- [x] grep confirms 'kiln train status' now appears in grpo.html