### PR TITLE
docs(site): surface kiln adapters list CLI in GRPO Watch-the-background-training-job

### DIFF
--- a/docs/site/grpo.html
+++ b/docs/site/grpo.html
@@ -374,6 +374,17 @@
           <h3 class="font-semibold mb-2">Training status</h3>
           <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>curl -s http://localhost:8420/v1/train/status | python3 -m json.tool</code></pre>
         </section>
+        <p class="leading-relaxed mt-5 mb-5" style="color: var(--fg-dim);">
+          Once a job is <code>completed</code>, confirm the new adapter actually landed and is active. If the <code>kiln</code> CLI is on your <code>PATH</code>, <code>kiln adapters list</code> shows the new adapter and which one is active. The curl command below hits the same endpoint for CI or scripted use.
+        </p>
+        <section class="endpoint mt-4">
+          <h3 class="font-semibold mb-2">Confirm the trained adapter from the CLI</h3>
+          <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>kiln adapters list</code></pre>
+        </section>
+        <section class="endpoint mt-4">
+          <h3 class="font-semibold mb-2">Confirm the trained adapter</h3>
+          <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>curl -s http://localhost:8420/v1/adapters | python3 -m json.tool</code></pre>
+        </section>
         <p class="text-sm mt-4" style="color: var(--fg-mute);">
           If a GRPO request is rejected or stays queued longer than expected, start with the <a href="troubleshooting.html">troubleshooting guide</a> and the full endpoint map in <a href="api.html#training">API training</a>.
         </p>


### PR DESCRIPTION
## What

Adds a \`kiln adapters list\` CLI probe + matching \`curl /v1/adapters\` HTTP probe to docs/site/grpo.html in the \"Watch the background training job\" article. Mirrors the cold-reader-CLI-surfacing pattern from #980 (kiln health → troubleshooting) and #981 (kiln train status → GRPO).

## Why

After a GRPO job finishes, a first-time reader needs a concrete CLI command to verify the new adapter actually landed and is active. The article previously only surfaced \`kiln train status\` (job-side) and pointed vaguely at \"the adapter APIs or the web UI\" without naming the probe. This closes that gap.

## Verification

- \`grep -n \"kiln adapters list\" docs/site/grpo.html\` returns the new section.
- \`grep -n \"/v1/adapters\" docs/site/grpo.html\` returns the new curl probe.
- Pages workflow auto-deploys on merge.