### PR TITLE
docs(quickstart): surface kiln health probe at end of step 3

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -185,6 +185,16 @@ Kiln binds to loopback (`127.0.0.1`) by default so a fresh install isn't reachab
 
 On Apple Silicon, Kiln auto-detects Metal and logs `Metal available — using Apple Silicon GPU` at startup instead of the CUDA availability line. On Linux AMD/Intel builds, the equivalent Vulkan log line is `Vulkan available — using Vulkan GPU (AMD/Intel)`. No config changes needed — the binary selects the backend that was compiled in.
 
+### Verify the server is up
+
+Before sending real inference traffic, run a quick health probe:
+
+```bash
+./target/release/kiln health
+```
+
+This prints a tree-style status of the server, model, and GPU and exits non-zero if the server is unreachable or unhealthy, which makes it easy to script in shell pipelines or CI. If `kiln health` reports a problem, see the [troubleshooting guide](https://ericflo.github.io/kiln/troubleshooting.html#start-with-three-probes) for the full probe sequence.
+
 ## 4. Test Inference
 
 Send a chat completion request (OpenAI-compatible):


### PR DESCRIPTION
## What
Adds a short 'Verify the server is up' subsection at the end of QUICKSTART.md step 3 'Start the Server' that surfaces the `kiln health` CLI as the canonical probe before step 4 sends real /v1/chat/completions traffic.

## Why
Cold readers landing on QUICKSTART previously had no probe between `kiln serve` and the first inference request. If the server wedged or the model failed to load, they would discover it via a confusing /v1/chat/completions failure in step 4 instead of via the CLI's tree-style health output. This extends the cold-reader-CLI-surfacing pattern from #980 (troubleshooting), #981 (GRPO 'Watch the background training job'), and #982 (GRPO adapter listing).

## Scope
Single-file doc-only change to QUICKSTART.md. No CLI changes — `kiln health` already exists. No CI changes. No GPU pod required.

## Verification
- `grep -c 'kiln health' QUICKSTART.md` returns >= 2 (existing step 7 mention + new step 3 probe; current count is 5)
- New `### Verify the server is up` subsection appears between step 3 and step 4
- `node scripts/check_docs_site_smoke.mjs` passes (exit 0)
- Cross-link to troubleshooting page anchor `#start-with-three-probes` resolves (verified in `docs/site/troubleshooting.html`)