### PR TITLE
docs(site): surface BENCHMARKS link in inner page footers

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -532,6 +532,7 @@ curl -s -X DELETE http://localhost:8420/v1/train/queue/$JOB_ID | python3 -m json
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/BENCHMARKS.md">Benchmarks</a>
         <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>
         <a href="https://github.com/ericflo/kiln/blob/main/SECURITY.md">Security</a>
         <a href="https://github.com/ericflo/kiln/blob/main/LICENSE">License</a>

--- a/docs/site/cli.html
+++ b/docs/site/cli.html
@@ -404,6 +404,7 @@ kiln adapters unload support-bot</code></pre>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/BENCHMARKS.md">Benchmarks</a>
         <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>
         <a href="https://github.com/ericflo/kiln/blob/main/SECURITY.md">Security</a>
         <a href="https://github.com/ericflo/kiln/blob/main/LICENSE">License</a>

--- a/docs/site/grpo.html
+++ b/docs/site/grpo.html
@@ -433,6 +433,7 @@
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/BENCHMARKS.md">Benchmarks</a>
         <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>
         <a href="https://github.com/ericflo/kiln/blob/main/SECURITY.md">Security</a>
         <a href="https://github.com/ericflo/kiln/blob/main/LICENSE">License</a>

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -522,6 +522,7 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/BENCHMARKS.md">Benchmarks</a>
         <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>
         <a href="https://github.com/ericflo/kiln/blob/main/SECURITY.md">Security</a>
         <a href="https://github.com/ericflo/kiln/blob/main/LICENSE">License</a>

--- a/docs/site/troubleshooting.html
+++ b/docs/site/troubleshooting.html
@@ -547,6 +547,7 @@ kiln adapters list --url http://gpu-box:8420</code></pre>
         <a href="demo/">Demo</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="architecture.html">Architecture</a>
+        <a href="https://github.com/ericflo/kiln/blob/main/BENCHMARKS.md">Benchmarks</a>
         <a href="https://github.com/ericflo/kiln/blob/main/CHANGELOG.md">Changelog</a>
         <a href="https://github.com/ericflo/kiln/blob/main/SECURITY.md">Security</a>
         <a href="https://github.com/ericflo/kiln/blob/main/LICENSE">License</a>


### PR DESCRIPTION
Cold-reader gap follow-up to #978 and #979. The inner docs/site pages (quickstart, troubleshooting, grpo, cli, api) have an identical 12-link footer nav block with no Benchmarks entry, so a reader who scrolls to the footer to navigate cannot reach the benchmark numbers without going back to the landing page or README. This adds the same canonical href used by index.html footer (#979) between Architecture and Changelog in all five inner pages. Doc-only, no behavior change.