### PR TITLE
docs(quickstart): link SFT in reader-map to in-page corrections anchor

### DIFF
--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -280,7 +280,7 @@
         <div class="card p-5">
           <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-4">Optional learning</span>
           <h3 class="font-semibold mb-2">Train after verification</h3>
-          <p style="color: var(--fg-dim);">Use SFT, <a href="grpo.html">GRPO</a>, and adapter workflows only after the server is healthy and you have sent one chat request.</p>
+          <p style="color: var(--fg-dim);">Use <a href="#sft-corrections">SFT</a>, <a href="grpo.html">GRPO</a>, and adapter workflows only after the server is healthy and you have sent one chat request.</p>
         </div>
         <div class="card p-5">
           <span class="pill inline-block text-xs px-2.5 py-1 rounded-full mb-4">Advanced reference</span>
@@ -442,7 +442,7 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
     "max_tokens": 64,
     "temperature": 0.7
   }' | python3 -m json.tool</code></pre>
-          <p class="text-sm mt-3" style="color: var(--fg-mute);">This is the first inference checkpoint: get one response before moving on to SFT or GRPO.</p>
+          <p class="text-sm mt-3" style="color: var(--fg-mute);">This is the first inference checkpoint: get one response before moving on to <a href="#sft-corrections">SFT</a> or <a href="grpo.html">GRPO</a>.</p>
         </div>
       </div>
       <figure class="card mt-6 overflow-hidden">
@@ -472,7 +472,7 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
       </div>
       <div class="grid sm:grid-cols-2 lg:grid-cols-7 gap-4">
         <a class="card p-5 block" href="api.html#training">
-          <h3 class="font-semibold mb-2">SFT corrections</h3>
+          <h3 id="sft-corrections" class="font-semibold mb-2">SFT corrections</h3>
           <p style="color: var(--fg-dim);">Post simple fixes to <code>/v1/train/sft</code> or use <code>kiln train sft</code> after first inference.</p>
         </a>
         <a class="card p-5 block" href="grpo.html">


### PR DESCRIPTION
## Summary
Cold-reader gap: in docs/site/quickstart.html, GRPO is linked from the reader-map paragraph (\`Train after verification\`) and from the \`Where to go next\` Training-file-shapes card, but SFT is mentioned in the same parallel positions with no link target. A cold reader following the GRPO link expects a parallel SFT destination and gets dead text instead.

Three small surgical edits in \`docs/site/quickstart.html\`:
- Add \`id="sft-corrections"\` to the existing \`SFT corrections\` h3 in the \`Where to go next\` section.
- Reader-map paragraph: link the leading \"SFT\" to \`#sft-corrections\` (mirrors the existing GRPO link to \`grpo.html\`).
- \`/health\` checkpoint paragraph: link \"SFT\" to \`#sft-corrections\` and \"GRPO\" to \`grpo.html\` so both destinations are reachable from the verify step.

Doc-only. No GPU. Mirrors the surgical pattern from PRs #983 and #984.

## Test plan
- [ ] Open the rendered \`docs/site/quickstart.html\` and click \"SFT\" in the \"Train after verification\" reader-map paragraph — verify it scrolls to the \"SFT corrections\" card.
- [ ] In the verify-step paragraph, click both \"SFT\" and \"GRPO\" — verify each lands at the correct destination.
- [ ] Diff is exactly 3 small edits to \`docs/site/quickstart.html\`, nothing else.