### PR TITLE
docs(quickstart): surface kiln train status probe after SFT corrections command

### DIFF
--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -473,7 +473,7 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
       <div class="grid sm:grid-cols-2 lg:grid-cols-7 gap-4">
         <a class="card p-5 block" href="api.html#training">
           <h3 id="sft-corrections" class="font-semibold mb-2">SFT corrections</h3>
-          <p style="color: var(--fg-dim);">Post simple fixes to <code>/v1/train/sft</code> or use <code>kiln train sft</code> after first inference.</p>
+          <p style="color: var(--fg-dim);">Post simple fixes to <code>/v1/train/sft</code> or use <code>kiln train sft</code> after first inference, then run <code>kiln train status</code> to confirm the job finished before the next chat request.</p>
         </a>
         <a class="card p-5 block" href="grpo.html">
           <h3 class="font-semibold mb-2">GRPO Guide</h3>


### PR DESCRIPTION
## What
Add a `kiln train status` verification probe sentence to the SFT corrections card in quickstart.html, parallel to PR #981's addition of `kiln train status` to the GRPO Watch-the-background-training-job section.

## Why
Cold-reader gap: a reader who runs `kiln train sft` from this card has no probe to confirm the SFT job finished, so they may follow up with a chat request before training has actually completed and conclude that hot-swap is broken. cli.html line 231-233 already documents the canonical `kiln train sft ... && kiln train status` pattern; this surfaces it inline at the cold-reader's first SFT touchpoint.

## Test plan
- Visual diff: only one line changed in docs/site/quickstart.html.
- Open quickstart.html in a browser, scroll to the SFT corrections card, confirm the new sentence renders cleanly inside the card, and confirm the link to api.html#training still works.