### PR TITLE
docs(api): surface kiln train status CLI in Training-status-check card

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -346,7 +346,9 @@
           </section>
           <section class="endpoint">
             <h3 class="font-semibold mb-2">Training status check</h3>
-            <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>curl -s http://localhost:8420/v1/train/status | python3 -m json.tool</code></pre>
+            <p class="text-sm mb-3" style="color: var(--fg-dim);">Use the CLI for a friendlier summary, or hit the endpoint directly:</p>
+            <pre class="overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>kiln train status</code></pre>
+            <pre class="overflow-x-auto text-sm leading-relaxed mt-3" style="color: var(--fg);"><code>curl -s http://localhost:8420/v1/train/status | python3 -m json.tool</code></pre>
           </section>
         </div>
       </article>


### PR DESCRIPTION
Mirrors merged PRs #981 (grpo.html) and #986 (quickstart.html) cold-reader pattern: api.html's Training-status-check card showed only the raw curl probe. Adds the friendlier kiln train status CLI as the first probe before the curl form so a cold reader landing on api.html discovers the CLI surface.