### PR TITLE
docs(quickstart): surface kiln health CLI in step 4 Verify card

### DIFF
--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -430,7 +430,8 @@ export KILN_MODEL_PATH=./Qwen3.5-4B</code></pre>
         </div>
         <div class="card p-5">
           <h3 class="font-semibold mb-2">Check <code>/health</code></h3>
-<pre class="text-sm"><code>curl -s http://127.0.0.1:8420/health \
+<pre class="text-sm"><code>kiln health</code></pre>
+<pre class="text-sm mt-3"><code>curl -s http://127.0.0.1:8420/health \
   | python3 -m json.tool</code></pre>
         </div>
         <div class="card p-5">


### PR DESCRIPTION
Cold-reader gap mirroring PRs #983 and #987.

PR #983 added `kiln health` probe to QUICKSTART.md (markdown source). PR #987 surfaced `kiln train status` alongside the curl probe in `docs/site/api.html`. The published `docs/site/quickstart.html` step 4 "Verify the server is up" 3-card grid still showed only `curl` in the "Check /health" card.

This adds a `kiln health` pre-block immediately above the curl pre-block in the same card, so cold readers landing on https://ericflo.github.io/kiln/quickstart.html see the CLI-first probe alongside the curl one. Same pattern as #987.

Doc-only change. No CI changes.