### PR TITLE
docs(readme): surface kiln health probe before curl chat in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ Vulkan builds auto-select a Vulkan physical device at startup. Use `KILN_VULKAN_
 
 The `GPU` and `VRAM` lines come from `nvidia-smi` and are skipped silently if it isn't installed.
 
+**Verify the server is up.** Run `kiln health` (binary at `./kiln` for Path 2/3 or `./target/release/kiln` for Path 4) before sending real requests — it prints a readable tree with model, scheduler, training, and GPU status, and exits non-zero if anything is wrong. See [troubleshooting](https://ericflo.github.io/kiln/troubleshooting.html#start-with-three-probes) for the full three-probe sequence.
+
+```bash
+./kiln health
+```
+
 ```bash
 # Chat
 curl http://localhost:8420/v1/chat/completions \


### PR DESCRIPTION
## What
After \`kiln serve\` shows its startup banner in the README Quick Start, the next snippet was a curl chat completion. This adds a one-line \`kiln health\` probe between the banner and the first curl block, mirroring the canonical 'Start with three probes' pattern shipped in PRs #980 (troubleshooting.html), #983/#988 (quickstart.html steps 3 + 4), and the QUICKSTART.md §\"Verify the server is up\" section.

## Why
README is the highest-traffic cold-reader onboarding surface. Every other major doc surface — QUICKSTART.md, docs/site/quickstart.html, docs/site/troubleshooting.html — already surfaces \`kiln health\` as the first server check after \`kiln serve\`. README was the lone outlier.

## Test plan
- [x] Doc-only insertion; no code changes
- [x] No additional sections expanded — minimum-required preamble preserved
- [x] Cross-links to existing troubleshooting three-probe anchor