### PR TITLE
docs(architecture): surface kiln train status and adapters list in LoRA hot-swap card

### DIFF
--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -342,6 +342,14 @@ training request
             <p>Scored completions become a generate &rarr; score &rarr; train loop through the same HTTP API.</p>
           </div>
         </div>
+        <p class="text-sm mt-5" style="color: var(--fg-dim);">
+          Inspect your live server&rsquo;s queue and registry: <code>kiln train status</code> shows pending and running jobs, and <code>kiln adapters list</code> shows the published adapters available to subsequent requests.
+        </p>
+        <pre class="mt-3 overflow-x-auto text-sm leading-relaxed" style="color: var(--fg);"><code>kiln train status
+kiln adapters list</code></pre>
+        <p class="text-xs mt-3" style="color: var(--fg-mute);">
+          See the <a href="cli.html">CLI Reference</a> for the full <code>kiln</code> command surface.
+        </p>
       </article>
 
       <article class="card p-6">


### PR DESCRIPTION
## Summary

The architecture page describes the live FIFO training queue and adapter registry in prose but the body had zero CLI probes for inspecting that state on a running server. This adds a short verify block in the LoRA hot-swap card with `kiln train status` and `kiln adapters list`, plus a link to the CLI reference. Doc-only.

Mirrors merged PRs #981 and #982 (same probe pattern in grpo.html).

## Test plan

- [x] grep -n "kiln train status\|kiln adapters list" docs/site/architecture.html prints both probes
- [x] Diff is exactly one insertion, no other changes