### PR TITLE
docs(site): surface kiln health probe on landing page after Install commands

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -503,6 +503,15 @@ docker run --gpus all -p 8420:8420 \
   -v /path/to/Qwen3.5-4B:/models/Qwen3.5-4B:ro \
   ghcr.io/ericflo/kiln-server:latest serve</code></pre>
 
+      <h3 class="font-semibold mb-2 mt-6">Verify the server is up</h3>
+      <p class="text-sm" style="color: var(--fg-mute);">
+        <code>kiln health</code> prints a tree-style status of the model, scheduler, training queue, and GPU, and
+        exits non-zero if anything is wrong &mdash; a fast confirmation that <code>kiln serve</code> actually
+        came up. See <a href="troubleshooting.html#start-with-three-probes">the full three-probe sequence</a>
+        for <code>kiln health</code>, <code>kiln train status</code>, and <code>kiln adapters list</code>.
+      </p>
+<pre><code>./kiln health</code></pre>
+
       <p class="text-sm mt-6" style="color: var(--fg-mute);">
         Each release is signed and SHA-256 checksums are published as <code>.sha256</code> sidecars on the
         <a href="https://github.com/ericflo/kiln/releases">releases page</a>. The


### PR DESCRIPTION
## What

Add a small "Verify the server is up" section to `docs/site/index.html` immediately after the Install commands (Linux CUDA, Linux Vulkan, macOS Metal, Windows CUDA, Docker) and before the existing "Each release is signed..." footer paragraph. The new section has one short paragraph and one `./kiln health` pre/code block, plus a link to the troubleshooting guide's three-probe sequence (`troubleshooting.html#start-with-three-probes`).

## Why

The landing page is the most cold-reader-facing surface. Cold readers run `kiln serve` from one of the install blocks and currently have no in-page verification step — the page jumps straight to release signing notes and redirects them to Quickstart. This continues the systematic `kiln health | kiln train status | kiln adapters list` probe pattern shipped in PRs #978–#990 (README Quick Start, quickstart.html steps 3+4, troubleshooting.html, grpo.html, api.html Training-status-check card, architecture.html LoRA hot-swap card).

## Test plan

- [x] Visual diff of `docs/site/index.html` shows exactly one new section (9 inserted lines) between the Docker `</pre>` and the "Each release is signed" footer paragraph
- [x] `kiln health` command card matches existing landing-page styling (`<h3 class="font-semibold mb-2 mt-6">` heading, `<p class="text-sm">` with `var(--fg-mute)` color, plain `<pre><code>` block matching adjacent platform install blocks)
- [x] Anchor `troubleshooting.html#start-with-three-probes` resolves (verified `id="start-with-three-probes"` exists at line 260 of `docs/site/troubleshooting.html`)
- [x] HTML parses cleanly via `html.parser.HTMLParser`
- [x] No unrelated changes (`git diff --stat` shows 1 file, +9/-0)