### PR TITLE
docs(site): surface Troubleshooting card in api.html Where-to-go-next

### DIFF
--- a/docs/site/api.html
+++ b/docs/site/api.html
@@ -500,7 +500,7 @@ curl -s -X DELETE http://localhost:8420/v1/train/queue/$JOB_ID | python3 -m json
   <section class="divider">
     <div class="max-w-4xl mx-auto px-6 py-12">
       <h2 id="where-to-go-next" class="text-2xl font-semibold tracking-tight mb-4">Where to go next</h2>
-      <div class="grid sm:grid-cols-3 gap-4">
+      <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
         <a class="card p-5 block" href="quickstart.html">
           <h3 class="font-semibold mb-2">Quickstart</h3>
           <p style="color: var(--fg-dim);">Run the server, send the first chat request, and post the first SFT job.</p>
@@ -508,6 +508,10 @@ curl -s -X DELETE http://localhost:8420/v1/train/queue/$JOB_ID | python3 -m json
         <a class="card p-5 block" href="grpo.html">
           <h3 class="font-semibold mb-2">GRPO guide</h3>
           <p style="color: var(--fg-dim);">See scored-completion payloads and the generate &rarr; score &rarr; train loop.</p>
+        </a>
+        <a class="card p-5 block" href="troubleshooting.html">
+          <h3 class="font-semibold mb-2">Troubleshooting</h3>
+          <p style="color: var(--fg-dim);">Check binary, CUDA or Metal setup, model path, health output, and adapter storage.</p>
         </a>
         <a class="card p-5 block" href="demo/">
           <h3 class="font-semibold mb-2">Demo</h3>


### PR DESCRIPTION
## Cold-reader gap

api.html's Where to go next cards link to Quickstart, GRPO guide, and Demo — but NOT Troubleshooting. Every other inner page surfaces troubleshooting prominently in its cards:

- architecture.html ✓
- grpo.html ✓
- quickstart.html ✓
- troubleshooting.html ✓ (links 6 cards)
- api.html ❌

Footer nav already has the link, but cold readers hitting API errors need the prominent card path, not a small footer line.

## Change

- docs/site/api.html: grid class `sm:grid-cols-3` → `sm:grid-cols-2 lg:grid-cols-4` (matches architecture.html convention for 4+ cards)
- New Troubleshooting card inserted after GRPO and before Demo
- Card copy borrowed verbatim from architecture.html for consistency

## Verification

- New `href="troubleshooting.html"` count: 4 (top nav + inline body link + new card + footer nav; baseline was 3)
- Final card order: Quickstart, GRPO guide, Troubleshooting, Demo
- Doc-only, no code changes, no test impact