### PR TITLE
docs(architecture): add CLI Reference card to Where to go next

### DIFF
--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -394,6 +394,10 @@ kiln adapters list</code></pre>
           <h3 class="font-semibold mb-2">Troubleshooting</h3>
           <p style="color: var(--fg-dim);">Check binary, CUDA or Metal setup, model path, health output, and adapter storage.</p>
         </a>
+        <a class="card p-5 block" href="cli.html">
+          <h3 class="font-semibold mb-2">CLI reference</h3>
+          <p style="color: var(--fg-dim);">Map architecture concepts to <code>kiln serve</code>, <code>kiln health</code>, <code>kiln adapters</code>, and training commands.</p>
+        </a>
         <a class="card p-5 block" href="https://github.com/ericflo/kiln/blob/main/BENCHMARKS.md">
           <h3 class="font-semibold mb-2">Benchmarks</h3>
           <p style="color: var(--fg-dim);">Decode tok/s, mean and p99 ITL on Qwen3.5-4B against external references on the same single-GPU class.</p>

--- a/docs/site/architecture.html
+++ b/docs/site/architecture.html
@@ -396,7 +396,7 @@ kiln adapters list</code></pre>
         </a>
         <a class="card p-5 block" href="cli.html">
           <h3 class="font-semibold mb-2">CLI reference</h3>
-          <p style="color: var(--fg-dim);">Map architecture concepts to <code>kiln serve</code>, <code>kiln health</code>, <code>kiln adapters</code>, and training commands.</p>
+          <p style="color: var(--fg-dim);">Map architecture concepts to <code>kiln serve</code>, <code>kiln health</code>, <code>kiln adapters list</code>, and training commands.</p>
         </a>
         <a class="card p-5 block" href="https://github.com/ericflo/kiln/blob/main/BENCHMARKS.md">
           <h3 class="font-semibold mb-2">Benchmarks</h3>


### PR DESCRIPTION
Cold-reader cross-link gap: architecture.html's Where-to-go-next section had 5 cards (Deep dive, GRPO guide, Quickstart, Troubleshooting, Benchmarks) but did NOT link to cli.html. Readers finishing the architecture page have no pointer to the practical CLI surface. Adds a CLI reference card between Troubleshooting and Benchmarks. Same shape as PR #992 (api.html → Troubleshooting cross-link). Doc-only, +4 lines.