### PR TITLE
Phase 12-B'': drop generation-lifetime BM+PC mutex hold (Verdict B, +10.76% c=8)

### DIFF
--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1521,18 +1521,15 @@ impl ModelRunner {
             .lock()
             .map_err(|e| anyhow::anyhow!("failed to lock CUDA graph runner: {e}"))?
             .is_enabled();
-        if cuda_graph_enabled {
-            let mut bm_guard = lock_block_manager(block_manager)?;
-            let mut pc_guard = lock_paged_cache(paged_cache)?;
-            return self.generate_from_tokens_paged(
-                prompt_tokens,
-                params,
-                &mut bm_guard,
-                &mut pc_guard,
-                cancel,
-            );
-        }
 
+        // Phase 12-B'': allocate blocks under a one-shot BlockManager lock and
+        // wrap them in `SharedBlockReservation` so the BM lock is released
+        // before any forward passes run. The CUDA-graph branch previously held
+        // both the BM and the PagedKvCache locks for the entire generation
+        // (~2.3 s for a 512-prompt, 128-decode run), which forced concurrent
+        // requests onto a serial staircase even with c=8. Both branches now
+        // route through interleaved variants that take `&Mutex<PagedKvCache>`
+        // and lock per-step, mirroring the non-CUDA-graph path.
         let max_total = prompt_tokens.len() + params.max_tokens;
         let (reservation, block_table) = {
             let mut bm_guard = lock_block_manager(block_manager)?;
@@ -1554,13 +1551,23 @@ impl ModelRunner {
             )
         };
 
-        let result = self.generate_from_tokens_paged_interleaved(
-            prompt_tokens,
-            params,
-            paged_cache,
-            &block_table,
-            cancel,
-        );
+        let result = if cuda_graph_enabled {
+            self.generate_from_tokens_paged_cuda_graph_interleaved(
+                prompt_tokens,
+                params,
+                paged_cache,
+                &block_table,
+                cancel,
+            )
+        } else {
+            self.generate_from_tokens_paged_interleaved(
+                prompt_tokens,
+                params,
+                paged_cache,
+                &block_table,
+                cancel,
+            )
+        };
 
         drop(reservation);
         result
@@ -2601,6 +2608,206 @@ impl ModelRunner {
                 step_seed,
             )?;
             seq_len += 1;
+        }
+
+        Ok(GenerationOutput {
+            text: String::new(),
+            token_ids: generated_tokens,
+            finish_reason: FinishReason::MaxTokens,
+        })
+    }
+
+    /// CUDA-graph variant of the interleaved decode path (Phase 12-B'').
+    ///
+    /// Mirrors `generate_from_tokens_paged_inner` (the path the old CUDA-graph
+    /// branch used) but takes `paged_cache: &Mutex<PagedKvCache>` and locks it
+    /// per forward pass instead of holding it across the entire generation.
+    /// The CUDA graph runner mutex is also acquired per decode step, so that
+    /// concurrent c=8 requests can interleave on a per-step granularity rather
+    /// than serialising on a generation-lifetime lock. Blocks are still
+    /// allocated once up-front by the caller (`generate_from_tokens_paged_shared`)
+    /// and freed via `SharedBlockReservation` when the caller drops the
+    /// reservation guard, mirroring the non-graph interleaved path.
+    fn generate_from_tokens_paged_cuda_graph_interleaved(
+        &self,
+        prompt_tokens: &[TokenId],
+        params: &SamplingParams,
+        paged_cache: &Mutex<PagedKvCache>,
+        block_table: &BlockTable,
+        cancel: Option<&CancelHandle>,
+    ) -> Result<GenerationOutput> {
+        let mut linear_state = self.new_linear_state()?;
+
+        // Prefill: lock the paged cache for one forward pass and drop it
+        // before the decode loop starts. The decode loop then re-acquires the
+        // cache per step.
+        let streaming_prefill =
+            streaming_prefill_enabled_for(self.backend.device(), prompt_tokens.len());
+        let prefill_source = {
+            let mut pc_guard = lock_paged_cache(paged_cache)?;
+            if streaming_prefill {
+                PrefillSampleSource::Logits(
+                    model_forward_paged_streaming(
+                        &*self.backend,
+                        prompt_tokens,
+                        &self.weights,
+                        &self.config,
+                        &mut pc_guard,
+                        block_table,
+                        0,
+                        Some(&mut linear_state),
+                        self.active_lora.as_ref(),
+                    )
+                    .context("prefill forward pass (paged, streaming) failed")?,
+                )
+            } else if params.is_effectively_greedy()
+                && matches!(self.backend.device(), candle_core::Device::Metal(_))
+            {
+                PrefillSampleSource::GreedyToken(
+                    model_forward_paged_last_token_greedy(
+                        &*self.backend,
+                        prompt_tokens,
+                        &self.weights,
+                        &self.config,
+                        &mut pc_guard,
+                        block_table,
+                        0,
+                        Some(&mut linear_state),
+                        self.active_lora.as_ref(),
+                        None,
+                    )
+                    .context("greedy prefill forward pass (paged) failed")?,
+                )
+            } else {
+                let logits = model_forward_paged_last_token(
+                    &*self.backend,
+                    prompt_tokens,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    0,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )
+                .context("prefill forward pass (paged) failed")?;
+                if let Some(cancel) = cancel {
+                    cancel.report_prefill_tokens_completed(prompt_tokens.len() as u64);
+                }
+                PrefillSampleSource::Logits(logits)
+            }
+        };
+
+        let mut seq_len = prompt_tokens.len();
+        let mut generated_tokens: Vec<TokenId> = Vec::new();
+        let mut step_seed = params.seed;
+
+        let mut next_token = match prefill_source {
+            PrefillSampleSource::GreedyToken(token) => token,
+            PrefillSampleSource::Logits(logits) => {
+                if params.is_effectively_greedy() {
+                    greedy_sample(&logits)?
+                } else {
+                    sample_with_params(
+                        &logits,
+                        params.temperature,
+                        params.top_p,
+                        params.top_k,
+                        step_seed,
+                    )?
+                }
+            }
+        };
+
+        for _step in 0..params.max_tokens {
+            check_cancelled(cancel)?;
+            if let Some(s) = step_seed.as_mut() {
+                *s = s.wrapping_add(1);
+            }
+
+            if self.eos_token_ids.contains(&next_token) {
+                return Ok(GenerationOutput {
+                    text: String::new(),
+                    token_ids: generated_tokens,
+                    finish_reason: FinishReason::Eos,
+                });
+            }
+
+            generated_tokens.push(next_token);
+
+            if !params.stop.is_empty() {
+                let decoded_so_far = self
+                    .tokenizer
+                    .decode(&generated_tokens)
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+                    .ok();
+                if let Some(text) = &decoded_so_far {
+                    for stop_seq in &params.stop {
+                        if text.contains(stop_seq.as_str()) {
+                            return Ok(GenerationOutput {
+                                text: String::new(),
+                                token_ids: generated_tokens,
+                                finish_reason: FinishReason::StopSequence(stop_seq.clone()),
+                            });
+                        }
+                    }
+                }
+            }
+
+            if generated_tokens.len() >= params.max_tokens {
+                break;
+            }
+
+            next_token = if params.is_effectively_greedy()
+                && matches!(self.backend.device(), candle_core::Device::Metal(_))
+            {
+                // Metal greedy path bypasses the CUDA graph runner entirely.
+                let mut pc_guard = lock_paged_cache(paged_cache)?;
+                let token = model_forward_paged_next_token_greedy(
+                    &*self.backend,
+                    next_token,
+                    &self.weights,
+                    &self.config,
+                    &mut pc_guard,
+                    block_table,
+                    seq_len,
+                    Some(&mut linear_state),
+                    self.active_lora.as_ref(),
+                    None,
+                )?;
+                seq_len += 1;
+                token
+            } else {
+                // CUDA graph decode step: acquire the graph runner and the
+                // paged cache for one step, then drop both before sampling so
+                // concurrent requests can interleave on the next step.
+                let logits = {
+                    let mut graph_runner = self.cuda_graph.lock().map_err(|e| {
+                        anyhow::anyhow!("failed to lock CUDA graph runner: {e}")
+                    })?;
+                    let mut pc_guard = lock_paged_cache(paged_cache)?;
+                    graph_runner.decode_step_paged(
+                        &*self.backend,
+                        next_token,
+                        &self.weights,
+                        &self.config,
+                        &mut pc_guard,
+                        block_table,
+                        seq_len,
+                        &mut linear_state,
+                        self.active_lora.as_ref(),
+                    )?
+                };
+                seq_len += 1;
+                sample_with_params(
+                    &logits,
+                    params.temperature,
+                    params.top_p,
+                    params.top_k,
+                    step_seed,
+                )?
+            };
         }
 
         Ok(GenerationOutput {


### PR DESCRIPTION
## Phase 12-B'': drop generation-lifetime BM+PC mutex hold for CUDA-graph path

**Status:** Draft. Posted as a result-of-record so the implementation work
isn't lost. Opener (this task) is *not* asking for merge — see the
"Verdict" section below for what to do with this branch.

### What changed

Predecessor task `5a313ab2950f36f6a3e87556` implemented Option A from
`docs/audits/PHASE12_B_PRIME_BATCHING_DIAGNOSIS.md` § 6.2:

- Allocate KV blocks once under a one-shot `BlockManager` lock and wrap
  them in `SharedBlockReservation`, so the BM lock is released before any
  forward pass runs (mirrors the existing non-CUDA-graph interleaved
  branch).
- Route the CUDA-graph branch in `generate_from_tokens_paged_shared`
  through a new `generate_from_tokens_paged_cuda_graph_interleaved`
  variant that takes `paged_cache: &Mutex<PagedKvCache>` and acquires it
  per forward pass.
- Acquire the `cuda_graph` runner mutex per decode step instead of once
  across the whole loop, so concurrent requests interleave at per-step
  granularity rather than serialising on a generation-lifetime lock.

The non-CUDA-graph branch is unchanged behaviourally; the only
caller-visible difference is that the CUDA-graph branch now allocates
blocks via `SharedBlockReservation` like the non-graph branch.

Diff: 1 file (`crates/kiln-model/src/generate.rs`), 225 +, 18 −.

### Hypothesis it tested

Per PR #995 / the audit: the c=8 batching collapse on Phase A HEAD vs
the PR #762 baseline (62.45 → ~47 tok/s) was driven by the BlockManager
+ PagedKvCache mutexes being held for the full generation lifetime in
the CUDA-graph branch (~2.3 s for a 512-prompt × 128-decode run).
Concurrent c=8 requests serialised on those two global mutexes,
producing the textbook ~2.3 s "staircase" pattern. If that hypothesis
were right, dropping the hold should largely close the gap to PR #762
at c=8.

### Result: **Verdict B — partial improvement (+10.76 % c=8)**

Measured on RunPod A6000, `KILN_W4A16=1`, `KILN_CUDA_GRAPHS=true`,
`KILN_PREFIX_CACHE_ENABLED=true`. Shape A throughput sweep (~512-token
unique prompts to defeat the prompt-cache short-circuit, 128 max output
tokens, 30 s warmup, 150 s steady-state window).

| c | main `eb55eac` agg tok/s | branch `2ffcd8d` agg tok/s | Δ tok/s | Δ % | p99 ITL Δ ms |
|---|---:|---:|---:|---:|---:|
| 1 | 55.61 | 61.05 | +5.44 | +9.78 % | −1.35 |
| 2 | 50.36 | 53.26 | +2.90 | +5.76 % | −2.54 |
| 4 | 49.00 | 53.76 | +4.76 | +9.71 % | −5.80 |
| **8** | **47.60** | **52.72** | **+5.12** | **+10.76 %** | **−16.31** |

The branch beats main at every concurrency, with the largest absolute
gains and the largest p99 ITL tightening at c=8 (−16.31 ms / −9 %).
That is consistent with the BM+PC mutex hold *being* a real per-step
contention source — the fix removes one batch of the staircase
serialization cost.

But the residual gap to PR #762 (62.45 tok/s c=8 baseline) is **−15.6 %**
on this branch (52.72 vs 62.45). The mutex hold was not the dominant
contributor to the c=8 collapse; at most ~10 of the missing ~24
percentage points came from it. There is at least one more bottleneck.

The audit and the predecessor's commit message already named the prime
suspect: the per-row GQA loop in
`model_forward_paged_batched_decode_hidden`
(`forward.rs:7878-7917`), explicitly tagged out-of-scope for this PR.

### Recommendation

**Land this branch (after re-review).** It is a strict win at every
concurrency, with no observed correctness regression (all c levels
finish_reason=length, zero errors, n_ok in line with main), and it
tightens the p99 ITL tail at higher concurrencies. +10.76 % at c=8 is
small for one PR but earned and reproducible.

**Then open Phase 12-B''' targeting the per-row GQA decode loop.**
Closing the residual ~16 % gap to PR #762's c=8 = 62.45 tok/s likely
requires a fused batched-GQA decode path in place of the per-row loop.

### Repro / evidence

Full diagnosis report and raw sweep data uploaded to B2 (kiln team
read-only):

```
b2://clouderic/diagnostics/kiln-phase12-bpp-null-result-2026-05-07/
├── REPORT.md
├── main-sweep.csv / main-sweep.json / main-sweep.log
├── branch-sweep.csv / branch-sweep.json / branch-sweep.log
└── sweep_harness.py   (Python stdlib only, ~512-tok unique prompts)
```

Reproduction commands and harness caveats are in `REPORT.md`. tl;dr —
the harness's `agg_decode_tok_s` field is a per-stream weighted average
(not a true wall-clock aggregate); multiply by concurrency to get the
"tok/s the server is producing", which is what the table above and the
verdict use.

### Out of scope

- Per-row GQA decode loop (`forward.rs:7878-7917`) — root cause #2 from
  the audit. Next PR.
- nsys deep-dive — only required for Verdict A; this is Verdict B.
- Refreshing `PHASE12_B_PRIME_BATCHING_DIAGNOSIS.md` — should happen
  before Phase 12-B''' starts.
