### PR TITLE
Phase 12-B''': fused batched-GQA decode dispatch (Verdict NULL, +2.96% c=8)

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -7953,44 +7953,91 @@ pub fn model_forward_paged_batched_decode_hidden(
                 linear_attn_idx += 1;
             }
             GpuAttentionWeights::Full(_) => {
-                let mut rows = Vec::with_capacity(batch_size);
-                for row_idx in 0..batch_size {
-                    let row_hidden = hidden.narrow(0, row_idx, 1)?;
-                    let pos = Tensor::new(&[sequence_lengths[row_idx] as f32], device)?;
-                    let rope_tables = rotary_tables_from_tensor(&pos, &weights.rotary_inv_freq)?;
-                    rows.push(
-                        transformer_block_paged_with_rope_tables(
-                            backend,
-                            &row_hidden,
-                            layer,
-                            config,
-                            &pos,
-                            sequence_lengths[row_idx],
-                            config.num_attention_heads,
-                            config.num_kv_heads,
-                            config.head_dim,
-                            config.rotary_dim(),
-                            &weights.rotary_inv_freq,
-                            Some((&rope_tables.0, &rope_tables.1)),
-                            config.rms_norm_eps,
-                            paged_cache,
-                            &block_tables[row_idx],
-                            full_attn_idx,
-                            layer_lora,
-                            #[cfg(feature = "cuda")]
-                            None,
-                            None,
-                        )
-                        .with_context(|| {
-                            format!(
-                                "batched decode row {row_idx} transformer block {layer_idx} (full attention, paged)"
-                            )
-                        })?,
-                    );
+                // Phase 12-B''': try the fused batched-GQA decode primitive
+                // when the batch is uniform enough for the contiguous paged-KV
+                // path (shared start_pos, non-fp8 cache). On Err we silently
+                // fall back to the per-row loop below, which preserves
+                // correctness for heterogeneous batches without losing the
+                // c=8 batching win when rows happen to align. The c=1
+                // per-stream rate is unaffected because batch_size==1 short-
+                // circuits at the top of this function.
+                let mut handled_via_batched = false;
+                let start_pos = sequence_lengths[0];
+                let same_start_pos = sequence_lengths.iter().all(|&p| p == start_pos);
+                let cache_supports_batched = !paged_cache.is_fp8();
+                if same_start_pos && cache_supports_batched {
+                    let positions = Tensor::from_slice(&[start_pos as f32], 1usize, device)?;
+                    let block_table_refs: Vec<&BlockTable> = block_tables.iter().collect();
+                    match transformer_block_paged_decode_contiguous_batch(
+                        backend,
+                        &hidden,
+                        layer,
+                        config,
+                        &positions,
+                        sequence_lengths,
+                        &weights.rotary_inv_freq,
+                        paged_cache,
+                        &block_table_refs,
+                        full_attn_idx,
+                        layer_lora,
+                        None,
+                        None,
+                    ) {
+                        Ok(h) => {
+                            hidden = h;
+                            handled_via_batched = true;
+                        }
+                        Err(_) => {
+                            // Fall through to per-row loop. The contiguous
+                            // batched path can decline (E340/E341) when the
+                            // KV slot windows aren't contiguous across the
+                            // batch; the per-row path is the strict fallback.
+                        }
+                    }
                 }
-                let row_refs: Vec<&Tensor> = rows.iter().collect();
-                hidden = Tensor::cat(&row_refs, 0)
-                    .with_context(|| format!("cat full-attention rows after layer {layer_idx}"))?;
+
+                if !handled_via_batched {
+                    let mut rows = Vec::with_capacity(batch_size);
+                    for row_idx in 0..batch_size {
+                        let row_hidden = hidden.narrow(0, row_idx, 1)?;
+                        let pos = Tensor::new(&[sequence_lengths[row_idx] as f32], device)?;
+                        let rope_tables =
+                            rotary_tables_from_tensor(&pos, &weights.rotary_inv_freq)?;
+                        rows.push(
+                            transformer_block_paged_with_rope_tables(
+                                backend,
+                                &row_hidden,
+                                layer,
+                                config,
+                                &pos,
+                                sequence_lengths[row_idx],
+                                config.num_attention_heads,
+                                config.num_kv_heads,
+                                config.head_dim,
+                                config.rotary_dim(),
+                                &weights.rotary_inv_freq,
+                                Some((&rope_tables.0, &rope_tables.1)),
+                                config.rms_norm_eps,
+                                paged_cache,
+                                &block_tables[row_idx],
+                                full_attn_idx,
+                                layer_lora,
+                                #[cfg(feature = "cuda")]
+                                None,
+                                None,
+                            )
+                            .with_context(|| {
+                                format!(
+                                    "batched decode row {row_idx} transformer block {layer_idx} (full attention, paged)"
+                                )
+                            })?,
+                        );
+                    }
+                    let row_refs: Vec<&Tensor> = rows.iter().collect();
+                    hidden = Tensor::cat(&row_refs, 0).with_context(|| {
+                        format!("cat full-attention rows after layer {layer_idx}")
+                    })?;
+                }
                 full_attn_idx += 1;
             }
         }


### PR DESCRIPTION
## Verdict NULL — fused batched-GQA dispatch does not move c=8 throughput

Replaces the per-row GQA decode loop in `model_forward_paged_batched_decode_hidden` (`crates/kiln-model/src/forward.rs:7955-7995`) with a guarded call to the existing batched primitive `transformer_block_paged_decode_contiguous_batch` (`forward.rs:6907`), per the Phase 12-B'' audit recommendation and the audit at `docs/audits/PHASE12_B_PRIME_BATCHING_DIAGNOSIS.md`.

**Goal:** close the residual ~16 % c=8 throughput gap to the PR #762 baseline (62.45 tok/s c=8) on Qwen3.5-4B / A6000 with `KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_PREFIX_CACHE_ENABLED=true`.

**Result:** **+2.96 % c=8 aggregate throughput** (49.98 → 51.46 tok/s), well below Verdict B's +10 % threshold and far below Verdict A's 62.45 tok/s absolute target. The only material signal is a **−26 % drop in c=8 p99 ITL** (412.71 → 303.93 ms), consistent with the fast path firing intermittently and tightening the tail.

### Throughput (12-point sweep, A6000, post-Phase-12-B'' baseline)

| c | main agg tok/s | branch agg tok/s | Δ | Δ % | Δ p50 ms | Δ p99 ms |
|---|---:|---:|---:|---:|---:|---:|
| 1 | 61.21 | 62.07 | +0.86 | +1.40% | −0.36 | +7.36 |
| 2 | 50.88 | 51.01 | +0.13 | +0.25% | −0.69 | +1.71 |
| 4 | 50.47 | 50.01 | −0.46 | −0.92% | +0.85 | +6.99 |
| 8 | 49.98 | 51.46 | **+1.48** | **+2.96%** | −5.07 | **−108.78** |

PR #762 c=8 reference: 62.45 tok/s. Branch is **−17.6 %** below it.

### Implementation

Conservative fast path with `Err` fallthrough to the existing per-row loop:

```rust
let same_start_pos = sequence_lengths.iter().all(|&p| p == sequence_lengths[0]);
let cache_supports_batched = !paged_cache.is_fp8();
if same_start_pos && cache_supports_batched {
    match transformer_block_paged_decode_contiguous_batch(...) {
        Ok(h) => { hidden = h; handled_via_batched = true; }
        Err(_) => { /* fall through */ }
    }
}
if !handled_via_batched { /* existing per-row loop */ }
```

Guards:
- `same_start_pos`: all streams at same decode position (because the underlying primitive takes a single-element `positions` tensor).
- `!is_fp8()`: FP8 KV cache layout is incompatible with the contiguous-batch path.
- `Err` fallthrough preserves correctness on any failure.

`batch_size == 1` short-circuits to `model_forward_paged_inner` at `forward.rs:7810`, so c=1 is unaffected.

### Why null

The likely root cause is the `same_start_pos` heuristic. Under continuous batching the harness stages requests at different times; per-stream `sequence_lengths[i]` diverges quickly after warmup and `same_start_pos` is rarely true, so the per-row loop fallback is what's actually executing.

Reading `model_forward_paged_decode_contiguous_batch_hidden` (`forward.rs:7001-7099`) suggests the underlying primitive is **already designed to accept per-stream `start_positions: &[usize]`** — the single `positions` tensor of shape `[1]` is the per-step offset, not a per-stream alignment constraint. So the gate may be stricter than necessary. A follow-up that drops the gate (with a fresh parity test) is the natural next experiment, but it's a separate correctness question and out of scope for this PR.

### Acceptance gates

| Gate | Result |
|---|---|
| c=8 ≥ 62.45 tok/s (Verdict A) | ❌ 51.46 |
| c=8 ≥ 58.0 + ≥10 % vs main (Verdict B) | ❌ 51.46 / +2.96 % |
| c=1 ≥ 49.3 tok/s (no regression) | ✅ 62.07 |
| Zero LM-head OOMs | ✅ 0 errors across 224 streams |
| `cargo nextest run` green on relevant tests | ⚠️ see note below |

### Pre-existing test failures (unrelated to this change)

`cargo nextest run -p kiln-model --features cuda` reports 2 failures on this pod that **reproduce identically on `main` HEAD** with the same toolchain:

- `forward::tests::test_causal_conv1d_update_matches_fallback`
- `forward::tests::test_gdn_chunk_body_matches_fallback` (`max_abs_diff 2.109375e0 exceeds 2e-2`)

Both cover GDN/conv1d Linear-attention kernels. This patch only touches the `GpuAttentionWeights::Full(_)` (full-attn) branch and does not touch GDN/conv1d code.

### Recommendation

Close as null, **or** gate the fast path behind `KILN_ENABLE_BATCHED_FULL_ATTN_DECODE` for opt-in testing if useful. Either way the next investigative step is dropping the `same_start_pos` gate and re-benching; if the unconditional batched path is also null, the c=8 bottleneck is not the per-row dispatch and a re-profile under continuous batching is required.

### Pod / build

- Pod: A6000 `6xufjcb9ri7fdv`, image `ghcr.io/ericflo/kiln-runpod:latest`
- Build: `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln`
- Server env: `KILN_MODEL_PATH=/workspace/qwen3.5-4b KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_PREFIX_CACHE_ENABLED=true KILN_SERVED_MODEL_ID=qwen3.5-4b`
- Harness: 30 s warmup + 150 s steady, 512-token UUID-nonce prompts, 128 max output tokens, temperature 0.0, c={1,2,4,8}

### Raw data

`b2://clouderic/diagnostics/kiln-phase12-bppp-null-result-2026-05-08/`

- `REPORT.md` — full report
- `{main,branch}-sweep.{csv,json,log}` — raw per-request rows + summaries
- `sweep_harness.py` — exact harness used