### PR TITLE
fix(metal): drop &mut from paged_kv_write_token_major helpers

### DIFF
--- a/crates/kiln-model/src/backend/metal.rs
+++ b/crates/kiln-model/src/backend/metal.rs
@@ -5923,8 +5923,8 @@ pub(crate) fn metal_paged_kv_write_token_major_supports(
 }
 
 pub(crate) fn metal_paged_kv_write_token_major_bf16(
-    k_pool: &mut Tensor,
-    v_pool: &mut Tensor,
+    k_pool: &Tensor,
+    v_pool: &Tensor,
     slot: usize,
     k: &Tensor,
     v: &Tensor,
@@ -6076,8 +6076,8 @@ pub(crate) fn metal_paged_kv_write_token_major_batch_supports(
 
 #[allow(dead_code)]
 pub(crate) fn metal_paged_kv_write_token_major_batch_bf16(
-    k_pool: &mut Tensor,
-    v_pool: &mut Tensor,
+    k_pool: &Tensor,
+    v_pool: &Tensor,
     slots: &Tensor,
     k: &Tensor,
     v: &Tensor,
@@ -10825,13 +10825,13 @@ mod tests {
                 .map(|idx| v.narrow(0, idx, 1).and_then(|row| row.contiguous()))
                 .collect::<candle_core::Result<Vec<_>>>()?;
             let rowwise_slots: Vec<usize> = slots_data.iter().map(|&slot| slot as usize).collect();
-            let mut k_pool_row =
+            let k_pool_row =
                 Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
-            let mut v_pool_row =
+            let v_pool_row =
                 Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
-            let mut k_pool_batch =
+            let k_pool_batch =
                 Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
-            let mut v_pool_batch =
+            let v_pool_batch =
                 Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
             device.synchronize()?;
 
@@ -10851,16 +10851,16 @@ mod tests {
                     &v_rows[idx],
                 ));
                 metal_paged_kv_write_token_major_bf16(
-                    &mut k_pool_row,
-                    &mut v_pool_row,
+                    &k_pool_row,
+                    &v_pool_row,
                     rowwise_slots[idx],
                     &k_rows[idx],
                     &v_rows[idx],
                 )?;
             }
             metal_paged_kv_write_token_major_batch_bf16(
-                &mut k_pool_batch,
-                &mut v_pool_batch,
+                &k_pool_batch,
+                &v_pool_batch,
                 &slots,
                 &k,
                 &v,
@@ -10877,8 +10877,8 @@ mod tests {
             let rowwise_us = bench_metal_unit_op(&device, warmup, iters, || {
                 for idx in 0..batch {
                     metal_paged_kv_write_token_major_bf16(
-                        &mut k_pool_row,
-                        &mut v_pool_row,
+                        &k_pool_row,
+                        &v_pool_row,
                         rowwise_slots[idx],
                         &k_rows[idx],
                         &v_rows[idx],
@@ -10888,8 +10888,8 @@ mod tests {
             })?;
             let batch_us = bench_metal_unit_op(&device, warmup, iters, || {
                 metal_paged_kv_write_token_major_batch_bf16(
-                    &mut k_pool_batch,
-                    &mut v_pool_batch,
+                    &k_pool_batch,
+                    &v_pool_batch,
                     &slots,
                     &k,
                     &v,
@@ -12754,13 +12754,13 @@ mod tests {
             .to_dtype(DType::BF16)?;
         let v = Tensor::from_slice(&v_data, (1usize, 1usize, heads, head_dim), &device)?
             .to_dtype(DType::BF16)?;
-        let mut k_pool = Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
-        let mut v_pool = Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
+        let k_pool = Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
+        let v_pool = Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
 
         assert!(metal_paged_kv_write_token_major_supports(
             &k_pool, &v_pool, slot, &k, &v
         ));
-        metal_paged_kv_write_token_major_bf16(&mut k_pool, &mut v_pool, slot, &k, &v)?;
+        metal_paged_kv_write_token_major_bf16(&k_pool, &v_pool, slot, &k, &v)?;
 
         let k_written = k_pool.narrow(0, slot, 1)?;
         let v_written = v_pool.narrow(0, slot, 1)?;
@@ -12804,13 +12804,13 @@ mod tests {
             .to_dtype(DType::BF16)?
             .contiguous()?;
         let slots = Tensor::from_slice(&slots_data, batch, &device)?.contiguous()?;
-        let mut k_pool = Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
-        let mut v_pool = Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
+        let k_pool = Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
+        let v_pool = Tensor::zeros((total_slots, heads, head_dim), DType::BF16, &device)?;
 
         assert!(metal_paged_kv_write_token_major_batch_supports(
             &k_pool, &v_pool, &slots, &k, &v
         ));
-        metal_paged_kv_write_token_major_batch_bf16(&mut k_pool, &mut v_pool, &slots, &k, &v)?;
+        metal_paged_kv_write_token_major_batch_bf16(&k_pool, &v_pool, &slots, &k, &v)?;
         device.synchronize()?;
 
         for (batch_idx, &slot) in slots_data.iter().enumerate() {

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -43,9 +43,9 @@ use kiln_core::config::ModelConfig;
 use crate::backend::BackendRuntime;
 #[cfg(feature = "cuda")]
 use crate::forward::PagedDecodeGraphInputs;
-use crate::forward::{
-    GpuWeights, LinearAttentionState, model_forward_paged, model_forward_paged_with_graph_inputs,
-};
+#[cfg(feature = "cuda")]
+use crate::forward::model_forward_paged_with_graph_inputs;
+use crate::forward::{GpuWeights, LinearAttentionState, model_forward_paged};
 use crate::lora_loader::LoraWeights;
 use crate::paged_kv_cache::PagedKvCache;
 


### PR DESCRIPTION
## What

Drop `&mut` from `metal_paged_kv_write_token_major_bf16` and `metal_paged_kv_write_token_major_batch_bf16`, plus gate `model_forward_paged_with_graph_inputs` behind `cuda` in `cuda_graph.rs`.

## Why

Phase 12-C (#1000) migrated `PagedKvCache::write_*` to `&self` via candle Tensor's `Arc<RwLock<...>>` interior mutability, but missed updating these two metal helper signatures. The `--features metal` build currently fails on macOS:

```
error[E0308]: arguments to this function are incorrect
   --> crates/kiln-model/src/paged_kv_cache.rs:267:21
    expected mutable reference `&mut candle_core::Tensor`
       found reference `&candle_core::Tensor`
```

The new `&Tensor` signature matches every other `metal_paged_*` helper in `backend/metal.rs` (~24 functions). The function bodies only call `storage_and_layout()` (which returns `(&Storage, &Layout)`) and dispatch a Metal compute kernel — no actual `&mut Tensor` operations are performed. The disjoint-block-table invariant from Phase 12-C still holds.

Also splits the `cuda_graph.rs` import so `model_forward_paged_with_graph_inputs` is only imported under `#[cfg(feature = "cuda")]` (it's only called from cuda-gated code), removing a metal-build warning.

Test bench/test sites updated to drop the now-unnecessary `let mut` / `&mut` to keep the build warning-free.

## Test plan

- `cargo check` (no features) — passes
- `cargo build --locked --features metal` — should now pass on macOS (cannot reproduce here; pod is Linux)