### PR TITLE
Phase 12-D: avoid CUDA batched LM-head OOM fallback

### DIFF
--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -149,8 +149,6 @@ pub struct CudaGraphRunner {
     adapter_generation: u64,
     /// Whether warmup is complete.
     warmup_done: bool,
-    /// Maximum captured decode graphs retained by this runner.
-    graph_cache_limit: usize,
 }
 
 /// Decode graph runners for concurrent generation streams.
@@ -195,25 +193,13 @@ impl CudaGraphRunners {
         let disable_pool = per_stream_graph_disabled();
         let slot_count = decode_parallelism();
         let slots = if use_runner_pool(runner_enabled, disable_pool, slot_count) {
-            let total_graph_cache_limit = cuda_graph_cache_limit();
             tracing::info!(
                 slots = slot_count,
-                total_graph_cache_limit,
                 "per-stream CUDA graph runner pool enabled"
             );
             CudaGraphSlots::Pool(Arc::new(CudaGraphPool {
                 slots: (0..slot_count)
-                    .map(|slot_idx| {
-                        Mutex::new(CudaGraphRunner::new_with_graph_cache_limit(
-                            device,
-                            enabled,
-                            graph_cache_limit_for_slot(
-                                slot_idx,
-                                slot_count,
-                                total_graph_cache_limit,
-                            ),
-                        ))
-                    })
+                    .map(|_| Mutex::new(CudaGraphRunner::new(device, enabled)))
                     .collect(),
                 leased: (0..slot_count).map(|_| AtomicBool::new(false)).collect(),
             }))
@@ -430,32 +416,9 @@ fn decode_parallelism() -> usize {
         .unwrap_or(8)
 }
 
-fn cuda_graph_cache_limit() -> usize {
-    std::env::var("KILN_CUDA_GRAPH_CACHE_MAX")
-        .ok()
-        .as_deref()
-        .and_then(cuda_graph_cache_limit_value)
-        .unwrap_or(DEFAULT_CUDA_GRAPH_CACHE_MAX)
-}
-
-fn cuda_graph_cache_limit_value(value: &str) -> Option<usize> {
-    value.parse::<usize>().ok()
-}
-
-fn graph_cache_limit_for_slot(slot_idx: usize, slot_count: usize, total_limit: usize) -> usize {
-    if slot_count == 0 {
-        return 0;
-    }
-    let base = total_limit / slot_count;
-    let remainder = total_limit % slot_count;
-    base + usize::from(slot_idx < remainder)
-}
-
 fn use_runner_pool(runner_enabled: bool, disable_pool: bool, slot_count: usize) -> bool {
     runner_enabled && !disable_pool && slot_count > 1
 }
-
-const DEFAULT_CUDA_GRAPH_CACHE_MAX: usize = 8;
 
 fn env_flag_enabled(value: &str) -> bool {
     matches!(value, "1" | "true" | "TRUE" | "yes" | "on")
@@ -468,17 +431,9 @@ fn decode_parallelism_value(value: &str) -> Option<usize> {
 impl CudaGraphRunner {
     /// Create a new graph runner. Enabled only on CUDA devices with the `cuda` feature.
     pub fn new(device: &Device, enabled: bool) -> Self {
-        Self::new_with_graph_cache_limit(device, enabled, cuda_graph_cache_limit())
-    }
-
-    fn new_with_graph_cache_limit(
-        device: &Device,
-        enabled: bool,
-        graph_cache_limit: usize,
-    ) -> Self {
         let actually_enabled = enabled && device.is_cuda();
         if actually_enabled {
-            tracing::info!(graph_cache_limit, "CUDA graphs enabled for decode");
+            tracing::info!("CUDA graphs enabled for decode");
         } else if enabled && !device.is_cuda() {
             tracing::debug!("CUDA graphs requested but no CUDA device, using eager decode");
         }
@@ -488,7 +443,6 @@ impl CudaGraphRunner {
             captured: HashMap::new(),
             adapter_generation: 0,
             warmup_done: false,
-            graph_cache_limit,
         }
     }
 
@@ -723,10 +677,9 @@ impl CudaGraphRunner {
                 );
             }
 
-            if self.captured.len() >= self.graph_cache_limit {
+            if self.captured.len() >= Self::max_cached_graphs() {
                 tracing::warn!(
                     cached_graphs = self.captured.len(),
-                    graph_cache_limit = self.graph_cache_limit,
                     requested_max_seqlen_k = requested_key.max_seqlen_k,
                     requested_max_blocks_per_seq = requested_key.max_blocks_per_seq,
                     "CUDA graph capture skipped: paged metadata shape cache is full"
@@ -1089,6 +1042,15 @@ impl CudaGraphRunner {
     }
 
     #[cfg(feature = "cuda")]
+    fn max_cached_graphs() -> usize {
+        std::env::var("KILN_CUDA_GRAPH_CACHE_MAX")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|&value| value > 0)
+            .unwrap_or(8)
+    }
+
+    #[cfg(feature = "cuda")]
     fn new_token_buffer(device: &Device, token_id: u32) -> Result<Tensor> {
         Tensor::new(&[token_id], device).context("create CUDA graph token buffer")
     }
@@ -1326,34 +1288,6 @@ mod tests {
     }
 
     #[test]
-    fn test_cuda_graph_cache_limit_value_accepts_numeric_values() {
-        assert_eq!(cuda_graph_cache_limit_value("0"), Some(0));
-        assert_eq!(cuda_graph_cache_limit_value("not-a-number"), None);
-        assert_eq!(cuda_graph_cache_limit_value("16"), Some(16));
-    }
-
-    #[test]
-    fn test_graph_cache_limit_distributes_across_slots() {
-        let limits: Vec<usize> = (0..8)
-            .map(|slot_idx| graph_cache_limit_for_slot(slot_idx, 8, 8))
-            .collect();
-        assert_eq!(limits, vec![1, 1, 1, 1, 1, 1, 1, 1]);
-
-        let uneven_limits: Vec<usize> = (0..4)
-            .map(|slot_idx| graph_cache_limit_for_slot(slot_idx, 4, 10))
-            .collect();
-        assert_eq!(uneven_limits, vec![3, 3, 2, 2]);
-    }
-
-    #[test]
-    fn test_graph_cache_limit_allows_zero_for_overflow_slots() {
-        let limits: Vec<usize> = (0..8)
-            .map(|slot_idx| graph_cache_limit_for_slot(slot_idx, 8, 3))
-            .collect();
-        assert_eq!(limits, vec![1, 1, 1, 0, 0, 0, 0, 0]);
-    }
-
-    #[test]
     fn test_env_flag_enabled_accepts_kill_switch_values() {
         assert!(env_flag_enabled("1"));
         assert!(env_flag_enabled("true"));
@@ -1433,37 +1367,6 @@ mod tests {
                     assert_eq!(runner.adapter_generation, 1);
                     assert!(!runner.warmup_done);
                 }
-            }
-            CudaGraphSlots::Single(_) => panic!("expected pool"),
-        }
-    }
-
-    #[test]
-    fn test_pool_uses_total_graph_cache_limit_across_slots() {
-        let runners = CudaGraphRunners {
-            enabled: true,
-            slots: CudaGraphSlots::Pool(Arc::new(CudaGraphPool {
-                slots: (0..4)
-                    .map(|slot_idx| {
-                        Mutex::new(CudaGraphRunner::new_with_graph_cache_limit(
-                            &Device::Cpu,
-                            false,
-                            graph_cache_limit_for_slot(slot_idx, 4, 6),
-                        ))
-                    })
-                    .collect(),
-                leased: (0..4).map(|_| AtomicBool::new(false)).collect(),
-            })),
-        };
-
-        match &runners.slots {
-            CudaGraphSlots::Pool(pool) => {
-                let limits: Vec<usize> = pool
-                    .slots
-                    .iter()
-                    .map(|slot| slot.lock().expect("slot lock").graph_cache_limit)
-                    .collect();
-                assert_eq!(limits, vec![2, 2, 1, 1]);
             }
             CudaGraphSlots::Single(_) => panic!("expected pool"),
         }

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -149,6 +149,8 @@ pub struct CudaGraphRunner {
     adapter_generation: u64,
     /// Whether warmup is complete.
     warmup_done: bool,
+    /// Maximum captured decode graphs retained by this runner.
+    graph_cache_limit: usize,
 }
 
 /// Decode graph runners for concurrent generation streams.
@@ -193,13 +195,25 @@ impl CudaGraphRunners {
         let disable_pool = per_stream_graph_disabled();
         let slot_count = decode_parallelism();
         let slots = if use_runner_pool(runner_enabled, disable_pool, slot_count) {
+            let total_graph_cache_limit = cuda_graph_cache_limit();
             tracing::info!(
                 slots = slot_count,
+                total_graph_cache_limit,
                 "per-stream CUDA graph runner pool enabled"
             );
             CudaGraphSlots::Pool(Arc::new(CudaGraphPool {
                 slots: (0..slot_count)
-                    .map(|_| Mutex::new(CudaGraphRunner::new(device, enabled)))
+                    .map(|slot_idx| {
+                        Mutex::new(CudaGraphRunner::new_with_graph_cache_limit(
+                            device,
+                            enabled,
+                            graph_cache_limit_for_slot(
+                                slot_idx,
+                                slot_count,
+                                total_graph_cache_limit,
+                            ),
+                        ))
+                    })
                     .collect(),
                 leased: (0..slot_count).map(|_| AtomicBool::new(false)).collect(),
             }))
@@ -416,9 +430,32 @@ fn decode_parallelism() -> usize {
         .unwrap_or(8)
 }
 
+fn cuda_graph_cache_limit() -> usize {
+    std::env::var("KILN_CUDA_GRAPH_CACHE_MAX")
+        .ok()
+        .as_deref()
+        .and_then(cuda_graph_cache_limit_value)
+        .unwrap_or(DEFAULT_CUDA_GRAPH_CACHE_MAX)
+}
+
+fn cuda_graph_cache_limit_value(value: &str) -> Option<usize> {
+    value.parse::<usize>().ok()
+}
+
+fn graph_cache_limit_for_slot(slot_idx: usize, slot_count: usize, total_limit: usize) -> usize {
+    if slot_count == 0 {
+        return 0;
+    }
+    let base = total_limit / slot_count;
+    let remainder = total_limit % slot_count;
+    base + usize::from(slot_idx < remainder)
+}
+
 fn use_runner_pool(runner_enabled: bool, disable_pool: bool, slot_count: usize) -> bool {
     runner_enabled && !disable_pool && slot_count > 1
 }
+
+const DEFAULT_CUDA_GRAPH_CACHE_MAX: usize = 8;
 
 fn env_flag_enabled(value: &str) -> bool {
     matches!(value, "1" | "true" | "TRUE" | "yes" | "on")
@@ -431,9 +468,17 @@ fn decode_parallelism_value(value: &str) -> Option<usize> {
 impl CudaGraphRunner {
     /// Create a new graph runner. Enabled only on CUDA devices with the `cuda` feature.
     pub fn new(device: &Device, enabled: bool) -> Self {
+        Self::new_with_graph_cache_limit(device, enabled, cuda_graph_cache_limit())
+    }
+
+    fn new_with_graph_cache_limit(
+        device: &Device,
+        enabled: bool,
+        graph_cache_limit: usize,
+    ) -> Self {
         let actually_enabled = enabled && device.is_cuda();
         if actually_enabled {
-            tracing::info!("CUDA graphs enabled for decode");
+            tracing::info!(graph_cache_limit, "CUDA graphs enabled for decode");
         } else if enabled && !device.is_cuda() {
             tracing::debug!("CUDA graphs requested but no CUDA device, using eager decode");
         }
@@ -443,6 +488,7 @@ impl CudaGraphRunner {
             captured: HashMap::new(),
             adapter_generation: 0,
             warmup_done: false,
+            graph_cache_limit,
         }
     }
 
@@ -677,9 +723,10 @@ impl CudaGraphRunner {
                 );
             }
 
-            if self.captured.len() >= Self::max_cached_graphs() {
+            if self.captured.len() >= self.graph_cache_limit {
                 tracing::warn!(
                     cached_graphs = self.captured.len(),
+                    graph_cache_limit = self.graph_cache_limit,
                     requested_max_seqlen_k = requested_key.max_seqlen_k,
                     requested_max_blocks_per_seq = requested_key.max_blocks_per_seq,
                     "CUDA graph capture skipped: paged metadata shape cache is full"
@@ -1042,15 +1089,6 @@ impl CudaGraphRunner {
     }
 
     #[cfg(feature = "cuda")]
-    fn max_cached_graphs() -> usize {
-        std::env::var("KILN_CUDA_GRAPH_CACHE_MAX")
-            .ok()
-            .and_then(|value| value.parse::<usize>().ok())
-            .filter(|&value| value > 0)
-            .unwrap_or(8)
-    }
-
-    #[cfg(feature = "cuda")]
     fn new_token_buffer(device: &Device, token_id: u32) -> Result<Tensor> {
         Tensor::new(&[token_id], device).context("create CUDA graph token buffer")
     }
@@ -1288,6 +1326,34 @@ mod tests {
     }
 
     #[test]
+    fn test_cuda_graph_cache_limit_value_accepts_numeric_values() {
+        assert_eq!(cuda_graph_cache_limit_value("0"), Some(0));
+        assert_eq!(cuda_graph_cache_limit_value("not-a-number"), None);
+        assert_eq!(cuda_graph_cache_limit_value("16"), Some(16));
+    }
+
+    #[test]
+    fn test_graph_cache_limit_distributes_across_slots() {
+        let limits: Vec<usize> = (0..8)
+            .map(|slot_idx| graph_cache_limit_for_slot(slot_idx, 8, 8))
+            .collect();
+        assert_eq!(limits, vec![1, 1, 1, 1, 1, 1, 1, 1]);
+
+        let uneven_limits: Vec<usize> = (0..4)
+            .map(|slot_idx| graph_cache_limit_for_slot(slot_idx, 4, 10))
+            .collect();
+        assert_eq!(uneven_limits, vec![3, 3, 2, 2]);
+    }
+
+    #[test]
+    fn test_graph_cache_limit_allows_zero_for_overflow_slots() {
+        let limits: Vec<usize> = (0..8)
+            .map(|slot_idx| graph_cache_limit_for_slot(slot_idx, 8, 3))
+            .collect();
+        assert_eq!(limits, vec![1, 1, 1, 0, 0, 0, 0, 0]);
+    }
+
+    #[test]
     fn test_env_flag_enabled_accepts_kill_switch_values() {
         assert!(env_flag_enabled("1"));
         assert!(env_flag_enabled("true"));
@@ -1367,6 +1433,37 @@ mod tests {
                     assert_eq!(runner.adapter_generation, 1);
                     assert!(!runner.warmup_done);
                 }
+            }
+            CudaGraphSlots::Single(_) => panic!("expected pool"),
+        }
+    }
+
+    #[test]
+    fn test_pool_uses_total_graph_cache_limit_across_slots() {
+        let runners = CudaGraphRunners {
+            enabled: true,
+            slots: CudaGraphSlots::Pool(Arc::new(CudaGraphPool {
+                slots: (0..4)
+                    .map(|slot_idx| {
+                        Mutex::new(CudaGraphRunner::new_with_graph_cache_limit(
+                            &Device::Cpu,
+                            false,
+                            graph_cache_limit_for_slot(slot_idx, 4, 6),
+                        ))
+                    })
+                    .collect(),
+                leased: (0..4).map(|_| AtomicBool::new(false)).collect(),
+            })),
+        };
+
+        match &runners.slots {
+            CudaGraphSlots::Pool(pool) => {
+                let limits: Vec<usize> = pool
+                    .slots
+                    .iter()
+                    .map(|slot| slot.lock().expect("slot lock").graph_cache_limit)
+                    .collect();
+                assert_eq!(limits, vec![2, 2, 1, 1]);
             }
             CudaGraphSlots::Single(_) => panic!("expected pool"),
         }

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -89,8 +89,8 @@ impl CudaGraphKey {
 
     fn stable_paged_metadata_enabled() -> bool {
         std::env::var("KILN_CUDA_GRAPH_STABLE_PAGED_METADATA")
-            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
-            .unwrap_or(false)
+            .map(|v| env_flag_enabled(&v))
+            .unwrap_or(true)
     }
 }
 

--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -89,8 +89,8 @@ impl CudaGraphKey {
 
     fn stable_paged_metadata_enabled() -> bool {
         std::env::var("KILN_CUDA_GRAPH_STABLE_PAGED_METADATA")
-            .map(|v| env_flag_enabled(&v))
-            .unwrap_or(true)
+            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
+            .unwrap_or(false)
     }
 }
 

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1982,17 +1982,20 @@ impl ModelRunner {
 
         // Fast path: when row_count > 1, all rows greedy with a common seq_len,
         // and the cache is non-FP8, route through the contiguous-batched
-        // primitive. That single forward pass batches GQA across rows and uses
-        // the fused argmax LM head, eliminating the per-row GQA loop and
-        // per-row [1, 1, vocab] LM-head allocations that produce the c=8
-        // throughput collapse documented in
-        // docs/audits/PHASE12_B_PRIME_BATCHING_DIAGNOSIS.md.
+        // primitive only when the backend can reduce the LM head to token IDs
+        // without materializing [batch, 1, vocab] logits. CUDA does not yet
+        // implement batched LM-head argmax; letting it fall through to the
+        // portable full-logits projection OOMs at c>=8.
         let common_seq_len = sequence_lengths[0];
         let positions_uniform = sequence_lengths.iter().all(|&n| n == common_seq_len);
         let all_greedy = params.iter().all(|p| p.temperature == 0.0);
         let cache_is_fp8 = lock_paged_cache(paged_cache)?.is_fp8();
-        let try_contiguous_batched =
-            row_count > 1 && positions_uniform && all_greedy && !cache_is_fp8;
+        let batched_argmax_supported = self.backend.supports_linear_decode_argmax_batch();
+        let try_contiguous_batched = row_count > 1
+            && positions_uniform
+            && all_greedy
+            && !cache_is_fp8
+            && batched_argmax_supported;
 
         let mut sampled: Option<Vec<TokenId>> = None;
         if try_contiguous_batched {
@@ -2067,6 +2070,58 @@ impl ModelRunner {
                     )?
                 };
                 vec![token]
+            } else if self.backend.name() == "cuda" {
+                drop(pc_guard);
+                let mut sampled = Vec::with_capacity(states.len());
+                for idx in 0..states.len() {
+                    let state = &mut states[idx];
+                    let pc_guard = lock_paged_cache(paged_cache)?;
+                    let row = if self.cuda_graph.is_enabled() {
+                        let lease = state
+                            .cuda_graph_lease
+                            .get_or_insert_with(|| self.cuda_graph.lease());
+                        lease
+                            .decode_step_paged(
+                                &*self.backend,
+                                input_tokens[idx],
+                                &self.weights,
+                                &self.config,
+                                pc_guard,
+                                &block_tables[idx],
+                                sequence_lengths[idx],
+                                &mut state.linear_state,
+                                self.active_lora.as_ref(),
+                            )
+                            .with_context(|| format!("CUDA rowwise decode row {idx} failed"))?
+                    } else {
+                        CudaGraphRunners::decode_step_paged_eager(
+                            &*self.backend,
+                            input_tokens[idx],
+                            &self.weights,
+                            &self.config,
+                            pc_guard,
+                            &block_tables[idx],
+                            sequence_lengths[idx],
+                            &mut state.linear_state,
+                            self.active_lora.as_ref(),
+                        )
+                        .with_context(|| format!("CUDA rowwise eager decode row {idx} failed"))?
+                    };
+                    let params = &params[idx];
+                    let token = if params.temperature == 0.0 {
+                        greedy_sample(&row)?
+                    } else {
+                        sample_with_params(
+                            &row,
+                            params.temperature,
+                            params.top_p,
+                            params.top_k,
+                            state.step_seed,
+                        )?
+                    };
+                    sampled.push(token);
+                }
+                sampled
             } else {
                 let mut linear_states: Vec<&mut LinearAttentionState> = states
                     .iter_mut()


### PR DESCRIPTION
## Summary

- Gates the contiguous-batched greedy decode fast path on backend support for batched LM-head argmax.
- Keeps CUDA off the unsupported `[batch, 1, vocab]` full-logits LM-head fallback that OOMs at c>=8 after PR #1003.
- Restores CUDA fallback to rowwise graph/eager decode for multi-row batches until a true CUDA batched LM-head argmax exists.

## Diagnosis

PR #1003 exposed a CUDA fallback that looked like a batched greedy path, but CUDA does not implement `linear_decode_argmax_batch`. The code therefore fell through to materializing batched full-vocab logits via `model_forward_head_backend_decode_if`, which repeatedly failed with `batched decode lm head: DriverError(CUDA_ERROR_OUT_OF_MEMORY, "out of memory")` under `KILN_DECODE_PARALLELISM=8`.

I also tested two graph-cache hypotheses:

- Pool-wide graph cache limiting fixed neither the root path nor performance enough by itself.
- Defaulting stable paged metadata removed cache-full warnings but caused CUDA illegal-address failures, so it was reverted and is not part of this PR.

## Validation

A6000 via `ce kiln-runpod-session`, kiln-runpod image, branch `phase-12-d-pr1003-oom-fix`.

- PASS: `cargo fmt --check`
- PASS: `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln`
- PASS: `KILN_CUDA_ARCHS=86 cargo nextest run --release -p kiln-model cuda_graph --features cuda`
- PASS: focused decode tests via nextest expression covering CUDA contiguous decode + decode batcher policy.
- NOTE: requested exact `cargo nextest run --release -p kiln-model --features cuda batched_decode` currently matches 0 tests on main and exits with `error: no tests to run`; nearest named tests were run instead.
- PASS reliability smoke: production server with `KILN_W4A16=1 KILN_CUDA_GRAPHS=true KILN_PREFIX_CACHE_ENABLED=true KILN_BATCHING_ENGINE=1 KILN_DECODE_PARALLELISM=8`.
  - c=8 Shape-A-style streaming smoke: 32/32 `finish_reason=length`, 0 errors, 0 LM-head OOM logs, 0 CUDA illegal-address logs.
  - c=8 launch-window aggregate: 58.51 tok/s (tail-including aggregate 44.66 tok/s; smoke script launches for 70s then waits for tail completions).
  - c=1 quick smoke: 12/12 `finish_reason=length`, 0 errors, 51.2 tok/s over the 30s launch window, 49.25 tok/s tail-including.

Artifacts attached to task: `pr1003_oom_fix_artifacts.tgz`.

## Follow-up

Do not auto-merge from this smoke alone. Next planning loop should run the full 12-point Phase 12 validation on this PR. If the full sweep reports Shape A c=8 below the >=56 tok/s reliability-recovery target under the canonical harness, treat this as a reliability fix that still needs a performance follow-up before merge.
