### PR TITLE
Phase 12-D: CUDA batched LM-head argmax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/kiln-flash-attn",
     "crates/kiln-flce-kernel",
     "crates/kiln-gdn-kernel",
+    "crates/kiln-lm-head-kernel",
     "crates/kiln-marlin-gemm",
     "crates/kiln-model",
     "crates/kiln-nvtx",
@@ -16,7 +17,7 @@ members = [
     "crates/kiln-vulkan-kernel",
 ]
 # kiln-conv1d-kernel, kiln-flash-attn, kiln-gdn-kernel, kiln-marlin-gemm,
-# kiln-rmsnorm-kernel, and kiln-vulkan-kernel unconditionally depend on
+# kiln-lm-head-kernel, kiln-rmsnorm-kernel, and kiln-vulkan-kernel unconditionally depend on
 # platform-specific GPU runtimes (cudarc, vulkan-rs) which fail to link on
 # hosts without the matching GPU stack. They're only compiled when a downstream
 # crate opts in via --features cuda or --features vulkan.
@@ -95,6 +96,7 @@ kiln-conv1d-kernel = { path = "crates/kiln-conv1d-kernel" }
 kiln-flash-attn = { path = "crates/kiln-flash-attn" }
 kiln-flce-kernel = { path = "crates/kiln-flce-kernel" }
 kiln-gdn-kernel = { path = "crates/kiln-gdn-kernel" }
+kiln-lm-head-kernel = { path = "crates/kiln-lm-head-kernel" }
 kiln-marlin-gemm = { path = "crates/kiln-marlin-gemm" }
 kiln-nvtx = { path = "crates/kiln-nvtx" }
 kiln-rmsnorm-kernel = { path = "crates/kiln-rmsnorm-kernel" }

--- a/crates/kiln-lm-head-kernel/Cargo.toml
+++ b/crates/kiln-lm-head-kernel/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "kiln-lm-head-kernel"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "CUDA LM-head greedy argmax kernels for batched decode"
+build = "build.rs"
+
+[dependencies]
+candle-core = { workspace = true, features = ["cuda"] }
+half = "2"
+
+[build-dependencies]
+cc = "1"

--- a/crates/kiln-lm-head-kernel/build.rs
+++ b/crates/kiln-lm-head-kernel/build.rs
@@ -1,0 +1,92 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let cuda_root = match find_cuda_root() {
+        Some(p) => p,
+        None => {
+            println!(
+                "cargo:warning=CUDA not found, kiln-lm-head-kernel will not compile CUDA kernels"
+            );
+            println!("cargo:warning=Set CUDA_ROOT or CUDA_HOME, or install CUDA toolkit");
+            return;
+        }
+    };
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let csrc_dir = manifest_dir.join("csrc");
+    let cuda_archs = env::var("KILN_CUDA_ARCHS").unwrap_or_else(|_| "80;86;89;90".to_string());
+
+    let mut build = cc::Build::new();
+    build.cuda(true);
+    build.cpp(true);
+    build.include(&csrc_dir);
+    build.include(cuda_root.join("include"));
+    build.flag("-std=c++17");
+    build.flag("-O3");
+    build.flag("--use_fast_math");
+    build.flag("--expt-relaxed-constexpr");
+    build.flag("--expt-extended-lambda");
+    build.flag("-Xcompiler").flag("-fPIC");
+    build.flag("-diag-suppress=177");
+    build.flag("-diag-suppress=174");
+
+    for arch in cuda_archs.split(';') {
+        let arch = arch.trim();
+        if !arch.is_empty() {
+            build.flag(&format!("-gencode=arch=compute_{arch},code=sm_{arch}"));
+        }
+    }
+
+    build.file(csrc_dir.join("lm_head_argmax.cu"));
+    build.compile("kiln_lm_head_kernel");
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        cuda_root.join("lib64").display()
+    );
+    println!("cargo:rustc-link-lib=cudart");
+    println!("cargo:rustc-link-lib=cublas");
+    println!("cargo:rerun-if-changed=csrc/");
+    println!("cargo:rerun-if-env-changed=CUDA_ROOT");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
+    println!("cargo:rerun-if-env-changed=KILN_CUDA_ARCHS");
+}
+
+fn find_cuda_root() -> Option<PathBuf> {
+    for var in &["CUDA_ROOT", "CUDA_HOME", "CUDA_PATH"] {
+        if let Ok(val) = env::var(var) {
+            let p = PathBuf::from(val);
+            if p.join("include").join("cuda.h").exists() {
+                return Some(p);
+            }
+        }
+    }
+    for path in &[
+        "/usr/local/cuda",
+        "/usr/local/cuda-12",
+        "/usr/local/cuda-12.4",
+        "/usr/local/cuda-12.6",
+        "/usr/local/cuda-12.8",
+        "/opt/cuda",
+    ] {
+        let p = PathBuf::from(path);
+        if p.join("include").join("cuda.h").exists() {
+            return Some(p);
+        }
+    }
+    if let Ok(output) = std::process::Command::new("which").arg("nvcc").output() {
+        if output.status.success() {
+            let nvcc_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let p = PathBuf::from(nvcc_path);
+            if let Some(bin_dir) = p.parent() {
+                if let Some(cuda_dir) = bin_dir.parent() {
+                    if cuda_dir.join("include").join("cuda.h").exists() {
+                        return Some(cuda_dir.to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/crates/kiln-lm-head-kernel/csrc/lm_head_argmax.cu
+++ b/crates/kiln-lm-head-kernel/csrc/lm_head_argmax.cu
@@ -1,0 +1,143 @@
+#include "lm_head_argmax.h"
+
+#include <cublas_v2.h>
+#include <cuda_runtime.h>
+#include <float.h>
+#include <mutex>
+
+namespace {
+
+constexpr int kThreads = 256;
+constexpr int kMaxBatch = 32;
+
+__device__ __forceinline__ bool better_pair(float score, unsigned int index, float best_score, unsigned int best_index) {
+    return score > best_score || (score == best_score && index < best_index);
+}
+
+__global__ void lm_head_argmax_reduce_kernel(
+    const float *__restrict__ scores,
+    unsigned int *__restrict__ tokens,
+    int vocab
+) {
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    float best_score = -FLT_MAX;
+    unsigned int best_index = 0;
+
+    for (int vocab_idx = tid; vocab_idx < vocab; vocab_idx += blockDim.x) {
+        const float score = scores[row * vocab + vocab_idx];
+        const unsigned int index = static_cast<unsigned int>(vocab_idx);
+        if (better_pair(score, index, best_score, best_index)) {
+            best_score = score;
+            best_index = index;
+        }
+    }
+
+    __shared__ float shared_scores[kThreads];
+    __shared__ unsigned int shared_indices[kThreads];
+    shared_scores[tid] = best_score;
+    shared_indices[tid] = best_index;
+    __syncthreads();
+
+    for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
+        if (tid < stride) {
+            const float score = shared_scores[tid + stride];
+            const unsigned int index = shared_indices[tid + stride];
+            if (better_pair(score, index, shared_scores[tid], shared_indices[tid])) {
+                shared_scores[tid] = score;
+                shared_indices[tid] = index;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (tid == 0) {
+        tokens[row] = shared_indices[0];
+    }
+}
+
+
+int get_cublas_handle(cublasHandle_t *out) {
+    static std::mutex mutex;
+    static cublasHandle_t handle = nullptr;
+    std::lock_guard<std::mutex> lock(mutex);
+    if (handle == nullptr) {
+        cublasStatus_t st = cublasCreate(&handle);
+        if (st != CUBLAS_STATUS_SUCCESS) {
+            return 10000 + static_cast<int>(st);
+        }
+    }
+    *out = handle;
+    return 0;
+}
+
+} // namespace
+
+extern "C" int kiln_lm_head_argmax_bf16_batch(
+    const void *x,
+    const void *weight_t,
+    float *scores,
+    unsigned int *tokens,
+    int batch,
+    int hidden,
+    int vocab,
+    void *stream
+) {
+    if (x == nullptr || weight_t == nullptr || scores == nullptr || tokens == nullptr) {
+        return 1;
+    }
+    if (batch <= 0 || batch > kMaxBatch || hidden <= 0 || vocab <= 0) {
+        return 2;
+    }
+
+    cudaStream_t cuda_stream = reinterpret_cast<cudaStream_t>(stream);
+    cublasHandle_t handle = nullptr;
+    int handle_status = get_cublas_handle(&handle);
+    if (handle_status != 0) {
+        return handle_status;
+    }
+    cublasStatus_t st = cublasSetStream(handle, cuda_stream);
+    if (st != CUBLAS_STATUS_SUCCESS) {
+        return 10100 + static_cast<int>(st);
+    }
+
+    const float alpha = 1.0f;
+    const float beta = 0.0f;
+
+    // Candle tensors are row-major. Interpreting them as column-major gives:
+    //   weight_t row-major [hidden, vocab] == column-major [vocab, hidden]
+    //   x        row-major [batch, hidden] == column-major [hidden, batch]
+    //   scores   row-major [batch, vocab]  == column-major [vocab, batch]
+    // Therefore C_col[vocab,batch] = W_col[vocab,hidden] * X_col[hidden,batch].
+    st = cublasGemmEx(
+        handle,
+        CUBLAS_OP_N,
+        CUBLAS_OP_N,
+        vocab,
+        batch,
+        hidden,
+        &alpha,
+        weight_t,
+        CUDA_R_16BF,
+        vocab,
+        x,
+        CUDA_R_16BF,
+        hidden,
+        &beta,
+        scores,
+        CUDA_R_32F,
+        vocab,
+        CUBLAS_COMPUTE_32F,
+        CUBLAS_GEMM_DEFAULT_TENSOR_OP
+    );
+    if (st != CUBLAS_STATUS_SUCCESS) {
+        return 10200 + static_cast<int>(st);
+    }
+
+    lm_head_argmax_reduce_kernel<<<batch, kThreads, 0, cuda_stream>>>(scores, tokens, vocab);
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        return 20000 + static_cast<int>(err);
+    }
+    return 0;
+}

--- a/crates/kiln-lm-head-kernel/csrc/lm_head_argmax.h
+++ b/crates/kiln-lm-head-kernel/csrc/lm_head_argmax.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int kiln_lm_head_argmax_bf16_batch(
+    const void *x,
+    const void *weight_t,
+    float *scores,
+    unsigned int *tokens,
+    int batch,
+    int hidden,
+    int vocab,
+    void *stream
+);
+
+#ifdef __cplusplus
+}
+#endif

--- a/crates/kiln-lm-head-kernel/src/lib.rs
+++ b/crates/kiln-lm-head-kernel/src/lib.rs
@@ -1,0 +1,210 @@
+//! CUDA kernels for batched greedy LM-head argmax.
+//!
+//! The production decode path needs one token id per batch row without
+//! materializing `[batch, 1, vocab]` logits. This crate computes BF16
+//! `x @ weight_t`, keeps the rowwise argmax reduction on GPU, and copies back
+//! only `[batch]` token ids.
+
+use candle_core::{DType, Device, Result, Tensor, cuda_backend::cudarc::driver::DevicePtr};
+use half::bf16;
+
+const MAX_BATCH: usize = 32;
+
+unsafe extern "C" {
+    fn kiln_lm_head_argmax_bf16_batch(
+        x: *const core::ffi::c_void,
+        weight_t: *const core::ffi::c_void,
+        scores: *mut f32,
+        tokens: *mut u32,
+        batch: i32,
+        hidden: i32,
+        vocab: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+}
+
+pub fn supports_bf16_batch(x: &Tensor, weight_t: &Tensor) -> bool {
+    if x.dtype() != DType::BF16 || weight_t.dtype() != DType::BF16 {
+        return false;
+    }
+    if !matches!(x.device(), Device::Cuda(_)) || !matches!(weight_t.device(), Device::Cuda(_)) {
+        return false;
+    }
+    if !x.is_contiguous() || !weight_t.is_contiguous() {
+        return false;
+    }
+    let Ok((batch, seq_len, hidden)) = x.dims3() else {
+        return false;
+    };
+    let Ok((weight_hidden, vocab)) = weight_t.dims2() else {
+        return false;
+    };
+    batch > 0
+        && batch <= MAX_BATCH
+        && seq_len == 1
+        && hidden == weight_hidden
+        && hidden <= i32::MAX as usize
+        && vocab > 0
+        && vocab <= i32::MAX as usize
+        && batch.checked_mul(vocab).is_some()
+}
+
+pub fn argmax_bf16_batch(x: &Tensor, weight_t: &Tensor) -> Result<Vec<u32>> {
+    if !supports_bf16_batch(x, weight_t) {
+        candle_core::bail!(
+            "kiln-lm-head-kernel: supports only contiguous CUDA BF16 [batch<=32,1,H] x [H,V]"
+        );
+    }
+
+    let (batch, _, hidden) = x.dims3()?;
+    let (_, vocab) = weight_t.dims2()?;
+    let device = x.device();
+    let scores = Tensor::zeros((batch, vocab), DType::F32, device)?;
+    let tokens = Tensor::zeros((batch,), DType::U32, device)?;
+
+    {
+        let (x_storage, x_layout) = x.storage_and_layout();
+        let (w_storage, w_layout) = weight_t.storage_and_layout();
+        let (s_storage, s_layout) = scores.storage_and_layout();
+        let (t_storage, t_layout) = tokens.storage_and_layout();
+
+        let x_cuda = match &*x_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-lm-head-kernel: x must be on CUDA"),
+        };
+        let w_cuda = match &*w_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-lm-head-kernel: weight_t must be on CUDA"),
+        };
+        let s_cuda = match &*s_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-lm-head-kernel: scores must be on CUDA"),
+        };
+        let t_cuda = match &*t_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-lm-head-kernel: tokens must be on CUDA"),
+        };
+
+        let stream = x_cuda.device.cuda_stream();
+        let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+        let x_slice = x_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(x_layout.start_offset()..);
+        let w_slice = w_cuda
+            .as_cuda_slice::<bf16>()?
+            .slice(w_layout.start_offset()..);
+        let s_slice = s_cuda
+            .as_cuda_slice::<f32>()?
+            .slice(s_layout.start_offset()..);
+        let t_slice = t_cuda
+            .as_cuda_slice::<u32>()?
+            .slice(t_layout.start_offset()..);
+
+        unsafe {
+            let (x_ptr, _g1) = x_slice.device_ptr(&stream);
+            let (w_ptr, _g2) = w_slice.device_ptr(&stream);
+            let (s_ptr, _g3) = s_slice.device_ptr(&stream);
+            let (t_ptr, _g4) = t_slice.device_ptr(&stream);
+            let status = kiln_lm_head_argmax_bf16_batch(
+                x_ptr as *const _,
+                w_ptr as *const _,
+                s_ptr as *mut f32,
+                t_ptr as *mut u32,
+                batch as i32,
+                hidden as i32,
+                vocab as i32,
+                raw_stream,
+            );
+            if status != 0 {
+                candle_core::bail!("kiln_lm_head_argmax_bf16_batch failed with status {status}");
+            }
+        }
+    }
+
+    tokens.to_vec1::<u32>()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn try_cuda_device() -> Option<Device> {
+        Device::new_cuda(0).ok()
+    }
+
+    fn deterministic_data(len: usize, seed: u32, scale: f32) -> Vec<f32> {
+        let mut state = seed;
+        (0..len)
+            .map(|_| {
+                state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+                let unit = ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0;
+                unit * scale
+            })
+            .collect()
+    }
+
+    fn assert_parity(batch: usize) -> Result<()> {
+        let Some(device) = try_cuda_device() else {
+            eprintln!("skipping CUDA LM-head argmax parity: no CUDA device");
+            return Ok(());
+        };
+        let hidden = 129usize;
+        let vocab = 263usize;
+        let x_data = deterministic_data(batch * hidden, 0xA11C_E55, 0.75);
+        let w_data = deterministic_data(hidden * vocab, 0xBADC_0DE, 0.5);
+        let x = Tensor::from_slice(&x_data, (batch, 1usize, hidden), &device)?
+            .to_dtype(DType::BF16)?
+            .contiguous()?;
+        let weight_t = Tensor::from_slice(&w_data, (hidden, vocab), &device)?
+            .to_dtype(DType::BF16)?
+            .contiguous()?;
+
+        assert!(supports_bf16_batch(&x, &weight_t));
+        let logits = x.broadcast_matmul(&weight_t)?;
+        let reference = crate_argmax_rows(&logits)?;
+        let fused = argmax_bf16_batch(&x, &weight_t)?;
+        assert_eq!(fused, reference, "batch={batch}");
+        Ok(())
+    }
+
+    fn crate_argmax_rows(logits: &Tensor) -> Result<Vec<u32>> {
+        let (batch, seq_len, _vocab) = logits.dims3()?;
+        if seq_len != 1 {
+            candle_core::bail!("test helper expects seq_len=1");
+        }
+        let rows = logits.squeeze(1)?.to_dtype(DType::F32)?.to_vec2::<f32>()?;
+        let mut out = Vec::with_capacity(batch);
+        for row in rows {
+            let mut best_idx = 0usize;
+            let mut best_score = f32::NEG_INFINITY;
+            for (idx, score) in row.iter().copied().enumerate() {
+                if score > best_score {
+                    best_score = score;
+                    best_idx = idx;
+                }
+            }
+            out.push(best_idx as u32);
+        }
+        Ok(out)
+    }
+
+    #[test]
+    fn test_cuda_lm_head_argmax_batch_1_matches_materialized_logits() -> Result<()> {
+        assert_parity(1)
+    }
+
+    #[test]
+    fn test_cuda_lm_head_argmax_batch_2_matches_materialized_logits() -> Result<()> {
+        assert_parity(2)
+    }
+
+    #[test]
+    fn test_cuda_lm_head_argmax_batch_4_matches_materialized_logits() -> Result<()> {
+        assert_parity(4)
+    }
+
+    #[test]
+    fn test_cuda_lm_head_argmax_batch_8_matches_materialized_logits() -> Result<()> {
+        assert_parity(8)
+    }
+}

--- a/crates/kiln-model/Cargo.toml
+++ b/crates/kiln-model/Cargo.toml
@@ -21,6 +21,7 @@ candle-metal-kernels = { version = "0.10", optional = true }
 kiln-conv1d-kernel = { workspace = true, optional = true }
 kiln-flash-attn = { workspace = true, optional = true }
 kiln-gdn-kernel = { workspace = true, optional = true }
+kiln-lm-head-kernel = { workspace = true, optional = true }
 kiln-marlin-gemm = { workspace = true, optional = true }
 kiln-rmsnorm-kernel = { workspace = true, optional = true }
 kiln-vulkan-kernel = { workspace = true, optional = true }
@@ -34,7 +35,7 @@ objc2-metal = { version = "0.3", optional = true }
 
 
 [features]
-cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-conv1d-kernel", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel", "dep:kiln-marlin-gemm", "dep:kiln-rmsnorm-kernel", "dep:half"]
+cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:kiln-conv1d-kernel", "dep:kiln-flash-attn", "dep:kiln-gdn-kernel", "dep:kiln-lm-head-kernel", "dep:kiln-marlin-gemm", "dep:kiln-rmsnorm-kernel", "dep:half"]
 # Enable candle's Metal backend on Apple Silicon. Pulls in candle-metal-kernels
 # (JIT-compiled MSL shaders cached in the MetalDevice); no Xcode required.
 metal = ["candle-core/metal", "candle-nn/metal", "dep:candle-metal-kernels", "dep:objc2-metal"]

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -27,6 +27,9 @@ pub struct CudaBackend {
     /// kiln/gdn/conv region). When off, forward.rs falls back to the
     /// candle to_f32/cat/sum/narrow chain.
     fused_conv1d_enabled: bool,
+    /// Kill switch for CUDA batched LM-head argmax. This path avoids the
+    /// full-logits `[batch, 1, vocab]` fallback under greedy decode.
+    lm_head_argmax_batch_enabled: bool,
 }
 
 impl CudaBackend {
@@ -41,6 +44,8 @@ impl CudaBackend {
         let gdn_decode_fused_enabled = gdn_gates_enabled
             && gdn_gated_rms_norm_enabled
             && std::env::var("KILN_DISABLE_FUSED_GDN_DECODE").is_err();
+        let lm_head_argmax_batch_enabled =
+            std::env::var("KILN_DISABLE_CUDA_LM_HEAD_ARGMAX_BATCH").is_err();
         Self {
             device,
             gdn_enabled,
@@ -48,6 +53,7 @@ impl CudaBackend {
             gdn_gated_rms_norm_enabled,
             gdn_decode_fused_enabled,
             fused_conv1d_enabled,
+            lm_head_argmax_batch_enabled,
         }
     }
 }
@@ -87,6 +93,26 @@ impl BackendRuntime for CudaBackend {
 
     fn supports_gdn_full_chunk_forward(&self) -> bool {
         self.gdn_enabled
+    }
+
+    fn supports_linear_decode_argmax_batch(&self) -> bool {
+        self.lm_head_argmax_batch_enabled
+    }
+
+    fn linear_decode_argmax_batch(
+        &self,
+        x: &Tensor,
+        weight_t: &Tensor,
+    ) -> Result<Option<Vec<u32>>> {
+        if !self.lm_head_argmax_batch_enabled {
+            return Ok(None);
+        }
+        if !kiln_lm_head_kernel::supports_bf16_batch(x, weight_t) {
+            return Ok(None);
+        }
+        let tokens = kiln_lm_head_kernel::argmax_bf16_batch(x, weight_t)
+            .context("CUDA batched LM-head argmax kernel failed")?;
+        Ok(Some(tokens))
     }
 
     fn flash_attn_prefill(
@@ -417,5 +443,55 @@ impl BackendRuntime for CudaBackend {
         let out = kiln_conv1d_kernel::causal_conv1d_prefill(x, weight, conv_state, kernel_size)
             .context("causal_conv1d_prefill kernel failed")?;
         Ok(Some(out))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn deterministic_data(len: usize, seed: u32, scale: f32) -> Vec<f32> {
+        let mut state = seed;
+        (0..len)
+            .map(|_| {
+                state = state.wrapping_mul(1664525).wrapping_add(1013904223);
+                let unit = ((state >> 8) as f32 / (1u32 << 24) as f32) * 2.0 - 1.0;
+                unit * scale
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_cuda_backend_lm_head_argmax_batch_matches_materialized_logits() -> Result<()> {
+        let device = match Device::new_cuda(0) {
+            Ok(device) => device,
+            Err(err) => {
+                eprintln!("CUDA unavailable, skipping CUDA LM-head argmax backend test: {err}");
+                return Ok(());
+            }
+        };
+        let backend = CudaBackend::new(device.clone());
+        assert!(backend.supports_linear_decode_argmax_batch());
+
+        for batch in [1usize, 2, 4, 8] {
+            let hidden = 129usize;
+            let vocab = 263usize;
+            let x_data = deterministic_data(batch * hidden, 0xDEC0_DED0 + batch as u32, 0.75);
+            let w_data = deterministic_data(hidden * vocab, 0xFACE_FEED, 0.5);
+            let x = Tensor::from_slice(&x_data, (batch, 1usize, hidden), &device)?
+                .to_dtype(DType::BF16)?
+                .contiguous()?;
+            let weight_t = Tensor::from_slice(&w_data, (hidden, vocab), &device)?
+                .to_dtype(DType::BF16)?
+                .contiguous()?;
+            let logits = x.broadcast_matmul(&weight_t)?;
+            let reference = crate::sampling::greedy_sample_rows(&logits)?;
+            let fused = backend
+                .linear_decode_argmax_batch(&x, &weight_t)?
+                .context("CUDA backend declined BF16 argmax batch test shape")?;
+            assert_eq!(fused, reference, "batch={batch}");
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary

- Adds `kiln-lm-head-kernel`, a CUDA BF16 batched LM-head greedy argmax path that returns one token id per decode row without materializing `[batch, 1, vocab]` logits.
- Wires CUDA `supports_linear_decode_argmax_batch()` / `linear_decode_argmax_batch()` so PR #1004's safety gate can enter contiguous-batched greedy decode when the new path supports the shape.
- Keeps a kill switch: `KILN_DISABLE_CUDA_LM_HEAD_ARGMAX_BATCH=1`.

## Validation

A6000 pool lease `pod-ca3fe95dc6e032e97c23f3c0`, kiln-runpod image, `KILN_CUDA_ARCHS=86`, W4A16, CUDA graphs, prefix cache, batching engine, `KILN_DECODE_PARALLELISM=8`.

- PASS: `cargo fmt --check`
- PASS: `KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln`
- PASS: `KILN_CUDA_ARCHS=86 cargo nextest run --release -p kiln-lm-head-kernel test_cuda_lm_head_argmax`
- PASS: `KILN_CUDA_ARCHS=86 cargo nextest run --release -p kiln-model test_cuda_backend_lm_head_argmax_batch_matches_materialized_logits --features cuda`
- PASS: `KILN_CUDA_ARCHS=86 cargo nextest run --release -p kiln-model cuda_graph --features cuda`
- NOTE: `cargo nextest run --release -p kiln-model batched_decode --features cuda` still matches no tests; command was run with the same known no-op behavior as PR #1004.
- PASS reliability smoke: c=8 Shape-A-style streaming smoke 32/32 `finish_reason=length`, 0 errors, 0 LM-head/CUDA OOMs, 0 illegal-address logs.
- PASS parity: focused CUDA kernel + backend argmax parity tests cover batch sizes 1/2/4/8 against materialized logits.

## Full sweep verdict

**ACCEPTANCE: FAIL / do not merge.**

Report: `b2://clouderic/diagnostics/kiln-phase12-d-cuda-argmax-validation-2026-05-09/REPORT.md`

- Shape A c=1: 44.37 tok/s vs floor 49.30 — FAIL
- Shape A c=8: 34.13 tok/s vs baseline recovery gate 62.45 — FAIL
- OOM log matches: 0 — PASS
- Illegal-address log matches: 0 — PASS
- HTTP errors: 0 in counted rows — PASS
- c>=8 non-length finishes: 0 in counted rows — PASS

Diagnosis: the CUDA argmax path fixes the missing backend capability/reliability problem, but the current cuBLAS BF16 GEMM + GPU reduce implementation is slower than PR #1004's rowwise reliable fallback and does not restore throughput. Leaving this draft as evidence; auto-merge is intentionally not enabled.