### PR TITLE
Phase 12-D: parallel CUDA rowwise fallback attempt

### DIFF
--- a/crates/kiln-model/src/cuda_graph.rs
+++ b/crates/kiln-model/src/cuda_graph.rs
@@ -333,6 +333,22 @@ impl CudaGraphRunners {
 }
 
 impl CudaGraphRunnerLease {
+    pub fn replay_ready(
+        &self,
+        block_table: &BlockTable,
+        paged_cache: &PagedKvCache,
+        seq_len: usize,
+    ) -> bool {
+        match &self.slot {
+            CudaGraphRunnerLeaseSlot::Single(_) => false,
+            CudaGraphRunnerLeaseSlot::Pool { pool, slot_idx } => pool.slots[*slot_idx]
+                .lock()
+                .map(|runner| runner.replay_ready(block_table, paged_cache, seq_len))
+                .unwrap_or(false),
+            CudaGraphRunnerLeaseSlot::Eager => true,
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn decode_step_paged(
         &self,
@@ -429,6 +445,32 @@ fn decode_parallelism_value(value: &str) -> Option<usize> {
 }
 
 impl CudaGraphRunner {
+    fn replay_ready(
+        &self,
+        block_table: &BlockTable,
+        paged_cache: &PagedKvCache,
+        seq_len: usize,
+    ) -> bool {
+        if !self.enabled {
+            return true;
+        }
+
+        #[cfg(feature = "cuda")]
+        {
+            let requested_key = CudaGraphKey::new(block_table, paged_cache, seq_len);
+            return self
+                .captured
+                .get(&requested_key)
+                .map(|captured| captured.adapter_gen == self.adapter_generation)
+                .unwrap_or(false);
+        }
+
+        #[cfg(not(feature = "cuda"))]
+        {
+            false
+        }
+    }
+
     /// Create a new graph runner. Enabled only on CUDA devices with the `cuda` feature.
     pub fn new(device: &Device, enabled: bool) -> Self {
         let actually_enabled = enabled && device.is_cuda();

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -1962,6 +1962,87 @@ impl ModelRunner {
     }
 
     #[allow(clippy::too_many_arguments)]
+    fn decode_cuda_rowwise_serial(
+        &self,
+        states: &mut [&mut PagedBatchedDecodeState],
+        params: &[SamplingParams],
+        paged_cache: &PagedKvCache,
+        input_tokens: &[TokenId],
+        block_tables: &[BlockTable],
+        sequence_lengths: &[usize],
+    ) -> Result<Vec<TokenId>> {
+        let mut sampled = Vec::with_capacity(states.len());
+        for idx in 0..states.len() {
+            let state = &mut states[idx];
+            let pc_guard = lock_paged_cache(paged_cache)?;
+            let row = if self.cuda_graph.is_enabled() {
+                let lease = state
+                    .cuda_graph_lease
+                    .get_or_insert_with(|| self.cuda_graph.lease());
+                lease
+                    .decode_step_paged(
+                        &*self.backend,
+                        input_tokens[idx],
+                        &self.weights,
+                        &self.config,
+                        pc_guard,
+                        &block_tables[idx],
+                        sequence_lengths[idx],
+                        &mut state.linear_state,
+                        self.active_lora.as_ref(),
+                    )
+                    .with_context(|| format!("CUDA rowwise decode row {idx} failed"))?
+            } else {
+                CudaGraphRunners::decode_step_paged_eager(
+                    &*self.backend,
+                    input_tokens[idx],
+                    &self.weights,
+                    &self.config,
+                    pc_guard,
+                    &block_tables[idx],
+                    sequence_lengths[idx],
+                    &mut state.linear_state,
+                    self.active_lora.as_ref(),
+                )
+                .with_context(|| format!("CUDA rowwise eager decode row {idx} failed"))?
+            };
+            let params = &params[idx];
+            let token = if params.temperature == 0.0 {
+                greedy_sample(&row)?
+            } else {
+                sample_with_params(
+                    &row,
+                    params.temperature,
+                    params.top_p,
+                    params.top_k,
+                    state.step_seed,
+                )?
+            };
+            sampled.push(token);
+        }
+        Ok(sampled)
+    }
+
+    fn cuda_rowwise_parallel_ready(
+        &self,
+        states: &mut [&mut PagedBatchedDecodeState],
+        paged_cache: &PagedKvCache,
+        block_tables: &[BlockTable],
+        sequence_lengths: &[usize],
+    ) -> bool {
+        if !self.cuda_graph.is_enabled() {
+            return true;
+        }
+        states.iter_mut().enumerate().all(|(idx, state)| {
+            state
+                .cuda_graph_lease
+                .as_ref()
+                .map(|lease| lease.replay_ready(&block_tables[idx], paged_cache, sequence_lengths[idx]))
+                .unwrap_or(false)
+        })
+    }
+
+    #[allow(clippy::too_many_arguments)]
     fn decode_cuda_rowwise_parallel(
         &self,
         states: &mut [&mut PagedBatchedDecodeState],
@@ -2181,14 +2262,30 @@ impl ModelRunner {
                 vec![token]
             } else if self.backend.name() == "cuda" {
                 let _ = pc_guard;
-                self.decode_cuda_rowwise_parallel(
+                if self.cuda_rowwise_parallel_ready(
                     states,
-                    params,
                     paged_cache,
-                    &input_tokens,
                     &block_tables,
                     &sequence_lengths,
-                )?
+                ) {
+                    self.decode_cuda_rowwise_parallel(
+                        states,
+                        params,
+                        paged_cache,
+                        &input_tokens,
+                        &block_tables,
+                        &sequence_lengths,
+                    )?
+                } else {
+                    self.decode_cuda_rowwise_serial(
+                        states,
+                        params,
+                        paged_cache,
+                        &input_tokens,
+                        &block_tables,
+                        &sequence_lengths,
+                    )?
+                }
             } else {
                 let mut linear_states: Vec<&mut LinearAttentionState> = states
                     .iter_mut()

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -2180,7 +2180,7 @@ impl ModelRunner {
                 };
                 vec![token]
             } else if self.backend.name() == "cuda" {
-                drop(pc_guard);
+                let _ = pc_guard;
                 self.decode_cuda_rowwise_parallel(
                     states,
                     params,

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -2037,7 +2037,9 @@ impl ModelRunner {
             state
                 .cuda_graph_lease
                 .as_ref()
-                .map(|lease| lease.replay_ready(&block_tables[idx], paged_cache, sequence_lengths[idx]))
+                .map(|lease| {
+                    lease.replay_ready(&block_tables[idx], paged_cache, sequence_lengths[idx])
+                })
                 .unwrap_or(false)
         })
     }

--- a/crates/kiln-model/src/generate.rs
+++ b/crates/kiln-model/src/generate.rs
@@ -12,6 +12,7 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
     mpsc,
 };
+use std::thread;
 
 use kiln_core::config::ModelConfig;
 use kiln_core::sampling::SamplingParams;
@@ -1960,6 +1961,109 @@ impl ModelRunner {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn decode_cuda_rowwise_parallel(
+        &self,
+        states: &mut [&mut PagedBatchedDecodeState],
+        params: &[SamplingParams],
+        paged_cache: &PagedKvCache,
+        input_tokens: &[TokenId],
+        block_tables: &[BlockTable],
+        sequence_lengths: &[usize],
+    ) -> Result<Vec<TokenId>> {
+        let row_count = states.len();
+        anyhow::ensure!(
+            params.len() == row_count
+                && input_tokens.len() == row_count
+                && block_tables.len() == row_count
+                && sequence_lengths.len() == row_count,
+            "CUDA rowwise decode metadata length mismatch"
+        );
+
+        let backend = &*self.backend;
+        let weights = &self.weights;
+        let config = &self.config;
+        let cuda_graph = &self.cuda_graph;
+        let cuda_graph_enabled = cuda_graph.is_enabled();
+        let active_lora = self.active_lora.as_ref();
+
+        let row_results = thread::scope(|scope| -> Result<Vec<(usize, TokenId)>> {
+            let mut handles = Vec::with_capacity(row_count);
+            for (idx, state_slot) in states.iter_mut().enumerate() {
+                let state = &mut **state_slot;
+                let params = params[idx].clone();
+                let input_token = input_tokens[idx];
+                let block_table = &block_tables[idx];
+                let sequence_length = sequence_lengths[idx];
+                let step_seed = state.step_seed;
+
+                handles.push(scope.spawn(move || -> Result<(usize, TokenId)> {
+                    let pc_guard = lock_paged_cache(paged_cache)?;
+                    let row = if cuda_graph_enabled {
+                        let lease = state
+                            .cuda_graph_lease
+                            .get_or_insert_with(|| cuda_graph.lease());
+                        lease
+                            .decode_step_paged(
+                                backend,
+                                input_token,
+                                weights,
+                                config,
+                                pc_guard,
+                                block_table,
+                                sequence_length,
+                                &mut state.linear_state,
+                                active_lora,
+                            )
+                            .with_context(|| format!("CUDA rowwise decode row {idx} failed"))?
+                    } else {
+                        CudaGraphRunners::decode_step_paged_eager(
+                            backend,
+                            input_token,
+                            weights,
+                            config,
+                            pc_guard,
+                            block_table,
+                            sequence_length,
+                            &mut state.linear_state,
+                            active_lora,
+                        )
+                        .with_context(|| format!("CUDA rowwise eager decode row {idx} failed"))?
+                    };
+
+                    let token = if params.temperature == 0.0 {
+                        greedy_sample(&row)?
+                    } else {
+                        sample_with_params(
+                            &row,
+                            params.temperature,
+                            params.top_p,
+                            params.top_k,
+                            step_seed,
+                        )?
+                    };
+                    Ok((idx, token))
+                }));
+            }
+
+            let mut row_results = Vec::with_capacity(row_count);
+            for handle in handles {
+                row_results.push(
+                    handle
+                        .join()
+                        .map_err(|_| anyhow::anyhow!("CUDA rowwise decode worker panicked"))??,
+                );
+            }
+            Ok(row_results)
+        })?;
+
+        let mut sampled = vec![0; row_count];
+        for (idx, token) in row_results {
+            sampled[idx] = token;
+        }
+        Ok(sampled)
+    }
+
     pub fn paged_batched_decode_step(
         &self,
         states: &mut [&mut PagedBatchedDecodeState],
@@ -2077,56 +2181,14 @@ impl ModelRunner {
                 vec![token]
             } else if self.backend.name() == "cuda" {
                 drop(pc_guard);
-                let mut sampled = Vec::with_capacity(states.len());
-                for idx in 0..states.len() {
-                    let state = &mut states[idx];
-                    let pc_guard = lock_paged_cache(paged_cache)?;
-                    let row = if self.cuda_graph.is_enabled() {
-                        let lease = state
-                            .cuda_graph_lease
-                            .get_or_insert_with(|| self.cuda_graph.lease());
-                        lease
-                            .decode_step_paged(
-                                &*self.backend,
-                                input_tokens[idx],
-                                &self.weights,
-                                &self.config,
-                                pc_guard,
-                                &block_tables[idx],
-                                sequence_lengths[idx],
-                                &mut state.linear_state,
-                                self.active_lora.as_ref(),
-                            )
-                            .with_context(|| format!("CUDA rowwise decode row {idx} failed"))?
-                    } else {
-                        CudaGraphRunners::decode_step_paged_eager(
-                            &*self.backend,
-                            input_tokens[idx],
-                            &self.weights,
-                            &self.config,
-                            pc_guard,
-                            &block_tables[idx],
-                            sequence_lengths[idx],
-                            &mut state.linear_state,
-                            self.active_lora.as_ref(),
-                        )
-                        .with_context(|| format!("CUDA rowwise eager decode row {idx} failed"))?
-                    };
-                    let params = &params[idx];
-                    let token = if params.temperature == 0.0 {
-                        greedy_sample(&row)?
-                    } else {
-                        sample_with_params(
-                            &row,
-                            params.temperature,
-                            params.top_p,
-                            params.top_k,
-                            state.step_seed,
-                        )?
-                    };
-                    sampled.push(token);
-                }
-                sampled
+                self.decode_cuda_rowwise_parallel(
+                    states,
+                    params,
+                    paged_cache,
+                    &input_tokens,
+                    &block_tables,
+                    &sequence_lengths,
+                )?
             } else {
                 let mut linear_states: Vec<&mut LinearAttentionState> = states
                     .iter_mut()


### PR DESCRIPTION
## Summary\n- Attempts to recover PR #1004 c=8 throughput by dispatching safe CUDA rowwise fallback rows concurrently.\n- Adds a replay-ready gate so row workers do not concurrently CUDA-graph-capture on Candle's shared CUDA stream.\n- Keeps PR #1005's cuBLAS+reduce argmax path closed and does not materialize batched CUDA LM-head logits.\n\n## Validation\n- PASS: cargo fmt --check\n- PASS: KILN_CUDA_ARCHS=86 cargo build --release --features cuda --bin kiln\n- PASS: KILN_CUDA_ARCHS=86 cargo nextest run --release -p kiln-model cuda_graph --features cuda\n- FAIL/known unrelated: KILN_CUDA_ARCHS=86 cargo nextest run --release -p kiln-model --features cuda hit existing CUDA kernel parity failures in test_causal_conv1d_update_matches_fallback and test_gdn_chunk_body_matches_fallback.\n- PASS: W4A16 dp1-vs-dp8 parity oracle, 0/256 selected-token mismatches.\n- FAIL: short Shape A c=1 smoke 43.81 tok/s (<49.30 floor), Shape A c=8 smoke 50.87 tok/s (<62.45 baseline), reliability clean.\n\nReport: b2://clouderic/diagnostics/kiln-phase12-d-rowwise-recovery-validation-2026-05-09/REPORT.md\n\n## Verdict\nDo not merge. Thread-level overlap is not enough to recover c=8, and the first ungated attempt showed concurrent CUDA graph capture invalidation. This PR is intentionally draft and should be closed as a measured regression.