### PR TITLE
docs/site: fix release-version drift checker findings

### DIFF
--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -77,7 +77,7 @@
     <section class="section section--tight hero">
       <div class="page hero-grid">
         <div class="hero-copy">
-          <span class="pill"><span class="pill-dot pill-dot--accent" aria-hidden="true"></span>kiln-v0.2.13 · pre-1.0 preview</span>
+          <span class="pill"><span class="pill-dot pill-dot--accent" aria-hidden="true"></span><a href="https://github.com/ericflo/kiln/releases/latest" style="color:inherit;text-decoration:none">latest release</a> · pre-1.0 preview</span>
           <h1 class="hero-title">Your model gets better<br><span class="txt-accent">every time you use it.</span></h1>
           <p class="hero-lede">
             Kiln is a pure-Rust, single-GPU inference server with live LoRA training built in.
@@ -426,7 +426,7 @@ tar xf "kiln-${KILN_VERSION}-aarch64-apple-darwin-metal.tar.gz"
 <pre id="snip-source"><code>git clone https://github.com/ericflo/kiln.git
 cd kiln
 KILN_CUDA_ARCHS=86 cargo build --release --features cuda
-./target/release/kiln serve --model Qwen/Qwen3.5-4B</code></pre>
+KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Post-merge fix for #1011. The Release Version Drift workflow flagged two violations on main, which also blocked the Pages deploy:

- `docs/site/index.html:80` — hardcoded \`kiln-v0.2.13\` text in the hero pill. Replaced with a link to \`/releases/latest\`.
- `docs/site/index.html:429` — \`./target/release/kiln serve --model Qwen/Qwen3.5-4B\` uses an unsupported \`--model\` flag. Replaced with \`KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve\`, matching README/QUICKSTART canonical form.

## Verification
\`\`\`
$ python3 scripts/check_release_versions.py
release version drift check passed: server examples avoid pinned 0.2.13; desktop pins match desktop-v0.2.2; CLI examples match cli.rs; docs/site local links resolve
\`\`\`

After merge, the Pages workflow should succeed and https://ericflo.github.io/kiln/ will reflect the v1 site overhaul from #1011.