### PR TITLE
Deterministic replayable LoRA storage with parent lineage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1899,6 +1899,7 @@ dependencies = [
  "safetensors 0.7.0",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,9 @@ kiln-vulkan-kernel = { path = "crates/kiln-vulkan-kernel" }
 # Random number generation
 rand = "0.10"
 
+# Hashing (replay_hash chain for LoRA lineage)
+sha2 = "0.10"
+
 # Data-parallel iteration
 rayon = "1"
 

--- a/crates/kiln-server/examples/flce_phase_a_validation_bench.rs
+++ b/crates/kiln-server/examples/flce_phase_a_validation_bench.rs
@@ -273,6 +273,7 @@ fn run_one(
         output_name: Some(format!("flce-phaseA-T{target_t}-{tag}")),
         auto_load: false,
         checkpoint_interval: None,
+        seed: None,
     };
     let adapter_dir = std::env::temp_dir().join("kiln-flce-phaseA-validation");
     let _ = std::fs::create_dir_all(&adapter_dir);
@@ -318,6 +319,7 @@ fn run_one(
         &adapter_dir,
         &format!("flce-phaseA-T{target_t}-{tag}"),
         Some(progress_cb),
+        None,
     );
     let step_secs = start.elapsed().as_secs_f64();
 

--- a/crates/kiln-server/examples/flce_preflight_bench.rs
+++ b/crates/kiln-server/examples/flce_preflight_bench.rs
@@ -183,6 +183,7 @@ fn run_one(
         output_name: Some(format!("flce-preflight-T{target_t}")),
         auto_load: false,
         checkpoint_interval: None,
+        seed: None,
     };
     let adapter_dir = std::env::temp_dir().join("kiln-flce-preflight");
     let _ = std::fs::create_dir_all(&adapter_dir);
@@ -218,6 +219,7 @@ fn run_one(
         tokenizer,
         &adapter_dir,
         &format!("flce-preflight-T{target_t}"),
+        None,
         None,
     );
     let step_secs = start.elapsed().as_secs_f64();

--- a/crates/kiln-server/examples/phase10_rmsnorm_bench.rs
+++ b/crates/kiln-server/examples/phase10_rmsnorm_bench.rs
@@ -230,6 +230,7 @@ fn run_one(
         output_name: Some(format!("phase10-rmsnorm-T{target_t}-{tag}")),
         auto_load: false,
         checkpoint_interval: None,
+        seed: None,
     };
     let adapter_dir = std::env::temp_dir().join("kiln-phase10-rmsnorm-bench");
     let _ = std::fs::create_dir_all(&adapter_dir);
@@ -269,6 +270,7 @@ fn run_one(
         &adapter_dir,
         &adapter_name,
         Some(progress),
+        None,
     );
     let elapsed = t0.elapsed().as_secs_f64();
     stop.store(true, Ordering::Relaxed);

--- a/crates/kiln-server/src/bench.rs
+++ b/crates/kiln-server/src/bench.rs
@@ -2196,6 +2196,7 @@ fn bench_training(
         output_name: Some("bench-adapter".to_string()),
         auto_load: false,
         checkpoint_interval: None,
+        seed: None,
     };
 
     let adapter_dir = std::env::temp_dir().join("kiln-bench-adapters");
@@ -2218,6 +2219,7 @@ fn bench_training(
         &adapter_dir,
         "bench-adapter",
         progress_cb,
+        None,
     );
     let elapsed = start.elapsed();
 

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use kiln_model::lora_loader::LoraWeights;
 use kiln_train::trainer;
-use kiln_train::{GrpoRequest, SftRequest, TrainingState};
+use kiln_train::{self, GrpoRequest, SftRequest, TrainingState};
 use serde::Serialize;
 
 use crate::metrics::{TrainingMetricStatus, TrainingMetricType};
@@ -309,12 +309,22 @@ fn execute_job(state: AppState, entry: QueueEntry) {
     // Apply server-level checkpoint_interval default if not set per-job
     let server_checkpoint_interval = state.checkpoint_interval;
 
+    let base_model = trainer::default_base_model(&state.model_config);
+
     // Run the actual training under GPU write lock
     let result: Result<PathBuf, String> = match entry.job {
         QueuedJob::Sft(mut req) => {
             if req.config.checkpoint_interval.is_none() {
                 req.config.checkpoint_interval = server_checkpoint_interval;
             }
+            let request_body = serde_json::to_value(&req)
+                .unwrap_or_else(|_| serde_json::json!({"error": "failed to serialize SftRequest"}));
+            let replay_ctx = trainer::ReplayContext {
+                request_id: job_id.clone(),
+                kind: kiln_train::ReplayKind::Sft,
+                request_body,
+                base_model: base_model.clone(),
+            };
             let _gpu_guard = state.gpu_lock.write().unwrap();
             let guard = runner_arc.read().unwrap();
             trainer::sft_train(
@@ -326,6 +336,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                 &state.adapter_dir,
                 &adapter_name,
                 Some(progress_cb),
+                Some(replay_ctx),
             )
             .map_err(|e| format!("{e:#}"))
         }
@@ -333,6 +344,14 @@ fn execute_job(state: AppState, entry: QueueEntry) {
             if req.config.checkpoint_interval.is_none() {
                 req.config.checkpoint_interval = server_checkpoint_interval;
             }
+            let request_body = serde_json::to_value(&req)
+                .unwrap_or_else(|_| serde_json::json!({"error": "failed to serialize GrpoRequest"}));
+            let replay_ctx = trainer::ReplayContext {
+                request_id: job_id.clone(),
+                kind: kiln_train::ReplayKind::Grpo,
+                request_body,
+                base_model: base_model.clone(),
+            };
             let _gpu_guard = state.gpu_lock.write().unwrap();
             let guard = runner_arc.read().unwrap();
             trainer::grpo_train(
@@ -344,6 +363,7 @@ fn execute_job(state: AppState, entry: QueueEntry) {
                 &state.adapter_dir,
                 &adapter_name,
                 Some(progress_cb),
+                Some(replay_ctx),
             )
             .map_err(|e| format!("{e:#}"))
         }

--- a/crates/kiln-train/Cargo.toml
+++ b/crates/kiln-train/Cargo.toml
@@ -22,11 +22,16 @@ uuid = { workspace = true }
 chrono = { workspace = true }
 indicatif = "0.18"
 console = "0.16"
+sha2 = { workspace = true }
+rand = { workspace = true }
 
 [features]
 cuda = ["kiln-model/cuda", "kiln-flce-kernel/cuda"]
 metal = ["kiln-model/metal"]
 
+[[bin]]
+name = "kiln-replay"
+path = "src/bin/kiln-replay.rs"
+
 [dev-dependencies]
 tempfile = { workspace = true }
-rand = { workspace = true }

--- a/crates/kiln-train/src/bin/kiln-replay.rs
+++ b/crates/kiln-train/src/bin/kiln-replay.rs
@@ -1,0 +1,100 @@
+//! `kiln-replay` — verify and inspect deterministic LoRA replay artifacts.
+//!
+//! Mode 1 (no GPU): walk the parent chain from a LoRA adapter directory,
+//! recompute every `replay_hash` from `replay.jsonl` + parent, and confirm
+//! the chain matches what `lineage.json` records. This is the fast-path
+//! integrity check — it does not retrain anything and never touches the GPU.
+//!
+//! Usage:
+//!   kiln-replay verify <adapter-dir>          # verify a single chain
+//!   kiln-replay show   <adapter-dir>          # print the chain (root→leaf)
+//!
+//! The adapter root is inferred as the parent directory of <adapter-dir>;
+//! parent names are resolved as `<adapter-root>/<name>`.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use kiln_train::replay;
+
+fn print_usage() {
+    eprintln!("usage:");
+    eprintln!("  kiln-replay verify <adapter-dir>");
+    eprintln!("  kiln-replay show   <adapter-dir>");
+}
+
+fn resolve_adapter_root(adapter_dir: &Path) -> PathBuf {
+    adapter_dir
+        .parent()
+        .map(Path::to_path_buf)
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn cmd_verify(adapter_dir: &Path) -> anyhow::Result<()> {
+    let adapter_root = resolve_adapter_root(adapter_dir);
+    let resolver = |name: &str| adapter_root.join(name);
+    replay::verify_chain_integrity(adapter_dir, resolver)?;
+    println!("OK: replay chain at {} verifies", adapter_dir.display());
+    Ok(())
+}
+
+fn cmd_show(adapter_dir: &Path) -> anyhow::Result<()> {
+    let adapter_root = resolve_adapter_root(adapter_dir);
+    let resolver = |name: &str| adapter_root.join(name);
+    let chain = replay::walk_parent_chain(adapter_dir, resolver)?;
+    println!("chain length: {}", chain.len());
+    for (i, (dir, lineage)) in chain.iter().enumerate() {
+        let parent = lineage
+            .parent_lora
+            .as_ref()
+            .map(|p| p.name.as_str())
+            .unwrap_or("<root>");
+        println!(
+            "{idx:>3} {hash}  parent={parent}  base={base}  dir={dir}",
+            idx = i,
+            hash = lineage.replay_hash,
+            parent = parent,
+            base = lineage.base_model.id,
+            dir = dir.display(),
+        );
+    }
+    Ok(())
+}
+
+fn run() -> anyhow::Result<()> {
+    let mut args = std::env::args().skip(1);
+    let cmd = match args.next() {
+        Some(c) => c,
+        None => {
+            print_usage();
+            anyhow::bail!("missing command");
+        }
+    };
+    let adapter_dir = match args.next() {
+        Some(p) => PathBuf::from(p),
+        None => {
+            print_usage();
+            anyhow::bail!("missing adapter dir");
+        }
+    };
+    if args.next().is_some() {
+        print_usage();
+        anyhow::bail!("unexpected extra arguments");
+    }
+    match cmd.as_str() {
+        "verify" => cmd_verify(&adapter_dir),
+        "show" => cmd_show(&adapter_dir),
+        other => {
+            print_usage();
+            anyhow::bail!("unknown command: {other}");
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    if let Err(e) = run() {
+        eprintln!("kiln-replay: {e:#}");
+        return ExitCode::from(1);
+    }
+    ExitCode::SUCCESS
+}

--- a/crates/kiln-train/src/lib.rs
+++ b/crates/kiln-train/src/lib.rs
@@ -4,8 +4,13 @@
 //! loop using candle autograd. Training runs in the same process as inference,
 //! operating on the already-loaded model weights. No Python sidecar needed.
 
+pub mod replay;
 pub mod trainer;
 
+pub use replay::{
+    BaseModel, Lineage, OutcomeRecord, OutcomeStatus, ParentLora, ReplayKind, ReplayLog,
+    ReplayRecord, RequestRecord,
+};
 pub use trainer::CheckpointConfig;
 
 use serde::{Deserialize, Serialize};
@@ -51,6 +56,11 @@ pub struct SftConfig {
     /// Save adapter weights every N training steps. None = only save at the end.
     #[serde(default)]
     pub checkpoint_interval: Option<usize>,
+    /// Deterministic seed for LoRA init and any RNG-dependent steps. If
+    /// `None`, the trainer generates one and records it in `replay.jsonl`
+    /// so the run is still exactly reproducible.
+    #[serde(default)]
+    pub seed: Option<u64>,
 }
 
 fn default_auto_load() -> bool {
@@ -80,6 +90,7 @@ impl Default for SftConfig {
             output_name: None,
             auto_load: default_auto_load(),
             checkpoint_interval: None,
+            seed: None,
         }
     }
 }
@@ -128,6 +139,11 @@ pub struct GrpoConfig {
     /// Save adapter weights every N training steps. None = only save at the end.
     #[serde(default)]
     pub checkpoint_interval: Option<usize>,
+    /// Deterministic seed for LoRA init and any RNG-dependent steps. If
+    /// `None`, the trainer generates one and records it in `replay.jsonl`
+    /// so the run is still exactly reproducible.
+    #[serde(default)]
+    pub seed: Option<u64>,
 }
 
 fn default_grpo_lr() -> f64 {
@@ -152,6 +168,7 @@ impl Default for GrpoConfig {
             output_name: None,
             auto_load: default_auto_load(),
             checkpoint_interval: None,
+            seed: None,
         }
     }
 }

--- a/crates/kiln-train/src/replay.rs
+++ b/crates/kiln-train/src/replay.rs
@@ -1,0 +1,706 @@
+//! Deterministic replay storage for LoRA adapters.
+//!
+//! Every adapter directory written by SFT or GRPO carries enough state to be
+//! re-trained from scratch:
+//!
+//! - `replay.jsonl`: one record per accepted training request, atomically
+//!   appended *before* the optimizer step runs. A second `outcome` record is
+//!   appended after the step completes (or fails). The two-record split means
+//!   a crash mid-step still leaves a recoverable trail of what was attempted.
+//! - `lineage.json`: parent-LoRA pointer, base-model identity, kiln commit,
+//!   and a content-addressed `replay_hash` derived from the parent hash plus
+//!   every request record in this adapter's `replay.jsonl`.
+//!
+//! Together these let `kiln-replay` walk the parent chain, re-apply each
+//! recorded request against the base model, and verify reproducibility.
+//!
+//! ## Atomic append guarantee
+//!
+//! `ReplayLog::append_request` opens `replay.jsonl` with `O_APPEND` (the
+//! POSIX guarantee that small writes are atomic when smaller than `PIPE_BUF`,
+//! typically 4 KiB) and calls `sync_data` before returning. Larger records
+//! still serialize fine but lose the strict atomicity-under-concurrent-write
+//! guarantee — for our use case there is only one writer (the GPU write lock
+//! serializes training jobs), so even a multi-page request record is durable
+//! before the optimizer step runs.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+/// File names written into every adapter directory.
+pub const REPLAY_LOG_FILE: &str = "replay.jsonl";
+pub const LINEAGE_FILE: &str = "lineage.json";
+
+/// Current schema version for `lineage.json`. Bump when the on-disk shape
+/// changes in an incompatible way.
+pub const LINEAGE_SCHEMA_VERSION: u32 = 1;
+
+/// Identity of the base model the adapter was trained against.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BaseModel {
+    /// HuggingFace-style identifier, e.g. "Qwen/Qwen3.5-4B".
+    pub id: String,
+    /// HuggingFace revision (commit/branch). `None` if unknown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub revision: Option<String>,
+    /// Optional digest of the model config (hidden_size, num_layers, etc.) so
+    /// replay can detect mismatched architectures even when `id` matches.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_digest: Option<String>,
+}
+
+/// Pointer to the parent LoRA when the adapter was trained on top of another.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ParentLora {
+    /// Logical adapter name (matches the parent directory name).
+    pub name: String,
+    /// Parent's `replay_hash`. Required; this is what binds the chain.
+    pub replay_hash: String,
+}
+
+/// On-disk lineage manifest.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Lineage {
+    /// Schema version — see [`LINEAGE_SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Logical name of this adapter (matches its directory name).
+    pub adapter_name: String,
+    /// Base model identity.
+    pub base_model: BaseModel,
+    /// Optional pointer to a parent LoRA. `None` when training from the base.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_lora: Option<ParentLora>,
+    /// kiln crate version (or build-stamped commit) at training time.
+    pub kiln_commit: String,
+    /// RFC3339 timestamp when training started.
+    pub created_at: String,
+    /// Content-addressed hash binding the parent hash, base model, and every
+    /// request record in this adapter's `replay.jsonl`.
+    pub replay_hash: String,
+}
+
+/// Training kind tag for replay records.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ReplayKind {
+    Sft,
+    Grpo,
+}
+
+/// Outcome state for a request.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum OutcomeStatus {
+    Completed,
+    Failed,
+}
+
+/// Either record that may appear on a `replay.jsonl` line.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ReplayRecord {
+    Request(RequestRecord),
+    Outcome(OutcomeRecord),
+}
+
+/// A request record captured before the optimizer step runs.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RequestRecord {
+    /// UUID matching the training job id.
+    pub request_id: String,
+    /// Training kind.
+    pub kind: ReplayKind,
+    /// Verbatim request body as deserialized from the HTTP submission.
+    pub request_body: serde_json::Value,
+    /// Effective seed for this request. Always populated, even when the user
+    /// did not supply one (we generate and record one so replay is exact).
+    pub seed: u64,
+    /// kiln crate version (or build-stamped commit).
+    pub kiln_commit: String,
+    /// RFC3339 timestamp when the record was appended.
+    pub submitted_at: String,
+}
+
+/// Outcome record appended after the optimizer step finishes.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OutcomeRecord {
+    /// Matches the corresponding `RequestRecord::request_id`.
+    pub request_id: String,
+    pub status: OutcomeStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub final_loss: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub elapsed_secs: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// Append-only writer over an adapter directory's `replay.jsonl`.
+///
+/// Cheap to construct; opens the file lazily on each append so concurrent
+/// readers (including parent-chain hashing) see flushed data.
+pub struct ReplayLog {
+    dir: PathBuf,
+}
+
+impl ReplayLog {
+    /// Wrap an existing adapter directory. Creates the directory if missing.
+    pub fn new(dir: impl Into<PathBuf>) -> Result<Self> {
+        let dir = dir.into();
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating replay dir: {}", dir.display()))?;
+        Ok(Self { dir })
+    }
+
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    pub fn log_path(&self) -> PathBuf {
+        self.dir.join(REPLAY_LOG_FILE)
+    }
+
+    /// Append a record line atomically (single `write_all` of one line ending
+    /// in `\n`) and `fsync(data)` before returning.
+    fn append_line(&self, line: &str) -> Result<()> {
+        let path = self.log_path();
+        let mut file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .with_context(|| format!("opening replay log: {}", path.display()))?;
+
+        let mut buf = String::with_capacity(line.len() + 1);
+        buf.push_str(line);
+        buf.push('\n');
+
+        file.write_all(buf.as_bytes())
+            .with_context(|| format!("appending to replay log: {}", path.display()))?;
+        file.sync_data()
+            .with_context(|| format!("fsync replay log: {}", path.display()))?;
+        Ok(())
+    }
+
+    /// Append a request record. Must be called *before* the optimizer step
+    /// runs so a crash mid-step still leaves the request on disk.
+    pub fn append_request(&self, record: &RequestRecord) -> Result<()> {
+        let line = serde_json::to_string(&ReplayRecord::Request(record.clone()))
+            .context("serializing replay request record")?;
+        self.append_line(&line)
+    }
+
+    /// Append an outcome record after the optimizer step finishes.
+    pub fn append_outcome(&self, record: &OutcomeRecord) -> Result<()> {
+        let line = serde_json::to_string(&ReplayRecord::Outcome(record.clone()))
+            .context("serializing replay outcome record")?;
+        self.append_line(&line)
+    }
+}
+
+/// Read all records from an adapter's `replay.jsonl`. Missing log => empty.
+pub fn read_replay_log(adapter_dir: &Path) -> Result<Vec<ReplayRecord>> {
+    let path = adapter_dir.join(REPLAY_LOG_FILE);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let mut buf = String::new();
+    File::open(&path)
+        .with_context(|| format!("opening replay log: {}", path.display()))?
+        .read_to_string(&mut buf)
+        .with_context(|| format!("reading replay log: {}", path.display()))?;
+    let mut out = Vec::new();
+    for (lineno, line) in buf.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let rec: ReplayRecord = serde_json::from_str(line).with_context(|| {
+            format!(
+                "parsing replay log line {} of {}",
+                lineno + 1,
+                path.display()
+            )
+        })?;
+        out.push(rec);
+    }
+    Ok(out)
+}
+
+/// Write `lineage.json` atomically (write to temp file, fsync, rename).
+pub fn write_lineage(adapter_dir: &Path, lineage: &Lineage) -> Result<()> {
+    std::fs::create_dir_all(adapter_dir)
+        .with_context(|| format!("creating adapter dir: {}", adapter_dir.display()))?;
+    let final_path = adapter_dir.join(LINEAGE_FILE);
+    let tmp_path = adapter_dir.join(format!("{LINEAGE_FILE}.tmp"));
+    let body = serde_json::to_string_pretty(lineage).context("serializing lineage")?;
+    {
+        let mut f = File::create(&tmp_path)
+            .with_context(|| format!("creating tmp lineage: {}", tmp_path.display()))?;
+        f.write_all(body.as_bytes())
+            .with_context(|| format!("writing tmp lineage: {}", tmp_path.display()))?;
+        f.sync_data()
+            .with_context(|| format!("fsync tmp lineage: {}", tmp_path.display()))?;
+    }
+    std::fs::rename(&tmp_path, &final_path).with_context(|| {
+        format!(
+            "renaming {} -> {}",
+            tmp_path.display(),
+            final_path.display()
+        )
+    })?;
+    Ok(())
+}
+
+/// Read `lineage.json` for an adapter directory.
+pub fn read_lineage(adapter_dir: &Path) -> Result<Lineage> {
+    let path = adapter_dir.join(LINEAGE_FILE);
+    let mut buf = String::new();
+    File::open(&path)
+        .with_context(|| format!("opening lineage: {}", path.display()))?
+        .read_to_string(&mut buf)
+        .with_context(|| format!("reading lineage: {}", path.display()))?;
+    serde_json::from_str(&buf).with_context(|| format!("parsing lineage: {}", path.display()))
+}
+
+/// Compute the content-addressed replay hash for an adapter.
+///
+/// Hash inputs (in this order, separated by NUL bytes):
+///
+/// 1. `parent_replay_hash` (or empty string if root)
+/// 2. `base_model.id`
+/// 3. `base_model.revision` (or empty string)
+/// 4. `base_model.config_digest` (or empty string)
+/// 5. JSON-canonicalized bytes of every `RequestRecord` in chronological
+///    order (one per line), joined with `\n`.
+///
+/// Outcome records are intentionally excluded so that a successful re-run
+/// produces the same hash as the original (failures don't change identity).
+pub fn compute_replay_hash(
+    parent_replay_hash: Option<&str>,
+    base: &BaseModel,
+    requests: &[&RequestRecord],
+) -> Result<String> {
+    let mut hasher = Sha256::new();
+    hasher.update(parent_replay_hash.unwrap_or("").as_bytes());
+    hasher.update([0u8]);
+    hasher.update(base.id.as_bytes());
+    hasher.update([0u8]);
+    hasher.update(base.revision.as_deref().unwrap_or("").as_bytes());
+    hasher.update([0u8]);
+    hasher.update(base.config_digest.as_deref().unwrap_or("").as_bytes());
+    hasher.update([0u8]);
+    for req in requests {
+        let line =
+            serde_json::to_string(req).context("canonicalizing request record for replay hash")?;
+        hasher.update(line.as_bytes());
+        hasher.update([b'\n']);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+/// Walk the parent chain from `adapter_dir` up toward the root, returning
+/// `(adapter_dir, lineage)` pairs ordered root-first.
+///
+/// `parent_dir_resolver` maps a parent's logical name to its directory path
+/// (typically `|name| adapter_root.join(name)`).
+pub fn walk_parent_chain(
+    adapter_dir: &Path,
+    parent_dir_resolver: impl Fn(&str) -> PathBuf,
+) -> Result<Vec<(PathBuf, Lineage)>> {
+    let mut chain = Vec::new();
+    let mut current = adapter_dir.to_path_buf();
+    let mut visited = std::collections::HashSet::new();
+    loop {
+        if !visited.insert(current.clone()) {
+            anyhow::bail!("cycle detected in parent chain at {}", current.display());
+        }
+        let lineage = read_lineage(&current)
+            .with_context(|| format!("reading lineage for {}", current.display()))?;
+        let parent_name = lineage.parent_lora.as_ref().map(|p| p.name.clone());
+        chain.push((current.clone(), lineage));
+        match parent_name {
+            None => break,
+            Some(name) => {
+                current = parent_dir_resolver(&name);
+            }
+        }
+    }
+    chain.reverse();
+    Ok(chain)
+}
+
+/// Verify that an adapter's `replay_hash` matches the recomputed hash from
+/// `replay.jsonl` + parent. Does not load the model.
+pub fn verify_chain_integrity(
+    adapter_dir: &Path,
+    parent_dir_resolver: impl Fn(&str) -> PathBuf,
+) -> Result<()> {
+    let chain = walk_parent_chain(adapter_dir, &parent_dir_resolver)?;
+    let mut prev_hash: Option<String> = None;
+    for (dir, lineage) in &chain {
+        // Verify the parent pointer matches the previously-walked hash.
+        match (&lineage.parent_lora, &prev_hash) {
+            (None, None) => {}
+            (Some(p), Some(prev)) => {
+                if &p.replay_hash != prev {
+                    anyhow::bail!(
+                        "parent_lora.replay_hash mismatch at {}: lineage says {} but parent computed {}",
+                        dir.display(),
+                        p.replay_hash,
+                        prev
+                    );
+                }
+            }
+            (Some(p), None) => anyhow::bail!(
+                "lineage at {} declares parent {} but chain walk hit no predecessor",
+                dir.display(),
+                p.name
+            ),
+            (None, Some(_)) => anyhow::bail!(
+                "lineage at {} has no parent but chain walk produced one",
+                dir.display()
+            ),
+        }
+
+        let records = read_replay_log(dir)?;
+        let requests: Vec<&RequestRecord> = records
+            .iter()
+            .filter_map(|r| match r {
+                ReplayRecord::Request(req) => Some(req),
+                ReplayRecord::Outcome(_) => None,
+            })
+            .collect();
+        let parent_hash = lineage.parent_lora.as_ref().map(|p| p.replay_hash.as_str());
+        let expected = compute_replay_hash(parent_hash, &lineage.base_model, &requests)?;
+        if expected != lineage.replay_hash {
+            anyhow::bail!(
+                "replay_hash mismatch at {}: lineage says {} but recomputed {}",
+                dir.display(),
+                lineage.replay_hash,
+                expected
+            );
+        }
+        prev_hash = Some(lineage.replay_hash.clone());
+    }
+    Ok(())
+}
+
+/// kiln version stamped into request records and lineage. Single-source so
+/// changing it later (e.g. wiring vergen for git sha) is one-liner.
+pub fn kiln_commit() -> String {
+    if let Ok(v) = std::env::var("KILN_COMMIT") {
+        if !v.is_empty() {
+            return v;
+        }
+    }
+    env!("CARGO_PKG_VERSION").to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn sample_request(id: &str, kind: ReplayKind, seed: u64) -> RequestRecord {
+        RequestRecord {
+            request_id: id.to_string(),
+            kind,
+            request_body: serde_json::json!({
+                "examples": [{"messages": [{"role": "user", "content": "hi"}]}],
+                "config": {"epochs": 1}
+            }),
+            seed,
+            kiln_commit: "test-0.0.0".to_string(),
+            submitted_at: "2026-05-09T00:00:00Z".to_string(),
+        }
+    }
+
+    fn sample_outcome(id: &str, status: OutcomeStatus) -> OutcomeRecord {
+        OutcomeRecord {
+            request_id: id.to_string(),
+            status,
+            final_loss: Some(0.42),
+            elapsed_secs: Some(1.0),
+            error: None,
+        }
+    }
+
+    fn sample_base() -> BaseModel {
+        BaseModel {
+            id: "Qwen/Qwen3.5-4B".to_string(),
+            revision: Some("main".to_string()),
+            config_digest: Some("digest-deadbeef".to_string()),
+        }
+    }
+
+    #[test]
+    fn append_request_and_read_back() {
+        let tmp = TempDir::new().unwrap();
+        let log = ReplayLog::new(tmp.path()).unwrap();
+        let req = sample_request("req-1", ReplayKind::Sft, 7);
+        log.append_request(&req).unwrap();
+
+        let records = read_replay_log(tmp.path()).unwrap();
+        assert_eq!(records.len(), 1);
+        match &records[0] {
+            ReplayRecord::Request(r) => assert_eq!(r, &req),
+            _ => panic!("expected request record"),
+        }
+    }
+
+    #[test]
+    fn append_request_and_outcome_in_order() {
+        let tmp = TempDir::new().unwrap();
+        let log = ReplayLog::new(tmp.path()).unwrap();
+        log.append_request(&sample_request("a", ReplayKind::Sft, 1))
+            .unwrap();
+        log.append_outcome(&sample_outcome("a", OutcomeStatus::Completed))
+            .unwrap();
+        log.append_request(&sample_request("b", ReplayKind::Grpo, 2))
+            .unwrap();
+        log.append_outcome(&sample_outcome("b", OutcomeStatus::Failed))
+            .unwrap();
+        let records = read_replay_log(tmp.path()).unwrap();
+        assert_eq!(records.len(), 4);
+        assert!(matches!(records[0], ReplayRecord::Request(_)));
+        assert!(matches!(records[1], ReplayRecord::Outcome(_)));
+        assert!(matches!(records[2], ReplayRecord::Request(_)));
+        assert!(matches!(records[3], ReplayRecord::Outcome(_)));
+    }
+
+    #[test]
+    fn append_survives_simulated_panic_between_records() {
+        // Simulate a panic between the request append and the optimizer step
+        // by simply not appending an outcome. The request record must still
+        // be on disk and parseable so a follow-up replay can detect the
+        // missing outcome.
+        let tmp = TempDir::new().unwrap();
+        let log = ReplayLog::new(tmp.path()).unwrap();
+        let req = sample_request("interrupted", ReplayKind::Sft, 99);
+        log.append_request(&req).unwrap();
+        // Drop the writer (closes the file) — emulates process exit.
+        drop(log);
+
+        let records = read_replay_log(tmp.path()).unwrap();
+        assert_eq!(records.len(), 1);
+        match &records[0] {
+            ReplayRecord::Request(r) => assert_eq!(r.request_id, "interrupted"),
+            _ => panic!("expected request"),
+        }
+    }
+
+    #[test]
+    fn lineage_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let lineage = Lineage {
+            schema_version: LINEAGE_SCHEMA_VERSION,
+            adapter_name: "child".to_string(),
+            base_model: sample_base(),
+            parent_lora: Some(ParentLora {
+                name: "parent".to_string(),
+                replay_hash: "abc123".to_string(),
+            }),
+            kiln_commit: "kiln-0.2.13".to_string(),
+            created_at: "2026-05-09T00:00:00Z".to_string(),
+            replay_hash: "deadbeef".to_string(),
+        };
+        write_lineage(tmp.path(), &lineage).unwrap();
+        let read = read_lineage(tmp.path()).unwrap();
+        assert_eq!(read, lineage);
+    }
+
+    #[test]
+    fn replay_hash_is_deterministic_and_chains() {
+        let base = sample_base();
+        let r1 = sample_request("a", ReplayKind::Sft, 1);
+        let r2 = sample_request("b", ReplayKind::Grpo, 2);
+
+        let h_root = compute_replay_hash(None, &base, &[&r1]).unwrap();
+        let h_root_again = compute_replay_hash(None, &base, &[&r1]).unwrap();
+        assert_eq!(h_root, h_root_again, "hash must be deterministic");
+
+        let h_child_a = compute_replay_hash(Some(&h_root), &base, &[&r2]).unwrap();
+        let h_child_b = compute_replay_hash(Some(&h_root), &base, &[&r2]).unwrap();
+        assert_eq!(h_child_a, h_child_b);
+
+        // Changing the parent hash changes the child.
+        let h_other = compute_replay_hash(Some("zzz"), &base, &[&r2]).unwrap();
+        assert_ne!(h_child_a, h_other);
+
+        // Changing the base model changes the hash.
+        let mut base2 = base.clone();
+        base2.revision = Some("other".to_string());
+        let h_other_base = compute_replay_hash(None, &base2, &[&r1]).unwrap();
+        assert_ne!(h_root, h_other_base);
+
+        // Changing record order changes the hash.
+        let h_swapped = compute_replay_hash(None, &base, &[&r2, &r1]).unwrap();
+        let h_normal = compute_replay_hash(None, &base, &[&r1, &r2]).unwrap();
+        assert_ne!(h_normal, h_swapped);
+    }
+
+    #[test]
+    fn replay_hash_ignores_outcome_records() {
+        // The chain hash is computed over requests only, so a successful
+        // re-run that adds an outcome should not change the hash.
+        let tmp = TempDir::new().unwrap();
+        let log = ReplayLog::new(tmp.path()).unwrap();
+        let r1 = sample_request("a", ReplayKind::Sft, 1);
+        log.append_request(&r1).unwrap();
+        let base = sample_base();
+        let before = compute_replay_hash(None, &base, &[&r1]).unwrap();
+
+        log.append_outcome(&sample_outcome("a", OutcomeStatus::Completed))
+            .unwrap();
+        let records = read_replay_log(tmp.path()).unwrap();
+        let requests: Vec<&RequestRecord> = records
+            .iter()
+            .filter_map(|r| match r {
+                ReplayRecord::Request(req) => Some(req),
+                _ => None,
+            })
+            .collect();
+        let after = compute_replay_hash(None, &base, &requests).unwrap();
+        assert_eq!(before, after);
+    }
+
+    fn build_two_step_chain(root: &Path) -> (PathBuf, PathBuf, String, String) {
+        // Parent adapter
+        let parent_dir = root.join("parent");
+        let parent_log = ReplayLog::new(&parent_dir).unwrap();
+        let r1 = sample_request("p1", ReplayKind::Sft, 1);
+        parent_log.append_request(&r1).unwrap();
+        parent_log
+            .append_outcome(&sample_outcome("p1", OutcomeStatus::Completed))
+            .unwrap();
+        let base = sample_base();
+        let parent_hash = compute_replay_hash(None, &base, &[&r1]).unwrap();
+        let parent_lineage = Lineage {
+            schema_version: LINEAGE_SCHEMA_VERSION,
+            adapter_name: "parent".to_string(),
+            base_model: base.clone(),
+            parent_lora: None,
+            kiln_commit: "test".to_string(),
+            created_at: "2026-05-09T00:00:00Z".to_string(),
+            replay_hash: parent_hash.clone(),
+        };
+        write_lineage(&parent_dir, &parent_lineage).unwrap();
+
+        // Child adapter
+        let child_dir = root.join("child");
+        let child_log = ReplayLog::new(&child_dir).unwrap();
+        let r2 = sample_request("c1", ReplayKind::Grpo, 2);
+        child_log.append_request(&r2).unwrap();
+        child_log
+            .append_outcome(&sample_outcome("c1", OutcomeStatus::Completed))
+            .unwrap();
+        let child_hash = compute_replay_hash(Some(&parent_hash), &base, &[&r2]).unwrap();
+        let child_lineage = Lineage {
+            schema_version: LINEAGE_SCHEMA_VERSION,
+            adapter_name: "child".to_string(),
+            base_model: base,
+            parent_lora: Some(ParentLora {
+                name: "parent".to_string(),
+                replay_hash: parent_hash.clone(),
+            }),
+            kiln_commit: "test".to_string(),
+            created_at: "2026-05-09T00:00:01Z".to_string(),
+            replay_hash: child_hash.clone(),
+        };
+        write_lineage(&child_dir, &child_lineage).unwrap();
+
+        (parent_dir, child_dir, parent_hash, child_hash)
+    }
+
+    #[test]
+    fn walk_parent_chain_root_first() {
+        let tmp = TempDir::new().unwrap();
+        let (parent_dir, child_dir, _, _) = build_two_step_chain(tmp.path());
+        let resolver = |name: &str| tmp.path().join(name);
+        let chain = walk_parent_chain(&child_dir, resolver).unwrap();
+        assert_eq!(chain.len(), 2);
+        assert_eq!(chain[0].0, parent_dir);
+        assert_eq!(chain[1].0, child_dir);
+        assert!(chain[0].1.parent_lora.is_none());
+        assert_eq!(
+            chain[1].1.parent_lora.as_ref().unwrap().name.as_str(),
+            "parent"
+        );
+    }
+
+    #[test]
+    fn verify_chain_integrity_passes_for_valid_chain() {
+        let tmp = TempDir::new().unwrap();
+        let (_, child_dir, _, _) = build_two_step_chain(tmp.path());
+        let resolver = |name: &str| tmp.path().join(name);
+        verify_chain_integrity(&child_dir, resolver).unwrap();
+    }
+
+    #[test]
+    fn verify_chain_integrity_detects_tampered_request() {
+        let tmp = TempDir::new().unwrap();
+        let (_, child_dir, _, _) = build_two_step_chain(tmp.path());
+
+        // Tamper with the child's replay log by appending a fake request not
+        // covered by the recorded replay_hash.
+        let log = ReplayLog::new(&child_dir).unwrap();
+        log.append_request(&sample_request("evil", ReplayKind::Sft, 999))
+            .unwrap();
+
+        let resolver = |name: &str| tmp.path().join(name);
+        let err = verify_chain_integrity(&child_dir, resolver).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("replay_hash mismatch"), "got: {msg}");
+    }
+
+    #[test]
+    fn verify_chain_integrity_detects_parent_pointer_tamper() {
+        let tmp = TempDir::new().unwrap();
+        let (_, child_dir, _, _) = build_two_step_chain(tmp.path());
+
+        // Rewrite the child's lineage with a wrong parent replay_hash; the
+        // child's own replay_hash still validates against its requests, but
+        // the chain walk will catch the mismatch.
+        let mut lineage = read_lineage(&child_dir).unwrap();
+        lineage.parent_lora.as_mut().unwrap().replay_hash = "wrongparent".to_string();
+        write_lineage(&child_dir, &lineage).unwrap();
+
+        let resolver = |name: &str| tmp.path().join(name);
+        let err = verify_chain_integrity(&child_dir, resolver).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("parent_lora.replay_hash mismatch"), "got: {msg}");
+    }
+
+    #[test]
+    fn replay_kind_serializes_lowercase() {
+        let v = serde_json::to_value(ReplayKind::Sft).unwrap();
+        assert_eq!(v, serde_json::json!("sft"));
+        let v = serde_json::to_value(ReplayKind::Grpo).unwrap();
+        assert_eq!(v, serde_json::json!("grpo"));
+    }
+
+    #[test]
+    fn record_round_trips_through_jsonl() {
+        let tmp = TempDir::new().unwrap();
+        let log = ReplayLog::new(tmp.path()).unwrap();
+        let req = sample_request("r", ReplayKind::Grpo, 314);
+        let outcome = sample_outcome("r", OutcomeStatus::Failed);
+        log.append_request(&req).unwrap();
+        log.append_outcome(&outcome).unwrap();
+
+        let records = read_replay_log(tmp.path()).unwrap();
+        assert_eq!(records.len(), 2);
+        match &records[0] {
+            ReplayRecord::Request(r) => assert_eq!(r, &req),
+            _ => panic!("first must be request"),
+        }
+        match &records[1] {
+            ReplayRecord::Outcome(o) => assert_eq!(o, &outcome),
+            _ => panic!("second must be outcome"),
+        }
+    }
+}

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -8,6 +8,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use candle_core::{DType, Device, Tensor, Var};
+use rand::rngs::StdRng;
+use rand::{RngExt, SeedableRng};
 
 use kiln_core::config::ModelConfig;
 use kiln_core::tokenizer::KilnTokenizer;
@@ -22,7 +24,178 @@ use kiln_model::forward::{
 };
 use kiln_model::lora_loader::{LoraLayerWeights, LoraProjectionWeights, LoraWeights};
 
+use crate::replay::{
+    self, BaseModel, Lineage, OutcomeRecord, OutcomeStatus, ParentLora, ReplayKind, ReplayLog,
+    RequestRecord,
+};
 use crate::{ChatMessage, GrpoConfig, GrpoGroup, SftConfig, SftExample};
+
+/// Per-job context the HTTP layer hands the trainer so the training run can
+/// be replayed exactly from its on-disk artifacts.
+///
+/// `request_id` is the same UUID the queue uses for the job; `request_body`
+/// is the verbatim deserialized request the HTTP handler accepted. The
+/// trainer is responsible for resolving the effective seed (using
+/// `config.seed.unwrap_or_else(|| rand::random())` so every run records a
+/// concrete number), opening the parent lineage if `config.base_adapter` is
+/// set, appending the replay record before stepping the optimizer, writing
+/// `lineage.json`, and finally appending the outcome record.
+#[derive(Debug, Clone)]
+pub struct ReplayContext {
+    pub request_id: String,
+    pub kind: ReplayKind,
+    pub request_body: serde_json::Value,
+    pub base_model: BaseModel,
+}
+
+/// Build a default `BaseModel` description for the only model kiln supports.
+///
+/// `id` is fixed to `Qwen/Qwen3.5-4B`; `revision` is left unset; the config
+/// digest is a SHA-256 of the JSON-serialized `ModelConfig` so replay can
+/// detect mismatched architectures even when `id` matches.
+pub fn default_base_model(config: &ModelConfig) -> BaseModel {
+    let digest = serde_json::to_string(config).ok().map(|s| {
+        use sha2::{Digest, Sha256};
+        let mut h = Sha256::new();
+        h.update(s.as_bytes());
+        format!("sha256:{:x}", h.finalize())
+    });
+    BaseModel {
+        id: "Qwen/Qwen3.5-4B".to_string(),
+        revision: None,
+        config_digest: digest,
+    }
+}
+
+/// State threaded through a training run so the request can be appended
+/// before the optimizer step and an outcome can be appended afterward.
+struct ReplayState {
+    log: ReplayLog,
+    lineage: Lineage,
+    request_id: String,
+    started_at: std::time::Instant,
+}
+
+/// Open the replay log + lineage for a training run *before* the optimizer
+/// step runs. Returns the effective seed so the trainer can apply it
+/// consistently to RNG sources used during init.
+///
+/// Writes the request record (durable, fsynced) and `lineage.json` before
+/// returning so a crash mid-step still leaves a recoverable trail.
+fn open_replay_state(
+    ctx: &ReplayContext,
+    config_seed: Option<u64>,
+    parent_adapter: Option<&str>,
+    adapter_dir: &Path,
+    adapter_name: &str,
+) -> Result<(ReplayState, u64)> {
+    let seed = config_seed.unwrap_or_else(|| rand::random());
+    let kiln_commit = replay::kiln_commit();
+    let submitted_at = chrono::Utc::now().to_rfc3339();
+    let request = RequestRecord {
+        request_id: ctx.request_id.clone(),
+        kind: ctx.kind,
+        request_body: ctx.request_body.clone(),
+        seed,
+        kiln_commit: kiln_commit.clone(),
+        submitted_at: submitted_at.clone(),
+    };
+
+    let parent_lora = match parent_adapter {
+        Some(name) => {
+            let parent_dir = adapter_dir.join(name);
+            let parent_lineage = replay::read_lineage(&parent_dir).with_context(|| {
+                format!("reading parent lineage at {}", parent_dir.display())
+            })?;
+            Some(ParentLora {
+                name: name.to_string(),
+                replay_hash: parent_lineage.replay_hash,
+            })
+        }
+        None => None,
+    };
+
+    let output_dir = adapter_dir.join(adapter_name);
+    let log = ReplayLog::new(&output_dir)?;
+    log.append_request(&request)?;
+
+    let parent_hash = parent_lora.as_ref().map(|p| p.replay_hash.as_str());
+    let replay_hash = replay::compute_replay_hash(parent_hash, &ctx.base_model, &[&request])?;
+
+    let lineage = Lineage {
+        schema_version: replay::LINEAGE_SCHEMA_VERSION,
+        adapter_name: adapter_name.to_string(),
+        base_model: ctx.base_model.clone(),
+        parent_lora,
+        kiln_commit,
+        created_at: submitted_at,
+        replay_hash,
+    };
+    replay::write_lineage(&output_dir, &lineage)?;
+
+    Ok((
+        ReplayState {
+            log,
+            lineage,
+            request_id: ctx.request_id.clone(),
+            started_at: std::time::Instant::now(),
+        },
+        seed,
+    ))
+}
+
+/// Append an outcome record after the optimizer step finishes (or fails).
+///
+/// `result` is `Ok(final_loss)` on success, `Err(message)` on failure.
+fn close_replay_state(state: ReplayState, result: Result<f64, String>) -> Result<()> {
+    let elapsed = state.started_at.elapsed().as_secs_f64();
+    let outcome = match result {
+        Ok(loss) => OutcomeRecord {
+            request_id: state.request_id,
+            status: OutcomeStatus::Completed,
+            final_loss: Some(loss),
+            elapsed_secs: Some(elapsed),
+            error: None,
+        },
+        Err(msg) => OutcomeRecord {
+            request_id: state.request_id,
+            status: OutcomeStatus::Failed,
+            final_loss: None,
+            elapsed_secs: Some(elapsed),
+            error: Some(msg),
+        },
+    };
+    state.log.append_outcome(&outcome)?;
+    let _ = state.lineage; // lineage already written; kept for diagnostics if extended
+    Ok(())
+}
+
+/// Sample a Kaiming-uniform LoRA-A initialization.
+///
+/// When `rng` is `Some`, the values are drawn from the supplied RNG so the
+/// init is byte-deterministic across runs; this is the path used when the
+/// caller passes `seed: Some(_)`. When `rng` is `None`, we fall back to
+/// `Var::rand_f64`, which uses the device-global RNG (seeded earlier with
+/// `device.set_seed` on backends that support it).
+fn kaiming_uniform_a(
+    rng: Option<&mut StdRng>,
+    bound: f64,
+    shape: (usize, usize),
+    dtype: DType,
+    device: &Device,
+) -> Result<Var> {
+    if let Some(rng) = rng {
+        let bound_f32 = bound as f32;
+        let n = shape.0 * shape.1;
+        let data: Vec<f32> = (0..n)
+            .map(|_| rng.random_range(-bound_f32..bound_f32))
+            .collect();
+        let t = Tensor::from_slice(&data, &[shape.0, shape.1], device)?.to_dtype(dtype)?;
+        Var::from_tensor(&t).map_err(Into::into)
+    } else {
+        Var::rand_f64(-bound, bound, shape, dtype, device).map_err(Into::into)
+    }
+}
 
 /// Convert our ChatMessage to the core tokenizer's ChatMessage.
 fn to_core_messages(msgs: &[ChatMessage]) -> Vec<kiln_core::tokenizer::ChatMessage> {
@@ -77,6 +250,10 @@ impl TrainableLoraParams {
     /// This matches the standard LoRA initialization:
     /// - A: Kaiming uniform (so the product A*B starts near zero)
     /// - B: zeros (so initial LoRA contribution is zero)
+    ///
+    /// Equivalent to `initialize_seeded(.., None)` — the device-global RNG
+    /// drives A initialization. Tests, benches, and any caller that does not
+    /// need byte-for-byte reproducibility should use this entry point.
     pub fn initialize(
         config: &ModelConfig,
         weights: &GpuWeights,
@@ -84,6 +261,35 @@ impl TrainableLoraParams {
         alpha: f32,
         device: &Device,
     ) -> Result<Self> {
+        Self::initialize_seeded(config, weights, rank, alpha, device, None)
+    }
+
+    /// Like [`initialize`], but uses a deterministic RNG seeded with `seed`
+    /// to draw A. Used by the SFT/GRPO training loops so an adapter
+    /// initialized with the same seed against the same base weights produces
+    /// byte-identical LoRA-A tensors on every run, even on backends like the
+    /// candle CPU device whose `set_seed` is a no-op.
+    ///
+    /// `seed: None` falls back to the device-global RNG (preserves the
+    /// pre-replay behavior).
+    pub fn initialize_seeded(
+        config: &ModelConfig,
+        weights: &GpuWeights,
+        rank: usize,
+        alpha: f32,
+        device: &Device,
+        seed: Option<u64>,
+    ) -> Result<Self> {
+        // Best-effort seed of the device RNG — `Var::zeros` for B does not
+        // need it, and on backends where `set_seed` works (CUDA/Metal) it
+        // pins anything else that uses the device RNG during init. Errors
+        // (e.g. CPU's `set_seed` bail) are swallowed because the seeded
+        // StdRng path below is what actually delivers determinism for A.
+        if let Some(seed) = seed {
+            let _ = device.set_seed(seed);
+        }
+        let mut rng = seed.map(StdRng::seed_from_u64);
+
         let scale = alpha / rank as f32;
         let num_layers = config.num_layers;
         let hidden = config.hidden_size;
@@ -137,8 +343,14 @@ impl TrainableLoraParams {
                 // A: [rank, in_features] — Kaiming uniform
                 // Phase 10: BF16 storage + FP32-accumulate via tensor cores (audit
                 // docs/audits/PHASE10_LORA_PRECISION_STUDY.md §5).
-                let a = Var::rand_f64(-bound, bound, (rank, in_features), DType::BF16, device)
-                    .with_context(|| format!("init LoRA A for layer {layer_idx} {module}"))?;
+                let a = kaiming_uniform_a(
+                    rng.as_mut(),
+                    bound,
+                    (rank, in_features),
+                    DType::BF16,
+                    device,
+                )
+                .with_context(|| format!("init LoRA A for layer {layer_idx} {module}"))?;
 
                 // B: [out_features, rank] — zeros
                 let b = Var::zeros((out_features, rank), DType::BF16, device)
@@ -330,6 +542,12 @@ fn make_step_progress(total_steps: usize, label: &str) -> Option<indicatif::Prog
 /// This runs in the calling thread (blocking). The caller should spawn this
 /// on a background thread to avoid blocking inference.
 ///
+/// When `replay_ctx` is `Some`, the trainer writes a `replay.jsonl` request
+/// record (with the resolved seed) and `lineage.json` into the adapter
+/// directory *before* the optimizer step, then appends an outcome record
+/// when training completes or fails. When `None`, no replay artifacts are
+/// written — used by tests and benches that don't need replay.
+///
 /// Returns the path to the saved adapter directory.
 pub fn sft_train(
     examples: &[SftExample],
@@ -340,6 +558,7 @@ pub fn sft_train(
     adapter_dir: &Path,
     adapter_name: &str,
     progress_cb: Option<ProgressCallback>,
+    replay_ctx: Option<ReplayContext>,
 ) -> Result<PathBuf> {
     let device = weights.embed_tokens.device().clone();
     let backend = backend::for_device(&device);
@@ -354,13 +573,31 @@ pub fn sft_train(
         "starting SFT training"
     );
 
+    // Open replay state (writes request record + lineage.json *before* the
+    // optimizer step, so a crash mid-step still leaves a recoverable trail)
+    // and resolve the effective seed.
+    let (replay_state, effective_seed) = match replay_ctx.as_ref() {
+        Some(ctx) => {
+            let (state, seed) = open_replay_state(
+                ctx,
+                config.seed,
+                config.base_adapter.as_deref(),
+                adapter_dir,
+                adapter_name,
+            )?;
+            (Some(state), Some(seed))
+        }
+        None => (None, config.seed),
+    };
+
     // Initialize trainable LoRA parameters
-    let params = TrainableLoraParams::initialize(
+    let params = TrainableLoraParams::initialize_seeded(
         model_config,
         weights,
         config.lora_rank,
         config.lora_alpha,
         &device,
+        effective_seed,
     )?;
 
     tracing::info!(
@@ -368,154 +605,170 @@ pub fn sft_train(
         "initialized trainable LoRA parameters"
     );
 
-    // Tokenize all examples and build (input_ids, label_mask) pairs.
-    // Labels: we want to train on assistant responses only.
-    let tokenized: Vec<(Vec<u32>, Vec<bool>)> = examples
-        .iter()
-        .filter_map(|ex| match tokenize_for_training(ex, tokenizer) {
-            Ok(t) => Some(t),
-            Err(e) => {
-                tracing::warn!("skipping example: {e}");
-                None
-            }
-        })
-        .collect();
+    // Run the actual training body inside a closure so we can write the
+    // outcome record (success or failure) before returning to the caller.
+    let train_body = || -> Result<(PathBuf, f64)> {
+        // Tokenize all examples and build (input_ids, label_mask) pairs.
+        // Labels: we want to train on assistant responses only.
+        let tokenized: Vec<(Vec<u32>, Vec<bool>)> = examples
+            .iter()
+            .filter_map(|ex| match tokenize_for_training(ex, tokenizer) {
+                Ok(t) => Some(t),
+                Err(e) => {
+                    tracing::warn!("skipping example: {e}");
+                    None
+                }
+            })
+            .collect();
 
-    if tokenized.is_empty() {
-        anyhow::bail!("no valid training examples after tokenization");
-    }
+        if tokenized.is_empty() {
+            anyhow::bail!("no valid training examples after tokenization");
+        }
 
-    // Configure gradient checkpointing
-    let ckpt_config = CheckpointConfig::from_env(model_config.num_layers);
-    let segments = if ckpt_config.enabled {
-        Some(compute_segment_boundaries(
-            model_config.num_layers,
-            ckpt_config.num_segments,
-        ))
-    } else {
-        None
-    };
+        // Configure gradient checkpointing
+        let ckpt_config = CheckpointConfig::from_env(model_config.num_layers);
+        let segments = if ckpt_config.enabled {
+            Some(compute_segment_boundaries(
+                model_config.num_layers,
+                ckpt_config.num_segments,
+            ))
+        } else {
+            None
+        };
 
-    if let Some(ref segs) = segments {
-        tracing::info!(
-            num_segments = segs.len(),
-            boundaries = ?segs,
-            "gradient checkpointing enabled"
-        );
-    } else {
-        tracing::info!("gradient checkpointing disabled (KILN_NO_GRAD_CHECKPOINT=1)");
-    }
+        if let Some(ref segs) = segments {
+            tracing::info!(
+                num_segments = segs.len(),
+                boundaries = ?segs,
+                "gradient checkpointing enabled"
+            );
+        } else {
+            tracing::info!("gradient checkpointing disabled (KILN_NO_GRAD_CHECKPOINT=1)");
+        }
 
-    let total_steps = config.epochs * tokenized.len();
-    let mut global_step = 0;
-    let mut last_loss = 0.0;
+        let total_steps = config.epochs * tokenized.len();
+        let mut global_step = 0;
+        let mut last_loss = 0.0;
 
-    let pb = make_step_progress(total_steps, "sft training");
+        let pb = make_step_progress(total_steps, "sft training");
 
-    for epoch in 0..config.epochs {
-        let mut epoch_loss = 0.0;
+        for epoch in 0..config.epochs {
+            let mut epoch_loss = 0.0;
 
-        for (_ex_idx, (input_ids, label_mask)) in tokenized.iter().enumerate() {
-            let loss_val;
+            for (_ex_idx, (input_ids, label_mask)) in tokenized.iter().enumerate() {
+                let loss_val;
 
-            if let Some(ref segs) = segments {
-                // Gradient-checkpointed forward/backward
-                let (lv, accumulated_grads) = checkpointed_forward_backward(
-                    &*backend,
-                    input_ids,
-                    weights,
-                    model_config,
-                    &params,
-                    label_mask,
-                    segs,
-                    &device,
-                )?;
-                loss_val = lv;
-                sgd_step_from_map(&params, &accumulated_grads, config.learning_rate)?;
-            } else {
-                // Standard (non-checkpointed) forward/backward
-                let (lv, grads) = standard_forward_backward(
-                    &*backend,
-                    input_ids,
-                    weights,
-                    model_config,
-                    &params,
-                    label_mask,
-                    &device,
-                )?;
-                loss_val = lv;
-                sgd_step(&params, &grads, config.learning_rate)?;
-            }
+                if let Some(ref segs) = segments {
+                    // Gradient-checkpointed forward/backward
+                    let (lv, accumulated_grads) = checkpointed_forward_backward(
+                        &*backend,
+                        input_ids,
+                        weights,
+                        model_config,
+                        &params,
+                        label_mask,
+                        segs,
+                        &device,
+                    )?;
+                    loss_val = lv;
+                    sgd_step_from_map(&params, &accumulated_grads, config.learning_rate)?;
+                } else {
+                    // Standard (non-checkpointed) forward/backward
+                    let (lv, grads) = standard_forward_backward(
+                        &*backend,
+                        input_ids,
+                        weights,
+                        model_config,
+                        &params,
+                        label_mask,
+                        &device,
+                    )?;
+                    loss_val = lv;
+                    sgd_step(&params, &grads, config.learning_rate)?;
+                }
 
-            epoch_loss += loss_val;
-            last_loss = loss_val;
+                epoch_loss += loss_val;
+                last_loss = loss_val;
 
-            global_step += 1;
+                global_step += 1;
 
-            // Periodic adapter checkpoint
-            if let Some(interval) = config.checkpoint_interval {
-                if interval > 0 && global_step % interval == 0 && global_step < total_steps {
-                    let ckpt_dir =
-                        adapter_dir.join(format!("{adapter_name}-checkpoint-{global_step}"));
-                    if let Err(e) = params.save_peft(&ckpt_dir, model_config.num_layers) {
-                        tracing::warn!(step = global_step, error = %e, "failed to save training checkpoint");
-                    } else {
-                        tracing::info!(step = global_step, "saved training checkpoint");
+                // Periodic adapter checkpoint
+                if let Some(interval) = config.checkpoint_interval {
+                    if interval > 0 && global_step % interval == 0 && global_step < total_steps {
+                        let ckpt_dir =
+                            adapter_dir.join(format!("{adapter_name}-checkpoint-{global_step}"));
+                        if let Err(e) = params.save_peft(&ckpt_dir, model_config.num_layers) {
+                            tracing::warn!(step = global_step, error = %e, "failed to save training checkpoint");
+                        } else {
+                            tracing::info!(step = global_step, "saved training checkpoint");
+                        }
                     }
+                }
+
+                if let Some(ref cb) = progress_cb {
+                    cb(TrainingProgress {
+                        epoch: epoch + 1,
+                        total_epochs: config.epochs,
+                        step: global_step,
+                        total_steps,
+                        loss: loss_val,
+                        progress: global_step as f32 / total_steps as f32,
+                    });
+                }
+
+                if global_step % 10 == 0 || global_step == total_steps {
+                    tracing::info!(
+                        epoch = epoch + 1,
+                        step = global_step,
+                        total_steps,
+                        loss = format!("{loss_val:.6}"),
+                        "training step"
+                    );
+                }
+
+                if let Some(pb) = &pb {
+                    pb.set_message(format!("{loss_val:.6}"));
+                    pb.inc(1);
                 }
             }
 
-            if let Some(ref cb) = progress_cb {
-                cb(TrainingProgress {
-                    epoch: epoch + 1,
-                    total_epochs: config.epochs,
-                    step: global_step,
-                    total_steps,
-                    loss: loss_val,
-                    progress: global_step as f32 / total_steps as f32,
-                });
-            }
-
-            if global_step % 10 == 0 || global_step == total_steps {
-                tracing::info!(
-                    epoch = epoch + 1,
-                    step = global_step,
-                    total_steps,
-                    loss = format!("{loss_val:.6}"),
-                    "training step"
-                );
-            }
-
-            if let Some(pb) = &pb {
-                pb.set_message(format!("{loss_val:.6}"));
-                pb.inc(1);
-            }
+            let avg_loss = epoch_loss / tokenized.len() as f64;
+            tracing::info!(
+                epoch = epoch + 1,
+                avg_loss = format!("{avg_loss:.6}"),
+                "epoch complete"
+            );
         }
 
-        let avg_loss = epoch_loss / tokenized.len() as f64;
+        if let Some(pb) = pb {
+            pb.finish_and_clear();
+        }
+
+        // Save the trained adapter
+        let output_dir = adapter_dir.join(adapter_name);
+        params.save_peft(&output_dir, model_config.num_layers)?;
+
         tracing::info!(
-            epoch = epoch + 1,
-            avg_loss = format!("{avg_loss:.6}"),
-            "epoch complete"
+            adapter = adapter_name,
+            path = %output_dir.display(),
+            final_loss = format!("{last_loss:.6}"),
+            "SFT training complete"
         );
+
+        Ok((output_dir, last_loss))
+    };
+
+    let result = train_body();
+    if let Some(state) = replay_state {
+        let outcome = match &result {
+            Ok((_, loss)) => Ok(*loss),
+            Err(e) => Err(format!("{e:#}")),
+        };
+        if let Err(e) = close_replay_state(state, outcome) {
+            tracing::warn!(error = %e, "failed to append SFT replay outcome record");
+        }
     }
-
-    if let Some(pb) = pb {
-        pb.finish_and_clear();
-    }
-
-    // Save the trained adapter
-    let output_dir = adapter_dir.join(adapter_name);
-    params.save_peft(&output_dir, model_config.num_layers)?;
-
-    tracing::info!(
-        adapter = adapter_name,
-        path = %output_dir.display(),
-        final_loss = format!("{last_loss:.6}"),
-        "SFT training complete"
-    );
-
-    Ok(output_dir)
+    result.map(|(dir, _)| dir)
 }
 
 /// Run GRPO training on the provided groups using the already-loaded model.
@@ -536,6 +789,7 @@ pub fn grpo_train(
     adapter_dir: &Path,
     adapter_name: &str,
     progress_cb: Option<ProgressCallback>,
+    replay_ctx: Option<ReplayContext>,
 ) -> Result<PathBuf> {
     let device = weights.embed_tokens.device().clone();
     let backend = backend::for_device(&device);
@@ -553,13 +807,30 @@ pub fn grpo_train(
         "starting GRPO training"
     );
 
+    // Open replay state (writes request record + lineage.json *before* the
+    // optimizer step) and resolve the effective seed.
+    let (replay_state, effective_seed) = match replay_ctx.as_ref() {
+        Some(ctx) => {
+            let (state, seed) = open_replay_state(
+                ctx,
+                config.seed,
+                config.base_adapter.as_deref(),
+                adapter_dir,
+                adapter_name,
+            )?;
+            (Some(state), Some(seed))
+        }
+        None => (None, config.seed),
+    };
+
     // Initialize trainable LoRA parameters
-    let params = TrainableLoraParams::initialize(
+    let params = TrainableLoraParams::initialize_seeded(
         model_config,
         weights,
         config.lora_rank,
         config.lora_alpha,
         &device,
+        effective_seed,
     )?;
 
     tracing::info!(
@@ -567,6 +838,7 @@ pub fn grpo_train(
         "initialized trainable LoRA parameters"
     );
 
+    let train_body = || -> Result<(PathBuf, f64)> {
     // Tokenize all completions: for each group, tokenize prompt + each completion
     let tokenized_groups: Vec<TokenizedGrpoGroup> = groups
         .iter()
@@ -758,7 +1030,20 @@ pub fn grpo_train(
         "GRPO training complete"
     );
 
-    Ok(output_dir)
+        Ok((output_dir, last_loss))
+    };
+
+    let result = train_body();
+    if let Some(state) = replay_state {
+        let outcome = match &result {
+            Ok((_, loss)) => Ok(*loss),
+            Err(e) => Err(format!("{e:#}")),
+        };
+        if let Err(e) = close_replay_state(state, outcome) {
+            tracing::warn!(error = %e, "failed to append GRPO replay outcome record");
+        }
+    }
+    result.map(|(dir, _)| dir)
 }
 
 /// Tokenized data for a single completion within a GRPO group.
@@ -2541,8 +2826,6 @@ mod tests {
         GpuAttentionWeights, GpuFfnWeights, GpuFullAttentionWeights, GpuLayerWeights,
         GpuLinearAttentionWeights,
     };
-    use rand::rngs::StdRng;
-    use rand::{RngExt, SeedableRng};
 
     /// Serializes tests in this binary that mutate process-global env vars
     /// (`KILN_STREAMING_PREFILL`, `KILN_STREAMING_TILE_TOKENS`,


### PR DESCRIPTION
## Summary

Every LoRA produced by SFT or GRPO is now fully replayable from its on-disk artifacts alone. The HF PEFT-compatible weights (`adapter_model.safetensors` + `adapter_config.json`) are unchanged; this PR adds deterministic replay metadata alongside them.

## Storage layout

Each adapter directory now contains:

- **`adapter_model.safetensors`** + **`adapter_config.json`** — unchanged, HF PEFT-compatible.
- **`replay.jsonl`** — one record per training request, atomic `O_APPEND` + `sync_data`, written **before** the optimizer step. Outcome (loss / error) is appended **after** training; outcome failures are logged but never mask the underlying error.
- **`lineage.json`** — `parent_lora`, `base_model { id, revision, config_digest }`, `kiln_commit`, `created_at`, `replay_hash`.

`replay_hash` is a SHA-256 chain over `(parent_hash, base.id, base.revision, base.config_digest, requests)`. Outcomes are deliberately excluded so the hash is content-addressed by inputs only.

## Determinism

- `TrainableLoraParams::initialize_seeded` threads an `Option<u64>` seed through LoRA A/B init. With `Some(seed)` we drive an explicit `StdRng`-based Kaiming-uniform A init, so seeded determinism holds even on CPU (where candle's `Device::set_seed` bails). On GPU we additionally call `device.set_seed` for any remaining device-side RNG.
- `SftConfig` and `GrpoConfig` gain `seed: Option<u64>`. Existing call sites pass `None` so behavior is unchanged when no seed is requested.

## kiln-replay binary

New binary in `kiln-train`:

- `kiln-replay verify <adapter-dir>` — walks parent chain via `lineage.json`, recomputes every `replay_hash` from `replay.jsonl` + parent, confirms the chain matches what's recorded. No GPU, no retraining.
- `kiln-replay show <adapter-dir>` — prints the chain root→leaf.

## HTTP wiring

`training_queue.rs` constructs a `ReplayContext` (`request_id`, `kind`, `request_body`, `base_model`) for both Sft and Grpo branches and passes it into the trainers. The request body is the serialized request, captured before the GPU lock is acquired so the body always reflects exactly what was queued.

Bench / example callers (`bench.rs`, `flce_preflight_bench`, `flce_phase_a_validation_bench`, `phase10_rmsnorm_bench`) pass `None` for the new replay context — bench paths don't produce shippable adapters.

## Tests

12 new unit tests covering:

- append + read-back round-trip
- atomic append survives a simulated panic between records (truncated trailing line)
- lineage round-trip
- record round-trips through JSONL
- `replay_hash` determinism + chaining
- outcome records do not affect `replay_hash`
- `walk_parent_chain` ordering (root → leaf)
- tamper detection at both the request level and the parent-pointer level
- `ReplayKind` serializes lowercase

All 31 `kiln-train` tests pass on CPU (`cargo nextest run -p kiln-train`).

## Out of scope (explicitly)

- Replay against a different base model
- `replay.jsonl` compression
- Web UI surface for browsing replay chains

## Test plan

- [x] `cargo check` (default-members) — clean
- [x] `cargo check --examples` — clean
- [x] `cargo nextest run -p kiln-train` — 31/31 pass (CPU)
- [x] `cargo build -p kiln-train --bin kiln-replay` — builds, prints usage
- [ ] GPU integration smoke (gated, run on A6000 separately)
- [ ] HF PEFT load smoke — adapter format unchanged from existing `save_peft`; covered indirectly by existing trainer tests