### PR TITLE
desktop: don't restore window visibility across launches

### DIFF
--- a/desktop/src/main.rs
+++ b/desktop/src/main.rs
@@ -1048,7 +1048,21 @@ fn main() {
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_notification::init())
-        .plugin(tauri_plugin_window_state::Builder::default().build())
+        // Persist size/position/maximized/etc. across launches, but NOT
+        // visibility. Otherwise tauri-plugin-window-state restores `visible:
+        // true` on every window the user happened to have open at last quit,
+        // so a user with Settings/Dashboard/Logs open ends up with 3-4 windows
+        // popping on every launch — even though tauri.conf.json says
+        // `visible: false`. Kiln Desktop is a tray app: windows should only
+        // open when the user explicitly invokes a tray menu item.
+        .plugin(
+            tauri_plugin_window_state::Builder::default()
+                .with_state_flags(
+                    tauri_plugin_window_state::StateFlags::all()
+                        & !tauri_plugin_window_state::StateFlags::VISIBLE,
+                )
+                .build(),
+        )
         .plugin(tauri_plugin_autostart::init(
             MacosLauncher::LaunchAgent,
             None,


### PR DESCRIPTION
## What

Stop persisting/restoring the `VISIBLE` flag for Kiln Desktop windows across launches.

## Why

`tauri_plugin_window_state::Builder::default()` uses `StateFlags::all()`, which includes `VISIBLE`. The plugin therefore saves each window's visibility on close and re-applies it on open. Any user who had Settings, Dashboard, and/or Logs open at last quit ended up with 3-4 windows popping on every launch — even though `tauri.conf.json` declares them all `visible: false`.

Kiln Desktop is a tray-first app: windows should only open when the user explicitly invokes a tray menu item. This patch switches the plugin to `StateFlags::all() & !StateFlags::VISIBLE` so size/position/maximized state still persist, but visibility is governed by `tauri.conf.json` + the tray menu handlers as intended.

## How to verify

1. Open Settings, Dashboard, and Logs.
2. Quit via the tray menu.
3. Relaunch — only the tray icon should appear; no windows should auto-open.
4. Click `Open Dashboard` from the tray — dashboard opens at its previously-saved size/position.

Existing unit tests untouched. Local `cargo check` for `desktop/` is not runnable in CI's CE pod (missing `glib-2.0` / `webkit2gtk` per `desktop-kiln-cargo-check-syslibs`); the desktop-build CI gate covers macOS/Linux/Windows.