### PR TITLE
release: bump server + desktop to 0.2.14 aligned cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Kiln Server Changelog
 
+## kiln-v0.2.14 — 2026-05-10
+
+This is a large release covering ~325 commits since v0.2.13: a new Vulkan
+backend, an embedded server-UI overhaul, replayable LoRA storage, the Phase 12
+batched-decode hot path, and continued CUDA / Metal kernel fusion.
+
+### Added
+- vulkan: bring up a Vulkan inference backend covering GDN (recurrent, conv1d,
+  in-projection, gated norm, QK norm), MLP (gate/up/down), batched gemv, and
+  paged decode. Ships with f32 + bf16 paths, rowpair / rowquad batched gemv
+  variants, batched chunk transfers, fused-submit conv1d prefill (now on by
+  default), and chained MLP dispatches. BF16 GDN state and device-local
+  recurrent batch state cut readback overhead and keep state resident on-device.
+- training: deterministic replayable LoRA storage with parent lineage so a
+  trained adapter records the exact replay set + parent chain it descended from.
+  Storage is content-addressed and reproducible across machines (#1015).
+- server UI: total visual overhaul of the embedded server dashboard — clearer
+  status, request feed, training, and adapter panels; live regions for
+  accessibility; mobile-friendly forms; sample training payloads; CLI/REST
+  cross-links from every panel (#1009, #1013).
+- windows: Windows CUDA release zips now bundle the CUDA 12.4 redist DLLs
+  (cudart, cublas, cublasLt, cuRAND, nvrtc) so users without the CUDA Toolkit
+  installed no longer hit `cublas64_12.dll was not found` on launch (#726).
+
+### Performance
+- phase 12 batched paged decode: per-stream graph replay, per-request
+  `KvWriteSlot` to eliminate the prefill mutex contention that bottlenecked
+  multi-stream decode, FA-2 varlen paged decode for batched (c>1) decode, and
+  batched paged decode API surface (#762, #968, #995, #996, #998, #1000, #1002,
+  #1008).
+- cuda fusion: fold GDN QK-norm into the recurrent kernel, fuse RoPE with QK,
+  fuse MLP SiLU and multiply, fuse attention-gate sigmoid+multiply, BF16 GDN
+  state, inference-only RMSNorm fast path, projection-original memory
+  compaction, rate-limited graph cache-full warnings.
+- metal: full SDPA prefill, GDN in-proj rowpair / rowquad / serial-x2 fast
+  paths, MLP gate/up rowquad gemv, batched gemv rowpair / rowquad / row-triple
+  variants for batch sizes ≥3 / ≥4 / ≥5, LoRA delta paths covering rank-4 /
+  rank-8 / serial-decode and all positive ranks, plus high-rank LoRA bench
+  coverage and qkv LoRA-linear bench coverage.
+- vulkan perf: enable GDN in-proj rowpair-batch3, GDN rowpair-batch3 chunk
+  transfers, fused-submit conv1d prefill (now default), chained MLP dispatches,
+  device-local recurrent batch state, BF16 inference state, skip the final GDN
+  state readback. f32 GDN recurrent step routing, bf16 hybrid MLP gate/up/down,
+  and gdn-recurrent kernel-stage profiling support.
+- scheduler / decode batcher: reduce batched linear-state scatter copies, route
+  through unexpanded GDN decode QK on both CUDA and Vulkan.
+
+### Fixed
+- compatibility: guard GDN fast paths from autograd tensors so training and
+  inference share the same kernel surface without aliasing autograd graph
+  state.
+- compatibility: disable CUDA graphs by default on WSL CUDA and guard the CUDA
+  decode batching default (and revert PR #1008's LM-head guard regression).
+- ui smoke: `docs/site` + server UI v1 overhaul follow-up — fix CI smoke checks
+  that broke against the new dashboard markup (#1013).
+- adapters: fix CLI adapter API routes (#774); fix adapter API docs examples
+  (#947); align training submission payload shapes (#739).
+- quickstart / cli: friendly error when the kiln server is unreachable (#972);
+  fix README quickstart timeout anchor (#896); fix quickstart training-status
+  command (#765); fix GRPO CLI file help (#738); device init now uses `?`
+  instead of a missing `anyhow::Context` import (#734).
+
+### Documentation
+- onboarding: cold-reader pass through README, QUICKSTART, and CLI help —
+  surface the kiln health probe before the chat curl, surface model-weights
+  download before the Docker block, deduplicate Desktop App install tables
+  between README and QUICKSTART, surface BENCHMARKS.md from README nav,
+  cross-link architecture and GRPO guides, drop legacy prefill notes, and
+  collapse the QUICKSTART reader map / prerequisites / KV-cache OOM section
+  (#964–#989, plus #969–#977).
+- ui: explain decode and scheduler metrics for cold readers via tooltips
+  (#971); persistent UI header help links (#798); accessible training tabs
+  (#782) and live regions for dashboard panels (#783).
+- governance: scrub stale publicity changelog entries and remove launch
+  announcement surfaces (#718, #719).
+
 ## kiln-v0.2.13 — 2026-05-02
 
 ### Observability

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "candle-core",
  "cc",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "candle-core",
  "cc",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "candle-core",
  "cc",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1826,11 +1826,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.13"
+version = "0.2.14"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "candle-core",
  "cc",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "axum",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-vulkan-kernel"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.13"
+version = "0.2.14"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"

--- a/README.md
+++ b/README.md
@@ -352,19 +352,19 @@ Kiln Desktop is a system-tray app that wraps the `kiln` server for people who do
 
 **Windows, Linux, and macOS (Apple Silicon).** Windows drives the CUDA build of `kiln`; Linux chooses CUDA on NVIDIA systems and Vulkan on AMD/Intel systems; macOS drives the candle-metal build on M-series hardware. Intel Macs are not supported.
 
-**Download — [Kiln Desktop v0.2.2](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2):**
+**Download — [Kiln Desktop v0.2.14](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14):**
 
-**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.2` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, so the version split is intentional.
+**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.14` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, so the version split is intentional.
 
 See **[desktop/CHANGELOG.md](desktop/CHANGELOG.md)** for the full version history.
 
 | Platform | Installer | Size |
 |---|---|---|
-| macOS (Apple Silicon) | [Kiln.Desktop_0.2.2_aarch64.dmg](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_aarch64.dmg) | 8.5 MB |
-| Windows | [Kiln.Desktop_0.2.2_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_x64-setup.exe) (NSIS) | 4.5 MB |
-| Windows | [Kiln.Desktop_0.2.2_x64_en-US.msi](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_x64_en-US.msi) (MSI) | 6.8 MB |
-| Linux | [Kiln.Desktop_0.2.2_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_amd64.deb) | 8.8 MB |
-| Linux | [Kiln.Desktop_0.2.2_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_amd64.AppImage) | 85.7 MB |
+| macOS (Apple Silicon) | [Kiln.Desktop_0.2.14_aarch64.dmg](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_aarch64.dmg) | 8.5 MB |
+| Windows | [Kiln.Desktop_0.2.14_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_x64-setup.exe) (NSIS) | 4.5 MB |
+| Windows | [Kiln.Desktop_0.2.14_x64_en-US.msi](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_x64_en-US.msi) (MSI) | 6.8 MB |
+| Linux | [Kiln.Desktop_0.2.14_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_amd64.deb) | 8.8 MB |
+| Linux | [Kiln.Desktop_0.2.14_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_amd64.AppImage) | 85.7 MB |
 
 The installer bundles the desktop wrapper only. On first launch the app offers to auto-download the matching prebuilt `kiln` server binary for your platform (macOS aarch64 / Metal, Linux x86_64 / CUDA 12.4 or Vulkan, Windows x86_64 / CUDA 12.4) from the latest `kiln-v*` GitHub release and verify it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be downloaded separately — the Settings window has a HuggingFace downloader, or you can use the CLI path in [QUICKSTART.md](QUICKSTART.md).
 

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Kiln Desktop Changelog
 
+## desktop-v0.2.14 — 2026-05-10
+
+Coordinated release aligned with kiln-v0.2.14 server. Re-aligns the desktop
+version number with the server after the server-only v0.2.3 → v0.2.13 sprint.
+
+### Added
+- ui: redesign the Tauri shell with the kiln amber design system — refreshed
+  dashboard, settings, logs, and about windows to match the new server UI
+  v1 visual identity (#1010).
+- onboarding: first-run help links surface the canonical kiln docs / quickstart
+  from the dashboard (#935).
+
+### Fixed
+- tray: stop restoring window visibility across launches. The
+  `tauri-plugin-window-state` defaults persisted the `VISIBLE` flag, so a user
+  who had Settings, Dashboard, and/or Logs open at last quit ended up with
+  3-4 windows popping on every launch — even though the windows are declared
+  `visible: false` in `tauri.conf.json`. Kiln Desktop is a tray-first app:
+  windows now only open when you explicitly invoke a tray menu item (#1016).
+
+### Server payload
+This cut ships with the kiln-v0.2.14 server binary, which includes the new
+Vulkan inference backend, Phase 12 batched paged decode, deterministic
+replayable LoRA storage, the embedded server-UI v1 overhaul, and Windows CUDA
+redist DLL bundling. See [CHANGELOG.md](../CHANGELOG.md) for the full server
+changelog.
+
 ## desktop-v0.2.2 — 2026-04-25
 
 Coordinated release aligned with kiln-v0.2.2 server. No desktop-side

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-desktop"
-version = "0.2.2"
+version = "0.2.14"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kiln-desktop"
-version = "0.2.2"
+version = "0.2.14"
 edition = "2021"
 description = "Kiln Desktop — system tray app for the kiln local LLM server"
 authors = ["Eric Florenzano <eric@eflorenzano.com>"]

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -12,13 +12,13 @@ would be strictly worse than running Linux in a VM.
 
 ## Releases
 
-[Kiln Desktop v0.2.2](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2) ships these installers:
+[Kiln Desktop v0.2.14](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14) ships these installers:
 
-- `Kiln.Desktop_0.2.2_aarch64.dmg` (macOS Apple Silicon DMG, 8.5 MB)
-- `Kiln.Desktop_0.2.2_x64-setup.exe` (Windows NSIS, 4.5 MB)
-- `Kiln.Desktop_0.2.2_x64_en-US.msi` (Windows MSI, 6.8 MB)
-- `Kiln.Desktop_0.2.2_amd64.deb` (Debian/Ubuntu, 8.8 MB)
-- `Kiln.Desktop_0.2.2_amd64.AppImage` (portable Linux, 85.7 MB)
+- `Kiln.Desktop_0.2.14_aarch64.dmg` (macOS Apple Silicon DMG, 8.5 MB)
+- `Kiln.Desktop_0.2.14_x64-setup.exe` (Windows NSIS, 4.5 MB)
+- `Kiln.Desktop_0.2.14_x64_en-US.msi` (Windows MSI, 6.8 MB)
+- `Kiln.Desktop_0.2.14_amd64.deb` (Debian/Ubuntu, 8.8 MB)
+- `Kiln.Desktop_0.2.14_amd64.AppImage` (portable Linux, 85.7 MB)
 
 The desktop installer bundles only the wrapper. On first launch the app offers to auto-download the prebuilt `kiln` server binary from the latest `kiln-v*` GitHub release — `aarch64-apple-darwin-metal` on macOS, `x86_64-unknown-linux-gnu-cuda124` or `x86_64-unknown-linux-gnu-vulkan` on Linux x86_64, `x86_64-pc-windows-msvc-cuda124` on Windows x86_64 — and verifies it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be installed separately; see the root [QUICKSTART.md](../QUICKSTART.md) or use the HuggingFace downloader in Settings.
 
@@ -28,7 +28,7 @@ Settings has a **Download from HuggingFace…** button next to the Model Path pi
 
 macOS `.dmg` releases are signed with a Developer ID certificate and notarized by Apple. See [docs/desktop/signing.md](../docs/desktop/signing.md) for the CI setup and required secrets.
 
-## What ships in v0.2.2
+## What ships in v0.2.14
 
 - **Subprocess supervisor** — Tokio child process driving the `kiln` binary, with stdout/stderr captured into an in-process ring buffer.
 - **Crash restart** with exponential backoff, and a clear error state surfaced in the tray.

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kiln Desktop",
-  "version": "0.2.2",
+  "version": "0.2.14",
   "identifier": "com.eflorenzano.kiln.desktop",
   "build": {
     "frontendDist": "ui",

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -55,7 +55,7 @@
       <a href="./" class="brand" aria-current="page" aria-label="Kiln home">
         <span class="brand-mark" aria-hidden="true"></span>
         <span>kiln</span>
-        <span class="brand-version">v0.2.13</span>
+        <span class="brand-version">v0.2.14</span>
       </a>
       <nav class="nav site-nav" aria-label="Primary">
         <a href="quickstart.html">Quickstart</a>
@@ -439,7 +439,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
           The Kiln Desktop app and the Kiln server use
           <strong>separate GitHub release tags/version numbers</strong>
           so each can ship at its own cadence. The latest desktop build is
-          <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2"><code>desktop-v0.2.2</code></a>;
+          <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14"><code>desktop-v0.2.14</code></a>;
           the server tracks the latest <code>kiln-v*</code> tag.
         </p>
         <table class="installer-table">
@@ -449,15 +449,15 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
           <tbody>
             <tr>
               <th scope="row">macOS (Apple Silicon)</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2">desktop-v0.2.2 · macOS</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14">desktop-v0.2.14 · macOS</a></td>
             </tr>
             <tr>
               <th scope="row">Windows</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2">desktop-v0.2.2 · Windows</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14">desktop-v0.2.14 · Windows</a></td>
             </tr>
             <tr>
               <th scope="row">Linux</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2">desktop-v0.2.2 · Linux</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14">desktop-v0.2.14 · Linux</a></td>
             </tr>
           </tbody>
         </table>
@@ -573,7 +573,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
     </div>
     <div class="page footer-meta">
       <span>© 2026 Eric Florenzano</span>
-      <span>Built with kiln · <code>v0.2.13</code></span>
+      <span>Built with kiln · <code>v0.2.14</code></span>
     </div>
   </footer>
 

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -307,7 +307,7 @@
         <div class="install-card">
           <h3 class="font-semibold mb-2">Desktop App &middot; recommended</h3>
           <p class="mb-3" style="color: var(--fg-dim);">
-            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.2">Kiln Desktop v0.2.2</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
+            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14">Kiln Desktop v0.2.14</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
           </p>
           <table class="installer-table mb-3" aria-label="Kiln Desktop installer downloads">
             <thead>
@@ -320,32 +320,32 @@
             <tbody>
               <tr>
                 <td>macOS Apple Silicon</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_aarch64.dmg">Kiln.Desktop_0.2.2_aarch64.dmg</a></td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_aarch64.dmg">Kiln.Desktop_0.2.14_aarch64.dmg</a></td>
                 <td>8.5 MB</td>
               </tr>
               <tr>
                 <td>Windows</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_x64-setup.exe">Kiln.Desktop_0.2.2_x64-setup.exe</a> (NSIS)</td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_x64-setup.exe">Kiln.Desktop_0.2.14_x64-setup.exe</a> (NSIS)</td>
                 <td>4.5 MB</td>
               </tr>
               <tr>
                 <td>Windows</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_x64_en-US.msi">Kiln.Desktop_0.2.2_x64_en-US.msi</a> (MSI)</td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_x64_en-US.msi">Kiln.Desktop_0.2.14_x64_en-US.msi</a> (MSI)</td>
                 <td>6.8 MB</td>
               </tr>
               <tr>
                 <td>Linux</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_amd64.deb">Kiln.Desktop_0.2.2_amd64.deb</a></td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_amd64.deb">Kiln.Desktop_0.2.14_amd64.deb</a></td>
                 <td>8.8 MB</td>
               </tr>
               <tr>
                 <td>Linux</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.2/Kiln.Desktop_0.2.2_amd64.AppImage">Kiln.Desktop_0.2.2_amd64.AppImage</a></td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_amd64.AppImage">Kiln.Desktop_0.2.14_amd64.AppImage</a></td>
                 <td>85.7 MB</td>
               </tr>
             </tbody>
           </table>
-          <p class="text-sm" style="color: var(--fg-mute);">Desktop and server release lines intentionally differ: <code>desktop-v0.2.2</code> is the latest Desktop app release, and the app downloads and verifies the latest <code>kiln-v*</code> server binary for you.</p>
+          <p class="text-sm" style="color: var(--fg-mute);">Desktop and server release lines intentionally differ: <code>desktop-v0.2.14</code> is the latest Desktop app release, and the app downloads and verifies the latest <code>kiln-v*</code> server binary for you.</p>
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">Linux x86_64 &middot; CUDA 12.4</h3>

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -768,7 +768,7 @@ function validateLandingDesktopVersionSplitCue() {
   const desktopInstallCopy = desktopInstallMatch[1];
   const requiredTerms = [
     'separate GitHub release tags/version numbers',
-    'desktop-v0.2.2',
+    'desktop-v0.2.14',
     'latest <code>kiln-v*</code>',
   ];
   for (const term of requiredTerms) {
@@ -785,7 +785,7 @@ function validateQuickstartDesktopVersionSplitCue() {
 
   const desktopInstallCopy = desktopInstallMatch[1];
   const requiredTerms = [
-    'desktop-v0.2.2',
+    'desktop-v0.2.14',
     'Desktop',
     'server',
     'release',


### PR DESCRIPTION
Coordinated release prep — re-aligns server and desktop on the same version number after the server-only v0.2.3 → v0.2.13 sprint, mirroring the v0.2.2 alignment pattern (PR #573).

## Server (~325 commits since v0.2.13)

- **Vulkan inference backend bring-up**: GDN, MLP, conv1d, batched gemv, paged decode (f32 + bf16 paths, rowpair/rowquad batching, fused-submit prefill, BF16 GDN state, device-local recurrent batch state).
- **Phase 12 batched paged decode hot path**: per-stream graph replay, per-request `KvWriteSlot` to remove the prefill mutex contention, FA-2 varlen paged decode for c>1 batched decode (#762, #968, #995, #996, #998, #1000, #1002, #1008).
- **Deterministic replayable LoRA storage with parent lineage** (#1015).
- **Embedded server-UI v1 visual overhaul** (#1009, #1013).
- **Windows CUDA release zips bundle CUDA 12.4 redist DLLs** (#726).
- Continued CUDA fusion: GDN QK-norm fold, RoPE+QK fuse, MLP SiLU+mul fuse, attention-gate sigmoid+mul fuse, BF16 GDN state, RMSNorm fast path.
- Continued Metal perf: full SDPA prefill, GDN/MLP rowpair/rowquad/rowtriple gemv variants, LoRA delta paths covering all positive ranks.
- Misc fixes: GDN autograd guard, WSL CUDA graph default off, CLI/quickstart polish.

## Desktop (5 commits since v0.2.2)

- **Tauri shell redesign with kiln amber design system** (#1010).
- **First-run help links** from the dashboard (#935).
- **Tray-only startup**: stop restoring window visibility across launches so Settings/Dashboard/Logs no longer pop on every launch (#1016).
- Bundled server payload now ships kiln-v0.2.14.

## Mechanical changes

- workspace `Cargo.toml` + `Cargo.lock`: 0.2.13 → 0.2.14 (13 kiln-* crates)
- `desktop/Cargo.toml` + `desktop/Cargo.lock`: 0.2.2 → 0.2.14
- `desktop/tauri.conf.json`: 0.2.2 → 0.2.14
- `CHANGELOG.md`: kiln-v0.2.14 entry
- `desktop/CHANGELOG.md`: desktop-v0.2.14 coordinated-release entry
- `README.md` / `desktop/README.md` / `docs/site/index.html` / `docs/site/quickstart.html`: bump desktop release pin 0.2.2 → 0.2.14
- `docs/site/index.html` brand-version pill: v0.2.13 → v0.2.14

## Validation

- `python3 scripts/check_release_versions.py` passes locally.
- `cargo metadata --no-deps` resolves all 13 workspace crates + kiln-desktop at 0.2.14.
- Local `cargo check` for the desktop crate not run in this CE pod (missing `glib-2.0` / `webkit2gtk` per `desktop-kiln-cargo-check-syslibs`); CI gates the Windows / macOS / Linux desktop build.

## Release plan after merge

1. Tag `kiln-v0.2.14` on the merge commit and push — triggers `server-release.yml` (~80 min Windows CUDA long pole) and `docker-server-release.yml` (~10-15 min).
2. Tag `desktop-v0.2.14` on the same commit and push — triggers `desktop-build.yml` for Linux/macOS/Windows installers.
3. After the desktop workflow finishes, promote the Draft release: `gh release edit desktop-v0.2.14 --repo ericflo/kiln --draft=false` (per `kiln-desktop-release-draft-publish`).
4. Verify server release assets include linux-cuda, macos-metal, windows-cuda binaries plus `.sha256` sidecars and `THIRD_PARTY_LICENSES.md`.