### PR TITLE
ci: install glslang-tools for linux-vulkan release job

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -297,7 +297,7 @@ jobs:
       - name: Install Vulkan shader tools
         run: |
           sudo apt-get update
-          sudo apt-get install -y glslc
+          sudo apt-get install -y glslang-tools
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
## What

Replace \`apt-get install glslc\` with \`apt-get install glslang-tools\` in the \`linux-vulkan\` release job.

## Why

The kiln-v0.2.14 tag push surfaced \`E: Unable to locate package glslc\` on \`ubuntu-22.04\`. \`glslc\` (Google shaderc CLI) is not packaged on jammy — it ships either via the LunarG Vulkan SDK or via Ubuntu 24.04+'s \`glslc\` deb. The CI workflow's \`linux-vulkan\` job already uses \`glslang-tools\` (which provides \`glslangValidator\`), and the kiln-vulkan-kernel build.rs falls back to \`glslangValidator\` cleanly when \`glslc\` is missing. Aligning the release job with CI unblocks the v0.2.14 release line.

## Aftermath

Once merged, I'll force-move the \`kiln-v0.2.14\` tag to include this fix so the release workflow re-runs end-to-end. The in-flight original run on the previous commit will be cancelled.

Linux Vulkan release job log: https://github.com/ericflo/kiln/actions/runs/25619746261/job/75204077105