### PR TITLE
Fix Metal build: pass backend=None to add_lora_delta_to_base

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -440,7 +440,7 @@ fn linear_with_lora_t_decode(
         {
             let base = crate::backend::metal::metal_transposed_coop_gemv_bf16(x, weight_t)
                 .context("metal transposed coop GEMV failed");
-            return add_lora_delta_to_base(base?, x, lora, lora_scale)
+            return add_lora_delta_to_base(None, base?, x, lora, lora_scale)
                 .context("metal transposed coop GEMV LoRA delta failed");
         }
     }


### PR DESCRIPTION
## What

Fixes the macOS Metal CI job failing with E0061/E0308 at `forward.rs:443`:

```
error[E0061]: this function takes 5 arguments but 4 arguments were supplied
   --> crates/kiln-model/src/forward.rs:443:20
    |
443 |             return add_lora_delta_to_base(base?, x, lora, lora_scale)
```

## Why

c2817d94 (Fuse CUDA LoRA decode add) added a `backend: Option<&dyn BackendRuntime>` parameter to `add_lora_delta_to_base` and updated two CUDA-side call sites, but missed the metal-feature-gated call site inside `linear_with_lora_t_decode`.

## How

Pass `None` for `backend`. The metal branch has no backend reference in scope; `None` short-circuits the backend path and falls through to the existing metal-specific delta helper inside `add_lora_delta_to_base`, preserving prior behavior.

## Verification

- `cargo check -p kiln-model` (default features) clean — same 4 pre-existing warnings, no errors
- Cannot run `cargo build --features metal` locally (Linux box, no Metal toolchain) — relies on CI

Failing run: https://github.com/ericflo/kiln/actions/runs/25628889459/job/75228863900