### PR TITLE
release: bump server + desktop to 0.2.15 aligned cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Kiln Server Changelog
 
+## kiln-v0.2.15 — 2026-05-10
+
+A short follow-up cut covering 15 commits since v0.2.14, focused on CUDA
+decode-path fusion and a macOS Metal build fix. No desktop source changes;
+the aligned desktop release simply re-pins to the new server payload.
+
+### Changed
+- cuda: combine full-attention QKV projections into a single GEMM at decode
+  time, mirroring the GDN AB combine in v0.2.14.
+- cuda: combine GDN AB projections at prefill (extending the decode-time
+  fusion) and use the combined projection on short prompts.
+- cuda: enable GDN prefill gates by default and route mixed GDN batches
+  through the row loop, with the row-loop forced path generalized for batched
+  GDN.
+- cuda: fast-path paged KV cache writes and route CUDA decode through paged
+  attention end-to-end.
+- cuda: fuse decode QKV prep, fuse GDN decode RMSNorm, and fuse the LoRA
+  decode add (new `kiln-rmsnorm-kernel/csrc/fused_lora_add.cu`) so single-token
+  decode dispatches fewer kernels per layer.
+- cuda: use empty CUDA outputs for overwrite kernels and align the default
+  ModelRunner CUDA graph behavior.
+- training: default CUDA projection drop on for the training fit path so
+  training memory residency tracks the inference path.
+
+### Fixed
+- macos: pass `backend=None` to `add_lora_delta_to_base` from the
+  metal-feature-gated decode path so `cargo build --features metal` compiles
+  again. The CUDA LoRA decode add fuse landed in this cut added a `backend`
+  parameter and missed the Metal call site (#1019).
+
 ## kiln-v0.2.14 — 2026-05-10
 
 This is a large release covering ~325 commits since v0.2.13: a new Vulkan

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1734,7 +1734,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "candle-core",
  "cc",
@@ -1743,7 +1743,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "chrono",
  "minijinja",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "candle-core",
  "cc",
@@ -1766,7 +1766,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1786,7 +1786,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "candle-core",
  "cc",
@@ -1795,7 +1795,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1826,11 +1826,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.14"
+version = "0.2.15"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "candle-core",
  "cc",
@@ -1839,7 +1839,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1848,7 +1848,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "axum",
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1908,7 +1908,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-vulkan-kernel"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.14"
+version = "0.2.15"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"

--- a/README.md
+++ b/README.md
@@ -352,19 +352,19 @@ Kiln Desktop is a system-tray app that wraps the `kiln` server for people who do
 
 **Windows, Linux, and macOS (Apple Silicon).** Windows drives the CUDA build of `kiln`; Linux chooses CUDA on NVIDIA systems and Vulkan on AMD/Intel systems; macOS drives the candle-metal build on M-series hardware. Intel Macs are not supported.
 
-**Download — [Kiln Desktop v0.2.14](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14):**
+**Download — [Kiln Desktop v0.2.15](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15):**
 
-**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.14` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, so the version split is intentional.
+**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.15` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, so the version split is intentional.
 
 See **[desktop/CHANGELOG.md](desktop/CHANGELOG.md)** for the full version history.
 
 | Platform | Installer | Size |
 |---|---|---|
-| macOS (Apple Silicon) | [Kiln.Desktop_0.2.14_aarch64.dmg](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_aarch64.dmg) | 8.5 MB |
-| Windows | [Kiln.Desktop_0.2.14_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_x64-setup.exe) (NSIS) | 4.5 MB |
-| Windows | [Kiln.Desktop_0.2.14_x64_en-US.msi](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_x64_en-US.msi) (MSI) | 6.8 MB |
-| Linux | [Kiln.Desktop_0.2.14_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_amd64.deb) | 8.8 MB |
-| Linux | [Kiln.Desktop_0.2.14_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_amd64.AppImage) | 85.7 MB |
+| macOS (Apple Silicon) | [Kiln.Desktop_0.2.15_aarch64.dmg](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_aarch64.dmg) | 8.5 MB |
+| Windows | [Kiln.Desktop_0.2.15_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_x64-setup.exe) (NSIS) | 4.5 MB |
+| Windows | [Kiln.Desktop_0.2.15_x64_en-US.msi](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_x64_en-US.msi) (MSI) | 6.8 MB |
+| Linux | [Kiln.Desktop_0.2.15_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_amd64.deb) | 8.8 MB |
+| Linux | [Kiln.Desktop_0.2.15_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_amd64.AppImage) | 85.7 MB |
 
 The installer bundles the desktop wrapper only. On first launch the app offers to auto-download the matching prebuilt `kiln` server binary for your platform (macOS aarch64 / Metal, Linux x86_64 / CUDA 12.4 or Vulkan, Windows x86_64 / CUDA 12.4) from the latest `kiln-v*` GitHub release and verify it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be downloaded separately — the Settings window has a HuggingFace downloader, or you can use the CLI path in [QUICKSTART.md](QUICKSTART.md).
 

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Kiln Desktop Changelog
 
+## desktop-v0.2.15 — 2026-05-10
+
+Aligned cut with kiln-v0.2.15 server. No desktop source changes since
+desktop-v0.2.14; this release re-pins the bundled server payload to the
+latest server cut so installers ship the new CUDA decode fusions and the
+Metal build fix.
+
+### Server payload
+This cut ships with the kiln-v0.2.15 server binary, which adds a round of
+CUDA decode-path fusion (combined QKV / GDN AB projections, fused decode
+QKV prep, fused GDN decode RMSNorm, fused LoRA decode add, fast-path paged
+KV writes, paged-attention decode routing) and fixes the macOS Metal build.
+See [CHANGELOG.md](../CHANGELOG.md) for the full server changelog.
+
 ## desktop-v0.2.14 — 2026-05-10
 
 Coordinated release aligned with kiln-v0.2.14 server. Re-aligns the desktop

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-desktop"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kiln-desktop"
-version = "0.2.14"
+version = "0.2.15"
 edition = "2021"
 description = "Kiln Desktop — system tray app for the kiln local LLM server"
 authors = ["Eric Florenzano <eric@eflorenzano.com>"]

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -12,13 +12,13 @@ would be strictly worse than running Linux in a VM.
 
 ## Releases
 
-[Kiln Desktop v0.2.14](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14) ships these installers:
+[Kiln Desktop v0.2.15](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15) ships these installers:
 
-- `Kiln.Desktop_0.2.14_aarch64.dmg` (macOS Apple Silicon DMG, 8.5 MB)
-- `Kiln.Desktop_0.2.14_x64-setup.exe` (Windows NSIS, 4.5 MB)
-- `Kiln.Desktop_0.2.14_x64_en-US.msi` (Windows MSI, 6.8 MB)
-- `Kiln.Desktop_0.2.14_amd64.deb` (Debian/Ubuntu, 8.8 MB)
-- `Kiln.Desktop_0.2.14_amd64.AppImage` (portable Linux, 85.7 MB)
+- `Kiln.Desktop_0.2.15_aarch64.dmg` (macOS Apple Silicon DMG, 8.5 MB)
+- `Kiln.Desktop_0.2.15_x64-setup.exe` (Windows NSIS, 4.5 MB)
+- `Kiln.Desktop_0.2.15_x64_en-US.msi` (Windows MSI, 6.8 MB)
+- `Kiln.Desktop_0.2.15_amd64.deb` (Debian/Ubuntu, 8.8 MB)
+- `Kiln.Desktop_0.2.15_amd64.AppImage` (portable Linux, 85.7 MB)
 
 The desktop installer bundles only the wrapper. On first launch the app offers to auto-download the prebuilt `kiln` server binary from the latest `kiln-v*` GitHub release — `aarch64-apple-darwin-metal` on macOS, `x86_64-unknown-linux-gnu-cuda124` or `x86_64-unknown-linux-gnu-vulkan` on Linux x86_64, `x86_64-pc-windows-msvc-cuda124` on Windows x86_64 — and verifies it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be installed separately; see the root [QUICKSTART.md](../QUICKSTART.md) or use the HuggingFace downloader in Settings.
 
@@ -28,7 +28,7 @@ Settings has a **Download from HuggingFace…** button next to the Model Path pi
 
 macOS `.dmg` releases are signed with a Developer ID certificate and notarized by Apple. See [docs/desktop/signing.md](../docs/desktop/signing.md) for the CI setup and required secrets.
 
-## What ships in v0.2.14
+## What ships in v0.2.15
 
 - **Subprocess supervisor** — Tokio child process driving the `kiln` binary, with stdout/stderr captured into an in-process ring buffer.
 - **Crash restart** with exponential backoff, and a clear error state surfaced in the tray.

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kiln Desktop",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "identifier": "com.eflorenzano.kiln.desktop",
   "build": {
     "frontendDist": "ui",

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -55,7 +55,7 @@
       <a href="./" class="brand" aria-current="page" aria-label="Kiln home">
         <span class="brand-mark" aria-hidden="true"></span>
         <span>kiln</span>
-        <span class="brand-version">v0.2.14</span>
+        <span class="brand-version">v0.2.15</span>
       </a>
       <nav class="nav site-nav" aria-label="Primary">
         <a href="quickstart.html">Quickstart</a>
@@ -439,7 +439,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
           The Kiln Desktop app and the Kiln server use
           <strong>separate GitHub release tags/version numbers</strong>
           so each can ship at its own cadence. The latest desktop build is
-          <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14"><code>desktop-v0.2.14</code></a>;
+          <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15"><code>desktop-v0.2.15</code></a>;
           the server tracks the latest <code>kiln-v*</code> tag.
         </p>
         <table class="installer-table">
@@ -449,15 +449,15 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
           <tbody>
             <tr>
               <th scope="row">macOS (Apple Silicon)</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14">desktop-v0.2.14 · macOS</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15">desktop-v0.2.15 · macOS</a></td>
             </tr>
             <tr>
               <th scope="row">Windows</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14">desktop-v0.2.14 · Windows</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15">desktop-v0.2.15 · Windows</a></td>
             </tr>
             <tr>
               <th scope="row">Linux</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14">desktop-v0.2.14 · Linux</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15">desktop-v0.2.15 · Linux</a></td>
             </tr>
           </tbody>
         </table>
@@ -573,7 +573,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
     </div>
     <div class="page footer-meta">
       <span>© 2026 Eric Florenzano</span>
-      <span>Built with kiln · <code>v0.2.14</code></span>
+      <span>Built with kiln · <code>v0.2.15</code></span>
     </div>
   </footer>
 

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -307,7 +307,7 @@
         <div class="install-card">
           <h3 class="font-semibold mb-2">Desktop App &middot; recommended</h3>
           <p class="mb-3" style="color: var(--fg-dim);">
-            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.14">Kiln Desktop v0.2.14</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
+            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15">Kiln Desktop v0.2.15</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
           </p>
           <table class="installer-table mb-3" aria-label="Kiln Desktop installer downloads">
             <thead>
@@ -320,32 +320,32 @@
             <tbody>
               <tr>
                 <td>macOS Apple Silicon</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_aarch64.dmg">Kiln.Desktop_0.2.14_aarch64.dmg</a></td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_aarch64.dmg">Kiln.Desktop_0.2.15_aarch64.dmg</a></td>
                 <td>8.5 MB</td>
               </tr>
               <tr>
                 <td>Windows</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_x64-setup.exe">Kiln.Desktop_0.2.14_x64-setup.exe</a> (NSIS)</td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_x64-setup.exe">Kiln.Desktop_0.2.15_x64-setup.exe</a> (NSIS)</td>
                 <td>4.5 MB</td>
               </tr>
               <tr>
                 <td>Windows</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_x64_en-US.msi">Kiln.Desktop_0.2.14_x64_en-US.msi</a> (MSI)</td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_x64_en-US.msi">Kiln.Desktop_0.2.15_x64_en-US.msi</a> (MSI)</td>
                 <td>6.8 MB</td>
               </tr>
               <tr>
                 <td>Linux</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_amd64.deb">Kiln.Desktop_0.2.14_amd64.deb</a></td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_amd64.deb">Kiln.Desktop_0.2.15_amd64.deb</a></td>
                 <td>8.8 MB</td>
               </tr>
               <tr>
                 <td>Linux</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.14/Kiln.Desktop_0.2.14_amd64.AppImage">Kiln.Desktop_0.2.14_amd64.AppImage</a></td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_amd64.AppImage">Kiln.Desktop_0.2.15_amd64.AppImage</a></td>
                 <td>85.7 MB</td>
               </tr>
             </tbody>
           </table>
-          <p class="text-sm" style="color: var(--fg-mute);">Desktop and server release lines intentionally differ: <code>desktop-v0.2.14</code> is the latest Desktop app release, and the app downloads and verifies the latest <code>kiln-v*</code> server binary for you.</p>
+          <p class="text-sm" style="color: var(--fg-mute);">Desktop and server release lines intentionally differ: <code>desktop-v0.2.15</code> is the latest Desktop app release, and the app downloads and verifies the latest <code>kiln-v*</code> server binary for you.</p>
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">Linux x86_64 &middot; CUDA 12.4</h3>

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -768,7 +768,7 @@ function validateLandingDesktopVersionSplitCue() {
   const desktopInstallCopy = desktopInstallMatch[1];
   const requiredTerms = [
     'separate GitHub release tags/version numbers',
-    'desktop-v0.2.14',
+    'desktop-v0.2.15',
     'latest <code>kiln-v*</code>',
   ];
   for (const term of requiredTerms) {
@@ -785,7 +785,7 @@ function validateQuickstartDesktopVersionSplitCue() {
 
   const desktopInstallCopy = desktopInstallMatch[1];
   const requiredTerms = [
-    'desktop-v0.2.14',
+    'desktop-v0.2.15',
     'Desktop',
     'server',
     'release',


### PR DESCRIPTION
Aligned cut following kiln-v0.2.14, covering 15 commits since the prior tag. Server-side work this cycle was all CUDA decode-path fusion plus a macOS Metal build fix; no desktop source changes since desktop-v0.2.14, so the desktop release just re-pins to the new server payload to keep server + desktop on the same version number.

## Server (15 commits since v0.2.14)

- cuda: combine full-attention QKV projections at decode (mirrors GDN AB combine in v0.2.14); combine GDN AB projections at prefill and use the combined projection on short prompts
- cuda: enable GDN prefill gates by default; route mixed GDN batches through the row loop with the row-loop forced path generalized for batched GDN
- cuda: fast-path paged KV cache writes; route CUDA decode through paged attention end-to-end
- cuda: fuse decode QKV prep, fuse GDN decode RMSNorm, fuse the LoRA decode add (new `kiln-rmsnorm-kernel/csrc/fused_lora_add.cu`)
- cuda: empty CUDA outputs for overwrite kernels; aligned ModelRunner CUDA graph default
- training: default CUDA projection drop on for the training fit path
- macos: pass `backend=None` to `add_lora_delta_to_base` from the metal-feature-gated decode path so `cargo build --features metal` compiles again (#1019)

## Desktop

No source commits since desktop-v0.2.14. Bundled server payload now ships kiln-v0.2.15.

## Mechanical changes

- workspace `Cargo.toml` + `Cargo.lock`: 0.2.14 → 0.2.15 (13 kiln-* crates)
- `desktop/Cargo.toml` + `desktop/Cargo.lock`: 0.2.14 → 0.2.15
- `desktop/tauri.conf.json`: 0.2.14 → 0.2.15
- `CHANGELOG.md`: kiln-v0.2.15 entry
- `desktop/CHANGELOG.md`: desktop-v0.2.15 entry
- `README.md` / `desktop/README.md` / `docs/site/index.html` / `docs/site/quickstart.html`: bump desktop release pin from 0.2.14 to 0.2.15
- `docs/site/index.html` brand-version pill: v0.2.14 → v0.2.15
- `scripts/check_docs_site_smoke.mjs`: smoke pin desktop-v0.2.14 → desktop-v0.2.15

## Verification

- `scripts/check_release_versions.py` passes
- `cargo check` (default features) clean