### PR TITLE
[codex] Bound CUDA exact SFT activation memory

### DIFF
--- a/crates/kiln-flash-attn/src/lib.rs
+++ b/crates/kiln-flash-attn/src/lib.rs
@@ -431,18 +431,45 @@ pub fn flash_attn_bwd(
     let head_dim_rounded = round_up(head_dim, 32);
 
     // Allocate gradient outputs
-    let dq = Tensor::zeros((b, seqlen_q, num_heads, head_dim), DType::BF16, device)?;
+    let dq =
+        Tensor::zeros((b, seqlen_q, num_heads, head_dim), DType::BF16, device).map_err(|e| {
+            candle_core::Error::Msg(format!(
+                "flash_attn_bwd alloc dq shape=[{b},{seqlen_q},{num_heads},{head_dim}] bf16: {e:?}"
+            ))
+        })?;
     // For GQA backward: expand dk/dv to num_heads, then sum later
-    let dk = Tensor::zeros((b, seqlen_k, num_heads, head_dim), DType::BF16, device)?;
-    let dv = Tensor::zeros((b, seqlen_k, num_heads, head_dim), DType::BF16, device)?;
+    let dk = Tensor::zeros((b, seqlen_k, num_heads, head_dim), DType::BF16, device).map_err(
+        |e| {
+            candle_core::Error::Msg(format!(
+                "flash_attn_bwd alloc expanded dk shape=[{b},{seqlen_k},{num_heads},{head_dim}] bf16: {e:?}"
+            ))
+        },
+    )?;
+    let dv = Tensor::zeros((b, seqlen_k, num_heads, head_dim), DType::BF16, device).map_err(
+        |e| {
+            candle_core::Error::Msg(format!(
+                "flash_attn_bwd alloc expanded dv shape=[{b},{seqlen_k},{num_heads},{head_dim}] bf16: {e:?}"
+            ))
+        },
+    )?;
 
     // Scratch buffers
-    let softmax_d = Tensor::zeros((b, num_heads, seqlen_q_rounded), DType::F32, device)?;
+    let softmax_d =
+        Tensor::zeros((b, num_heads, seqlen_q_rounded), DType::F32, device).map_err(|e| {
+            candle_core::Error::Msg(format!(
+                "flash_attn_bwd alloc softmax_d shape=[{b},{num_heads},{seqlen_q_rounded}] f32: {e:?}"
+            ))
+        })?;
     let dq_accum = Tensor::zeros(
         (b, seqlen_q_rounded, num_heads, head_dim_rounded),
         DType::F32,
         device,
-    )?;
+    )
+    .map_err(|e| {
+        candle_core::Error::Msg(format!(
+            "flash_attn_bwd alloc dq_accum shape=[{b},{seqlen_q_rounded},{num_heads},{head_dim_rounded}] f32: {e:?}"
+        ))
+    })?;
 
     // Scope the storage borrows so they're dropped before we return/reshape the tensors
     {

--- a/crates/kiln-model/src/backend/cuda.rs
+++ b/crates/kiln-model/src/backend/cuda.rs
@@ -369,8 +369,7 @@ impl BackendRuntime for CudaBackend {
         softmax_scale: f32,
         causal: bool,
     ) -> Result<Option<Tensor>> {
-        if any_tracks_op(&[q, k_pool, v_pool, block_table, seqused_k]) || q.dtype() != DType::BF16
-        {
+        if any_tracks_op(&[q, k_pool, v_pool, block_table, seqused_k]) || q.dtype() != DType::BF16 {
             return Ok(None);
         }
         let out = kiln_flash_attn::flash_attn_paged_decode_dyn_seqlen(
@@ -945,7 +944,9 @@ mod tests {
         let device = match Device::new_cuda(0) {
             Ok(device) => device,
             Err(err) => {
-                eprintln!("CUDA unavailable, skipping cuda_sgd_step_resident_round_trip_f32: {err}");
+                eprintln!(
+                    "CUDA unavailable, skipping cuda_sgd_step_resident_round_trip_f32: {err}"
+                );
                 return Ok(());
             }
         };
@@ -959,7 +960,10 @@ mod tests {
         let actual = param.to_vec1::<f32>()?;
         let expected = [0.975f32, -1.95, 0.375, 2.75];
         for (a, e) in actual.iter().zip(expected.iter()) {
-            assert!((a - e).abs() < 1e-6, "actual={actual:?} expected={expected:?}");
+            assert!(
+                (a - e).abs() < 1e-6,
+                "actual={actual:?} expected={expected:?}"
+            );
         }
         Ok(())
     }
@@ -969,7 +973,9 @@ mod tests {
         let device = match Device::new_cuda(0) {
             Ok(device) => device,
             Err(err) => {
-                eprintln!("CUDA unavailable, skipping cuda_adamw_step_resident_round_trip_f32: {err}");
+                eprintln!(
+                    "CUDA unavailable, skipping cuda_adamw_step_resident_round_trip_f32: {err}"
+                );
                 return Ok(());
             }
         };
@@ -1023,14 +1029,16 @@ mod tests {
         let device = match Device::new_cuda(0) {
             Ok(device) => device,
             Err(err) => {
-                eprintln!("CUDA unavailable, skipping cuda_sgd_and_adamw_resident_round_trip_bf16: {err}");
+                eprintln!(
+                    "CUDA unavailable, skipping cuda_sgd_and_adamw_resident_round_trip_bf16: {err}"
+                );
                 return Ok(());
             }
         };
         let backend = CudaBackend::new(device.clone());
 
-        let param = Tensor::from_slice(&[1.0f32, -2.0, 0.5, 3.0], (4,), &device)?
-            .to_dtype(DType::BF16)?;
+        let param =
+            Tensor::from_slice(&[1.0f32, -2.0, 0.5, 3.0], (4,), &device)?.to_dtype(DType::BF16)?;
         let grad = Tensor::from_slice(&[0.25f32, -0.5, 0.5, -0.25], (4,), &device)?
             .to_dtype(DType::BF16)?;
         backend.register_resident_activation(&param)?;
@@ -1039,11 +1047,14 @@ mod tests {
         let sgd_actual = param.to_dtype(DType::F32)?.to_vec1::<f32>()?;
         let sgd_expected = [0.875f32, -1.75, 0.25, 3.125];
         for (a, e) in sgd_actual.iter().zip(sgd_expected.iter()) {
-            assert!((a - e).abs() < 0.02, "actual={sgd_actual:?} expected={sgd_expected:?}");
+            assert!(
+                (a - e).abs() < 0.02,
+                "actual={sgd_actual:?} expected={sgd_expected:?}"
+            );
         }
 
-        let adam_param = Tensor::from_slice(&[1.0f32, -2.0, 0.5, 3.0], (4,), &device)?
-            .to_dtype(DType::BF16)?;
+        let adam_param =
+            Tensor::from_slice(&[1.0f32, -2.0, 0.5, 3.0], (4,), &device)?.to_dtype(DType::BF16)?;
         let adam_grad = Tensor::from_slice(&[0.5f32, -0.5, 0.25, -0.25], (4,), &device)?
             .to_dtype(DType::BF16)?;
         let m = Tensor::zeros((4,), DType::BF16, &device)?;
@@ -1083,7 +1094,10 @@ mod tests {
         let q = q_var.as_tensor();
         let k = Tensor::zeros((1, 2, 1, 128), DType::BF16, &Device::Cpu)?;
         let v = Tensor::zeros((1, 2, 1, 128), DType::BF16, &Device::Cpu)?;
-        assert!(q.track_op(), "test precondition: q must be autograd-tracked");
+        assert!(
+            q.track_op(),
+            "test precondition: q must be autograd-tracked"
+        );
         assert!(
             backend.flash_attn_prefill(q, &k, &v, 1.0, true)?.is_none(),
             "CUDA FlashAttention prefill must decline tracked tensors until it has a bwd hook"
@@ -1099,7 +1113,16 @@ mod tests {
 
         assert!(
             backend
-                .flash_attn_paged_decode(q_decode, &k_pool, &v_pool, &block_table, 128, 128, 1.0, true)?
+                .flash_attn_paged_decode(
+                    q_decode,
+                    &k_pool,
+                    &v_pool,
+                    &block_table,
+                    128,
+                    128,
+                    1.0,
+                    true
+                )?
                 .is_none(),
             "CUDA paged decode attention must decline tracked tensors"
         );
@@ -1128,7 +1151,9 @@ mod tests {
         let device = match Device::new_cuda(0) {
             Ok(device) => device,
             Err(err) => {
-                eprintln!("CUDA unavailable, skipping cuda_linear_prefill_apply_matches_candle_cuda_matmul: {err}");
+                eprintln!(
+                    "CUDA unavailable, skipping cuda_linear_prefill_apply_matches_candle_cuda_matmul: {err}"
+                );
                 return Ok(());
             }
         };
@@ -1136,7 +1161,9 @@ mod tests {
 
         let x = Tensor::from_slice(&[1.0f32, -2.0, 0.5, 3.0, 4.0, -1.0], (2, 3), &device)?;
         let w = Tensor::from_slice(
-            &[0.5f32, 1.0, -1.5, 2.0, -0.25, 0.75, 1.25, -0.5, 2.0, -1.0, 0.0, 0.5],
+            &[
+                0.5f32, 1.0, -1.5, 2.0, -0.25, 0.75, 1.25, -0.5, 2.0, -1.0, 0.0, 0.5,
+            ],
             (3, 4),
             &device,
         )?;
@@ -1154,7 +1181,9 @@ mod tests {
         let device = match Device::new_cuda(0) {
             Ok(device) => device,
             Err(err) => {
-                eprintln!("CUDA unavailable, skipping cuda_linear_prefill_apply_offset_matches_candle_cuda_chunk: {err}");
+                eprintln!(
+                    "CUDA unavailable, skipping cuda_linear_prefill_apply_offset_matches_candle_cuda_chunk: {err}"
+                );
                 return Ok(());
             }
         };
@@ -1163,8 +1192,8 @@ mod tests {
         let x = Tensor::from_slice(&[1.0f32, -2.0, 0.5, 3.0, 4.0, -1.0], (2, 3), &device)?;
         let w = Tensor::from_slice(
             &[
-                0.5f32, 1.0, -1.5, 2.0, 3.0, -0.25, 0.75, 1.25, -0.5, 0.25, 2.0, -1.0, 0.0,
-                0.5, -2.0,
+                0.5f32, 1.0, -1.5, 2.0, 3.0, -0.25, 0.75, 1.25, -0.5, 0.25, 2.0, -1.0, 0.0, 0.5,
+                -2.0,
             ],
             (3, 5),
             &device,
@@ -1184,7 +1213,9 @@ mod tests {
         let device = match Device::new_cuda(0) {
             Ok(device) => device,
             Err(err) => {
-                eprintln!("CUDA unavailable, skipping cuda_registered_lora_delta_matches_candle_cuda_reference: {err}");
+                eprintln!(
+                    "CUDA unavailable, skipping cuda_registered_lora_delta_matches_candle_cuda_reference: {err}"
+                );
                 return Ok(());
             }
         };
@@ -1192,7 +1223,11 @@ mod tests {
 
         let x = Tensor::from_slice(&[0.5f32, -1.0, 2.0, 1.5, 0.25, -0.75], (2, 3), &device)?;
         let a = Tensor::from_slice(&[0.25f32, -0.5, 1.0, 1.5, 0.0, -1.0], (2, 3), &device)?;
-        let b = Tensor::from_slice(&[1.0f32, -0.25, 0.5, 0.75, -1.0, 0.25, 0.0, 1.5], (4, 2), &device)?;
+        let b = Tensor::from_slice(
+            &[1.0f32, -0.25, 0.5, 0.75, -1.0, 0.25, 0.0, 1.5],
+            (4, 2),
+            &device,
+        )?;
         let scale = 0.5;
 
         assert!(backend.lora_delta_resident(&x, &a, &b, scale)?.is_none());

--- a/crates/kiln-model/src/backend/mod.rs
+++ b/crates/kiln-model/src/backend/mod.rs
@@ -1070,7 +1070,10 @@ mod tests {
     fn cuda_training_capabilities_do_not_overclaim_native_training() {
         let caps = cuda::CudaBackend::training_capabilities_static();
         assert!(caps.projection_training.contains("offset chunk hook"));
-        assert!(caps.lora_delta_training.contains("declines tracked tensors"));
+        assert!(
+            caps.lora_delta_training
+                .contains("declines tracked tensors")
+        );
         assert_eq!(
             caps.resident_activation,
             "TensorId lifecycle registry; candle CUDA tensors are canonical"

--- a/crates/kiln-model/src/cuda_train.rs
+++ b/crates/kiln-model/src/cuda_train.rs
@@ -6,13 +6,13 @@
 //! kernels. Higher-level native CUDA training can build on this without
 //! accepting CPU tensors by accident.
 
-use anyhow::{ensure, Context, Result};
-use candle_core::{DType, Device, Tensor, TensorId, D};
+use anyhow::{Context, Result, ensure};
+use candle_core::{D, DType, Device, Tensor, TensorId};
 use kiln_core::config::ModelConfig;
 use kiln_core::env_flag::env_flag;
 use std::collections::{HashMap, HashSet};
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::forward::{
     GpuAttentionWeights, GpuFullAttentionWeights, GpuLayerWeights, GpuLinearAttentionWeights,
@@ -2480,7 +2480,9 @@ pub fn cuda_causal_depthwise_conv1d_prefill_with_state(
     conv_state: &CudaTrainTensor,
 ) -> Result<(CudaTrainTensor, CudaTrainTensor)> {
     ensure!(
-        input.dtype() == DType::F32 && weight.dtype() == DType::F32 && conv_state.dtype() == DType::F32,
+        input.dtype() == DType::F32
+            && weight.dtype() == DType::F32
+            && conv_state.dtype() == DType::F32,
         "cuda_causal_depthwise_conv1d_prefill_with_state: expected F32 input/weight/state, got {:?}/{:?}/{:?}",
         input.dtype(),
         weight.dtype(),
@@ -2561,7 +2563,9 @@ pub fn cuda_causal_depthwise_conv1d_prefill_with_state_inplace_input_grad(
     conv_state: &CudaTrainTensor,
 ) -> Result<(CudaTrainTensor, CudaTrainTensor)> {
     ensure!(
-        input.dtype() == DType::F32 && weight.dtype() == DType::F32 && conv_state.dtype() == DType::F32,
+        input.dtype() == DType::F32
+            && weight.dtype() == DType::F32
+            && conv_state.dtype() == DType::F32,
         "cuda_causal_depthwise_conv1d_prefill_with_state_inplace_input_grad: expected F32 input/weight/state, got {:?}/{:?}/{:?}",
         input.dtype(),
         weight.dtype(),
@@ -2583,7 +2587,9 @@ pub fn cuda_causal_depthwise_conv1d_prefill_with_state_inplace_input_grad(
         "cuda_causal_depthwise_conv1d_prefill_with_state_inplace_input_grad: weight gradients are not supported"
     );
     ensure!(
-        !conv_state.requires_grad() && conv_state.grad_fn().is_none() && conv_state.param_id().is_none(),
+        !conv_state.requires_grad()
+            && conv_state.grad_fn().is_none()
+            && conv_state.param_id().is_none(),
         "cuda_causal_depthwise_conv1d_prefill_with_state_inplace_input_grad: state gradients are not supported"
     );
     ensure!(
@@ -5310,11 +5316,13 @@ mod tests {
             assert_eq!(layer.recurrent_state.dims(), &[3, 4, 5, 6]);
             assert_eq!(layer.conv_n_elements, 3 * 7 * 3);
             assert_eq!(layer.conv_state.dims(), &[3, 7, 3]);
-            assert!(layer
-                .recurrent_state
-                .to_vec_f32()?
-                .iter()
-                .all(|v| *v == 0.0));
+            assert!(
+                layer
+                    .recurrent_state
+                    .to_vec_f32()?
+                    .iter()
+                    .all(|v| *v == 0.0)
+            );
             assert!(layer.conv_state.to_vec_f32()?.iter().all(|v| *v == 0.0));
         }
         Ok(())
@@ -6144,7 +6152,9 @@ mod tests {
         let grads = cuda_backward(&loss)?;
         assert_eq!(
             grads.get(param_id).expect("param grad").to_vec_f32()?,
-            vec![1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 4.0, 5.0, 6.0, 1.0, 2.0, 3.0]
+            vec![
+                1.0, 2.0, 3.0, 10.0, 20.0, 30.0, 4.0, 5.0, 6.0, 1.0, 2.0, 3.0
+            ]
         );
         Ok(())
     }
@@ -6297,7 +6307,9 @@ mod tests {
         let grads = cuda_backward(&loss)?;
         assert_eq!(
             grads.get(lhs_id).expect("lhs grad").to_vec_f32()?,
-            vec![11.0, 22.0, 33.0, 11.0, 22.0, 33.0, 5.0, 7.0, 9.0, 5.0, 7.0, 9.0]
+            vec![
+                11.0, 22.0, 33.0, 11.0, 22.0, 33.0, 5.0, 7.0, 9.0, 5.0, 7.0, 9.0
+            ]
         );
         assert_eq!(
             grads.get(rhs_id).expect("rhs grad").to_vec_f32()?,
@@ -7852,16 +7864,20 @@ mod tests {
 
         let state = states.get(&param_id).expect("adamw state");
         assert_eq!(state.step, 1);
-        assert!(state
-            .first_moment
-            .to_vec_f32()?
-            .iter()
-            .any(|v| v.abs() > 0.0));
-        assert!(state
-            .second_moment
-            .to_vec_f32()?
-            .iter()
-            .any(|v| v.abs() > 0.0));
+        assert!(
+            state
+                .first_moment
+                .to_vec_f32()?
+                .iter()
+                .any(|v| v.abs() > 0.0)
+        );
+        assert!(
+            state
+                .second_moment
+                .to_vec_f32()?
+                .iter()
+                .any(|v| v.abs() > 0.0)
+        );
 
         let after = cuda_sum_all(&cuda_mul(&param, &param)?)?;
         let after_loss = after.to_vec_f32()?[0];

--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -6,6 +6,12 @@
 
 use anyhow::{Context, Result};
 use candle_core::backend::BackendDevice;
+#[cfg(feature = "cuda")]
+use candle_core::backend::BackendStorage;
+#[cfg(feature = "cuda")]
+use candle_core::op::BackpropOp;
+#[cfg(feature = "cuda")]
+use candle_core::{CpuStorage, CudaStorage, CustomOp2, CustomOp3, Layout, Shape, Storage};
 use candle_core::{DType, Device, Tensor};
 use std::cell::Cell;
 use std::sync::{Mutex, OnceLock};
@@ -501,6 +507,14 @@ fn add_lora_delta_to_base(
     let Some(proj) = lora else {
         return Ok(base);
     };
+    #[cfg(feature = "cuda")]
+    if let Some(out) = cuda_lora_add_training_f32(&base, x, proj, lora_scale)? {
+        return Ok(out);
+    }
+    #[cfg(feature = "cuda")]
+    if let Some(out) = cuda_lora_add_training_bf16(&base, x, proj, lora_scale)? {
+        return Ok(out);
+    }
     if let Some(backend) = backend {
         if let Some(out) = backend.lora_decode_add(&base, x, &proj.a, &proj.b, lora_scale)? {
             return Ok(out);
@@ -539,6 +553,699 @@ fn add_lora_delta_to_base(
     Ok((base + delta)?)
 }
 
+#[cfg(feature = "cuda")]
+fn cuda_lora_training_add_disabled() -> bool {
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| std::env::var("KILN_DISABLE_CUDA_LORA_TRAINING_ADD").is_ok())
+}
+
+#[cfg(feature = "cuda")]
+fn cuda_lora_training_linear_disabled() -> bool {
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| std::env::var("KILN_DISABLE_CUDA_LORA_TRAINING_LINEAR").is_ok())
+}
+
+#[cfg(feature = "cuda")]
+fn to_dtype_if_needed(t: &Tensor, dtype: DType) -> candle_core::Result<Tensor> {
+    if t.dtype() == dtype {
+        Ok(t.clone())
+    } else {
+        t.to_dtype(dtype)
+    }
+}
+
+#[cfg(feature = "cuda")]
+fn cuda_lora_bwd_tile_rows() -> usize {
+    static TILE_ROWS: OnceLock<usize> = OnceLock::new();
+    *TILE_ROWS.get_or_init(|| {
+        std::env::var("KILN_CUDA_LORA_BWD_TILE_ROWS")
+            .ok()
+            .and_then(|value| value.parse::<usize>().ok())
+            .filter(|&value| value > 0)
+            .unwrap_or(512)
+    })
+}
+
+#[cfg(feature = "cuda")]
+fn cuda_lora_linear_training_bf16(
+    x: &Tensor,
+    weight_t: &Tensor,
+    lora: Option<&LoraProjectionWeights>,
+    scale: f32,
+) -> Result<Option<Tensor>> {
+    let Some(proj) = lora else {
+        return Ok(None);
+    };
+    if cuda_lora_training_linear_disabled()
+        || x.dtype() != DType::BF16
+        || weight_t.dtype() != DType::BF16
+        || !x.track_op()
+        || !matches!(x.device(), Device::Cuda(_))
+        || !matches!(weight_t.device(), Device::Cuda(_))
+    {
+        return Ok(None);
+    }
+
+    let x_dims = x.dims();
+    if x_dims.len() < 2 {
+        return Ok(None);
+    }
+    let Ok((in_features, out_dim)) = weight_t.dims2() else {
+        return Ok(None);
+    };
+    if *x_dims.last().unwrap() != in_features {
+        return Ok(None);
+    }
+    let rows: usize = x_dims[..x_dims.len() - 1].iter().product();
+    if rows == 0 {
+        let mut out_dims = x_dims.to_vec();
+        *out_dims.last_mut().unwrap() = out_dim;
+        return Ok(Some(Tensor::zeros(out_dims, DType::BF16, x.device())?));
+    }
+
+    let Ok((rank, a_in)) = proj.a.dims2() else {
+        return Ok(None);
+    };
+    let Ok((b_out, b_rank)) = proj.b.dims2() else {
+        return Ok(None);
+    };
+    if a_in != in_features || b_out != out_dim || b_rank != rank {
+        return Ok(None);
+    }
+
+    let x_2d = x.reshape((rows, in_features))?;
+    if !x_2d.is_contiguous() {
+        return Ok(None);
+    }
+    let a_bf16 = to_dtype_if_needed(&proj.a, DType::BF16)?.contiguous()?;
+    let b_bf16 = to_dtype_if_needed(&proj.b, DType::BF16)?.contiguous()?;
+    let out_2d = x_2d
+        .apply_op3(
+            &a_bf16,
+            &b_bf16,
+            CudaLoraLinearBf16 {
+                weight_t: weight_t.clone(),
+                scale,
+            },
+        )
+        .context("cuda BF16 LoRA training fused linear")?;
+    let mut out_dims = x_dims.to_vec();
+    *out_dims.last_mut().unwrap() = out_dim;
+    Ok(Some(out_2d.reshape(out_dims)?))
+}
+
+#[cfg(feature = "cuda")]
+fn cuda_lora_add_training_f32(
+    base: &Tensor,
+    x: &Tensor,
+    proj: &LoraProjectionWeights,
+    scale: f32,
+) -> Result<Option<Tensor>> {
+    if cuda_lora_training_add_disabled()
+        || base.dtype() != DType::F32
+        || x.dtype() != DType::F32
+        || !matches!(base.device(), Device::Cuda(_))
+        || !matches!(x.device(), Device::Cuda(_))
+    {
+        return Ok(None);
+    }
+
+    let base_dims = base.dims();
+    let x_dims = x.dims();
+    if base_dims.len() < 2 || x_dims.len() != base_dims.len() {
+        return Ok(None);
+    }
+    if base_dims[..base_dims.len() - 1] != x_dims[..x_dims.len() - 1] {
+        return Ok(None);
+    }
+    let out_dim = *base_dims.last().unwrap();
+    let in_features = *x_dims.last().unwrap();
+    let rows: usize = base_dims[..base_dims.len() - 1].iter().product();
+    if rows == 0 {
+        return Ok(Some(base.clone()));
+    }
+
+    let Ok((rank, a_in)) = proj.a.dims2() else {
+        return Ok(None);
+    };
+    let Ok((b_out, b_rank)) = proj.b.dims2() else {
+        return Ok(None);
+    };
+    if a_in != in_features || b_out != out_dim || b_rank != rank {
+        return Ok(None);
+    }
+
+    let base_2d = base.reshape((rows, out_dim))?;
+    let x_2d = x.reshape((rows, in_features))?;
+    if !base_2d.is_contiguous() || !x_2d.is_contiguous() {
+        return Ok(None);
+    }
+
+    let a_f32 = proj.a.to_dtype(DType::F32)?.contiguous()?;
+    let b_f32 = proj.b.to_dtype(DType::F32)?.contiguous()?;
+    let a_t = a_f32.t()?.contiguous()?;
+    let hidden = x_2d
+        .matmul(&a_t)
+        .context("cuda LoRA training add hidden matmul")?
+        .contiguous()
+        .context("cuda LoRA training add hidden contiguous")?;
+    let out_2d = base_2d
+        .apply_op3(&hidden, &b_f32, CudaLoraAddF32 { scale })
+        .context("cuda LoRA training add CustomOp3")?;
+    Ok(Some(out_2d.reshape(base_dims)?))
+}
+
+#[cfg(feature = "cuda")]
+fn cuda_lora_add_training_bf16(
+    base: &Tensor,
+    x: &Tensor,
+    proj: &LoraProjectionWeights,
+    scale: f32,
+) -> Result<Option<Tensor>> {
+    if cuda_lora_training_add_disabled()
+        || base.dtype() != DType::BF16
+        || x.dtype() != DType::BF16
+        || !matches!(base.device(), Device::Cuda(_))
+        || !matches!(x.device(), Device::Cuda(_))
+    {
+        return Ok(None);
+    }
+
+    let base_dims = base.dims();
+    let x_dims = x.dims();
+    if base_dims.len() < 2 || x_dims.len() != base_dims.len() {
+        return Ok(None);
+    }
+    if base_dims[..base_dims.len() - 1] != x_dims[..x_dims.len() - 1] {
+        return Ok(None);
+    }
+    let out_dim = *base_dims.last().unwrap();
+    let in_features = *x_dims.last().unwrap();
+    let rows: usize = base_dims[..base_dims.len() - 1].iter().product();
+    if rows == 0 {
+        return Ok(Some(base.clone()));
+    }
+
+    let Ok((rank, a_in)) = proj.a.dims2() else {
+        return Ok(None);
+    };
+    let Ok((b_out, b_rank)) = proj.b.dims2() else {
+        return Ok(None);
+    };
+    if a_in != in_features || b_out != out_dim || b_rank != rank {
+        return Ok(None);
+    }
+
+    let base_2d = base.reshape((rows, out_dim))?;
+    let x_2d = x.reshape((rows, in_features))?;
+    if !base_2d.is_contiguous() || !x_2d.is_contiguous() {
+        return Ok(None);
+    }
+
+    let a_bf16 = proj.a.to_dtype(DType::BF16)?.contiguous()?;
+    let b_bf16 = proj.b.to_dtype(DType::BF16)?.contiguous()?;
+    let a_t = a_bf16.t()?.contiguous()?;
+    let hidden = x_2d
+        .matmul(&a_t)
+        .context("cuda BF16 LoRA training add hidden matmul")?
+        .to_dtype(DType::F32)?
+        .contiguous()
+        .context("cuda BF16 LoRA training add hidden contiguous")?;
+    let out_2d = base_2d
+        .apply_op3(&hidden, &b_bf16, CudaLoraAddBf16 { scale })
+        .context("cuda BF16 LoRA training add CustomOp3")?;
+    Ok(Some(out_2d.reshape(base_dims)?))
+}
+
+#[cfg(feature = "cuda")]
+#[derive(Debug, Clone, Copy)]
+struct CudaLoraAddF32 {
+    scale: f32,
+}
+
+#[cfg(feature = "cuda")]
+impl CustomOp3 for CudaLoraAddF32 {
+    fn name(&self) -> &'static str {
+        "kiln-cuda-lora-add-f32"
+    }
+
+    fn cpu_fwd(
+        &self,
+        s_base: &CpuStorage,
+        l_base: &Layout,
+        s_hidden: &CpuStorage,
+        l_hidden: &Layout,
+        s_b: &CpuStorage,
+        l_b: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        if !l_base.is_contiguous()
+            || !l_hidden.is_contiguous()
+            || !l_b.is_contiguous()
+            || l_base.start_offset() != 0
+            || l_hidden.start_offset() != 0
+            || l_b.start_offset() != 0
+        {
+            candle_core::bail!("CudaLoraAddF32 CPU fallback requires compact contiguous inputs");
+        }
+        let base = Tensor::from_storage(
+            Storage::Cpu(s_base.clone()),
+            Shape::from(l_base.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let hidden = Tensor::from_storage(
+            Storage::Cpu(s_hidden.clone()),
+            Shape::from(l_hidden.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let b = Tensor::from_storage(
+            Storage::Cpu(s_b.clone()),
+            Shape::from(l_b.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let delta = (hidden.matmul(&b.t()?)? * self.scale as f64)?;
+        let out = (base + delta)?;
+        let (storage, layout) = out.storage_and_layout();
+        let storage = storage.try_clone(layout)?;
+        match storage {
+            Storage::Cpu(storage) => Ok((storage, Shape::from(l_base.dims().to_vec()))),
+            _ => candle_core::bail!("CudaLoraAddF32 CPU fallback produced non-CPU storage"),
+        }
+    }
+
+    fn cuda_fwd(
+        &self,
+        s_base: &CudaStorage,
+        l_base: &Layout,
+        s_hidden: &CudaStorage,
+        l_hidden: &Layout,
+        s_b: &CudaStorage,
+        l_b: &Layout,
+    ) -> candle_core::Result<(CudaStorage, Shape)> {
+        if !l_base.is_contiguous() || !l_hidden.is_contiguous() || !l_b.is_contiguous() {
+            candle_core::bail!("CudaLoraAddF32 CUDA path requires contiguous inputs");
+        }
+        let out_storage = s_base.try_clone(l_base)?;
+        let out_shape = Shape::from(l_base.dims().to_vec());
+        let out_layout = Layout::contiguous(out_shape.clone());
+        kiln_rmsnorm_kernel::lora_add_inplace_f32_storage(
+            &out_storage,
+            &out_layout,
+            s_hidden,
+            l_hidden,
+            s_b,
+            l_b,
+            self.scale,
+        )
+        .map_err(|e| candle_core::Error::Msg(format!("CudaLoraAddF32 CUDA add: {e:?}")))?;
+        Ok((out_storage, out_shape))
+    }
+
+    fn bwd(
+        &self,
+        _base: &Tensor,
+        hidden: &Tensor,
+        b: &Tensor,
+        _res: &Tensor,
+        grad_y: &Tensor,
+    ) -> candle_core::Result<(Option<Tensor>, Option<Tensor>, Option<Tensor>)> {
+        let grad_base = grad_y.clone();
+        let grad_y_f32 = to_dtype_if_needed(grad_y, DType::F32)?;
+        let grad_delta = (grad_y_f32 * self.scale as f64)?;
+        let b_f32 = to_dtype_if_needed(b, DType::F32)?;
+        let hidden_f32 = to_dtype_if_needed(hidden, DType::F32)?;
+        let grad_hidden = grad_delta.matmul(&b_f32)?;
+        let grad_b = grad_delta.t()?.contiguous()?.matmul(&hidden_f32)?;
+        Ok((Some(grad_base), Some(grad_hidden), Some(grad_b)))
+    }
+}
+
+#[cfg(feature = "cuda")]
+#[derive(Debug, Clone, Copy)]
+struct CudaLoraAddBf16 {
+    scale: f32,
+}
+
+#[cfg(feature = "cuda")]
+#[derive(Debug, Clone)]
+struct CudaLoraLinearBf16 {
+    weight_t: Tensor,
+    scale: f32,
+}
+
+#[cfg(feature = "cuda")]
+impl CudaLoraLinearBf16 {
+    fn forward_tensor(&self, x: &Tensor, a: &Tensor, b: &Tensor) -> candle_core::Result<Tensor> {
+        let base = x.matmul(&self.weight_t)?;
+        let a_t = a.t()?.contiguous()?;
+        let hidden = x.matmul(&a_t)?.to_dtype(DType::F32)?.contiguous()?;
+        base.apply_op3_no_bwd(&hidden, b, &CudaLoraAddBf16 { scale: self.scale })
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl CustomOp3 for CudaLoraLinearBf16 {
+    fn name(&self) -> &'static str {
+        "kiln-cuda-lora-linear-bf16"
+    }
+
+    fn cpu_fwd(
+        &self,
+        s_x: &CpuStorage,
+        l_x: &Layout,
+        s_a: &CpuStorage,
+        l_a: &Layout,
+        s_b: &CpuStorage,
+        l_b: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        if !l_x.is_contiguous()
+            || !l_a.is_contiguous()
+            || !l_b.is_contiguous()
+            || l_x.start_offset() != 0
+            || l_a.start_offset() != 0
+            || l_b.start_offset() != 0
+        {
+            candle_core::bail!(
+                "CudaLoraLinearBf16 CPU fallback requires compact contiguous inputs"
+            );
+        }
+        let x = Tensor::from_storage(
+            Storage::Cpu(s_x.clone()),
+            Shape::from(l_x.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let a = Tensor::from_storage(
+            Storage::Cpu(s_a.clone()),
+            Shape::from(l_a.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let b = Tensor::from_storage(
+            Storage::Cpu(s_b.clone()),
+            Shape::from(l_b.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let out = self.forward_tensor(&x, &a, &b)?;
+        let (storage, layout) = out.storage_and_layout();
+        let storage = storage.try_clone(layout)?;
+        match storage {
+            Storage::Cpu(storage) => Ok((storage, Shape::from(out.dims().to_vec()))),
+            _ => candle_core::bail!("CudaLoraLinearBf16 CPU fallback produced non-CPU storage"),
+        }
+    }
+
+    fn cuda_fwd(
+        &self,
+        s_x: &CudaStorage,
+        l_x: &Layout,
+        s_a: &CudaStorage,
+        l_a: &Layout,
+        s_b: &CudaStorage,
+        l_b: &Layout,
+    ) -> candle_core::Result<(CudaStorage, Shape)> {
+        if !l_x.is_contiguous() || !l_a.is_contiguous() || !l_b.is_contiguous() {
+            candle_core::bail!("CudaLoraLinearBf16 CUDA path requires contiguous inputs");
+        }
+        let x_dims = l_x.dims();
+        let a_dims = l_a.dims();
+        let b_dims = l_b.dims();
+        if x_dims.len() != 2 || a_dims.len() != 2 || b_dims.len() != 2 {
+            candle_core::bail!(
+                "CudaLoraLinearBf16 CUDA path expects rank-2 inputs, got x={x_dims:?} a={a_dims:?} b={b_dims:?}"
+            );
+        }
+        let (rows, in_features) = (x_dims[0], x_dims[1]);
+        let (rank, a_in) = (a_dims[0], a_dims[1]);
+        let (out_dim, b_rank) = (b_dims[0], b_dims[1]);
+        if a_in != in_features || b_rank != rank {
+            candle_core::bail!(
+                "CudaLoraLinearBf16 CUDA shape mismatch x={x_dims:?} a={a_dims:?} b={b_dims:?}"
+            );
+        }
+        let (weight_storage, weight_layout) = self.weight_t.storage_and_layout();
+        let Storage::Cuda(weight_storage) = &*weight_storage else {
+            candle_core::bail!("CudaLoraLinearBf16 CUDA path requires CUDA weight storage");
+        };
+        if weight_layout.dims() != [in_features, out_dim] {
+            candle_core::bail!(
+                "CudaLoraLinearBf16 CUDA weight shape mismatch weight={:?} x={x_dims:?} b={b_dims:?}",
+                weight_layout.dims()
+            );
+        }
+
+        let out_shape = Shape::from(vec![rows, out_dim]);
+        let out_layout = Layout::contiguous(out_shape.clone());
+        let out_storage = s_x.matmul(
+            weight_storage,
+            (1, rows, out_dim, in_features),
+            l_x,
+            weight_layout,
+        )?;
+
+        let a_t_layout = l_a.transpose(0, 1)?;
+        let hidden_bf16 = s_x.matmul(s_a, (1, rows, rank, in_features), l_x, &a_t_layout)?;
+        let hidden_shape = Shape::from(vec![rows, rank]);
+        let hidden_layout = Layout::contiguous(hidden_shape);
+        let hidden_f32 = hidden_bf16.to_dtype(&hidden_layout, DType::F32)?;
+        kiln_rmsnorm_kernel::lora_add_bf16_storage(
+            &out_storage,
+            &out_layout,
+            &out_storage,
+            &out_layout,
+            &hidden_f32,
+            &hidden_layout,
+            s_b,
+            l_b,
+            self.scale,
+        )
+        .map_err(|e| candle_core::Error::Msg(format!("CudaLoraLinearBf16 CUDA add: {e:?}")))?;
+        Ok((out_storage, out_shape))
+    }
+
+    fn bwd(
+        &self,
+        x: &Tensor,
+        a: &Tensor,
+        b: &Tensor,
+        _res: &Tensor,
+        grad_y: &Tensor,
+    ) -> candle_core::Result<(Option<Tensor>, Option<Tensor>, Option<Tensor>)> {
+        let rows = grad_y.dim(0)?;
+        let tile_rows = cuda_lora_bwd_tile_rows().min(rows.max(1));
+        let weight_t_t = self.weight_t.t()?;
+        let a_bf16 = to_dtype_if_needed(a, DType::BF16)?;
+        let a_t_bf16 = a_bf16.t()?.contiguous()?;
+        let a_f32 = to_dtype_if_needed(a, DType::F32)?;
+        let b_f32 = to_dtype_if_needed(b, DType::F32)?;
+        let x_in = x.dim(1)?;
+        let grad_x_shape = Shape::from(vec![rows, x_in]);
+        let Device::Cuda(cuda_device) = x.device() else {
+            candle_core::bail!("CudaLoraLinearBf16 backward requires CUDA input");
+        };
+        let mut grad_x_storage = unsafe { cuda_device.alloc_uninit(&grad_x_shape, DType::BF16)? };
+        let mut grad_a_acc: Option<Tensor> = None;
+        let mut grad_b_acc: Option<Tensor> = None;
+
+        for start in (0..rows).step_by(tile_rows) {
+            let len = (rows - start).min(tile_rows);
+            let x_tile = x.narrow(0, start, len)?;
+            let x_tile_f32 = to_dtype_if_needed(&x_tile, DType::F32)?;
+            let grad_y_tile = grad_y.narrow(0, start, len)?;
+            let grad_y_tile_bf16 = to_dtype_if_needed(&grad_y_tile, DType::BF16)?;
+            let grad_y_tile_f32 = to_dtype_if_needed(&grad_y_tile, DType::F32)?;
+
+            let grad_x_base = grad_y_tile_bf16.matmul(&weight_t_t)?;
+            let grad_hidden = grad_y_tile_f32
+                .matmul(&b_f32)?
+                .affine(self.scale as f64, 0.0)?;
+            let grad_x_lora = grad_hidden.matmul(&a_f32)?.to_dtype(DType::BF16)?;
+            let grad_x_tile = (grad_x_base + grad_x_lora)?;
+            let (grad_x_tile_storage, grad_x_tile_layout) = grad_x_tile.storage_and_layout();
+            let Storage::Cuda(grad_x_tile_storage) = &*grad_x_tile_storage else {
+                candle_core::bail!("CudaLoraLinearBf16 backward produced non-CUDA grad_x tile");
+            };
+            grad_x_tile_storage.copy2d(
+                &mut grad_x_storage,
+                len,
+                x_in,
+                x_in,
+                x_in,
+                grad_x_tile_layout.start_offset(),
+                start * x_in,
+            )?;
+
+            let hidden = x_tile
+                .matmul(&a_t_bf16)?
+                .to_dtype(DType::F32)?
+                .contiguous()?;
+            let grad_b_tile = grad_y_tile_f32
+                .t()?
+                .matmul(&hidden)?
+                .affine(self.scale as f64, 0.0)?;
+            grad_b_acc = Some(match grad_b_acc {
+                Some(acc) => (acc + grad_b_tile)?,
+                None => grad_b_tile,
+            });
+
+            let grad_a_tile = grad_hidden.t()?.matmul(&x_tile_f32)?;
+            grad_a_acc = Some(match grad_a_acc {
+                Some(acc) => (acc + grad_a_tile)?,
+                None => grad_a_tile,
+            });
+        }
+
+        let grad_x = Tensor::from_storage(
+            Storage::Cuda(grad_x_storage),
+            grad_x_shape,
+            BackpropOp::none(),
+            false,
+        );
+        let Some(grad_a_acc) = grad_a_acc else {
+            candle_core::bail!("CudaLoraLinearBf16 backward produced no A gradient tiles");
+        };
+        let Some(grad_b_acc) = grad_b_acc else {
+            candle_core::bail!("CudaLoraLinearBf16 backward produced no B gradient tiles");
+        };
+        let grad_a = grad_a_acc.to_dtype(a.dtype())?;
+        let grad_b = grad_b_acc.to_dtype(b.dtype())?;
+        Ok((Some(grad_x), Some(grad_a), Some(grad_b)))
+    }
+}
+
+#[cfg(feature = "cuda")]
+impl CustomOp3 for CudaLoraAddBf16 {
+    fn name(&self) -> &'static str {
+        "kiln-cuda-lora-add-bf16"
+    }
+
+    fn cpu_fwd(
+        &self,
+        s_base: &CpuStorage,
+        l_base: &Layout,
+        s_hidden: &CpuStorage,
+        l_hidden: &Layout,
+        s_b: &CpuStorage,
+        l_b: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        if !l_base.is_contiguous()
+            || !l_hidden.is_contiguous()
+            || !l_b.is_contiguous()
+            || l_base.start_offset() != 0
+            || l_hidden.start_offset() != 0
+            || l_b.start_offset() != 0
+        {
+            candle_core::bail!("CudaLoraAddBf16 CPU fallback requires compact contiguous inputs");
+        }
+        let base = Tensor::from_storage(
+            Storage::Cpu(s_base.clone()),
+            Shape::from(l_base.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let hidden = Tensor::from_storage(
+            Storage::Cpu(s_hidden.clone()),
+            Shape::from(l_hidden.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let b = Tensor::from_storage(
+            Storage::Cpu(s_b.clone()),
+            Shape::from(l_b.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let delta = (hidden
+            .to_dtype(DType::F32)?
+            .matmul(&b.to_dtype(DType::F32)?.t()?)?
+            * self.scale as f64)?;
+        let out = (base.to_dtype(DType::F32)? + delta)?.to_dtype(DType::BF16)?;
+        let (storage, layout) = out.storage_and_layout();
+        let storage = storage.try_clone(layout)?;
+        match storage {
+            Storage::Cpu(storage) => Ok((storage, Shape::from(l_base.dims().to_vec()))),
+            _ => candle_core::bail!("CudaLoraAddBf16 CPU fallback produced non-CPU storage"),
+        }
+    }
+
+    fn cuda_fwd(
+        &self,
+        s_base: &CudaStorage,
+        l_base: &Layout,
+        s_hidden: &CudaStorage,
+        l_hidden: &Layout,
+        s_b: &CudaStorage,
+        l_b: &Layout,
+    ) -> candle_core::Result<(CudaStorage, Shape)> {
+        if !l_base.is_contiguous() || !l_hidden.is_contiguous() || !l_b.is_contiguous() {
+            candle_core::bail!("CudaLoraAddBf16 CUDA path requires contiguous inputs");
+        }
+        let out_storage = s_base.try_clone(l_base)?;
+        let out_shape = Shape::from(l_base.dims().to_vec());
+        let out_layout = Layout::contiguous(out_shape.clone());
+        kiln_rmsnorm_kernel::lora_add_bf16_storage(
+            &out_storage,
+            &out_layout,
+            s_base,
+            l_base,
+            s_hidden,
+            l_hidden,
+            s_b,
+            l_b,
+            self.scale,
+        )
+        .map_err(|e| candle_core::Error::Msg(format!("CudaLoraAddBf16 CUDA add: {e:?}")))?;
+        Ok((out_storage, out_shape))
+    }
+
+    fn bwd(
+        &self,
+        _base: &Tensor,
+        hidden: &Tensor,
+        b: &Tensor,
+        _res: &Tensor,
+        grad_y: &Tensor,
+    ) -> candle_core::Result<(Option<Tensor>, Option<Tensor>, Option<Tensor>)> {
+        let grad_base = to_dtype_if_needed(grad_y, DType::BF16)?;
+        let rows = grad_y.dim(0)?;
+        let tile_rows = cuda_lora_bwd_tile_rows().min(rows.max(1));
+        let b_f32 = to_dtype_if_needed(b, DType::F32)?;
+        let mut grad_hidden_tiles = Vec::with_capacity(rows.div_ceil(tile_rows));
+        let mut grad_b_acc: Option<Tensor> = None;
+
+        for start in (0..rows).step_by(tile_rows) {
+            let len = (rows - start).min(tile_rows);
+            let grad_y_tile = grad_y.narrow(0, start, len)?;
+            let grad_y_tile_f32 = to_dtype_if_needed(&grad_y_tile, DType::F32)?;
+            let hidden_tile = hidden.narrow(0, start, len)?;
+            let hidden_tile_f32 = to_dtype_if_needed(&hidden_tile, DType::F32)?;
+            let grad_hidden_tile = grad_y_tile_f32
+                .matmul(&b_f32)?
+                .affine(self.scale as f64, 0.0)?;
+            let grad_b_tile = grad_y_tile_f32
+                .t()?
+                .matmul(&hidden_tile_f32)?
+                .affine(self.scale as f64, 0.0)?;
+            grad_hidden_tiles.push(grad_hidden_tile);
+            grad_b_acc = Some(match grad_b_acc {
+                Some(acc) => (acc + grad_b_tile)?,
+                None => grad_b_tile,
+            });
+        }
+
+        let grad_hidden_refs = grad_hidden_tiles.iter().collect::<Vec<_>>();
+        let grad_hidden = Tensor::cat(&grad_hidden_refs, 0)?;
+        let Some(grad_b_acc) = grad_b_acc else {
+            candle_core::bail!("CudaLoraAddBf16 backward produced no B gradient tiles");
+        };
+        let grad_b = grad_b_acc.to_dtype(b.dtype())?;
+        Ok((Some(grad_base), Some(grad_hidden), Some(grad_b)))
+    }
+}
+
 fn linear_with_lora_t_decode_if(
     use_metal_decode_gemv: bool,
     x: &Tensor,
@@ -561,6 +1268,10 @@ fn linear_with_lora_t_backend_decode_if(
     lora: Option<&LoraProjectionWeights>,
     lora_scale: f32,
 ) -> Result<Tensor> {
+    #[cfg(feature = "cuda")]
+    if let Some(out) = cuda_lora_linear_training_bf16(x, weight_t, lora, lora_scale)? {
+        return Ok(out);
+    }
     if let Some(backend) = backend {
         // Autograd-tracked input → prefer the autograd-safe Vulkan
         // CustomOp1 (linear_prefill_apply). The existing linear_decode
@@ -625,6 +1336,9 @@ fn attention_output_gate_decode_if(
 
     #[cfg(feature = "cuda")]
     {
+        if let Some(out) = cuda_sigmoid_mul_training_bf16(&attn_output, gate)? {
+            return Ok(out);
+        }
         if !cuda_fused_attn_sigmoid_mul_disabled()
             && !attn_output.track_op()
             && !gate.track_op()
@@ -638,6 +1352,182 @@ fn attention_output_gate_decode_if(
 
     let sigmoid_gate = cuda_sigmoid(gate)?;
     Ok((attn_output * sigmoid_gate)?)
+}
+
+#[cfg(feature = "cuda")]
+fn cuda_sigmoid_mul_training_bf16(x: &Tensor, gate: &Tensor) -> Result<Option<Tensor>> {
+    if cuda_fused_attn_sigmoid_mul_disabled()
+        || (!x.track_op() && !gate.track_op())
+        || !kiln_rmsnorm_kernel::supports_sigmoid_mul(x, gate)
+    {
+        return Ok(None);
+    }
+    let out = x
+        .apply_op2(gate, CudaSigmoidMulTrainingBf16)
+        .context("cuda training sigmoid/mul CustomOp2")?;
+    Ok(Some(out))
+}
+
+#[cfg(feature = "cuda")]
+#[derive(Debug, Clone, Copy)]
+struct CudaSigmoidMulTrainingBf16;
+
+#[cfg(feature = "cuda")]
+impl CustomOp2 for CudaSigmoidMulTrainingBf16 {
+    fn name(&self) -> &'static str {
+        "kiln-cuda-sigmoid-mul-training-bf16"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s_x: &CpuStorage,
+        _l_x: &Layout,
+        _s_gate: &CpuStorage,
+        _l_gate: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        candle_core::bail!("CudaSigmoidMulTrainingBf16 requires CUDA inputs");
+    }
+
+    fn cuda_fwd(
+        &self,
+        s_x: &CudaStorage,
+        l_x: &Layout,
+        s_gate: &CudaStorage,
+        l_gate: &Layout,
+    ) -> candle_core::Result<(CudaStorage, Shape)> {
+        if !l_x.is_contiguous()
+            || !l_gate.is_contiguous()
+            || l_x.start_offset() != 0
+            || l_gate.start_offset() != 0
+        {
+            candle_core::bail!(
+                "CudaSigmoidMulTrainingBf16 CUDA path requires compact contiguous inputs"
+            );
+        }
+        let out_storage = s_x.try_clone(l_x)?;
+        let out_shape = Shape::from(l_x.dims().to_vec());
+        let out_layout = Layout::contiguous(out_shape.clone());
+        kiln_rmsnorm_kernel::fused_sigmoid_mul_storage(
+            &out_storage,
+            &out_layout,
+            s_x,
+            l_x,
+            s_gate,
+            l_gate,
+        )
+        .map_err(|e| {
+            candle_core::Error::Msg(format!("CudaSigmoidMulTrainingBf16 CUDA fwd: {e:?}"))
+        })?;
+        Ok((out_storage, out_shape))
+    }
+
+    fn bwd(
+        &self,
+        x: &Tensor,
+        gate: &Tensor,
+        _res: &Tensor,
+        grad_y: &Tensor,
+    ) -> candle_core::Result<(Option<Tensor>, Option<Tensor>)> {
+        let dims = x.dims();
+        if dims != gate.dims() || dims != grad_y.dims() {
+            candle_core::bail!(
+                "CudaSigmoidMulTrainingBf16 backward shape mismatch x={:?} gate={:?} grad={:?}",
+                dims,
+                gate.dims(),
+                grad_y.dims()
+            );
+        }
+        let Some(&width) = dims.last() else {
+            candle_core::bail!("CudaSigmoidMulTrainingBf16 backward requires non-scalar input");
+        };
+        let rows = x.elem_count() / width.max(1);
+        if rows == 0 {
+            return Ok((
+                Some(Tensor::zeros(dims, x.dtype(), x.device())?),
+                Some(Tensor::zeros(dims, gate.dtype(), gate.device())?),
+            ));
+        }
+        let Device::Cuda(cuda_device) = x.device() else {
+            candle_core::bail!("CudaSigmoidMulTrainingBf16 backward requires CUDA input");
+        };
+        x.device().synchronize()?;
+
+        let x_2d = x.reshape((rows, width))?;
+        let gate_2d = gate.reshape((rows, width))?;
+        let grad_y_2d = grad_y.reshape((rows, width))?;
+        let out_shape = Shape::from(vec![rows, width]);
+        let mut grad_x_storage = unsafe { cuda_device.alloc_uninit(&out_shape, x.dtype()) }
+            .map_err(|e| candle_core::Error::Msg(format!("sigmoid-mul bwd grad_x alloc: {e:?}")))?;
+        let mut grad_gate_storage = unsafe { cuda_device.alloc_uninit(&out_shape, gate.dtype()) }
+            .map_err(|e| {
+            candle_core::Error::Msg(format!("sigmoid-mul bwd grad_gate alloc: {e:?}"))
+        })?;
+        let tile_rows = cuda_lora_bwd_tile_rows().min(rows.max(1));
+
+        for start in (0..rows).step_by(tile_rows) {
+            let len = (rows - start).min(tile_rows);
+            let x_tile = x_2d.narrow(0, start, len)?;
+            let gate_tile = gate_2d.narrow(0, start, len)?;
+            let grad_y_tile = grad_y_2d.narrow(0, start, len)?;
+
+            let sigmoid_gate = (gate_tile.neg()?.exp()? + 1.0)?.recip()?;
+            let grad_x_tile = (grad_y_tile.clone() * sigmoid_gate.clone())?;
+            let (grad_x_tile_storage, grad_x_tile_layout) = grad_x_tile.storage_and_layout();
+            let Storage::Cuda(grad_x_tile_storage) = &*grad_x_tile_storage else {
+                candle_core::bail!(
+                    "CudaSigmoidMulTrainingBf16 backward produced non-CUDA grad_x tile"
+                );
+            };
+            grad_x_tile_storage.copy2d(
+                &mut grad_x_storage,
+                len,
+                width,
+                width,
+                width,
+                grad_x_tile_layout.start_offset(),
+                start * width,
+            )?;
+
+            let sigmoid_f32 = sigmoid_gate.to_dtype(DType::F32)?;
+            let one_minus_sigmoid = (sigmoid_f32.neg()? + 1.0)?;
+            let gate_deriv = (sigmoid_f32 * one_minus_sigmoid)?;
+            let grad_gate_tile =
+                (grad_y_tile.to_dtype(DType::F32)? * x_tile.to_dtype(DType::F32)?)?;
+            let grad_gate_tile = (grad_gate_tile * gate_deriv)?.to_dtype(gate.dtype())?;
+            let (grad_gate_tile_storage, grad_gate_tile_layout) =
+                grad_gate_tile.storage_and_layout();
+            let Storage::Cuda(grad_gate_tile_storage) = &*grad_gate_tile_storage else {
+                candle_core::bail!(
+                    "CudaSigmoidMulTrainingBf16 backward produced non-CUDA grad_gate tile"
+                );
+            };
+            grad_gate_tile_storage.copy2d(
+                &mut grad_gate_storage,
+                len,
+                width,
+                width,
+                width,
+                grad_gate_tile_layout.start_offset(),
+                start * width,
+            )?;
+        }
+
+        let grad_x = Tensor::from_storage(
+            Storage::Cuda(grad_x_storage),
+            out_shape.clone(),
+            BackpropOp::none(),
+            false,
+        )
+        .reshape(dims)?;
+        let grad_gate = Tensor::from_storage(
+            Storage::Cuda(grad_gate_storage),
+            out_shape,
+            BackpropOp::none(),
+            false,
+        )
+        .reshape(dims)?;
+        Ok((Some(grad_x), Some(grad_gate)))
+    }
 }
 
 fn full_attn_qkv_proj_decode_if(
@@ -781,14 +1671,10 @@ fn flash_attention_forward(
     let softmax_scale = 1.0 / (head_dim as f32).sqrt();
     let causal = true;
 
-    // GQA: expand K/V heads to match Q head count for flash_attn.
-    // The `expand(..).contiguous()` path is required because `expand` produces a
-    // strided view (stride=0 along the broadcast dim) that the flash kernel cannot
-    // consume directly. For the non-GQA branch, callers already pass contiguous
-    // K/V (the KV-cache concat produces contiguous tensors), so no extra copy is
-    // needed. Similarly, the flash kernel returns a freshly-allocated contiguous
-    // tensor, so the post-flash reshape does not need a `.contiguous()` call.
-    let (k, v) = if num_heads != num_kv_heads {
+    // GQA: the vendored CUDA FA2 wrapper receives `num_heads_k` separately, so
+    // it can consume grouped K/V directly. Other backends still take the
+    // historic expanded layout through this trait method.
+    let (k, v) = if num_heads != num_kv_heads && backend.name() != "cuda" {
         let gqa_ratio = num_heads / num_kv_heads;
         let (batch, kv_len, _kv_heads, hd) = k.dims4()?;
         // [batch, kv_len, num_kv_heads, head_dim] -> [batch, kv_len, num_heads, head_dim]
@@ -815,6 +1701,187 @@ fn flash_attention_forward(
     let (batch, seq_len, _heads, _hd) = attn_output.dims4()?;
     let attn_output = attn_output.reshape((batch, seq_len, num_heads * head_dim))?;
     Ok(Some(attn_output))
+}
+
+#[cfg(feature = "cuda")]
+fn cuda_flash_attention_training_disabled() -> bool {
+    env_truthy("KILN_DISABLE_CUDA_FLASH_ATTN_TRAINING")
+}
+
+#[cfg(feature = "cuda")]
+fn cuda_flash_attention_training_bf16(
+    q: &Tensor,
+    k: &Tensor,
+    v: &Tensor,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+) -> Result<Option<Tensor>> {
+    if cuda_flash_attention_training_disabled() || !any_tensor_tracks_op(&[q, k, v]) {
+        return Ok(None);
+    }
+    if q.dtype() != DType::BF16
+        || k.dtype() != DType::BF16
+        || v.dtype() != DType::BF16
+        || !matches!(q.device(), Device::Cuda(_))
+        || !matches!(k.device(), Device::Cuda(_))
+        || !matches!(v.device(), Device::Cuda(_))
+        || !q.is_contiguous()
+        || !k.is_contiguous()
+        || !v.is_contiguous()
+        || !matches!(head_dim, 128 | 256)
+        || num_kv_heads == 0
+        || num_heads % num_kv_heads != 0
+    {
+        return Ok(None);
+    }
+    let (bq, _sq, hq, dq) = q.dims4()?;
+    let (bk, sk, hk, dk) = k.dims4()?;
+    let (bv, sv, hv, dv) = v.dims4()?;
+    if bq != bk
+        || bq != bv
+        || sk != sv
+        || hq != num_heads
+        || hk != num_kv_heads
+        || hv != num_kv_heads
+        || dq != head_dim
+        || dk != head_dim
+        || dv != head_dim
+    {
+        return Ok(None);
+    }
+
+    let softmax_scale = 1.0 / (head_dim as f32).sqrt();
+    let out = q
+        .apply_op3(
+            k,
+            v,
+            CudaFlashAttentionTrainingBf16 {
+                softmax_scale,
+                causal: true,
+            },
+        )
+        .context("cuda training FlashAttention CustomOp3")?;
+    Ok(Some(out))
+}
+
+#[cfg(feature = "cuda")]
+#[derive(Debug, Clone, Copy)]
+struct CudaFlashAttentionTrainingBf16 {
+    softmax_scale: f32,
+    causal: bool,
+}
+
+#[cfg(feature = "cuda")]
+impl CustomOp3 for CudaFlashAttentionTrainingBf16 {
+    fn name(&self) -> &'static str {
+        "kiln-cuda-flash-attn-training-bf16"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _s_q: &CpuStorage,
+        _l_q: &Layout,
+        _s_k: &CpuStorage,
+        _l_k: &Layout,
+        _s_v: &CpuStorage,
+        _l_v: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        candle_core::bail!("CudaFlashAttentionTrainingBf16 requires CUDA inputs");
+    }
+
+    fn cuda_fwd(
+        &self,
+        s_q: &CudaStorage,
+        l_q: &Layout,
+        s_k: &CudaStorage,
+        l_k: &Layout,
+        s_v: &CudaStorage,
+        l_v: &Layout,
+    ) -> candle_core::Result<(CudaStorage, Shape)> {
+        if !l_q.is_contiguous()
+            || !l_k.is_contiguous()
+            || !l_v.is_contiguous()
+            || l_q.start_offset() != 0
+            || l_k.start_offset() != 0
+            || l_v.start_offset() != 0
+        {
+            candle_core::bail!(
+                "CudaFlashAttentionTrainingBf16 CUDA path requires compact contiguous inputs"
+            );
+        }
+        let q = Tensor::from_storage(
+            Storage::Cuda(s_q.try_clone(l_q)?),
+            Shape::from(l_q.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let k = Tensor::from_storage(
+            Storage::Cuda(s_k.try_clone(l_k)?),
+            Shape::from(l_k.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let v = Tensor::from_storage(
+            Storage::Cuda(s_v.try_clone(l_v)?),
+            Shape::from(l_v.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let (out, _softmax_lse) =
+            kiln_flash_attn::flash_attn_fwd(&q, &k, &v, self.softmax_scale, self.causal).map_err(
+                |e| {
+                    candle_core::Error::Msg(format!(
+                        "CudaFlashAttentionTrainingBf16 CUDA fwd: {e:?}"
+                    ))
+                },
+            )?;
+        let out_shape = Shape::from(out.dims().to_vec());
+        let (storage, layout) = out.storage_and_layout();
+        let storage = storage.try_clone(layout)?;
+        match storage {
+            Storage::Cuda(storage) => Ok((storage, out_shape)),
+            _ => candle_core::bail!("CudaFlashAttentionTrainingBf16 produced non-CUDA storage"),
+        }
+    }
+
+    fn bwd(
+        &self,
+        q: &Tensor,
+        k: &Tensor,
+        v: &Tensor,
+        res: &Tensor,
+        grad_y: &Tensor,
+    ) -> candle_core::Result<(Option<Tensor>, Option<Tensor>, Option<Tensor>)> {
+        let (recomputed_out, softmax_lse) =
+            kiln_flash_attn::flash_attn_fwd(q, k, v, self.softmax_scale, self.causal).map_err(
+                |e| {
+                    candle_core::Error::Msg(format!(
+                        "CudaFlashAttentionTrainingBf16 bwd recompute: {e:?}"
+                    ))
+                },
+            )?;
+        drop(recomputed_out);
+        let dout = if grad_y.dtype() == DType::BF16 {
+            grad_y.clone()
+        } else {
+            grad_y.to_dtype(DType::BF16)?
+        };
+        let (dq, dk, dv) = kiln_flash_attn::flash_attn_bwd(
+            &dout,
+            q,
+            k,
+            v,
+            res,
+            &softmax_lse,
+            self.softmax_scale,
+            self.causal,
+        )
+        .map_err(|e| {
+            candle_core::Error::Msg(format!("CudaFlashAttentionTrainingBf16 bwd: {e:?}"))
+        })?;
+        Ok((Some(dq), Some(dk), Some(dv)))
+    }
 }
 
 /// Compute attention using a backend fast path when Q/K/V are already in
@@ -3771,6 +4838,24 @@ fn apply_rope(
     head_dim: usize,
     rotary_dim: usize,
 ) -> Result<Tensor> {
+    #[cfg(feature = "cuda")]
+    {
+        if !cuda_fused_rotary_qk_disabled()
+            && cuda_rotary_one_training_bf16_supported(x, cos, sin, head_dim, rotary_dim)
+        {
+            return x
+                .apply_op3(
+                    cos,
+                    sin,
+                    CudaRotaryOneBf16 {
+                        head_dim,
+                        rotary_dim,
+                    },
+                )
+                .context("cuda rotary one CustomOp3");
+        }
+    }
+
     let half_rotary = rotary_dim / 2;
     let x_dtype = x.dtype();
 
@@ -3806,6 +4891,191 @@ fn apply_rope(
     Ok(out.to_dtype(x_dtype)?)
 }
 
+#[cfg(feature = "cuda")]
+fn cuda_rotary_one_training_bf16_supported(
+    x: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    head_dim: usize,
+    rotary_dim: usize,
+) -> bool {
+    if !matches!(x.device(), Device::Cuda(_))
+        || !matches!(cos.device(), Device::Cuda(_))
+        || !matches!(sin.device(), Device::Cuda(_))
+        || x.dtype() != DType::BF16
+        || cos.dtype() != DType::F32
+        || sin.dtype() != DType::F32
+        || !x.is_contiguous()
+        || !cos.is_contiguous()
+        || !sin.is_contiguous()
+        || x.rank() != 4
+        || rotary_dim == 0
+        || rotary_dim > head_dim
+        || rotary_dim % 2 != 0
+    {
+        return false;
+    }
+    let dims = x.dims();
+    let seq_len = dims[1];
+    dims[3] == head_dim
+        && cos.dims() == [seq_len, rotary_dim / 2]
+        && sin.dims() == [seq_len, rotary_dim / 2]
+}
+
+#[cfg(feature = "cuda")]
+#[derive(Debug, Clone, Copy)]
+struct CudaRotaryOneBf16 {
+    head_dim: usize,
+    rotary_dim: usize,
+}
+
+#[cfg(feature = "cuda")]
+impl CustomOp3 for CudaRotaryOneBf16 {
+    fn name(&self) -> &'static str {
+        "kiln-cuda-rotary-one-bf16"
+    }
+
+    fn cpu_fwd(
+        &self,
+        s_x: &CpuStorage,
+        l_x: &Layout,
+        s_cos: &CpuStorage,
+        l_cos: &Layout,
+        s_sin: &CpuStorage,
+        l_sin: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        if !l_x.is_contiguous()
+            || !l_cos.is_contiguous()
+            || !l_sin.is_contiguous()
+            || l_x.start_offset() != 0
+            || l_cos.start_offset() != 0
+            || l_sin.start_offset() != 0
+        {
+            candle_core::bail!("CudaRotaryOneBf16 CPU fallback requires compact contiguous inputs");
+        }
+        let x = Tensor::from_storage(
+            Storage::Cpu(s_x.clone()),
+            Shape::from(l_x.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let cos = Tensor::from_storage(
+            Storage::Cpu(s_cos.clone()),
+            Shape::from(l_cos.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let sin = Tensor::from_storage(
+            Storage::Cpu(s_sin.clone()),
+            Shape::from(l_sin.dims().to_vec()),
+            BackpropOp::none(),
+            false,
+        );
+        let out = apply_rope(&x, &cos, &sin, self.head_dim, self.rotary_dim).map_err(|e| {
+            candle_core::Error::Msg(format!("CudaRotaryOneBf16 CPU fallback: {e:?}"))
+        })?;
+        let (storage, layout) = out.storage_and_layout();
+        let storage = storage.try_clone(layout)?;
+        match storage {
+            Storage::Cpu(storage) => Ok((storage, Shape::from(l_x.dims().to_vec()))),
+            _ => candle_core::bail!("CudaRotaryOneBf16 CPU fallback produced non-CPU storage"),
+        }
+    }
+
+    fn cuda_fwd(
+        &self,
+        s_x: &CudaStorage,
+        l_x: &Layout,
+        s_cos: &CudaStorage,
+        l_cos: &Layout,
+        s_sin: &CudaStorage,
+        l_sin: &Layout,
+    ) -> candle_core::Result<(CudaStorage, Shape)> {
+        if !l_x.is_contiguous() || !l_cos.is_contiguous() || !l_sin.is_contiguous() {
+            candle_core::bail!("CudaRotaryOneBf16 CUDA path requires contiguous inputs");
+        }
+        let out_storage = s_x.try_clone(l_x)?;
+        let out_shape = Shape::from(l_x.dims().to_vec());
+        let out_layout = Layout::contiguous(out_shape.clone());
+        kiln_rmsnorm_kernel::rotary_one_bf16_storage(
+            &out_storage,
+            &out_layout,
+            s_x,
+            l_x,
+            s_cos,
+            l_cos,
+            s_sin,
+            l_sin,
+            self.head_dim,
+            self.rotary_dim,
+        )
+        .map_err(|e| candle_core::Error::Msg(format!("CudaRotaryOneBf16 CUDA fwd: {e:?}")))?;
+        Ok((out_storage, out_shape))
+    }
+
+    fn bwd(
+        &self,
+        _x: &Tensor,
+        cos: &Tensor,
+        sin: &Tensor,
+        _res: &Tensor,
+        grad_y: &Tensor,
+    ) -> candle_core::Result<(Option<Tensor>, Option<Tensor>, Option<Tensor>)> {
+        if kiln_rmsnorm_kernel::supports_rotary_one_bwd_bf16(
+            grad_y,
+            cos,
+            sin,
+            self.head_dim,
+            self.rotary_dim,
+        ) {
+            let grad_x = kiln_rmsnorm_kernel::rotary_one_bwd_bf16(
+                grad_y,
+                cos,
+                sin,
+                self.head_dim,
+                self.rotary_dim,
+            )
+            .map_err(|e| candle_core::Error::Msg(format!("CudaRotaryOneBf16 CUDA bwd: {e:?}")))?;
+            return Ok((Some(grad_x), None, None));
+        }
+        let grad_x = rotary_one_backward(grad_y, cos, sin, self.head_dim, self.rotary_dim)
+            .map_err(|e| candle_core::Error::Msg(format!("CudaRotaryOneBf16 bwd: {e:?}")))?;
+        Ok((Some(grad_x), None, None))
+    }
+}
+
+#[cfg(feature = "cuda")]
+fn rotary_one_backward(
+    grad_y: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    head_dim: usize,
+    rotary_dim: usize,
+) -> Result<Tensor> {
+    let half_rotary = rotary_dim / 2;
+    let grad_dtype = grad_y.dtype();
+    let grad = grad_y.to_dtype(DType::F32)?;
+    let grad_rot = grad.narrow(candle_core::D::Minus1, 0, rotary_dim)?;
+    let grad_pass = if rotary_dim < head_dim {
+        Some(grad.narrow(candle_core::D::Minus1, rotary_dim, head_dim - rotary_dim)?)
+    } else {
+        None
+    };
+
+    let g1 = grad_rot.narrow(candle_core::D::Minus1, 0, half_rotary)?;
+    let g2 = grad_rot.narrow(candle_core::D::Minus1, half_rotary, half_rotary)?;
+    let cos = cos.to_dtype(DType::F32)?.unsqueeze(0)?.unsqueeze(2)?;
+    let sin = sin.to_dtype(DType::F32)?.unsqueeze(0)?.unsqueeze(2)?;
+
+    let dx1 = (g1.broadcast_mul(&cos)? + g2.broadcast_mul(&sin)?)?;
+    let dx2 = (g2.broadcast_mul(&cos)? - g1.broadcast_mul(&sin)?)?;
+    let out = match grad_pass {
+        Some(pass) => Tensor::cat(&[&dx1, &dx2, &pass], candle_core::D::Minus1)?,
+        None => Tensor::cat(&[&dx1, &dx2], candle_core::D::Minus1)?,
+    };
+    Ok(out.to_dtype(grad_dtype)?)
+}
+
 /// SwiGLU feed-forward network.
 ///
 /// Computes: down_proj @ (silu(gate_proj @ x) * (up_proj @ x))
@@ -3829,10 +5099,6 @@ pub fn swiglu_ffn(
 }
 
 /// SwiGLU gate/up half used by exact training-time split backprop.
-///
-/// Returns `silu(gate_proj(x)) * up_proj(x)` without applying the down
-/// projection. This mirrors the unfused path inside [`swiglu_ffn`] so callers
-/// can backprop the large MLP block as two smaller exact subgraphs.
 pub fn swiglu_ffn_gated_hidden(
     x: &Tensor,
     mlp: &GpuFfnWeights,
@@ -3871,6 +5137,17 @@ pub fn swiglu_ffn_gated_hidden(
         if crate::backend::metal::metal_mlp_silu_mul_supports(&gate, &up) {
             return crate::backend::metal::metal_mlp_silu_mul_bf16(&gate, &up)
                 .context("metal mlp silu*mul kernel failed");
+        }
+    }
+    #[cfg(feature = "cuda")]
+    {
+        if !cuda_fused_mlp_silu_mul_disabled()
+            && !gate.track_op()
+            && !up.track_op()
+            && kiln_rmsnorm_kernel::supports_mlp_silu_mul(&gate, &up)
+        {
+            return kiln_rmsnorm_kernel::fused_mlp_silu_mul(&gate, &up)
+                .context("cuda fused mlp silu*mul kernel failed");
         }
     }
     let gate = cuda_silu(&gate)?;
@@ -3948,6 +5225,102 @@ fn swiglu_ffn_backend_profiled(
 }
 
 fn swiglu_ffn_impl(
+    backend: Option<&dyn BackendRuntime>,
+    x: &Tensor,
+    mlp: &GpuFfnWeights,
+    lora: Option<(&LoraLayerWeights, f32)>,
+    use_metal_decode_gemv: bool,
+    profile_context: Option<(usize, usize)>,
+) -> Result<Tensor> {
+    #[cfg(feature = "cuda")]
+    let (_, seq_len, _) = x.dims3()?;
+    #[cfg(feature = "cuda")]
+    {
+        let chunk_tokens = cuda_training_mlp_chunk_tokens();
+        if !cuda_training_mlp_chunking_disabled()
+            && chunk_tokens > 0
+            && seq_len > chunk_tokens
+            && (x.track_op() || lora.is_some())
+            && matches!(x.device(), Device::Cuda(_))
+        {
+            return swiglu_ffn_impl_chunked(
+                backend,
+                x,
+                mlp,
+                lora,
+                use_metal_decode_gemv,
+                profile_context,
+                chunk_tokens,
+            );
+        }
+    }
+
+    swiglu_ffn_impl_no_chunk(
+        backend,
+        x,
+        mlp,
+        lora,
+        use_metal_decode_gemv,
+        profile_context,
+    )
+}
+
+#[cfg(feature = "cuda")]
+fn cuda_training_mlp_chunking_disabled() -> bool {
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| env_truthy("KILN_DISABLE_CUDA_TRAINING_MLP_CHUNKING"))
+}
+
+#[cfg(feature = "cuda")]
+fn cuda_training_mlp_chunk_tokens() -> usize {
+    static CHUNK_TOKENS: OnceLock<usize> = OnceLock::new();
+    *CHUNK_TOKENS.get_or_init(|| {
+        std::env::var("KILN_CUDA_TRAINING_MLP_CHUNK_TOKENS")
+            .ok()
+            .and_then(|value| value.trim().parse::<usize>().ok())
+            .filter(|&value| value > 0)
+            .unwrap_or(1024)
+    })
+}
+
+#[cfg(feature = "cuda")]
+fn swiglu_ffn_impl_chunked(
+    backend: Option<&dyn BackendRuntime>,
+    x: &Tensor,
+    mlp: &GpuFfnWeights,
+    lora: Option<(&LoraLayerWeights, f32)>,
+    use_metal_decode_gemv: bool,
+    profile_context: Option<(usize, usize)>,
+    chunk_tokens: usize,
+) -> Result<Tensor> {
+    let (_, seq_len, _) = x.dims3()?;
+    let mut outputs = Vec::with_capacity(seq_len.div_ceil(chunk_tokens));
+    let mut start = 0usize;
+    while start < seq_len {
+        let len = (seq_len - start).min(chunk_tokens);
+        let x_chunk = x.narrow(1, start, len).with_context(|| {
+            format!(
+                "chunked CUDA training MLP input tile [{start}, {})",
+                start + len
+            )
+        })?;
+        let out = swiglu_ffn_impl_no_chunk(
+            backend,
+            &x_chunk,
+            mlp,
+            lora,
+            use_metal_decode_gemv,
+            profile_context,
+        )
+        .with_context(|| format!("chunked CUDA training MLP tile [{start}, {})", start + len))?;
+        outputs.push(out);
+        start += len;
+    }
+    let output_refs: Vec<&Tensor> = outputs.iter().collect();
+    Tensor::cat(&output_refs, 1).context("chunked CUDA training MLP cat")
+}
+
+fn swiglu_ffn_impl_no_chunk(
     backend: Option<&dyn BackendRuntime>,
     x: &Tensor,
     mlp: &GpuFfnWeights,
@@ -7439,8 +8812,554 @@ fn q_proj_forward_decode_if(
     )
 }
 
-/// Returns: [batch, seq_len, hidden_size]
-pub fn gqa_attention(
+#[cfg(feature = "cuda")]
+fn cuda_split_q_gate_training_disabled() -> bool {
+    static DISABLED: OnceLock<bool> = OnceLock::new();
+    *DISABLED.get_or_init(|| env_truthy("KILN_DISABLE_CUDA_SPLIT_Q_GATE_TRAINING"))
+}
+
+#[cfg(feature = "cuda")]
+#[allow(clippy::too_many_arguments)]
+fn cuda_split_q_gate_training_bf16(
+    backend: &dyn BackendRuntime,
+    use_metal_decode_gemv: bool,
+    x: &Tensor,
+    attn_weights: &GpuFullAttentionWeights,
+    lora: Option<&LoraProjectionWeights>,
+    lora_scale: f32,
+    seq_len: usize,
+    num_heads: usize,
+    head_dim: usize,
+) -> Result<Option<(Tensor, Tensor)>> {
+    if cuda_split_q_gate_training_disabled()
+        || !x.track_op()
+        || x.dtype() != DType::BF16
+        || !matches!(x.device(), Device::Cuda(_))
+        || attn_weights.q_proj_marlin.is_some()
+    {
+        return Ok(None);
+    }
+
+    let q_dim = num_heads * head_dim;
+    let Ok((_, q_out_dim)) = attn_weights.q_proj_t.dims2() else {
+        return Ok(None);
+    };
+    if q_out_dim != q_dim * 2 {
+        return Ok(None);
+    }
+
+    let q_weight_t = attn_weights.q_proj_t.narrow(1, 0, q_dim)?.contiguous()?;
+    let gate_weight_t = attn_weights
+        .q_proj_t
+        .narrow(1, q_dim, q_dim)?
+        .contiguous()?;
+
+    let mut q_lora = None;
+    let mut gate_lora = None;
+    if let Some(proj) = lora {
+        let Ok((b_out, _rank)) = proj.b.dims2() else {
+            return Ok(None);
+        };
+        if b_out != q_dim * 2 {
+            return Ok(None);
+        }
+        q_lora = Some(LoraProjectionWeights {
+            a: proj.a.clone(),
+            b: proj.b.narrow(0, 0, q_dim)?.contiguous()?,
+        });
+        gate_lora = Some(LoraProjectionWeights {
+            a: proj.a.clone(),
+            b: proj.b.narrow(0, q_dim, q_dim)?.contiguous()?,
+        });
+    }
+
+    let q_flat = linear_with_lora_t_backend_decode_if(
+        Some(backend),
+        use_metal_decode_gemv,
+        x,
+        &q_weight_t,
+        q_lora.as_ref(),
+        lora_scale,
+    )?;
+    let gate = linear_with_lora_t_backend_decode_if(
+        Some(backend),
+        use_metal_decode_gemv,
+        x,
+        &gate_weight_t,
+        gate_lora.as_ref(),
+        lora_scale,
+    )?;
+    let q = q_flat.reshape(((), seq_len, num_heads, head_dim))?;
+    let gate = gate.reshape(((), seq_len, q_dim))?;
+    Ok(Some((q, gate)))
+}
+
+pub struct GqaAttentionPrepared {
+    pub q: Tensor,
+    pub k: Tensor,
+    pub v: Tensor,
+    pub gate: Option<Tensor>,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gqa_attention_q_gate_prefill(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    attn_weights: &GpuFullAttentionWeights,
+    positions: &[u32],
+    num_heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+    inv_freq: &Tensor,
+    rms_norm_eps: f64,
+    attn_output_gate: bool,
+    lora: Option<(&LoraLayerWeights, f32)>,
+) -> Result<(Tensor, Option<Tensor>)> {
+    let (_batch, seq_len, _hidden) = x.dims3()?;
+    let use_metal_decode_gemv = false;
+    let (lora_layer, lora_scale) = match lora {
+        Some((l, s)) => (Some(l), s),
+        None => (None, 0.0),
+    };
+    let split_q_gate = {
+        #[cfg(feature = "cuda")]
+        {
+            if attn_output_gate {
+                cuda_split_q_gate_training_bf16(
+                    backend,
+                    use_metal_decode_gemv,
+                    x,
+                    attn_weights,
+                    lora_layer.and_then(|l| l.q_proj.as_ref()),
+                    lora_scale,
+                    seq_len,
+                    num_heads,
+                    head_dim,
+                )?
+            } else {
+                None
+            }
+        }
+        #[cfg(not(feature = "cuda"))]
+        {
+            None
+        }
+    };
+
+    let (q, gate) = if let Some((q, gate)) = split_q_gate {
+        (q, Some(gate))
+    } else {
+        let q_raw = q_proj_forward_decode_if(
+            Some(backend),
+            use_metal_decode_gemv,
+            x,
+            attn_weights,
+            lora_layer.and_then(|l| l.q_proj.as_ref()),
+            lora_scale,
+        )?;
+        if attn_output_gate {
+            let q_raw = q_raw.reshape(((), seq_len, num_heads, head_dim * 2))?;
+            let q = q_raw.narrow(3, 0, head_dim)?;
+            let gate = q_raw.narrow(3, head_dim, head_dim)?;
+            let gate = gate
+                .contiguous()?
+                .reshape(((), seq_len, num_heads * head_dim))?;
+            (q.contiguous()?, Some(gate))
+        } else {
+            (q_raw.reshape(((), seq_len, num_heads, head_dim))?, None)
+        }
+    };
+
+    let q = rms_norm(&q, &attn_weights.q_norm, rms_norm_eps)?;
+    let (q, _) = rotary_embedding(&q, &q, positions, head_dim, rotary_dim, inv_freq)?;
+    Ok((q, gate))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gqa_attention_kv_prefill(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    attn_weights: &GpuFullAttentionWeights,
+    positions: &[u32],
+    num_kv_heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+    inv_freq: &Tensor,
+    rms_norm_eps: f64,
+    lora: Option<(&LoraLayerWeights, f32)>,
+) -> Result<(Tensor, Tensor)> {
+    let (_batch, seq_len, _hidden) = x.dims3()?;
+    let (lora_layer, lora_scale) = match lora {
+        Some((l, s)) => (Some(l), s),
+        None => (None, 0.0),
+    };
+    let k = linear_with_lora_t_backend_decode_if(
+        Some(backend),
+        false,
+        x,
+        &attn_weights.k_proj_t,
+        lora_layer.and_then(|l| l.k_proj.as_ref()),
+        lora_scale,
+    )?
+    .reshape(((), seq_len, num_kv_heads, head_dim))?;
+    let v = linear_with_lora_t_backend_decode_if(
+        Some(backend),
+        false,
+        x,
+        &attn_weights.v_proj_t,
+        lora_layer.and_then(|l| l.v_proj.as_ref()),
+        lora_scale,
+    )?
+    .reshape(((), seq_len, num_kv_heads, head_dim))?;
+    let k = rms_norm(&k, &attn_weights.k_norm, rms_norm_eps)?;
+    let (k, _) = rotary_embedding(&k, &k, positions, head_dim, rotary_dim, inv_freq)?;
+    Ok((k, v))
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gqa_attention_prepare_prefill(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    attn_weights: &GpuFullAttentionWeights,
+    positions: &[u32],
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+    inv_freq: &Tensor,
+    rms_norm_eps: f64,
+    attn_output_gate: bool,
+    lora: Option<(&LoraLayerWeights, f32)>,
+) -> Result<GqaAttentionPrepared> {
+    let (_batch, seq_len, _hidden) = x.dims3()?;
+    let use_metal_decode_gemv = false;
+    let (lora_layer, lora_scale) = match lora {
+        Some((l, s)) => (Some(l), s),
+        None => (None, 0.0),
+    };
+    let split_q_gate = {
+        #[cfg(feature = "cuda")]
+        {
+            if attn_output_gate {
+                cuda_split_q_gate_training_bf16(
+                    backend,
+                    use_metal_decode_gemv,
+                    x,
+                    attn_weights,
+                    lora_layer.and_then(|l| l.q_proj.as_ref()),
+                    lora_scale,
+                    seq_len,
+                    num_heads,
+                    head_dim,
+                )?
+            } else {
+                None
+            }
+        }
+        #[cfg(not(feature = "cuda"))]
+        {
+            None
+        }
+    };
+
+    let (q_raw, k, v) = {
+        kiln_nvtx::range!(c"kiln/proj/qkv");
+        if split_q_gate.is_some() {
+            let k = linear_with_lora_t_backend_decode_if(
+                Some(backend),
+                use_metal_decode_gemv,
+                x,
+                &attn_weights.k_proj_t,
+                lora_layer.and_then(|l| l.k_proj.as_ref()),
+                lora_scale,
+            )?;
+            let v = linear_with_lora_t_backend_decode_if(
+                Some(backend),
+                use_metal_decode_gemv,
+                x,
+                &attn_weights.v_proj_t,
+                lora_layer.and_then(|l| l.v_proj.as_ref()),
+                lora_scale,
+            )?;
+            (None, k, v)
+        } else {
+            let (q_raw, k, v) = full_attn_qkv_proj_decode_if(
+                backend,
+                use_metal_decode_gemv,
+                x,
+                attn_weights,
+                lora_layer,
+                lora_scale,
+            )?;
+            (Some(q_raw), k, v)
+        }
+    };
+
+    let (q, gate) = if let Some((q, gate)) = split_q_gate {
+        (q, Some(gate))
+    } else if attn_output_gate {
+        let q_raw = q_raw
+            .as_ref()
+            .expect("q_raw is present when split_q_gate is inactive");
+        let q_raw = q_raw.reshape(((), seq_len, num_heads, head_dim * 2))?;
+        let q = q_raw.narrow(3, 0, head_dim)?;
+        let gate = q_raw.narrow(3, head_dim, head_dim)?;
+        let gate = gate
+            .contiguous()?
+            .reshape(((), seq_len, num_heads * head_dim))?;
+        (q.contiguous()?, Some(gate))
+    } else {
+        let q_raw = q_raw
+            .as_ref()
+            .expect("q_raw is present when attention output gate is disabled");
+        let q = q_raw.reshape(((), seq_len, num_heads, head_dim))?;
+        (q, None)
+    };
+
+    let k = k.reshape(((), seq_len, num_kv_heads, head_dim))?;
+    let v = v.reshape(((), seq_len, num_kv_heads, head_dim))?;
+    let q = rms_norm(&q, &attn_weights.q_norm, rms_norm_eps)?;
+    let k = rms_norm(&k, &attn_weights.k_norm, rms_norm_eps)?;
+    let (q, k) = rotary_embedding(&q, &k, positions, head_dim, rotary_dim, inv_freq)?;
+
+    Ok(GqaAttentionPrepared { q, k, v, gate })
+}
+
+pub fn gqa_attention_core_prefill(
+    backend: &dyn BackendRuntime,
+    prepared: &GqaAttentionPrepared,
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+) -> Result<Tensor> {
+    let (_batch, seq_len, _heads, _hd) = prepared.q.dims4()?;
+    if seq_len > 1 && backend.supports_flash_attn_prefill() {
+        let q = prepared.q.contiguous()?;
+        let k = prepared.k.contiguous()?;
+        let v = prepared.v.contiguous()?;
+        #[cfg(feature = "cuda")]
+        if let Some(attn_output) =
+            cuda_flash_attention_training_bf16(&q, &k, &v, num_heads, num_kv_heads, head_dim)?
+        {
+            return Ok(attn_output.reshape(((), seq_len, num_heads * head_dim))?);
+        }
+        if let Some(attn_output) =
+            flash_attention_forward(backend, &q, &k, &v, num_heads, num_kv_heads, head_dim)?
+        {
+            return Ok(attn_output);
+        }
+    }
+
+    let q = prepared.q.transpose(1, 2)?.contiguous()?;
+    let k = prepared.k.transpose(1, 2)?.contiguous()?;
+    let v = prepared.v.transpose(1, 2)?.contiguous()?;
+    let gqa_ratio = num_heads / num_kv_heads;
+    let batch = k.dim(0)?;
+    let (k, v) = if gqa_ratio > 1 {
+        let k = k
+            .unsqueeze(2)?
+            .expand(&[batch, num_kv_heads, gqa_ratio, seq_len, head_dim])?
+            .contiguous()?
+            .reshape((batch, num_heads, seq_len, head_dim))?;
+        let v = v
+            .unsqueeze(2)?
+            .expand(&[batch, num_kv_heads, gqa_ratio, seq_len, head_dim])?
+            .contiguous()?
+            .reshape((batch, num_heads, seq_len, head_dim))?;
+        (k, v)
+    } else {
+        (k.contiguous()?, v.contiguous()?)
+    };
+
+    let scale = (head_dim as f64).sqrt();
+    let attn_scores = q.broadcast_matmul(&k.t()?)?;
+    let attn_scores = (attn_scores / scale)?;
+    let attn_scores = apply_causal_mask_with_offset(&attn_scores, seq_len, seq_len, 0)?;
+    let attn_weights_softmax = cuda_softmax_last_dim(&attn_scores)?;
+    let attn_output = attn_weights_softmax.broadcast_matmul(&v)?;
+    Ok(attn_output
+        .transpose(1, 2)?
+        .contiguous()?
+        .reshape(((), seq_len, num_heads * head_dim))?)
+}
+
+pub fn gqa_attention_apply_output_gate(
+    attn_output: Tensor,
+    gate: Option<&Tensor>,
+) -> Result<Tensor> {
+    attention_output_gate_decode_if(false, attn_output, gate)
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn gqa_attention_pre_o_chunked_prefill(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    attn_weights: &GpuFullAttentionWeights,
+    positions: &[u32],
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+    inv_freq: &Tensor,
+    rms_norm_eps: f64,
+    attn_output_gate: bool,
+    lora: Option<(&LoraLayerWeights, f32)>,
+    tile_size: usize,
+) -> Result<Tensor> {
+    let (_batch, seq_len, _hidden) = x.dims3()?;
+    if tile_size == 0 || tile_size >= seq_len {
+        return gqa_attention_pre_o(
+            backend,
+            x,
+            attn_weights,
+            positions,
+            num_heads,
+            num_kv_heads,
+            head_dim,
+            rotary_dim,
+            inv_freq,
+            rms_norm_eps,
+            None,
+            0,
+            attn_output_gate,
+            lora,
+        );
+    }
+
+    let (lora_layer, lora_scale) = match lora {
+        Some((l, s)) => (Some(l), s),
+        None => (None, 0.0),
+    };
+
+    let k = linear_with_lora_t_backend_decode_if(
+        Some(backend),
+        false,
+        x,
+        &attn_weights.k_proj_t,
+        lora_layer.and_then(|l| l.k_proj.as_ref()),
+        lora_scale,
+    )
+    .context("chunked full-attention pre-o k projection")?
+    .reshape(((), seq_len, num_kv_heads, head_dim))
+    .context("chunked full-attention pre-o k reshape")?;
+    let v = linear_with_lora_t_backend_decode_if(
+        Some(backend),
+        false,
+        x,
+        &attn_weights.v_proj_t,
+        lora_layer.and_then(|l| l.v_proj.as_ref()),
+        lora_scale,
+    )
+    .context("chunked full-attention pre-o v projection")?
+    .reshape(((), seq_len, num_kv_heads, head_dim))
+    .context("chunked full-attention pre-o v reshape")?;
+    let k = rms_norm(&k, &attn_weights.k_norm, rms_norm_eps)
+        .context("chunked full-attention pre-o k norm")?;
+    let (k, _) = rotary_embedding(&k, &k, positions, head_dim, rotary_dim, inv_freq)
+        .context("chunked full-attention pre-o k rotary")?;
+
+    let mut output_tiles = Vec::with_capacity(seq_len.div_ceil(tile_size));
+    let mut tile_start = 0usize;
+    while tile_start < seq_len {
+        let tile_len = (seq_len - tile_start).min(tile_size);
+        let tile_end = tile_start + tile_len;
+
+        let x_tile = x.narrow(1, tile_start, tile_len).with_context(|| {
+            format!("chunked full-attention pre-o input tile [{tile_start}, {tile_end})")
+        })?;
+        let q_raw = q_proj_forward_decode_if(
+            Some(backend),
+            false,
+            &x_tile,
+            attn_weights,
+            lora_layer.and_then(|l| l.q_proj.as_ref()),
+            lora_scale,
+        )
+        .with_context(|| {
+            format!("chunked full-attention pre-o q projection [{tile_start}, {tile_end})")
+        })?;
+        let (q_tile, gate_tile) = if attn_output_gate {
+            let q_raw = q_raw
+                .reshape(((), tile_len, num_heads, head_dim * 2))
+                .with_context(|| {
+                    format!(
+                        "chunked full-attention pre-o q/gate reshape [{tile_start}, {tile_end})"
+                    )
+                })?;
+            let q = q_raw
+                .narrow(3, 0, head_dim)
+                .with_context(|| {
+                    format!("chunked full-attention pre-o q split [{tile_start}, {tile_end})")
+                })?
+                .contiguous()
+                .context("chunked full-attention pre-o q contiguous")?;
+            let gate = q_raw
+                .narrow(3, head_dim, head_dim)
+                .with_context(|| {
+                    format!("chunked full-attention pre-o gate split [{tile_start}, {tile_end})")
+                })?
+                .contiguous()
+                .context("chunked full-attention pre-o gate contiguous")?
+                .reshape(((), tile_len, num_heads * head_dim))
+                .context("chunked full-attention pre-o gate reshape")?;
+            (q, Some(gate))
+        } else {
+            (
+                q_raw
+                    .reshape(((), tile_len, num_heads, head_dim))
+                    .with_context(|| {
+                        format!("chunked full-attention pre-o q reshape [{tile_start}, {tile_end})")
+                    })?,
+                None,
+            )
+        };
+        let q_tile = rms_norm(&q_tile, &attn_weights.q_norm, rms_norm_eps)
+            .context("chunked full-attention pre-o q norm")?;
+        let tile_positions = &positions[tile_start..tile_end];
+        let (q_tile, _) = rotary_embedding(
+            &q_tile,
+            &q_tile,
+            tile_positions,
+            head_dim,
+            rotary_dim,
+            inv_freq,
+        )
+        .with_context(|| {
+            format!("chunked full-attention pre-o q rotary [{tile_start}, {tile_end})")
+        })?;
+        let k_prefix = k.narrow(1, 0, tile_end).with_context(|| {
+            format!("chunked full-attention pre-o k prefix [0, {tile_end}) for tile {tile_start}")
+        })?;
+        let v_prefix = v.narrow(1, 0, tile_end).with_context(|| {
+            format!("chunked full-attention pre-o v prefix [0, {tile_end}) for tile {tile_start}")
+        })?;
+        let tile_prepared = GqaAttentionPrepared {
+            q: q_tile,
+            k: k_prefix,
+            v: v_prefix,
+            gate: None,
+        };
+        let attn_core =
+            gqa_attention_core_prefill(backend, &tile_prepared, num_heads, num_kv_heads, head_dim)
+                .with_context(|| {
+                    format!("chunked full-attention pre-o core tile [{tile_start}, {tile_end})")
+                })?;
+        let attn_output = gqa_attention_apply_output_gate(attn_core, gate_tile.as_ref())
+            .with_context(|| {
+                format!("chunked full-attention pre-o gate tile [{tile_start}, {tile_end})")
+            })?;
+        output_tiles.push(attn_output);
+
+        tile_start = tile_end;
+    }
+
+    let output_refs: Vec<&Tensor> = output_tiles.iter().collect();
+    Tensor::cat(&output_refs, 1).context("chunked full-attention pre-o cat")
+}
+
+/// Returns the gated attention value before the final output projection:
+/// [batch, seq_len, num_heads * head_dim].
+pub fn gqa_attention_pre_o(
     backend: &dyn BackendRuntime,
     x: &Tensor,
     attn_weights: &GpuFullAttentionWeights,
@@ -7474,6 +9393,31 @@ pub fn gqa_attention(
         Some((l, s)) => (Some(l), s),
         None => (None, 0.0),
     };
+    let split_q_gate = {
+        #[cfg(feature = "cuda")]
+        {
+            if attn_output_gate {
+                cuda_split_q_gate_training_bf16(
+                    backend,
+                    use_metal_decode_gemv,
+                    x,
+                    attn_weights,
+                    lora_layer.and_then(|l| l.q_proj.as_ref()),
+                    lora_scale,
+                    seq_len,
+                    num_heads,
+                    head_dim,
+                )?
+            } else {
+                None
+            }
+        }
+        #[cfg(not(feature = "cuda"))]
+        {
+            None
+        }
+    };
+
     let (q_raw, k, v) = {
         let stage_profile = start_named_full_attn_stage_profile(
             profile_device,
@@ -7482,14 +9426,35 @@ pub fn gqa_attention(
             seq_len,
         )?;
         kiln_nvtx::range!(c"kiln/proj/qkv");
-        let out = full_attn_qkv_proj_decode_if(
-            backend,
-            use_metal_decode_gemv,
-            x,
-            attn_weights,
-            lora_layer,
-            lora_scale,
-        )?;
+        let out = if split_q_gate.is_some() {
+            let k = linear_with_lora_t_backend_decode_if(
+                Some(backend),
+                use_metal_decode_gemv,
+                x,
+                &attn_weights.k_proj_t,
+                lora_layer.and_then(|l| l.k_proj.as_ref()),
+                lora_scale,
+            )?;
+            let v = linear_with_lora_t_backend_decode_if(
+                Some(backend),
+                use_metal_decode_gemv,
+                x,
+                &attn_weights.v_proj_t,
+                lora_layer.and_then(|l| l.v_proj.as_ref()),
+                lora_scale,
+            )?;
+            (None, k, v)
+        } else {
+            let (q_raw, k, v) = full_attn_qkv_proj_decode_if(
+                backend,
+                use_metal_decode_gemv,
+                x,
+                attn_weights,
+                lora_layer,
+                lora_scale,
+            )?;
+            (Some(q_raw), k, v)
+        };
         finish_full_attn_stage_profile(
             profile_device,
             profile_context,
@@ -7501,36 +9466,28 @@ pub fn gqa_attention(
     };
 
     // Split Q and gate if output gate is enabled
-    let (q, gate) = {
-        let stage_profile = start_named_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "q_split",
-            seq_len,
-        )?;
-        let out = if attn_output_gate {
-            // q_raw: [batch, seq_len, num_heads * head_dim * 2]
-            // Reshape to [batch, seq_len, num_heads, head_dim * 2] then split
-            let q_raw = q_raw.reshape(((), seq_len, num_heads, head_dim * 2))?;
-            let q = q_raw.narrow(3, 0, head_dim)?;
-            let gate = q_raw.narrow(3, head_dim, head_dim)?;
-            // gate needs to be [batch, seq_len, num_heads * head_dim] for later
-            let gate = gate
-                .contiguous()?
-                .reshape(((), seq_len, num_heads * head_dim))?;
-            (q.contiguous()?, Some(gate))
-        } else {
-            let q = q_raw.reshape(((), seq_len, num_heads, head_dim))?;
-            (q, None)
-        };
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "q_split",
-            seq_len,
-            stage_profile,
-        )?;
-        out
+    let (q, gate) = if let Some((q, gate)) = split_q_gate {
+        (q, Some(gate))
+    } else if attn_output_gate {
+        let q_raw = q_raw
+            .as_ref()
+            .expect("q_raw is present when split_q_gate is inactive");
+        // q_raw: [batch, seq_len, num_heads * head_dim * 2]
+        // Reshape to [batch, seq_len, num_heads, head_dim * 2] then split
+        let q_raw = q_raw.reshape(((), seq_len, num_heads, head_dim * 2))?;
+        let q = q_raw.narrow(3, 0, head_dim)?;
+        let gate = q_raw.narrow(3, head_dim, head_dim)?;
+        // gate needs to be [batch, seq_len, num_heads * head_dim] for later
+        let gate = gate
+            .contiguous()?
+            .reshape(((), seq_len, num_heads * head_dim))?;
+        (q.contiguous()?, Some(gate))
+    } else {
+        let q_raw = q_raw
+            .as_ref()
+            .expect("q_raw is present when attention output gate is disabled");
+        let q = q_raw.reshape(((), seq_len, num_heads, head_dim))?;
+        (q, None)
     };
 
     // Reshape K, V to [batch, seq_len, num_heads, head_dim]
@@ -7601,78 +9558,22 @@ pub fn gqa_attention(
     // Backend declines (returns None) on dtype mismatch so non-BF16 configs
     // (e.g. tests on F32) transparently fall back to naive softmax+matmul.
     if seq_len > 1 && kv_cache.is_none() && backend.supports_flash_attn_prefill() {
-        let (q, k, v) = {
-            let stage_profile = start_named_full_attn_stage_profile(
-                profile_device,
-                profile_context,
-                "prefill_qkv_layout",
-                seq_len,
-            )?;
-            let out = (q.contiguous()?, k.contiguous()?, v.contiguous()?);
-            finish_full_attn_stage_profile(
-                profile_device,
-                profile_context,
-                "prefill_qkv_layout",
-                seq_len,
-                stage_profile,
-            )?;
-            out
-        };
-        let stage_profile = start_named_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "prefill_attn",
-            seq_len,
-        )?;
-        let attn_output =
-            flash_attention_forward(backend, &q, &k, &v, num_heads, num_kv_heads, head_dim)?;
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "prefill_attn",
-            seq_len,
-            stage_profile,
-        )?;
-        if let Some(attn_output) = attn_output {
-            let stage_profile = start_named_full_attn_stage_profile(
-                profile_device,
-                profile_context,
-                "attn_gate",
-                seq_len,
-            )?;
+        let q = q.contiguous()?;
+        let k = k.contiguous()?;
+        let v = v.contiguous()?;
+        #[cfg(feature = "cuda")]
+        if let Some(attn_output) =
+            cuda_flash_attention_training_bf16(&q, &k, &v, num_heads, num_kv_heads, head_dim)?
+        {
+            let attn_output = attn_output.reshape(((), seq_len, num_heads * head_dim))?;
             let attn_output = attention_output_gate_decode_if(false, attn_output, gate.as_ref())?;
-            finish_full_attn_stage_profile(
-                profile_device,
-                profile_context,
-                "attn_gate",
-                seq_len,
-                stage_profile,
-            )?;
-            let stage_profile = start_named_full_attn_stage_profile(
-                profile_device,
-                profile_context,
-                "o_proj",
-                seq_len,
-            )?;
-            let out = {
-                kiln_nvtx::range!(c"kiln/proj/o");
-                linear_with_lora_t_backend_decode_if(
-                    Some(backend),
-                    false,
-                    &attn_output,
-                    &attn_weights.o_proj_t,
-                    lora_layer.and_then(|l| l.o_proj.as_ref()),
-                    lora_scale,
-                )?
-            };
-            finish_full_attn_stage_profile(
-                profile_device,
-                profile_context,
-                "o_proj",
-                seq_len,
-                stage_profile,
-            )?;
-            return Ok(out);
+            return Ok(attn_output);
+        }
+        if let Some(attn_output) =
+            flash_attention_forward(backend, &q, &k, &v, num_heads, num_kv_heads, head_dim)?
+        {
+            let attn_output = attention_output_gate_decode_if(false, attn_output, gate.as_ref())?;
+            return Ok(attn_output);
         }
     }
 
@@ -7858,52 +9759,77 @@ pub fn gqa_attention(
         out
     };
 
-    let attn_output = {
-        let stage_profile = start_named_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "attn_gate",
-            seq_len,
-        )?;
-        let out =
-            attention_output_gate_decode_if(use_metal_decode_gemv, attn_output, gate.as_ref())?;
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "attn_gate",
-            seq_len,
-            stage_profile,
-        )?;
-        out
-    };
+    let attn_output =
+        attention_output_gate_decode_if(use_metal_decode_gemv, attn_output, gate.as_ref())?;
+    Ok(attn_output)
+}
 
-    // Output projection
-    let out = {
-        let stage_profile = start_named_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "o_proj",
-            seq_len,
-        )?;
-        kiln_nvtx::range!(c"kiln/proj/o");
-        let out = linear_with_lora_t_backend_decode_if(
-            Some(backend),
-            use_metal_decode_gemv,
-            &attn_output,
-            &attn_weights.o_proj_t,
-            lora_layer.and_then(|l| l.o_proj.as_ref()),
-            lora_scale,
-        )?;
-        finish_full_attn_stage_profile(
-            profile_device,
-            profile_context,
-            "o_proj",
-            seq_len,
-            stage_profile,
-        )?;
-        out
+pub fn gqa_attention_output_projection(
+    backend: &dyn BackendRuntime,
+    attn_output: &Tensor,
+    attn_weights: &GpuFullAttentionWeights,
+    use_metal_decode_gemv: bool,
+    lora: Option<(&LoraLayerWeights, f32)>,
+) -> Result<Tensor> {
+    let (lora_layer, lora_scale) = match lora {
+        Some((l, s)) => (Some(l), s),
+        None => (None, 0.0),
     };
-    Ok(out)
+    kiln_nvtx::range!(c"kiln/proj/o");
+    linear_with_lora_t_backend_decode_if(
+        Some(backend),
+        use_metal_decode_gemv,
+        attn_output,
+        &attn_weights.o_proj_t,
+        lora_layer.and_then(|l| l.o_proj.as_ref()),
+        lora_scale,
+    )
+}
+
+/// Returns: [batch, seq_len, hidden_size]
+pub fn gqa_attention(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    attn_weights: &GpuFullAttentionWeights,
+    positions: &[u32],
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+    inv_freq: &Tensor,
+    rms_norm_eps: f64,
+    kv_cache: Option<&mut KvCache>,
+    full_attn_layer_idx: usize,
+    attn_output_gate: bool,
+    lora: Option<(&LoraLayerWeights, f32)>,
+) -> Result<Tensor> {
+    let (_batch, seq_len, _hidden) = x.dims3()?;
+    let use_metal_decode_gemv = seq_len == 1
+        && kv_cache.is_some()
+        && !crate::mtp_debug::is_mtp_single_token_self_attn_armed();
+    let attn_output = gqa_attention_pre_o(
+        backend,
+        x,
+        attn_weights,
+        positions,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        inv_freq,
+        rms_norm_eps,
+        kv_cache,
+        full_attn_layer_idx,
+        attn_output_gate,
+        lora,
+    )?;
+    gqa_attention_output_projection(
+        backend,
+        &attn_output,
+        attn_weights,
+        use_metal_decode_gemv,
+        lora,
+    )
 }
 
 #[cfg(feature = "cuda")]
@@ -9999,6 +11925,25 @@ pub fn transformer_block(
         && kv_cache.is_some()
         && !crate::mtp_debug::is_mtp_single_token_self_attn_armed();
 
+    if let Some(out) = transformer_block_detached_cuda_prefill_chunked(
+        backend,
+        x,
+        layer,
+        config,
+        positions,
+        num_heads,
+        num_kv_heads,
+        head_dim,
+        rotary_dim,
+        inv_freq,
+        rms_norm_eps,
+        kv_cache.is_some(),
+        full_attn_layer_idx,
+        lora,
+    )? {
+        return Ok(out);
+    }
+
     // Pre-attention norm
     let normed = {
         kiln_nvtx::range!(c"kiln/norm/pre_attn");
@@ -10048,6 +11993,203 @@ pub fn transformer_block(
         (x + ffn_out)?
     };
     Ok(out)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn transformer_block_detached_cuda_prefill_chunked(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    layer: &GpuLayerWeights,
+    config: &kiln_core::config::ModelConfig,
+    positions: &[u32],
+    num_heads: usize,
+    num_kv_heads: usize,
+    head_dim: usize,
+    rotary_dim: usize,
+    inv_freq: &Tensor,
+    rms_norm_eps: f64,
+    has_kv_cache: bool,
+    full_attn_layer_idx: usize,
+    lora: Option<(&LoraLayerWeights, f32)>,
+) -> Result<Option<Tensor>> {
+    if backend.name() != "cuda" || has_kv_cache || x.track_op() {
+        return Ok(None);
+    }
+    let (_batch, seq_len, _hidden) = x.dims3()?;
+    if !streaming_prefill_enabled_for(x.device(), seq_len) {
+        return Ok(None);
+    }
+    let tile_size = streaming_tile_tokens_for(x.device());
+    if tile_size == 0 || tile_size >= seq_len {
+        return Ok(None);
+    }
+
+    let GpuAttentionWeights::Full(attn_weights) = &layer.attention else {
+        return Ok(None);
+    };
+
+    tracing::info!(
+        layer = full_attn_layer_idx,
+        seq_len,
+        tile_size,
+        "detached CUDA full-attention prefill chunked"
+    );
+
+    let normed = {
+        kiln_nvtx::range!(c"kiln/norm/pre_attn_chunked");
+        rms_norm(x, &layer.input_layernorm, rms_norm_eps)?
+    };
+    let (lora_layer, lora_scale) = match lora {
+        Some((l, s)) => (Some(l), s),
+        None => (None, 0.0),
+    };
+    let k = linear_with_lora_t_backend_decode_if(
+        Some(backend),
+        false,
+        &normed,
+        &attn_weights.k_proj_t,
+        lora_layer.and_then(|l| l.k_proj.as_ref()),
+        lora_scale,
+    )
+    .context("chunked full-attention k projection")?
+    .reshape(((), seq_len, num_kv_heads, head_dim))
+    .context("chunked full-attention k reshape")?;
+    let v = linear_with_lora_t_backend_decode_if(
+        Some(backend),
+        false,
+        &normed,
+        &attn_weights.v_proj_t,
+        lora_layer.and_then(|l| l.v_proj.as_ref()),
+        lora_scale,
+    )
+    .context("chunked full-attention v projection")?
+    .reshape(((), seq_len, num_kv_heads, head_dim))
+    .context("chunked full-attention v reshape")?;
+    let k = rms_norm(&k, &attn_weights.k_norm, rms_norm_eps)
+        .context("chunked full-attention k norm")?;
+    let (k, _) = rotary_embedding(&k, &k, positions, head_dim, rotary_dim, inv_freq)
+        .context("chunked full-attention k rotary")?;
+
+    let mut output_tiles = Vec::with_capacity(seq_len.div_ceil(tile_size));
+    let mut tile_start = 0usize;
+    while tile_start < seq_len {
+        let tile_len = (seq_len - tile_start).min(tile_size);
+        let tile_end = tile_start + tile_len;
+
+        let normed_tile = normed.narrow(1, tile_start, tile_len).with_context(|| {
+            format!("chunked full-attention normed tile [{tile_start}, {tile_end})")
+        })?;
+        let q_raw = q_proj_forward_decode_if(
+            Some(backend),
+            false,
+            &normed_tile,
+            attn_weights,
+            lora_layer.and_then(|l| l.q_proj.as_ref()),
+            lora_scale,
+        )
+        .with_context(|| {
+            format!("chunked full-attention q projection [{tile_start}, {tile_end})")
+        })?;
+        let (q_tile, gate_tile) = if config.attn_output_gate {
+            let q_raw = q_raw
+                .reshape(((), tile_len, num_heads, head_dim * 2))
+                .with_context(|| {
+                    format!("chunked full-attention q/gate reshape [{tile_start}, {tile_end})")
+                })?;
+            let q = q_raw
+                .narrow(3, 0, head_dim)
+                .with_context(|| {
+                    format!("chunked full-attention q split [{tile_start}, {tile_end})")
+                })?
+                .contiguous()
+                .context("chunked full-attention q contiguous")?;
+            let gate = q_raw
+                .narrow(3, head_dim, head_dim)
+                .with_context(|| {
+                    format!("chunked full-attention gate split [{tile_start}, {tile_end})")
+                })?
+                .contiguous()
+                .context("chunked full-attention gate contiguous")?
+                .reshape(((), tile_len, num_heads * head_dim))
+                .context("chunked full-attention gate reshape")?;
+            (q, Some(gate))
+        } else {
+            (
+                q_raw
+                    .reshape(((), tile_len, num_heads, head_dim))
+                    .with_context(|| {
+                        format!("chunked full-attention q reshape [{tile_start}, {tile_end})")
+                    })?,
+                None,
+            )
+        };
+        let q_tile = rms_norm(&q_tile, &attn_weights.q_norm, rms_norm_eps)
+            .context("chunked full-attention q norm")?;
+        let tile_positions = &positions[tile_start..tile_end];
+        let (q_tile, _) = rotary_embedding(
+            &q_tile,
+            &q_tile,
+            tile_positions,
+            head_dim,
+            rotary_dim,
+            inv_freq,
+        )
+        .with_context(|| format!("chunked full-attention q rotary [{tile_start}, {tile_end})"))?;
+        let k_prefix = k.narrow(1, 0, tile_end).with_context(|| {
+            format!("chunked full-attention k prefix [0, {tile_end}) for tile {tile_start}")
+        })?;
+        let v_prefix = v.narrow(1, 0, tile_end).with_context(|| {
+            format!("chunked full-attention v prefix [0, {tile_end}) for tile {tile_start}")
+        })?;
+        let tile_prepared = GqaAttentionPrepared {
+            q: q_tile,
+            k: k_prefix,
+            v: v_prefix,
+            gate: None,
+        };
+
+        let attn_core =
+            gqa_attention_core_prefill(backend, &tile_prepared, num_heads, num_kv_heads, head_dim)
+                .with_context(|| {
+                    format!("chunked full-attention core tile [{tile_start}, {tile_end})")
+                })?;
+        let attn_output = gqa_attention_apply_output_gate(attn_core, gate_tile.as_ref())
+            .with_context(|| {
+                format!("chunked full-attention gate tile [{tile_start}, {tile_end})")
+            })?;
+        let attn_out =
+            gqa_attention_output_projection(backend, &attn_output, attn_weights, false, lora)
+                .with_context(|| {
+                    format!("chunked full-attention o-proj tile [{tile_start}, {tile_end})")
+                })?;
+        let x_tile = x.narrow(1, tile_start, tile_len).with_context(|| {
+            format!("chunked full-attention residual tile [{tile_start}, {tile_end})")
+        })?;
+        let residual = (&x_tile + attn_out).with_context(|| {
+            format!("chunked full-attention attention residual tile [{tile_start}, {tile_end})")
+        })?;
+        let normed_post = rms_norm(&residual, &layer.post_attention_layernorm, rms_norm_eps)
+            .with_context(|| {
+                format!("chunked full-attention post norm tile [{tile_start}, {tile_end})")
+            })?;
+        let ffn_out = swiglu_ffn(&normed_post, &layer.mlp, lora).with_context(|| {
+            format!("chunked full-attention MLP tile [{tile_start}, {tile_end})")
+        })?;
+        let out_tile = (residual + ffn_out)
+            .with_context(|| {
+                format!("chunked full-attention output tile [{tile_start}, {tile_end})")
+            })?
+            .detach();
+        output_tiles.push(out_tile);
+
+        tile_start = tile_end;
+    }
+
+    let output_refs: Vec<&Tensor> = output_tiles.iter().collect();
+    let output = Tensor::cat(&output_refs, 1)
+        .context("chunked full-attention output cat")?
+        .detach();
+    Ok(Some(output))
 }
 
 /// Transformer block using paged KV cache.

--- a/crates/kiln-model/src/lib.rs
+++ b/crates/kiln-model/src/lib.rs
@@ -2,9 +2,9 @@ pub mod adapter_merge;
 pub mod backend;
 pub mod c1_attr;
 pub mod cancel;
+pub mod cuda_graph;
 #[cfg(feature = "cuda")]
 pub mod cuda_train;
-pub mod cuda_graph;
 pub mod decode_buffers;
 pub mod engine;
 pub mod forward;

--- a/crates/kiln-model/src/vk_forward.rs
+++ b/crates/kiln-model/src/vk_forward.rs
@@ -21,10 +21,10 @@
 
 #![cfg(feature = "vulkan")]
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use candle_core::{DType, Device, Tensor, TensorId, Var};
 use kiln_core::config::ModelConfig;
-use kiln_vulkan_kernel::vk_autograd::{vk_backward, VkGradStore};
+use kiln_vulkan_kernel::vk_autograd::{VkGradStore, vk_backward};
 use kiln_vulkan_kernel::vk_ops::attention::{
     vk_flash_sdpa_decode_split_flat_no_grad, vk_flash_sdpa_prefill_flat,
 };

--- a/crates/kiln-rmsnorm-kernel/csrc/fused_rotary_qk.cu
+++ b/crates/kiln-rmsnorm-kernel/csrc/fused_rotary_qk.cu
@@ -55,6 +55,80 @@ __global__ void fused_rotary_qk_kernel(
     out[local] = __float2bfloat16(y);
 }
 
+__global__ void fused_rotary_one_kernel(
+    const __nv_bfloat16 *__restrict__ x,
+    const float *__restrict__ cos,
+    const float *__restrict__ sin,
+    __nv_bfloat16 *__restrict__ out,
+    size_t elems,
+    int seq_len,
+    int heads,
+    int head_dim,
+    int rotary_dim
+) {
+    const size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= elems) return;
+
+    const int d = static_cast<int>(idx % head_dim);
+    const size_t row = idx / head_dim;
+    const int t = static_cast<int>((row / heads) % seq_len);
+
+    float y;
+    if (d < rotary_dim) {
+        const int half = rotary_dim / 2;
+        const bool first_half = d < half;
+        const int pair_d = first_half ? d + half : d - half;
+        const int table_d = first_half ? d : pair_d;
+        const float c = cos[static_cast<size_t>(t) * half + table_d];
+        const float s = sin[static_cast<size_t>(t) * half + table_d];
+        const size_t base = row * head_dim;
+        const float xv = __bfloat162float(x[base + d]);
+        const float pair = __bfloat162float(x[base + pair_d]);
+        y = first_half ? (xv * c - pair * s) : (pair * s + xv * c);
+    } else {
+        y = __bfloat162float(x[idx]);
+    }
+
+    out[idx] = __float2bfloat16(y);
+}
+
+__global__ void fused_rotary_one_bwd_kernel(
+    const __nv_bfloat16 *__restrict__ grad_y,
+    const float *__restrict__ cos,
+    const float *__restrict__ sin,
+    __nv_bfloat16 *__restrict__ grad_x,
+    size_t elems,
+    int seq_len,
+    int heads,
+    int head_dim,
+    int rotary_dim
+) {
+    const size_t idx = static_cast<size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    if (idx >= elems) return;
+
+    const int d = static_cast<int>(idx % head_dim);
+    const size_t row = idx / head_dim;
+    const int t = static_cast<int>((row / heads) % seq_len);
+
+    float y;
+    if (d < rotary_dim) {
+        const int half = rotary_dim / 2;
+        const bool first_half = d < half;
+        const int pair_d = first_half ? d + half : d - half;
+        const int table_d = first_half ? d : pair_d;
+        const float c = cos[static_cast<size_t>(t) * half + table_d];
+        const float s = sin[static_cast<size_t>(t) * half + table_d];
+        const size_t base = row * head_dim;
+        const float gv = __bfloat162float(grad_y[base + d]);
+        const float pair = __bfloat162float(grad_y[base + pair_d]);
+        y = first_half ? (gv * c + pair * s) : (gv * c - pair * s);
+    } else {
+        y = __bfloat162float(grad_y[idx]);
+    }
+
+    grad_x[idx] = __float2bfloat16(y);
+}
+
 }  // namespace
 
 extern "C" int32_t kiln_fused_rotary_qk(
@@ -93,6 +167,76 @@ extern "C" int32_t kiln_fused_rotary_qk(
         seq_len,
         q_heads,
         k_heads,
+        head_dim,
+        rotary_dim);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) return static_cast<int32_t>(err);
+    return 0;
+}
+
+extern "C" int32_t kiln_fused_rotary_one(
+    const void *x,
+    const float *cos,
+    const float *sin,
+    void *out,
+    int32_t batch,
+    int32_t seq_len,
+    int32_t heads,
+    int32_t head_dim,
+    int32_t rotary_dim,
+    void *stream
+) {
+    if (batch <= 0 || seq_len <= 0 || heads <= 0) return -1;
+    if (head_dim <= 0 || rotary_dim <= 0 || rotary_dim > head_dim || (rotary_dim & 1)) return -2;
+
+    const size_t elems = static_cast<size_t>(batch) * seq_len * heads * head_dim;
+    const int blocks = static_cast<int>((elems + kThreadsPerBlock - 1) / kThreadsPerBlock);
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+
+    fused_rotary_one_kernel<<<blocks, kThreadsPerBlock, 0, s>>>(
+        reinterpret_cast<const __nv_bfloat16 *>(x),
+        cos,
+        sin,
+        reinterpret_cast<__nv_bfloat16 *>(out),
+        elems,
+        seq_len,
+        heads,
+        head_dim,
+        rotary_dim);
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) return static_cast<int32_t>(err);
+    return 0;
+}
+
+extern "C" int32_t kiln_fused_rotary_one_bwd(
+    const void *grad_y,
+    const float *cos,
+    const float *sin,
+    void *grad_x,
+    int32_t batch,
+    int32_t seq_len,
+    int32_t heads,
+    int32_t head_dim,
+    int32_t rotary_dim,
+    void *stream
+) {
+    if (batch <= 0 || seq_len <= 0 || heads <= 0) return -1;
+    if (head_dim <= 0 || rotary_dim <= 0 || rotary_dim > head_dim || (rotary_dim & 1)) return -2;
+
+    const size_t elems = static_cast<size_t>(batch) * seq_len * heads * head_dim;
+    const int blocks = static_cast<int>((elems + kThreadsPerBlock - 1) / kThreadsPerBlock);
+    cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+
+    fused_rotary_one_bwd_kernel<<<blocks, kThreadsPerBlock, 0, s>>>(
+        reinterpret_cast<const __nv_bfloat16 *>(grad_y),
+        cos,
+        sin,
+        reinterpret_cast<__nv_bfloat16 *>(grad_x),
+        elems,
+        seq_len,
+        heads,
         head_dim,
         rotary_dim);
 

--- a/crates/kiln-rmsnorm-kernel/csrc/fused_rotary_qk.h
+++ b/crates/kiln-rmsnorm-kernel/csrc/fused_rotary_qk.h
@@ -32,6 +32,30 @@ int32_t kiln_fused_rotary_qk(
     int32_t rotary_dim,
     void *stream);
 
+int32_t kiln_fused_rotary_one(
+    const void *x,
+    const float *cos,
+    const float *sin,
+    void *out,
+    int32_t batch,
+    int32_t seq_len,
+    int32_t heads,
+    int32_t head_dim,
+    int32_t rotary_dim,
+    void *stream);
+
+int32_t kiln_fused_rotary_one_bwd(
+    const void *grad_y,
+    const float *cos,
+    const float *sin,
+    void *grad_x,
+    int32_t batch,
+    int32_t seq_len,
+    int32_t heads,
+    int32_t head_dim,
+    int32_t rotary_dim,
+    void *stream);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crates/kiln-rmsnorm-kernel/src/lib.rs
+++ b/crates/kiln-rmsnorm-kernel/src/lib.rs
@@ -74,8 +74,8 @@
 //! ([`fused_rmsnorm_backward`]); the QK-norm kernels remain forward-only.
 
 use candle_core::{
-    backend::BackendStorage, cuda_backend::cudarc::driver::DevicePtr, CpuStorage, CudaStorage,
-    DType, Device, Layout, Result, Shape, Tensor,
+    CpuStorage, CudaStorage, DType, Device, Layout, Result, Shape, Tensor, backend::BackendStorage,
+    cuda_backend::cudarc::driver::DevicePtr,
 };
 use half::bf16;
 use std::sync::OnceLock;
@@ -147,6 +147,32 @@ unsafe extern "C" {
         seq_len: i32,
         q_heads: i32,
         k_heads: i32,
+        head_dim: i32,
+        rotary_dim: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
+    fn kiln_fused_rotary_one(
+        x: *const core::ffi::c_void,
+        cos: *const f32,
+        sin: *const f32,
+        out: *mut core::ffi::c_void,
+        batch: i32,
+        seq_len: i32,
+        heads: i32,
+        head_dim: i32,
+        rotary_dim: i32,
+        stream: *mut core::ffi::c_void,
+    ) -> i32;
+
+    fn kiln_fused_rotary_one_bwd(
+        grad_y: *const core::ffi::c_void,
+        cos: *const f32,
+        sin: *const f32,
+        grad_x: *mut core::ffi::c_void,
+        batch: i32,
+        seq_len: i32,
+        heads: i32,
         head_dim: i32,
         rotary_dim: i32,
         stream: *mut core::ffi::c_void,
@@ -1477,6 +1503,332 @@ pub fn fused_rotary_qk(
     Ok((q_out, k_out))
 }
 
+/// Storage-level single-tensor BF16 RoPE for CUDA custom ops.
+pub fn rotary_one_bf16_storage(
+    out_cuda: &CudaStorage,
+    out_layout: &Layout,
+    x_cuda: &CudaStorage,
+    x_layout: &Layout,
+    cos_cuda: &CudaStorage,
+    cos_layout: &Layout,
+    sin_cuda: &CudaStorage,
+    sin_layout: &Layout,
+    head_dim: usize,
+    rotary_dim: usize,
+) -> Result<()> {
+    let x_dims = x_layout.dims();
+    let out_dims = out_layout.dims();
+    if x_dims.len() != 4 || out_dims != x_dims {
+        candle_core::bail!(
+            "rotary_one_bf16_storage: x/out must be matching rank-4 tensors, got x={x_dims:?} out={out_dims:?}"
+        );
+    }
+    if rotary_dim == 0 || rotary_dim > head_dim || rotary_dim % 2 != 0 {
+        candle_core::bail!(
+            "rotary_one_bf16_storage: invalid head_dim={head_dim} rotary_dim={rotary_dim}"
+        );
+    }
+    let (batch, seq_len, heads, x_head_dim) = (x_dims[0], x_dims[1], x_dims[2], x_dims[3]);
+    if x_head_dim != head_dim {
+        candle_core::bail!(
+            "rotary_one_bf16_storage: x head dim {x_head_dim} != head_dim {head_dim}"
+        );
+    }
+    if cos_layout.dims() != [seq_len, rotary_dim / 2]
+        || sin_layout.dims() != [seq_len, rotary_dim / 2]
+    {
+        candle_core::bail!(
+            "rotary_one_bf16_storage: table shape mismatch cos={:?} sin={:?} expected=[{seq_len}, {}]",
+            cos_layout.dims(),
+            sin_layout.dims(),
+            rotary_dim / 2
+        );
+    }
+    if out_cuda.dtype() != DType::BF16
+        || x_cuda.dtype() != DType::BF16
+        || cos_cuda.dtype() != DType::F32
+        || sin_cuda.dtype() != DType::F32
+    {
+        candle_core::bail!(
+            "rotary_one_bf16_storage: expected out/x BF16 and cos/sin F32, got out={:?} x={:?} cos={:?} sin={:?}",
+            out_cuda.dtype(),
+            x_cuda.dtype(),
+            cos_cuda.dtype(),
+            sin_cuda.dtype()
+        );
+    }
+    if !out_layout.is_contiguous()
+        || !x_layout.is_contiguous()
+        || !cos_layout.is_contiguous()
+        || !sin_layout.is_contiguous()
+    {
+        candle_core::bail!("rotary_one_bf16_storage: tensors must be contiguous");
+    }
+    if batch > i32::MAX as usize
+        || seq_len > i32::MAX as usize
+        || heads > i32::MAX as usize
+        || head_dim > i32::MAX as usize
+        || rotary_dim > i32::MAX as usize
+    {
+        candle_core::bail!("rotary_one_bf16_storage: dimensions exceed i32 kernel envelope");
+    }
+
+    let stream = x_cuda.device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+    let x_slice = x_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(x_layout.start_offset()..);
+    let cos_slice = cos_cuda
+        .as_cuda_slice::<f32>()?
+        .slice(cos_layout.start_offset()..);
+    let sin_slice = sin_cuda
+        .as_cuda_slice::<f32>()?
+        .slice(sin_layout.start_offset()..);
+    let out_slice = out_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(out_layout.start_offset()..);
+
+    let status = unsafe {
+        let (x_ptr, _x_guard) = x_slice.device_ptr(&stream);
+        let (cos_ptr, _cos_guard) = cos_slice.device_ptr(&stream);
+        let (sin_ptr, _sin_guard) = sin_slice.device_ptr(&stream);
+        let (out_ptr, _out_guard) = out_slice.device_ptr(&stream);
+        kiln_fused_rotary_one(
+            x_ptr as *const _,
+            cos_ptr as *const f32,
+            sin_ptr as *const f32,
+            out_ptr as *mut _,
+            batch as i32,
+            seq_len as i32,
+            heads as i32,
+            head_dim as i32,
+            rotary_dim as i32,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        candle_core::bail!("kiln_fused_rotary_one failed with status {status}");
+    }
+    Ok(())
+}
+
+/// Whether the fused single-tensor BF16 RoPE backward kernel is available.
+pub fn supports_rotary_one_bwd_bf16(
+    grad_y: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    head_dim: usize,
+    rotary_dim: usize,
+) -> bool {
+    if !matches!(grad_y.device(), Device::Cuda(_))
+        || !matches!(cos.device(), Device::Cuda(_))
+        || !matches!(sin.device(), Device::Cuda(_))
+        || grad_y.dtype() != DType::BF16
+        || cos.dtype() != DType::F32
+        || sin.dtype() != DType::F32
+        || !grad_y.is_contiguous()
+        || !cos.is_contiguous()
+        || !sin.is_contiguous()
+        || grad_y.rank() != 4
+        || rotary_dim == 0
+        || rotary_dim > head_dim
+        || rotary_dim % 2 != 0
+    {
+        return false;
+    }
+    let dims = grad_y.dims();
+    let batch = dims[0];
+    let seq_len = dims[1];
+    let heads = dims[2];
+    dims[3] == head_dim
+        && cos.dims() == [seq_len, rotary_dim / 2]
+        && sin.dims() == [seq_len, rotary_dim / 2]
+        && batch <= i32::MAX as usize
+        && seq_len <= i32::MAX as usize
+        && heads <= i32::MAX as usize
+        && head_dim <= i32::MAX as usize
+        && rotary_dim <= i32::MAX as usize
+}
+
+/// Run fused single-tensor BF16 RoPE backward.
+pub fn rotary_one_bwd_bf16(
+    grad_y: &Tensor,
+    cos: &Tensor,
+    sin: &Tensor,
+    head_dim: usize,
+    rotary_dim: usize,
+) -> Result<Tensor> {
+    if !supports_rotary_one_bwd_bf16(grad_y, cos, sin, head_dim, rotary_dim) {
+        candle_core::bail!(
+            "kiln-rmsnorm-kernel: rotary_one_bwd unsupported shapes grad_y={:?} cos={:?} sin={:?} dtypes=({:?},{:?},{:?}) head_dim={head_dim} rotary_dim={rotary_dim}",
+            grad_y.shape(),
+            cos.shape(),
+            sin.shape(),
+            grad_y.dtype(),
+            cos.dtype(),
+            sin.dtype()
+        );
+    }
+
+    let grad_x = if cuda_empty_kernel_outputs_enabled() {
+        unsafe { Tensor::empty(grad_y.dims(), DType::BF16, grad_y.device())? }
+    } else {
+        Tensor::zeros(grad_y.dims(), DType::BF16, grad_y.device())?
+    };
+
+    {
+        let (grad_y_storage, grad_y_layout) = grad_y.storage_and_layout();
+        let (cos_storage, cos_layout) = cos.storage_and_layout();
+        let (sin_storage, sin_layout) = sin.storage_and_layout();
+        let (grad_x_storage, grad_x_layout) = grad_x.storage_and_layout();
+
+        let grad_y_cuda = match &*grad_y_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: rotary_one_bwd grad_y must be on CUDA"),
+        };
+        let cos_cuda = match &*cos_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: rotary_one_bwd cos must be on CUDA"),
+        };
+        let sin_cuda = match &*sin_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: rotary_one_bwd sin must be on CUDA"),
+        };
+        let grad_x_cuda = match &*grad_x_storage {
+            candle_core::Storage::Cuda(c) => c,
+            _ => candle_core::bail!("kiln-rmsnorm-kernel: rotary_one_bwd grad_x must be on CUDA"),
+        };
+
+        rotary_one_bwd_bf16_storage(
+            grad_x_cuda,
+            &grad_x_layout,
+            grad_y_cuda,
+            &grad_y_layout,
+            cos_cuda,
+            &cos_layout,
+            sin_cuda,
+            &sin_layout,
+            head_dim,
+            rotary_dim,
+        )?;
+    }
+    Ok(grad_x)
+}
+
+/// Storage-level single-tensor BF16 RoPE backward for CUDA custom ops.
+pub fn rotary_one_bwd_bf16_storage(
+    grad_x_cuda: &CudaStorage,
+    grad_x_layout: &Layout,
+    grad_y_cuda: &CudaStorage,
+    grad_y_layout: &Layout,
+    cos_cuda: &CudaStorage,
+    cos_layout: &Layout,
+    sin_cuda: &CudaStorage,
+    sin_layout: &Layout,
+    head_dim: usize,
+    rotary_dim: usize,
+) -> Result<()> {
+    let grad_y_dims = grad_y_layout.dims();
+    let grad_x_dims = grad_x_layout.dims();
+    if grad_y_dims.len() != 4 || grad_x_dims != grad_y_dims {
+        candle_core::bail!(
+            "rotary_one_bwd_bf16_storage: grad_y/grad_x must be matching rank-4 tensors, got grad_y={grad_y_dims:?} grad_x={grad_x_dims:?}"
+        );
+    }
+    if rotary_dim == 0 || rotary_dim > head_dim || rotary_dim % 2 != 0 {
+        candle_core::bail!(
+            "rotary_one_bwd_bf16_storage: invalid head_dim={head_dim} rotary_dim={rotary_dim}"
+        );
+    }
+    let (batch, seq_len, heads, grad_head_dim) = (
+        grad_y_dims[0],
+        grad_y_dims[1],
+        grad_y_dims[2],
+        grad_y_dims[3],
+    );
+    if grad_head_dim != head_dim {
+        candle_core::bail!(
+            "rotary_one_bwd_bf16_storage: grad_y head dim {grad_head_dim} != head_dim {head_dim}"
+        );
+    }
+    if cos_layout.dims() != [seq_len, rotary_dim / 2]
+        || sin_layout.dims() != [seq_len, rotary_dim / 2]
+    {
+        candle_core::bail!(
+            "rotary_one_bwd_bf16_storage: table shape mismatch cos={:?} sin={:?} expected=[{seq_len}, {}]",
+            cos_layout.dims(),
+            sin_layout.dims(),
+            rotary_dim / 2
+        );
+    }
+    if grad_x_cuda.dtype() != DType::BF16
+        || grad_y_cuda.dtype() != DType::BF16
+        || cos_cuda.dtype() != DType::F32
+        || sin_cuda.dtype() != DType::F32
+    {
+        candle_core::bail!(
+            "rotary_one_bwd_bf16_storage: expected grad_x/grad_y BF16 and cos/sin F32, got grad_x={:?} grad_y={:?} cos={:?} sin={:?}",
+            grad_x_cuda.dtype(),
+            grad_y_cuda.dtype(),
+            cos_cuda.dtype(),
+            sin_cuda.dtype()
+        );
+    }
+    if !grad_x_layout.is_contiguous()
+        || !grad_y_layout.is_contiguous()
+        || !cos_layout.is_contiguous()
+        || !sin_layout.is_contiguous()
+    {
+        candle_core::bail!("rotary_one_bwd_bf16_storage: tensors must be contiguous");
+    }
+    if batch > i32::MAX as usize
+        || seq_len > i32::MAX as usize
+        || heads > i32::MAX as usize
+        || head_dim > i32::MAX as usize
+        || rotary_dim > i32::MAX as usize
+    {
+        candle_core::bail!("rotary_one_bwd_bf16_storage: dimensions exceed i32 kernel envelope");
+    }
+
+    let stream = grad_y_cuda.device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+    let grad_y_slice = grad_y_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(grad_y_layout.start_offset()..);
+    let cos_slice = cos_cuda
+        .as_cuda_slice::<f32>()?
+        .slice(cos_layout.start_offset()..);
+    let sin_slice = sin_cuda
+        .as_cuda_slice::<f32>()?
+        .slice(sin_layout.start_offset()..);
+    let grad_x_slice = grad_x_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(grad_x_layout.start_offset()..);
+
+    let status = unsafe {
+        let (grad_y_ptr, _grad_y_guard) = grad_y_slice.device_ptr(&stream);
+        let (cos_ptr, _cos_guard) = cos_slice.device_ptr(&stream);
+        let (sin_ptr, _sin_guard) = sin_slice.device_ptr(&stream);
+        let (grad_x_ptr, _grad_x_guard) = grad_x_slice.device_ptr(&stream);
+        kiln_fused_rotary_one_bwd(
+            grad_y_ptr as *const _,
+            cos_ptr as *const f32,
+            sin_ptr as *const f32,
+            grad_x_ptr as *mut _,
+            batch as i32,
+            seq_len as i32,
+            heads as i32,
+            head_dim as i32,
+            rotary_dim as i32,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        candle_core::bail!("kiln_fused_rotary_one_bwd failed with status {status}");
+    }
+    Ok(())
+}
+
 /// Whether the fused single-token decode QKV-prep kernel is available.
 ///
 /// Supports post-projection CUDA bf16 tensors for a decode step:
@@ -1946,6 +2298,77 @@ pub fn fused_sigmoid_mul(x: &Tensor, gate: &Tensor) -> Result<Tensor> {
     }
 
     Ok(out)
+}
+
+/// Storage-level variant of [`fused_sigmoid_mul`] for CUDA custom ops.
+///
+/// Computes `out = x * sigmoid(gate)` for matching contiguous BF16 CUDA
+/// tensors. `out` may alias neither input.
+pub fn fused_sigmoid_mul_storage(
+    out_cuda: &CudaStorage,
+    out_layout: &Layout,
+    x_cuda: &CudaStorage,
+    x_layout: &Layout,
+    gate_cuda: &CudaStorage,
+    gate_layout: &Layout,
+) -> Result<()> {
+    let out_dims = out_layout.dims();
+    let x_dims = x_layout.dims();
+    let gate_dims = gate_layout.dims();
+    if out_dims != x_dims || out_dims != gate_dims {
+        candle_core::bail!(
+            "fused_sigmoid_mul_storage: shape mismatch out={out_dims:?} x={x_dims:?} gate={gate_dims:?}"
+        );
+    }
+    if out_cuda.dtype() != DType::BF16
+        || x_cuda.dtype() != DType::BF16
+        || gate_cuda.dtype() != DType::BF16
+    {
+        candle_core::bail!(
+            "fused_sigmoid_mul_storage: expected BF16 tensors, got out={:?} x={:?} gate={:?}",
+            out_cuda.dtype(),
+            x_cuda.dtype(),
+            gate_cuda.dtype()
+        );
+    }
+    if !out_layout.is_contiguous() || !x_layout.is_contiguous() || !gate_layout.is_contiguous() {
+        candle_core::bail!("fused_sigmoid_mul_storage: tensors must be contiguous");
+    }
+    let elems: usize = out_dims.iter().product();
+    if elems > i64::MAX as usize {
+        candle_core::bail!("fused_sigmoid_mul_storage: element count exceeds i64");
+    }
+    if elems == 0 {
+        return Ok(());
+    }
+
+    let stream = x_cuda.device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+    let x_slice = x_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(x_layout.start_offset()..);
+    let gate_slice = gate_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(gate_layout.start_offset()..);
+    let out_slice = out_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(out_layout.start_offset()..);
+    let status = unsafe {
+        let (x_ptr, _x_guard) = x_slice.device_ptr(&stream);
+        let (gate_ptr, _gate_guard) = gate_slice.device_ptr(&stream);
+        let (out_ptr, _out_guard) = out_slice.device_ptr(&stream);
+        kiln_fused_sigmoid_mul_bf16(
+            x_ptr as *const _,
+            gate_ptr as *const _,
+            out_ptr as *mut _,
+            elems as i64,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        candle_core::bail!("kiln_fused_sigmoid_mul_bf16 failed with status {status}");
+    }
+    Ok(())
 }
 
 /// Whether the fused forward-only LoRA delta/add decode kernels support this shape.
@@ -2513,6 +2936,74 @@ pub fn lora_add_inplace_f32(base: &Tensor, hidden: &Tensor, b: &Tensor, scale: f
         candle_core::Storage::Cuda(c) => c,
         _ => candle_core::bail!("lora_add_inplace_f32: B must be CUDA"),
     };
+    lora_add_inplace_f32_storage(
+        base_cuda,
+        base_layout,
+        hidden_cuda,
+        hidden_layout,
+        b_cuda,
+        b_layout,
+        scale,
+    )
+}
+
+/// Storage-level variant of [`lora_add_inplace_f32`] for CUDA custom ops.
+///
+/// `base` is mutated in-place. Layouts must describe contiguous rank-2 F32
+/// tensors with shapes `base=[rows,out]`, `hidden=[rows,rank]`,
+/// `b=[out,rank]`.
+pub fn lora_add_inplace_f32_storage(
+    base_cuda: &CudaStorage,
+    base_layout: &Layout,
+    hidden_cuda: &CudaStorage,
+    hidden_layout: &Layout,
+    b_cuda: &CudaStorage,
+    b_layout: &Layout,
+    scale: f32,
+) -> Result<()> {
+    let base_dims = base_layout.dims();
+    let hidden_dims = hidden_layout.dims();
+    let b_dims = b_layout.dims();
+    if base_dims.len() != 2 {
+        candle_core::bail!("lora_add_inplace_f32_storage: base must be rank-2, got {base_dims:?}");
+    }
+    if hidden_dims.len() != 2 {
+        candle_core::bail!(
+            "lora_add_inplace_f32_storage: hidden must be rank-2, got {hidden_dims:?}"
+        );
+    }
+    if b_dims.len() != 2 {
+        candle_core::bail!("lora_add_inplace_f32_storage: B must be rank-2, got {b_dims:?}");
+    }
+    let (rows, out_dim) = (base_dims[0], base_dims[1]);
+    let (hidden_rows, rank) = (hidden_dims[0], hidden_dims[1]);
+    let (b_out, b_rank) = (b_dims[0], b_dims[1]);
+    if rows != hidden_rows || out_dim != b_out || rank != b_rank {
+        candle_core::bail!(
+            "lora_add_inplace_f32_storage: shape mismatch base={base_dims:?} hidden={hidden_dims:?} b={b_dims:?}"
+        );
+    }
+    if base_cuda.dtype() != DType::F32
+        || hidden_cuda.dtype() != DType::F32
+        || b_cuda.dtype() != DType::F32
+    {
+        candle_core::bail!(
+            "lora_add_inplace_f32_storage: expected F32 tensors, got base={:?} hidden={:?} b={:?}",
+            base_cuda.dtype(),
+            hidden_cuda.dtype(),
+            b_cuda.dtype()
+        );
+    }
+    if !base_layout.is_contiguous() || !hidden_layout.is_contiguous() || !b_layout.is_contiguous() {
+        candle_core::bail!("lora_add_inplace_f32_storage: tensors must be contiguous");
+    }
+    if rows > i32::MAX as usize || out_dim > i32::MAX as usize || rank > i32::MAX as usize {
+        candle_core::bail!("lora_add_inplace_f32_storage: dimensions exceed i32 kernel envelope");
+    }
+    if rows == 0 || out_dim == 0 || rank == 0 {
+        return Ok(());
+    }
+
     let stream = base_cuda.device().cuda_stream();
     let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
     let base_slice = base_cuda
@@ -2542,6 +3033,109 @@ pub fn lora_add_inplace_f32(base: &Tensor, hidden: &Tensor, b: &Tensor, scale: f
     };
     if status != 0 {
         candle_core::bail!("kiln_lora_add_inplace_f32 failed with status {status}");
+    }
+    Ok(())
+}
+
+/// Storage-level BF16 LoRA add for CUDA custom ops.
+///
+/// Computes `out = base + scale * hidden @ b.T`, where
+/// `base=[rows,out]` and `b=[out,rank]` are BF16, `hidden=[rows,rank]`
+/// is F32, and `out=[rows,out]` is BF16.
+pub fn lora_add_bf16_storage(
+    out_cuda: &CudaStorage,
+    out_layout: &Layout,
+    base_cuda: &CudaStorage,
+    base_layout: &Layout,
+    hidden_cuda: &CudaStorage,
+    hidden_layout: &Layout,
+    b_cuda: &CudaStorage,
+    b_layout: &Layout,
+    scale: f32,
+) -> Result<()> {
+    let out_dims = out_layout.dims();
+    let base_dims = base_layout.dims();
+    let hidden_dims = hidden_layout.dims();
+    let b_dims = b_layout.dims();
+    if out_dims.len() != 2 || base_dims.len() != 2 {
+        candle_core::bail!(
+            "lora_add_bf16_storage: out/base must be rank-2, got out={out_dims:?} base={base_dims:?}"
+        );
+    }
+    if hidden_dims.len() != 2 || b_dims.len() != 2 {
+        candle_core::bail!(
+            "lora_add_bf16_storage: hidden/B must be rank-2, got hidden={hidden_dims:?} b={b_dims:?}"
+        );
+    }
+    let (rows, out_dim) = (base_dims[0], base_dims[1]);
+    let (hidden_rows, rank) = (hidden_dims[0], hidden_dims[1]);
+    let (b_out, b_rank) = (b_dims[0], b_dims[1]);
+    if out_dims != base_dims || rows != hidden_rows || out_dim != b_out || rank != b_rank {
+        candle_core::bail!(
+            "lora_add_bf16_storage: shape mismatch out={out_dims:?} base={base_dims:?} hidden={hidden_dims:?} b={b_dims:?}"
+        );
+    }
+    if out_cuda.dtype() != DType::BF16
+        || base_cuda.dtype() != DType::BF16
+        || hidden_cuda.dtype() != DType::F32
+        || b_cuda.dtype() != DType::BF16
+    {
+        candle_core::bail!(
+            "lora_add_bf16_storage: expected out/base BF16, hidden F32, B BF16; got out={:?} base={:?} hidden={:?} b={:?}",
+            out_cuda.dtype(),
+            base_cuda.dtype(),
+            hidden_cuda.dtype(),
+            b_cuda.dtype()
+        );
+    }
+    if !out_layout.is_contiguous()
+        || !base_layout.is_contiguous()
+        || !hidden_layout.is_contiguous()
+        || !b_layout.is_contiguous()
+    {
+        candle_core::bail!("lora_add_bf16_storage: tensors must be contiguous");
+    }
+    if rows > i32::MAX as usize || out_dim > i32::MAX as usize || rank > i32::MAX as usize {
+        candle_core::bail!("lora_add_bf16_storage: dimensions exceed i32 kernel envelope");
+    }
+    if rows == 0 || out_dim == 0 || rank == 0 {
+        return Ok(());
+    }
+
+    let stream = base_cuda.device().cuda_stream();
+    let raw_stream = stream.cu_stream() as *mut core::ffi::c_void;
+    let out_slice = out_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(out_layout.start_offset()..);
+    let base_slice = base_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(base_layout.start_offset()..);
+    let hidden_slice = hidden_cuda
+        .as_cuda_slice::<f32>()?
+        .slice(hidden_layout.start_offset()..);
+    let b_slice = b_cuda
+        .as_cuda_slice::<bf16>()?
+        .slice(b_layout.start_offset()..);
+
+    let status = unsafe {
+        let (base_ptr, _base_guard) = base_slice.device_ptr(&stream);
+        let (hidden_ptr, _hidden_guard) = hidden_slice.device_ptr(&stream);
+        let (b_ptr, _b_guard) = b_slice.device_ptr(&stream);
+        let (out_ptr, _out_guard) = out_slice.device_ptr(&stream);
+        kiln_lora_decode_add_bf16(
+            base_ptr as *const _,
+            hidden_ptr as *const f32,
+            b_ptr as *const _,
+            out_ptr as *mut _,
+            scale,
+            rows as i32,
+            out_dim as i32,
+            rank as i32,
+            raw_stream,
+        )
+    };
+    if status != 0 {
+        candle_core::bail!("kiln_lora_decode_add_bf16 failed with status {status}");
     }
     Ok(())
 }

--- a/crates/kiln-server/examples/flce_preflight_bench.rs
+++ b/crates/kiln-server/examples/flce_preflight_bench.rs
@@ -28,8 +28,8 @@ use kiln_train::trainer::sft_train;
 use kiln_train::{ChatMessage, SftConfig, SftExample};
 use std::path::PathBuf;
 use std::sync::{
-    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
 use std::thread;
 use std::time::{Duration, Instant};

--- a/crates/kiln-train/examples/cuda_sft_file.rs
+++ b/crates/kiln-train/examples/cuda_sft_file.rs
@@ -4,8 +4,8 @@ use anyhow::Result;
 use std::path::PathBuf;
 #[cfg(feature = "cuda")]
 use std::sync::{
-    atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
 };
 #[cfg(feature = "cuda")]
 use std::thread;
@@ -25,6 +25,33 @@ use kiln_train::{Optimizer, SftConfig, SftExample};
 
 #[cfg(feature = "cuda")]
 #[derive(Debug)]
+enum TrainerKind {
+    Native,
+    Generic,
+}
+
+#[cfg(feature = "cuda")]
+impl TrainerKind {
+    fn parse(value: &str) -> Result<Self> {
+        match value {
+            "native" => Ok(Self::Native),
+            "generic" | "server" | "default" => Ok(Self::Generic),
+            other => {
+                anyhow::bail!("--trainer must be native, generic, server, or default; got {other}")
+            }
+        }
+    }
+
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Native => "native",
+            Self::Generic => "generic",
+        }
+    }
+}
+
+#[cfg(feature = "cuda")]
+#[derive(Debug)]
 struct Args {
     data: PathBuf,
     model_path: PathBuf,
@@ -33,6 +60,7 @@ struct Args {
     epochs: usize,
     max_examples: Option<usize>,
     skip_examples: usize,
+    trainer: TrainerKind,
 }
 
 #[cfg(feature = "cuda")]
@@ -45,6 +73,7 @@ impl Args {
         let mut epochs = 1usize;
         let mut max_examples = None;
         let mut skip_examples = 0usize;
+        let mut trainer = TrainerKind::Native;
 
         let mut args = std::env::args().skip(1);
         while let Some(arg) = args.next() {
@@ -82,11 +111,19 @@ impl Args {
                         .parse()
                         .context("--skip-examples must be a non-negative integer")?
                 }
+                "--trainer" => {
+                    trainer = TrainerKind::parse(
+                        &args
+                            .next()
+                            .context("--trainer requires native, generic, server, or default")?,
+                    )?
+                }
                 "--help" | "-h" => {
                     println!(
                         "usage: cuda_sft_file --data <jsonl> --model-path <dir> \
                          [--output-dir <dir>] [--adapter-name <name>] \
-                         [--epochs <n>] [--skip-examples <n>] [--max-examples <n>]"
+                         [--epochs <n>] [--skip-examples <n>] [--max-examples <n>] \
+                         [--trainer native|generic|server|default]"
                     );
                     std::process::exit(0);
                 }
@@ -105,6 +142,7 @@ impl Args {
             epochs,
             max_examples,
             skip_examples,
+            trainer,
         })
     }
 }
@@ -196,10 +234,11 @@ fn main() -> Result<()> {
     let examples = load_examples(&args.data, args.skip_examples, args.max_examples)?;
     anyhow::ensure!(!examples.is_empty(), "no examples selected");
     println!(
-        "selected_examples={} skip={} max={:?}",
+        "selected_examples={} skip={} max={:?} trainer={}",
         examples.len(),
         args.skip_examples,
-        args.max_examples
+        args.max_examples,
+        args.trainer.as_str()
     );
 
     let tokenizer = load_tokenizer(&args.model_path)?;
@@ -275,16 +314,29 @@ fn main() -> Result<()> {
         );
     }) as kiln_train::trainer::ProgressCallback);
 
-    let result = kiln_train::cuda_train::cuda_native_sft_train(
-        &examples,
-        &config,
-        &model_config,
-        &gpu_weights,
-        &tokenizer,
-        &args.output_dir,
-        &args.adapter_name,
-        progress,
-    );
+    let result = match args.trainer {
+        TrainerKind::Native => kiln_train::cuda_train::cuda_native_sft_train(
+            &examples,
+            &config,
+            &model_config,
+            &gpu_weights,
+            &tokenizer,
+            &args.output_dir,
+            &args.adapter_name,
+            progress,
+        ),
+        TrainerKind::Generic => kiln_train::trainer::sft_train(
+            &examples,
+            &config,
+            &model_config,
+            &gpu_weights,
+            &tokenizer,
+            &args.output_dir,
+            &args.adapter_name,
+            progress,
+            None,
+        ),
+    };
 
     stop.store(true, Ordering::Relaxed);
     let _ = poller.join();

--- a/crates/kiln-train/src/cuda_train.rs
+++ b/crates/kiln-train/src/cuda_train.rs
@@ -5,28 +5,27 @@
 //! to an optimizer step in the training crate, mirroring the direction of the
 //! Vulkan `vk_train` module without claiming full model coverage yet.
 
-use anyhow::{ensure, Context, Result};
+use anyhow::{Context, Result, ensure};
 use candle_core::{DType, Device, Tensor, TensorId};
 use kiln_core::config::ModelConfig;
 use kiln_core::tokenizer::KilnTokenizer;
 use kiln_model::cuda_train::{
-    cuda_adamw_step_from_store, cuda_add, cuda_add_last_dim_bias, cuda_backward,
-    cuda_causal_depthwise_conv1d_prefill_with_state_inplace_input_grad, cuda_embedding_lookup,
-    cuda_exp, cuda_flash_attn_prefill_causal_f32, cuda_frozen_matmul, cuda_full_attention_layer,
-    cuda_gdn_multi_head_sequence_recurrence, cuda_lora_linear_fused, cuda_matmul, cuda_mul,
-    cuda_mul_last_dim_weight, cuda_narrow_last_dim, cuda_permute_hr_to_rh, cuda_permute_rh_to_hr,
-    cuda_repeat_kv_heads, cuda_reshape, cuda_rmsnorm, cuda_rope, cuda_scale,
-    cuda_sdpa_prefill_causal, cuda_shifted_linear_cross_entropy_loss, cuda_sigmoid, cuda_silu,
-    cuda_silu_inplace, cuda_softplus, cuda_sum_all, cuda_to_dtype, cuda_transpose2d,
     CudaAdamWConfig, CudaAdamWState, CudaFullAttentionLayer, CudaGdnLayerState, CudaLayerWeights,
     CudaLinearAttentionState, CudaModelWeights, CudaOwnedLinearAttentionLayer, CudaRopeTables,
-    CudaTrainArena, CudaTrainTensor,
+    CudaTrainArena, CudaTrainTensor, cuda_adamw_step_from_store, cuda_add, cuda_add_last_dim_bias,
+    cuda_backward, cuda_causal_depthwise_conv1d_prefill_with_state_inplace_input_grad,
+    cuda_embedding_lookup, cuda_exp, cuda_flash_attn_prefill_causal_f32, cuda_frozen_matmul,
+    cuda_full_attention_layer, cuda_gdn_multi_head_sequence_recurrence, cuda_lora_linear_fused,
+    cuda_matmul, cuda_mul, cuda_mul_last_dim_weight, cuda_narrow_last_dim, cuda_permute_hr_to_rh,
+    cuda_permute_rh_to_hr, cuda_repeat_kv_heads, cuda_reshape, cuda_rmsnorm, cuda_rope, cuda_scale,
+    cuda_sdpa_prefill_causal, cuda_shifted_linear_cross_entropy_loss, cuda_sigmoid, cuda_silu,
+    cuda_silu_inplace, cuda_softplus, cuda_sum_all, cuda_to_dtype, cuda_transpose2d,
 };
 use kiln_model::forward::GpuWeights;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use crate::trainer::{tokenize_for_training, ProgressCallback, TrainingProgress};
+use crate::trainer::{ProgressCallback, TrainingProgress, tokenize_for_training};
 use crate::{SftConfig, SftExample};
 
 pub type CudaAdamWBook = HashMap<TensorId, CudaAdamWState>;
@@ -2379,11 +2378,13 @@ mod tests {
         )?;
 
         assert!(loss.is_finite());
-        assert!(gdn_state.layers[0]
-            .recurrent_state
-            .to_vec_f32()?
-            .iter()
-            .any(|value| value.abs() > 1e-6));
+        assert!(
+            gdn_state.layers[0]
+                .recurrent_state
+                .to_vec_f32()?
+                .iter()
+                .any(|value| value.abs() > 1e-6)
+        );
         let losses = cuda_lora_train_token_sequences_with_gdn_state(
             &model,
             &lora_layers,

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -8,7 +8,11 @@ use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use anyhow::{Context, Result};
-use candle_core::{DType, Device, Tensor, Var};
+#[cfg(feature = "cuda")]
+use candle_core::CudaStorage;
+#[cfg(feature = "cuda")]
+use candle_core::backend::BackendStorage;
+use candle_core::{CpuStorage, CustomOp1, DType, Device, Layout, Shape, Tensor, Var};
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
 
@@ -22,13 +26,16 @@ use kiln_flce_kernel::{
 };
 use kiln_model::backend::{self, BackendRuntime};
 use kiln_model::forward::{
-    GDN_CHUNK_SIZE, GpuAttentionWeights, GpuWeights, LinearAttentionState,
+    GDN_CHUNK_SIZE, GpuAttentionWeights, GpuWeights, GqaAttentionPrepared, LinearAttentionState,
     gdn_attention_in_projections, gdn_attention_input_norm, gdn_attention_residual_block,
     gdn_gated_norm_from_recurrent, gdn_gates_from_ab_training, gdn_out_proj_from_gated_norm,
     gdn_qkv_from_mixed_training, gdn_recurrent_backward_no_grad, gdn_recurrent_forward_from_parts,
-    model_forward, model_forward_embed, model_forward_final_norm, model_forward_head,
-    model_forward_no_head, model_forward_segment, streaming_prefill_enabled_for,
-    streaming_tile_tokens_for, transformer_mlp_down_from_gated, transformer_mlp_gated_hidden,
+    gqa_attention_apply_output_gate, gqa_attention_core_prefill, gqa_attention_kv_prefill,
+    gqa_attention_output_projection, gqa_attention_pre_o, gqa_attention_pre_o_chunked_prefill,
+    gqa_attention_prepare_prefill, gqa_attention_q_gate_prefill, model_forward,
+    model_forward_embed, model_forward_final_norm, model_forward_head, model_forward_no_head,
+    model_forward_segment, rms_norm, streaming_prefill_enabled_for, streaming_tile_tokens_for,
+    swiglu_ffn, transformer_mlp_down_from_gated, transformer_mlp_gated_hidden,
 };
 use kiln_model::lora_loader::{LoraLayerWeights, LoraProjectionWeights, LoraWeights};
 
@@ -2156,8 +2163,11 @@ fn recompute_checkpoint_boundaries(seq_len: usize) -> bool {
     seq_len >= threshold
 }
 
-fn spool_checkpoint_boundaries() -> bool {
-    kiln_core::env_flag::env_tristate("KILN_SPOOL_CHECKPOINT_BOUNDARIES").unwrap_or(false)
+fn spool_checkpoint_boundaries(device: &Device) -> bool {
+    if let Some(forced) = kiln_core::env_flag::env_tristate("KILN_SPOOL_CHECKPOINT_BOUNDARIES") {
+        return forced;
+    }
+    matches!(device, Device::Cuda(_))
 }
 
 fn profile_checkpoint_segments() -> bool {
@@ -2488,10 +2498,14 @@ fn accumulate_grads(
     for var in vars {
         if let Some(grad) = src.get(var.as_tensor()) {
             let id = var.as_tensor().id();
+            let grad = grad
+                .to_device(&Device::Cpu)
+                .context("offload accumulated gradient to CPU")?
+                .detach();
             if let Some(existing) = dst.get(&id) {
-                dst.insert(id, (existing + grad)?.detach());
+                dst.insert(id, (existing + &grad)?.detach());
             } else {
-                dst.insert(id, grad.detach());
+                dst.insert(id, grad);
             }
         }
     }
@@ -2509,6 +2523,45 @@ fn grad_or_zeros_like(
     }
 }
 
+fn offload_checkpoint_tensor_to_cpu(tensor: Tensor, enabled: bool) -> Result<Tensor> {
+    if enabled && !tensor.device().is_cpu() {
+        Ok(tensor
+            .to_device(&Device::Cpu)
+            .context("offload checkpoint tensor to CPU")?
+            .detach())
+    } else {
+        Ok(tensor.detach())
+    }
+}
+
+fn tensor_on_device(tensor: &Tensor, device: &Device) -> Result<Tensor> {
+    if tensor.device().same_device(device) {
+        Ok(tensor.clone())
+    } else {
+        tensor
+            .to_device(device)
+            .context("reload checkpoint tensor to device")
+    }
+}
+
+fn accumulate_cpu_tensor_slot(
+    slot: &mut Option<Tensor>,
+    tensor: Tensor,
+    context: &str,
+) -> Result<()> {
+    let tensor_cpu = tensor
+        .to_device(&Device::Cpu)
+        .with_context(|| format!("{context} CPU offload"))?
+        .detach();
+    *slot = Some(match slot.take() {
+        Some(existing) => (&existing + &tensor_cpu)
+            .with_context(|| format!("{context} CPU accumulate"))?
+            .detach(),
+        None => tensor_cpu,
+    });
+    Ok(())
+}
+
 /// SGD update from accumulated gradient map (not GradStore).
 fn sgd_step_from_map(
     backend: &dyn BackendRuntime,
@@ -2520,7 +2573,12 @@ fn sgd_step_from_map(
     for var in params.all_vars() {
         let id = var.as_tensor().id();
         if let Some(grad) = grads.get(&id) {
-            apply_sgd_update(backend, var, grad, lr, resident_activation)?;
+            let grad = if grad.device().same_device(var.as_tensor().device()) {
+                grad.clone()
+            } else {
+                grad.to_device(var.as_tensor().device())?
+            };
+            apply_sgd_update(backend, var, &grad, lr, resident_activation)?;
         }
     }
     Ok(())
@@ -2552,6 +2610,11 @@ fn optimizer_step_from_map(
             for var in params.all_vars() {
                 let id = var.as_tensor().id();
                 if let Some(grad) = grads.get(&id) {
+                    let grad = if grad.device().same_device(var.as_tensor().device()) {
+                        grad.clone()
+                    } else {
+                        grad.to_device(var.as_tensor().device())?
+                    };
                     let moments = state.moments.get(&id).ok_or_else(|| {
                         anyhow::anyhow!(
                             "optimizer_step_from_map: missing AdamW moments for Var id {:?}",
@@ -2561,7 +2624,7 @@ fn optimizer_step_from_map(
                     apply_adamw_update(
                         backend,
                         var,
-                        grad,
+                        &grad,
                         moments,
                         lr,
                         beta1,
@@ -2831,6 +2894,14 @@ fn exact_gdn_reverse_tile_size(
 }
 
 fn exact_gdn_backward_tile_tokens_for(device: &Device) -> usize {
+    fn fallback_tile(device: &Device) -> usize {
+        if matches!(device, Device::Cuda(_)) {
+            1024
+        } else {
+            streaming_tile_tokens_for(device)
+        }
+    }
+
     match std::env::var("KILN_EXACT_GDN_BACKWARD_TILE_TOKENS") {
         Ok(raw) => match raw.parse::<usize>() {
             Ok(tile) if tile > 0 && tile % GDN_CHUNK_SIZE == 0 => tile,
@@ -2840,10 +2911,10 @@ fn exact_gdn_backward_tile_tokens_for(device: &Device) -> usize {
                     chunk_size = GDN_CHUNK_SIZE,
                     "ignoring invalid KILN_EXACT_GDN_BACKWARD_TILE_TOKENS"
                 );
-                streaming_tile_tokens_for(device)
+                fallback_tile(device)
             }
         },
-        Err(_) => streaming_tile_tokens_for(device),
+        Err(_) => fallback_tile(device),
     }
 }
 
@@ -2852,7 +2923,7 @@ fn profile_exact_gdn_reverse_tiles() -> bool {
 }
 
 fn exact_gdn_split_recurrent_backward_enabled() -> bool {
-    kiln_core::env_flag::env_tristate("KILN_EXACT_GDN_SPLIT_RECURRENT_BACKWARD").unwrap_or(false)
+    kiln_core::env_flag::env_tristate("KILN_EXACT_GDN_SPLIT_RECURRENT_BACKWARD").unwrap_or(true)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2887,6 +2958,947 @@ fn finish_exact_gdn_reverse_tile_stage(
         );
     }
     Ok(Instant::now())
+}
+
+fn full_attention_mlp_reverse_tile_size(
+    weights: &GpuWeights,
+    seq_len: usize,
+    seg_start: usize,
+    seg_end: usize,
+) -> Option<usize> {
+    if !kiln_core::env_flag::env_tristate("KILN_EXACT_FULL_ATTN_MLP_TILE_BACKWARD").unwrap_or(true)
+    {
+        return None;
+    }
+    if seg_end != seg_start + 1 {
+        return None;
+    }
+    if !matches!(
+        weights.layers[seg_start].attention,
+        GpuAttentionWeights::Full(_)
+    ) {
+        return None;
+    }
+    let tile = std::env::var("KILN_CUDA_TRAINING_MLP_CHUNK_TOKENS")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|&value| value > 0)
+        .unwrap_or(1024);
+    if tile >= seq_len { None } else { Some(tile) }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn full_attention_attention_pre_o_forward(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    weights: &GpuWeights,
+    model_config: &ModelConfig,
+    positions: &[u32],
+    layer_idx: usize,
+    full_attn_layer_idx: usize,
+    lora: Option<(&LoraLayerWeights, f32)>,
+) -> Result<Tensor> {
+    let layer = &weights.layers[layer_idx];
+    let attn_weights = match &layer.attention {
+        GpuAttentionWeights::Full(attn_weights) => attn_weights,
+        GpuAttentionWeights::Linear(_) => {
+            anyhow::bail!("full_attention_attention_pre_o_forward called for GDN layer {layer_idx}")
+        }
+    };
+    let normed = rms_norm(x, &layer.input_layernorm, model_config.rms_norm_eps)?;
+    let (_batch, seq_len, _hidden) = normed.dims3()?;
+    let tile_size = streaming_tile_tokens_for(normed.device());
+    let attn_out = if backend.name() == "cuda"
+        && streaming_prefill_enabled_for(normed.device(), seq_len)
+        && tile_size > 0
+        && tile_size < seq_len
+    {
+        gqa_attention_pre_o_chunked_prefill(
+            backend,
+            &normed,
+            attn_weights,
+            positions,
+            model_config.num_attention_heads,
+            model_config.num_kv_heads,
+            model_config.head_dim,
+            model_config.rotary_dim(),
+            &weights.rotary_inv_freq,
+            model_config.rms_norm_eps,
+            model_config.attn_output_gate,
+            lora,
+            tile_size,
+        )
+    } else {
+        gqa_attention_pre_o(
+            backend,
+            &normed,
+            attn_weights,
+            positions,
+            model_config.num_attention_heads,
+            model_config.num_kv_heads,
+            model_config.head_dim,
+            model_config.rotary_dim(),
+            &weights.rotary_inv_freq,
+            model_config.rms_norm_eps,
+            None,
+            full_attn_layer_idx,
+            model_config.attn_output_gate,
+            lora,
+        )
+    }
+    .with_context(|| format!("full attention pre-o forward layer {layer_idx}"))?;
+    Ok(attn_out)
+}
+
+#[allow(clippy::too_many_arguments, dead_code)]
+fn full_attention_attention_prepare_forward(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    weights: &GpuWeights,
+    model_config: &ModelConfig,
+    positions: &[u32],
+    layer_idx: usize,
+    lora: Option<(&LoraLayerWeights, f32)>,
+) -> Result<GqaAttentionPrepared> {
+    let layer = &weights.layers[layer_idx];
+    let attn_weights = match &layer.attention {
+        GpuAttentionWeights::Full(attn_weights) => attn_weights,
+        GpuAttentionWeights::Linear(_) => {
+            anyhow::bail!(
+                "full_attention_attention_prepare_forward called for GDN layer {layer_idx}"
+            )
+        }
+    };
+    let normed = rms_norm(x, &layer.input_layernorm, model_config.rms_norm_eps)?;
+    gqa_attention_prepare_prefill(
+        backend,
+        &normed,
+        attn_weights,
+        positions,
+        model_config.num_attention_heads,
+        model_config.num_kv_heads,
+        model_config.head_dim,
+        model_config.rotary_dim(),
+        &weights.rotary_inv_freq,
+        model_config.rms_norm_eps,
+        model_config.attn_output_gate,
+        lora,
+    )
+    .with_context(|| format!("full attention prepare forward layer {layer_idx}"))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn full_attention_attention_forward(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    weights: &GpuWeights,
+    model_config: &ModelConfig,
+    positions: &[u32],
+    layer_idx: usize,
+    full_attn_layer_idx: usize,
+    lora: Option<(&LoraLayerWeights, f32)>,
+) -> Result<Tensor> {
+    let layer = &weights.layers[layer_idx];
+    let attn_weights = match &layer.attention {
+        GpuAttentionWeights::Full(attn_weights) => attn_weights,
+        GpuAttentionWeights::Linear(_) => {
+            anyhow::bail!("full_attention_attention_forward called for GDN layer {layer_idx}")
+        }
+    };
+    let attn_output = full_attention_attention_pre_o_forward(
+        backend,
+        x,
+        weights,
+        model_config,
+        positions,
+        layer_idx,
+        full_attn_layer_idx,
+        lora,
+    )?;
+    gqa_attention_output_projection(backend, &attn_output, attn_weights, false, lora)
+        .with_context(|| format!("full attention output projection layer {layer_idx}"))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn full_attention_residual_forward(
+    backend: &dyn BackendRuntime,
+    x: &Tensor,
+    weights: &GpuWeights,
+    model_config: &ModelConfig,
+    positions: &[u32],
+    layer_idx: usize,
+    full_attn_layer_idx: usize,
+    lora: Option<(&LoraLayerWeights, f32)>,
+) -> Result<Tensor> {
+    let attn_out = full_attention_attention_forward(
+        backend,
+        x,
+        weights,
+        model_config,
+        positions,
+        layer_idx,
+        full_attn_layer_idx,
+        lora,
+    )?;
+    Ok((x + attn_out)?)
+}
+
+#[derive(Clone)]
+struct InjectTensorGradient {
+    upstream: Tensor,
+}
+
+impl std::fmt::Debug for InjectTensorGradient {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InjectTensorGradient")
+            .field("upstream_dtype", &self.upstream.dtype())
+            .field("upstream_dims", &self.upstream.dims())
+            .finish()
+    }
+}
+
+impl CustomOp1 for InjectTensorGradient {
+    fn name(&self) -> &'static str {
+        "kiln-inject-tensor-gradient"
+    }
+
+    fn cpu_fwd(
+        &self,
+        _storage: &CpuStorage,
+        _layout: &Layout,
+    ) -> candle_core::Result<(CpuStorage, Shape)> {
+        Ok((CpuStorage::F32(vec![0.0]), Shape::from(())))
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        storage: &CudaStorage,
+        _layout: &Layout,
+    ) -> candle_core::Result<(CudaStorage, Shape)> {
+        let device = storage.device();
+        let out_slice = device.clone_htod(&[0.0f32])?;
+        Ok((
+            CudaStorage::wrap_cuda_slice(out_slice, device.clone()),
+            Shape::from(()),
+        ))
+    }
+
+    fn bwd(
+        &self,
+        arg: &Tensor,
+        _res: &Tensor,
+        _grad_res: &Tensor,
+    ) -> candle_core::Result<Option<Tensor>> {
+        if self.upstream.dims() != arg.dims() {
+            candle_core::bail!(
+                "InjectTensorGradient shape mismatch: upstream {:?}, arg {:?}",
+                self.upstream.dims(),
+                arg.dims()
+            );
+        }
+        let upstream = self.upstream.to_device(arg.device())?;
+        let grad = if upstream.dtype() == arg.dtype() {
+            upstream
+        } else {
+            upstream.to_dtype(arg.dtype())?
+        };
+        Ok(Some(grad))
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn full_attention_single_layer_tiled_mlp_reverse(
+    backend: &dyn BackendRuntime,
+    layer_idx: usize,
+    full_attn_layer_idx: usize,
+    seg_input: &Tensor,
+    upstream_grad: &Tensor,
+    weights: &GpuWeights,
+    model_config: &ModelConfig,
+    positions: &[u32],
+    params: &TrainableLoraParams,
+    lora_detached: &LoraWeights,
+    tile_size: usize,
+    device: &Device,
+    accumulated_grads: &mut HashMap<candle_core::TensorId, Tensor>,
+    all_vars: &[&Var],
+) -> Result<Tensor> {
+    let layer = &weights.layers[layer_idx];
+    let attn_weights = match &layer.attention {
+        GpuAttentionWeights::Full(attn_weights) => attn_weights,
+        GpuAttentionWeights::Linear(_) => {
+            anyhow::bail!(
+                "full-attention tiled MLP reverse called for non-full-attention layer {layer_idx}"
+            )
+        }
+    };
+    let (_, total_tokens, _hidden_size) = seg_input.dims3()?;
+    anyhow::ensure!(
+        upstream_grad.dims() == seg_input.dims(),
+        "full-attention tiled MLP reverse upstream/input shape mismatch: {:?} vs {:?}",
+        upstream_grad.dims(),
+        seg_input.dims()
+    );
+
+    let lora_weights_for_seg = params.as_lora_weights();
+    let layer_lora: Option<(&LoraLayerWeights, f32)> = lora_weights_for_seg
+        .layers
+        .get(layer_idx)
+        .map(|ll| (ll, lora_weights_for_seg.scale));
+    let detached_layer_lora: Option<(&LoraLayerWeights, f32)> = lora_detached
+        .layers
+        .get(layer_idx)
+        .map(|ll| (ll, lora_detached.scale));
+
+    tracing::info!(
+        layer = layer_idx,
+        full_attn_layer_idx,
+        total_tokens,
+        tile_size,
+        num_tiles = total_tokens.div_ceil(tile_size),
+        "exact full-attention tiled MLP reverse begin"
+    );
+
+    let attn_residual_value = full_attention_residual_forward(
+        backend,
+        seg_input,
+        weights,
+        model_config,
+        positions,
+        layer_idx,
+        full_attn_layer_idx,
+        detached_layer_lora,
+    )
+    .with_context(|| format!("full-attention tiled MLP value residual layer {layer_idx}"))?
+    .detach();
+    synchronize_checkpoint_boundary(device, || {
+        format!("synchronize full-attention tiled MLP value residual layer {layer_idx}")
+    })?;
+
+    let mut residual_grad_tiles = Vec::with_capacity(total_tokens.div_ceil(tile_size));
+    let mut tile_start = 0usize;
+    while tile_start < total_tokens {
+        let tile_len = (total_tokens - tile_start).min(tile_size);
+        let tile_end = tile_start + tile_len;
+        let residual_tile = attn_residual_value
+            .narrow(1, tile_start, tile_len)
+            .with_context(|| {
+                format!("full-attention MLP residual tile [{tile_start}, {tile_end})")
+            })?
+            .detach();
+        let upstream_tile = upstream_grad
+            .narrow(1, tile_start, tile_len)
+            .with_context(|| {
+                format!("full-attention MLP upstream tile [{tile_start}, {tile_end})")
+            })?
+            .detach();
+        let residual_tile_var = Var::from_tensor(&residual_tile).with_context(|| {
+            format!("full-attention MLP residual tile Var [{tile_start}, {tile_end})")
+        })?;
+        let normed_tile = rms_norm(
+            residual_tile_var.as_tensor(),
+            &layer.post_attention_layernorm,
+            model_config.rms_norm_eps,
+        )
+        .with_context(|| format!("full-attention MLP post norm tile [{tile_start}, {tile_end})"))?;
+        let ffn_out = swiglu_ffn(&normed_tile, &layer.mlp, layer_lora)
+            .with_context(|| format!("full-attention MLP tile [{tile_start}, {tile_end})"))?;
+        let tile_output = (residual_tile_var.as_tensor() + ffn_out).with_context(|| {
+            format!("full-attention MLP residual add tile [{tile_start}, {tile_end})")
+        })?;
+        let tile_output_f32 = tile_output.to_dtype(DType::F32)?;
+        let upstream_tile_f32 = upstream_tile.to_dtype(DType::F32)?;
+        let injected = (&tile_output_f32 * &upstream_tile_f32)?
+            .sum_all()
+            .with_context(|| {
+                format!("full-attention MLP gradient injection tile [{tile_start}, {tile_end})")
+            })?;
+        let grads = injected.backward().with_context(|| {
+            format!("full-attention MLP backward tile [{tile_start}, {tile_end})")
+        })?;
+        accumulate_grads(accumulated_grads, &grads, all_vars)?;
+        let residual_grad = grads
+            .get(residual_tile_var.as_tensor())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "full-attention MLP reverse did not produce residual grad for tile [{tile_start}, {tile_end})"
+                )
+            })?
+            .clone()
+            .detach();
+        residual_grad_tiles.push(residual_grad);
+
+        drop(grads);
+        drop(injected);
+        drop(upstream_tile_f32);
+        drop(tile_output_f32);
+        drop(tile_output);
+        drop(normed_tile);
+        drop(residual_tile_var);
+        drop(upstream_tile);
+        drop(residual_tile);
+        synchronize_checkpoint_boundary(device, || {
+            format!("synchronize full-attention MLP tile [{tile_start}, {tile_end}) cleanup")
+        })?;
+        tile_start = tile_end;
+    }
+
+    let residual_grad_refs: Vec<&Tensor> = residual_grad_tiles.iter().collect();
+    let residual_grad = Tensor::cat(&residual_grad_refs, 1)
+        .context("full-attention tiled MLP residual grad cat")?
+        .detach();
+    drop(residual_grad_tiles);
+    drop(attn_residual_value);
+    let residual_grad_cpu = residual_grad
+        .to_device(&Device::Cpu)
+        .context("full-attention tiled MLP residual grad CPU offload")?
+        .detach();
+    drop(residual_grad);
+    device.synchronize().with_context(|| {
+        format!("synchronize full-attention residual grad offload layer {layer_idx}")
+    })?;
+    synchronize_checkpoint_boundary(device, || {
+        format!("synchronize full-attention tiled MLP value cleanup layer {layer_idx}")
+    })?;
+
+    let pre_o_value = full_attention_attention_pre_o_forward(
+        backend,
+        seg_input,
+        weights,
+        model_config,
+        positions,
+        layer_idx,
+        full_attn_layer_idx,
+        detached_layer_lora,
+    )
+    .with_context(|| format!("full-attention pre-o value layer {layer_idx}"))?
+    .detach();
+    synchronize_checkpoint_boundary(device, || {
+        format!("synchronize full-attention pre-o value layer {layer_idx}")
+    })?;
+
+    let mut pre_o_grad_tiles = Vec::with_capacity(total_tokens.div_ceil(tile_size));
+    let mut tile_start = 0usize;
+    while tile_start < total_tokens {
+        let tile_len = (total_tokens - tile_start).min(tile_size);
+        let tile_end = tile_start + tile_len;
+        let pre_o_tile = pre_o_value
+            .narrow(1, tile_start, tile_len)
+            .with_context(|| format!("full-attention pre-o tile [{tile_start}, {tile_end})"))?
+            .detach();
+        let upstream_tile = residual_grad_cpu
+            .narrow(1, tile_start, tile_len)
+            .with_context(|| {
+                format!("full-attention o-proj upstream tile [{tile_start}, {tile_end})")
+            })?
+            .detach();
+        let pre_o_tile_var = Var::from_tensor(&pre_o_tile).with_context(|| {
+            format!("full-attention o-proj pre-o tile Var [{tile_start}, {tile_end})")
+        })?;
+        let out_proj_tile = gqa_attention_output_projection(
+            backend,
+            pre_o_tile_var.as_tensor(),
+            attn_weights,
+            false,
+            layer_lora,
+        )
+        .with_context(|| {
+            format!("full-attention o-proj forward tile [{tile_start}, {tile_end})")
+        })?;
+        let injected = out_proj_tile
+            .apply_op1(InjectTensorGradient {
+                upstream: upstream_tile.clone(),
+            })
+            .with_context(|| {
+                format!("full-attention o-proj gradient injection tile [{tile_start}, {tile_end})")
+            })?;
+        let grads = injected.backward().with_context(|| {
+            format!("full-attention o-proj backward tile [{tile_start}, {tile_end})")
+        })?;
+        accumulate_grads(accumulated_grads, &grads, all_vars)?;
+        let pre_o_grad = grads
+            .get(pre_o_tile_var.as_tensor())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "full-attention o-proj reverse did not produce pre-o grad for tile [{tile_start}, {tile_end})"
+                )
+            })?
+            .clone()
+            .detach();
+        pre_o_grad_tiles.push(pre_o_grad);
+
+        drop(grads);
+        drop(injected);
+        drop(out_proj_tile);
+        drop(pre_o_tile_var);
+        drop(upstream_tile);
+        drop(pre_o_tile);
+        synchronize_checkpoint_boundary(device, || {
+            format!("synchronize full-attention o-proj tile [{tile_start}, {tile_end}) cleanup")
+        })?;
+        tile_start = tile_end;
+    }
+
+    let pre_o_grad_refs: Vec<&Tensor> = pre_o_grad_tiles.iter().collect();
+    let pre_o_grad = Tensor::cat(&pre_o_grad_refs, 1)
+        .context("full-attention tiled o-proj pre-o grad cat")?
+        .detach();
+    drop(pre_o_grad_tiles);
+    drop(pre_o_value);
+    let pre_o_grad_cpu = pre_o_grad
+        .to_device(&Device::Cpu)
+        .context("full-attention tiled o-proj pre-o grad CPU offload")?
+        .detach();
+    drop(pre_o_grad);
+    device.synchronize().with_context(|| {
+        format!("synchronize full-attention pre-o grad offload layer {layer_idx}")
+    })?;
+    synchronize_checkpoint_boundary(device, || {
+        format!("synchronize full-attention tiled o-proj cleanup layer {layer_idx}")
+    })?;
+
+    let total_tiles = total_tokens.div_ceil(tile_size);
+    let normed_value = rms_norm(seg_input, &layer.input_layernorm, model_config.rms_norm_eps)
+        .with_context(|| format!("full-attention core value norm layer {layer_idx}"))?
+        .detach();
+    let (k_value, v_value) = gqa_attention_kv_prefill(
+        backend,
+        &normed_value,
+        attn_weights,
+        positions,
+        model_config.num_kv_heads,
+        model_config.head_dim,
+        model_config.rotary_dim(),
+        &weights.rotary_inv_freq,
+        model_config.rms_norm_eps,
+        detached_layer_lora,
+    )
+    .with_context(|| format!("full-attention K/V value layer {layer_idx}"))?;
+    let k_value = k_value.detach();
+    let v_value = v_value.detach();
+    synchronize_checkpoint_boundary(device, || {
+        format!("synchronize full-attention K/V value layer {layer_idx}")
+    })?;
+
+    let mut q_grad_tiles_cpu: Vec<Option<Tensor>> = vec![None; total_tiles];
+    let mut gate_grad_tiles_cpu: Vec<Option<Tensor>> = vec![None; total_tiles];
+    let mut k_grad_tiles_cpu: Vec<Option<Tensor>> = vec![None; total_tiles];
+    let mut v_grad_tiles_cpu: Vec<Option<Tensor>> = vec![None; total_tiles];
+
+    for tile_idx in 0..total_tiles {
+        let tile_start = tile_idx * tile_size;
+        let tile_len = (total_tokens - tile_start).min(tile_size);
+        let tile_end = tile_start + tile_len;
+        let normed_tile = normed_value
+            .narrow(1, tile_start, tile_len)
+            .with_context(|| {
+                format!("full-attention core normed tile [{tile_start}, {tile_end})")
+            })?;
+        let (q_value, gate_value) = gqa_attention_q_gate_prefill(
+            backend,
+            &normed_tile,
+            attn_weights,
+            &positions[tile_start..tile_end],
+            model_config.num_attention_heads,
+            model_config.head_dim,
+            model_config.rotary_dim(),
+            &weights.rotary_inv_freq,
+            model_config.rms_norm_eps,
+            model_config.attn_output_gate,
+            detached_layer_lora,
+        )
+        .with_context(|| format!("full-attention Q/Gate value tile [{tile_start}, {tile_end})"))?;
+        let k_prefix = k_value
+            .narrow(1, 0, tile_end)
+            .with_context(|| format!("full-attention K prefix tile {tile_idx}"))?
+            .detach();
+        let v_prefix = v_value
+            .narrow(1, 0, tile_end)
+            .with_context(|| format!("full-attention V prefix tile {tile_idx}"))?
+            .detach();
+        let q_var = Var::from_tensor(&q_value.detach())
+            .with_context(|| format!("full-attention q Var tile [{tile_start}, {tile_end})"))?;
+        let k_var = Var::from_tensor(&k_prefix).with_context(|| {
+            format!("full-attention k Var prefix [0, {tile_end}) tile {tile_idx}")
+        })?;
+        let v_var = Var::from_tensor(&v_prefix).with_context(|| {
+            format!("full-attention v Var prefix [0, {tile_end}) tile {tile_idx}")
+        })?;
+        let gate_var = gate_value
+            .as_ref()
+            .map(|gate| {
+                Var::from_tensor(&gate.detach()).with_context(|| {
+                    format!("full-attention gate Var tile [{tile_start}, {tile_end})")
+                })
+            })
+            .transpose()?;
+        let prepared_vars = GqaAttentionPrepared {
+            q: q_var.as_tensor().clone(),
+            k: k_var.as_tensor().clone(),
+            v: v_var.as_tensor().clone(),
+            gate: None,
+        };
+        let attn_core = gqa_attention_core_prefill(
+            backend,
+            &prepared_vars,
+            model_config.num_attention_heads,
+            model_config.num_kv_heads,
+            model_config.head_dim,
+        )
+        .with_context(|| format!("full-attention core recompute tile {tile_idx}"))?;
+        let pre_o = gqa_attention_apply_output_gate(
+            attn_core,
+            gate_var.as_ref().map(|gate| gate.as_tensor()),
+        )
+        .with_context(|| format!("full-attention output gate recompute tile {tile_idx}"))?;
+        let pre_o_grad_tile = pre_o_grad_cpu
+            .narrow(1, tile_start, tile_len)
+            .with_context(|| {
+                format!("full-attention core upstream tile [{tile_start}, {tile_end})")
+            })?
+            .detach();
+        let injected = pre_o
+            .apply_op1(InjectTensorGradient {
+                upstream: pre_o_grad_tile,
+            })
+            .with_context(|| format!("full-attention core gradient injection tile {tile_idx}"))?;
+        let grads = injected
+            .backward()
+            .with_context(|| format!("full-attention core backward tile {tile_idx}"))?;
+
+        let q_grad = grads
+            .get(q_var.as_tensor())
+            .ok_or_else(|| anyhow::anyhow!("full-attention core did not produce q grad tile"))?
+            .clone();
+        accumulate_cpu_tensor_slot(
+            &mut q_grad_tiles_cpu[tile_idx],
+            q_grad,
+            &format!("full-attention q grad tile [{tile_start}, {tile_end})"),
+        )?;
+
+        if let Some(gate_var) = gate_var.as_ref() {
+            let gate_grad = grads
+                .get(gate_var.as_tensor())
+                .ok_or_else(|| {
+                    anyhow::anyhow!("full-attention core did not produce gate grad tile")
+                })?
+                .clone();
+            accumulate_cpu_tensor_slot(
+                &mut gate_grad_tiles_cpu[tile_idx],
+                gate_grad,
+                &format!("full-attention gate grad tile [{tile_start}, {tile_end})"),
+            )?;
+        }
+
+        let k_grad_prefix_cpu = grads
+            .get(k_var.as_tensor())
+            .ok_or_else(|| anyhow::anyhow!("full-attention core did not produce k grad prefix"))?
+            .to_device(&Device::Cpu)
+            .context("full-attention k grad prefix CPU offload")?
+            .detach();
+        let v_grad_prefix_cpu = grads
+            .get(v_var.as_tensor())
+            .ok_or_else(|| anyhow::anyhow!("full-attention core did not produce v grad prefix"))?
+            .to_device(&Device::Cpu)
+            .context("full-attention v grad prefix CPU offload")?
+            .detach();
+        for source_idx in 0..=tile_idx {
+            let source_start = source_idx * tile_size;
+            let source_len = (tile_end - source_start).min(tile_size);
+            let source_end = source_start + source_len;
+            let k_source_grad = k_grad_prefix_cpu
+                .narrow(1, source_start, source_len)
+                .with_context(|| {
+                    format!(
+                        "full-attention k source grad [{source_start}, {source_end}) from tile {tile_idx}"
+                    )
+                })?;
+            accumulate_cpu_tensor_slot(
+                &mut k_grad_tiles_cpu[source_idx],
+                k_source_grad,
+                &format!(
+                    "full-attention k grad source [{source_start}, {source_end}) from tile {tile_idx}"
+                ),
+            )?;
+            let v_source_grad = v_grad_prefix_cpu
+                .narrow(1, source_start, source_len)
+                .with_context(|| {
+                    format!(
+                        "full-attention v source grad [{source_start}, {source_end}) from tile {tile_idx}"
+                    )
+                })?;
+            accumulate_cpu_tensor_slot(
+                &mut v_grad_tiles_cpu[source_idx],
+                v_source_grad,
+                &format!(
+                    "full-attention v grad source [{source_start}, {source_end}) from tile {tile_idx}"
+                ),
+            )?;
+        }
+
+        drop(grads);
+        drop(injected);
+        drop(pre_o);
+        drop(prepared_vars);
+        drop(gate_var);
+        drop(v_var);
+        drop(k_var);
+        drop(q_var);
+        drop(gate_value);
+        drop(v_prefix);
+        drop(k_prefix);
+        drop(normed_tile);
+        synchronize_checkpoint_boundary(device, || {
+            format!("synchronize full-attention core backward tile {tile_idx}")
+        })?;
+    }
+    drop(k_value);
+    drop(v_value);
+    drop(normed_value);
+    device.synchronize().with_context(|| {
+        format!("synchronize full-attention tiled core grad offload layer {layer_idx}")
+    })?;
+
+    let mut attention_input_grad_tiles_cpu: Vec<Option<Tensor>> = vec![None; total_tiles];
+    for tile_idx in 0..total_tiles {
+        let tile_start = tile_idx * tile_size;
+        let tile_len = (total_tokens - tile_start).min(tile_size);
+        let tile_end = tile_start + tile_len;
+        let seg_input_tile = seg_input
+            .narrow(1, tile_start, tile_len)
+            .with_context(|| {
+                format!("full-attention prepare input tile [{tile_start}, {tile_end})")
+            })?
+            .detach();
+
+        let mut q_gate_terms_present = q_grad_tiles_cpu[tile_idx].is_some();
+        q_gate_terms_present |= gate_grad_tiles_cpu[tile_idx].is_some();
+        if q_gate_terms_present {
+            let seg_input_var = Var::from_tensor(&seg_input_tile).with_context(|| {
+                format!("full-attention q/gate input Var tile [{tile_start}, {tile_end})")
+            })?;
+            let normed_tile = rms_norm(
+                seg_input_var.as_tensor(),
+                &layer.input_layernorm,
+                model_config.rms_norm_eps,
+            )
+            .with_context(|| {
+                format!("full-attention q/gate norm tile [{tile_start}, {tile_end})")
+            })?;
+            let (q, gate) = gqa_attention_q_gate_prefill(
+                backend,
+                &normed_tile,
+                attn_weights,
+                &positions[tile_start..tile_end],
+                model_config.num_attention_heads,
+                model_config.head_dim,
+                model_config.rotary_dim(),
+                &weights.rotary_inv_freq,
+                model_config.rms_norm_eps,
+                model_config.attn_output_gate,
+                layer_lora,
+            )
+            .with_context(|| {
+                format!("full-attention q/gate prepare tile [{tile_start}, {tile_end})")
+            })?;
+            let mut inject_terms = Vec::with_capacity(2);
+            if let Some(q_grad_cpu) = q_grad_tiles_cpu[tile_idx].as_ref() {
+                inject_terms.push(
+                    q.apply_op1(InjectTensorGradient {
+                        upstream: q_grad_cpu.clone(),
+                    })
+                    .context("full-attention q tile gradient injection")?,
+                );
+            }
+            if let (Some(gate), Some(gate_grad_cpu)) =
+                (gate.as_ref(), gate_grad_tiles_cpu[tile_idx].as_ref())
+            {
+                inject_terms.push(
+                    gate.apply_op1(InjectTensorGradient {
+                        upstream: gate_grad_cpu.clone(),
+                    })
+                    .context("full-attention gate tile gradient injection")?,
+                );
+            }
+            let mut injected = inject_terms
+                .first()
+                .context("full-attention q/gate missing gradient injections")?
+                .clone();
+            for term in inject_terms.iter().skip(1) {
+                injected =
+                    (&injected + term).context("full-attention q/gate gradient injection add")?;
+            }
+            let grads = injected.backward().with_context(|| {
+                format!("full-attention q/gate prepare backward tile {tile_idx}")
+            })?;
+            accumulate_grads(accumulated_grads, &grads, all_vars)?;
+            let input_grad = match grads.get(seg_input_var.as_tensor()) {
+                Some(grad) => grad.detach(),
+                None => Tensor::zeros(seg_input_tile.dims(), seg_input_tile.dtype(), device)
+                    .context("alloc zero full-attention q/gate input grad tile")?,
+            };
+            accumulate_cpu_tensor_slot(
+                &mut attention_input_grad_tiles_cpu[tile_idx],
+                input_grad,
+                &format!("full-attention q/gate input grad tile {tile_idx}"),
+            )?;
+            drop(grads);
+            drop(injected);
+            drop(inject_terms);
+            drop(gate);
+            drop(q);
+            drop(normed_tile);
+            drop(seg_input_var);
+            synchronize_checkpoint_boundary(device, || {
+                format!("synchronize full-attention q/gate prepare tile {tile_idx}")
+            })?;
+        }
+
+        let mut kv_terms_present = k_grad_tiles_cpu[tile_idx].is_some();
+        kv_terms_present |= v_grad_tiles_cpu[tile_idx].is_some();
+        if kv_terms_present {
+            let seg_input_var = Var::from_tensor(&seg_input_tile).with_context(|| {
+                format!("full-attention k/v input Var tile [{tile_start}, {tile_end})")
+            })?;
+            let normed_tile = rms_norm(
+                seg_input_var.as_tensor(),
+                &layer.input_layernorm,
+                model_config.rms_norm_eps,
+            )
+            .with_context(|| format!("full-attention k/v norm tile [{tile_start}, {tile_end})"))?;
+            let (k, v) = gqa_attention_kv_prefill(
+                backend,
+                &normed_tile,
+                attn_weights,
+                &positions[tile_start..tile_end],
+                model_config.num_kv_heads,
+                model_config.head_dim,
+                model_config.rotary_dim(),
+                &weights.rotary_inv_freq,
+                model_config.rms_norm_eps,
+                layer_lora,
+            )
+            .with_context(|| {
+                format!("full-attention k/v prepare tile [{tile_start}, {tile_end})")
+            })?;
+            let mut inject_terms = Vec::with_capacity(2);
+            if let Some(k_grad_cpu) = k_grad_tiles_cpu[tile_idx].as_ref() {
+                inject_terms.push(
+                    k.apply_op1(InjectTensorGradient {
+                        upstream: k_grad_cpu.clone(),
+                    })
+                    .context("full-attention k tile gradient injection")?,
+                );
+            }
+            if let Some(v_grad_cpu) = v_grad_tiles_cpu[tile_idx].as_ref() {
+                inject_terms.push(
+                    v.apply_op1(InjectTensorGradient {
+                        upstream: v_grad_cpu.clone(),
+                    })
+                    .context("full-attention v tile gradient injection")?,
+                );
+            }
+            let mut injected = inject_terms
+                .first()
+                .context("full-attention k/v missing gradient injections")?
+                .clone();
+            for term in inject_terms.iter().skip(1) {
+                injected =
+                    (&injected + term).context("full-attention k/v gradient injection add")?;
+            }
+            let grads = injected
+                .backward()
+                .with_context(|| format!("full-attention k/v prepare backward tile {tile_idx}"))?;
+            accumulate_grads(accumulated_grads, &grads, all_vars)?;
+            let input_grad = match grads.get(seg_input_var.as_tensor()) {
+                Some(grad) => grad.detach(),
+                None => Tensor::zeros(seg_input_tile.dims(), seg_input_tile.dtype(), device)
+                    .context("alloc zero full-attention k/v input grad tile")?,
+            };
+            accumulate_cpu_tensor_slot(
+                &mut attention_input_grad_tiles_cpu[tile_idx],
+                input_grad,
+                &format!("full-attention k/v input grad tile {tile_idx}"),
+            )?;
+            drop(grads);
+            drop(injected);
+            drop(inject_terms);
+            drop(v);
+            drop(k);
+            drop(normed_tile);
+            drop(seg_input_var);
+            synchronize_checkpoint_boundary(device, || {
+                format!("synchronize full-attention k/v prepare tile {tile_idx}")
+            })?;
+        }
+    }
+
+    let mut attention_input_grad_tile_values = Vec::with_capacity(total_tiles);
+    for tile_idx in 0..total_tiles {
+        let tile_start = tile_idx * tile_size;
+        let tile_len = (total_tokens - tile_start).min(tile_size);
+        let tile = match attention_input_grad_tiles_cpu[tile_idx].take() {
+            Some(tile) => tile,
+            None => Tensor::zeros(
+                (1usize, tile_len, seg_input.dim(2)?),
+                seg_input.dtype(),
+                &Device::Cpu,
+            )
+            .with_context(|| format!("alloc zero full-attention input grad tile {tile_idx}"))?,
+        };
+        if tile.dim(1)? != tile_len {
+            anyhow::bail!(
+                "full-attention input grad tile length mismatch at {tile_start}: {} vs {tile_len}",
+                tile.dim(1)?
+            );
+        }
+        attention_input_grad_tile_values.push(tile);
+    }
+    let attention_input_grad_tile_refs: Vec<&Tensor> =
+        attention_input_grad_tile_values.iter().collect();
+    let attention_input_grad_cpu = Tensor::cat(&attention_input_grad_tile_refs, 1)
+        .context("full-attention tiled prepare input grad cat")?
+        .detach();
+    let attention_input_grad = attention_input_grad_cpu
+        .to_device(device)
+        .context("full-attention attention input grad GPU reload")?;
+    let residual_grad_for_passthrough = residual_grad_cpu
+        .to_device(device)
+        .context("full-attention residual passthrough grad GPU reload")?;
+    let residual_passthrough_grad =
+        if residual_grad_for_passthrough.dtype() == attention_input_grad.dtype() {
+            residual_grad_for_passthrough.clone()
+        } else {
+            residual_grad_for_passthrough
+                .to_dtype(attention_input_grad.dtype())
+                .context("full-attention residual passthrough grad dtype conversion")?
+        };
+    let input_grad = (&attention_input_grad + &residual_passthrough_grad)?.detach();
+
+    drop(residual_grad_for_passthrough);
+    drop(residual_passthrough_grad);
+    drop(attention_input_grad);
+    drop(attention_input_grad_cpu);
+    drop(q_grad_tiles_cpu);
+    drop(gate_grad_tiles_cpu);
+    drop(k_grad_tiles_cpu);
+    drop(v_grad_tiles_cpu);
+    drop(attention_input_grad_tile_values);
+    drop(pre_o_grad_cpu);
+    drop(residual_grad_cpu);
+    synchronize_checkpoint_boundary(device, || {
+        format!("synchronize full-attention tiled MLP reverse layer {layer_idx} cleanup")
+    })?;
+    tracing::info!(
+        layer = layer_idx,
+        full_attn_layer_idx,
+        total_tokens,
+        tile_size,
+        "exact full-attention tiled MLP reverse complete"
+    );
+
+    Ok(input_grad)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -3000,6 +4012,7 @@ fn exact_gdn_single_layer_tiled_reverse(
         }
     }
 
+    let lora_weights_for_seg = params.as_lora_weights();
     let all_vars = params.all_vars();
     let mut input_grad_chunks: Vec<Option<Tensor>> = (0..num_tiles).map(|_| None).collect();
     let mut next_recurrent_grad: Option<Tensor> = None;
@@ -3042,7 +4055,6 @@ fn exact_gdn_single_layer_tiled_reverse(
             stage_started,
         )?;
 
-        let lora_weights_for_seg = params.as_lora_weights();
         let layer_lora = lora_weights_for_seg
             .layers
             .get(layer_idx)
@@ -3084,18 +4096,14 @@ fn exact_gdn_single_layer_tiled_reverse(
             stage_started,
         )?;
 
-        let gated_value = transformer_mlp_gated_hidden(
-            &after_attn_value,
-            layer,
-            model_config,
-            detached_layer_lora,
-        )
-        .with_context(|| {
-            format!(
-                "exact tiled GDN reverse MLP gated value layer {layer_idx} tile [{tile_start}, {tile_end})"
-            )
-        })?
-        .detach();
+        let gated_value =
+            transformer_mlp_gated_hidden(&after_attn_value, layer, model_config, detached_layer_lora)
+                .with_context(|| {
+                    format!(
+                        "exact tiled GDN reverse MLP gated value layer {layer_idx} tile [{tile_start}, {tile_end})"
+                    )
+                })?
+                .detach();
         stage_started = finish_exact_gdn_reverse_tile_stage(
             device,
             profile_tiles,
@@ -3108,13 +4116,12 @@ fn exact_gdn_single_layer_tiled_reverse(
             stage_started,
         )?;
         let gated_var = Var::from_tensor(&gated_value)?;
-        let down_out =
-            transformer_mlp_down_from_gated(gated_var.as_tensor(), layer, layer_lora)
-                .with_context(|| {
-                    format!(
-                        "exact tiled GDN reverse MLP down layer {layer_idx} tile [{tile_start}, {tile_end})"
-                    )
-                })?;
+        let down_out = transformer_mlp_down_from_gated(gated_var.as_tensor(), layer, layer_lora)
+            .with_context(|| {
+                format!(
+                    "exact tiled GDN reverse MLP down layer {layer_idx} tile [{tile_start}, {tile_end})"
+                )
+            })?;
         let down_out_f32 = down_out.to_dtype(DType::F32)?;
         let down_scalar = (&down_out_f32 * &tile_grad_out_f32)?
             .sum_all()
@@ -3148,17 +4155,13 @@ fn exact_gdn_single_layer_tiled_reverse(
         drop(gated_value);
 
         let after_attn_var = Var::from_tensor(&after_attn_value)?;
-        let gated_tracked = transformer_mlp_gated_hidden(
-            after_attn_var.as_tensor(),
-            layer,
-            model_config,
-            layer_lora,
-        )
-        .with_context(|| {
-            format!(
-                "exact tiled GDN reverse MLP gate/up layer {layer_idx} tile [{tile_start}, {tile_end})"
-            )
-        })?;
+        let gated_tracked =
+            transformer_mlp_gated_hidden(after_attn_var.as_tensor(), layer, model_config, layer_lora)
+                .with_context(|| {
+                    format!(
+                        "exact tiled GDN reverse MLP gate/up layer {layer_idx} tile [{tile_start}, {tile_end})"
+                    )
+                })?;
         let gated_tracked_f32 = gated_tracked.to_dtype(DType::F32)?;
         let grad_gated_f32 = grad_gated.to_dtype(DType::F32)?;
         let gate_scalar = (&gated_tracked_f32 * &grad_gated_f32)?
@@ -3565,107 +4568,129 @@ fn exact_gdn_single_layer_tiled_reverse(
                 "attn_input_norm_backward",
                 stage_started,
             )?;
-        } else {
-            let tile_input_var = Var::from_tensor(&tile_input)?;
-            let recurrent_var = Var::from_tensor(&recurrent_boundaries[tile_idx])?;
-            let conv_var = Var::from_tensor(&conv_boundaries[tile_idx])?;
 
-            let mut tile_state = LinearAttentionState::new(model_config, device)?;
-            tile_state.recurrent_states[linear_attn_idx] = recurrent_var.as_tensor().clone();
-            tile_state.conv_states[linear_attn_idx] = conv_var.as_tensor().clone();
+            drop(upstream_after_attn);
+            drop(tile_grad_out_f32);
+            drop(tile_grad_out);
+            drop(tile_input);
 
-            let after_attn = gdn_attention_residual_block(
-                backend,
-                tile_input_var.as_tensor(),
-                layer,
-                model_config,
-                &mut tile_state.recurrent_states[linear_attn_idx],
-                &mut tile_state.conv_states[linear_attn_idx],
-                layer_lora,
-            )
-            .with_context(|| {
-                format!(
-                    "exact tiled GDN reverse forward layer {layer_idx} tile [{tile_start}, {tile_end})"
-                )
-            })?;
-            stage_started = finish_exact_gdn_reverse_tile_stage(
-                device,
-                profile_tiles,
-                layer_idx,
-                tile_idx,
-                num_tiles,
-                tile_start,
-                tile_end,
-                "attention_forward",
-                stage_started,
-            )?;
-
-            let after_attn_f32 = after_attn.to_dtype(DType::F32)?;
-            let upstream_after_attn_f32 = upstream_after_attn.to_dtype(DType::F32)?;
-            let mut scalar = (&after_attn_f32 * &upstream_after_attn_f32)?
-                .sum_all()
-                .with_context(|| format!("exact tiled GDN output injection tile {tile_idx}"))?;
-
-            if let Some(grad) = next_recurrent_grad.as_ref() {
-                let exit_state_f32 =
-                    tile_state.recurrent_states[linear_attn_idx].to_dtype(DType::F32)?;
-                let grad_f32 = grad.to_dtype(DType::F32)?;
-                let state_scalar = (&exit_state_f32 * &grad_f32)?.sum_all().with_context(|| {
-                    format!("exact tiled GDN recurrent-state injection tile {tile_idx}")
+            if matches!(device, Device::Metal(_)) {
+                synchronize_checkpoint_boundary(device, || {
+                    format!("synchronize exact tiled GDN reverse layer {layer_idx} tile {tile_idx}")
                 })?;
-                scalar = (scalar + state_scalar)?;
             }
-            if let Some(grad) = next_conv_grad.as_ref() {
-                let exit_state_f32 =
-                    tile_state.conv_states[linear_attn_idx].to_dtype(DType::F32)?;
-                let grad_f32 = grad.to_dtype(DType::F32)?;
-                let state_scalar = (&exit_state_f32 * &grad_f32)?.sum_all().with_context(|| {
-                    format!("exact tiled GDN conv-state injection tile {tile_idx}")
-                })?;
-                scalar = (scalar + state_scalar)?;
+            if profile_tiles {
+                tracing::info!(
+                    layer = layer_idx,
+                    tile = tile_idx + 1,
+                    num_tiles,
+                    tile_start,
+                    tile_end,
+                    elapsed_ms = tile_started.elapsed().as_millis() as u64,
+                    last_stage_elapsed_ms = stage_started.elapsed().as_millis() as u64,
+                    "exact tiled GDN reverse tile complete"
+                );
             }
-
-            let tile_grads = scalar
-                .backward()
-                .with_context(|| format!("exact tiled GDN backward tile {tile_idx}"))?;
-            accumulate_grads(accumulated_grads, &tile_grads, &all_vars)?;
-            stage_started = finish_exact_gdn_reverse_tile_stage(
-                device,
-                profile_tiles,
-                layer_idx,
-                tile_idx,
-                num_tiles,
-                tile_start,
-                tile_end,
-                "attention_backward",
-                stage_started,
-            )?;
-
-            let input_grad = match tile_grads.get(tile_input_var.as_tensor()) {
-                Some(grad) => grad.detach(),
-                None => Tensor::zeros((1, tile_len, hidden_size), seg_input.dtype(), device)
-                    .with_context(|| format!("alloc zero GDN tiled input grad tile {tile_idx}"))?,
-            };
-            input_grad_chunks[tile_idx] = Some(input_grad);
-            next_recurrent_grad = tile_grads
-                .get(recurrent_var.as_tensor())
-                .map(Tensor::detach);
-            next_conv_grad = tile_grads.get(conv_var.as_tensor()).map(Tensor::detach);
-
-            drop(tile_grads);
-            drop(scalar);
-            drop(upstream_after_attn_f32);
-            drop(after_attn_f32);
-            drop(after_attn);
-            drop(tile_state);
-            drop(conv_var);
-            drop(recurrent_var);
-            drop(tile_input_var);
+            continue;
         }
 
+        let tile_input_var = Var::from_tensor(&tile_input)?;
+        let recurrent_var = Var::from_tensor(&recurrent_boundaries[tile_idx])?;
+        let conv_var = Var::from_tensor(&conv_boundaries[tile_idx])?;
+
+        let mut tile_state = LinearAttentionState::new(model_config, device)?;
+        tile_state.recurrent_states[linear_attn_idx] = recurrent_var.as_tensor().clone();
+        tile_state.conv_states[linear_attn_idx] = conv_var.as_tensor().clone();
+
+        let after_attn = gdn_attention_residual_block(
+            backend,
+            tile_input_var.as_tensor(),
+            layer,
+            model_config,
+            &mut tile_state.recurrent_states[linear_attn_idx],
+            &mut tile_state.conv_states[linear_attn_idx],
+            layer_lora,
+        )
+        .with_context(|| {
+            format!(
+                "exact tiled GDN reverse forward layer {layer_idx} tile [{tile_start}, {tile_end})"
+            )
+        })?;
+        stage_started = finish_exact_gdn_reverse_tile_stage(
+            device,
+            profile_tiles,
+            layer_idx,
+            tile_idx,
+            num_tiles,
+            tile_start,
+            tile_end,
+            "attention_forward",
+            stage_started,
+        )?;
+
+        let after_attn_f32 = after_attn.to_dtype(DType::F32)?;
+        let upstream_after_attn_f32 = upstream_after_attn.to_dtype(DType::F32)?;
+        let mut scalar = (&after_attn_f32 * &upstream_after_attn_f32)?
+            .sum_all()
+            .with_context(|| format!("exact tiled GDN output injection tile {tile_idx}"))?;
+
+        if let Some(grad) = next_recurrent_grad.as_ref() {
+            let exit_state_f32 =
+                tile_state.recurrent_states[linear_attn_idx].to_dtype(DType::F32)?;
+            let grad_f32 = grad.to_dtype(DType::F32)?;
+            let state_scalar = (&exit_state_f32 * &grad_f32)?.sum_all().with_context(|| {
+                format!("exact tiled GDN recurrent-state injection tile {tile_idx}")
+            })?;
+            scalar = (scalar + state_scalar)?;
+        }
+        if let Some(grad) = next_conv_grad.as_ref() {
+            let exit_state_f32 = tile_state.conv_states[linear_attn_idx].to_dtype(DType::F32)?;
+            let grad_f32 = grad.to_dtype(DType::F32)?;
+            let state_scalar = (&exit_state_f32 * &grad_f32)?
+                .sum_all()
+                .with_context(|| format!("exact tiled GDN conv-state injection tile {tile_idx}"))?;
+            scalar = (scalar + state_scalar)?;
+        }
+
+        let tile_grads = scalar
+            .backward()
+            .with_context(|| format!("exact tiled GDN backward tile {tile_idx}"))?;
+        accumulate_grads(accumulated_grads, &tile_grads, &all_vars)?;
+        stage_started = finish_exact_gdn_reverse_tile_stage(
+            device,
+            profile_tiles,
+            layer_idx,
+            tile_idx,
+            num_tiles,
+            tile_start,
+            tile_end,
+            "attention_backward",
+            stage_started,
+        )?;
+
+        let input_grad = match tile_grads.get(tile_input_var.as_tensor()) {
+            Some(grad) => grad.detach(),
+            None => Tensor::zeros((1, tile_len, hidden_size), seg_input.dtype(), device)
+                .with_context(|| format!("alloc zero GDN tiled input grad tile {tile_idx}"))?,
+        };
+        input_grad_chunks[tile_idx] = Some(input_grad);
+        next_recurrent_grad = tile_grads
+            .get(recurrent_var.as_tensor())
+            .map(Tensor::detach);
+        next_conv_grad = tile_grads.get(conv_var.as_tensor()).map(Tensor::detach);
+
+        drop(tile_grads);
+        drop(scalar);
+        drop(upstream_after_attn_f32);
+        drop(after_attn_f32);
+        drop(after_attn);
         drop(upstream_after_attn);
         drop(tile_grad_out_f32);
         drop(tile_grad_out);
+        drop(tile_state);
+        drop(conv_var);
+        drop(recurrent_var);
+        drop(tile_input_var);
         drop(tile_input);
 
         if matches!(device, Device::Metal(_)) {
@@ -4400,7 +5425,7 @@ fn checkpointed_forward_backward(
     let lora_detached = lora_weights_detached(params);
     let resident_activation = backend.supports_resident_activation();
     let recompute_boundaries = recompute_checkpoint_boundaries(input_ids.len());
-    let should_spool_boundaries = recompute_boundaries && spool_checkpoint_boundaries();
+    let should_spool_boundaries = recompute_boundaries && spool_checkpoint_boundaries(device);
     let profile_checkpoint_segments = profile_checkpoint_segments();
 
     let detached_boundary = |boundary_idx: usize| -> Result<Tensor> {
@@ -4635,6 +5660,7 @@ fn checkpointed_forward_backward(
     )
     .context("analytic SFT tail gradient")?
     .detach();
+    upstream_grad = offload_checkpoint_tensor_to_cpu(upstream_grad, recompute_boundaries)?;
     drop(loss);
     drop(final_hidden);
     synchronize_checkpoint_boundary(device, || {
@@ -4692,15 +5718,16 @@ fn checkpointed_forward_backward(
             boundary_states[seg_idx] = Tensor::zeros((1usize,), DType::BF16, device)
                 .context("phase3.2: alloc boundary stub")?;
         }
+        let upstream_grad_for_seg = tensor_on_device(&upstream_grad, device)?;
 
         if let Some(tile_size) =
             exact_gdn_reverse_tile_size(weights, device, input_ids.len(), seg_start, seg_end)
         {
-            upstream_grad = exact_gdn_single_layer_tiled_reverse(
+            let next_upstream_grad = exact_gdn_single_layer_tiled_reverse(
                 backend,
                 seg_start,
                 &seg_input,
-                &upstream_grad,
+                &upstream_grad_for_seg,
                 weights,
                 model_config,
                 &positions,
@@ -4716,6 +5743,9 @@ fn checkpointed_forward_backward(
                 )
             })?;
             drop(seg_input);
+            drop(upstream_grad_for_seg);
+            upstream_grad =
+                offload_checkpoint_tensor_to_cpu(next_upstream_grad, recompute_boundaries)?;
             synchronize_checkpoint_boundary(device, || {
                 format!("synchronize checkpointed tiled GDN reverse segment {seg_idx} cleanup")
             })?;
@@ -4726,6 +5756,55 @@ fn checkpointed_forward_backward(
                 end_layer = seg_end,
                 tile_size,
                 "checkpointed tiled GDN reverse segment complete"
+            );
+            continue;
+        }
+
+        if let Some(tile_size) =
+            full_attention_mlp_reverse_tile_size(weights, input_ids.len(), seg_start, seg_end)
+        {
+            let full_attn_layer_idx = (0..seg_start)
+                .filter(|&idx| {
+                    matches!(weights.layers[idx].attention, GpuAttentionWeights::Full(_))
+                })
+                .count();
+            let next_upstream_grad = full_attention_single_layer_tiled_mlp_reverse(
+                backend,
+                seg_start,
+                full_attn_layer_idx,
+                &seg_input,
+                &upstream_grad_for_seg,
+                weights,
+                model_config,
+                &positions,
+                params,
+                &lora_detached,
+                tile_size,
+                device,
+                &mut accumulated_grads,
+                &all_vars,
+            )
+            .with_context(|| {
+                format!(
+                    "exact full-attention tiled MLP reverse segment {seg_idx} layer {seg_start} tile_size={tile_size}"
+                )
+            })?;
+            drop(seg_input);
+            drop(upstream_grad_for_seg);
+            upstream_grad =
+                offload_checkpoint_tensor_to_cpu(next_upstream_grad, recompute_boundaries)?;
+            synchronize_checkpoint_boundary(device, || {
+                format!(
+                    "synchronize checkpointed full-attention tiled MLP reverse segment {seg_idx} cleanup"
+                )
+            })?;
+            tracing::info!(
+                segment = seg_idx + 1,
+                num_segments,
+                start_layer = seg_start,
+                end_layer = seg_end,
+                tile_size,
+                "checkpointed full-attention tiled MLP reverse segment complete"
             );
             continue;
         }
@@ -4747,7 +5826,7 @@ fn checkpointed_forward_backward(
         )?;
 
         let seg_output_f32 = seg_output.to_dtype(DType::F32)?;
-        let upstream_f32 = upstream_grad.to_dtype(DType::F32)?;
+        let upstream_f32 = upstream_grad_for_seg.to_dtype(DType::F32)?;
         let injected = (&seg_output_f32 * &upstream_f32)?
             .sum_all()
             .with_context(|| format!("checkpointed gradient injection for segment {seg_idx}"))?;
@@ -4766,6 +5845,7 @@ fn checkpointed_forward_backward(
                 })?
                 .clone()
                 .detach();
+            upstream_grad = offload_checkpoint_tensor_to_cpu(upstream_grad, recompute_boundaries)?;
         }
         drop(grads);
         drop(injected);
@@ -4774,6 +5854,7 @@ fn checkpointed_forward_backward(
         drop(seg_output);
         drop(seg_input_var);
         drop(seg_input);
+        drop(upstream_grad_for_seg);
         synchronize_checkpoint_boundary(device, || {
             format!("synchronize checkpointed reverse segment {seg_idx} cleanup")
         })?;

--- a/crates/kiln-vulkan-kernel/src/vk_ops/gdn_chunkwise.rs
+++ b/crates/kiln-vulkan-kernel/src/vk_ops/gdn_chunkwise.rs
@@ -27,7 +27,7 @@ use crate::vk_ops::gdn_chunk_bwd::{
     vk_gdn_chunk_prep_bwd_no_grad, vk_gdn_chunk_scan_bwd_no_grad, vk_gdn_state_exit_bwd_no_grad,
     vk_solve_tri_transpose_no_grad,
 };
-use crate::vk_ops::gdn_chunk_prep::{vk_gdn_chunk_prep_no_grad, GdnChunkPrepOutput};
+use crate::vk_ops::gdn_chunk_prep::{GdnChunkPrepOutput, vk_gdn_chunk_prep_no_grad};
 use crate::vk_ops::mask::vk_scale_no_grad;
 use crate::vk_ops::matmul_batched::{vk_matmul_batched_no_grad, vk_transpose_batched_2d_no_grad};
 use crate::vk_ops::narrow::vk_narrow_lastdim_no_grad;

--- a/crates/kiln-vulkan-kernel/src/vk_ops/l2norm.rs
+++ b/crates/kiln-vulkan-kernel/src/vk_ops/l2norm.rs
@@ -39,12 +39,7 @@ fn dispatch_l2norm_forward(
         workgroups <= limit,
         "vk_l2_norm_forward: rows {workgroups} > device limit {limit}"
     );
-    let push = [
-        rows as u32,
-        hidden as u32,
-        scale.to_bits(),
-        eps.to_bits(),
-    ];
+    let push = [rows as u32, hidden as u32, scale.to_bits(), eps.to_bits()];
     dispatch_simple(
         device,
         "vk_l2_norm_lastdim_f32",
@@ -70,12 +65,7 @@ fn dispatch_l2norm_backward(
         workgroups <= limit,
         "vk_l2_norm_backward: rows {workgroups} > device limit {limit}"
     );
-    let push = [
-        rows as u32,
-        hidden as u32,
-        scale.to_bits(),
-        eps.to_bits(),
-    ];
+    let push = [rows as u32, hidden as u32, scale.to_bits(), eps.to_bits()];
     dispatch_simple(
         device,
         "vk_l2_norm_lastdim_bwd_f32",
@@ -134,16 +124,8 @@ impl VkBackwardOp for L2NormBackward {
 pub fn vk_l2_norm_lastdim_no_grad(x: &VkTensor, scale: f32, eps: f32) -> Result<VkTensor> {
     let (rows, hidden) = check_l2norm_shape(x)?;
     let out = alloc_f32(x.device(), x.num_elements())?;
-    dispatch_l2norm_forward(
-        x.device(),
-        x.buffer(),
-        &out,
-        rows,
-        hidden,
-        scale,
-        eps,
-    )
-    .context("vk_l2_norm forward dispatch")?;
+    dispatch_l2norm_forward(x.device(), x.buffer(), &out, rows, hidden, scale, eps)
+        .context("vk_l2_norm forward dispatch")?;
     Ok(VkTensor::from_buffer(
         out,
         x.shape().to_vec(),

--- a/crates/kiln-vulkan-kernel/src/vk_tensor.rs
+++ b/crates/kiln-vulkan-kernel/src/vk_tensor.rs
@@ -15,8 +15,8 @@ use crate::{VulkanBuffer, VulkanDevice};
 use anyhow::{Context, Result};
 use candle_core::{CpuStorage, DType, Device, Storage, Tensor, TensorId};
 use half::bf16;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 /// Element type of a `VkTensor`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]

--- a/crates/kiln-vulkan-kernel/tests/vk_flce_parity.rs
+++ b/crates/kiln-vulkan-kernel/tests/vk_flce_parity.rs
@@ -2,12 +2,12 @@
 
 use anyhow::Result;
 use candle_core::{DType, Device, Tensor, Var};
+use kiln_vulkan_kernel::VulkanDevice;
 use kiln_vulkan_kernel::vk_autograd::vk_backward;
 use kiln_vulkan_kernel::vk_ops::flce::{
     flce_recommended_chunk_len_from_limits, vk_flce_loss, vk_grpo_loss, vk_selected_log_probs,
 };
 use kiln_vulkan_kernel::vk_tensor::VkTensor;
-use kiln_vulkan_kernel::VulkanDevice;
 use std::sync::Arc;
 
 fn vk_dev() -> Option<Arc<VulkanDevice>> {
@@ -208,7 +208,7 @@ fn candle_selected_log_probs_and_grpo(
     hidden_dim: usize,
     vocab: usize,
 ) -> Result<(Vec<f32>, f32, Vec<f32>)> {
-    use candle_core::{DType, D};
+    use candle_core::{D, DType};
 
     let dev = Device::Cpu;
     let hidden_var = Var::from_tensor(&Tensor::from_vec(

--- a/crates/kiln-vulkan-kernel/tests/vk_tensor_parity.rs
+++ b/crates/kiln-vulkan-kernel/tests/vk_tensor_parity.rs
@@ -7,6 +7,7 @@
 
 use anyhow::Result;
 use candle_core::{DType, Device, Tensor};
+use kiln_vulkan_kernel::VulkanDevice;
 use kiln_vulkan_kernel::vk_autograd::vk_backward;
 use kiln_vulkan_kernel::vk_ops::cast::{
     vk_cast, vk_cast_bf16_to_f32_no_grad, vk_cast_f32_to_bf16_no_grad,
@@ -15,7 +16,6 @@ use kiln_vulkan_kernel::vk_ops::elementwise::{vk_add, vk_div, vk_mul, vk_sub};
 use kiln_vulkan_kernel::vk_ops::reduce::{vk_mean_all, vk_sum_all};
 use kiln_vulkan_kernel::vk_ops::shape::{vk_reshape, vk_transpose_2d, vk_transpose_2d_no_grad};
 use kiln_vulkan_kernel::vk_tensor::{VkDType, VkTensor};
-use kiln_vulkan_kernel::VulkanDevice;
 use std::sync::Arc;
 
 fn vk_dev() -> Option<Arc<VulkanDevice>> {

--- a/vendor/candle-core/src/backprop.rs
+++ b/vendor/candle-core/src/backprop.rs
@@ -183,32 +183,24 @@ impl Tensor {
             if let Some(op) = node.op() {
                 match op {
                     Op::Binary(lhs, rhs, BinaryOp::Add) => {
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&grad)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.add(&grad)?;
+                        grads.insert_or_add(lhs, grad.clone())?;
+                        grads.insert_or_add(rhs, grad.clone())?;
                     }
                     Op::Binary(lhs, rhs, BinaryOp::Sub) => {
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&grad)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.sub(&grad)?;
+                        grads.insert_or_add(lhs, grad.clone())?;
+                        grads.insert_or_sub(rhs, grad.clone())?;
                     }
                     Op::Binary(lhs, rhs, BinaryOp::Mul) => {
                         let lhs_grad = grad.mul(rhs)?;
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?;
+                        grads.insert_or_add(lhs, lhs_grad)?;
                         let rhs_grad = grad.mul(lhs)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.add(&rhs_grad)?;
+                        grads.insert_or_add(rhs, rhs_grad)?;
                     }
                     Op::Binary(lhs, rhs, BinaryOp::Div) => {
                         let lhs_grad = grad.div(rhs)?;
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?;
+                        grads.insert_or_add(lhs, lhs_grad)?;
                         let rhs_grad = grad.mul(lhs)?.div(&rhs.sqr()?)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.sub(&rhs_grad)?;
+                        grads.insert_or_sub(rhs, rhs_grad)?;
                     }
                     Op::Binary(lhs, rhs, BinaryOp::Minimum)
                     | Op::Binary(lhs, rhs, BinaryOp::Maximum) => {
@@ -218,21 +210,17 @@ impl Tensor {
                         // If both masks are 1 one the same point, we want to scale the
                         // gradient by 0.5 rather than 1.
                         let lhs_grad = mask_lhs.mul(&grad)?.div(&(&mask_rhs + 1.)?)?;
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?;
+                        grads.insert_or_add(lhs, lhs_grad)?;
 
                         let rhs_grad = mask_rhs.mul(&grad)?.div(&(&mask_lhs + 1.)?)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.add(&rhs_grad)?;
+                        grads.insert_or_add(rhs, rhs_grad)?;
                     }
                     Op::WhereCond(pred, t, f) => {
                         let zeros = grad.zeros_like()?;
-                        let t_sum_grad = grads.or_insert(t)?;
                         let t_grad = pred.where_cond(&grad, &zeros)?;
-                        *t_sum_grad = t_sum_grad.add(&t_grad)?;
-                        let f_sum_grad = grads.or_insert(f)?;
+                        grads.insert_or_add(t, t_grad)?;
                         let f_grad = pred.where_cond(&zeros, &grad)?;
-                        *f_sum_grad = f_sum_grad.add(&f_grad)?;
+                        grads.insert_or_add(f, f_grad)?;
                     }
                     Op::Conv1D {
                         arg,
@@ -458,21 +446,23 @@ impl Tensor {
                         // Skipping checks, the op went ok, we can skip
                         // the matmul size checks for now.
 
+                        let grad = if grad.is_contiguous() {
+                            grad
+                        } else {
+                            grad.contiguous()?
+                        };
                         let lhs_grad = grad.matmul(&rhs.t()?)?;
-                        let lhs_sum_grad = grads.or_insert(lhs)?;
-                        *lhs_sum_grad = lhs_sum_grad.add(&lhs_grad)?;
+                        grads.insert_or_add(lhs, lhs_grad)?;
 
                         let rhs_grad = lhs.t()?.matmul(&grad)?;
-                        let rhs_sum_grad = grads.or_insert(rhs)?;
-                        *rhs_sum_grad = rhs_sum_grad.add(&rhs_grad)?;
+                        grads.insert_or_add(rhs, rhs_grad)?;
                     }
                     Op::Cat(args, dim) => {
                         let mut start_idx = 0;
                         for arg in args {
                             let len = arg.dims()[*dim];
                             let arg_grad = grad.narrow(*dim, start_idx, len)?;
-                            let sum_grad = grads.or_insert(arg)?;
-                            *sum_grad = sum_grad.add(&arg_grad)?;
+                            grads.insert_or_add(arg, arg_grad)?;
                             start_idx += len;
                         }
                     }
@@ -496,76 +486,71 @@ impl Tensor {
                         for _i in 0..left_dims {
                             arg_grad = arg_grad.squeeze(0)?
                         }
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad.broadcast_as(sum_grad.dims())?)?;
+                        let arg_grad = arg_grad.broadcast_as(arg.dims())?;
+                        grads.insert_or_add(arg, arg_grad)?;
                     }
                     Op::Reduce(arg, ReduceOp::Sum, reduced_dims) => {
                         let grad = broadcast_back(arg, &grad, reduced_dims)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad)?;
+                        grads.insert_or_add(arg, grad)?;
                     }
                     Op::Reduce(arg, ReduceOp::Max, reduced_dims) => {
                         let node = broadcast_back(arg, node, reduced_dims)?;
                         let grad = broadcast_back(arg, &grad, reduced_dims)?;
                         let grad = node.eq(arg)?.to_dtype(grad.dtype())?.mul(&grad)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad.broadcast_as(sum_grad.dims())?)?;
+                        let grad = grad.broadcast_as(arg.dims())?;
+                        grads.insert_or_add(arg, grad)?;
                     }
                     Op::Reduce(arg, ReduceOp::Min, reduced_dims) => {
                         let node = broadcast_back(arg, node, reduced_dims)?;
                         let grad = broadcast_back(arg, &grad, reduced_dims)?;
                         let grad = node.eq(arg)?.to_dtype(grad.dtype())?.mul(&grad)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad.broadcast_as(sum_grad.dims())?)?;
+                        let grad = grad.broadcast_as(arg.dims())?;
+                        grads.insert_or_add(arg, grad)?;
                     }
                     Op::ToDType(arg) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad.to_dtype(arg.dtype())?)?
+                        let arg_grad = grad.to_dtype(arg.dtype())?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Copy(arg) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&grad)?
+                        grads.insert_or_add(arg, grad.clone())?
                     }
                     Op::Affine { arg, mul, .. } => {
                         let arg_grad = grad.affine(*mul, 0.)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::Log) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&(grad / arg)?)?
+                        let arg_grad = (grad / arg)?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::Sin) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&(&grad * arg.cos())?)?
+                        let arg_grad = (&grad * arg.cos())?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::Cos) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.sub(&(&grad * arg.sin())?)?
+                        let arg_grad = (&grad * arg.sin())?;
+                        grads.insert_or_sub(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::Tanh) => {
-                        let sum_grad = grads.or_insert(arg)?;
                         let minus_dtanh = (node.sqr()? - 1.)?;
-                        *sum_grad = sum_grad.sub(&(&grad * &minus_dtanh)?)?
+                        let arg_grad = (&grad * &minus_dtanh)?;
+                        grads.insert_or_sub(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::Abs) => {
-                        let sum_grad = grads.or_insert(arg)?;
                         let ones = arg.ones_like()?;
                         let abs_grad = arg.ge(&arg.zeros_like()?)?.where_cond(&ones, &ones.neg()?);
-                        *sum_grad = sum_grad.add(&(&grad * abs_grad)?)?
+                        let arg_grad = (&grad * abs_grad)?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::Exp) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&(&grad * *node)?)?
+                        let arg_grad = (&grad * *node)?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::Neg) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.sub(&grad)?
+                        grads.insert_or_sub(arg, grad.clone())?
                     }
                     Op::Unary(arg, UnaryOp::Recip) => {
-                        let sum_grad = grads.or_insert(arg)?;
                         let grad = (grad / arg.sqr()?)?;
-                        *sum_grad = sum_grad.sub(&grad)?
+                        grads.insert_or_sub(arg, grad)?
                     }
                     &Op::Narrow(ref arg, dim, start_idx, len) => {
                         let arg_dims = arg.dims();
@@ -590,8 +575,7 @@ impl Tensor {
                             (None, Some(r)) => Tensor::cat(&[&grad, &r], dim)?,
                             (Some(l), Some(r)) => Tensor::cat(&[&l, &grad, &r], dim)?,
                         };
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(_, UnaryOp::Floor)
                     | Op::Unary(_, UnaryOp::Round)
@@ -601,116 +585,104 @@ impl Tensor {
                     | Op::Cmp(_, _) => {}
                     Op::Reshape(arg) => {
                         let arg_grad = grad.reshape(arg.dims())?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(_, UnaryOp::Ceil) => Err(Error::BackwardNotSupported { op: "ceil" })?,
                     Op::Unary(arg, UnaryOp::Gelu) => {
-                        let sum_grad = grads.or_insert(arg)?;
                         let cube = arg.powf(3.)?;
                         let tanh = (0.0356774 * &cube + (0.797885 * arg)?)?.tanh()?;
                         let gelu_grad = (((0.5 * &tanh)?
                             + (0.0535161 * cube + (0.398942 * arg)?)? * (1. - tanh.powf(2.)?))?
                             + 0.5)?;
-                        *sum_grad = sum_grad.add(&(&grad * gelu_grad)?)?
+                        let arg_grad = (&grad * gelu_grad)?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::Erf) => {
-                        let sum_grad = grads.or_insert(arg)?;
                         // d/dx erf(x) = 2/sqrt(pi) * e^(-x^2)
                         let erf_grad =
                             (2. / std::f64::consts::PI.sqrt()) * (arg.sqr()?.neg()?).exp()?;
-                        *sum_grad = sum_grad.add(&(&grad * erf_grad)?)?
+                        let arg_grad = (&grad * erf_grad)?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::GeluErf) => {
-                        let sum_grad = grads.or_insert(arg)?;
                         // d/dx gelu_erf(x) = 0.5 + 0.398942 e^(-x^2/2) x + 0.5 erf(x/sqrt(2))
                         let neg_half_square = (arg.sqr()?.neg()? / 2.)?;
                         let scaled_exp_arg = (0.398942 * neg_half_square.exp()? * arg)?;
                         let arg_scaled_sqrt = (arg / 2f64.sqrt())?;
                         let erf_scaled_sqrt = (0.5 * arg_scaled_sqrt.erf()?)?;
                         let gelu_erf_grad = (0.5 + scaled_exp_arg + erf_scaled_sqrt)?;
-                        *sum_grad = sum_grad.add(&(&grad * gelu_erf_grad)?)?;
+                        let arg_grad = (&grad * gelu_erf_grad)?;
+                        grads.insert_or_add(arg, arg_grad)?;
                     }
                     Op::Unary(arg, UnaryOp::Relu) => {
-                        let sum_grad = grads.or_insert(arg)?;
                         let relu_grad = arg.ge(&arg.zeros_like()?)?.to_dtype(arg.dtype())?;
-                        *sum_grad = sum_grad.add(&(&grad * relu_grad)?)?
+                        let arg_grad = (&grad * relu_grad)?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::Silu) => {
-                        let sum_grad = grads.or_insert(arg)?;
                         // d/dx silu = sigmoid(x) * (1 + x * (1 - sigmoid(x))) = sigmoid(x) * (1 - node) + node
                         let sigmoid_arg = (arg.neg()?.exp()? + 1.)?.recip()?;
                         let silu_grad = &sigmoid_arg * (1. - *node) + *node;
-                        *sum_grad = sum_grad.add(&(&grad * silu_grad)?)?
+                        let arg_grad = (&grad * silu_grad)?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Elu(arg, alpha) => {
                         // d/dx elu(x) = 1 for x > 0, alpha * e^x for x <= 0
-                        let sum_grad = grads.or_insert(arg)?;
                         let zeros = arg.zeros_like()?;
                         let positive_mask = arg.gt(&zeros)?.to_dtype(arg.dtype())?;
                         let negative_mask = arg.le(&zeros)?.to_dtype(arg.dtype())?;
                         // node == alpha * (e^x - 1) for x <= 0, reuse it
                         let negative_exp_mask = (negative_mask * (*node + *alpha))?;
                         let combined_mask = (positive_mask + negative_exp_mask)?;
-                        *sum_grad = sum_grad.add(&(grad * combined_mask)?)?
+                        let arg_grad = (grad * combined_mask)?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Powf(arg, e) => {
                         let arg_grad = (&(grad * arg.powf(e - 1.)?)? * *e)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::CustomOp1(arg, c) => {
                         if let Some(arg_grad) = c.bwd(arg, node, &grad)? {
-                            let sum_grad = grads.or_insert(arg)?;
-                            *sum_grad = sum_grad.add(&arg_grad)?
+                            grads.insert_or_add(arg, arg_grad)?
                         }
                     }
                     Op::CustomOp2(arg1, arg2, c) => {
                         let (arg_grad1, arg_grad2) = c.bwd(arg1, arg2, node, &grad)?;
                         if let Some(arg_grad1) = arg_grad1 {
-                            let sum_grad = grads.or_insert(arg1)?;
-                            *sum_grad = sum_grad.add(&arg_grad1)?
+                            grads.insert_or_add(arg1, arg_grad1)?
                         }
                         if let Some(arg_grad2) = arg_grad2 {
-                            let sum_grad = grads.or_insert(arg2)?;
-                            *sum_grad = sum_grad.add(&arg_grad2)?
+                            grads.insert_or_add(arg2, arg_grad2)?
                         }
                     }
                     Op::CustomOp3(arg1, arg2, arg3, c) => {
                         let (arg_grad1, arg_grad2, arg_grad3) =
                             c.bwd(arg1, arg2, arg3, node, &grad)?;
                         if let Some(arg_grad1) = arg_grad1 {
-                            let sum_grad = grads.or_insert(arg1)?;
-                            *sum_grad = sum_grad.add(&arg_grad1)?
+                            grads.insert_or_add(arg1, arg_grad1)?
                         }
                         if let Some(arg_grad2) = arg_grad2 {
-                            let sum_grad = grads.or_insert(arg2)?;
-                            *sum_grad = sum_grad.add(&arg_grad2)?
+                            grads.insert_or_add(arg2, arg_grad2)?
                         }
                         if let Some(arg_grad3) = arg_grad3 {
-                            let sum_grad = grads.or_insert(arg3)?;
-                            *sum_grad = sum_grad.add(&arg_grad3)?
+                            grads.insert_or_add(arg3, arg_grad3)?
                         }
                     }
                     Op::Unary(arg, UnaryOp::Sqr) => {
                         let arg_grad = arg.mul(&grad)?.affine(2., 0.)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Unary(arg, UnaryOp::Sqrt) => {
                         let arg_grad = grad.div(node)?.affine(0.5, 0.)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::ToDevice(arg) => {
-                        let sum_grad = grads.or_insert(arg)?;
-                        let arg_grad = grad.to_device(sum_grad.device())?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        let arg_grad = grad.to_device(arg.device())?;
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Transpose(arg, dim1, dim2) => {
                         let arg_grad = grad.transpose(*dim1, *dim2)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                     Op::Permute(arg, dims) => {
                         let mut inv_dims = vec![0; dims.len()];
@@ -718,8 +690,7 @@ impl Tensor {
                             inv_dims[dim_idx] = i
                         }
                         let arg_grad = grad.permute(inv_dims)?;
-                        let sum_grad = grads.or_insert(arg)?;
-                        *sum_grad = sum_grad.add(&arg_grad)?
+                        grads.insert_or_add(arg, arg_grad)?
                     }
                 };
             }
@@ -775,6 +746,24 @@ impl GradStore {
             }
         };
         Ok(grad)
+    }
+
+    fn insert_or_add(&mut self, tensor: &Tensor, grad: Tensor) -> Result<()> {
+        use std::collections::hash_map::Entry;
+        match self.0.entry(tensor.id()) {
+            Entry::Occupied(mut entry) => {
+                let sum = entry.get().add(&grad)?;
+                *entry.get_mut() = sum;
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(grad);
+            }
+        }
+        Ok(())
+    }
+
+    fn insert_or_sub(&mut self, tensor: &Tensor, grad: Tensor) -> Result<()> {
+        self.insert_or_add(tensor, grad.neg()?)
     }
 
     /// Get the tensor ids of the stored gradient tensors


### PR DESCRIPTION
## Summary

- Adds CUDA exact-SFT memory controls for long Qwen3.5-style GDN/full-attention examples.
- Splits exact GDN reverse into smaller MLP, out-proj, gated-norm, recurrent, qkv/conv, gate, in-proj, and input-norm stages inspired by the recent Vulkan/Metal GDN work on `origin/main`.
- Adds CUDA full-attention MLP tiling/offload and safer CUDA defaults: exact GDN backward tile defaults to 1024 tokens on CUDA, and split recurrent GDN backward is enabled by default.
- Keeps server/default CLI routing on the generic trainer path and preserves native selection as explicit opt-in.

## Validation

- `cargo fmt --all -- --check`
- `CUDA_HOME=/usr/local/cuda CUDARC_CUDA_VERSION=12040 KILN_CUDA_ARCHS=89 CARGO_BUILD_JOBS=1 cargo build --release --locked -p kiln-train --features cuda --example cuda_sft_file`
- `cargo test --locked -p kiln-train test_exact_gdn_split_recurrent_reverse_gradients_match_standard_cpu`
- `cargo test --locked -p kiln-train test_grpo_trainable_lora_params_include_exact_gdn_targets`
- Worst record smoke: 76,170 tokens, `loss=1.166049`, peak VRAM `16008 MiB`, elapsed `2415.808s`.
- Rebased default smoke: 22,484 tokens with exact-GDN split/tile env vars unset, `loss=1.046851`, peak VRAM `13584 MiB`, elapsed `699.824s`.

## Notes

A full 100-record epoch was not run locally: the file is 18 MB, 92/100 records are over 100k JSON bytes, and the worst single record takes about 40 minutes on this 16 GB GPU.