### PR TITLE
release: bump server + desktop to 0.2.16 aligned cut

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Kiln Server Changelog
 
-## Unreleased — Phase 11 evals as a first-class peer of training
+## kiln-v0.2.16 — 2026-05-15 — Phase 11 evals as a first-class peer of training
 
 Adds an end-to-end eval system: pluggable scorers, dataset → suite synthesis, post-training auto-eval, head-to-head adapter comparison, and the local A/B judgment flywheel. The whole loop runs on the same single-GPU binary; no frontier-LLM call is ever required.
 
@@ -49,7 +49,7 @@ Adds an end-to-end eval system: pluggable scorers, dataset → suite synthesis, 
 - Suites, datasets, and judgments persist under `<eval-root>/{suites,datasets,judgments}/`
   (defaults to `<state_dir>/eval`).
 
-## Unreleased — Phase 2 Vulkan training hardening
+## kiln-v0.2.16 — 2026-05-15 — Phase 2 Vulkan training hardening
 
 Active branch since v0.2.15. Targets the Strix Halo / unified-memory APU
 training path that previously OOM-killed `kiln serve` and (after the first

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "candle-core",
  "cc",
@@ -1741,7 +1741,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "chrono",
  "kiln-vulkan-kernel",
@@ -1757,7 +1757,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-eval"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "chrono",
  "rand 0.10.1",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "candle-core",
  "cc",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1792,7 +1792,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1803,7 +1803,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "candle-core",
  "cc",
@@ -1812,7 +1812,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1844,11 +1844,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.15"
+version = "0.2.16"
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "candle-core",
  "cc",
@@ -1857,7 +1857,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1932,7 +1932,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-vulkan-kernel"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.15"
+version = "0.2.16"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"

--- a/README.md
+++ b/README.md
@@ -424,19 +424,19 @@ Kiln Desktop is a system-tray app that wraps the `kiln` server for people who do
 
 **Windows, Linux, and macOS (Apple Silicon).** Windows drives the CUDA build of `kiln`; Linux chooses CUDA on NVIDIA systems and Vulkan on AMD/Intel systems; macOS drives the candle-metal build on M-series hardware. Intel Macs are not supported.
 
-**Download — [Kiln Desktop v0.2.15](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15):**
+**Download — [Kiln Desktop v0.2.16](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16):**
 
-**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.15` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, so the version split is intentional.
+**Release note:** Desktop and server binaries use separate GitHub release tags/version numbers. `desktop-v0.2.16` is the latest Desktop release; it downloads and verifies the matching server binary from the latest `kiln-v*` release line, so the version split is intentional.
 
 See **[desktop/CHANGELOG.md](desktop/CHANGELOG.md)** for the full version history.
 
 | Platform | Installer | Size |
 |---|---|---|
-| macOS (Apple Silicon) | [Kiln.Desktop_0.2.15_aarch64.dmg](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_aarch64.dmg) | 8.5 MB |
-| Windows | [Kiln.Desktop_0.2.15_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_x64-setup.exe) (NSIS) | 4.5 MB |
-| Windows | [Kiln.Desktop_0.2.15_x64_en-US.msi](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_x64_en-US.msi) (MSI) | 6.8 MB |
-| Linux | [Kiln.Desktop_0.2.15_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_amd64.deb) | 8.8 MB |
-| Linux | [Kiln.Desktop_0.2.15_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_amd64.AppImage) | 85.7 MB |
+| macOS (Apple Silicon) | [Kiln.Desktop_0.2.16_aarch64.dmg](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_aarch64.dmg) | 8.5 MB |
+| Windows | [Kiln.Desktop_0.2.16_x64-setup.exe](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_x64-setup.exe) (NSIS) | 4.5 MB |
+| Windows | [Kiln.Desktop_0.2.16_x64_en-US.msi](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_x64_en-US.msi) (MSI) | 6.8 MB |
+| Linux | [Kiln.Desktop_0.2.16_amd64.deb](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_amd64.deb) | 8.8 MB |
+| Linux | [Kiln.Desktop_0.2.16_amd64.AppImage](https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_amd64.AppImage) | 85.7 MB |
 
 The installer bundles the desktop wrapper only. On first launch the app offers to auto-download the matching prebuilt `kiln` server binary for your platform (macOS aarch64 / Metal, Linux x86_64 / CUDA 12.4 or Vulkan, Windows x86_64 / CUDA 12.4) from the latest `kiln-v*` GitHub release and verify it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be downloaded separately — the Settings window has a HuggingFace downloader, or you can use the CLI path in [QUICKSTART.md](QUICKSTART.md).
 

--- a/desktop/CHANGELOG.md
+++ b/desktop/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Kiln Desktop Changelog
 
+## desktop-v0.2.16 — 2026-05-15
+
+Aligned cut with kiln-v0.2.16 server. No desktop source changes since
+desktop-v0.2.15; this release re-pins the bundled server payload to the
+latest server cut so installers ship the new eval system, the Phase 2
+Vulkan training hardening, the full Qwen3.5 stochastic sampler, and the
+Playground overhaul.
+
+### Server payload
+This cut ships with the kiln-v0.2.16 server binary. Highlights:
+
+- **Phase 11 — Evals as a first-class peer of training:** end-to-end eval
+  system with pluggable scorers (`exact_match`, `contains`, `regex`,
+  `json_validity`, `multiple_choice`, `numeric_tolerance`, `tool_call`,
+  `code`, `llm_judge`, `all` / `any` composites), dataset → suite synthesis,
+  post-training auto-eval, head-to-head adapter compare, and an A/B
+  `JudgmentStore`. The embedded `/ui` gains a Cmd-K command palette, eval /
+  training / adapter detail modals with live progress, loss curves with
+  downsampled history, the A/B compare playground with keyboard shortcuts,
+  a VRAM donut, and a tok/s sparkline. New `/v1/eval/*` and `/v1/judgments/*`
+  HTTP surface, `kiln-eval` CLI binary, `[eval]` config section.
+- **Phase 2 — Vulkan training hardening (Strix Halo / unified-memory APUs):**
+  on-device AdamW (`adamw_step_{f32,bf16}.comp`, decoupled weight decay)
+  alongside the BF16 SGD path; lazy candle-CPU-storage sync removes the
+  per-step GPU→CPU readback; `VulkanLinearOp` (CustomOp1) with autograd
+  parity and in-op chunking via `KILN_VULKAN_LINEAR_MAX_GFLOP`;
+  `sdpa_prefill_f32.comp` replaces the old `flash_attn.comp` placeholder;
+  FLCE auto-engages at `active_count ≥ 16` and `KILN_USE_FLCE`,
+  `KILN_VULKAN_LINEAR`, and `KILN_VULKAN_SDPA` default ON; unified-memory
+  APU VRAM-budget correction; HTTP 413 rejection with actionable hints for
+  oversized training submissions.
+- **Sampling — full Qwen3.5 stochastic sampler:** fused on Vulkan, Metal,
+  and CUDA (zero vocab readback on Vulkan), new penalty fields, and
+  Qwen3.5 recommended defaults everywhere.
+- **Playground overhaul:** compare mode that streams both sides with
+  reasoning, markdown rendering, inline edit-and-resend on user turns,
+  per-turn badges + scroll lock + retry + transcript export, system-prompt
+  and advanced-sampling controls, live `<think>` drain.
+- **Reliability:** near-instant Ctrl+C shutdown; SSE parser hardened with a
+  first-token >5 s hint; uptime cap only applies after the drain signal;
+  default batching engine ON with `KILN_BATCHING_ENGINE=0` opt-out.
+
+See [CHANGELOG.md](../CHANGELOG.md) for the full server changelog.
+
 ## desktop-v0.2.15 — 2026-05-10
 
 Aligned cut with kiln-v0.2.15 server. No desktop source changes since

--- a/desktop/Cargo.lock
+++ b/desktop/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-desktop"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "dirs 5.0.1",
  "flate2",

--- a/desktop/Cargo.toml
+++ b/desktop/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "kiln-desktop"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2021"
 description = "Kiln Desktop — system tray app for the kiln local LLM server"
 authors = ["Eric Florenzano <eric@eflorenzano.com>"]

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -12,13 +12,13 @@ would be strictly worse than running Linux in a VM.
 
 ## Releases
 
-[Kiln Desktop v0.2.15](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15) ships these installers:
+[Kiln Desktop v0.2.16](https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16) ships these installers:
 
-- `Kiln.Desktop_0.2.15_aarch64.dmg` (macOS Apple Silicon DMG, 8.5 MB)
-- `Kiln.Desktop_0.2.15_x64-setup.exe` (Windows NSIS, 4.5 MB)
-- `Kiln.Desktop_0.2.15_x64_en-US.msi` (Windows MSI, 6.8 MB)
-- `Kiln.Desktop_0.2.15_amd64.deb` (Debian/Ubuntu, 8.8 MB)
-- `Kiln.Desktop_0.2.15_amd64.AppImage` (portable Linux, 85.7 MB)
+- `Kiln.Desktop_0.2.16_aarch64.dmg` (macOS Apple Silicon DMG, 8.5 MB)
+- `Kiln.Desktop_0.2.16_x64-setup.exe` (Windows NSIS, 4.5 MB)
+- `Kiln.Desktop_0.2.16_x64_en-US.msi` (Windows MSI, 6.8 MB)
+- `Kiln.Desktop_0.2.16_amd64.deb` (Debian/Ubuntu, 8.8 MB)
+- `Kiln.Desktop_0.2.16_amd64.AppImage` (portable Linux, 85.7 MB)
 
 The desktop installer bundles only the wrapper. On first launch the app offers to auto-download the prebuilt `kiln` server binary from the latest `kiln-v*` GitHub release — `aarch64-apple-darwin-metal` on macOS, `x86_64-unknown-linux-gnu-cuda124` or `x86_64-unknown-linux-gnu-vulkan` on Linux x86_64, `x86_64-pc-windows-msvc-cuda124` on Windows x86_64 — and verifies it against the published SHA-256. You can also point it at an existing `kiln` binary from Settings. Model weights still need to be installed separately; see the root [QUICKSTART.md](../QUICKSTART.md) or use the HuggingFace downloader in Settings.
 
@@ -28,7 +28,7 @@ Settings has a **Download from HuggingFace…** button next to the Model Path pi
 
 macOS `.dmg` releases are signed with a Developer ID certificate and notarized by Apple. See [docs/desktop/signing.md](../docs/desktop/signing.md) for the CI setup and required secrets.
 
-## What ships in v0.2.15
+## What ships in v0.2.16
 
 - **Subprocess supervisor** — Tokio child process driving the `kiln` binary, with stdout/stderr captured into an in-process ring buffer.
 - **Crash restart** with exponential backoff, and a clear error state surfaced in the tray.

--- a/desktop/tauri.conf.json
+++ b/desktop/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Kiln Desktop",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "identifier": "com.eflorenzano.kiln.desktop",
   "build": {
     "frontendDist": "ui",

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -55,7 +55,7 @@
       <a href="./" class="brand" aria-current="page" aria-label="Kiln home">
         <span class="brand-mark" aria-hidden="true"></span>
         <span>kiln</span>
-        <span class="brand-version">v0.2.15</span>
+        <span class="brand-version">v0.2.16</span>
       </a>
       <nav class="nav site-nav" aria-label="Primary">
         <a href="quickstart.html">Quickstart</a>
@@ -448,7 +448,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
           The Kiln Desktop app and the Kiln server use
           <strong>separate GitHub release tags/version numbers</strong>
           so each can ship at its own cadence. The latest desktop build is
-          <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15"><code>desktop-v0.2.15</code></a>;
+          <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16"><code>desktop-v0.2.16</code></a>;
           the server tracks the latest <code>kiln-v*</code> tag.
         </p>
         <table class="installer-table">
@@ -458,15 +458,15 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
           <tbody>
             <tr>
               <th scope="row">macOS (Apple Silicon)</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15">desktop-v0.2.15 · macOS</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16">desktop-v0.2.16 · macOS</a></td>
             </tr>
             <tr>
               <th scope="row">Windows</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15">desktop-v0.2.15 · Windows</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16">desktop-v0.2.16 · Windows</a></td>
             </tr>
             <tr>
               <th scope="row">Linux</th>
-              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15">desktop-v0.2.15 · Linux</a></td>
+              <td><a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16">desktop-v0.2.16 · Linux</a></td>
             </tr>
           </tbody>
         </table>
@@ -593,7 +593,7 @@ KILN_MODEL_PATH=./Qwen3.5-4B ./target/release/kiln serve</code></pre>
     </div>
     <div class="page footer-meta">
       <span>© 2026 Eric Florenzano</span>
-      <span>Built with kiln · <code>v0.2.15</code></span>
+      <span>Built with kiln · <code>v0.2.16</code></span>
     </div>
   </footer>
 

--- a/docs/site/quickstart.html
+++ b/docs/site/quickstart.html
@@ -308,7 +308,7 @@
         <div class="install-card">
           <h3 class="font-semibold mb-2">Desktop App &middot; recommended</h3>
           <p class="mb-3" style="color: var(--fg-dim);">
-            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.15">Kiln Desktop v0.2.15</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
+            Download <a href="https://github.com/ericflo/kiln/releases/tag/desktop-v0.2.16">Kiln Desktop v0.2.16</a>, then choose or download the Qwen3.5-4B model in the app and start the server from the GUI.
           </p>
           <table class="installer-table mb-3" aria-label="Kiln Desktop installer downloads">
             <thead>
@@ -321,32 +321,32 @@
             <tbody>
               <tr>
                 <td>macOS Apple Silicon</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_aarch64.dmg">Kiln.Desktop_0.2.15_aarch64.dmg</a></td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_aarch64.dmg">Kiln.Desktop_0.2.16_aarch64.dmg</a></td>
                 <td>8.5 MB</td>
               </tr>
               <tr>
                 <td>Windows</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_x64-setup.exe">Kiln.Desktop_0.2.15_x64-setup.exe</a> (NSIS)</td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_x64-setup.exe">Kiln.Desktop_0.2.16_x64-setup.exe</a> (NSIS)</td>
                 <td>4.5 MB</td>
               </tr>
               <tr>
                 <td>Windows</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_x64_en-US.msi">Kiln.Desktop_0.2.15_x64_en-US.msi</a> (MSI)</td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_x64_en-US.msi">Kiln.Desktop_0.2.16_x64_en-US.msi</a> (MSI)</td>
                 <td>6.8 MB</td>
               </tr>
               <tr>
                 <td>Linux</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_amd64.deb">Kiln.Desktop_0.2.15_amd64.deb</a></td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_amd64.deb">Kiln.Desktop_0.2.16_amd64.deb</a></td>
                 <td>8.8 MB</td>
               </tr>
               <tr>
                 <td>Linux</td>
-                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.15/Kiln.Desktop_0.2.15_amd64.AppImage">Kiln.Desktop_0.2.15_amd64.AppImage</a></td>
+                <td><a href="https://github.com/ericflo/kiln/releases/download/desktop-v0.2.16/Kiln.Desktop_0.2.16_amd64.AppImage">Kiln.Desktop_0.2.16_amd64.AppImage</a></td>
                 <td>85.7 MB</td>
               </tr>
             </tbody>
           </table>
-          <p class="text-sm" style="color: var(--fg-mute);">Desktop and server release lines intentionally differ: <code>desktop-v0.2.15</code> is the latest Desktop app release, and the app downloads and verifies the latest <code>kiln-v*</code> server binary for you.</p>
+          <p class="text-sm" style="color: var(--fg-mute);">Desktop and server release lines intentionally differ: <code>desktop-v0.2.16</code> is the latest Desktop app release, and the app downloads and verifies the latest <code>kiln-v*</code> server binary for you.</p>
         </div>
         <div class="install-card">
           <h3 class="font-semibold mb-2">Linux x86_64 &middot; CUDA 12.4</h3>

--- a/scripts/check_docs_site_smoke.mjs
+++ b/scripts/check_docs_site_smoke.mjs
@@ -768,7 +768,7 @@ function validateLandingDesktopVersionSplitCue() {
   const desktopInstallCopy = desktopInstallMatch[1];
   const requiredTerms = [
     'separate GitHub release tags/version numbers',
-    'desktop-v0.2.15',
+    'desktop-v0.2.16',
     'latest <code>kiln-v*</code>',
   ];
   for (const term of requiredTerms) {
@@ -785,7 +785,7 @@ function validateQuickstartDesktopVersionSplitCue() {
 
   const desktopInstallCopy = desktopInstallMatch[1];
   const requiredTerms = [
-    'desktop-v0.2.15',
+    'desktop-v0.2.16',
     'Desktop',
     'server',
     'release',


### PR DESCRIPTION
Aligned cut following kiln-v0.2.15, covering ~450 commits since the prior tag. Server-side work this cycle was the new end-to-end eval system (Phase 11) and Vulkan training hardening on unified-memory APUs (Phase 2), plus a full Qwen3.5 stochastic sampler and a Playground overhaul. No desktop source changes since `desktop-v0.2.15`, so the desktop release just re-pins to the new server payload to keep server + desktop on the same version number.

## Server highlights (since v0.2.15)

- **Phase 11 — Evals as a first-class peer of training:** pluggable scorer enum (`exact_match` / `contains` / `regex` / `json_validity` / `multiple_choice` / `numeric_tolerance` / `tool_call` / `code` / `llm_judge` plus `all`/`any` composites), dataset → suite synthesis, post-training auto-eval, head-to-head adapter compare, A/B `JudgmentStore`, `kiln-eval` CLI binary, new `/v1/eval/*` and `/v1/judgments/*` HTTP surface, `[eval]` config section, and an embedded `/ui` overhaul with Cmd-K palette, drill-in modals for eval/training/adapter detail with live progress, loss curves with downsampled history, A/B compare playground, VRAM donut, tok/s sparkline.
- **Phase 2 — Vulkan training hardening (Strix Halo / unified-memory APUs):** on-device AdamW (`adamw_step_{f32,bf16}.comp`, decoupled weight decay) alongside the BF16 SGD path; lazy candle-CPU-storage sync removes the per-step GPU→CPU readback; `VulkanLinearOp` (CustomOp1) with autograd parity and in-op chunking via `KILN_VULKAN_LINEAR_MAX_GFLOP`; `sdpa_prefill_f32.comp` replaces the old `flash_attn.comp` placeholder; FLCE auto-engages at `active_count ≥ 16` and `KILN_USE_FLCE` / `KILN_VULKAN_LINEAR` / `KILN_VULKAN_SDPA` default ON; unified-memory APU VRAM-budget correction; HTTP 413 rejection with actionable hints for oversized training submissions; trainer-side resident-activation registry hooks; agentic eval suite tested end-to-end through the executor.
- **Sampling:** full Qwen3.5 stochastic sampler fused on Vulkan, Metal, and CUDA (zero vocab readback on Vulkan); new penalty fields and Qwen3.5 recommended defaults everywhere.
- **Playground:** compare mode that streams both sides with reasoning, markdown rendering, inline edit-and-resend on user turns, per-turn badges + scroll lock + retry + transcript export, system prompt and advanced sampling controls, live `<think>` drain.
- **Reliability:** near-instant Ctrl+C shutdown; hardened SSE parser with first-token >5 s hint; uptime cap only applies after the drain signal; default batching engine ON with `KILN_BATCHING_ENGINE=0` opt-out; silenced all workspace build warnings.

## Desktop

No source commits since `desktop-v0.2.15`. Bundled server payload now ships `kiln-v0.2.16`.

## Mechanical changes (12 files, +93/-49)

- workspace `Cargo.toml` + `Cargo.lock`: 0.2.15 → 0.2.16 (14 `kiln-*` crates)
- `desktop/Cargo.toml` + `desktop/Cargo.lock`: 0.2.15 → 0.2.16
- `desktop/tauri.conf.json`: 0.2.15 → 0.2.16
- `CHANGELOG.md`: promote the two Unreleased sections (Phase 11 evals, Phase 2 Vulkan training hardening) to `kiln-v0.2.16 — 2026-05-15`
- `desktop/CHANGELOG.md`: `desktop-v0.2.16` aligned-cut entry
- `README.md` / `desktop/README.md` / `docs/site/index.html` / `docs/site/quickstart.html`: bump desktop release pin from 0.2.15 → 0.2.16
- `docs/site/index.html` brand-version pill: v0.2.15 → v0.2.16
- `scripts/check_docs_site_smoke.mjs`: smoke pin `desktop-v0.2.15` → `desktop-v0.2.16`

`scripts/check_release_versions.py` passes.

## After merge

I will push the `kiln-v0.2.16` and `desktop-v0.2.16` tags to fire the Kiln server release and Build kiln-desktop workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)