### PR TITLE
remote_teacher: mark vLLM HTTP example as text in doctest

### DIFF
--- a/crates/kiln-train/src/remote_teacher.rs
+++ b/crates/kiln-train/src/remote_teacher.rs
@@ -257,7 +257,7 @@ impl LogitSource for RemoteTeacher {
 /// vLLM / sglang `/v1/completions` `prompt_logprobs` impl.
 ///
 /// vLLM exposes top-K logprobs at every prompt position via:
-/// ```
+/// ```text
 /// POST /v1/completions
 /// { "model": "...", "prompt": [token ids...],
 ///   "max_tokens": 1, "temperature": 0,


### PR DESCRIPTION
## What
Change the unlabeled \`\`\` code fence in the \`fetch_logprobs_vllm\` doc comment to \`\`\`text. The block holds a non-Rust HTTP request example (\`POST /v1/completions { ... }\`) but rustdoc defaults unlabeled fences to Rust and tries to compile them.

## Why
CI is red on \`main\` for both Linux / default features and macOS / Metal because of this doctest:

\`\`\`
test crates/kiln-train/src/remote_teacher.rs - remote_teacher::fetch_logprobs_vllm (line 260) ... FAILED
error: expected identifier, found \`\"model\"\`
\`\`\`

Both jobs in run 25979257336 hit it. Marking the fence as \`text\` skips compilation.

## Verification
\`cargo test -p kiln-train --doc\` now passes locally.