### PR TITLE
deps: bump sha2 to 0.11 and migrate LowerHex sites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +495,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -581,6 +596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cudaforge"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,7 +617,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "walkdir",
  "which",
@@ -707,8 +731,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -1445,6 +1480,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1765,7 +1809,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "unicode-normalization",
@@ -1902,7 +1946,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -1939,7 +1983,7 @@ dependencies = [
  "safetensors 0.7.0",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
@@ -3066,7 +3110,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ kiln-vulkan-kernel = { path = "crates/kiln-vulkan-kernel" }
 rand = "0.10"
 
 # Hashing (replay_hash chain for LoRA lineage)
-sha2 = "0.10"
+sha2 = "0.11"
 
 # Data-parallel iteration
 rayon = "1"

--- a/crates/kiln-train/src/replay.rs
+++ b/crates/kiln-train/src/replay.rs
@@ -299,7 +299,8 @@ pub fn compute_replay_hash(
         hasher.update(line.as_bytes());
         hasher.update([b'\n']);
     }
-    Ok(format!("{:x}", hasher.finalize()))
+    let digest = hasher.finalize();
+    Ok(digest.iter().map(|b| format!("{b:02x}")).collect())
 }
 
 /// Walk the parent chain from `adapter_dir` up toward the root, returning

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -73,7 +73,8 @@ pub fn default_base_model(config: &ModelConfig) -> BaseModel {
         use sha2::{Digest, Sha256};
         let mut h = Sha256::new();
         h.update(s.as_bytes());
-        format!("sha256:{:x}", h.finalize())
+        let hex: String = h.finalize().iter().map(|b| format!("{b:02x}")).collect();
+        format!("sha256:{hex}")
     });
     BaseModel {
         id: "Qwen/Qwen3.5-4B".to_string(),


### PR DESCRIPTION
## Summary

sha2 0.11 changes the digest output from `GenericArray<u8, _>` (which implements `LowerHex`) to `Array<u8, _>` (which does not). The two `format!("{:x}", hasher.finalize())` sites in `kiln-train` fail to compile against the new version.

This PR:
- Bumps the workspace `sha2` dep from `0.10` to `0.11`
- Replaces the two `LowerHex` formatter call sites in `crates/kiln-train/src/replay.rs` and `crates/kiln-train/src/trainer.rs` with a byte-iteration hex encoder
- The new pattern matches what `kiln-eval` and `kiln-server` already use for the same purpose, so the hash output format is preserved

Supersedes #1026 (Dependabot couldn't apply the migration on its own).

## Test plan

- [x] `cargo check --tests --examples` — passes
- [x] `cargo nextest run -p kiln-train --lib` — 123/123 pass, including `replay_hash_is_deterministic_and_chains` and the lineage roundtrip tests that exercise the migrated `compute_replay_hash` path