### PR TITLE
grpo: fix cuda_grpo_ablation import path

### DIFF
--- a/crates/kiln-train/examples/cuda_grpo_ablation.rs
+++ b/crates/kiln-train/examples/cuda_grpo_ablation.rs
@@ -34,9 +34,10 @@ use kiln_core::tokenizer::KilnTokenizer;
 #[cfg(feature = "cuda")]
 use kiln_model::forward::GpuWeights;
 #[cfg(feature = "cuda")]
+use kiln_train::trainer::grpo_train_jsonl;
+#[cfg(feature = "cuda")]
 use kiln_train::{
     AdvantageMode, GrpoConfig, IsLevel, KlEstimator, LossAggregation, Optimizer, ReferencePolicy,
-    grpo_train_jsonl,
 };
 
 #[cfg(feature = "cuda")]


### PR DESCRIPTION
Hotfix: `grpo_train_jsonl` is in `kiln_train::trainer`, not re-exported at the crate root. CUDA-feature build failed with E0432 against #1042. Hostside `cargo check --example cuda_grpo_ablation` succeeds without the cuda feature so this wasn't caught earlier — needs the cuda gate to compile that import.