### PR TITLE
grpo: fix ablation runner Mode::Baseline after defaults flip

### DIFF
--- a/crates/kiln-train/examples/cuda_grpo_ablation.rs
+++ b/crates/kiln-train/examples/cuda_grpo_ablation.rs
@@ -102,7 +102,21 @@ impl Mode {
 
     fn apply(self, base: GrpoConfig) -> GrpoConfig {
         match self {
-            Self::Baseline => base,
+            // Historical pre-#1045 DeepSeekMath/R1 recipe. With the defaults
+            // flipped, `GrpoConfig::default()` is now Phase 1, so the
+            // baseline mode must explicitly restore the old knobs.
+            Self::Baseline => GrpoConfig {
+                advantage_mode: AdvantageMode::Vanilla,
+                loss_aggregation: LossAggregation::PerSample,
+                clip_epsilon: 0.20,
+                clip_eps_high: None,
+                kl_estimator: KlEstimator::K1,
+                dynamic_sampling: false,
+                is_level: IsLevel::Token,
+                reference_policy: ReferencePolicy::BasePerStep,
+                entropy_aware_kl_quantile: None,
+                ..base
+            },
             Self::Phase1 => GrpoConfig {
                 advantage_mode: AdvantageMode::DrGrpo,
                 loss_aggregation: LossAggregation::TokenLevel,


### PR DESCRIPTION
After #1045 flipped `GrpoConfig::default()` to the Phase 1 recipe (DrGrpo + TokenLevel + dynamic_sampling), the ablation runner's `Mode::Baseline => base` arm silently became identical to `Mode::Phase1` — both used the same default config.

Restore the historical pre-Phase-1 recipe explicitly so the ablation matrix actually compares against the original DeepSeekMath/R1 settings (Vanilla advantage, PerSample aggregation, dynamic_sampling=false).

Caught while running the Phase 3 ablation matrix on an A100 pod — baseline and phase1 produced bit-identical training trajectories because the binary was running the new defaults under both labels.