### PR TITLE
kiln-eval: PythonDoctest scorer (verifier-based pass@1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1792,6 +1792,7 @@ dependencies = [
 name = "kiln-eval"
 version = "0.2.16"
 dependencies = [
+ "anyhow",
  "chrono",
  "rand 0.10.1",
  "rand_core 0.10.1",

--- a/crates/kiln-eval/Cargo.toml
+++ b/crates/kiln-eval/Cargo.toml
@@ -20,3 +20,4 @@ rand_core = "0.10"
 
 [dev-dependencies]
 tempfile = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/kiln-eval/examples/doctest_cross_check.rs
+++ b/crates/kiln-eval/examples/doctest_cross_check.rs
@@ -1,0 +1,114 @@
+//! Cross-check the PythonDoctest scorer against an existing GRPO dataset's
+//! baked-in rewards. The humaneval-derived datasets in
+//! `capabilities/sft/python-algo/datasets/` carry reward labels presumably
+//! produced by a similar doctest-based verifier; running our scorer over
+//! the same completions should reproduce those labels.
+
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use kiln_eval::scorers::{NoopJudgeRunner, Scorer, score_completion};
+use kiln_eval::suite::{EvalChatMessage, EvalExample};
+
+#[derive(serde::Deserialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+#[derive(serde::Deserialize)]
+struct ScoredCompletion {
+    text: String,
+    reward: f64,
+}
+#[derive(serde::Deserialize)]
+struct GrpoGroup {
+    messages: Vec<ChatMessage>,
+    completions: Vec<ScoredCompletion>,
+}
+
+fn main() -> Result<()> {
+    let mut args = std::env::args().skip(1);
+    let path = args
+        .next()
+        .map(PathBuf::from)
+        .context("usage: doctest_cross_check <dataset.jsonl> [max_groups]")?;
+    let max_groups: usize = args
+        .next()
+        .map(|s| s.parse().unwrap_or(usize::MAX))
+        .unwrap_or(usize::MAX);
+
+    let f = File::open(&path).with_context(|| format!("open {}", path.display()))?;
+    let scorer = Scorer::PythonDoctest {
+        timeout_seconds: 5.0,
+        python_bin: None,
+    };
+    let runner = NoopJudgeRunner;
+
+    let mut agree = 0usize;
+    let mut disagree = 0usize;
+    let mut total = 0usize;
+    let mut my_pass = 0usize;
+    let mut dataset_pass = 0usize;
+    let mut invalid = 0usize;
+
+    for (i, line) in BufReader::new(f).lines().enumerate() {
+        if i >= max_groups {
+            break;
+        }
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let g: GrpoGroup = serde_json::from_str(&line)
+            .with_context(|| format!("parsing line {}", i + 1))?;
+        let example = EvalExample {
+            id: Some(format!("group_{i}")),
+            messages: g
+                .messages
+                .into_iter()
+                .map(|m| EvalChatMessage::new(m.role, m.content))
+                .collect(),
+            target: None,
+            aliases: Vec::new(),
+            tags: Vec::new(),
+            metadata: None,
+            scorer: None,
+            generation: None,
+            weight: 1.0,
+            tools: None,
+        };
+        for (j, c) in g.completions.iter().enumerate() {
+            total += 1;
+            let outcome = score_completion(&scorer, &example, &c.text, &runner)?;
+            let my_passed = matches!(outcome.kind, kiln_eval::result::EvalOutcomeKind::Pass);
+            let ds_passed = c.reward >= 0.99;
+            if my_passed {
+                my_pass += 1;
+            }
+            if ds_passed {
+                dataset_pass += 1;
+            }
+            if matches!(outcome.kind, kiln_eval::result::EvalOutcomeKind::Invalid) {
+                invalid += 1;
+            }
+            if my_passed == ds_passed {
+                agree += 1;
+            } else {
+                disagree += 1;
+                if disagree <= 5 {
+                    eprintln!(
+                        "disagree group={} comp={} mine={} ds={} reward={} detail={:?}",
+                        i, j, my_passed, ds_passed, c.reward, outcome.detail
+                    );
+                }
+            }
+        }
+    }
+    println!(
+        "total={total} agree={agree} disagree={disagree} invalid={invalid} my_pass={my_pass} dataset_pass={dataset_pass} agreement={:.2}%",
+        100.0 * agree as f32 / total.max(1) as f32
+    );
+    Ok(())
+}

--- a/crates/kiln-eval/src/scorers/mod.rs
+++ b/crates/kiln-eval/src/scorers/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod json_validity;
 pub mod llm_judge;
 pub(crate) mod multiple_choice;
 pub(crate) mod numeric;
+pub mod python_doctest;
 pub(crate) mod regex_match;
 pub(crate) mod tool_call;
 
@@ -137,6 +138,23 @@ pub enum Scorer {
         #[serde(default)]
         style: CodeStyle,
     },
+    /// Python doctest scorer: executes the model's completion against the
+    /// `>>>` doctest assertions embedded in the prompt's user message.
+    /// The score is the fraction of doctests that pass; the outcome is
+    /// `Pass` only when every doctest matches.
+    ///
+    /// This is the "real" verifier for the humaneval / python-algo
+    /// datasets — every other built-in scorer is text-similarity based.
+    /// Requires `python3` on PATH (overridable via `python_bin` or the
+    /// `KILN_DOCTEST_PYTHON` env var); each completion runs in an
+    /// `python3 -I -S` isolated subprocess with a wall-clock timeout
+    /// (default 5 s).
+    PythonDoctest {
+        #[serde(default = "default_doctest_timeout")]
+        timeout_seconds: f32,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        python_bin: Option<String>,
+    },
     /// Composite: every sub-scorer must pass for the outcome to be Pass.
     /// Score is the mean of sub-scores. Use this for "JSON valid AND
     /// numeric answer correct" kinds of metrics.
@@ -154,6 +172,9 @@ fn is_false(b: &bool) -> bool {
 fn default_choices() -> Vec<String> {
     vec!["A".into(), "B".into(), "C".into(), "D".into()]
 }
+fn default_doctest_timeout() -> f32 {
+    python_doctest::DEFAULT_TIMEOUT_SECONDS
+}
 
 impl Scorer {
     /// Stable label used in metric breakdowns. Borrowed from the variant name
@@ -169,6 +190,7 @@ impl Scorer {
             Scorer::LlmJudge { .. } => "llm_judge",
             Scorer::ToolCall { .. } => "tool_call",
             Scorer::Code { .. } => "code",
+            Scorer::PythonDoctest { .. } => "python_doctest",
             Scorer::All { .. } => "all",
             Scorer::Any { .. } => "any",
         }
@@ -309,6 +331,13 @@ pub fn score_completion(
         )?,
         Scorer::Code { language, style } => {
             code::score(example, answer_for_scorer, language.as_deref(), style)?
+        }
+        Scorer::PythonDoctest {
+            timeout_seconds,
+            python_bin,
+        } => {
+            let bin = python_doctest::resolve_python_bin(python_bin.as_deref());
+            python_doctest::score(example, answer_for_scorer, *timeout_seconds, &bin)?
         }
         Scorer::All { scorers } => {
             if scorers.is_empty() {

--- a/crates/kiln-eval/src/scorers/python_doctest.rs
+++ b/crates/kiln-eval/src/scorers/python_doctest.rs
@@ -1,0 +1,488 @@
+//! Python doctest scorer.
+//!
+//! The humaneval / python-algo eval datasets ship the test cases inside the
+//! prompt's docstring as `>>> call_to_function(args)` / `expected_value`
+//! pairs. This scorer parses those out of the user message, extracts the
+//! Python function the model generated from a fenced code block, runs the
+//! function under a Python subprocess against each doctest assertion, and
+//! returns a fractional pass rate.
+//!
+//! Design choices:
+//!
+//! - The scorer reaches into [`EvalExample::messages`] to find the prompt
+//!   text — every other built-in scorer only inspects the completion +
+//!   `target`, but doctest-style verification structurally needs the
+//!   problem statement.
+//! - Execution is a single short-lived `python3` subprocess per completion,
+//!   with stdin used to feed the generated function plus a small harness.
+//!   The harness compares `repr(actual)` to the expected string from the
+//!   docstring after both have been stripped of trailing whitespace, so the
+//!   classic `>>> f()\n5` form matches whether the function returned `5` or
+//!   `5L` / `5.0` etc. — same `repr` normalization Python's stdlib doctest
+//!   module applies.
+//! - Each subprocess gets a hard wall-clock timeout (default 5 s). On
+//!   timeout the score is 0 and the outcome is `Error`. The subprocess is
+//!   killed with SIGKILL via `Child::kill` so a runaway `while True:`
+//!   doesn't leak.
+//! - We never hit the network or write to anywhere outside the spawned
+//!   subprocess's own memory. The harness is self-contained text fed on
+//!   stdin.
+
+use std::io::{Read, Write};
+use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::result::EvalOutcomeKind;
+use crate::scorers::ScorerError;
+use crate::suite::EvalExample;
+
+/// Default execution time budget for a single completion's doctests.
+pub const DEFAULT_TIMEOUT_SECONDS: f32 = 5.0;
+
+/// Default Python interpreter command. Overridable via the scorer config
+/// or the `KILN_DOCTEST_PYTHON` environment variable.
+pub const DEFAULT_PYTHON_BIN: &str = "python3";
+
+/// One extracted doctest pair: a callable expression and the expected
+/// result (already stripped of leading `>>> ` and trailing whitespace).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Doctest {
+    pub call: String,
+    pub expected: String,
+}
+
+/// Parse `>>> expr\n<expected>` pairs out of a docstring-bearing prompt.
+///
+/// Recognizes the classical Python doctest layout: any line beginning with
+/// `>>>` (after optional indentation) starts a doctest; subsequent lines that
+/// begin with `... ` (continuation) are appended to the same call; the first
+/// non-empty line that does NOT begin with `>>> ` / `... ` is the expected
+/// result. An empty result line (e.g. `>>> f()\n\n>>> g()\n...`) is treated
+/// as expected output `None` — the canonical "function returned None and
+/// printed nothing" doctest convention.
+pub(crate) fn parse_doctests(prompt: &str) -> Vec<Doctest> {
+    let mut out = Vec::new();
+    let mut lines = prompt.lines().peekable();
+    while let Some(line) = lines.next() {
+        let trimmed = line.trim_start();
+        let Some(call_start) = trimmed.strip_prefix(">>> ") else {
+            // also accept `>>>` with no trailing space + empty body
+            if trimmed.trim_end() == ">>>" {
+                continue;
+            }
+            continue;
+        };
+        let mut call = call_start.trim_end().to_string();
+        // Greedily fold `... ` continuation lines into the call.
+        while let Some(next) = lines.peek() {
+            let nt = next.trim_start();
+            if let Some(cont) = nt.strip_prefix("... ").or_else(|| nt.strip_prefix("...")) {
+                call.push('\n');
+                call.push_str(cont.trim_end());
+                lines.next();
+            } else {
+                break;
+            }
+        }
+        // The expected line: the next non-doctest-prefixed line. If it's
+        // blank or a new `>>>`, expected is `None` (the function returned
+        // None or printed nothing).
+        let expected = match lines.peek() {
+            None => "None".to_string(),
+            Some(next) => {
+                let nt = next.trim_end();
+                let nt_lead = next.trim_start();
+                if nt_lead.starts_with(">>> ")
+                    || nt_lead == ">>>"
+                    || nt_lead.starts_with("```")
+                    || nt.is_empty()
+                {
+                    "None".to_string()
+                } else {
+                    let consumed = lines.next().unwrap();
+                    consumed.trim_end().trim_start().to_string()
+                }
+            }
+        };
+        out.push(Doctest { call, expected });
+    }
+    out
+}
+
+/// Extract the first python (or generic) fenced code block from the
+/// completion. Falls back to the whole completion when no fence is present
+/// (covers models that emit raw code without markdown).
+pub(crate) fn extract_python_block(completion: &str) -> String {
+    let mut iter = completion.split("```");
+    // First piece is text BEFORE the first fence — drop.
+    if iter.next().is_none() {
+        return completion.trim().to_string();
+    }
+    let Some(fenced) = iter.next() else {
+        return completion.trim().to_string();
+    };
+    // The fenced segment may start with the language tag on its first line.
+    let body = match fenced.split_once('\n') {
+        Some((tag, rest)) => {
+            let lower = tag.trim().to_lowercase();
+            if lower.is_empty() || lower == "python" || lower == "py" || lower == "python3" {
+                rest
+            } else {
+                // Other-language tag (e.g. `bash`) — still take the body so
+                // we at least try to score; the harness will fail to import.
+                rest
+            }
+        }
+        None => fenced,
+    };
+    body.trim_end().trim_end_matches('`').trim_end().to_string()
+}
+
+/// Internal harness assembled per call.
+fn build_harness(user_code: &str, doctests: &[Doctest]) -> String {
+    // We test by `repr(actual) == expected` after a strip. Python's stdlib
+    // doctest does the same thing under "no special doctest directives"
+    // mode. We catch user exceptions per-test and report them as failures.
+    let mut harness = String::from(
+        "import sys, json, traceback\n_kdt_results = []\n",
+    );
+    harness.push_str("try:\n");
+    for line in user_code.lines() {
+        harness.push_str("    ");
+        harness.push_str(line);
+        harness.push('\n');
+    }
+    if user_code.is_empty() {
+        harness.push_str("    pass\n");
+    }
+    harness.push_str("except Exception:\n");
+    harness.push_str("    _kdt_results.append({\"ok\": False, \"detail\": \"import_error: \" + traceback.format_exc()[-200:]})\n");
+    harness.push_str("    print(json.dumps(_kdt_results))\n");
+    harness.push_str("    sys.exit(0)\n");
+    for (i, dt) in doctests.iter().enumerate() {
+        // `call` is a Python EXPRESSION — emit verbatim. Multi-line calls
+        // (from `... ` continuations) are joined with embedded newlines,
+        // which need to stay readable as Python; wrap in parens to make
+        // multi-line expressions parse.
+        let call_expr = if dt.call.contains('\n') {
+            format!("(\n{}\n)", dt.call)
+        } else {
+            dt.call.clone()
+        };
+        // `expected` goes INSIDE a Python string literal — escape the
+        // backslashes and double quotes only.
+        let expected_lit = dt.expected.replace('\\', "\\\\").replace('"', "\\\"");
+        // `_kdt_safe_*` field values use json.dumps later so they survive
+        // whatever weirdness is inside the actual/repr output.
+        harness.push_str(&format!(
+            "try:\n    _kdt_actual = {call_expr}\n    _kdt_expected = \"{expected_lit}\"\n    _kdt_ok = repr(_kdt_actual).strip() == _kdt_expected.strip()\n    _kdt_results.append({{\"i\": {i}, \"ok\": _kdt_ok, \"expected\": _kdt_expected, \"actual\": repr(_kdt_actual)[:200]}})\nexcept Exception as e:\n    _kdt_results.append({{\"i\": {i}, \"ok\": False, \"expected\": \"{expected_lit}\", \"err\": traceback.format_exc()[-300:]}})\n",
+            call_expr = call_expr,
+            i = i,
+            expected_lit = expected_lit
+        ));
+    }
+    harness.push_str("print(json.dumps(_kdt_results))\n");
+    harness
+}
+
+/// Outcome of running the harness for one completion.
+pub(crate) struct DoctestRunOutcome {
+    pub passed: usize,
+    pub total: usize,
+    pub timed_out: bool,
+    pub spawn_error: Option<String>,
+    pub first_failure_detail: Option<String>,
+}
+
+/// Run `python3` against the harness assembled from `user_code` + `doctests`.
+/// `timeout` caps the wall-clock budget; an overrun returns `timed_out=true`.
+///
+/// The child is polled via `try_wait` so we can call `kill` when the
+/// deadline expires — this handles infinite-loop / `while True:` user
+/// code correctly. stdout is then drained from the (now-closed) pipe.
+pub(crate) fn run_doctests(
+    python_bin: &str,
+    user_code: &str,
+    doctests: &[Doctest],
+    timeout: Duration,
+) -> DoctestRunOutcome {
+    let harness = build_harness(user_code, doctests);
+    let mut child = match Command::new(python_bin)
+        .arg("-I") // isolated mode: no PYTHONPATH, no user site
+        .arg("-S") // no site-packages init
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            return DoctestRunOutcome {
+                passed: 0,
+                total: doctests.len(),
+                timed_out: false,
+                spawn_error: Some(format!("spawn {python_bin}: {e}")),
+                first_failure_detail: None,
+            };
+        }
+    };
+    // Feed the harness on stdin in a thread so a blocked stdin write can't
+    // deadlock the parent. Drop the writer afterward so the child sees EOF.
+    if let Some(mut stdin) = child.stdin.take() {
+        let bytes = harness.into_bytes();
+        thread::spawn(move || {
+            let _ = stdin.write_all(&bytes);
+            // stdin is dropped here, closing the pipe so the child sees EOF.
+        });
+    }
+    // Poll for child exit until the deadline, killing on overrun.
+    let deadline = Instant::now() + timeout;
+    let timed_out;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_status)) => {
+                timed_out = false;
+                break;
+            }
+            Ok(None) => {
+                if Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    timed_out = true;
+                    break;
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+            Err(e) => {
+                return DoctestRunOutcome {
+                    passed: 0,
+                    total: doctests.len(),
+                    timed_out: false,
+                    spawn_error: Some(format!("try_wait: {e}")),
+                    first_failure_detail: None,
+                };
+            }
+        }
+    }
+    // Drain stdout/stderr now that the child has exited.
+    let mut stdout_buf = Vec::new();
+    if let Some(mut out) = child.stdout.take() {
+        let _ = out.read_to_end(&mut stdout_buf);
+    }
+    if timed_out {
+        return DoctestRunOutcome {
+            passed: 0,
+            total: doctests.len(),
+            timed_out: true,
+            spawn_error: None,
+            first_failure_detail: Some(format!("timeout after {:.1}s", timeout.as_secs_f32())),
+        };
+    }
+    let stdout = String::from_utf8_lossy(&stdout_buf);
+    let parsed: Vec<serde_json::Value> = serde_json::from_str(stdout.trim()).unwrap_or_default();
+    let mut passed = 0usize;
+    let mut first_failure: Option<String> = None;
+    for entry in &parsed {
+        let ok = entry.get("ok").and_then(|v| v.as_bool()).unwrap_or(false);
+        if ok {
+            passed += 1;
+        } else if first_failure.is_none() {
+            let exp = entry
+                .get("expected")
+                .and_then(|v| v.as_str())
+                .unwrap_or("<no expected>");
+            let actual = entry
+                .get("actual")
+                .or_else(|| entry.get("err"))
+                .or_else(|| entry.get("detail"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("<no actual>");
+            first_failure = Some(format!("expected {exp} got {actual}"));
+        }
+    }
+    DoctestRunOutcome {
+        passed,
+        total: doctests.len(),
+        timed_out: false,
+        spawn_error: None,
+        first_failure_detail: first_failure,
+    }
+}
+
+/// Score entry point. Returns `(score, kind, detail)` matching the rest of
+/// the scorer surface in `crate::scorers`.
+pub(super) fn score(
+    example: &EvalExample,
+    completion_text: &str,
+    timeout_seconds: f32,
+    python_bin: &str,
+) -> Result<(f32, EvalOutcomeKind, Option<String>), ScorerError> {
+    let timeout = Duration::from_secs_f32(timeout_seconds.max(0.1));
+
+    // Find the prompt's last user message — that's where humaneval-style
+    // problems put the function signature + docstring + doctests.
+    let prompt_text = example
+        .messages
+        .iter()
+        .rev()
+        .find(|m| m.role == "user")
+        .map(|m| m.content.clone())
+        .unwrap_or_default();
+    let doctests = parse_doctests(&prompt_text);
+    if doctests.is_empty() {
+        return Ok((
+            0.0,
+            EvalOutcomeKind::Invalid,
+            Some("no doctest examples found in prompt".to_string()),
+        ));
+    }
+    let user_code = extract_python_block(completion_text);
+    if user_code.trim().is_empty() {
+        return Ok((
+            0.0,
+            EvalOutcomeKind::Invalid,
+            Some("no python code block in completion".to_string()),
+        ));
+    }
+    let outcome = run_doctests(python_bin, &user_code, &doctests, timeout);
+    if let Some(err) = outcome.spawn_error {
+        return Ok((0.0, EvalOutcomeKind::Error, Some(err)));
+    }
+    if outcome.timed_out {
+        return Ok((
+            0.0,
+            EvalOutcomeKind::Error,
+            outcome.first_failure_detail,
+        ));
+    }
+    let score = if outcome.total == 0 {
+        0.0
+    } else {
+        outcome.passed as f32 / outcome.total as f32
+    };
+    let kind = if outcome.total > 0 && outcome.passed == outcome.total {
+        EvalOutcomeKind::Pass
+    } else {
+        EvalOutcomeKind::Fail
+    };
+    let detail = if matches!(kind, EvalOutcomeKind::Pass) {
+        Some(format!("{}/{} doctests passed", outcome.passed, outcome.total))
+    } else {
+        Some(format!(
+            "{}/{} doctests passed{}",
+            outcome.passed,
+            outcome.total,
+            outcome
+                .first_failure_detail
+                .map(|d| format!(" ({d})"))
+                .unwrap_or_default()
+        ))
+    };
+    Ok((score, kind, detail))
+}
+
+/// Resolve the python binary to use, honoring the env override.
+pub(crate) fn resolve_python_bin(configured: Option<&str>) -> String {
+    if let Some(c) = configured {
+        if !c.is_empty() {
+            return c.to_string();
+        }
+    }
+    std::env::var("KILN_DOCTEST_PYTHON").unwrap_or_else(|_| DEFAULT_PYTHON_BIN.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::suite::EvalChatMessage;
+
+    fn user(content: &str) -> EvalExample {
+        EvalExample {
+            id: None,
+            messages: vec![EvalChatMessage::new("user", content)],
+            target: None,
+            aliases: Vec::new(),
+            tags: Vec::new(),
+            metadata: None,
+            scorer: None,
+            generation: None,
+            weight: 1.0,
+            tools: None,
+        }
+    }
+
+    #[test]
+    fn parse_doctests_extracts_call_expected_pairs() {
+        let prompt = "    >>> add(2, 3)\n    5\n    >>> add(5, 7)\n    12\n";
+        let parsed = parse_doctests(prompt);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].call, "add(2, 3)");
+        assert_eq!(parsed[0].expected, "5");
+        assert_eq!(parsed[1].call, "add(5, 7)");
+        assert_eq!(parsed[1].expected, "12");
+    }
+
+    #[test]
+    fn parse_doctests_handles_empty_result_as_none() {
+        let prompt = "    >>> longest([])\n\n    >>> longest(['a', 'b'])\n    'a'\n";
+        let parsed = parse_doctests(prompt);
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].expected, "None");
+        assert_eq!(parsed[1].expected, "'a'");
+    }
+
+    #[test]
+    fn extract_python_block_pulls_first_fenced_block() {
+        let completion =
+            "Here you go:\n```python\ndef add(x, y):\n    return x + y\n```\nAll done!";
+        let code = extract_python_block(completion);
+        assert!(code.contains("def add"));
+        assert!(!code.contains("Here you go"));
+    }
+
+    #[test]
+    fn extract_python_block_falls_back_to_raw_completion() {
+        let completion = "def add(x, y):\n    return x + y\n";
+        let code = extract_python_block(completion);
+        assert!(code.contains("def add"));
+    }
+
+    #[test]
+    #[ignore = "requires python3 on PATH"]
+    fn score_passes_when_all_doctests_match() {
+        let example = user(
+            "Complete the function:\n```python\ndef add(x, y):\n    \"\"\"Add.\n    >>> add(2, 3)\n    5\n    >>> add(-1, 1)\n    0\n    \"\"\"\n```",
+        );
+        let completion = "```python\ndef add(x, y):\n    return x + y\n```";
+        let (score, kind, _) = score(&example, completion, 5.0, "python3").unwrap();
+        assert_eq!(score, 1.0);
+        assert_eq!(kind, EvalOutcomeKind::Pass);
+    }
+
+    #[test]
+    #[ignore = "requires python3 on PATH"]
+    fn score_fails_when_some_doctests_miss() {
+        let example = user(
+            "```python\ndef add(x, y):\n    \"\"\"Add.\n    >>> add(2, 3)\n    5\n    >>> add(0, 0)\n    0\n    \"\"\"\n```",
+        );
+        // Wrong: ignores y
+        let completion = "```python\ndef add(x, y):\n    return x\n```";
+        let (score, kind, _) = score(&example, completion, 5.0, "python3").unwrap();
+        assert!(score < 1.0);
+        assert_eq!(kind, EvalOutcomeKind::Fail);
+    }
+
+    #[test]
+    #[ignore = "requires python3 on PATH"]
+    fn score_returns_error_on_runaway_loop() {
+        let example = user(
+            "```python\ndef f():\n    \"\"\"\n    >>> f()\n    1\n    \"\"\"\n```",
+        );
+        let completion = "```python\ndef f():\n    while True:\n        pass\n```";
+        let (score, kind, _) = score(&example, completion, 0.5, "python3").unwrap();
+        assert_eq!(score, 0.0);
+        assert_eq!(kind, EvalOutcomeKind::Error);
+    }
+}

--- a/crates/kiln-train/examples/cuda_grpo_behavioral_eval.rs
+++ b/crates/kiln-train/examples/cuda_grpo_behavioral_eval.rs
@@ -40,6 +40,12 @@ use kiln_model::forward::GpuWeights;
 #[cfg(feature = "cuda")]
 use kiln_model::generate::{FinishReason, ModelRunner};
 #[cfg(feature = "cuda")]
+use kiln_eval::result::EvalOutcomeKind;
+#[cfg(feature = "cuda")]
+use kiln_eval::scorers::{NoopJudgeRunner, Scorer, score_completion};
+#[cfg(feature = "cuda")]
+use kiln_eval::suite::{EvalChatMessage, EvalExample};
+#[cfg(feature = "cuda")]
 use kiln_train::{ChatMessage, GrpoGroup};
 
 #[cfg(feature = "cuda")]
@@ -55,6 +61,8 @@ struct Args {
     top_p: f32,
     seed_base: u64,
     label: String,
+    score_doctests: bool,
+    doctest_timeout_seconds: f32,
 }
 
 #[cfg(feature = "cuda")]
@@ -70,6 +78,8 @@ impl Args {
         let mut top_p: f32 = 0.95;
         let mut seed_base: u64 = 0xC0DE_BEEF;
         let mut label = "eval".to_string();
+        let mut score_doctests = false;
+        let mut doctest_timeout_seconds: f32 = 5.0;
         let mut args = std::env::args().skip(1);
         while let Some(arg) = args.next() {
             match arg.as_str() {
@@ -125,6 +135,14 @@ impl Args {
                         .context("--seed must be u64")?
                 }
                 "--label" => label = args.next().context("--label needs value")?,
+                "--score-doctests" => score_doctests = true,
+                "--doctest-timeout" => {
+                    doctest_timeout_seconds = args
+                        .next()
+                        .context("--doctest-timeout needs value")?
+                        .parse()
+                        .context("--doctest-timeout must be a float")?
+                }
                 "--help" | "-h" => {
                     println!(
                         "cuda_grpo_behavioral_eval --data <jsonl> --model <dir> \
@@ -148,6 +166,8 @@ impl Args {
             top_p,
             seed_base,
             label,
+            score_doctests,
+            doctest_timeout_seconds,
         })
     }
 }
@@ -306,10 +326,26 @@ fn main() -> Result<()> {
     let mut all_rep: Vec<f32> = Vec::new();
     let mut truncated = 0usize;
     let mut per_prompt_diversity: Vec<f32> = Vec::new();
+    let mut total_doctest_attempts = 0usize;
+    let mut total_doctest_passes = 0usize;
+    let mut total_doctest_invalid = 0usize;
+    let mut prompts_with_doctests = 0usize;
+    let mut prompts_with_any_pass = 0usize;
+    let mut prompts_with_all_pass = 0usize;
+    let doctest_scorer = if args.score_doctests {
+        Some(Scorer::PythonDoctest {
+            timeout_seconds: args.doctest_timeout_seconds,
+            python_bin: None,
+        })
+    } else {
+        None
+    };
+    let judge_runner = NoopJudgeRunner;
 
     for (prompt_idx, group) in groups.iter().enumerate() {
         let pt = prompt_text(group, &tokenizer)?;
         let mut samples_tokens: Vec<Vec<u32>> = Vec::with_capacity(args.num_samples);
+        let mut sample_texts: Vec<String> = Vec::with_capacity(args.num_samples);
         for s in 0..args.num_samples {
             let mut sp = SamplingParams::default();
             sp.temperature = args.temperature;
@@ -330,6 +366,7 @@ fn main() -> Result<()> {
             all_lengths.push(len);
             all_rep.push(rep);
             samples_tokens.push(out.token_ids);
+            sample_texts.push(out.text.clone());
             println!(
                 "{{\"label\":\"{}\",\"prompt\":{},\"sample\":{},\"len\":{},\"rep\":{:.6},\"truncated\":{}}}",
                 args.label, prompt_idx, s, len, rep, truncated_here
@@ -341,6 +378,79 @@ fn main() -> Result<()> {
             "{{\"label\":\"{}\",\"prompt\":{},\"mean_bigram_jaccard\":{:.6}}}",
             args.label, prompt_idx, div
         );
+
+        // Phase 3+ — per-completion doctest scoring. Each sample gets a
+        // pass/fail; we also derive per-prompt pass@1 (mean) and pass@k
+        // (any) aggregates over the N samples.
+        if let Some(scorer) = doctest_scorer.as_ref() {
+            let example = EvalExample {
+                id: Some(format!("group_{prompt_idx}")),
+                messages: group
+                    .messages
+                    .iter()
+                    .map(|m| EvalChatMessage::new(m.role.clone(), m.content.clone()))
+                    .collect(),
+                target: None,
+                aliases: Vec::new(),
+                tags: Vec::new(),
+                metadata: None,
+                scorer: None,
+                generation: None,
+                weight: 1.0,
+                tools: None,
+            };
+            let mut prompt_attempts = 0usize;
+            let mut prompt_passes = 0usize;
+            let mut prompt_invalid = 0usize;
+            for (s, text) in sample_texts.iter().enumerate() {
+                let outcome = score_completion(scorer, &example, text, &judge_runner)
+                    .with_context(|| format!("score doctest prompt={prompt_idx} sample={s}"))?;
+                let kind_str = match outcome.kind {
+                    EvalOutcomeKind::Pass => "pass",
+                    EvalOutcomeKind::Fail => "fail",
+                    EvalOutcomeKind::Invalid => "invalid",
+                    EvalOutcomeKind::Error => "error",
+                };
+                if matches!(outcome.kind, EvalOutcomeKind::Invalid) {
+                    prompt_invalid += 1;
+                } else {
+                    prompt_attempts += 1;
+                    if matches!(outcome.kind, EvalOutcomeKind::Pass) {
+                        prompt_passes += 1;
+                    }
+                }
+                println!(
+                    "{{\"label\":\"{}\",\"prompt\":{},\"sample\":{},\"doctest_kind\":\"{}\",\"doctest_score\":{:.4}}}",
+                    args.label, prompt_idx, s, kind_str, outcome.score
+                );
+            }
+            if prompt_invalid < args.num_samples {
+                // Prompt had at least one scoreable sample.
+                prompts_with_doctests += 1;
+                if prompt_passes > 0 {
+                    prompts_with_any_pass += 1;
+                }
+                if prompt_attempts > 0 && prompt_passes == prompt_attempts {
+                    prompts_with_all_pass += 1;
+                }
+            }
+            total_doctest_attempts += prompt_attempts;
+            total_doctest_passes += prompt_passes;
+            total_doctest_invalid += prompt_invalid;
+            println!(
+                "{{\"label\":\"{}\",\"prompt\":{},\"doctest_pass_at_1\":{:.4},\"doctest_any_pass\":{},\"doctest_scoreable_samples\":{},\"doctest_invalid\":{}}}",
+                args.label,
+                prompt_idx,
+                if prompt_attempts == 0 {
+                    0.0
+                } else {
+                    prompt_passes as f32 / prompt_attempts as f32
+                },
+                prompt_passes > 0,
+                prompt_attempts,
+                prompt_invalid
+            );
+        }
     }
 
     // Aggregate.
@@ -370,8 +480,23 @@ fn main() -> Result<()> {
     } else {
         truncated as f32 / total_samples as f32
     };
+    let pass_at_1 = if total_doctest_attempts == 0 {
+        0.0
+    } else {
+        total_doctest_passes as f32 / total_doctest_attempts as f32
+    };
+    let pass_any = if prompts_with_doctests == 0 {
+        0.0
+    } else {
+        prompts_with_any_pass as f32 / prompts_with_doctests as f32
+    };
+    let pass_all = if prompts_with_doctests == 0 {
+        0.0
+    } else {
+        prompts_with_all_pass as f32 / prompts_with_doctests as f32
+    };
     println!(
-        "{{\"label\":\"{}\",\"summary\":true,\"prompts\":{},\"samples\":{},\"mean_len\":{:.2},\"p50_len\":{},\"p95_len\":{},\"p99_len\":{},\"max_len\":{},\"mean_rep_rate\":{:.6},\"mean_bigram_jaccard\":{:.6},\"truncation_rate\":{:.6},\"elapsed_secs\":{:.2}}}",
+        "{{\"label\":\"{}\",\"summary\":true,\"prompts\":{},\"samples\":{},\"mean_len\":{:.2},\"p50_len\":{},\"p95_len\":{},\"p99_len\":{},\"max_len\":{},\"mean_rep_rate\":{:.6},\"mean_bigram_jaccard\":{:.6},\"truncation_rate\":{:.6},\"doctest_scored\":{},\"doctest_scoreable_prompts\":{},\"doctest_scoreable_samples\":{},\"doctest_invalid_samples\":{},\"doctest_pass_at_1\":{:.4},\"doctest_pass_any_at_n\":{:.4},\"doctest_pass_all_at_n\":{:.4},\"elapsed_secs\":{:.2}}}",
         args.label,
         groups.len(),
         total_samples,
@@ -383,6 +508,13 @@ fn main() -> Result<()> {
         mean_rep,
         mean_div,
         trunc_rate,
+        args.score_doctests,
+        prompts_with_doctests,
+        total_doctest_attempts,
+        total_doctest_invalid,
+        pass_at_1,
+        pass_any,
+        pass_all,
         started.elapsed().as_secs_f64()
     );
     Ok(())


### PR DESCRIPTION
Closes the gap called out in the Phase 3 ablation report (#1046): every existing kiln-eval scorer is text-similarity based, so there's no way to measure pass@1 on the humaneval-derived python-algo datasets without an external verifier.

## How it works

- Pulls `>>>` doctest pairs out of the prompt's last `user` message (classical Python doctest layout — `>>> call` followed by the expected result line; blank-result is treated as expected `None` to match stdlib convention).
- Extracts the first python (or generic) fenced code block from the completion; falls back to the raw completion for models that omit fences.
- Assembles a small JSON-emitting harness around the user code plus per-doctest `try` blocks; feeds it on stdin to a short-lived `python3 -I -S` (isolated, no site-packages) subprocess. Comparison is `repr(actual).strip() == expected.strip()` — the same value-level check stdlib doctest does by default.
- The subprocess is polled for exit; on wall-clock timeout (default 5 s) the child is killed via `Child::kill + wait` so a runaway `while True:` doesn't hang the scorer.
- Score = fraction of doctests that pass. `Pass` only when every doctest matches; `Fail` otherwise. Prompts with no parsable doctests return `Invalid` so the orchestrator can skip them.

New `Scorer::PythonDoctest { timeout_seconds, python_bin }` variant; composes through `Scorer::All` / `Scorer::Any` automatically. No new workspace deps — execution is `std::process::Command` and the harness output is parsed with the existing `serde_json`.

## Validation

- 4 pure-Rust unit tests covering the doctest parser and code-block extractor (run unconditionally).
- 3 integration tests with `#[ignore]` driving real `python3` subprocesses — all-pass, partial-fail, and runaway-loop-timeout cases.
- A new `doctest_cross_check` example replays the scorer over an entire GRPO dataset and compares against the baked-in rewards. On the full `grpo-humaneval-best.jsonl` slice (440 completions): **95.45% agreement** with the dataset's existing pass/fail labels. The 20 disagreements all come from prompts whose 'examples' section uses informal `f(x) returns y` prose instead of `>>>` doctests — a hard limit of doctest-style verification, not a parser bug.

## What's next

Wire the scorer into `cuda_grpo_behavioral_eval` so the Phase 3 ablation matrix gets a pass@1 signal alongside the existing length / repetition / diversity diagnostics. That re-run is the gating evidence for any further default flips.

## Test plan

- [x] \`cargo nextest run -p kiln-eval --lib python_doctest\` — 4/4 pure tests pass
- [x] \`cargo nextest run -p kiln-eval --lib python_doctest --run-ignored only\` — 3/3 subprocess tests pass
- [x] \`cargo run --example doctest_cross_check\` on grpo-humaneval-best.jsonl — 95.45% agreement
- [ ] CI green