### PR TITLE
kiln-gdn-kernel: clear cudaGetLastError() before fused gates launch (H100 fix)

### DIFF
--- a/crates/kiln-gdn-kernel/csrc/gdn_gates.cu
+++ b/crates/kiln-gdn-kernel/csrc/gdn_gates.cu
@@ -161,6 +161,15 @@ int32_t launch_gdn_gates_bf16(
     dim3 grid(rows);
     dim3 block(threads);
 
+    // Clear any previously-latched error state so we attribute only this
+    // launch's failure. Without this, a sticky error from an unrelated
+    // CUDA op can show up here as a spurious launch failure. This
+    // surfaced on H100 (SM90) as "kiln_gdn_gates_bf16 failed with status
+    // 500" while A100 / A6000 (SM80 / SM86) happened not to leave a
+    // residual error in this code path. Mirrors the pattern used by
+    // `kiln_gdn_gate_beta_bf16` and `kiln_gdn_gate_g_bf16` below.
+    cudaGetLastError();
+
     gdn_gates_bf16_kernel<ALogT, DtBiasT><<<grid, block, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(a),
         reinterpret_cast<const __nv_bfloat16*>(b),


### PR DESCRIPTION
## Summary

\`kiln_gdn_gates_bf16\` checked \`cudaGetLastError()\` after the kernel
launch but never cleared the latched error state beforehand, so any
sticky CUDA error from an earlier op surfaced as a spurious launch
failure of this kernel.

On H100 (SM90), this manifested as **every** Qwen3.5-4B prefill
failing on the very first token:

\`\`\`
Text generation failed: prefill forward pass (paged) failed:
gated deltanet layer 0 (linear attention, paged): gdn decode
gates fused backend: gdn_gates kernel failed:
kiln_gdn_gates_bf16 failed with status 500
\`\`\`

A100 / A6000 (SM80 / SM86) happened to leave a clean error state in
this code path, so the bug only manifested on H100.

The two non-fused variants (\`kiln_gdn_gate_beta_bf16\` and
\`kiln_gdn_gate_g_bf16\`) already used this \`cudaGetLastError()\` clear;
this just brings the fused launch in line with the same pattern.

## Test plan

- Verified locally that the fused kernel still works on the H100 pod
  with all kernels enabled (\`KILN_BATCHING_ENGINE=1\`, no
  \`KILN_DISABLE_*\` flags).
- Post-fix, first chat completion succeeds; subsequent requests
  take ~0.3s end-to-end with all kernels enabled.
- A100 / A6000 paths unchanged (the clear is a no-op when error
  state was already clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)