### PR TITLE
Improve long-context trajectory throughput visibility

### DIFF
--- a/crates/kiln-server/src/api/metrics.rs
+++ b/crates/kiln-server/src/api/metrics.rs
@@ -8,6 +8,7 @@ use axum::{
     routing::get,
 };
 
+use crate::batching_engine::BatchingEngineSnapshot;
 use crate::metrics::SnapshotGauges;
 use crate::state::{AppState, ModelBackend};
 use kiln_train::TrainingState;
@@ -22,6 +23,8 @@ async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
         prefix_cache,
         decode_batcher_enabled,
         decode_batcher,
+        batching_engine_enabled,
+        batching_engine,
     ) = match state.backend.as_ref() {
         ModelBackend::Mock { scheduler, .. } => {
             let sched = scheduler.lock().await;
@@ -34,28 +37,43 @@ async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
                 sched.prefix_cache_stats(),
                 false,
                 kiln_model::DecodeBatcherStats::default(),
+                false,
+                BatchingEngineSnapshot::default(),
             )
         }
         ModelBackend::Real {
             block_manager,
             prefix_cache,
+            batching_engine,
             decode_batcher,
             ..
         } => {
-            let bm = block_manager.lock().unwrap();
-            let prefix_cache = prefix_cache.lock().unwrap().stats();
+            let (blocks_used, blocks_total) = {
+                let bm = block_manager.lock().unwrap();
+                (bm.num_used(), bm.num_blocks())
+            };
+            let prefix_cache = {
+                let cache = prefix_cache.lock().unwrap();
+                cache.stats()
+            };
             let batcher_stats = decode_batcher
                 .as_ref()
                 .map(|batcher| batcher.stats())
                 .unwrap_or_default();
+            let batching_engine_snapshot = match batching_engine {
+                Some(engine) => engine.snapshot().await.unwrap_or_default(),
+                None => BatchingEngineSnapshot::default(),
+            };
             (
                 0,
                 0,
-                bm.num_used(),
-                bm.num_blocks(),
+                blocks_used,
+                blocks_total,
                 prefix_cache,
                 decode_batcher.is_some(),
                 batcher_stats,
+                batching_engine.is_some(),
+                batching_engine_snapshot,
             )
         }
     };
@@ -97,6 +115,8 @@ async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
         prompt_token_cache_entries,
         decode_batcher_enabled,
         decode_batcher,
+        batching_engine_enabled,
+        batching_engine,
         training_active,
         active_adapter,
     };

--- a/crates/kiln-server/src/batching_engine.rs
+++ b/crates/kiln-server/src/batching_engine.rs
@@ -27,6 +27,7 @@ use crate::state::{GpuCoordinationLock, RealPrefixCache};
 const DEFAULT_ENGINE_CHANNEL: usize = 1024;
 const DEFAULT_RESPONSE_CHANNEL: usize = 64;
 const DEFAULT_MAX_DECODE_BATCH: usize = 8;
+const DEFAULT_PREFIX_AWARE_ADMISSION: bool = true;
 
 fn blocks_needed_for_tokens(num_tokens: usize, block_size: usize) -> usize {
     num_tokens.div_ceil(block_size)
@@ -44,6 +45,16 @@ fn env_max_decode_batch() -> usize {
         .and_then(|raw| raw.trim().parse::<usize>().ok())
         .filter(|&n| n > 0)
         .unwrap_or(DEFAULT_MAX_DECODE_BATCH)
+}
+
+fn env_prefix_aware_admission() -> bool {
+    match std::env::var("KILN_BATCH_PREFIX_AWARE_ADMISSION") {
+        Ok(raw) => !matches!(
+            raw.trim(),
+            "0" | "false" | "FALSE" | "off" | "OFF" | "no" | "NO"
+        ),
+        Err(_) => DEFAULT_PREFIX_AWARE_ADMISSION,
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -87,6 +98,8 @@ pub struct BatchingEngineSnapshot {
     pub total_prefill_tokens: u64,
     pub total_errors: u64,
     pub adapter_groups_waiting: usize,
+    pub prefix_deferred_waiting: usize,
+    pub prefix_admission_deferrals: u64,
 }
 
 pub enum DecodeSlot {
@@ -140,6 +153,9 @@ fn collect_ready_decode_indices(
 
 pub trait DecodeForward: Send + Sync + 'static {
     fn prepare_request(&self, req: &EngineRequest) -> Result<DecodeSlot>;
+    fn can_reuse_as_strict_prefix(&self, _prompt_token_len: usize) -> bool {
+        false
+    }
     fn forward_decode(
         &self,
         slots: &mut [&mut DecodeSlot],
@@ -296,6 +312,13 @@ impl RealDecodeForward {
 }
 
 impl DecodeForward for RealDecodeForward {
+    fn can_reuse_as_strict_prefix(&self, prompt_token_len: usize) -> bool {
+        self.prefix_cache
+            .lock()
+            .map(|cache| cache.can_register_strict_prefix_len(prompt_token_len))
+            .unwrap_or(false)
+    }
+
     fn prepare_request(&self, req: &EngineRequest) -> Result<DecodeSlot> {
         let _gpu_guard = self.gpu_lock.read().unwrap();
         let hit = {
@@ -492,8 +515,21 @@ impl BatchingEngineHandle {
     }
 
     pub fn start_with_options(forward: Arc<dyn DecodeForward>, max_decode_batch: usize) -> Self {
+        Self::start_with_policy(
+            forward,
+            max_decode_batch.max(1),
+            env_prefix_aware_admission(),
+        )
+    }
+
+    fn start_with_policy(
+        forward: Arc<dyn DecodeForward>,
+        max_decode_batch: usize,
+        prefix_aware_admission: bool,
+    ) -> Self {
         let (tx, rx) = mpsc::channel(DEFAULT_ENGINE_CHANNEL);
-        let actor = BatchingEngineActor::new(rx, forward, max_decode_batch.max(1));
+        let actor =
+            BatchingEngineActor::new(rx, forward, max_decode_batch.max(1), prefix_aware_admission);
         thread::Builder::new()
             .name("kiln-batching-engine".to_string())
             .spawn(move || actor.run())
@@ -586,6 +622,7 @@ struct BatchingEngineActor {
     accepting: bool,
     stopped: bool,
     max_decode_batch: usize,
+    prefix_aware_admission: bool,
     snapshot: BatchingEngineSnapshot,
 }
 
@@ -594,6 +631,7 @@ impl BatchingEngineActor {
         rx: mpsc::Receiver<EngineCommand>,
         forward: Arc<dyn DecodeForward>,
         max_decode_batch: usize,
+        prefix_aware_admission: bool,
     ) -> Self {
         Self {
             rx,
@@ -603,6 +641,7 @@ impl BatchingEngineActor {
             accepting: true,
             stopped: false,
             max_decode_batch,
+            prefix_aware_admission,
             snapshot: BatchingEngineSnapshot {
                 accepting: true,
                 ..BatchingEngineSnapshot::default()
@@ -704,10 +743,25 @@ impl BatchingEngineActor {
     }
 
     fn admit_waiting(&mut self) {
-        while self.active.len() < self.max_decode_batch {
-            let Some(queued) = self.waiting.pop_front() else {
+        while self.active.len() < self.max_decode_batch && !self.waiting.is_empty() {
+            let Some(waiting_idx) = self
+                .waiting
+                .iter()
+                .position(|queued| !self.should_defer_for_active_prefix(queued))
+            else {
+                self.snapshot.prefix_admission_deferrals =
+                    self.snapshot.prefix_admission_deferrals.saturating_add(
+                        self.waiting
+                            .iter()
+                            .filter(|queued| self.should_defer_for_active_prefix(queued))
+                            .count() as u64,
+                    );
                 break;
             };
+            let queued = self
+                .waiting
+                .remove(waiting_idx)
+                .expect("waiting index selected from VecDeque");
             let started = Instant::now();
             match self.forward.prepare_request(&queued.req) {
                 Ok(slot) => {
@@ -727,6 +781,22 @@ impl BatchingEngineActor {
                 }
             }
         }
+        self.refresh_snapshot();
+    }
+
+    fn should_defer_for_active_prefix(&self, queued: &QueuedRequest) -> bool {
+        self.prefix_aware_admission
+            && self.active.iter().any(|active| {
+                active.req.adapter == queued.req.adapter
+                    && active.req.prompt_tokens.len() < queued.req.prompt_tokens.len()
+                    && queued
+                        .req
+                        .prompt_tokens
+                        .starts_with(&active.req.prompt_tokens)
+                    && self
+                        .forward
+                        .can_reuse_as_strict_prefix(active.req.prompt_tokens.len())
+            })
     }
 
     fn run_decode_batch(&mut self) {
@@ -904,6 +974,11 @@ impl BatchingEngineActor {
         self.snapshot.queue_depth = self.waiting.len();
         self.snapshot.active_decode = self.active.len();
         self.snapshot.adapter_groups_waiting = usize::from(!self.waiting.is_empty());
+        self.snapshot.prefix_deferred_waiting = self
+            .waiting
+            .iter()
+            .filter(|queued| self.should_defer_for_active_prefix(queued))
+            .count();
     }
 }
 
@@ -917,9 +992,14 @@ mod tests {
     #[derive(Default)]
     struct MockForward {
         calls: StdMutex<Vec<Vec<TokenId>>>,
+        reusable_prefixes: bool,
     }
 
     impl DecodeForward for MockForward {
+        fn can_reuse_as_strict_prefix(&self, prompt_token_len: usize) -> bool {
+            self.reusable_prefixes && prompt_token_len > 0
+        }
+
         fn prepare_request(&self, req: &EngineRequest) -> Result<DecodeSlot> {
             Ok(DecodeSlot::Mock {
                 next_token: req.prompt_tokens.last().copied().unwrap_or_default(),
@@ -980,9 +1060,13 @@ mod tests {
     }
 
     fn request(prompt_last: TokenId, max_tokens: usize) -> EngineRequest {
+        request_with_tokens(vec![1, prompt_last], max_tokens)
+    }
+
+    fn request_with_tokens(prompt_tokens: Vec<TokenId>, max_tokens: usize) -> EngineRequest {
         EngineRequest {
             request_id: Uuid::new_v4(),
-            prompt_tokens: vec![1, prompt_last],
+            prompt_tokens,
             sampling: SamplingParams {
                 max_tokens,
                 ..SamplingParams::default()
@@ -1109,6 +1193,48 @@ mod tests {
 
         let calls = forward.calls.lock().unwrap().clone();
         assert_eq!(calls, vec![vec![101, 202]]);
+        handle.stop().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn prefix_aware_admission_defers_strict_descendants_but_admits_independent_rows() {
+        let forward = Arc::new(MockForward {
+            reusable_prefixes: true,
+            ..MockForward::default()
+        });
+        let handle = BatchingEngineHandle::start_with_policy(forward.clone(), 8, true);
+
+        let mut prefix_rx = handle
+            .enqueue(request_with_tokens(vec![1, 2], 1))
+            .await
+            .unwrap();
+        let mut descendant_rx = handle
+            .enqueue(request_with_tokens(vec![1, 2, 3], 1))
+            .await
+            .unwrap();
+        let mut independent_rx = handle
+            .enqueue(request_with_tokens(vec![9, 9], 1))
+            .await
+            .unwrap();
+
+        assert_eq!(prefix_rx.recv().await, Some(EngineEvent::Token(12)));
+        assert!(matches!(
+            prefix_rx.recv().await,
+            Some(EngineEvent::Done { .. })
+        ));
+        assert_eq!(independent_rx.recv().await, Some(EngineEvent::Token(19)));
+        assert!(matches!(
+            independent_rx.recv().await,
+            Some(EngineEvent::Done { .. })
+        ));
+        assert_eq!(descendant_rx.recv().await, Some(EngineEvent::Token(13)));
+        assert!(matches!(
+            descendant_rx.recv().await,
+            Some(EngineEvent::Done { .. })
+        ));
+
+        let calls = forward.calls.lock().unwrap().clone();
+        assert_eq!(calls, vec![vec![2, 9], vec![3]]);
         handle.stop().await.unwrap();
     }
 

--- a/crates/kiln-server/src/metrics.rs
+++ b/crates/kiln-server/src/metrics.rs
@@ -8,6 +8,8 @@ use kiln_scheduler::PrefixCacheStats;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use crate::batching_engine::BatchingEngineSnapshot;
+
 const LATENCY_BUCKETS_SECONDS: [f64; 13] = [
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
 ];
@@ -486,6 +488,120 @@ impl Metrics {
             ),
         );
 
+        out.push_str("# HELP kiln_batching_engine_enabled Whether the real-model batching engine actor is enabled.\n");
+        out.push_str("# TYPE kiln_batching_engine_enabled gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_enabled {}",
+                if gauges.batching_engine_enabled { 1 } else { 0 }
+            ),
+        );
+
+        out.push_str("# HELP kiln_batching_engine_queue_depth Requests waiting inside the real-model batching engine.\n");
+        out.push_str("# TYPE kiln_batching_engine_queue_depth gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_queue_depth {}",
+                gauges.batching_engine.queue_depth
+            ),
+        );
+
+        out.push_str("# HELP kiln_batching_engine_active_decode Requests currently active inside the real-model batching engine.\n");
+        out.push_str("# TYPE kiln_batching_engine_active_decode gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_active_decode {}",
+                gauges.batching_engine.active_decode
+            ),
+        );
+
+        out.push_str("# HELP kiln_batching_engine_last_batch_size Last decode batch size selected by the real-model batching engine.\n");
+        out.push_str("# TYPE kiln_batching_engine_last_batch_size gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_last_batch_size {}",
+                gauges.batching_engine.last_batch_size
+            ),
+        );
+
+        out.push_str("# HELP kiln_batching_engine_last_forward_ms Last decode forward wall time in milliseconds.\n");
+        out.push_str("# TYPE kiln_batching_engine_last_forward_ms gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_last_forward_ms {:.6}",
+                gauges.batching_engine.last_forward_ms
+            ),
+        );
+
+        out.push_str(
+            "# HELP kiln_batching_engine_last_prefill_ms Last prefill wall time in milliseconds.\n",
+        );
+        out.push_str("# TYPE kiln_batching_engine_last_prefill_ms gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_last_prefill_ms {:.6}",
+                gauges.batching_engine.last_prefill_ms
+            ),
+        );
+
+        out.push_str("# HELP kiln_batching_engine_decode_tokens_total Decode tokens emitted by the real-model batching engine.\n");
+        out.push_str("# TYPE kiln_batching_engine_decode_tokens_total counter\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_decode_tokens_total {}",
+                gauges.batching_engine.total_decode_tokens
+            ),
+        );
+
+        out.push_str("# HELP kiln_batching_engine_prefill_tokens_total Prompt tokens prefilled by the real-model batching engine.\n");
+        out.push_str("# TYPE kiln_batching_engine_prefill_tokens_total counter\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_prefill_tokens_total {}",
+                gauges.batching_engine.total_prefill_tokens
+            ),
+        );
+
+        out.push_str(
+            "# HELP kiln_batching_engine_errors_total Real-model batching engine errors.\n",
+        );
+        out.push_str("# TYPE kiln_batching_engine_errors_total counter\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_errors_total {}",
+                gauges.batching_engine.total_errors
+            ),
+        );
+
+        out.push_str("# HELP kiln_batching_engine_prefix_deferred_waiting Queued requests currently held back because an active same-adapter request can become their reusable strict prefix.\n");
+        out.push_str("# TYPE kiln_batching_engine_prefix_deferred_waiting gauge\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_prefix_deferred_waiting {}",
+                gauges.batching_engine.prefix_deferred_waiting
+            ),
+        );
+
+        out.push_str("# HELP kiln_batching_engine_prefix_admission_deferrals_total Prefix-aware admission deferral observations in the real-model batching engine.\n");
+        out.push_str("# TYPE kiln_batching_engine_prefix_admission_deferrals_total counter\n");
+        push_line(
+            &mut out,
+            &format!(
+                "kiln_batching_engine_prefix_admission_deferrals_total {}",
+                gauges.batching_engine.prefix_admission_deferrals
+            ),
+        );
+
         // --- Scheduler ---
         out.push_str("# HELP kiln_scheduler_waiting Requests waiting to be scheduled.\n");
         out.push_str("# TYPE kiln_scheduler_waiting gauge\n");
@@ -809,6 +925,8 @@ pub struct SnapshotGauges {
     pub prompt_token_cache_entries: usize,
     pub decode_batcher_enabled: bool,
     pub decode_batcher: DecodeBatcherStats,
+    pub batching_engine_enabled: bool,
+    pub batching_engine: BatchingEngineSnapshot,
     pub training_active: u8,
     pub active_adapter: Option<String>,
 }
@@ -942,6 +1060,20 @@ mod tests {
                 runner_busy_jobs: 1,
                 failed_jobs: 0,
             },
+            batching_engine_enabled: true,
+            batching_engine: BatchingEngineSnapshot {
+                queue_depth: 2,
+                active_decode: 3,
+                last_batch_size: 3,
+                last_forward_ms: 12.5,
+                last_prefill_ms: 250.0,
+                total_decode_tokens: 128,
+                total_prefill_tokens: 8192,
+                total_errors: 1,
+                prefix_deferred_waiting: 1,
+                prefix_admission_deferrals: 4,
+                ..BatchingEngineSnapshot::default()
+            },
             training_active: 0,
             active_adapter: Some("my-adapter".to_string()),
         };
@@ -977,6 +1109,17 @@ mod tests {
         assert!(output.contains("kiln_prompt_token_cache_lookups_total{result=\"hit\"} 5"));
         assert!(output.contains("kiln_prompt_token_cache_lookups_total{result=\"miss\"} 2"));
         assert!(output.contains("kiln_prompt_token_cache_entries 4"));
+        assert!(output.contains("kiln_batching_engine_enabled 1"));
+        assert!(output.contains("kiln_batching_engine_queue_depth 2"));
+        assert!(output.contains("kiln_batching_engine_active_decode 3"));
+        assert!(output.contains("kiln_batching_engine_last_batch_size 3"));
+        assert!(output.contains("kiln_batching_engine_last_forward_ms 12.500000"));
+        assert!(output.contains("kiln_batching_engine_last_prefill_ms 250.000000"));
+        assert!(output.contains("kiln_batching_engine_decode_tokens_total 128"));
+        assert!(output.contains("kiln_batching_engine_prefill_tokens_total 8192"));
+        assert!(output.contains("kiln_batching_engine_errors_total 1"));
+        assert!(output.contains("kiln_batching_engine_prefix_deferred_waiting 1"));
+        assert!(output.contains("kiln_batching_engine_prefix_admission_deferrals_total 4"));
         assert!(output.contains("kiln_active_adapter{name=\"my-adapter\"} 1"));
         assert!(output.contains(r#"kiln_request_duration_seconds_bucket{le="0.5"} 1"#));
         assert!(output.contains(r#"kiln_request_duration_seconds_bucket{le="+Inf"} 1"#));
@@ -1014,6 +1157,8 @@ mod tests {
             prompt_token_cache_entries: 0,
             decode_batcher_enabled: false,
             decode_batcher: DecodeBatcherStats::default(),
+            batching_engine_enabled: false,
+            batching_engine: BatchingEngineSnapshot::default(),
             training_active: 0,
             active_adapter: None,
         };

--- a/crates/kiln-server/src/state.rs
+++ b/crates/kiln-server/src/state.rs
@@ -880,6 +880,13 @@ impl RealPrefixCache {
             && prompt_tokens.len() >= self.min_register_tokens
     }
 
+    pub fn can_register_strict_prefix_len(&self, prompt_len: usize) -> bool {
+        self.is_enabled()
+            && prompt_len >= self.min_register_tokens
+            && self.block_size > 0
+            && prompt_len % self.block_size == 0
+    }
+
     pub fn should_lookup_prompt(&self, prompt_tokens: &[TokenId]) -> bool {
         self.should_register_prompt(prompt_tokens)
     }

--- a/docs/TRAJECTORY_TURN_THROUGHPUT.md
+++ b/docs/TRAJECTORY_TURN_THROUGHPUT.md
@@ -1,0 +1,77 @@
+# Trajectory Turn Throughput
+
+This benchmark drives Kiln against trajectory-trainer turns materialized by
+`/data/apps/trajectory-trainer/scripts/materialize_turn.py`. It is intended for
+long-context adapter inference sweeps, especially adapters stored under:
+
+```text
+b2://clouderic/trajectory-trainer/turn-analysis/adapters/
+```
+
+Run it on a RunPod Kiln pod, not on a shared local worker.
+
+## Server Setup
+
+Start Kiln with the batching engine and prefix cache enabled. They are on by
+default, but the explicit environment makes benchmark artifacts easier to read:
+
+```bash
+export KILN_BATCHING_ENGINE=1
+export KILN_BATCH_PREFIX_AWARE_ADMISSION=1
+export KILN_PREFIX_CACHE_ENABLED=1
+export KILN_MAX_DECODE_BATCH=16
+export KILN_ADAPTER_DIR=/workspace/kiln-adapters
+export KILN_W4A16=1
+export KILN_CUDA_GRAPHS=true
+
+./target/release/kiln serve --host 0.0.0.0 --port 8420
+```
+
+`KILN_BATCH_PREFIX_AWARE_ADMISSION=1` makes the batching actor hold a queued
+request when an active same-adapter request is a strict token prefix that can be
+reused by the real prefix cache. This avoids duplicate long-prefill work for
+consecutive turns from the same trajectory while still admitting unrelated rows
+that can fill the decode batch.
+
+## Benchmark
+
+The benchmark script can sync an adapter directory from B2, or download and
+unpack a `.tar.gz` adapter archive from B2, load it once through Kiln, then
+materialize turns as `prompt-chosen-jsonl` and issue either
+`/v1/completions/batch`, concurrent `/v1/chat/completions`, or both:
+
+```bash
+python3 scripts/bench-trajectory-turns.py \
+  --host http://127.0.0.1:8420 \
+  --db /workspace/trajectory-trainer/trajectories.db \
+  --adapter-uri b2://clouderic/trajectory-trainer/turn-analysis/adapters/<adapter-name>.tar.gz \
+  --adapter-dir /workspace/kiln-adapters \
+  --mode batch \
+  --order session \
+  --batch-size 16 \
+  --http-workers 1 \
+  --max-tokens 64 \
+  --out /workspace/bench/trajectory-turn-throughput.json
+```
+
+Use `--limit 256` for smoke runs, then remove the limit for the full sweep.
+`--order session` keeps consecutive turns together so the prefix-aware admission
+path has the best chance to reuse long shared trajectory prefixes.
+
+The JSON report includes aggregate completion tok/s plus metric deltas from
+`/metrics`, including:
+
+- `prefix_hit_tokens_delta`
+- `batching_prefill_tokens_delta`
+- `batching_decode_tokens_delta`
+- `batching_prefix_deferrals_delta`
+- `batching_errors_delta`
+
+If `batching_prefix_deferrals_delta` is zero, the selected materialized turns
+did not produce queued prompts whose complete rendered prompt was a strict token
+prefix of a later queued prompt. In that case this admission policy is correctly
+idle, and the run is still useful as a long-context batching smoke.
+
+For an A/B run, execute the same command once with
+`KILN_BATCH_PREFIX_AWARE_ADMISSION=0` and once with it enabled, using the same
+turn selection, adapter, `max_tokens`, and batch settings.

--- a/scripts/bench-trajectory-turns.py
+++ b/scripts/bench-trajectory-turns.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""Run Kiln throughput sweeps over trajectory-trainer materialized turns."""
+
+import argparse
+import concurrent.futures
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import sqlite3
+import subprocess
+import sys
+import tarfile
+import tempfile
+import time
+import urllib.error
+import urllib.request
+
+
+DEFAULT_MATERIALIZE = "/data/apps/trajectory-trainer/scripts/materialize_turn.py"
+
+
+def post_json(url, body, timeout):
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url, data=data, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as err:
+        detail = err.read().decode("utf-8", "replace")
+        raise RuntimeError(f"POST {url} failed: HTTP {err.code}: {detail}") from err
+
+
+def get_text(url, timeout):
+    with urllib.request.urlopen(url, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", "replace")
+
+
+def parse_prometheus(text):
+    out = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or " " not in line:
+            continue
+        name, value = line.split(None, 1)
+        name = name.split("{", 1)[0]
+        try:
+            out[name] = float(value)
+        except ValueError:
+            continue
+    return out
+
+
+def metric_delta(before, after, name):
+    return after.get(name, 0.0) - before.get(name, 0.0)
+
+
+def query_turns(db_path, args):
+    clauses = []
+    params = []
+    if args.session_id:
+        clauses.append("session_id = ?")
+        params.append(args.session_id)
+    if args.split:
+        clauses.append("split = ?")
+        params.append(args.split)
+    if args.min_input_tokens is not None:
+        clauses.append("input_tokens >= ?")
+        params.append(args.min_input_tokens)
+    if args.max_input_tokens is not None:
+        clauses.append("input_tokens <= ?")
+        params.append(args.max_input_tokens)
+
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    order_by = {
+        "session": "session_id, timestamp",
+        "time": "timestamp",
+        "longest": "input_tokens DESC, timestamp",
+    }[args.order]
+    limit = "" if args.limit == 0 else "LIMIT ?"
+    if args.limit:
+        params.append(args.limit)
+
+    sql = f"""
+        SELECT id, session_id, timestamp, input_tokens, output_tokens
+        FROM turns
+        {where}
+        ORDER BY {order_by}
+        {limit}
+    """
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(sql, params).fetchall()
+    return [dict(row) for row in rows]
+
+
+def materialize_turn(materialize_script, db_path, turn_id):
+    cmd = [
+        sys.executable,
+        materialize_script,
+        "--db",
+        db_path,
+        "--turn-id",
+        turn_id,
+        "--format",
+        "prompt-chosen-jsonl",
+    ]
+    raw = subprocess.check_output(cmd, text=True)
+    return json.loads(raw)
+
+
+def materialize_all(turns, materialize_script, db_path, workers):
+    by_id = {}
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, workers)) as pool:
+        future_to_id = {
+            pool.submit(materialize_turn, materialize_script, db_path, row["id"]): row["id"]
+            for row in turns
+        }
+        for idx, future in enumerate(concurrent.futures.as_completed(future_to_id), 1):
+            turn_id = future_to_id[future]
+            by_id[turn_id] = future.result()
+            if idx % 100 == 0:
+                print(f"materialized {idx}/{len(turns)} turns", flush=True)
+    return [by_id[row["id"]] for row in turns]
+
+
+def stable_tools_key(item):
+    tools = item.get("tools") or []
+    raw = json.dumps(tools, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest(), tools
+
+
+def chunks(items, size):
+    for i in range(0, len(items), size):
+        yield items[i : i + size]
+
+
+def adapter_name_from_uri(uri):
+    stripped = uri.rstrip("/")
+    name = stripped.rsplit("/", 1)[-1] if stripped.startswith("b2://") else Path(stripped).name
+    for suffix in (".tar.gz", ".tgz"):
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return name
+
+
+def adapter_ready(path):
+    return (
+        path.is_dir()
+        and (path / "adapter_config.json").is_file()
+        and (path / "adapter_model.safetensors").is_file()
+    )
+
+
+def safe_extract_adapter_archive(archive_path, adapter_dir, adapter_name):
+    adapter_root = Path(adapter_dir)
+    adapter_root.mkdir(parents=True, exist_ok=True)
+    target_dir = adapter_root / adapter_name
+    if adapter_ready(target_dir):
+        return
+
+    with tempfile.TemporaryDirectory(prefix=f".extract-{adapter_name}-", dir=adapter_root) as tmp:
+        staging = Path(tmp)
+        staging_root = staging.resolve()
+        with tarfile.open(archive_path, "r:gz") as tar:
+            for member in tar.getmembers():
+                if not (member.isfile() or member.isdir()):
+                    raise RuntimeError(f"unsupported adapter archive entry: {member.name}")
+                member_path = Path(member.name)
+                if member_path.is_absolute() or ".." in member_path.parts:
+                    raise RuntimeError(f"unsafe adapter archive path: {member.name}")
+                resolved = (staging / member_path).resolve()
+                if staging_root not in (resolved, *resolved.parents):
+                    raise RuntimeError(f"adapter archive path escapes staging dir: {member.name}")
+            tar.extractall(staging)
+
+        candidates = [staging]
+        candidates.extend(path for path in staging.iterdir() if path.is_dir())
+        source = next((path for path in candidates if adapter_ready(path)), None)
+        if source is None:
+            raise RuntimeError(
+                "adapter archive did not contain adapter_config.json and "
+                "adapter_model.safetensors"
+            )
+
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        if source == staging:
+            target_dir.mkdir(parents=True)
+            for child in staging.iterdir():
+                shutil.move(str(child), str(target_dir / child.name))
+        else:
+            shutil.move(str(source), str(target_dir))
+
+
+def sync_adapter(adapter_uri, adapter_dir, adapter_name, authorize):
+    if not adapter_uri:
+        return None
+    adapter_name = adapter_name or adapter_name_from_uri(adapter_uri)
+    adapter_root = Path(adapter_dir)
+    adapter_root.mkdir(parents=True, exist_ok=True)
+
+    archive_like = adapter_uri.rstrip("/").endswith((".tar.gz", ".tgz"))
+    if authorize:
+        subprocess.run(["b2", "account", "authorize"], check=True)
+
+    if archive_like:
+        archive_path = adapter_root / Path(adapter_uri.rstrip("/")).name
+        if adapter_uri.startswith("b2://"):
+            subprocess.run(
+                ["b2", "file", "download", adapter_uri, str(archive_path)],
+                check=True,
+            )
+        else:
+            archive_path = Path(adapter_uri)
+        safe_extract_adapter_archive(archive_path, adapter_root, adapter_name)
+    elif adapter_uri.startswith("b2://"):
+        local_dir = adapter_root / adapter_name
+        local_dir.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["b2", "sync", adapter_uri.rstrip("/") + "/", str(local_dir)],
+            check=True,
+        )
+    else:
+        source = Path(adapter_uri)
+        if not adapter_ready(source):
+            raise ValueError(
+                "--adapter-uri must be a b2:// URI, a .tar.gz adapter archive, "
+                "or a local adapter directory"
+            )
+        target_dir = adapter_root / adapter_name
+        if source.resolve() != target_dir.resolve():
+            if target_dir.exists():
+                shutil.rmtree(target_dir)
+            shutil.copytree(source, target_dir)
+    return adapter_name
+
+
+def load_adapter(host, adapter_name, timeout):
+    if not adapter_name:
+        return None
+    return post_json(
+        f"{host.rstrip('/')}/v1/adapters/load",
+        {"name": adapter_name},
+        timeout,
+    )
+
+
+def completion_usage(resp):
+    usage = resp.get("usage") or {}
+    prompt = int(usage.get("prompt_tokens") or 0)
+    completion = int(usage.get("completion_tokens") or 0)
+    return prompt, completion
+
+
+def run_batch_requests(host, groups, args, adapter_name):
+    jobs = []
+    for _, tools, items in groups:
+        for batch in chunks(items, args.batch_size):
+            body = {
+                "prompts": [item["prompt_messages"] for item in batch],
+                "max_tokens": args.max_tokens,
+                "temperature": args.temperature,
+                "seed": args.seed,
+            }
+            if args.top_k is not None:
+                body["top_k"] = args.top_k
+            if tools and not args.drop_tools:
+                body["tools"] = tools
+            if adapter_name:
+                body["adapter"] = adapter_name
+            jobs.append((len(batch), body))
+
+    def one(job):
+        count, body = job
+        started = time.perf_counter()
+        resp = post_json(
+            f"{host.rstrip('/')}/v1/completions/batch", body, args.request_timeout
+        )
+        elapsed = time.perf_counter() - started
+        prompt, completion = completion_usage(resp)
+        return {
+            "requests": count,
+            "elapsed_s": elapsed,
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+        }
+
+    started = time.perf_counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, args.http_workers)) as pool:
+        results = list(pool.map(one, jobs))
+    elapsed = time.perf_counter() - started
+    return summarize_results("batch", results, elapsed)
+
+
+def run_concurrent_requests(host, groups, args, adapter_name):
+    requests = []
+    for _, tools, items in groups:
+        for item in items:
+            body = {
+                "messages": item["prompt_messages"],
+                "max_tokens": args.max_tokens,
+                "temperature": args.temperature,
+                "seed": args.seed,
+                "stream": False,
+            }
+            if args.top_k is not None:
+                body["top_k"] = args.top_k
+            if tools and not args.drop_tools:
+                body["tools"] = tools
+            if adapter_name:
+                body["adapter"] = adapter_name
+            requests.append(body)
+
+    def one(body):
+        started = time.perf_counter()
+        resp = post_json(
+            f"{host.rstrip('/')}/v1/chat/completions", body, args.request_timeout
+        )
+        elapsed = time.perf_counter() - started
+        prompt, completion = completion_usage(resp)
+        return {
+            "requests": 1,
+            "elapsed_s": elapsed,
+            "prompt_tokens": prompt,
+            "completion_tokens": completion,
+        }
+
+    started = time.perf_counter()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, args.http_workers)) as pool:
+        results = list(pool.map(one, requests))
+    elapsed = time.perf_counter() - started
+    return summarize_results("concurrent", results, elapsed)
+
+
+def summarize_results(mode, results, elapsed):
+    prompt_tokens = sum(r["prompt_tokens"] for r in results)
+    completion_tokens = sum(r["completion_tokens"] for r in results)
+    request_count = sum(r["requests"] for r in results)
+    latencies = sorted(r["elapsed_s"] for r in results)
+    p50 = latencies[len(latencies) // 2] if latencies else 0.0
+    p99 = latencies[max(0, int(len(latencies) * 0.99) - 1)] if latencies else 0.0
+    return {
+        "mode": mode,
+        "request_count": request_count,
+        "http_call_count": len(results),
+        "elapsed_s": elapsed,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "completion_tok_s": completion_tokens / elapsed if elapsed > 0 else 0.0,
+        "p50_http_latency_s": p50,
+        "p99_http_latency_s": p99,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="http://127.0.0.1:8420")
+    parser.add_argument("--db", required=True)
+    parser.add_argument("--materialize-script", default=DEFAULT_MATERIALIZE)
+    parser.add_argument("--adapter-uri")
+    parser.add_argument("--adapter-dir", default="/workspace/kiln-adapters")
+    parser.add_argument("--adapter-name")
+    parser.add_argument("--b2-authorize", action="store_true")
+    parser.add_argument("--mode", choices=["batch", "concurrent", "both"], default="batch")
+    parser.add_argument("--order", choices=["session", "time", "longest"], default="session")
+    parser.add_argument("--session-id")
+    parser.add_argument("--split")
+    parser.add_argument("--min-input-tokens", type=int)
+    parser.add_argument("--max-input-tokens", type=int)
+    parser.add_argument("--limit", type=int, default=0, help="0 means all matching turns")
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--http-workers", type=int, default=1)
+    parser.add_argument("--materialize-workers", type=int, default=8)
+    parser.add_argument("--max-tokens", type=int, default=64)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--top-k", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--drop-tools", action="store_true")
+    parser.add_argument("--request-timeout", type=int, default=1800)
+    parser.add_argument("--out", default="trajectory-turn-throughput.json")
+    args = parser.parse_args()
+
+    selected_adapter = sync_adapter(
+        args.adapter_uri, args.adapter_dir, args.adapter_name, args.b2_authorize
+    )
+    adapter_name = args.adapter_name or selected_adapter
+    if adapter_name:
+        load_adapter(args.host, adapter_name, args.request_timeout)
+
+    turns = query_turns(args.db, args)
+    if not turns:
+        raise SystemExit("no matching turns")
+    print(f"selected {len(turns)} turns", flush=True)
+    materialized = materialize_all(
+        turns, args.materialize_script, args.db, args.materialize_workers
+    )
+
+    grouped = {}
+    for item in materialized:
+        key, tools = stable_tools_key(item)
+        grouped.setdefault(key, {"tools": tools, "items": []})["items"].append(item)
+    groups = [
+        (key, group["tools"], group["items"])
+        for key, group in sorted(grouped.items(), key=lambda kv: len(kv[1]["items"]), reverse=True)
+    ]
+    print(f"grouped into {len(groups)} shared-tool batches", flush=True)
+
+    before = parse_prometheus(get_text(f"{args.host.rstrip('/')}/metrics", 30))
+    summaries = []
+    if args.mode in ("batch", "both"):
+        summaries.append(run_batch_requests(args.host, groups, args, adapter_name))
+    if args.mode in ("concurrent", "both"):
+        summaries.append(run_concurrent_requests(args.host, groups, args, adapter_name))
+    after = parse_prometheus(get_text(f"{args.host.rstrip('/')}/metrics", 30))
+
+    metrics = {
+        "prefix_hit_tokens_delta": metric_delta(
+            before, after, "kiln_prefix_cache_hit_tokens_total"
+        ),
+        "prefix_hit_blocks_delta": metric_delta(
+            before, after, "kiln_prefix_cache_hit_blocks_total"
+        ),
+        "batching_decode_tokens_delta": metric_delta(
+            before, after, "kiln_batching_engine_decode_tokens_total"
+        ),
+        "batching_prefill_tokens_delta": metric_delta(
+            before, after, "kiln_batching_engine_prefill_tokens_total"
+        ),
+        "batching_prefix_deferrals_delta": metric_delta(
+            before, after, "kiln_batching_engine_prefix_admission_deferrals_total"
+        ),
+        "batching_errors_delta": metric_delta(
+            before, after, "kiln_batching_engine_errors_total"
+        ),
+    }
+
+    report = {
+        "config": vars(args),
+        "adapter": adapter_name,
+        "turn_count": len(turns),
+        "tool_group_count": len(groups),
+        "summaries": summaries,
+        "metric_deltas": metrics,
+    }
+    Path(args.out).write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(json.dumps(report, indent=2), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check_release_versions.py
+++ b/scripts/check_release_versions.py
@@ -115,6 +115,11 @@ def arg_flags(attrs: str, field_name: str) -> set[str]:
         if explicit_long:
             long_name = explicit_long.group(1)
         flags.add(f"--{long_name}")
+        for alias in re.findall(r'\b(?:alias|visible_alias)\s*=\s*"([^"]+)"', attrs):
+            flags.add(f"--{alias}")
+        for alias_list in re.findall(r'\b(?:aliases|visible_aliases)\s*=\s*&?\s*\[([^\]]*)\]', attrs):
+            for alias in re.findall(r'"([^"]+)"', alias_list):
+                flags.add(f"--{alias}")
     if "short" in attrs:
         short_name = field_name[0]
         explicit_short = re.search(r"short\s*=\s*'([^']+)'", attrs)


### PR DESCRIPTION
## Summary

- add prefix-aware batching-engine admission for queued strict-prefix descendants behind `KILN_BATCH_PREFIX_AWARE_ADMISSION` (default on)
- expose real batching-engine actor state and prefix-admission counters in `/metrics`
- add a RunPod benchmark runner for trajectory-trainer materialized turns and B2/local adapter archives
- document the long-context trajectory throughput workflow and how to interpret zero-deferral runs

## Validation

All build/test work was run on RunPod pod `tggx3lbkkh5g26`; no local cargo build/test commands were run.

- `rustfmt --edition 2024 --check crates/kiln-server/src/api/metrics.rs crates/kiln-server/src/batching_engine.rs crates/kiln-server/src/metrics.rs crates/kiln-server/src/state.rs`
- `cargo test -p kiln-server batching_engine --lib`
- `cargo test -p kiln-server metrics::tests --lib`
- `cargo check -p kiln-server --lib`
- `KILN_CUDA_ARCHS=86 CARGO_TARGET_DIR=/workspace/kiln-target cargo build --release --features cuda --bin kiln`
- smoke: Qwen3.5-4B + `turn-analysis-v12-full-canary-a6000-ckpt32` adapter, 16 trajectory turns, 311,399 prompt tokens, 64 completion tokens, 0 batching errors

Observed smoke note: selected real trajectory samples produced zero strict-prefix deferrals, so the new admission policy remained idle there; the metrics now make that visible.