### PR TITLE
release: bump server workspace to 0.2.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "candle-core",
  "cc",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "chrono",
  "kiln-vulkan-kernel",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-eval"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "candle-core",
  "cc",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "candle-core",
  "cc",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1878,11 +1878,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.16"
+version = "0.2.17"
 
 [[package]]
 name = "kiln-opd-loss-kernel"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "candle-core",
  "cc",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "axum",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-vulkan-kernel"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "anyhow",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.16"
+version = "0.2.17"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## What
Bump workspace version 0.2.16 → 0.2.17 to cut a fresh server release.

Server-only this cycle. `desktop/Cargo.toml` stays at 0.2.16 (separate workspace; docs reference `desktop-v0.2.16` and the drift check still passes).

## Why
Material work has landed since `kiln-v0.2.16`:
- GDN kernel: clear `cudaGetLastError()` before fused gates launch (#1050)
- Trainer/GRPO: per-layer tile reverse over multi-layer segments (#1056), shared prompt-prefix reference forward (#1055), ECHO env cross-entropy hybrid throughout agentic GRPO (#1054)
- Fix batched KV growth for large `max_tokens`
- Stop Qwen tool-call overruns; normalize tool-call output; merge Qwen tool-call output and Pi setup
- Fix tool stream disconnect handling
- Pi setup: prefix-caching required for OPD teacher launches; tool-call + prefix-caching fixes; restore Qwen thinking defaults
- Long-context trajectory throughput visibility (#1052)
- PythonDoctest scorer in `kiln-eval` (#1048)
- GRPO Phase 1/2/3 (DAPO + Dr. GRPO knobs, IsLevel/GSPO/CISPO, EMA reference + selective KL + behavioral eval) and flipped defaults to the Phase 1 ablation-validated recipe
- Dependency bumps: `sha2` 0.11, cargo-minor-and-patch group, several `actions/*` upgrades

## Validation
- `python3 scripts/check_release_versions.py` → passes locally (`desktop-v0.2.16` pin still matches; server examples don't pin `0.2.17`)
- `cargo update --workspace` updated 15 in-workspace crates to 0.2.17; no transitive churn

After merge: tag `kiln-v0.2.17` on the merge commit to trigger `.github/workflows/server-release.yml` (macOS Metal, Linux CUDA 12.4, Linux Vulkan, Windows CUDA 12.4 → publish job flips draft→published).