### PR TITLE
release: 0.2.18 + fix Windows CUDA build (cl rejects -Wno-unused-parameter)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "candle-core",
  "cc",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "chrono",
  "kiln-vulkan-kernel",
@@ -1790,7 +1790,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-eval"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1808,7 +1808,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "candle-core",
  "cc",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1837,7 +1837,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "candle-core",
  "cc",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1878,11 +1878,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.17"
+version = "0.2.18"
 
 [[package]]
 name = "kiln-opd-loss-kernel"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1894,7 +1894,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "candle-core",
  "cc",
@@ -1903,7 +1903,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "axum",
@@ -1953,7 +1953,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1984,7 +1984,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-vulkan-kernel"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "anyhow",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.17"
+version = "0.2.18"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"

--- a/crates/kiln-flash-attn/build.rs
+++ b/crates/kiln-flash-attn/build.rs
@@ -49,7 +49,13 @@ fn main() {
     build.flag("-diag-suppress=177"); // variable declared but never referenced
     build.flag("-diag-suppress=174"); // expression has no effect
     // Host compiler emits these on vendored CUTLASS headers; nothing we can fix upstream.
-    build.flag("-Xcompiler").flag("-Wno-unused-parameter");
+    // GCC/clang-only — `-Wno-unused-parameter` becomes `/Wno-unused-parameter` to cl.exe
+    // on Windows, which rejects it with D8021 ("invalid numeric argument"). cl.exe doesn't
+    // emit the GCC-style "unused parameter" warning anyway, so there's nothing to silence.
+    let target = env::var("TARGET").unwrap_or_default();
+    if !target.ends_with("-msvc") {
+        build.flag("-Xcompiler").flag("-Wno-unused-parameter");
+    }
 
     // Architecture flags — only sm80+ (flash-attn requirement)
     for arch in cuda_archs.split(';') {


### PR DESCRIPTION
## What
- Bump workspace version 0.2.17 → 0.2.18.
- Gate `-Xcompiler -Wno-unused-parameter` in `kiln-flash-attn/build.rs` behind non-MSVC targets.

## Why
The 0.2.17 tag failed `windows-cuda` in `.github/workflows/server-release.yml` and stranded the release in draft. Root cause:

```
cl : Command line error D8021 : invalid numeric argument '/Wno-unused-parameter'
error: failed to run custom build command for `kiln-flash-attn v0.2.17`
```

On Windows, nvcc forwards `-Xcompiler -Wno-unused-parameter` to `cl.exe`, which sees it as `/Wno-unused-parameter` and parses it as a malformed `/W<n>` flag — hence D8021. Regression from #dde5a289 (2026-05-16) which added the flag to silence GCC warnings on the vendored CUTLASS templates. cl.exe doesn't emit the GCC-style unused-parameter warning anyway, so the conditional drop is lossless on Windows.

`kiln-v0.2.16` was tagged the day before #dde5a289 landed, so it shipped clean — that's why this only surfaced tonight when cutting 0.2.17.

## Why 0.2.18 and not 0.2.17
The 0.2.17 tag already exists and has a partial draft release with 3-platform artifacts attached. Re-tagging would either require force-push (risky) or leave the partial draft confusing. Bumping to 0.2.18 is the cleaner ledger — I'll delete the 0.2.17 draft after 0.2.18 publishes.

## Validation
- `python3 scripts/check_release_versions.py` → passes (`desktop-v0.2.16` pin still matches; server examples don't pin `0.2.18`).
- `cargo update --workspace` updated 15 in-workspace crates to 0.2.18.

After merge: tag `kiln-v0.2.18` to trigger the 4-platform release workflow.