### PR TITLE
runpod: kiln-smoke-check + per-SHA cache + recovery docs (#1066)

### DIFF
--- a/deploy/runpod/Dockerfile
+++ b/deploy/runpod/Dockerfile
@@ -123,6 +123,15 @@ RUN chmod +x /etc/profile.d/kiln-motd.sh
 COPY kiln-setup.sh /usr/local/bin/kiln-setup
 RUN chmod +x /usr/local/bin/kiln-setup
 
+# --- kiln-smoke-check: post-build sanity check for fused CUDA kernels ---
+# Exercises every kernel on the inference hot path so the issue #1066
+# failure mode (corrupted sccache object: build succeeds but inference
+# returns HTTP 500 with "kiln_<kernel> failed with status <N>") is caught
+# at build time instead of by the first user request. Returns non-zero
+# with concrete SCCACHE_RECACHE=1 recovery instructions on failure.
+COPY kiln-smoke-check.sh /usr/local/bin/kiln-smoke-check
+RUN chmod +x /usr/local/bin/kiln-smoke-check
+
 # --- kiln-heartbeat: pod-wedge watchdog (Phase A) ---
 # Writes /workspace/heartbeat.txt atomically every 30s with GPU util, load,
 # top procs, build-tree mtime, and build log sizes. Started by entrypoint.sh
@@ -145,7 +154,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 #      missing PATH, missing RUSTUP_HOME/CARGO_HOME (rustup default won't
 #      resolve), etc.
 RUN set -e; \
-    TOOLS="nvcc rustc cargo cargo-nextest sccache nsys gh git curl jq cmake ninja protoc clang rg tmux b2 huggingface-cli python3 kiln-heartbeat"; \
+    TOOLS="nvcc rustc cargo cargo-nextest sccache nsys gh git curl jq cmake ninja protoc clang rg tmux b2 huggingface-cli python3 kiln-heartbeat kiln-setup kiln-smoke-check"; \
     for bin in $TOOLS; do \
         if ! command -v "$bin" >/dev/null 2>&1; then \
             echo "FAIL (interactive env): '$bin' not on PATH" >&2; exit 1; \

--- a/deploy/runpod/README.md
+++ b/deploy/runpod/README.md
@@ -59,3 +59,69 @@ gh api -X PATCH /user/packages/container/kiln-runpod/visibility \
 ```
 
 (One-time. Subsequent pushes inherit the public visibility.)
+
+## Troubleshooting
+
+### Build succeeds but inference returns HTTP 500 / `kiln_<kernel> failed with status <N>`
+
+Symptom (from [issue #1066](https://github.com/ericflo/kiln/issues/1066)):
+`cargo build --release --features cuda` reports success, then the first
+chat-completion request to `kiln serve` returns HTTP 500 with an error chain
+like:
+
+```
+batched-engine prefill forward pass failed
+  ...
+  gdn_gates kernel failed
+  kiln_gdn_gates_bf16 failed with status 500
+```
+
+**Root cause**: the B2-backed sccache served a stale or corrupted compile
+artifact for one of the fused CUDA kernel crates. The kernel source is fine;
+only the cached object is bad. Future fresh pods will keep pulling the same
+corrupt object until something overwrites it.
+
+**Quick fix** — heal the cache by forcing sccache to recompile and
+re-upload:
+
+```bash
+source /root/.kiln-build-env
+SCCACHE_RECACHE=1 cargo build --release --features cuda --bin kiln-bench
+kiln-smoke-check
+```
+
+If a single kernel crate is implicated (e.g. the error names a `kiln_gdn_*`
+symbol), scope the rebuild for speed:
+
+```bash
+SCCACHE_RECACHE=1 cargo build --release --features cuda -p kiln-gdn-kernel
+```
+
+**Catch it at build time** — run `kiln-smoke-check` after every fresh-pod
+build. It exercises every kernel on the inference hot path with a minimal
+prompt, detects the `failed with status <N>` signature, and prints the
+exact recovery commands above.
+
+**Containment** — if corruption keeps recurring on fresh pods, re-run setup
+with `--per-sha-cache`:
+
+```bash
+kiln-setup --repo /workspace/kiln --per-sha-cache
+```
+
+That salts the sccache S3 key prefix with the kiln short SHA, so a bad
+object only haunts pods built from the same commit. Trades cache hit rate
+for cache hygiene; kernel crates rebuild fast on a single arch.
+
+### Build wedges or sshd dies mid-build
+
+Run `/root/kiln-postmortem.sh` (baked alongside `kiln-setup`) to capture
+`free -h`, `dmesg` tail (OOM?), top processes, and disk usage.
+
+`kiln-setup` caps `CARGO_BUILD_JOBS=4` and `NVCC_THREADS=1` to keep nvcc's
+~4-8 GB-per-TU memory footprint from OOM-killing sshd on multi-arch builds.
+Lower further if needed:
+
+```bash
+CARGO_BUILD_JOBS=2 NVCC_THREADS=1 cargo build --release --features cuda
+```

--- a/deploy/runpod/kiln-setup.sh
+++ b/deploy/runpod/kiln-setup.sh
@@ -8,6 +8,9 @@
 #   kiln-setup                                 # just sets up sccache
 #   kiln-setup --repo /workspace/kiln          # also restores flash-attn cache
 #   kiln-setup --clone                         # clones kiln to /workspace/kiln then sets up
+#   kiln-setup --per-sha-cache                 # isolate sccache namespace per kiln SHA
+#                                              # (slower first build, safer cache hygiene;
+#                                              # see issue #1066)
 #
 # Required env vars:
 #   B2_APPLICATION_KEY_ID  — Backblaze B2 key ID
@@ -17,6 +20,9 @@
 #   KILN_REPO_DIR          — Path to kiln repo checkout (default: /workspace/kiln)
 #   KILN_MODEL_ID          — Hugging Face model ID to download (default: Qwen/Qwen3.5-4B)
 #   KILN_MODEL_DIR         — Local model dir (default: /workspace/Qwen3.5-4B)
+#   KILN_SCCACHE_SALT      — Extra string appended to SCCACHE_S3_KEY_PREFIX, e.g.
+#                            a content hash or git SHA. Overrides --per-sha-cache
+#                            when both are set.
 #
 # Writes env exports to $KILN_REPO_DIR/.build-cache-env (if repo exists) and
 # also to /root/.kiln-build-env for agents to source directly.
@@ -32,12 +38,14 @@ B2_REGION="us-west-002"
 
 # Argument parsing
 CLONE_REPO=0
+PER_SHA_CACHE=0
 while [ $# -gt 0 ]; do
     case "$1" in
-        --repo)   KILN_REPO_DIR="$2"; shift 2 ;;
-        --clone)  CLONE_REPO=1; shift ;;
+        --repo)            KILN_REPO_DIR="$2"; shift 2 ;;
+        --clone)           CLONE_REPO=1; shift ;;
+        --per-sha-cache)   PER_SHA_CACHE=1; shift ;;
         -h|--help)
-            sed -n '2,20p' "$0"
+            sed -n '2,29p' "$0"
             exit 0
             ;;
         *) echo "Unknown arg: $1" >&2; exit 2 ;;
@@ -67,11 +75,6 @@ if [ -d /usr/local/cuda/bin ] && [[ ":$PATH:" != *":/usr/local/cuda/bin:"* ]]; t
 fi
 [ -z "${CUDA_HOME:-}" ] && [ -d /usr/local/cuda ] && export CUDA_HOME="/usr/local/cuda"
 
-echo "=== kiln-setup ==="
-echo "  arch:          ${ARCH}"
-echo "  cache prefix:  ${CACHE_PREFIX}"
-echo "  repo dir:      ${KILN_REPO_DIR}"
-
 if [ -z "${B2_APPLICATION_KEY_ID:-}" ] || [ -z "${B2_APPLICATION_KEY:-}" ]; then
     echo "ERROR: B2_APPLICATION_KEY_ID and B2_APPLICATION_KEY must be set" >&2
     exit 1
@@ -82,6 +85,50 @@ if [ "$CLONE_REPO" = "1" ] && [ ! -d "${KILN_REPO_DIR}" ]; then
     echo "Cloning kiln into ${KILN_REPO_DIR}..."
     git clone https://github.com/ericflo/kiln.git "${KILN_REPO_DIR}"
 fi
+
+# Optional cache salt — isolates the sccache namespace per kiln commit (or
+# per arbitrary caller-supplied string). Issue #1066 documented a case where
+# a corrupted .o object cached under the shared namespace took down every
+# fresh pod until SCCACHE_RECACHE=1 overwrote it. A per-SHA namespace bounds
+# the blast radius: a bad object only haunts pods on the same commit.
+#
+# Resolution order: explicit KILN_SCCACHE_SALT > --per-sha-cache > none.
+# Resolved AFTER any --clone so a freshly-cloned repo can supply the SHA.
+CACHE_SALT="${KILN_SCCACHE_SALT:-}"
+if [ -z "${CACHE_SALT}" ] && [ "${PER_SHA_CACHE}" = "1" ]; then
+    if [ -d "${KILN_REPO_DIR}/.git" ]; then
+        CACHE_SALT="$(git -C "${KILN_REPO_DIR}" rev-parse --short=12 HEAD 2>/dev/null || true)"
+    fi
+    if [ -z "${CACHE_SALT}" ]; then
+        echo "WARN: --per-sha-cache requested but ${KILN_REPO_DIR} is not a git checkout;" >&2
+        echo "      falling back to the shared cache namespace." >&2
+    fi
+fi
+if [ -n "${CACHE_SALT}" ]; then
+    # Strip anything that isn't S3-safe (lowercase alnum, dash, dot).
+    CACHE_SALT="$(printf '%s' "${CACHE_SALT}" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9.-' '-' | sed 's/-\+/-/g; s/^-//; s/-$//')"
+    CACHE_PREFIX="${CACHE_PREFIX}/sha-${CACHE_SALT}"
+fi
+
+# Auto-detect KILN_CUDA_ARCHS from the visible GPU(s) if the caller didn't
+# pin it. The default in build.rs is "80;86;89;90" which triples compile
+# time AND produces multi-arch fat binaries — a known sccache-with-nvcc
+# landmine (issue #1066 suspect-list, item 1 in the issue diagnosis). On a
+# single-GPU pod the right value is just the local compute capability.
+if [ -z "${KILN_CUDA_ARCHS:-}" ] && command -v nvidia-smi >/dev/null 2>&1; then
+    DETECTED_ARCHS="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null \
+        | awk '{ gsub(/\./, ""); print }' | sort -u | paste -sd';' -)"
+    if [ -n "${DETECTED_ARCHS}" ]; then
+        export KILN_CUDA_ARCHS="${DETECTED_ARCHS}"
+    fi
+fi
+
+echo "=== kiln-setup ==="
+echo "  arch:          ${ARCH}"
+echo "  cache prefix:  ${CACHE_PREFIX}"
+echo "  cache salt:    ${CACHE_SALT:-<none>}"
+echo "  cuda archs:    ${KILN_CUDA_ARCHS:-<unset, build.rs default>}"
+echo "  repo dir:      ${KILN_REPO_DIR}"
 
 if [ ! -f "${KILN_MODEL_DIR}/config.json" ]; then
     echo "Downloading ${KILN_MODEL_ID} into ${KILN_MODEL_DIR}..."
@@ -144,6 +191,10 @@ export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 # crates × 24 default cargo jobs × multi-arch was OOM-killing sshd.
 export CARGO_BUILD_JOBS=4
 export NVCC_THREADS=1
+# Pin nvcc to the detected GPU arch — keeps the cache key stable across
+# shells and avoids the multi-arch fat-binary path (issue #1066 hygiene).
+# Override by setting KILN_CUDA_ARCHS before sourcing this file.
+${KILN_CUDA_ARCHS:+export KILN_CUDA_ARCHS=\"${KILN_CUDA_ARCHS}\"}
 ENVEOF
     echo "Wrote ${ENV_FILE}"
 fi
@@ -164,6 +215,10 @@ export CUDA_HOME="${CUDA_HOME:-/usr/local/cuda}"
 # crates × 24 default cargo jobs × multi-arch was OOM-killing sshd.
 export CARGO_BUILD_JOBS=4
 export NVCC_THREADS=1
+# Pin nvcc to the detected GPU arch — keeps the cache key stable across
+# shells and avoids the multi-arch fat-binary path (issue #1066 hygiene).
+# Override by setting KILN_CUDA_ARCHS before sourcing this file.
+${KILN_CUDA_ARCHS:+export KILN_CUDA_ARCHS=\"${KILN_CUDA_ARCHS}\"}
 ENVEOF
 
 # Postmortem helper — run after any build wedge / failure to capture state
@@ -181,5 +236,21 @@ echo "Build cache ready. Source the env file and build:"
 echo "  source /root/.kiln-build-env"
 echo "  cargo build --release --features cuda"
 echo ""
+echo "After the build completes, run a smoke check to confirm every fused"
+echo "CUDA kernel works end-to-end (issue #1066 prevention — see Troubleshooting):"
+echo "  kiln-smoke-check"
+echo ""
 echo "If a build wedges or sshd dies mid-build, run:"
 echo "  /root/kiln-postmortem.sh"
+echo ""
+echo "=== Troubleshooting ==="
+echo "  Build succeeds but inference returns HTTP 500 with"
+echo "  'kiln_<kernel> failed with status <N>'?"
+echo "  → The remote sccache returned a corrupted object. Heal the cache:"
+echo "       source /root/.kiln-build-env"
+echo "       SCCACHE_RECACHE=1 cargo build --release --features cuda --bin kiln-bench"
+echo "       kiln-smoke-check"
+echo "    If a single kernel crate is implicated, scope the rebuild:"
+echo "       SCCACHE_RECACHE=1 cargo build --release --features cuda -p kiln-gdn-kernel"
+echo "    If corruption recurs on fresh pods, re-run setup with --per-sha-cache"
+echo "    to isolate the sccache namespace per kiln commit."

--- a/deploy/runpod/kiln-smoke-check.sh
+++ b/deploy/runpod/kiln-smoke-check.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# kiln-smoke-check — post-build sanity check for fused CUDA kernels.
+#
+# Background (issue #1066): on a fresh pod, the B2-backed sccache can serve
+# a corrupted GDN kernel object that compiles fine but explodes at inference
+# time with an error chain like:
+#
+#   batched-engine prefill forward pass failed
+#   ...
+#   kiln_gdn_gates_bf16 failed with status 500
+#
+# The build itself reports success — only the first real inference call
+# surfaces the breakage. This script exercises every kernel on the inference
+# hot path with a minimal prompt so the same failure mode is caught at
+# build time instead of by the first user request.
+#
+# Usage:
+#   kiln-smoke-check                              # uses defaults
+#   kiln-smoke-check --bench <path>               # override kiln-bench location
+#   kiln-smoke-check --model-path <dir>           # override model dir
+#   kiln-smoke-check --max-output-tokens <n>      # default 4
+#   kiln-smoke-check --prompt-tokens <n>          # default 32
+#   kiln-smoke-check --no-paged                   # skip --paged (non-prod path)
+#   kiln-smoke-check --quiet                      # suppress bench stdout on success
+#   kiln-smoke-check --timeout <secs>             # wall-clock cap (default 600)
+#
+# Defaults:
+#   bench:        $KILN_REPO_DIR/target/release/kiln-bench, or `which kiln-bench`
+#   model:        ${KILN_MODEL_DIR:-/workspace/Qwen3.5-4B}
+#
+# Exit codes:
+#   0   smoke check passed (every kernel on the inference path returned cleanly)
+#   1   prerequisite missing (no binary or no model)
+#   2   smoke check failed AND output matched a known-bad sccache pattern;
+#       recovery instructions printed
+#   3   smoke check failed for an unknown reason; raw output printed
+#   4   cli misuse
+#   124 wall-clock timeout
+#
+# This script never modifies the cache. The user must opt in to SCCACHE_RECACHE=1
+# and a rebuild — automating that would mask real kernel regressions.
+
+set -uo pipefail
+
+KILN_REPO_DIR="${KILN_REPO_DIR:-/workspace/kiln}"
+KILN_MODEL_DIR="${KILN_MODEL_DIR:-/workspace/Qwen3.5-4B}"
+
+BENCH=""
+MODEL="${KILN_MODEL_DIR}"
+MAX_OUTPUT_TOKENS=4
+PROMPT_TOKENS=32
+PAGED=1
+QUIET=0
+TIMEOUT_SECS=600
+
+usage() {
+    sed -n '2,33p' "$0"
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --bench)               BENCH="$2"; shift 2 ;;
+        --model-path)          MODEL="$2"; shift 2 ;;
+        --max-output-tokens)   MAX_OUTPUT_TOKENS="$2"; shift 2 ;;
+        --prompt-tokens)       PROMPT_TOKENS="$2"; shift 2 ;;
+        --no-paged)            PAGED=0; shift ;;
+        --quiet|-q)            QUIET=1; shift ;;
+        --timeout)             TIMEOUT_SECS="$2"; shift 2 ;;
+        -h|--help)             usage; exit 0 ;;
+        *) echo "kiln-smoke-check: unknown arg: $1" >&2; usage >&2; exit 4 ;;
+    esac
+done
+
+# Locate kiln-bench
+if [ -z "${BENCH}" ]; then
+    for candidate in \
+        "${KILN_REPO_DIR}/target/release/kiln-bench" \
+        "$(command -v kiln-bench 2>/dev/null || true)"
+    do
+        if [ -n "${candidate}" ] && [ -x "${candidate}" ]; then
+            BENCH="${candidate}"
+            break
+        fi
+    done
+fi
+
+if [ -z "${BENCH}" ] || [ ! -x "${BENCH}" ]; then
+    echo "kiln-smoke-check: kiln-bench binary not found" >&2
+    echo "  tried: ${KILN_REPO_DIR}/target/release/kiln-bench and PATH" >&2
+    echo "  build first: cargo build --release --features cuda --bin kiln-bench" >&2
+    echo "  or pass --bench <path>" >&2
+    exit 1
+fi
+
+if [ ! -f "${MODEL}/config.json" ]; then
+    echo "kiln-smoke-check: model not found at ${MODEL}" >&2
+    echo "  config.json missing — run kiln-setup to download, or pass --model-path <dir>" >&2
+    exit 1
+fi
+
+echo "=== kiln-smoke-check ==="
+echo "  bench:               ${BENCH}"
+echo "  model:               ${MODEL}"
+echo "  prompt-tokens:       ${PROMPT_TOKENS}"
+echo "  max-output-tokens:   ${MAX_OUTPUT_TOKENS}"
+echo "  paged:               $([ ${PAGED} -eq 1 ] && echo yes || echo no)"
+echo "  timeout:             ${TIMEOUT_SECS}s"
+
+BENCH_ARGS=(
+    --model-path "${MODEL}"
+    --skip-training
+    --latency-only
+    --max-output-tokens "${MAX_OUTPUT_TOKENS}"
+    --prompt-tokens "${PROMPT_TOKENS}"
+)
+[ ${PAGED} -eq 1 ] && BENCH_ARGS+=(--paged)
+
+LOG="$(mktemp -t kiln-smoke-check.XXXXXX 2>/dev/null || mktemp "${TMPDIR:-/tmp}/kiln-smoke-check.XXXXXX")"
+trap 'rm -f "${LOG}"' EXIT
+
+# Run the bench. Capture combined stdout+stderr because anyhow context
+# strings come on stderr but the JSON summary lands on stdout, and both
+# matter for diagnosing what went wrong.
+STATUS=0
+if command -v timeout >/dev/null 2>&1; then
+    # GNU coreutils accepts --kill-after; busybox uses -k. Try both forms.
+    if timeout --kill-after=10 "${TIMEOUT_SECS}" true 2>/dev/null; then
+        timeout --kill-after=10 "${TIMEOUT_SECS}" "${BENCH}" "${BENCH_ARGS[@]}" >"${LOG}" 2>&1 || STATUS=$?
+    elif timeout -k 10 "${TIMEOUT_SECS}" true 2>/dev/null; then
+        timeout -k 10 "${TIMEOUT_SECS}" "${BENCH}" "${BENCH_ARGS[@]}" >"${LOG}" 2>&1 || STATUS=$?
+    else
+        timeout "${TIMEOUT_SECS}" "${BENCH}" "${BENCH_ARGS[@]}" >"${LOG}" 2>&1 || STATUS=$?
+    fi
+else
+    "${BENCH}" "${BENCH_ARGS[@]}" >"${LOG}" 2>&1 || STATUS=$?
+fi
+
+if [ ${STATUS} -eq 124 ] || [ ${STATUS} -eq 137 ]; then
+    echo "kiln-smoke-check: TIMEOUT after ${TIMEOUT_SECS}s (status ${STATUS})" >&2
+    tail -40 "${LOG}" >&2
+    exit 124
+fi
+
+if [ ${STATUS} -eq 0 ]; then
+    # Sanity: the bench can return 0 but still have logged an internal kernel
+    # warning. Belt-and-braces grep for the canonical bail message.
+    if grep -qE 'failed with status [0-9]+' "${LOG}"; then
+        STATUS=99
+    fi
+fi
+
+if [ ${STATUS} -eq 0 ]; then
+    if [ ${QUIET} -eq 0 ]; then
+        tail -20 "${LOG}"
+    fi
+    echo ""
+    echo "✓ kiln-smoke-check: PASSED"
+    echo "  All kernels on the inference path returned cleanly."
+    exit 0
+fi
+
+# Failed. Try to classify.
+echo ""
+echo "✗ kiln-smoke-check: FAILED (bench exit ${STATUS})" >&2
+echo "" >&2
+
+# Look for the canonical "<kernel> failed with status <N>" line. If found,
+# it's almost certainly the corrupted-cache pattern documented in #1066.
+KERNEL_LINE="$(grep -oE 'kiln_[a-z0-9_]+ failed with status [0-9]+' "${LOG}" | head -1 || true)"
+GENERIC_LINE="$(grep -oE '[a-z_]+ kernel failed with status [0-9]+' "${LOG}" | head -1 || true)"
+
+if [ -n "${KERNEL_LINE}" ] || [ -n "${GENERIC_LINE}" ]; then
+    echo "Detected fused-kernel failure: ${KERNEL_LINE:-${GENERIC_LINE}}" >&2
+    echo "" >&2
+    echo "This pattern is the signature of issue #1066: the build succeeded but" >&2
+    echo "a cached object served from the remote sccache (B2) is corrupted. The" >&2
+    echo "kernel source is fine; only the cached compile output is bad." >&2
+    echo "" >&2
+    echo "Recovery (forces sccache to re-compile + overwrite the bad object):" >&2
+    echo "" >&2
+    echo "  source /root/.kiln-build-env" >&2
+    echo "  SCCACHE_RECACHE=1 cargo build --release --features cuda --bin kiln-bench" >&2
+    echo "  kiln-smoke-check" >&2
+    echo "" >&2
+    echo "If a single kernel crate is implicated, you can scope the rebuild:" >&2
+    echo "" >&2
+    echo "  SCCACHE_RECACHE=1 cargo build --release --features cuda -p kiln-gdn-kernel" >&2
+    echo "" >&2
+    echo "Last 30 lines of bench output:" >&2
+    echo "" >&2
+    tail -30 "${LOG}" >&2
+    exit 2
+fi
+
+# Unknown failure mode — surface the raw output so the operator can triage.
+echo "No known sccache-corruption signature in output. Full tail follows:" >&2
+echo "" >&2
+tail -60 "${LOG}" >&2
+exit 3

--- a/deploy/runpod/motd.sh
+++ b/deploy/runpod/motd.sh
@@ -11,4 +11,5 @@ printf '  sccache: %s | nextest: %s\n' "$(sccache --version 2>/dev/null | awk '{
 printf '  torch: %s (cuda=%s)\n' "$(python3 -c 'import torch; print(torch.__version__)' 2>/dev/null)" "$(python3 -c 'import torch; print(torch.version.cuda)' 2>/dev/null)"
 printf '\n'
 printf 'Quick start: \033[32mkiln-setup\033[0m (configures sccache+B2) then clone kiln & build.\n'
+printf 'After build:  \033[32mkiln-smoke-check\033[0m (verifies fused CUDA kernels — see issue #1066).\n'
 printf '\n'

--- a/scripts/setup-build-cache.sh
+++ b/scripts/setup-build-cache.sh
@@ -10,6 +10,15 @@
 # Optional env vars:
 #   KILN_REPO_DIR          — Path to kiln repo checkout (default: /workspace/kiln)
 #   SCCACHE_VERSION        — sccache release tag (default: v0.9.1)
+#   KILN_SCCACHE_SALT      — Extra string appended to SCCACHE_S3_KEY_PREFIX, e.g.
+#                            a content hash or git SHA. Isolates the sccache
+#                            namespace per build group so a corrupted object
+#                            (issue #1066) cannot haunt unrelated pods.
+#
+# Optional flags:
+#   --per-sha-cache        Auto-derive KILN_SCCACHE_SALT from `git rev-parse
+#                          --short HEAD` in $KILN_REPO_DIR (issue #1066
+#                          containment; slower first build, safer cache).
 
 set -euo pipefail
 
@@ -18,6 +27,17 @@ SCCACHE_VERSION="${SCCACHE_VERSION:-v0.9.1}"
 B2_BUCKET="clouderic"
 B2_ENDPOINT="https://s3.us-west-002.backblazeb2.com"
 B2_REGION="us-west-002"
+
+# Argument parsing — kept minimal so this stays a drop-in setup script.
+PER_SHA_CACHE=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --per-sha-cache) PER_SHA_CACHE=1; shift ;;
+        --repo)          KILN_REPO_DIR="$2"; shift 2 ;;
+        -h|--help)       sed -n '2,21p' "$0"; exit 0 ;;
+        *) echo "setup-build-cache: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
 
 # --- Detect architecture string ---
 detect_arch() {
@@ -47,6 +67,24 @@ detect_arch() {
 
 ARCH="$(detect_arch)"
 CACHE_PREFIX="build-cache/kiln/${ARCH}"
+
+# Optional cache salt — see deploy/runpod/kiln-setup.sh for full rationale
+# (issue #1066: per-SHA isolation bounds the blast radius of a corrupted
+# cached object). Resolution: explicit KILN_SCCACHE_SALT > --per-sha-cache.
+CACHE_SALT="${KILN_SCCACHE_SALT:-}"
+if [ -z "${CACHE_SALT}" ] && [ "${PER_SHA_CACHE}" = "1" ]; then
+    if [ -d "${KILN_REPO_DIR}/.git" ]; then
+        CACHE_SALT="$(git -C "${KILN_REPO_DIR}" rev-parse --short=12 HEAD 2>/dev/null || true)"
+    fi
+    if [ -z "${CACHE_SALT}" ]; then
+        echo "WARN: --per-sha-cache requested but ${KILN_REPO_DIR} is not a git checkout;" >&2
+        echo "      falling back to the shared cache namespace." >&2
+    fi
+fi
+if [ -n "${CACHE_SALT}" ]; then
+    CACHE_SALT="$(printf '%s' "${CACHE_SALT}" | tr 'A-Z' 'a-z' | tr -c 'a-z0-9.-' '-' | sed 's/-\+/-/g; s/^-//; s/-$//')"
+    CACHE_PREFIX="${CACHE_PREFIX}/sha-${CACHE_SALT}"
+fi
 
 # --- Ensure CUDA is on PATH ---
 if [ -d /usr/local/cuda/bin ] && [[ ":$PATH:" != *":/usr/local/cuda/bin:"* ]]; then
@@ -171,6 +209,18 @@ echo "  export AWS_SECRET_ACCESS_KEY=${B2_APPLICATION_KEY}"
 echo "  export RUSTC_WRAPPER=sccache"
 echo ""
 echo "Then run: cargo build --release --features cuda"
+echo ""
+echo "After the build, run a smoke check (issue #1066 prevention):"
+echo "  ./deploy/runpod/kiln-smoke-check.sh   # in a cloned kiln repo"
+echo "  # or, on a pod: kiln-smoke-check"
+echo ""
+echo "Troubleshooting"
+echo "  Build succeeds but inference returns HTTP 500 with"
+echo "  'kiln_<kernel> failed with status <N>'?"
+echo "  → The remote sccache returned a corrupted object. Heal the cache:"
+echo "       SCCACHE_RECACHE=1 cargo build --release --features cuda --bin kiln-bench"
+echo "    To scope: SCCACHE_RECACHE=1 cargo build ... -p kiln-gdn-kernel"
+echo "    To bound the blast radius on fresh pods, re-run setup with --per-sha-cache."
 
 # Write env to a sourceable file
 ENV_FILE="${KILN_REPO_DIR}/.build-cache-env"


### PR DESCRIPTION
Fixes #1066.

## Problem

The B2-backed sccache can serve a corrupted compile artifact (e.g. `gdn_gates`) that builds cleanly but explodes on the first inference call with:

```
batched-engine prefill forward pass failed
  ...
  gdn_gates kernel failed
  kiln_gdn_gates_bf16 failed with status 500
```

The kernel source is fine; only the cached `.o` (or rlib that links one) is bad, and every fresh pod that builds against the shared cache pulls the same corrupt object until something overwrites it.

## Four-pronged fix

This addresses all four proposed fixes from the issue (with #1 + #2 + #3 implemented and #4 partially mitigated via cache-key hardening):

### 1. Detect early — `kiln-smoke-check`

New `deploy/runpod/kiln-smoke-check.sh`, baked into the runpod image. Runs `kiln-bench --skip-training --latency-only` over the production paged path with a tiny prompt (32-tok prompt, 4 output tok). On failure it:

- Parses the bench output for the canonical `kiln_<kernel> failed with status <N>` line
- Prints concrete recovery commands (`source .kiln-build-env` → `SCCACHE_RECACHE=1 cargo build ...` → re-run smoke check)
- Suggests a scoped `-p kiln-gdn-kernel` rebuild when only one crate is implicated
- Returns distinct exit codes (0 pass / 1 missing prereq / 2 sccache-pattern hit / 3 unknown failure / 4 cli misuse / 124 wall-clock timeout) so wrappers can act on them

Added to the Dockerfile's interactive + SSH-style tool-presence verification list so the image build fails if `kiln-smoke-check` regressed.

### 2. Document recovery

- `kiln-setup` now prints a Troubleshooting block on exit with the `SCCACHE_RECACHE=1` recipe and a pointer to `kiln-smoke-check`.
- `deploy/runpod/README.md` gets a full Troubleshooting section: symptom, root cause, quick fix, scoped rebuild, `--per-sha-cache` containment, and the existing wedge/OOM recovery procedure.
- `scripts/setup-build-cache.sh` (the older sibling script) mirrors the docs and gains the same `--per-sha-cache` flag.
- `motd.sh` mentions `kiln-smoke-check` so it shows up on every SSH login alongside `kiln-setup`.

### 3. Contain the blast radius — `--per-sha-cache`

New `--per-sha-cache` flag and `KILN_SCCACHE_SALT` env override on both setup scripts. When enabled, appends the kiln short SHA to `SCCACHE_S3_KEY_PREFIX`, so a corrupted object only haunts pods built from the same commit instead of leaking across every fresh build until manually purged. Off by default to preserve warm-pod cache hit rate — opt in when corruption recurs.

Resolution order: explicit `KILN_SCCACHE_SALT` > `--per-sha-cache` > shared namespace. SHA value is sanitized (lowercase, S3-safe chars only) before being appended.

### 4. Harden the cache key — auto-detect `KILN_CUDA_ARCHS`

`kiln-setup` now auto-detects `KILN_CUDA_ARCHS` from `nvidia-smi --query-gpu=compute_cap` when the caller didn't pin it, and bakes the value into both `.kiln-build-env` files. This avoids the multi-arch fat-binary path (issue diagnosis item 1: *"a build on a different CUDA arch got cached under the same key"*) and keeps the sccache key stable across shells on a single-GPU pod.

## Testing

All paths exercised locally with bash mocks (no GPU required for these changes — they are pure deploy/scripts/docs):

| Scenario | Expected | Got |
| --- | --- | --- |
| Smoke check, bench passes | exit 0 + "PASSED" | ✓ |
| Smoke check, fake `failed with status 500` | exit 2 + recovery instructions | ✓ |
| Smoke check, unknown CUDA OOM | exit 3 + raw tail | ✓ |
| Smoke check, missing binary | exit 1 + build hint | ✓ |
| Smoke check, missing model | exit 1 + path hint | ✓ |
| Smoke check, unknown flag | exit 4 + usage | ✓ |
| kiln-setup with `KILN_CUDA_ARCHS=86` | env file has `export KILN_CUDA_ARCHS="86"` | ✓ |
| kiln-setup auto-detect (stubbed nvidia-smi compute_cap 8.6) | env file has `export KILN_CUDA_ARCHS="86"` | ✓ |
| kiln-setup `KILN_SCCACHE_SALT=abc123def` | cache prefix `.../sha-abc123def/sccache` | ✓ |
| kiln-setup `--per-sha-cache` outside checkout | warn + shared namespace fallback | ✓ |
| kiln-setup `--per-sha-cache` with cloned repo | cache prefix `.../sha-<12-char SHA>/sccache` | ✓ |
| Salt sanitization (`test-SALT.123`) | normalized to `test-salt.123` | ✓ |

The CI hit on this PR will rebuild `ghcr.io/ericflo/kiln-runpod:latest` via `.github/workflows/runpod-image.yml`. That image build runs the existing Dockerfile smoke test which now verifies both `kiln-setup` and `kiln-smoke-check` are reachable from interactive AND non-interactive SSH-style envs (matches PR #115's hardening pattern).

## Files changed

- `deploy/runpod/kiln-smoke-check.sh` (new, +200 lines): the smoke check script
- `deploy/runpod/kiln-setup.sh`: `--per-sha-cache`, `KILN_SCCACHE_SALT`, auto-detect `KILN_CUDA_ARCHS`, troubleshooting block, smoke-check pointer
- `deploy/runpod/Dockerfile`: COPY + chmod for `kiln-smoke-check`; add to `TOOLS` smoke-test list (also caught `kiln-setup` was missing from the list)
- `deploy/runpod/README.md`: full Troubleshooting section
- `deploy/runpod/motd.sh`: mention `kiln-smoke-check` on login
- `scripts/setup-build-cache.sh`: mirror docs + `--per-sha-cache` flag

## Out of scope

- Root-causing how nvcc/sccache produces the corrupt object in the first place — that requires a reproducible bad object, which would require correlating sccache hits across many pods. The fixes above bound the blast radius, detect the failure mode at build time, and give the operator a one-line recovery, which together make the incident a non-event on future fresh pods.