### PR TITLE
cuda_sft_file: auto-flatten output when --output-dir basename matches --adapter-name (#1065)

### DIFF
--- a/crates/kiln-train/examples/cuda_sft_file.rs
+++ b/crates/kiln-train/examples/cuda_sft_file.rs
@@ -183,7 +183,18 @@ impl Args {
                          [--checkpoint-interval <n>] [--vram-poll-millis <n>] \
                          [--base-adapter <dir>] [--allow-adapter-shape-conversion] \
                          [--allow-high-lora-scale] \
-                         [--trainer native|generic|server|default]"
+                         [--trainer native|generic|server|default]\n\
+                         \n\
+                         Output layout:\n  \
+                         The adapter is written to <output-dir>/<adapter-name>/ \
+                         (registry layout), suitable for `kiln serve --adapter-dir \
+                         <output-dir>`. If the basename of <output-dir> already \
+                         equals <adapter-name>, the adapter is written directly \
+                         to <output-dir>/ so the layout matches the flat shape \
+                         kiln serve's adapter loader requires. In practice that \
+                         means `--output-dir /workspace/adapters/foo --adapter-name \
+                         foo` puts the adapter at /workspace/adapters/foo/ — no \
+                         post-train `mv`/`rmdir` flatten dance needed."
                     );
                     std::process::exit(0);
                 }
@@ -342,8 +353,16 @@ fn main() -> Result<()> {
     drop(model_weights);
     println!("model_loaded_vram_mib={}", current_vram_mib());
 
-    std::fs::create_dir_all(&args.output_dir)
-        .with_context(|| format!("creating {}", args.output_dir.display()))?;
+    // Resolve the user-facing `--output-dir`/`--adapter-name` pair into the
+    // arguments the library training entrypoints actually consume. This makes
+    // `--output-dir /foo --adapter-name foo` produce `/foo/` (flat, loadable
+    // by `kiln serve`) instead of `/foo/foo/` (nested, rejected). Registry
+    // usage (`--output-dir /workspace/adapters --adapter-name foo`) is
+    // unchanged. See issue #1065.
+    let layout =
+        kiln_train::resolve_sft_output_layout(&args.output_dir, &args.adapter_name);
+    std::fs::create_dir_all(&layout.adapter_dir)
+        .with_context(|| format!("creating {}", layout.adapter_dir.display()))?;
     let config = SftConfig {
         epochs: args.epochs,
         learning_rate: args.learning_rate,
@@ -352,19 +371,33 @@ fn main() -> Result<()> {
         base_adapter: args.base_adapter.clone(),
         allow_adapter_shape_conversion: args.allow_adapter_shape_conversion,
         allow_high_lora_scale: args.allow_high_lora_scale,
-        output_name: Some(args.adapter_name.clone()),
+        output_name: Some(layout.adapter_name.clone()),
         auto_load: false,
         checkpoint_interval: args.checkpoint_interval,
         seed: Some(0xC0DA_5EED),
         optimizer: Optimizer::default(),
         adapter_smoke_test: false,
     };
+    if layout.flattened {
+        println!(
+            "output_layout=flat output_dir={} adapter_name={} final_adapter_dir={} \
+             (basename of --output-dir matches --adapter-name; writing flat layout \
+             so `kiln serve --adapter-dir <output-dir>` can load it directly)",
+            args.output_dir.display(),
+            layout.adapter_name,
+            layout.final_adapter_dir.display(),
+        );
+    } else {
+        println!(
+            "output_layout=registry output_dir={} adapter_name={} final_adapter_dir={}",
+            args.output_dir.display(),
+            layout.adapter_name,
+            layout.final_adapter_dir.display(),
+        );
+    }
     println!(
-        "output_dir={} adapter_name={} checkpoint_interval={:?} vram_poll_millis={}",
-        args.output_dir.display(),
-        args.adapter_name,
-        args.checkpoint_interval,
-        args.vram_poll_millis
+        "checkpoint_interval={:?} vram_poll_millis={}",
+        args.checkpoint_interval, args.vram_poll_millis
     );
 
     let stop = Arc::new(AtomicBool::new(false));
@@ -405,8 +438,8 @@ fn main() -> Result<()> {
             &model_config,
             &gpu_weights,
             &tokenizer,
-            &args.output_dir,
-            &args.adapter_name,
+            &layout.adapter_dir,
+            &layout.adapter_name,
             progress,
         ),
         TrainerKind::Generic => kiln_train::trainer::sft_train(
@@ -415,8 +448,8 @@ fn main() -> Result<()> {
             &model_config,
             &gpu_weights,
             &tokenizer,
-            &args.output_dir,
-            &args.adapter_name,
+            &layout.adapter_dir,
+            &layout.adapter_name,
             progress,
             None,
         ),

--- a/crates/kiln-train/src/adapter_output.rs
+++ b/crates/kiln-train/src/adapter_output.rs
@@ -73,6 +73,87 @@ struct AdapterOutputConfig {
     lora_alpha: f32,
 }
 
+/// Result of resolving a `--output-dir`/`--adapter-name` CLI pair into the
+/// `(adapter_dir, adapter_name)` arguments expected by `sft_train` and the
+/// other library training entry points.
+///
+/// The trainer always writes the adapter to `<adapter_dir>/<adapter_name>/`
+/// — correct for a "registry" use where `--adapter-dir /workspace/adapters`
+/// holds many adapter subdirectories. Users frequently pass
+/// `--output-dir /workspace/adapters/foo --adapter-name foo` expecting the
+/// adapter to land at `/workspace/adapters/foo/`, but get
+/// `/workspace/adapters/foo/foo/` instead, which `kiln serve`'s adapter
+/// loader rejects. `resolve_sft_output_layout` detects that case from the
+/// user-facing arguments and returns the pair to forward to the library.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedSftOutputLayout {
+    /// Value to pass as `adapter_dir` to the library training entry point.
+    pub adapter_dir: PathBuf,
+    /// Value to pass as `adapter_name` to the library training entry point.
+    pub adapter_name: String,
+    /// Final on-disk directory the adapter will be written to:
+    /// `adapter_dir.join(&adapter_name)`. Provided for convenient logging.
+    pub final_adapter_dir: PathBuf,
+    /// `true` when the user-supplied layout was rewritten to avoid the
+    /// nested-directory pitfall. `false` when the user-supplied layout was
+    /// preserved verbatim (registry pattern).
+    pub flattened: bool,
+}
+
+/// Resolve a user-facing `--output-dir` / `--adapter-name` pair into the
+/// `(adapter_dir, adapter_name)` that should actually be forwarded to
+/// `sft_train` / `cuda_native_sft_train` / `grpo_train_jsonl`, so that the
+/// adapter lands at exactly the directory the user named when their intent is
+/// unambiguous.
+///
+/// Policy: if the last path component of `output_dir` equals `adapter_name`,
+/// rewrite the pair so the adapter is written directly into `output_dir`. The
+/// rewrite passes `output_dir.parent()` as `adapter_dir` so the library's
+/// `adapter_dir.join(adapter_name)` lands at `output_dir`. Otherwise the
+/// arguments are returned unchanged so the existing registry layout
+/// (`<output_dir>/<adapter_name>/`) is preserved.
+///
+/// This is a pure function on the user-facing arguments; it does not look at
+/// the filesystem and so behaves identically whether `output_dir` exists or
+/// not.
+pub fn resolve_sft_output_layout(
+    output_dir: &Path,
+    adapter_name: &str,
+) -> ResolvedSftOutputLayout {
+    let basename_matches = output_dir
+        .file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == adapter_name);
+
+    if basename_matches {
+        // `Path::parent` returns `Some("")` for a single-component relative
+        // path (e.g. "foo") and `None` only for the root or an empty path.
+        // In both edge cases we substitute "." so the resulting adapter_dir
+        // is always non-empty and joining it with `adapter_name` still
+        // yields the user-supplied `output_dir`.
+        let parent = output_dir
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let final_adapter_dir = parent.join(adapter_name);
+        ResolvedSftOutputLayout {
+            adapter_dir: parent,
+            adapter_name: adapter_name.to_string(),
+            final_adapter_dir,
+            flattened: true,
+        }
+    } else {
+        let final_adapter_dir = output_dir.join(adapter_name);
+        ResolvedSftOutputLayout {
+            adapter_dir: output_dir.to_path_buf(),
+            adapter_name: adapter_name.to_string(),
+            final_adapter_dir,
+            flattened: false,
+        }
+    }
+}
+
 pub fn validate_adapter_output_dir(adapter_dir: &Path) -> Result<PathBuf> {
     if !adapter_dir.exists() || !adapter_dir.is_dir() {
         bail!("adapter directory does not exist: {}", adapter_dir.display());
@@ -733,6 +814,118 @@ mod tests {
         .to_string();
 
         assert!(err.contains("safetensors_hash mismatch"));
+    }
+
+    #[test]
+    fn resolve_sft_output_layout_flattens_when_basename_matches_adapter_name() {
+        // The pi-faithful-completion repro from the issue:
+        // `--output-dir /workspace/adapters/foo --adapter-name foo`.
+        let layout =
+            resolve_sft_output_layout(Path::new("/workspace/adapters/foo"), "foo");
+        assert!(layout.flattened);
+        assert_eq!(layout.adapter_dir, PathBuf::from("/workspace/adapters"));
+        assert_eq!(layout.adapter_name, "foo");
+        // The trainer joins `adapter_dir.join(adapter_name)` to produce the
+        // final adapter directory — verify that path equals the user's
+        // original `--output-dir`.
+        assert_eq!(
+            layout.adapter_dir.join(&layout.adapter_name),
+            PathBuf::from("/workspace/adapters/foo")
+        );
+        assert_eq!(
+            layout.final_adapter_dir,
+            PathBuf::from("/workspace/adapters/foo")
+        );
+    }
+
+    #[test]
+    fn resolve_sft_output_layout_preserves_registry_layout_when_basename_differs() {
+        // Classic registry usage: --output-dir is the parent registry,
+        // --adapter-name is the specific adapter under it.
+        let layout = resolve_sft_output_layout(Path::new("/workspace/adapters"), "foo");
+        assert!(!layout.flattened);
+        assert_eq!(layout.adapter_dir, PathBuf::from("/workspace/adapters"));
+        assert_eq!(layout.adapter_name, "foo");
+        assert_eq!(
+            layout.final_adapter_dir,
+            PathBuf::from("/workspace/adapters/foo")
+        );
+    }
+
+    #[test]
+    fn resolve_sft_output_layout_handles_relative_single_component_output_dir() {
+        // `--output-dir foo --adapter-name foo`: `foo.parent()` is `Some("")`,
+        // which we substitute with "." so joining still produces `./foo`,
+        // pointing at the user's intended adapter directory.
+        let layout = resolve_sft_output_layout(Path::new("foo"), "foo");
+        assert!(layout.flattened);
+        assert_eq!(layout.adapter_dir, PathBuf::from("."));
+        assert_eq!(layout.adapter_name, "foo");
+        assert_eq!(layout.final_adapter_dir, PathBuf::from("./foo"));
+    }
+
+    #[test]
+    fn resolve_sft_output_layout_handles_relative_dotted_path() {
+        let layout = resolve_sft_output_layout(Path::new("./foo"), "foo");
+        assert!(layout.flattened);
+        assert_eq!(layout.adapter_dir, PathBuf::from("."));
+        assert_eq!(layout.adapter_name, "foo");
+        assert_eq!(layout.final_adapter_dir, PathBuf::from("./foo"));
+    }
+
+    #[test]
+    fn resolve_sft_output_layout_handles_trailing_slash_in_output_dir() {
+        // Path::file_name strips a trailing slash, so "/workspace/adapters/foo/"
+        // still matches adapter-name "foo" and is flattened correctly.
+        let layout =
+            resolve_sft_output_layout(Path::new("/workspace/adapters/foo/"), "foo");
+        assert!(layout.flattened);
+        assert_eq!(layout.adapter_dir, PathBuf::from("/workspace/adapters"));
+        assert_eq!(
+            layout.final_adapter_dir,
+            PathBuf::from("/workspace/adapters/foo")
+        );
+    }
+
+    #[test]
+    fn resolve_sft_output_layout_preserves_layout_when_basename_is_partial_match() {
+        // `foo-bar` is not equal to `foo` — registry layout preserved.
+        let layout =
+            resolve_sft_output_layout(Path::new("/workspace/adapters/foo-bar"), "foo");
+        assert!(!layout.flattened);
+        assert_eq!(
+            layout.adapter_dir,
+            PathBuf::from("/workspace/adapters/foo-bar")
+        );
+        assert_eq!(
+            layout.final_adapter_dir,
+            PathBuf::from("/workspace/adapters/foo-bar/foo")
+        );
+    }
+
+    #[test]
+    fn resolve_sft_output_layout_round_trip_after_flatten_is_loadable_layout() {
+        // After flattening, writing the adapter files at `final_adapter_dir`
+        // produces a directory that `validate_adapter_output_dir` accepts.
+        let tmp = tempfile::tempdir().unwrap();
+        let output_dir = tmp.path().join("my-adapter");
+        let layout = resolve_sft_output_layout(&output_dir, "my-adapter");
+        assert!(layout.flattened);
+        assert_eq!(layout.final_adapter_dir, output_dir);
+        write_minimal_adapter(&layout.final_adapter_dir);
+        // The flattened layout passes the same validation `kiln serve` uses.
+        validate_adapter_output_dir(&layout.final_adapter_dir)
+            .expect("flattened layout must satisfy validate_adapter_output_dir");
+    }
+
+    #[test]
+    fn resolve_sft_output_layout_handles_root_only_path() {
+        // Defensive: `/` has no file_name, so layout falls through to the
+        // registry branch. Don't crash, don't lose adapter_name.
+        let layout = resolve_sft_output_layout(Path::new("/"), "foo");
+        assert!(!layout.flattened);
+        assert_eq!(layout.adapter_dir, PathBuf::from("/"));
+        assert_eq!(layout.final_adapter_dir, PathBuf::from("/foo"));
     }
 
     #[test]

--- a/crates/kiln-train/src/lib.rs
+++ b/crates/kiln-train/src/lib.rs
@@ -37,8 +37,9 @@ pub use remote_teacher::{CostTally, RemoteProvider, RemoteTeacher, RemoteTeacher
 pub use adapter_output::{
     ADAPTER_MANIFEST_FILENAME, ADAPTER_MANIFEST_SCHEMA_VERSION, ADAPTER_RECEIPT_FILENAME,
     AdapterManifest, AdapterManifestFiles, AdapterOutputReceipt, AdapterRestoreOptions,
-    AdapterRestoreReceipt, install_adapter_symlink, read_adapter_manifest,
-    read_adapter_manifest_from_adapter_dir, restore_adapter_from_manifest,
+    AdapterRestoreReceipt, ResolvedSftOutputLayout, install_adapter_symlink,
+    read_adapter_manifest, read_adapter_manifest_from_adapter_dir,
+    resolve_sft_output_layout, restore_adapter_from_manifest,
     validate_adapter_output_dir, validate_install_adapter_name,
     write_adapter_manifest_from_train_receipt, write_adapter_output_receipt,
 };


### PR DESCRIPTION
Fixes #1065.

## Problem

`cuda_sft_file` writes the trained adapter to `<output-dir>/<adapter-name>/`,
which is correct for "registry" use (one parent dir holding many adapter
subdirs) but surprises users who pass `--output-dir /workspace/adapters/foo
--adapter-name foo` expecting the adapter at `/workspace/adapters/foo/`. Today
they get `/workspace/adapters/foo/foo/`, which `kiln serve`'s adapter loader
rejects until the files are manually `mv`'d up and the empty inner dir is
`rmdir`'d. The pi-faithful-completion run hit this every SFT step from iter5
through iter23 — iter5's first eval ran for ten minutes producing 0.023 base
scores before we noticed the adapter wasn't actually loaded.

## Fix

This is issue #1065's **Option 1** — auto-flatten inside `cuda_sft_file` — which
the issue ranks as the cleanest of the three proposed fixes.

The policy is a pure function on the user-facing arguments:

- If `output_dir.file_name() == adapter_name`, rewrite the pair so the trainer
  writes the adapter directly at `output_dir`. The library always joins
  `adapter_dir.join(adapter_name)` internally, so we pass `output_dir.parent()`
  as `adapter_dir`.
- Otherwise leave the registry layout untouched (full backward compatibility
  for `--output-dir /workspace/adapters --adapter-name foo` and friends).

A startup line now prints `output_layout=flat` or `output_layout=registry` plus
`final_adapter_dir=…` so the chosen path is obvious in training logs and there
is no ambiguity about where the adapter landed.

## Code shape

- `kiln_train::resolve_sft_output_layout(output_dir, adapter_name) -> ResolvedSftOutputLayout`
  in `crates/kiln-train/src/adapter_output.rs` encapsulates the policy. It's a
  pure function on the user-facing arguments and does not touch the filesystem.
- `crates/kiln-train/examples/cuda_sft_file.rs` calls the helper, uses the
  resolved `adapter_dir` / `adapter_name` when invoking `cuda_native_sft_train`
  and `sft_train`, and surfaces the layout in startup logs and `--help`.

I deliberately scoped this to `cuda_sft_file` since that's the example named in
the issue. The other example binaries (`cuda_grpo_ablation`, `cuda_opd_remote`)
have a separate atomic install path (`--install-adapter-dir` /
`--install-adapter-name`) so they don't exhibit the same pain. The helper is
public so they can opt in later.

## Tests

`adapter_output::tests` gets 8 new tests, all passing:

- `resolve_sft_output_layout_flattens_when_basename_matches_adapter_name` —
  the exact issue repro (`/workspace/adapters/foo` + `foo` → flat).
- `resolve_sft_output_layout_preserves_registry_layout_when_basename_differs` —
  the registry case is untouched.
- `resolve_sft_output_layout_handles_relative_single_component_output_dir` —
  `foo` + `foo` → `./foo` (Path::parent quirk for single-component paths).
- `resolve_sft_output_layout_handles_relative_dotted_path` — `./foo` + `foo`.
- `resolve_sft_output_layout_handles_trailing_slash_in_output_dir` — confirms
  `Path::file_name` strips the trailing slash so flattening still triggers.
- `resolve_sft_output_layout_preserves_layout_when_basename_is_partial_match` —
  `foo-bar` ≠ `foo`, registry preserved.
- `resolve_sft_output_layout_handles_root_only_path` — defensive guard so a
  pathological `/` + name doesn't crash.
- `resolve_sft_output_layout_round_trip_after_flatten_is_loadable_layout` —
  writes a minimal adapter at the flattened `final_adapter_dir` and re-runs
  `validate_adapter_output_dir` (the same check `kiln serve` uses) to prove the
  result is loadable end-to-end.

Full `cargo nextest run -p kiln-train` — **263 tests, all passing**.
`cargo build -p kiln-train --examples` clean.

## What is intentionally **not** in this PR

- Issue #1065's Option 2 (auto-detect on load in `kiln serve`). It's still a
  reasonable secondary fix, but the issue prefers Option 1 because the server
  becoming more forgiving could mask configuration mistakes elsewhere. If you
  want the server lenient too, happy to do it as a follow-up.
- Doc updates to `capabilities/NEXT_ROUND.md`, `capabilities/DISTILLATION.md`,
  `.agents/skills/capability-creator/resources/kiln-cli-reference.md`. Those
  docs use a different flag vocabulary (`--output`, `--adapter`,
  `--install-adapter-*`) that doesn't match the binary's actual flags, so they
  appear to describe a wrapper layer rather than `cuda_sft_file` directly.
  Touching them is out of scope here.