### PR TITLE
cuda_sft_file: default --trainer to generic; hoist native trainer allocs (#1063)

### DIFF
--- a/.agents/skills/capability-creator/resources/sft-mode.md
+++ b/.agents/skills/capability-creator/resources/sft-mode.md
@@ -202,11 +202,16 @@ applied to a different cap would pick different distributions.
 
 ## Practical gotchas
 
-- **Use `--trainer generic`.** The native trainer
-  (`cuda_native_sft_train`) is currently ~50× slower than generic on
-  Qwen3.5-4B; the generic path (`sft_train` in `trainer.rs`) routes
-  through `BackendRuntime` and gets the production-tuned kernels. See
-  kiln issue #1063 for the backport tracking the native trainer.
+- **Use `--trainer generic` (now the default).** As of the kiln issue
+  #1063 fix, `cuda_sft_file` defaults to `--trainer generic` so the
+  CLI no longer silently picks the slow path. The legacy CUDA-native
+  trainer (`cuda_native_sft_train`) is exposed as
+  `--trainer native-experimental` and is currently ~50× slower than
+  generic on Qwen3.5-4B; the generic path (`sft_train` in
+  `trainer.rs`) routes through `BackendRuntime` and gets the
+  production-tuned kernels. Existing capabilities that still pass
+  `--trainer generic` continue to work — leaving the flag in is
+  defensible and a clearer signal of intent.
 - **Flatten the adapter directory after training.** `cuda_sft_file`
   writes to `<output-dir>/<adapter-name>/...` but kiln serve expects
   `<output-dir>/...` directly. After training, `mv` the inner files up

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,67 @@
 # Kiln Server Changelog
 
+## Unreleased — cuda_sft_file defaults to --trainer generic (issue #1063)
+
+`cuda_sft_file` no longer silently picks the ~50× slower CUDA-native
+SFT path. The legacy CUDA-native trainer (`cuda_native_sft_train`) is
+exposed as `--trainer native-experimental` and runs ~180 s/step on
+Qwen3.5-4B (rank 4, lr 1e-5) vs ~3.5 s/step for the generic trainer
+(`sft_train` -> `BackendRuntime`); the default now matches the
+recommended workflow used by `caps/pi-faithful-completion` and other
+production SFT capabilities.
+
+### Changed
+- `cuda_sft_file` `--trainer` now defaults to `generic` rather than the
+  experimental CUDA-native path. New CLI value
+  `--trainer native-experimental` opts into `cuda_native_sft_train`;
+  the legacy `--trainer native` is accepted as an alias for backwards
+  compatibility but now routes to the same experimental path and
+  prints a clear startup warning citing kiln issue #1063.
+- `--help` text on `cuda_sft_file` now documents the trainer choices,
+  marks `generic` as the recommended/default path, and labels
+  `native-experimental` as ~50× slower today.
+
+### Performance
+- `cuda_native_sft_train` (the experimental path) hoists the
+  per-step `CudaTrainArena::new()` and
+  `cuda_linear_attention_state_zeros_for_model()` allocations out of
+  the inner training loop. The arena is now reused via
+  `CudaTrainArena::clear()` per step, and the GDN state is reset via
+  the new `CudaLinearAttentionState::zero_in_place()` method.
+  `cuda_lora_train_token_sequences_with_gdn_state` and
+  `cuda_full_attention_lora_train_token_sequences` receive the same
+  hoist. These changes close the malloc/zeros pressure in
+  cuda_native_sft_train but do not close the 50× gap on their own —
+  the remaining gap is the small-launch + CPU-sync structure of the
+  inner step kernel, tracked as future work on the issue.
+- `cuda_native_sft_train` now supports length-sorted iteration via
+  the new `KILN_CUDA_LENGTH_SORT_SFT` env tristate, mirroring the
+  Vulkan side's `KILN_VK_LENGTH_SORT_SFT`. Default heuristic: enable
+  when any example is at least 8K tokens AND there is more than one
+  example to reorder. Sort changes step order only; the trainer never
+  truncates.
+- `cuda_native_sft_train` now logs `seq_len`, `original_index`, and
+  per-step `step_ms` on the periodic info line so the slow path is
+  diagnosable from a single tail.
+
+### Added
+- `CudaLinearAttentionState::zero_in_place(&mut self)` on
+  `kiln-model` — per-step reset hook used by the training loops that
+  hoist GDN-state allocation out of their inner loop. Today it
+  re-`Tensor::zeros(...)`s into the same shapes (CUDA caching
+  allocator reuses the device buffers); the call site is structured
+  so a future in-place memset kernel can drop in without touching
+  callers.
+- Unit test for `CudaLinearAttentionState::zero_in_place` verifies
+  zero, shape, dtype, and metadata preservation across two
+  consecutive resets (idempotence).
+
+### Docs
+- `.agents/skills/capability-creator/resources/sft-mode.md` updated:
+  `--trainer generic` is now the default rather than just the
+  recommended workaround. Existing `--trainer generic` in capability
+  scripts continues to work and is the clearer signal of intent.
+
 ## Unreleased — ECHO: agentic multi-turn GRPO loss term
 
 Wires the ECHO technique (Shrivastava, Awadallah, Papailiopoulos — MSR

--- a/crates/kiln-model/src/cuda_train.rs
+++ b/crates/kiln-model/src/cuda_train.rs
@@ -1408,6 +1408,50 @@ impl CudaLinearAttentionState {
         }
         Ok(Self { layers })
     }
+
+    /// Reset all per-layer GDN tensors to zero, preserving shapes/dtypes.
+    ///
+    /// This is the per-step reset hook used by training loops that hoist the
+    /// state allocation out of their inner loop (kiln issue #1063). Today the
+    /// implementation issues a fresh `Tensor::zeros(...)` per tensor; candle's
+    /// CUDA caching allocator will reuse the same device buffer in steady
+    /// state, so the cost converges to one cudaMemset per tensor instead of
+    /// `malloc + memset`. A future change can swap the body for a single
+    /// fused in-place memset kernel without touching call sites.
+    pub fn zero_in_place(&mut self) -> Result<()> {
+        for (idx, layer) in self.layers.iter_mut().enumerate() {
+            // Clone device + capture shapes/dtypes up front so the immutable
+            // borrows of `layer.recurrent_state` / `layer.conv_state` end
+            // before we reassign them below.
+            let device = layer.recurrent_state.as_tensor().device().clone();
+            ensure!(
+                matches!(&device, Device::Cuda(_)),
+                "CudaLinearAttentionState::zero_in_place: layer {idx} recurrent_state \
+                 is not on CUDA (got {device:?})",
+            );
+            let recurrent_dims: Vec<usize> = layer.recurrent_state.as_tensor().dims().to_vec();
+            let recurrent_dtype = layer.recurrent_state.as_tensor().dtype();
+            let conv_dims: Vec<usize> = layer.conv_state.as_tensor().dims().to_vec();
+            let conv_dtype = layer.conv_state.as_tensor().dtype();
+            layer.recurrent_state = CudaTrainTensor::new(
+                Tensor::zeros(recurrent_dims, recurrent_dtype, &device).with_context(|| {
+                    format!(
+                        "CudaLinearAttentionState::zero_in_place: reset recurrent_state \
+                         for layer {idx}"
+                    )
+                })?,
+            )?;
+            layer.conv_state = CudaTrainTensor::new(
+                Tensor::zeros(conv_dims, conv_dtype, &device).with_context(|| {
+                    format!(
+                        "CudaLinearAttentionState::zero_in_place: reset conv_state \
+                         for layer {idx}"
+                    )
+                })?,
+            )?;
+        }
+        Ok(())
+    }
 }
 
 /// Count how many imported CUDA layers are GDN (LinearAttention).
@@ -5316,6 +5360,83 @@ mod tests {
             assert_eq!(layer.recurrent_state.dims(), &[3, 4, 5, 6]);
             assert_eq!(layer.conv_n_elements, 3 * 7 * 3);
             assert_eq!(layer.conv_state.dims(), &[3, 7, 3]);
+            assert!(
+                layer
+                    .recurrent_state
+                    .to_vec_f32()?
+                    .iter()
+                    .all(|v| *v == 0.0)
+            );
+            assert!(layer.conv_state.to_vec_f32()?.iter().all(|v| *v == 0.0));
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn cuda_linear_attention_state_zero_in_place_resets_layer_state() -> Result<()> {
+        let device = match Device::new_cuda(0) {
+            Ok(device) => device,
+            Err(err) => {
+                eprintln!(
+                    "CUDA unavailable, skipping cuda GDN state zero_in_place smoke: {err}"
+                );
+                return Ok(());
+            }
+        };
+
+        // Build a small state, perturb it to non-zero values, then verify
+        // that zero_in_place restores all tensors to zero while preserving
+        // shapes, dtypes, and the per-layer scalar metadata. This is the
+        // contract relied on by cuda_native_sft_train's per-step reset.
+        let mut state = CudaLinearAttentionState::zeros(&device, 2, 1, 2, 3, 4, 5, 4)?;
+        let recurrent_dims = state.layers[0].recurrent_state.dims().to_vec();
+        let conv_dims = state.layers[0].conv_state.dims().to_vec();
+        let recurrent_n = state.layers[0].recurrent_n_elements;
+        let conv_n = state.layers[0].conv_n_elements;
+        for layer in state.layers.iter_mut() {
+            let perturbed_recurrent = (layer.recurrent_state.as_tensor() + 1.0f64)?;
+            layer.recurrent_state = CudaTrainTensor::new(perturbed_recurrent)?;
+            let perturbed_conv = (layer.conv_state.as_tensor() + 2.0f64)?;
+            layer.conv_state = CudaTrainTensor::new(perturbed_conv)?;
+        }
+        assert!(
+            state.layers[0]
+                .recurrent_state
+                .to_vec_f32()?
+                .iter()
+                .all(|v| (*v - 1.0).abs() < 1e-6)
+        );
+        assert!(
+            state.layers[0]
+                .conv_state
+                .to_vec_f32()?
+                .iter()
+                .all(|v| (*v - 2.0).abs() < 1e-6)
+        );
+
+        state.zero_in_place()?;
+        assert_eq!(state.layers.len(), 2);
+        for layer in &state.layers {
+            assert_eq!(layer.recurrent_state.dims(), recurrent_dims.as_slice());
+            assert_eq!(layer.conv_state.dims(), conv_dims.as_slice());
+            assert_eq!(layer.recurrent_n_elements, recurrent_n);
+            assert_eq!(layer.conv_n_elements, conv_n);
+            assert_eq!(layer.recurrent_state.dtype(), DType::F32);
+            assert_eq!(layer.conv_state.dtype(), DType::F32);
+            assert!(
+                layer
+                    .recurrent_state
+                    .to_vec_f32()?
+                    .iter()
+                    .all(|v| *v == 0.0)
+            );
+            assert!(layer.conv_state.to_vec_f32()?.iter().all(|v| *v == 0.0));
+        }
+
+        // Repeat once: the reset must be idempotent so multi-step training
+        // can call it at the top of every step without accumulating state.
+        state.zero_in_place()?;
+        for layer in &state.layers {
             assert!(
                 layer
                     .recurrent_state

--- a/crates/kiln-train/examples/cuda_sft_file.rs
+++ b/crates/kiln-train/examples/cuda_sft_file.rs
@@ -26,7 +26,14 @@ use kiln_train::{Optimizer, SftConfig, SftExample};
 #[cfg(feature = "cuda")]
 #[derive(Debug)]
 enum TrainerKind {
-    Native,
+    /// The experimental `cuda_native_sft_train` path. ~50× slower than
+    /// `Generic` on Qwen3.5-4B today (kiln issue #1063). Kept for
+    /// development of the native CUDA training stack and bench parity, but
+    /// never the default for production training.
+    NativeExperimental,
+    /// `kiln_train::trainer::sft_train` — production trainer that routes
+    /// through `BackendRuntime` and inherits the fused-kernel paths used by
+    /// the inference server.
     Generic,
 }
 
@@ -34,17 +41,23 @@ enum TrainerKind {
 impl TrainerKind {
     fn parse(value: &str) -> Result<Self> {
         match value {
-            "native" => Ok(Self::Native),
+            // Legacy `native` alias kept so existing scripts/capabilities do
+            // not break overnight, but it now routes to the experimental
+            // path and the caller is loudly warned at startup.
+            "native" | "native-experimental" => Ok(Self::NativeExperimental),
             "generic" | "server" | "default" => Ok(Self::Generic),
             other => {
-                anyhow::bail!("--trainer must be native, generic, server, or default; got {other}")
+                anyhow::bail!(
+                    "--trainer must be generic, server, default, or native-experimental \
+                     (legacy alias: native); got {other}"
+                )
             }
         }
     }
 
     fn as_str(&self) -> &'static str {
         match self {
-            Self::Native => "native",
+            Self::NativeExperimental => "native-experimental",
             Self::Generic => "generic",
         }
     }
@@ -83,7 +96,11 @@ impl Args {
         let mut skip_examples = 0usize;
         let mut checkpoint_interval = None;
         let mut vram_poll_millis = 1_000u64;
-        let mut trainer = TrainerKind::Native;
+        // Default to the production-tuned generic trainer. The experimental
+        // CUDA-native path (`cuda_native_sft_train`) is currently ~50×
+        // slower on Qwen3.5-4B (kiln issue #1063); callers must opt into
+        // it explicitly with `--trainer native-experimental`.
+        let mut trainer = TrainerKind::Generic;
         let mut lora_rank = 8usize;
         let mut lora_alpha = 16.0f32;
         let mut learning_rate = 1e-4f64;
@@ -170,9 +187,10 @@ impl Args {
                 }
                 "--trainer" => {
                     trainer = TrainerKind::parse(
-                        &args
-                            .next()
-                            .context("--trainer requires native, generic, server, or default")?,
+                        &args.next().context(
+                            "--trainer requires generic, server, default, or \
+                             native-experimental (legacy: native)",
+                        )?,
                     )?
                 }
                 "--help" | "-h" => {
@@ -183,7 +201,17 @@ impl Args {
                          [--checkpoint-interval <n>] [--vram-poll-millis <n>] \
                          [--base-adapter <dir>] [--allow-adapter-shape-conversion] \
                          [--allow-high-lora-scale] \
-                         [--trainer native|generic|server|default]\n\
+                         [--trainer generic|server|default|native-experimental]\n\
+                         \n\
+                         Trainer selection:\n  \
+                         `generic` (default, recommended): routes through the \
+                         production `sft_train` -> BackendRuntime path and inherits \
+                         the fused-kernel paths used by the inference server. \
+                         `native-experimental` (legacy alias: `native`): the \
+                         in-progress CUDA-native SFT path \
+                         (`cuda_native_sft_train`). Currently ~50× slower than \
+                         `generic` on Qwen3.5-4B; use only for development of \
+                         the native CUDA training stack. See kiln issue #1063.\n\
                          \n\
                          Output layout:\n  \
                          The adapter is written to <output-dir>/<adapter-name>/ \
@@ -320,10 +348,22 @@ fn main() -> Result<()> {
         args.max_examples,
         args.trainer.as_str()
     );
-    if matches!(args.trainer, TrainerKind::Native) && args.base_adapter.is_some() {
+    if matches!(args.trainer, TrainerKind::NativeExperimental) && args.base_adapter.is_some() {
         anyhow::bail!(
             "--base-adapter requires --trainer generic until CUDA-native base-adapter loading is implemented"
         );
+    }
+    if matches!(args.trainer, TrainerKind::NativeExperimental) {
+        // The user explicitly opted into the experimental native trainer.
+        // Re-state the perf gap loudly so this can never be mistaken for
+        // the default path; on a real training run this is the single
+        // most expensive misconfiguration in cuda_sft_file today.
+        eprintln!(
+            "WARNING: --trainer native-experimental selected. cuda_native_sft_train \
+             is currently ~50× slower than --trainer generic on Qwen3.5-4B \
+             (see kiln issue #1063). Production runs should use --trainer generic."
+        );
+        println!("trainer_warning=cuda_native_experimental_50x_slower issue=1063");
     }
 
     let tokenizer = load_tokenizer(&args.model_path)?;
@@ -432,7 +472,7 @@ fn main() -> Result<()> {
     }) as kiln_train::trainer::ProgressCallback);
 
     let result = match args.trainer {
-        TrainerKind::Native => kiln_train::cuda_train::cuda_native_sft_train(
+        TrainerKind::NativeExperimental => kiln_train::cuda_train::cuda_native_sft_train(
             &examples,
             &config,
             &model_config,

--- a/crates/kiln-train/src/cuda_train.rs
+++ b/crates/kiln-train/src/cuda_train.rs
@@ -1189,10 +1189,15 @@ pub fn cuda_lora_train_token_sequences_with_gdn_state(
     );
     let device = model.token_embedding.as_tensor().device();
     let mut losses = Vec::with_capacity(epochs * token_sequences.len());
+    // Hoist allocations out of the per-step loop (kiln issue #1063).
+    let mut arena = CudaTrainArena::new(device)?;
+    let mut gdn_state = cuda_linear_attention_state_zeros_for_model(model, 1)?;
     for _epoch in 0..epochs {
         for token_ids in token_sequences {
-            let mut arena = CudaTrainArena::new(device)?;
-            let mut gdn_state = cuda_linear_attention_state_zeros_for_model(model, 1)?;
+            arena.clear();
+            gdn_state.zero_in_place().context(
+                "cuda_lora_train_token_sequences_with_gdn_state: zero GDN state",
+            )?;
             let loss = cuda_lora_model_adamw_step_with_gdn_state_with_arena(
                 model,
                 lora_layers,
@@ -1261,9 +1266,11 @@ pub fn cuda_full_attention_lora_train_token_sequences(
     );
     let device = model.token_embedding.as_tensor().device();
     let mut losses = Vec::with_capacity(epochs * token_sequences.len());
+    // Hoist arena allocation out of the per-step loop (kiln issue #1063).
+    let mut arena = CudaTrainArena::new(device)?;
     for _epoch in 0..epochs {
         for token_ids in token_sequences {
-            let mut arena = CudaTrainArena::new(device)?;
+            arena.clear();
             let loss = cuda_full_attention_lora_model_adamw_step_with_arena(
                 model,
                 lora_layers,
@@ -1349,6 +1356,17 @@ pub fn cuda_native_sft_train(
         alpha = config.lora_alpha,
         adapter_name,
         "starting cuda-native SFT training"
+    );
+    // Surface the known performance gap (kiln issue #1063) so anyone watching
+    // logs sees the slowdown explained rather than as silent degradation.
+    // The generic trainer (`sft_train`) routes through `BackendRuntime` and
+    // inherits the production-tuned fused-kernel paths; this path does not
+    // yet, and runs ~50× slower on Qwen3.5-4B in current benchmarks.
+    tracing::warn!(
+        trainer = "cuda_native_sft_train",
+        issue = "https://github.com/ericflo/kiln/issues/1063",
+        "cuda_native_sft_train is currently ~50× slower than --trainer generic on \
+         Qwen3.5-4B; prefer the generic trainer for production runs"
     );
 
     let alpha_over_rank = match crate::lora_scaling::validate_lora_scaling(
@@ -1460,21 +1478,78 @@ pub fn cuda_native_sft_train(
         .layers
         .iter()
         .any(|layer| matches!(layer, CudaLayerWeights::LinearAttention(_)));
+
+    // Length-sorted iteration mirrors `vk_native_sft_train`: sort once so
+    // shorter, full-context examples reach finite progress before the
+    // longest O(T^2) attention examples. Tristate env override matches the
+    // VK side (`KILN_VK_LENGTH_SORT_SFT`), with the same default heuristic:
+    // auto-enable when at least one example is >= 8K tokens AND there is
+    // more than one example to reorder. The trainer never truncates;
+    // length sort only changes step order.
+    let mut step_order: Vec<usize> = (0..tokenized.len()).collect();
+    let min_seq_len = tokenized
+        .iter()
+        .map(|(ids, _)| ids.len())
+        .min()
+        .unwrap_or(0);
+    let max_seq_len = tokenized
+        .iter()
+        .map(|(ids, _)| ids.len())
+        .max()
+        .unwrap_or(0);
+    let length_sorted = kiln_core::env_flag::env_tristate("KILN_CUDA_LENGTH_SORT_SFT")
+        .unwrap_or(max_seq_len >= 8192 && tokenized.len() > 1);
+    if length_sorted {
+        step_order.sort_by_key(|&i| (tokenized[i].0.len(), i));
+    }
+    tracing::info!(
+        examples = tokenized.len(),
+        min_seq_len,
+        max_seq_len,
+        first_seq_len = tokenized[step_order[0]].0.len(),
+        first_original_index = step_order[0],
+        length_sorted,
+        "cuda-native tokenized full SFT examples"
+    );
+
+    // Hoist per-step allocations out of the loop (kiln issue #1063). The
+    // arena's `clear()` drops the per-step tracked tensors so candle's CUDA
+    // caching allocator can reuse the device buffers across steps. The GDN
+    // state, when present, is zero-reset in place at the top of each step
+    // via `CudaLinearAttentionState::zero_in_place`, avoiding a fresh
+    // `Vec<CudaGdnLayerState>` and the per-step `Tensor::zeros` malloc
+    // pressure that motivated the issue.
+    let device = model.token_embedding.as_tensor().device().clone();
+    let mut arena = CudaTrainArena::new(&device)?;
+    let mut gdn_state = if has_gdn {
+        Some(cuda_linear_attention_state_zeros_for_model(&model, 1)?)
+    } else {
+        None
+    };
+
     let mut global_step = 0usize;
     let mut last_loss = 0.0f32;
     for epoch in 0..config.epochs {
         let mut epoch_loss = 0.0f32;
-        for (token_ids, label_mask) in &tokenized {
+        for &example_idx in &step_order {
+            let (token_ids, label_mask) = &tokenized[example_idx];
             global_step += 1;
-            let mut arena = CudaTrainArena::new(model.token_embedding.as_tensor().device())?;
-            let loss = if has_gdn {
-                let mut gdn_state = cuda_linear_attention_state_zeros_for_model(&model, 1)?;
+            let step_started = std::time::Instant::now();
+            arena.clear();
+            let loss = if let Some(gdn_state) = gdn_state.as_mut() {
+                gdn_state.zero_in_place().with_context(|| {
+                    format!(
+                        "cuda_native_sft_train: zero GDN state at step {} epoch {}",
+                        global_step,
+                        epoch + 1
+                    )
+                })?;
                 cuda_lora_model_adamw_step_with_gdn_state_with_arena(
                     &model,
                     &lora_layers,
                     token_ids,
                     Some(label_mask),
-                    &mut gdn_state,
+                    gdn_state,
                     &mut adamw,
                     cfg,
                     &mut arena,
@@ -1535,6 +1610,9 @@ pub fn cuda_native_sft_train(
                     epoch = epoch + 1,
                     step = global_step,
                     total_steps,
+                    seq_len = token_ids.len(),
+                    original_index = example_idx,
+                    step_ms = step_started.elapsed().as_millis() as u64,
                     loss = format!("{loss:.6}"),
                     "cuda-native training step"
                 );


### PR DESCRIPTION
Closes #1063 (the user-visible 50× slowdown). Tracks the deeper
BackendRuntime backport as follow-up.

## What changes

### User-visible fix (the 50× win for all callers today)
- `cuda_sft_file` now **defaults to `--trainer generic`**. The
  legacy CUDA-native trainer (`cuda_native_sft_train`) was the silent
  default and is currently ~180 s/step on Qwen3.5-4B (rank 4, lr
  1e-5) vs ~3.5 s/step for the generic trainer that routes through
  `sft_train` -> `BackendRuntime`.
- The experimental CUDA-native path is now exposed as
  `--trainer native-experimental`. `--trainer native` is retained as
  a legacy alias that maps to the same path so existing scripts and
  capabilities do not break overnight, but it now prints a clear
  startup warning citing this issue.
- `cuda_sft_file --help` documents the trainer choices, marks
  `generic` as the recommended/default path, and labels
  `native-experimental` as ~50× slower today.

### Structural backport from `vk_native_sft_train` (per the issue body)
- `cuda_native_sft_train` hoists per-step `CudaTrainArena::new()` and
  `cuda_linear_attention_state_zeros_for_model()` out of the inner
  loop. The arena is reused via `CudaTrainArena::clear()` and the
  GDN state is reset via the new
  `CudaLinearAttentionState::zero_in_place()` method.
- `cuda_lora_train_token_sequences_with_gdn_state` and
  `cuda_full_attention_lora_train_token_sequences` get the same
  hoist for consistency.
- New `KILN_CUDA_LENGTH_SORT_SFT` env tristate enables length-sorted
  iteration, mirroring `KILN_VK_LENGTH_SORT_SFT`. Default heuristic:
  auto-on when any example is at least 8K tokens AND there is more
  than one example to reorder. Sort changes step order only; the
  trainer never truncates.
- Per-step `info!` now logs `seq_len`, `original_index`, and
  `step_ms` so the slow path is diagnosable from a single tail
  (matches `vk_native_sft_train`'s log shape).
- Startup `warn!` on entry into `cuda_native_sft_train` re-states the
  perf gap and links this issue, so anyone watching logs sees the
  slowdown explained rather than as silent degradation.

### Test
- New unit test
  `cuda_linear_attention_state_zero_in_place_resets_layer_state`
  verifies zero/shape/dtype/metadata preservation and idempotence
  across two consecutive resets.

## What this does *not* change

These hoists close the malloc/zeros pressure flagged in the issue
diagnosis (items 1–2) but do **not** close the 50× gap on their own —
the remaining gap is the small-launch + CPU-sync structure of the
inner step kernel (item 3, "BackendRuntime routing"). Closing item 3
is a substantially larger refactor that should land as its own PR
once the path is scoped. The default flip is what eliminates the 50×
gap for all `cuda_sft_file` users today, exactly as the issue's
"easier interim" recommends.

## Build / validation

I was unable to run `cargo build --release --features cuda` on a real
A6000 for this PR: RunPod A6000 capacity was unavailable across 6
acquire attempts (HTTP 500 "no longer any instances available with
the requested specifications"). Per the `runpod-capacity-fallback`
pattern I'm shipping the code and flagging the validation gap so a
follow-up smoke test can land once capacity is back.

The changes are deliberately conservative for that reason:

- `cuda_sft_file.rs` changes are a default-value flip plus a renamed
  variant; no kernel changes.
- The arena hoist is semantically equivalent: `let mut arena =
  CudaTrainArena::new(...)` inside the loop drops the arena (and its
  tracked tensors) at end of iteration; `arena.clear()` at the top of
  the next iteration explicitly drops the same `Vec<CudaTrainTensor>`
  before the next step begins. The CUDA caching allocator behaves
  identically.
- `zero_in_place` re-creates the same-shape/same-dtype zero tensors
  on the same device — bit-for-bit equivalent to the previous
  per-step `cuda_linear_attention_state_zeros_for_model` call.
- Length-sort defaults to OFF (`max_seq_len < 8192 || tokenized.len()
  <= 1`), so the default training path for small/short SFT datasets
  is identical to before.

Suggested smoke test once A6000 is available:

```bash
# 1) Build verifies the new TrainerKind variant + zero_in_place compile.
KILN_CUDA_ARCHS=86 cargo build --release --features cuda --example cuda_sft_file

# 2) Library tests cover the new zero_in_place behavior.
KILN_CUDA_ARCHS=86 cargo test --release --features cuda -p kiln-model \
  cuda_linear_attention_state_zero_in_place

# 3) Smoke that the new default works end-to-end on a tiny SFT slice:
./target/release/examples/cuda_sft_file \
  --data examples.jsonl --model-path /workspace/qwen3.5-4b \
  --output-dir /workspace/tmp/sft --adapter-name smoke \
  --epochs 1 --max-examples 4
# expect: "trainer=generic" in the startup banner, NO 50×-slowness
# warning, total wall < 1 min on 4 short examples.

# 4) Confirm the legacy alias still routes (and warns) into the
#    experimental path:
./target/release/examples/cuda_sft_file --trainer native \
  --data examples.jsonl --model-path /workspace/qwen3.5-4b \
  --output-dir /workspace/tmp/sft-legacy --adapter-name smoke-legacy \
  --epochs 1 --max-examples 2
# expect: "trainer=native-experimental" in the startup banner, the
# new WARNING line printed to stderr, the
# trainer_warning=cuda_native_experimental_50x_slower line on stdout.
```

## Files

- `crates/kiln-train/examples/cuda_sft_file.rs` — default flip,
  rename, warning, help text.
- `crates/kiln-train/src/cuda_train.rs` — hoist arena + gdn_state in
  three functions, add length-sort tristate, add per-step tracing,
  add startup warn on the experimental path.
- `crates/kiln-model/src/cuda_train.rs` — new
  `CudaLinearAttentionState::zero_in_place` + unit test.
- `.agents/skills/capability-creator/resources/sft-mode.md` —
  capability-creator guidance updated for the default flip.
- `CHANGELOG.md` — Unreleased entry.

Auto-merge once Eric (or anyone reviewing) is satisfied with the
shape. Per kiln convention this PR has no `CE:` prefix and there is
no deploy-request — kiln does not have CI today, so `gh pr checks`
will report empty.