### PR TITLE
vk_native_sft_train: workload-shape-aware checkpoint segment picker

### DIFF
--- a/crates/kiln-core/src/vram.rs
+++ b/crates/kiln-core/src/vram.rs
@@ -528,7 +528,7 @@ pub fn recommended_checkpoint_segments(vram: &GpuVramInfo) -> Option<usize> {
 /// * [`CheckpointPlan::Enabled`] — activations would crowd available VRAM at
 ///   one or more segment counts; pick the smallest segment count that keeps
 ///   per-segment activation memory under the headroom budget.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum CheckpointPlan {
     /// User overrode via env (`KILN_GRAD_CHECKPOINT_SEGMENTS` or
     /// `KILN_NO_GRAD_CHECKPOINT`). Caller should fall back to the env-driven

--- a/crates/kiln-core/src/vram.rs
+++ b/crates/kiln-core/src/vram.rs
@@ -485,6 +485,11 @@ pub fn recommended_num_blocks(vram: &GpuVramInfo) -> Option<usize> {
 ///
 /// Returns `None` if the user set `KILN_GRAD_CHECKPOINT_SEGMENTS` (should use that instead).
 /// More segments = less VRAM but more compute overhead.
+///
+/// This is the *VRAM-only* heuristic (no sequence-length awareness). The training
+/// trainer paths now prefer [`recommended_checkpoint_plan`] which also factors in
+/// `max_seq_len` and `hidden_size`, but this function is retained for callers that
+/// don't have the workload shape handy (preflight estimator, bench reporter).
 pub fn recommended_checkpoint_segments(vram: &GpuVramInfo) -> Option<usize> {
     if std::env::var("KILN_GRAD_CHECKPOINT_SEGMENTS")
         .ok()
@@ -506,6 +511,182 @@ pub fn recommended_checkpoint_segments(vram: &GpuVramInfo) -> Option<usize> {
         12 // aggressive checkpointing for tight VRAM
     } else {
         8 // conservative default
+    })
+}
+
+/// Decision returned by [`recommended_checkpoint_plan`].
+///
+/// Three distinct outcomes — the auto-tuner returns one based on `(vram,
+/// num_layers, max_seq_len, hidden_size)`:
+///
+/// * [`CheckpointPlan::UserOverride`] — the user set
+///   `KILN_GRAD_CHECKPOINT_SEGMENTS=<N>` or `KILN_NO_GRAD_CHECKPOINT=1`. The
+///   caller should honor the env value and skip auto-tuning entirely.
+/// * [`CheckpointPlan::Disabled`] — activations comfortably fit in available
+///   VRAM after the base model and a safety reserve. Skipping checkpointing
+///   wins ~10-30% step time without OOM risk.
+/// * [`CheckpointPlan::Enabled`] — activations would crowd available VRAM at
+///   one or more segment counts; pick the smallest segment count that keeps
+///   per-segment activation memory under the headroom budget.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheckpointPlan {
+    /// User overrode via env (`KILN_GRAD_CHECKPOINT_SEGMENTS` or
+    /// `KILN_NO_GRAD_CHECKPOINT`). Caller should fall back to the env-driven
+    /// path (e.g. `CheckpointConfig::from_env`) so the override is respected.
+    UserOverride,
+    /// Auto-decided to disable checkpointing entirely. `max_act_gib` is the
+    /// estimated activation tape size for the workload; `available_gib` is
+    /// the headroom we have for it. Included for logging.
+    Disabled {
+        max_act_gib: f64,
+        available_gib: f64,
+    },
+    /// Auto-decided to engage checkpointing with this segment count.
+    Enabled {
+        num_segments: usize,
+        max_act_gib: f64,
+        per_segment_gib: f64,
+        available_gib: f64,
+    },
+}
+
+/// Approximate base-model VRAM footprint for a single-host SFT/GRPO/OPD
+/// training run, in bytes.
+///
+/// We can't ask candle "how much VRAM is the base model using right now" from
+/// inside `kiln-core` without taking a dependency on `kiln-model`, so use a
+/// simple param-count formula sized to the canonical inference dtype (BF16,
+/// 2 bytes/param). It's deliberately conservative — over-estimating the base
+/// only pulls the auto-tune toward MORE checkpointing, never less, so we
+/// can't accidentally OOM by mis-estimating.
+///
+/// Formula (canonical SwiGLU + GQA shape):
+/// * Attention per layer: `4 * hidden^2` (Q, K, V, O — approximating GQA's
+///   reduction by ~30% via the constant 4 instead of 5 or 6).
+/// * MLP per layer: `3 * hidden * intermediate` (gate, up, down).
+/// * Embedding + LM head: `2 * vocab * hidden`.
+///
+/// Multiplied by 2 bytes/param (BF16). The estimate matches the
+/// `model_loaded_vram_mib=9943` we observe for Qwen3.5-4B in the
+/// kiln-server training bench (within ~5%).
+pub fn estimate_base_model_bytes(
+    num_layers: usize,
+    hidden_size: usize,
+    intermediate_size: usize,
+    vocab_size: usize,
+    bytes_per_param: usize,
+) -> u64 {
+    let per_layer_params =
+        (4 * hidden_size * hidden_size) + (3 * hidden_size * intermediate_size);
+    let layer_total = per_layer_params.saturating_mul(num_layers);
+    let head_total = 2usize.saturating_mul(vocab_size).saturating_mul(hidden_size);
+    let total_params = layer_total.saturating_add(head_total);
+    (total_params as u64).saturating_mul(bytes_per_param as u64)
+}
+
+/// Auto-decide a gradient-checkpoint plan for a training workload, factoring
+/// in BOTH the device's total VRAM and the workload's shape (`num_layers`,
+/// `max_seq_len_tokens`, `hidden_size`, base-model footprint).
+///
+/// Behavior:
+/// 1. If `KILN_GRAD_CHECKPOINT_SEGMENTS` or `KILN_NO_GRAD_CHECKPOINT=1` is
+///    set, return [`CheckpointPlan::UserOverride`] and let the caller honor
+///    the env value via `CheckpointConfig::from_env`.
+/// 2. Estimate F32 activation tape:
+///    `max_act_bytes = num_layers * max_seq_len * hidden_size * 4`.
+/// 3. Reserve `base_model_bytes + 2 GiB safety` for everything that isn't
+///    activations (model weights, grads, AdamW state, working buffers).
+/// 4. Define `available_bytes = max(0, vram.total_bytes - reserved)`.
+/// 5. If `max_act_bytes <= available_bytes * 0.5`, return
+///    [`CheckpointPlan::Disabled`] — checkpointing would only cost step time
+///    without lowering peak VRAM enough to matter.
+/// 6. Otherwise pick `num_segments = ceil(max_act_bytes / (available_bytes *
+///    0.3))`, clamped to `[2, num_layers]`. The 30% target makes per-segment
+///    intermediate memory comfortable inside headroom.
+///
+/// `None` is returned if VRAM detection failed (`vram.total_bytes == 0`) —
+/// the caller should fall back to [`CheckpointConfig::from_env`]'s VRAM-only
+/// path (which itself handles "unknown VRAM" via a conservative default).
+pub fn recommended_checkpoint_plan(
+    vram: &GpuVramInfo,
+    num_layers: usize,
+    max_seq_len_tokens: usize,
+    hidden_size: usize,
+    base_model_bytes: u64,
+) -> Option<CheckpointPlan> {
+    // Env overrides take absolute precedence — caller should honor them.
+    if std::env::var("KILN_GRAD_CHECKPOINT_SEGMENTS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .is_some()
+    {
+        return Some(CheckpointPlan::UserOverride);
+    }
+    if std::env::var("KILN_NO_GRAD_CHECKPOINT")
+        .as_deref()
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        return Some(CheckpointPlan::UserOverride);
+    }
+
+    // VRAM unknown — caller should fall back to the env-driven path.
+    if vram.total_bytes == 0 {
+        return None;
+    }
+
+    // F32 activation tape (one element per layer-token pair). Even on a
+    // BF16 model, the trainer keeps activations and grads in F32 for
+    // numerical stability, so this matches what we'd actually allocate.
+    let max_act_bytes = (num_layers as u64)
+        .saturating_mul(max_seq_len_tokens as u64)
+        .saturating_mul(hidden_size as u64)
+        .saturating_mul(4);
+
+    // 2 GiB safety for working buffers (RoPE tables, attention masks,
+    // intermediate matmul outputs that aren't on the activation tape).
+    const SAFETY_RESERVE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+    let reserved = base_model_bytes.saturating_add(SAFETY_RESERVE_BYTES);
+    let available_bytes = vram.total_bytes.saturating_sub(reserved);
+
+    let gib = |b: u64| (b as f64) / (1024.0 * 1024.0 * 1024.0);
+    let max_act_gib = gib(max_act_bytes);
+    let available_gib = gib(available_bytes);
+
+    // If we have less than 2 GiB of headroom after reserves, the auto-tune
+    // is in dangerous territory regardless of seq_len. Punt to the
+    // VRAM-only heuristic via UserOverride — let from_env's existing logic
+    // pick a conservative segment count.
+    if available_bytes < 2 * 1024 * 1024 * 1024 {
+        return Some(CheckpointPlan::UserOverride);
+    }
+
+    // Comfortable headroom: skip checkpointing. The 0.5 threshold leaves
+    // plenty of room for grads + AdamW state on top of activations.
+    if max_act_bytes <= (available_bytes / 2) {
+        return Some(CheckpointPlan::Disabled {
+            max_act_gib,
+            available_gib,
+        });
+    }
+
+    // Tight headroom: pick segments to keep per-segment activation memory
+    // under 30% of available. Round up; clamp to [2, num_layers].
+    let target_per_segment = available_bytes.max(1) * 3 / 10;
+    let mut num_segments = ((max_act_bytes + target_per_segment - 1) / target_per_segment) as usize;
+    if num_segments < 2 {
+        num_segments = 2;
+    }
+    if num_segments > num_layers {
+        num_segments = num_layers;
+    }
+
+    let per_segment_gib = max_act_gib / (num_segments as f64);
+    Some(CheckpointPlan::Enabled {
+        num_segments,
+        max_act_gib,
+        per_segment_gib,
+        available_gib,
     })
 }
 
@@ -592,6 +773,165 @@ mod tests {
             source: VramSource::NvidiaSmi,
         };
         assert_eq!(recommended_checkpoint_segments(&vram_16gb), Some(12));
+    }
+
+    fn vram(gb: u64) -> GpuVramInfo {
+        GpuVramInfo {
+            total_bytes: gb * 1024 * 1024 * 1024,
+            source: VramSource::NvidiaSmi,
+        }
+    }
+
+    fn act_gib(num_layers: usize, max_seq_len: usize, hidden_size: usize) -> f64 {
+        let bytes = (num_layers as u64)
+            * (max_seq_len as u64)
+            * (hidden_size as u64)
+            * 4;
+        (bytes as f64) / (1024.0 * 1024.0 * 1024.0)
+    }
+
+    #[test]
+    fn estimate_base_model_bytes_qwen35_4b_matches_observed_vram() {
+        // Qwen3.5-4B: hidden=2560, intermediate=10240, num_layers=32, vocab=151936.
+        // BF16 weights observed at runtime: ~9943 MiB. Estimator must
+        // land within ±15% of that or our auto-tune's headroom math will
+        // be skewed.
+        let est = estimate_base_model_bytes(32, 2560, 10240, 151936, 2);
+        let gib = est as f64 / (1024.0 * 1024.0 * 1024.0);
+        assert!(
+            gib >= 8.0 && gib <= 11.5,
+            "Qwen3.5-4B base estimate {gib:.2} GiB outside ±15% of observed ~9.7 GiB"
+        );
+    }
+
+    #[test]
+    fn recommended_checkpoint_plan_disables_on_short_prompts_big_vram() {
+        // A6000 (48 GiB) + Qwen3.5-4B + 30-token prompts: activation tape
+        // is ~10 MiB. Auto-tune should disable checkpointing entirely.
+        // This is the bench scenario where #1071's PR was leaving 10-30%
+        // step time on the table.
+        let plan = recommended_checkpoint_plan(
+            &vram(48),
+            32,
+            30,
+            2560,
+            estimate_base_model_bytes(32, 2560, 10240, 151936, 2),
+        );
+        assert!(matches!(plan, Some(CheckpointPlan::Disabled { .. })));
+    }
+
+    #[test]
+    fn recommended_checkpoint_plan_enables_for_long_prompts_big_vram() {
+        // A6000 (48 GiB) + Qwen3.5-4B + 32K prompts: activation tape is
+        // ~10.7 GiB. Headroom is ~36 GiB. 30% of headroom is ~11 GiB so
+        // a single segment fits — but we still want >=2 segments since
+        // the heuristic clamps to that. Critically: must engage, must
+        // not disable.
+        let plan = recommended_checkpoint_plan(
+            &vram(48),
+            32,
+            32 * 1024,
+            2560,
+            estimate_base_model_bytes(32, 2560, 10240, 151936, 2),
+        )
+        .expect("plan");
+        let n = match plan {
+            CheckpointPlan::Enabled { num_segments, .. } => num_segments,
+            other => panic!("expected Enabled, got {other:?}"),
+        };
+        assert!(
+            (2..=32).contains(&n),
+            "expected 2..=32 segments for long-context, got {n}"
+        );
+    }
+
+    #[test]
+    fn recommended_checkpoint_plan_aggressive_on_tight_vram_long_prompts() {
+        // RTX 3090 (24 GiB) + Qwen3.5-4B + 16K prompts: activation tape
+        // ~5.4 GiB, headroom ~12 GiB → must engage with >= 4 segments
+        // (per-segment ~1.4 GiB inside the 30% target).
+        let plan = recommended_checkpoint_plan(
+            &vram(24),
+            32,
+            16 * 1024,
+            2560,
+            estimate_base_model_bytes(32, 2560, 10240, 151936, 2),
+        )
+        .expect("plan");
+        let n = match plan {
+            CheckpointPlan::Enabled { num_segments, .. } => num_segments,
+            other => panic!("expected Enabled, got {other:?}"),
+        };
+        assert!(
+            n >= 2,
+            "expected aggressive checkpointing on tight VRAM + long prompts, got {n} segments"
+        );
+        // Sanity-check the activation math hasn't drifted.
+        assert!((act_gib(32, 16 * 1024, 2560) - 5.0).abs() < 1.0);
+    }
+
+    #[test]
+    fn recommended_checkpoint_plan_respects_user_override() {
+        let _g = crate::env_flag::TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::set_var("KILN_GRAD_CHECKPOINT_SEGMENTS", "12");
+        }
+        let plan = recommended_checkpoint_plan(
+            &vram(48),
+            32,
+            30,
+            2560,
+            estimate_base_model_bytes(32, 2560, 10240, 151936, 2),
+        );
+        unsafe {
+            std::env::remove_var("KILN_GRAD_CHECKPOINT_SEGMENTS");
+        }
+        assert!(matches!(plan, Some(CheckpointPlan::UserOverride)));
+    }
+
+    #[test]
+    fn recommended_checkpoint_plan_respects_disable_env() {
+        let _g = crate::env_flag::TEST_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::set_var("KILN_NO_GRAD_CHECKPOINT", "1");
+        }
+        let plan = recommended_checkpoint_plan(
+            &vram(48),
+            32,
+            32 * 1024,
+            2560,
+            estimate_base_model_bytes(32, 2560, 10240, 151936, 2),
+        );
+        unsafe {
+            std::env::remove_var("KILN_NO_GRAD_CHECKPOINT");
+        }
+        assert!(matches!(plan, Some(CheckpointPlan::UserOverride)));
+    }
+
+    #[test]
+    fn recommended_checkpoint_plan_returns_none_when_vram_unknown() {
+        let unknown = GpuVramInfo {
+            total_bytes: 0,
+            source: VramSource::None,
+        };
+        let plan = recommended_checkpoint_plan(&unknown, 32, 1024, 2560, 10 * 1024 * 1024 * 1024);
+        assert!(plan.is_none());
+    }
+
+    #[test]
+    fn recommended_checkpoint_plan_falls_back_when_headroom_too_small() {
+        // 12 GiB GPU + 10 GiB base estimate = 2 GiB before safety reserve;
+        // 2 GiB after safety. We're under the 2 GiB cliff so the plan
+        // should punt to UserOverride and let from_env's VRAM-only path
+        // pick a conservative segment count.
+        let plan = recommended_checkpoint_plan(
+            &vram(12),
+            32,
+            1024,
+            2560,
+            10 * 1024 * 1024 * 1024,
+        );
+        assert!(matches!(plan, Some(CheckpointPlan::UserOverride)));
     }
 
     #[test]

--- a/crates/kiln-core/src/vram.rs
+++ b/crates/kiln-core/src/vram.rs
@@ -566,9 +566,12 @@ pub enum CheckpointPlan {
 /// * MLP per layer: `3 * hidden * intermediate` (gate, up, down).
 /// * Embedding + LM head: `2 * vocab * hidden`.
 ///
-/// Multiplied by 2 bytes/param (BF16). The estimate matches the
-/// `model_loaded_vram_mib=9943` we observe for Qwen3.5-4B in the
-/// kiln-server training bench (within ~5%).
+/// Multiplied by `bytes_per_param` and then by a 1.2× working-buffer
+/// overhead factor (RoPE tables, attention masks, paged-KV scratch,
+/// candle's own intermediate tensor pool, the LoRA Vars and AdamW state
+/// registry). The 1.2× lands the Qwen3.5-4B estimate at ~9.5 GiB,
+/// matching the observed `model_loaded_vram_mib=9943` from the
+/// kiln-server training bench within ±5%.
 pub fn estimate_base_model_bytes(
     num_layers: usize,
     hidden_size: usize,
@@ -581,7 +584,24 @@ pub fn estimate_base_model_bytes(
     let layer_total = per_layer_params.saturating_mul(num_layers);
     let head_total = 2usize.saturating_mul(vocab_size).saturating_mul(hidden_size);
     let total_params = layer_total.saturating_add(head_total);
-    (total_params as u64).saturating_mul(bytes_per_param as u64)
+    let raw_bytes = (total_params as u64).saturating_mul(bytes_per_param as u64);
+    // 1.2× working-buffer overhead. Implemented as (raw * 6) / 5 to stay
+    // in integer math.
+    raw_bytes.saturating_mul(6) / 5
+}
+
+/// Multiplier from "forward activation tape" to "peak training memory for
+/// activations + grads + scratch". Forward saves activations once; backward
+/// materializes grads of the same shape and uses transient scratch matmul
+/// buffers of similar size during the chain rule. Empirically peak is
+/// ~2-3× the forward tape; 2.5× is a conservative middle that doesn't pull
+/// aggressive checkpointing for short prompts but engages it before
+/// backward OOMs on long ones. Implemented as `* 5 / 2` to stay in u64.
+const ACTIVATION_PEAK_NUMER: u64 = 5;
+const ACTIVATION_PEAK_DENOM: u64 = 2;
+
+fn peak_activation_bytes(forward_tape_bytes: u64) -> u64 {
+    forward_tape_bytes.saturating_mul(ACTIVATION_PEAK_NUMER) / ACTIVATION_PEAK_DENOM
 }
 
 /// Auto-decide a gradient-checkpoint plan for a training workload, factoring
@@ -635,13 +655,19 @@ pub fn recommended_checkpoint_plan(
         return None;
     }
 
-    // F32 activation tape (one element per layer-token pair). Even on a
-    // BF16 model, the trainer keeps activations and grads in F32 for
+    // F32 forward activation tape (one element per layer-token pair).
+    // Even on a BF16 model, the trainer keeps activations in F32 for
     // numerical stability, so this matches what we'd actually allocate.
-    let max_act_bytes = (num_layers as u64)
+    let forward_tape_bytes = (num_layers as u64)
         .saturating_mul(max_seq_len_tokens as u64)
         .saturating_mul(hidden_size as u64)
         .saturating_mul(4);
+
+    // Peak training memory for activations + grads + scratch. The forward
+    // tape alone under-estimates peak — backward doubles the activation
+    // footprint and matmul scratch adds ~50% on top. Compare the *peak*,
+    // not the forward, against headroom.
+    let max_act_bytes = peak_activation_bytes(forward_tape_bytes);
 
     // 2 GiB safety for working buffers (RoPE tables, attention masks,
     // intermediate matmul outputs that aren't on the activation tape).
@@ -661,8 +687,11 @@ pub fn recommended_checkpoint_plan(
         return Some(CheckpointPlan::UserOverride);
     }
 
-    // Comfortable headroom: skip checkpointing. The 0.5 threshold leaves
-    // plenty of room for grads + AdamW state on top of activations.
+    // Comfortable headroom: skip checkpointing. The 0.5 threshold compares
+    // *peak* activation memory (forward tape × 2.5 amplification for
+    // backward + scratch) against available headroom, so "Disabled" means
+    // we have ≥2× the peak on hand — comfortable across CUDA's caching
+    // allocator fragmentation.
     if max_act_bytes <= (available_bytes / 2) {
         return Some(CheckpointPlan::Disabled {
             max_act_gib,

--- a/crates/kiln-core/src/vram.rs
+++ b/crates/kiln-core/src/vram.rs
@@ -939,6 +939,17 @@ mod tests {
 
     #[test]
     fn recommended_checkpoint_plan_returns_none_when_vram_unknown() {
+        // Take the env lock + scrub the two override env vars so a
+        // parallel test that's mid-`set_var` can't make us return
+        // UserOverride via env before we reach the VRAM check. macOS CI
+        // reproducibly hit this on the parallel test interleave.
+        let _g = crate::env_flag::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::remove_var("KILN_GRAD_CHECKPOINT_SEGMENTS");
+            std::env::remove_var("KILN_NO_GRAD_CHECKPOINT");
+        }
         let unknown = GpuVramInfo {
             total_bytes: 0,
             source: VramSource::None,
@@ -953,6 +964,17 @@ mod tests {
         // 2 GiB after safety. We're under the 2 GiB cliff so the plan
         // should punt to UserOverride and let from_env's VRAM-only path
         // pick a conservative segment count.
+        //
+        // Same env isolation as the test above — scrub the overrides so
+        // a parallel test can't make us return UserOverride via env
+        // before we reach the headroom check.
+        let _g = crate::env_flag::TEST_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        unsafe {
+            std::env::remove_var("KILN_GRAD_CHECKPOINT_SEGMENTS");
+            std::env::remove_var("KILN_NO_GRAD_CHECKPOINT");
+        }
         let plan = recommended_checkpoint_plan(
             &vram(12),
             32,

--- a/crates/kiln-train/src/opd.rs
+++ b/crates/kiln-train/src/opd.rs
@@ -2085,6 +2085,22 @@ pub fn opd_train(
     let device = weights.embed_tokens.device().clone();
     let backend_rt = backend::for_device(&device);
 
+    // Cache VRAM + base-model footprint estimate for the per-step
+    // gradient-checkpointing auto-tune below. OPD's input_ids length
+    // varies per step (rollouts are model-sampled), so we feed each
+    // step's actual seq_len into the decision rather than picking a
+    // single segment count up front like SFT/GRPO do. Detection is
+    // cheap (env var or one nvidia-smi spawn) but no reason to
+    // re-detect on every step.
+    let opd_vram_cache = kiln_core::vram::detect_vram();
+    let opd_base_model_bytes = kiln_core::vram::estimate_base_model_bytes(
+        model_config.num_layers,
+        model_config.hidden_size,
+        model_config.intermediate_size,
+        model_config.vocab_size,
+        2, // BF16 base weights
+    );
+
     // §6 data-multiplier: auto-scale samples_per_prompt when the
     // dataset is small. Lu (2025) §3.5.4: 4 if |prompts| ≥ 200,
     // 16 if 50 ≤ |prompts| < 200, 64 if |prompts| < 50. We respect
@@ -2558,7 +2574,31 @@ pub fn opd_train(
                 // on a single 48GB GPU.
                 let positions: Vec<u32> = (0..input_ids.len()).map(|p| p as u32).collect();
                 let lora_detached = lora_weights_detached(&params);
-                let num_segments = 8usize.min(model_config.num_layers);
+                // Per-step auto-tune: pick segment count based on this
+                // step's actual seq_len. Falls back to the legacy
+                // hardcoded 8 if VRAM detection or the auto-tune punts.
+                let num_segments = match kiln_core::vram::recommended_checkpoint_plan(
+                    &opd_vram_cache,
+                    model_config.num_layers,
+                    input_ids.len(),
+                    model_config.hidden_size,
+                    opd_base_model_bytes,
+                ) {
+                    Some(kiln_core::vram::CheckpointPlan::Enabled { num_segments, .. }) => {
+                        num_segments.min(model_config.num_layers).max(1)
+                    }
+                    Some(kiln_core::vram::CheckpointPlan::Disabled { .. }) => {
+                        // Activations fit comfortably — collapse to a
+                        // single segment, which makes the checkpointed
+                        // forward+backward trivially equivalent to the
+                        // non-checkpointed path while preserving this
+                        // branch's existing structure.
+                        1
+                    }
+                    None | Some(kiln_core::vram::CheckpointPlan::UserOverride) => {
+                        8usize.min(model_config.num_layers)
+                    }
+                };
                 let segments = compute_segment_boundaries(model_config.num_layers, num_segments);
 
                 // === Step 1: detached forward; save segment boundaries ===

--- a/crates/kiln-train/src/trainer.rs
+++ b/crates/kiln-train/src/trainer.rs
@@ -1954,6 +1954,7 @@ pub fn sft_train(
         // the entire run.
         let mut valid_indices = Vec::new();
         let mut one_epoch_counts = crate::train_receipt::TokenCountReceipt::default();
+        let mut max_seq_len_tokens: usize = 0;
         for (idx, ex) in examples.iter().enumerate() {
             match tokenize_for_training(ex, tokenizer) {
                 Ok((input_ids, label_mask)) => {
@@ -1964,6 +1965,9 @@ pub fn sft_train(
                         one_epoch_counts.context_tokens.saturating_add(
                             input_ids.len().saturating_sub(action_tokens as usize) as u64,
                         );
+                    if input_ids.len() > max_seq_len_tokens {
+                        max_seq_len_tokens = input_ids.len();
+                    }
                     valid_indices.push(idx);
                 }
                 Err(e) => {
@@ -1985,8 +1989,17 @@ pub fn sft_train(
             .context_tokens
             .saturating_mul(config.epochs as u64);
 
-        // Configure gradient checkpointing
-        let ckpt_config = CheckpointConfig::from_env(model_config.num_layers);
+        // Auto-tune gradient checkpointing for this workload's actual
+        // sequence length, not just VRAM. On a big GPU with short prompts
+        // this typically disables checkpointing entirely (~10-30% faster).
+        let ckpt_config = CheckpointConfig::auto_for_workload(
+            model_config.num_layers,
+            max_seq_len_tokens,
+            model_config.hidden_size,
+            model_config.intermediate_size,
+            model_config.vocab_size,
+            2, // BF16 base weights (canonical kiln inference dtype)
+        );
         let segments = if ckpt_config.enabled {
             Some(compute_segment_boundaries(
                 model_config.num_layers,
@@ -2544,8 +2557,27 @@ pub fn grpo_train(
             anyhow::bail!("no valid GRPO groups after tokenization");
         }
 
-        // Configure gradient checkpointing (same as SFT)
-        let ckpt_config = CheckpointConfig::from_env(model_config.num_layers);
+        // Compute the max seq_len across every completion in every group
+        // so the auto-tuner sizes checkpointing against the longest path,
+        // not the average.
+        let max_seq_len_tokens: usize = tokenized_groups
+            .iter()
+            .flat_map(|g| g.completions.iter())
+            .map(|c| c.input_ids.len())
+            .max()
+            .unwrap_or(0);
+
+        // Auto-tune gradient checkpointing for this workload's actual
+        // sequence length. Same pattern as `sft_train`: skip checkpointing
+        // when activation tape comfortably fits in available VRAM.
+        let ckpt_config = CheckpointConfig::auto_for_workload(
+            model_config.num_layers,
+            max_seq_len_tokens,
+            model_config.hidden_size,
+            model_config.intermediate_size,
+            model_config.vocab_size,
+            2, // BF16 base weights
+        );
         let segments = if ckpt_config.enabled {
             Some(compute_segment_boundaries(
                 model_config.num_layers,
@@ -3195,6 +3227,10 @@ pub fn grpo_train_jsonl(
     };
 
     let mut train_body = || -> Result<(PathBuf, f64)> {
+        // Streaming GRPO can't pre-compute max_seq_len without consuming the
+        // dataset, so we stay on the VRAM-only auto-tune path here. The
+        // (non-streaming) `grpo_train` path uses the workload-shape-aware
+        // `CheckpointConfig::auto_for_workload` after tokenization.
         let ckpt_config = CheckpointConfig::from_env(model_config.num_layers);
         let segments = if ckpt_config.enabled {
             Some(compute_segment_boundaries(
@@ -6950,6 +6986,12 @@ impl CheckpointConfig {
     /// 1. `KILN_GRAD_CHECKPOINT_SEGMENTS` env var (user override)
     /// 2. Auto-detect from GPU VRAM via `kiln_core::vram`
     /// 3. Fallback to 4 segments
+    ///
+    /// This is the *VRAM-only* path. Callers that know the workload's
+    /// `max_seq_len` should prefer [`CheckpointConfig::auto_for_workload`],
+    /// which can additionally choose to *disable* checkpointing when the
+    /// activation tape comfortably fits in available VRAM (typical on big
+    /// GPUs with short prompts).
     pub fn from_env(num_layers: usize) -> Self {
         let enabled = std::env::var("KILN_NO_GRAD_CHECKPOINT")
             .map(|v| v != "1" && v.to_lowercase() != "true")
@@ -6989,6 +7031,107 @@ impl CheckpointConfig {
             num_segments,
             enabled,
             auto_configured,
+        }
+    }
+
+    /// Create config with **VRAM + workload-shape** auto-tuning. Preferred over
+    /// [`CheckpointConfig::from_env`] for trainer call sites that have the
+    /// `max_seq_len` available after tokenization.
+    ///
+    /// Behavior:
+    /// * `KILN_GRAD_CHECKPOINT_SEGMENTS` / `KILN_NO_GRAD_CHECKPOINT` env
+    ///   overrides are honored unchanged (falls through to `from_env`).
+    /// * Otherwise calls [`kiln_core::vram::recommended_checkpoint_plan`]
+    ///   which can *disable* checkpointing entirely when the activation tape
+    ///   comfortably fits in available VRAM. On A6000 + Qwen3.5-4B, this
+    ///   skips checkpointing for sequences up to ~12K tokens and only
+    ///   engages it (with the right number of segments) for longer contexts.
+    ///
+    /// `bytes_per_base_param` is used to estimate base-model footprint —
+    /// pass 2 for BF16 (canonical kiln inference dtype) or 4 for F32.
+    #[allow(clippy::too_many_arguments)]
+    pub fn auto_for_workload(
+        num_layers: usize,
+        max_seq_len_tokens: usize,
+        hidden_size: usize,
+        intermediate_size: usize,
+        vocab_size: usize,
+        bytes_per_base_param: usize,
+    ) -> Self {
+        // Env overrides always win and route to from_env's tested code path.
+        if std::env::var("KILN_GRAD_CHECKPOINT_SEGMENTS")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .is_some()
+            || std::env::var("KILN_NO_GRAD_CHECKPOINT")
+                .as_deref()
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false)
+        {
+            return Self::from_env(num_layers);
+        }
+
+        let vram = kiln_core::vram::detect_vram();
+        let base_bytes = kiln_core::vram::estimate_base_model_bytes(
+            num_layers,
+            hidden_size,
+            intermediate_size,
+            vocab_size,
+            bytes_per_base_param,
+        );
+
+        match kiln_core::vram::recommended_checkpoint_plan(
+            &vram,
+            num_layers,
+            max_seq_len_tokens,
+            hidden_size,
+            base_bytes,
+        ) {
+            None | Some(kiln_core::vram::CheckpointPlan::UserOverride) => {
+                // VRAM detection failed or env override is set — fall back
+                // to the existing VRAM-only path.
+                Self::from_env(num_layers)
+            }
+            Some(kiln_core::vram::CheckpointPlan::Disabled {
+                max_act_gib,
+                available_gib,
+            }) => {
+                tracing::info!(
+                    max_seq_len_tokens,
+                    activation_tape_gib = format!("{max_act_gib:.2}"),
+                    available_gib = format!("{available_gib:.2}"),
+                    vram_total_gb = vram.total_bytes as f64 / 1e9,
+                    vram_source = %vram.source,
+                    "auto-tuned: gradient checkpointing DISABLED — activation tape fits comfortably in available VRAM"
+                );
+                Self {
+                    num_segments: 1,
+                    enabled: false,
+                    auto_configured: true,
+                }
+            }
+            Some(kiln_core::vram::CheckpointPlan::Enabled {
+                num_segments,
+                max_act_gib,
+                per_segment_gib,
+                available_gib,
+            }) => {
+                tracing::info!(
+                    num_segments,
+                    max_seq_len_tokens,
+                    activation_tape_gib = format!("{max_act_gib:.2}"),
+                    per_segment_gib = format!("{per_segment_gib:.2}"),
+                    available_gib = format!("{available_gib:.2}"),
+                    vram_total_gb = vram.total_bytes as f64 / 1e9,
+                    vram_source = %vram.source,
+                    "auto-tuned: gradient checkpointing engaged for workload shape"
+                );
+                Self {
+                    num_segments,
+                    enabled: true,
+                    auto_configured: true,
+                }
+            }
         }
     }
 }

--- a/crates/kiln-train/src/vk_train.rs
+++ b/crates/kiln-train/src/vk_train.rs
@@ -1387,6 +1387,12 @@ pub fn vk_compute_segment_boundaries(num_layers: usize, num_segments: usize) -> 
 /// Recommended number of gradient-checkpoint segments for a given
 /// model layer count. Mirrors `trainer::compute_segment_boundaries`'s
 /// default (clamps to 1..=num_layers).
+///
+/// This is the *VRAM-blind* default — kept for callers that don't have the
+/// workload shape handy. Production VK SFT prefers
+/// [`vk_recommended_checkpoint_plan_for_workload`] which factors in
+/// `max_seq_len` and `hidden_size` to optionally skip checkpointing
+/// entirely on big GPUs with short prompts.
 pub fn vk_recommended_checkpoint_segments(num_layers: usize) -> usize {
     std::env::var("KILN_GRAD_CHECKPOINT_SEGMENTS")
         .ok()
@@ -1400,6 +1406,101 @@ pub fn vk_recommended_checkpoint_segments(num_layers: usize) -> usize {
             // ~5 GB.
             4.min(num_layers).max(1)
         })
+}
+
+/// Workload-shape-aware checkpoint decision for the VK SFT trainer.
+///
+/// Mirrors the candle path's [`CheckpointConfig::auto_for_workload`]: routes
+/// through [`kiln_core::vram::recommended_checkpoint_plan`] so the segment
+/// count (or "disabled" decision) is sized against `max_seq_len_tokens` and
+/// `hidden_size`, not just total VRAM.
+///
+/// Returns:
+/// * `Some(n)` with `n >= 2` — engage checkpointing with `n` segments.
+/// * `Some(1)` — explicit "1 segment" override (legacy fallback when env
+///   pins `KILN_GRAD_CHECKPOINT_SEGMENTS=1`).
+/// * `None` — skip checkpointing (Disabled plan, `KILN_NO_GRAD_CHECKPOINT=1`,
+///   or workload-shape estimate says activations fit comfortably in
+///   available VRAM).
+///
+/// `vk_native_sft_train` already special-cases `KILN_NO_GRAD_CHECKPOINT` at
+/// the call site; this function additionally returns `None` for the
+/// auto-Disabled case so the caller can skip both the checkpointed and
+/// recompute paths in favor of the full-tape `vk_train_step` family.
+pub fn vk_recommended_checkpoint_plan_for_workload(
+    num_layers: usize,
+    max_seq_len_tokens: usize,
+    hidden_size: usize,
+    intermediate_size: usize,
+    vocab_size: usize,
+    bytes_per_base_param: usize,
+) -> Option<usize> {
+    // KILN_NO_GRAD_CHECKPOINT=1 → caller already handles this, but mirror
+    // the explicit "skip" here for callers that route only through this
+    // function.
+    if std::env::var("KILN_NO_GRAD_CHECKPOINT")
+        .as_deref()
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        return None;
+    }
+
+    let vram = kiln_core::vram::detect_vram();
+    let base_bytes = kiln_core::vram::estimate_base_model_bytes(
+        num_layers,
+        hidden_size,
+        intermediate_size,
+        vocab_size,
+        bytes_per_base_param,
+    );
+
+    match kiln_core::vram::recommended_checkpoint_plan(
+        &vram,
+        num_layers,
+        max_seq_len_tokens,
+        hidden_size,
+        base_bytes,
+    ) {
+        Some(kiln_core::vram::CheckpointPlan::Disabled {
+            max_act_gib,
+            available_gib,
+        }) => {
+            tracing::info!(
+                max_seq_len_tokens,
+                activation_tape_gib = format!("{max_act_gib:.2}"),
+                available_gib = format!("{available_gib:.2}"),
+                vram_total_gb = vram.total_bytes as f64 / 1e9,
+                vram_source = %vram.source,
+                "vk-native auto-tuned: gradient checkpointing DISABLED — activation tape fits comfortably in available VRAM"
+            );
+            None
+        }
+        Some(kiln_core::vram::CheckpointPlan::Enabled {
+            num_segments,
+            max_act_gib,
+            per_segment_gib,
+            available_gib,
+        }) => {
+            tracing::info!(
+                num_segments,
+                max_seq_len_tokens,
+                activation_tape_gib = format!("{max_act_gib:.2}"),
+                per_segment_gib = format!("{per_segment_gib:.2}"),
+                available_gib = format!("{available_gib:.2}"),
+                vram_total_gb = vram.total_bytes as f64 / 1e9,
+                vram_source = %vram.source,
+                "vk-native auto-tuned: gradient checkpointing engaged for workload shape"
+            );
+            Some(num_segments)
+        }
+        None | Some(kiln_core::vram::CheckpointPlan::UserOverride) => {
+            // VRAM unknown or user override (KILN_GRAD_CHECKPOINT_SEGMENTS
+            // set) — fall back to the env-driven path.
+            let segs = vk_recommended_checkpoint_segments(num_layers);
+            if segs > 1 { Some(segs) } else { None }
+        }
+    }
 }
 
 /// Single-step training (no gradient checkpointing — full forward
@@ -4852,11 +4953,23 @@ pub fn vk_native_sft_train(
     //
     // The checkpointed path is FullAttn-only for now; hybrid models
     // (with GDN layers) fall back to vk_train_step.
+    // Workload-shape-aware checkpoint segment picker. The decision now
+    // factors in `max_seq_len` (just computed above) and the device's
+    // available VRAM, not just the layer count — so a 30-token job on an
+    // A6000 correctly skips checkpointing while a 16K-token job picks
+    // the right segment count. Mirrors the candle path's
+    // `CheckpointConfig::auto_for_workload` (issue #1063 follow-up).
     let ckpt_segments = if needs_state || std::env::var("KILN_NO_GRAD_CHECKPOINT").is_ok() {
         None
     } else {
-        let segs = vk_recommended_checkpoint_segments(model_config.num_layers);
-        if segs > 1 { Some(segs) } else { None }
+        vk_recommended_checkpoint_plan_for_workload(
+            model_config.num_layers,
+            max_seq_len,
+            model_config.hidden_size,
+            model_config.intermediate_size,
+            model_config.vocab_size,
+            2, // BF16 base weights
+        )
     };
     if let Some(segs) = ckpt_segments {
         tracing::info!(


### PR DESCRIPTION
Extends the workload-shape-aware gradient checkpointing auto-tune from #1073 to the Vulkan-native trainer. Closes the "VK side also needs this" gap raised in #1073's review.

Stacked on top of #1073 — base = `ckpt-autotune-workload-shape`. Merge that one first.

## The gap this fixes

`vk_recommended_checkpoint_segments(num_layers)` was VRAM-blind — it returned 4 segments for any model with 32 layers, regardless of sequence length or available VRAM. An A6000 running 30-token examples got the same 4-segment plan as an A6000 running 16K-token examples; short-prompt jobs paid checkpointing overhead with zero memory benefit.

## What this PR does

Adds `vk_recommended_checkpoint_plan_for_workload(num_layers, max_seq_len, hidden, intermediate, vocab, bytes_per_base_param)` which routes through `kiln_core::vram::recommended_checkpoint_plan` (the same function #1073 added for the candle path). Returns `Option<usize>`:

* `Some(n)` with `n >= 2` — engage checkpointing with `n` segments.
* `None` — skip checkpointing entirely (Disabled plan, `KILN_NO_GRAD_CHECKPOINT=1`, or estimate says activations fit comfortably).

`vk_native_sft_train` now feeds the `max_seq_len` it already tracks at line 4919 into the new picker. The 3-way step dispatch (checkpointed / recompute / plain) is unchanged — only the segment count decision is now workload-aware.

The legacy `vk_recommended_checkpoint_segments` is kept for the fallback path when `KILN_GRAD_CHECKPOINT_SEGMENTS` is set or VRAM detection fails, so user overrides still work the way they always did.

## Per-workload decisions (Qwen3.5-4B FullAttn-only model)

| Workload | Peak activations | A6000 (48 GiB) | RTX 3090 (24 GiB) | RTX 4060 (16 GiB) |
|---|---|---|---|---|
| 30 tok | 0.02 GiB | **Disabled** | **Disabled** | **Disabled** |
| 1K tok | 0.78 GiB | **Disabled** | **Disabled** | **Disabled** |
| 4K tok | 3.1 GiB | **Disabled** | **Disabled** | Enabled (3 segs) |
| 16K tok | 12.5 GiB | **Disabled** | Enabled (4 segs) | Enabled (9 segs) |
| 32K tok | 25.0 GiB | Enabled (3 segs) | Enabled (7 segs) | (out of headroom) |

Same matrix as the candle path in #1073 — that's the point.

## What this PR does *not* change

- **Hybrid (GDN) models** — `vk_native_sft_train`'s GDN path is `vk_recompute_train_step_with_state_masked`, which is unconditional layerwise recompute. The boundary-cache auto-engagement inside that step (`KILN_VK_RECOMPUTE_BOUNDARY_CACHE` based on `MemAvailable - 4 GiB`) already handles memory pressure on the other axis. The workload-shape-aware "skip recompute on comfortable VRAM" choice would need a `vk_train_step_with_state_masked` non-recompute alternative path with proper state plumbing for hybrid backward — that's larger kernel work and a separate follow-up.
- **`vk_native_grpo_train`** — uses `vk_recompute_grpo_train_step_with_state` unconditionally. No checkpointing-segments alternative exists. Adding a workload-aware non-recompute GRPO kernel needs new shader work; out of scope.
- **`vk_native_opd_train`** — doesn't exist yet (separate gap from earlier discussion). When it lands, it should call the same `vk_recommended_checkpoint_plan_for_workload` function added here.

## Files

- `crates/kiln-train/src/vk_train.rs` — new `vk_recommended_checkpoint_plan_for_workload`, call site update in `vk_native_sft_train`.

No new tests on this side — the underlying `recommended_checkpoint_plan` function is fully unit-tested in #1073 (`kiln_core::vram::tests`, 8 tests covering all three plan outcomes plus env overrides and headroom edge cases). The VK adapter is straight-line code that just maps `CheckpointPlan` variants to `Option<usize>`; it has no logic worth testing independently.

## Bench validation pending

Vulkan bench requires either a Vulkan-capable RunPod image or local Linux+Vulkan hardware, neither of which I have right now. The decision math is identical to the candle path's, which was validated on A6000 + Qwen3.5-4B in #1073 (auto-tuned short-prompt step time matches `KILN_NO_GRAD_CHECKPOINT=1`, ~13% faster than the old fixed 4-segment default). I'll fold a Vulkan bench number into this PR's description once #1073 lands and I can re-acquire a Vulkan-capable pod.