### PR TITLE
vk-native: add vk_native_opd_train + KILN_VK_NATIVE_OPD route (#1075)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Kiln Server Changelog
 
+## Unreleased — vk-native OPD training entrypoint (#1075)
+
+Add `vk_native_opd_train`, the off-policy distillation (OPD) analogue
+of the existing `vk_native_sft_train` and `vk_native_grpo_train`. The
+trainer takes pre-masked `OpdPrompt`s + an `Arc<dyn LogitSource>`
+teacher, fetches top-K logprobs at the action positions, and drives
+either `vk_opd_train_step_with_state` (FullAttn-only) or
+`vk_recompute_opd_train_step_with_state` (hybrid Qwen3.5-4B) per step
+through Vulkan kernels and the existing AdamW state book. Adapter
+artifacts (`adapter_model.safetensors`, `adapter_config.json`),
+checkpoint cadence, and the training receipt all match the
+candle-path `opd_train`'s contract.
+
+The server's `run_opd` now picks between the candle path and the
+new VK path via `KILN_VK_NATIVE_OPD` (falls back to
+`KILN_VK_NATIVE_TRAINING` when unset, mirroring how
+`KILN_VK_NATIVE_GRPO` was wired up). V1 envelope is intentionally
+narrow: `training_mode = off_policy`, `objective = reverse_kl`,
+`loss = teacher_top_k`, `top_k ∈ {16, 32}`, no `base_adapter`, no
+ECHO env-CE — anything outside that envelope returns an explicit
+"use the candle path" error so misconfiguration is loud instead of
+silently wrong.
+
+The hybrid-GDN fast path (no recompute, single-pass forward+backward)
+is tracked as #1076 — the kernel for the OPD step exists but the
+single-pass plumbing matches the GRPO follow-up. For now hybrid
+models always go through layerwise reverse-recompute, which is the
+same speed/memory trade as `vk_recompute_train_step_with_state`.
+
 ## Unreleased — cuda_native: route SFT *and* GRPO through BackendRuntime (closes #1063)
 
 Closes #1063 (cuda_native_sft_train ~50x slower than `--trainer

--- a/crates/kiln-server/src/training_queue.rs
+++ b/crates/kiln-server/src/training_queue.rs
@@ -436,6 +436,20 @@ fn vk_native_grpo_enabled(backend_name: &str) -> bool {
     }
 }
 
+/// Whether the OPD job should route through `vk_native_opd_train` instead
+/// of the candle `opd_train` path.
+///
+/// Mirrors `vk_native_grpo_enabled`'s shape (#1075). The explicit
+/// `KILN_VK_NATIVE_OPD` env wins; otherwise we fall back to
+/// `KILN_VK_NATIVE_TRAINING`, so users who set the parent flag get a
+/// uniformly vk-native experience across SFT, GRPO, and OPD.
+fn vk_native_opd_enabled(backend_name: &str) -> bool {
+    match env_tristate("KILN_VK_NATIVE_OPD") {
+        Some(enabled) => enabled,
+        None => vk_native_sft_enabled(backend_name),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn run_grpo(
     cuda_native: bool,
@@ -638,6 +652,7 @@ fn run_grpo(
 /// produce a much larger PR than this milestone wants.
 #[allow(clippy::too_many_arguments)]
 fn run_opd(
+    vk_native: bool,
     req: &OpdRequest,
     model_config: &kiln_core::config::ModelConfig,
     weights: &kiln_model::forward::GpuWeights,
@@ -648,6 +663,8 @@ fn run_opd(
     teacher_registry: &crate::api::teachers::TeacherRegistry,
     job_id: &str,
 ) -> std::result::Result<PathBuf, String> {
+    #[cfg(not(feature = "vulkan"))]
+    let _ = vk_native;
     if req.prompts.is_empty() && req.dataset_path.is_none() {
         return Err("OPD request must include at least one prompt or a dataset_path".into());
     }
@@ -785,18 +802,60 @@ fn run_opd(
 
     let trainer_progress_cb: trainer::ProgressCallback = progress_cb;
 
-    let output_dir = kiln_train::opd::opd_train(
-        prompts,
-        &req.config,
-        model_config,
-        weights,
-        tokenizer,
-        teacher,
-        adapter_dir,
-        adapter_name,
-        Some(trainer_progress_cb),
-    )
-    .map_err(|e| format!("opd_train failed: {e:#}"))?;
+    let output_dir = if vk_native {
+        #[cfg(feature = "vulkan")]
+        {
+            tracing::info!(
+                job_id = %job_id,
+                "KILN_VK_NATIVE_OPD=1 - routing to vk_native_opd_train"
+            );
+            kiln_train::vk_train::vk_native_opd_train(
+                prompts,
+                &req.config,
+                model_config,
+                weights,
+                tokenizer,
+                teacher,
+                adapter_dir,
+                adapter_name,
+                Some(trainer_progress_cb),
+            )
+            .map_err(|e| format!("vk_native_opd_train failed: {e:#}"))?
+        }
+        #[cfg(not(feature = "vulkan"))]
+        {
+            tracing::warn!(
+                job_id = %job_id,
+                "KILN_VK_NATIVE_OPD=1 set but kiln-server was built without \
+                 --features vulkan - falling back to candle OPD trainer"
+            );
+            kiln_train::opd::opd_train(
+                prompts,
+                &req.config,
+                model_config,
+                weights,
+                tokenizer,
+                teacher,
+                adapter_dir,
+                adapter_name,
+                Some(trainer_progress_cb),
+            )
+            .map_err(|e| format!("opd_train failed: {e:#}"))?
+        }
+    } else {
+        kiln_train::opd::opd_train(
+            prompts,
+            &req.config,
+            model_config,
+            weights,
+            tokenizer,
+            teacher,
+            adapter_dir,
+            adapter_name,
+            Some(trainer_progress_cb),
+        )
+        .map_err(|e| format!("opd_train failed: {e:#}"))?
+    };
 
     if let Some(path) = req.dataset_path.as_deref() {
         match kiln_train::TrainReceipt::read_from_adapter_dir(&output_dir) {
@@ -2157,7 +2216,10 @@ fn execute_job(state: AppState, entry: QueueEntry) {
             }
             let _gpu_guard = state.gpu_lock.write().unwrap();
             let guard = runner_arc.read().unwrap();
+            let backend_name = guard.backend_name();
+            let vk_native = vk_native_opd_enabled(backend_name);
             run_opd(
+                vk_native,
                 &req,
                 &state.model_config,
                 &guard.weights,

--- a/crates/kiln-train/src/opd.rs
+++ b/crates/kiln-train/src/opd.rs
@@ -719,14 +719,20 @@ pub struct PreparedOffPolicyDistillation {
     pub summary: OffPolicyDistillationSummary,
 }
 
-struct TokenizedOpdPrompt {
-    input_ids: Vec<u32>,
-    action_mask: Vec<bool>,
-    env_mask: Vec<bool>,
-    total_obs_len: usize,
+/// Shared OPD tokenization output used by `opd_train` and `vk_native_opd_train`.
+///
+/// `pub(crate)` so the VK-native OPD trainer (`crate::vk_train::vk_native_opd_train`)
+/// can reuse exactly the same tokenization + ECHO env-mask plumbing that the
+/// candle path uses, avoiding two divergent definitions of "what does an OPD
+/// step's active mask mean."
+pub(crate) struct TokenizedOpdPrompt {
+    pub(crate) input_ids: Vec<u32>,
+    pub(crate) action_mask: Vec<bool>,
+    pub(crate) env_mask: Vec<bool>,
+    pub(crate) total_obs_len: usize,
 }
 
-fn tokenize_opd_prompt_for_training(
+pub(crate) fn tokenize_opd_prompt_for_training(
     prompt: &OpdPrompt,
     tokenizer: &kiln_core::tokenizer::KilnTokenizer,
     echo: Option<&crate::EchoConfig>,

--- a/crates/kiln-train/src/vk_train.rs
+++ b/crates/kiln-train/src/vk_train.rs
@@ -44,8 +44,9 @@ use std::sync::Arc;
 
 use crate::trainer::{ProgressCallback, TrainingProgress, tokenize_for_training};
 use crate::{
-    AdvantageMode, GrpoConfig, GrpoGroup, IsLevel, KlEstimator, LossAggregation, Optimizer,
-    ReferencePolicy, SftConfig, SftExample,
+    AdvantageMode, GrpoConfig, GrpoGroup, IsLevel, KlEstimator, LogitSource, LogprobBatch,
+    LossAggregation, OpdConfig, OpdLossGranularity, OpdObjective, OpdPrompt, OpdTrainingMode,
+    Optimizer, ReferencePolicy, SftConfig, SftExample,
 };
 
 struct TokenizedSftExample {
@@ -4791,6 +4792,572 @@ pub fn vk_native_grpo_train_jsonl(
     );
 
     Ok(output_dir)
+}
+
+// ---------------------------------------------------------------------------
+// Vulkan-native OPD training (issue #1075)
+// ---------------------------------------------------------------------------
+
+/// Vulkan-native OPD (off-policy distillation) training loop.
+///
+/// Mirrors `trainer::opd_train()`'s shape (same args + a teacher
+/// `Arc<dyn LogitSource>`) but executes the entire per-step forward →
+/// backward → AdamW chain on `VkTensor` parameters via the existing OPD
+/// step kernels (`vk_recompute_opd_train_step_with_state` for hybrid GDN
+/// models, `vk_opd_train_step_with_state` for FullAttn-only). The
+/// shaders themselves landed in the OPD reverse-KL milestone; this
+/// function wires them into a top-level training entry point so kiln's
+/// `KILN_VK_NATIVE_TRAINING=1` flag becomes uniformly applicable across
+/// SFT, GRPO, and OPD — closing the parity gap tracked in #1075.
+///
+/// # Supported config envelope (v1)
+///
+/// The v1 envelope is deliberately narrow to match the existing OPD
+/// step kernels' contract. Anything outside it bails with a clear error
+/// pointing the user back at the candle path:
+///
+/// * `training_mode == OffPolicy` — on-policy training samples fresh
+///   student rollouts via `sample_student_rollout`, which has no
+///   Vulkan-native counterpart yet.
+/// * `objective == ReverseKl` and `loss == TeacherTopK` — the VK kernel
+///   `vk_opd_top_k_reverse_kl_loss` does top-K reverse KL only.
+///   `CrossEntropy` / `SampledToken` / `FullVocab` need different math
+///   and don't map onto this kernel.
+/// * `top_k ∈ {16, 32}` — the kernel's supported K envelope.
+/// * `base_adapter` unset — loading prior LoRA params into VK tensors
+///   needs the same plumbing the SFT path has but the OPD trainer
+///   doesn't share it yet.
+/// * `echo` unset — the VK-native OPD step kernels don't have an
+///   integrated ECHO env-CE term (GRPO's `vk_recompute_grpo_train_step_with_state`
+///   does, via `VkEchoStepParams`; the analogous parameter on the OPD
+///   step is a follow-up).
+///
+/// # Step kernel selection
+///
+/// Mirrors `vk_native_grpo_train`'s structure: hybrid GDN models go
+/// through the layerwise reverse-recompute step
+/// (`vk_recompute_opd_train_step_with_state`) which auto-engages the
+/// boundary cache via `KILN_VK_RECOMPUTE_BOUNDARY_CACHE` / `MemAvailable
+/// - 4 GiB`. FullAttn-only models use the non-recompute
+/// `vk_opd_train_step_with_state` (full activation tape). A future
+/// follow-up (#1076) adds a non-recompute step for hybrid models so
+/// big-VRAM workloads can skip the recompute cost; until then hybrid
+/// GDN models always recompute.
+#[allow(clippy::too_many_arguments)]
+pub fn vk_native_opd_train(
+    prompts: &[OpdPrompt],
+    config: &OpdConfig,
+    model_config: &ModelConfig,
+    weights: &GpuWeights,
+    tokenizer: &KilnTokenizer,
+    teacher: Arc<dyn LogitSource>,
+    adapter_dir: &Path,
+    adapter_name: &str,
+    progress_cb: Option<ProgressCallback>,
+) -> Result<PathBuf> {
+    let run_started = std::time::Instant::now();
+    anyhow::ensure!(!prompts.is_empty(), "vk_native_opd_train: no prompts");
+    if !VulkanDevice::probe() {
+        bail!(
+            "vk_native_opd_train: no Vulkan device available - unset \
+             KILN_VK_NATIVE_TRAINING / KILN_VK_NATIVE_OPD to use the candle path"
+        );
+    }
+
+    // Preflight: clamp the v1 envelope. Match `vk_native_grpo_train`'s
+    // shape — fail fast with an explicit "use the candle path" pointer
+    // rather than silently producing wrong gradients.
+    if !matches!(config.training_mode, OpdTrainingMode::OffPolicy) {
+        bail!(
+            "vk-native OPD only supports `training_mode = off_policy` in v1 \
+             (#1075). For on-policy student-rollout OPD use the candle path \
+             (unset KILN_VK_NATIVE_TRAINING / KILN_VK_NATIVE_OPD) or set \
+             training_mode = off_policy."
+        );
+    }
+    if !matches!(config.objective, OpdObjective::ReverseKl) {
+        bail!(
+            "vk-native OPD only supports `objective = reverse_kl` in v1 \
+             (#1075). The VK kernel `vk_opd_top_k_reverse_kl_loss` does \
+             top-K reverse KL only. For `cross_entropy` use the candle path."
+        );
+    }
+    if !matches!(config.loss, OpdLossGranularity::TeacherTopK) {
+        bail!(
+            "vk-native OPD only supports `loss = teacher_top_k` in v1 \
+             (#1075). For `sampled_token` or `full_vocab` use the candle \
+             path."
+        );
+    }
+    if config.top_k != 16 && config.top_k != 32 {
+        bail!(
+            "vk-native OPD requires `top_k` ∈ {{16, 32}} (got {}). The VK \
+             kernel `vk_opd_top_k_reverse_kl_loss` is specialised for those \
+             two support sizes.",
+            config.top_k
+        );
+    }
+    if config.base_adapter.is_some() {
+        bail!(
+            "vk-native OPD does not yet support `base_adapter` (#1075 v1). \
+             For continual-learning resume from a prior adapter, use the \
+             candle path."
+        );
+    }
+    if config.echo.is_some() {
+        bail!(
+            "vk-native OPD does not yet support the ECHO env-CE term \
+             (#1075 v1). For trajectory-mode OPD with ECHO use the candle \
+             path; tracked as a follow-up to the VK OPD step kernel."
+        );
+    }
+
+    let effective_seed = config.seed.unwrap_or_else(|| {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(0x0fd0_5eed)
+    });
+    let alpha_over_rank =
+        crate::lora_scaling::alpha_over_rank(config.lora_rank, config.lora_alpha).ok();
+
+    // Validate teacher capabilities now so we fail before the
+    // first (expensive) `fetch_logprobs` round-trip.
+    let teacher_caps = teacher.capabilities();
+    if config.top_k > teacher_caps.max_top_k {
+        bail!(
+            "vk-native OPD: requested top_k={} exceeds teacher {:?} max_top_k={}",
+            config.top_k,
+            teacher_caps.teacher_id,
+            teacher_caps.max_top_k
+        );
+    }
+    let resolved_top_k = config.top_k;
+
+    let vk_device = Arc::new(
+        VulkanDevice::new().context("vk_native_opd_train: failed to create Vulkan device")?,
+    );
+
+    let upload_start = std::time::Instant::now();
+    tracing::info!("uploading frozen model weights into vk-native OPD tensors");
+    let vk_weights = VkModelWeights::from_gpu_weights(weights, model_config, &vk_device)
+        .context("vk_native_opd_train: VkModelWeights::from_gpu_weights")?;
+    tracing::info!(
+        elapsed_ms = upload_start.elapsed().as_millis() as u64,
+        "vk-native OPD frozen model weights ready"
+    );
+
+    let lora_layers = vk_init_lora_layers(
+        &vk_device,
+        &vk_weights,
+        model_config,
+        config.lora_rank,
+        config.lora_alpha,
+        effective_seed,
+    )?;
+    let mut adamw = allocate_adamw_state(&vk_device, &lora_layers)?;
+    let cfg = VkAdamWConfig {
+        lr: config.learning_rate as f32,
+        ..Default::default()
+    };
+    let num_gdn_layers = vk_count_gdn_layers(&vk_weights);
+    let needs_state = num_gdn_layers > 0;
+
+    // Tokenize every prompt up front — same shape as the candle path
+    // (`opd_train` at `opd.rs:2190`). Skip prompts that produce no
+    // supervised action tokens; their teacher query would have no
+    // active positions and the step kernel would bail.
+    let tokenize_start = std::time::Instant::now();
+    let mut tokenized: Vec<crate::opd::TokenizedOpdPrompt> = Vec::with_capacity(prompts.len());
+    let mut filtered = 0usize;
+    for (idx, prompt) in prompts.iter().enumerate() {
+        match crate::opd::tokenize_opd_prompt_for_training(prompt, tokenizer, config.echo.as_ref())
+        {
+            Ok(t) => {
+                if !t.action_mask.iter().any(|&m| m) {
+                    tracing::warn!(
+                        prompt_idx = idx,
+                        "vk-native OPD: skipping prompt with no action tokens"
+                    );
+                    filtered += 1;
+                    continue;
+                }
+                if t.input_ids.len() < 2 {
+                    tracing::warn!(
+                        prompt_idx = idx,
+                        len = t.input_ids.len(),
+                        "vk-native OPD: skipping prompt with <2 tokens (recompute step requires >=2)"
+                    );
+                    filtered += 1;
+                    continue;
+                }
+                tokenized.push(t);
+            }
+            Err(e) => {
+                tracing::warn!(prompt_idx = idx, error = %e, "vk-native OPD: skipping prompt");
+                filtered += 1;
+            }
+        }
+    }
+    if tokenized.is_empty() {
+        bail!(
+            "vk_native_opd_train: every prompt was filtered during tokenization \
+             (no action tokens or <2-token prompts)"
+        );
+    }
+    tracing::info!(
+        prompts_total = prompts.len(),
+        prompts_trained = tokenized.len(),
+        prompts_filtered = filtered,
+        elapsed_ms = tokenize_start.elapsed().as_millis() as u64,
+        "vk-native OPD tokenization complete"
+    );
+
+    let mut data_stats = crate::train_receipt::DataStatsReceipt {
+        examples_read: prompts.len(),
+        examples_filtered: filtered,
+        examples_trained: tokenized.len().saturating_mul(config.epochs.max(1)),
+        ..Default::default()
+    };
+    let mut token_counts = crate::train_receipt::TokenCountReceipt::default();
+
+    tracing::info!(
+        num_prompts = tokenized.len(),
+        epochs = config.epochs.max(1),
+        top_k = resolved_top_k,
+        teacher = %teacher_caps.teacher_id,
+        lr = config.learning_rate,
+        rank = config.lora_rank,
+        alpha = config.lora_alpha,
+        adapter_name,
+        "starting vk-native OPD training"
+    );
+
+    let epochs = config.epochs.max(1);
+    let total_steps = epochs.saturating_mul(tokenized.len());
+    let mut optimizer_step = 0u32;
+    let mut global_step = 0usize;
+    let mut last_loss = 0.0f32;
+
+    for epoch in 0..epochs {
+        let mut epoch_loss = 0.0f32;
+        let mut epoch_steps = 0usize;
+        for (prompt_idx, t_prompt) in tokenized.iter().enumerate() {
+            global_step += 1;
+            optimizer_step += 1;
+            let step_started = std::time::Instant::now();
+
+            // Active positions: indices into input_ids where the student
+            // is supervised. Off-policy comes pre-masked via
+            // `tokenize_opd_prompt_for_training`'s action_mask (same
+            // contract `opd_train`'s off-policy branch uses at
+            // `opd.rs:2539`).
+            let active_positions: Vec<usize> = t_prompt
+                .action_mask
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &m)| if m { Some(i) } else { None })
+                .collect();
+            if active_positions.is_empty() {
+                // Should be unreachable since we filtered above, but
+                // defend against teacher / mask drift between
+                // tokenization and step time.
+                tracing::warn!(
+                    prompt_idx,
+                    "vk-native OPD: prompt has no active positions at step time"
+                );
+                continue;
+            }
+
+            // Query teacher for top-K logprobs at the active positions.
+            // Match the candle path's `opd_step_loss` shape exactly so a
+            // future parity test against `opd_train` compares apples to
+            // apples on the same teacher contract.
+            let batch = teacher
+                .fetch_logprobs(&t_prompt.input_ids, &active_positions, Some(resolved_top_k))
+                .with_context(|| {
+                    format!(
+                        "vk-native OPD: fetch_logprobs from teacher {:?} \
+                         (prompt {}, {} active positions, top_k={})",
+                        teacher_caps.teacher_id,
+                        prompt_idx,
+                        active_positions.len(),
+                        resolved_top_k,
+                    )
+                })?;
+            let topk = match batch {
+                LogprobBatch::TopK(t) => t,
+                LogprobBatch::FullVocab { .. } => bail!(
+                    "vk-native OPD: teacher returned full-vocab logprobs but the \
+                     VK kernel requires top-K. Use a teacher that supports top-K \
+                     responses or switch to the candle path."
+                ),
+            };
+            anyhow::ensure!(
+                topk.top_k == resolved_top_k,
+                "vk-native OPD: teacher returned top_k {} but expected {}",
+                topk.top_k,
+                resolved_top_k
+            );
+            let expected_lpq = active_positions.len() * resolved_top_k;
+            anyhow::ensure!(
+                topk.indices.len() == expected_lpq && topk.logprobs.len() == expected_lpq,
+                "vk-native OPD: teacher returned {} indices / {} logprobs but \
+                 expected {} (active_positions={} × top_k={})",
+                topk.indices.len(),
+                topk.logprobs.len(),
+                expected_lpq,
+                active_positions.len(),
+                resolved_top_k,
+            );
+
+            // Convert to the VK kernel's u32 active_rows shape.
+            let active_rows: Vec<u32> = active_positions.iter().map(|&p| p as u32).collect();
+
+            // Account token counts (action tokens supervised by the
+            // teacher; env tokens stay 0 in v1 since ECHO is rejected
+            // up-front).
+            token_counts.action_tokens = token_counts
+                .action_tokens
+                .saturating_add(active_positions.len() as u64);
+            token_counts.context_tokens = token_counts.context_tokens.saturating_add(
+                (t_prompt.input_ids.len().saturating_sub(active_positions.len())) as u64,
+            );
+
+            // Dispatch the per-step kernel. Hybrid (Qwen3.5-4B-style)
+            // models always go through layerwise reverse-recompute —
+            // see #1076 for the future non-recompute fast path.
+            let loss = if needs_state {
+                vk_recompute_opd_train_step_with_state(
+                    &vk_weights,
+                    &lora_layers,
+                    &t_prompt.input_ids,
+                    &active_rows,
+                    &topk.indices,
+                    &topk.logprobs,
+                    resolved_top_k,
+                    model_config,
+                    num_gdn_layers,
+                    &mut adamw,
+                    &cfg,
+                    config.optimizer,
+                    optimizer_step,
+                )
+                .with_context(|| {
+                    format!(
+                        "vk_recompute_opd_train_step_with_state (epoch {}, prompt {})",
+                        epoch + 1,
+                        prompt_idx + 1
+                    )
+                })?
+            } else {
+                vk_opd_train_step_with_state(
+                    &vk_weights,
+                    &lora_layers,
+                    &t_prompt.input_ids,
+                    &active_rows,
+                    &topk.indices,
+                    &topk.logprobs,
+                    resolved_top_k,
+                    None,
+                    &mut adamw,
+                    &cfg,
+                    config.optimizer,
+                    optimizer_step,
+                )
+                .with_context(|| {
+                    format!(
+                        "vk_opd_train_step_with_state (epoch {}, prompt {})",
+                        epoch + 1,
+                        prompt_idx + 1
+                    )
+                })?
+            };
+
+            anyhow::ensure!(
+                loss.is_finite(),
+                "vk_native_opd_train: non-finite loss {loss} at optimizer step {optimizer_step}"
+            );
+            epoch_loss += loss;
+            epoch_steps += 1;
+            last_loss = loss;
+
+            let step_ms = step_started.elapsed().as_millis();
+            tracing::info!(
+                epoch = epoch + 1,
+                step = global_step,
+                total_steps,
+                seq_len = t_prompt.input_ids.len(),
+                active_positions = active_positions.len(),
+                loss = format!("{loss:.6}"),
+                step_ms,
+                "vk-native OPD step"
+            );
+
+            if let Some(ref cb) = progress_cb {
+                cb(TrainingProgress {
+                    epoch: epoch + 1,
+                    total_epochs: epochs,
+                    step: global_step,
+                    total_steps,
+                    loss: loss as f64,
+                    progress: global_step as f32 / total_steps.max(1) as f32,
+                });
+            }
+
+            if let Some(interval) = config.checkpoint_interval {
+                if interval > 0
+                    && global_step % interval == 0
+                    && global_step < total_steps
+                {
+                    let ckpt_dir =
+                        adapter_dir.join(format!("{adapter_name}-checkpoint-{global_step}"));
+                    std::fs::create_dir_all(&ckpt_dir).with_context(|| {
+                        format!("create vk-native OPD checkpoint dir {}", ckpt_dir.display())
+                    })?;
+                    if let Err(err) = save_vk_lora_adapter(
+                        &lora_layers,
+                        config.lora_rank,
+                        config.lora_alpha,
+                        &ckpt_dir.join("adapter_model.safetensors"),
+                    ) {
+                        tracing::warn!(step = global_step, error = %err, "save vk-native OPD checkpoint failed");
+                    }
+                    let _ = write_vk_adapter_config(&ckpt_dir, config.lora_rank, config.lora_alpha);
+                }
+            }
+        }
+        if epoch_steps > 0 {
+            tracing::info!(
+                epoch = epoch + 1,
+                avg_loss = format!("{:.6}", epoch_loss / epoch_steps as f32),
+                "vk-native OPD epoch complete"
+            );
+        }
+    }
+
+    data_stats.examples_trained = tokenized.len().saturating_mul(epochs);
+
+    let output_dir = adapter_dir.join(adapter_name);
+    std::fs::create_dir_all(&output_dir).with_context(|| {
+        format!(
+            "vk_native_opd_train: create adapter dir {}",
+            output_dir.display()
+        )
+    })?;
+    save_vk_lora_adapter(
+        &lora_layers,
+        config.lora_rank,
+        config.lora_alpha,
+        &output_dir.join("adapter_model.safetensors"),
+    )?;
+    write_vk_adapter_config(&output_dir, config.lora_rank, config.lora_alpha)?;
+
+    write_vk_opd_train_receipt_best_effort(
+        adapter_name,
+        model_config,
+        tokenizer,
+        config,
+        &output_dir,
+        crate::train_receipt::TrainingDataReceipt {
+            source: "inline_opd_prompts".to_string(),
+            path: None,
+            sha256: crate::train_receipt::sha256_json_serializable(&prompts),
+        },
+        data_stats,
+        token_counts,
+        run_started.elapsed().as_millis() as u64,
+        alpha_over_rank,
+        Some(last_loss as f64),
+        Some(effective_seed),
+    );
+
+    tracing::info!(
+        adapter = adapter_name,
+        path = %output_dir.display(),
+        final_loss = format!("{last_loss:.6}"),
+        "vk-native OPD training complete"
+    );
+
+    Ok(output_dir)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn write_vk_opd_train_receipt_best_effort(
+    adapter_name: &str,
+    model_config: &ModelConfig,
+    tokenizer: &KilnTokenizer,
+    config: &OpdConfig,
+    output_dir: &Path,
+    training_data: crate::train_receipt::TrainingDataReceipt,
+    data: crate::train_receipt::DataStatsReceipt,
+    token_counts: crate::train_receipt::TokenCountReceipt,
+    wall_clock_ms: u64,
+    alpha_over_rank: Option<f32>,
+    final_opd_loss: Option<f64>,
+    seed: Option<u64>,
+) {
+    let mut receipt = crate::train_receipt::TrainReceipt::new(
+        adapter_name,
+        "vk_opd",
+        model_config,
+        tokenizer,
+        crate::train_receipt::HyperparameterReceipt {
+            mode: "vk_opd".to_string(),
+            rank: config.lora_rank,
+            alpha: config.lora_alpha,
+            alpha_over_rank,
+            learning_rate: config.learning_rate,
+            epochs: config.epochs.max(1),
+            seed,
+        },
+        serde_json::to_value(config).unwrap_or(serde_json::Value::Null),
+    );
+    receipt.training_data = training_data;
+    receipt.opd = Some(crate::train_receipt::OpdReceipt {
+        training_mode: serde_json::to_value(config.training_mode)
+            .ok()
+            .and_then(|v| v.as_str().map(ToString::to_string))
+            .unwrap_or_else(|| "off_policy".to_string()),
+        objective: serde_json::to_value(config.objective)
+            .ok()
+            .and_then(|v| v.as_str().map(ToString::to_string))
+            .unwrap_or_else(|| "reverse_kl".to_string()),
+        loss_granularity: serde_json::to_value(config.loss)
+            .ok()
+            .and_then(|v| v.as_str().map(ToString::to_string))
+            .unwrap_or_else(|| "teacher_top_k".to_string()),
+        teacher_id: None,
+        top_k: Some(config.top_k),
+        samples_per_prompt: config.samples_per_prompt,
+        action_tokens: token_counts.action_tokens,
+        env_tokens: token_counts.env_tokens,
+        echo_combined: false,
+        echo_lambda: None,
+        initial_opd_loss: None,
+        final_opd_loss,
+    });
+    receipt.echo = crate::train_receipt::EchoReceipt::disabled();
+    receipt.adapters.output = crate::train_receipt::adapter_file_receipt(Some(output_dir));
+    receipt.data = data;
+    receipt.token_counts = token_counts;
+    receipt.runtime.wall_clock_ms = wall_clock_ms;
+    crate::train_receipt::log_training_token_counts("vk_opd", &receipt.token_counts);
+    receipt.lora_delta_norms = crate::train_receipt::lora_delta_norm_summary_from_adapter(
+        output_dir,
+        alpha_over_rank.unwrap_or(0.0) as f64,
+    )
+    .unwrap_or_default();
+    crate::train_receipt::warn_lora_delta_norms(
+        "vk_opd",
+        adapter_name,
+        &receipt.lora_delta_norms,
+        alpha_over_rank.unwrap_or(0.0) as f64,
+    );
+    if let Err(err) = receipt.write_to_adapter_dir(output_dir) {
+        tracing::warn!(adapter = adapter_name, error = %err, "failed to write vk-native OPD train receipt");
+    }
 }
 
 /// Vulkan-native SFT training loop.

--- a/crates/kiln-train/tests/vk_train_smoke.rs
+++ b/crates/kiln-train/tests/vk_train_smoke.rs
@@ -36,7 +36,7 @@ use kiln_train::Optimizer;
 use kiln_train::vk_train::{
     VkAdamWConfig, allocate_adamw_state, grpo_jsonl_stats, save_vk_lora_adapter,
     validate_vk_grpo_seq_lens, vk_init_lora_layers, vk_native_grpo_train_jsonl,
-    vk_opd_train_step_with_state, vk_recompute_grpo_train_step_with_state,
+    vk_native_opd_train, vk_opd_train_step_with_state, vk_recompute_grpo_train_step_with_state,
     vk_recompute_opd_train_step_with_state, vk_recompute_train_step_with_state_masked,
     vk_train_step,
 };
@@ -128,6 +128,133 @@ fn build_tiny_model(dev: &Arc<VulkanDevice>) -> Result<VkModelWeights> {
         vocab,
         hidden,
     })
+}
+
+fn tiny_gpu_opd_model_config() -> ModelConfig {
+    // OPD's TeacherTopK loss requires top_k ∈ {16, 32} and the kernel
+    // checks each top-K index against vocab_size. The GRPO smoke uses
+    // vocab=8 which can't fit top_k=16, so OPD gets a 32-vocab variant
+    // with otherwise identical 1-layer FullAttention shape.
+    ModelConfig {
+        hidden_size: 16,
+        num_layers: 1,
+        num_attention_heads: 1,
+        num_kv_heads: 1,
+        head_dim: 16,
+        intermediate_size: 32,
+        vocab_size: 32,
+        max_position_embeddings: 128,
+        rms_norm_eps: 1e-5,
+        rope_theta: 10_000.0,
+        dtype: DType::FP32,
+        num_full_attention_layers: 1,
+        full_attention_interval: 1,
+        attn_output_gate: false,
+        linear_num_key_heads: 1,
+        linear_key_head_dim: 16,
+        linear_num_value_heads: 1,
+        linear_value_head_dim: 16,
+        linear_conv_kernel_dim: 4,
+        partial_rotary_factor: 0.0,
+    }
+}
+
+fn build_tiny_gpu_opd_weights() -> Result<GpuWeights> {
+    let config = tiny_gpu_opd_model_config();
+    let vocab = config.vocab_size;
+    let hidden = config.hidden_size;
+    let intermediate = config.intermediate_size;
+    let head_dim = config.head_dim;
+
+    let embed_tokens = cpu_tensor(small_random(vocab * hidden, 601), (vocab, hidden))?;
+    let embed_tokens_t = transpose_2d(&embed_tokens)?;
+    let q_proj = cpu_tensor(small_random(hidden * hidden, 602), (hidden, hidden))?;
+    let k_proj = cpu_tensor(small_random(hidden * hidden, 603), (hidden, hidden))?;
+    let v_proj = cpu_tensor(small_random(hidden * hidden, 604), (hidden, hidden))?;
+    let o_proj = cpu_tensor(small_random(hidden * hidden, 605), (hidden, hidden))?;
+    let gate_proj = cpu_tensor(
+        small_random(intermediate * hidden, 606),
+        (intermediate, hidden),
+    )?;
+    let up_proj = cpu_tensor(
+        small_random(intermediate * hidden, 607),
+        (intermediate, hidden),
+    )?;
+    let down_proj = cpu_tensor(
+        small_random(hidden * intermediate, 608),
+        (hidden, intermediate),
+    )?;
+
+    Ok(GpuWeights {
+        embed_tokens,
+        embed_tokens_t,
+        layers: vec![GpuLayerWeights {
+            input_layernorm: cpu_tensor(vec![0.0; hidden], (hidden,))?,
+            post_attention_layernorm: cpu_tensor(vec![0.0; hidden], (hidden,))?,
+            attention: GpuAttentionWeights::Full(GpuFullAttentionWeights {
+                q_proj: q_proj.clone(),
+                k_proj: k_proj.clone(),
+                v_proj: v_proj.clone(),
+                o_proj: o_proj.clone(),
+                q_norm: cpu_tensor(vec![0.0; head_dim], (head_dim,))?,
+                k_norm: cpu_tensor(vec![0.0; head_dim], (head_dim,))?,
+                q_proj_t: transpose_2d(&q_proj)?,
+                k_proj_t: transpose_2d(&k_proj)?,
+                v_proj_t: transpose_2d(&v_proj)?,
+                qkv_proj_t: None,
+                o_proj_t: transpose_2d(&o_proj)?,
+                q_proj_marlin: None,
+            }),
+            mlp: GpuFfnWeights {
+                gate_proj: gate_proj.clone(),
+                up_proj: up_proj.clone(),
+                down_proj: down_proj.clone(),
+                gate_proj_t: transpose_2d(&gate_proj)?,
+                up_proj_t: transpose_2d(&up_proj)?,
+                down_proj_t: transpose_2d(&down_proj)?,
+                gate_proj_marlin: None,
+                up_proj_marlin: None,
+                down_proj_marlin: None,
+            },
+        }],
+        final_norm: cpu_tensor(vec![0.0; hidden], (hidden,))?,
+        rotary_inv_freq: cpu_tensor(Vec::<f32>::new(), (0,))?,
+        mtp: None,
+    })
+}
+
+/// Tokenizer with chat-template markers so the OPD trainer's action
+/// mask picks up the assistant span. Vocab is large enough that top-K
+/// over the action positions has room.
+fn tiny_opd_tokenizer() -> Result<KilnTokenizer> {
+    let mut vocab_map = serde_json::Map::new();
+    let chars =
+        "abcdefghijklmnopqrstuvwxyz <|im_start|><|im_end|>user assistantsystemtoolcontent\nrol";
+    let mut seen = std::collections::HashSet::new();
+    let mut id = 0u32;
+    for ch in chars.chars() {
+        let key = ch.to_string();
+        if !seen.insert(key.clone()) {
+            continue;
+        }
+        vocab_map.insert(key, serde_json::Value::from(id));
+        id += 1;
+    }
+    let vocab_json = serde_json::Value::Object(vocab_map);
+    let json = serde_json::json!({
+        "version": "1.0",
+        "model": {
+            "type": "BPE",
+            "vocab": vocab_json,
+            "merges": []
+        }
+    });
+    let template =
+        "{% for message in messages -%}<|im_start|>{{ message.role }}\n{{ message.content }}<|im_end|>\n{% endfor %}";
+    Ok(
+        KilnTokenizer::from_bytes(json.to_string().as_bytes())?
+            .with_chat_template(template.to_string()),
+    )
 }
 
 fn tiny_gpu_grpo_model_config() -> ModelConfig {
@@ -2127,6 +2254,298 @@ fn vk_native_grpo_jsonl_smoke_streams_large_dataset() -> Result<()> {
     );
 
     let _ = std::fs::remove_file(dataset);
+    let _ = std::fs::remove_dir_all(adapter_root);
+    Ok(())
+}
+
+/// End-to-end smoke for the new `vk_native_opd_train` entrypoint
+/// introduced in #1075.
+///
+/// Builds the small FullAttention GpuWeights variant, wires up a
+/// deterministic uniform LogitSource as the teacher, runs the trainer
+/// over a few small OffPolicy prompts for 2 epochs, and asserts:
+///
+/// 1. The adapter directory + safetensors land on disk.
+/// 2. `adapter_config.json` enumerates the expected LoRA targets.
+/// 3. A mid-run checkpoint dir was written when checkpoint_interval is set.
+/// 4. The progress callback was invoked at least once per step and
+///    finished at progress ≥ 0.999.
+///
+/// This is the OPD analogue of
+/// `vk_native_grpo_jsonl_smoke_streams_and_saves_adapter` — it proves
+/// that the new dispatch (server → trainer → kernels) is end-to-end
+/// runnable, that the off-policy mask plumbing matches the candle path
+/// (`opd::tokenize_opd_prompt_for_training`), and that the artifacts a
+/// caller relies on (adapter dir, checkpoint dir, progress events) all
+/// land in the right shape.
+#[test]
+fn vk_native_opd_train_smoke_saves_adapter() -> Result<()> {
+    use kiln_core::tokenizer::ChatMessage;
+    use kiln_train::logit_source::{DeterministicUniformLogitSource, LogitSource};
+    use kiln_train::opd::{
+        OpdConfig, OpdLossGranularity, OpdObjective, OpdPrompt, OpdTrainingMode,
+    };
+    use std::sync::Arc;
+
+    let Some(_dev) = vk_dev() else {
+        eprintln!("Vulkan device not available — skipping");
+        return Ok(());
+    };
+
+    let adapter_root = std::env::temp_dir().join(format!(
+        "kiln-vk-native-opd-smoke-adapters-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&adapter_root);
+    std::fs::create_dir_all(&adapter_root)?;
+
+    let model_config = tiny_gpu_opd_model_config();
+    let weights = build_tiny_gpu_opd_weights()?;
+    let tokenizer = tiny_opd_tokenizer()?;
+
+    // Three off-policy prompts — small but each has a non-empty
+    // assistant turn so the action-mask plumbing picks up real
+    // supervised positions.
+    let prompts = vec![
+        OpdPrompt {
+            messages: vec![
+                ChatMessage {
+                    role: "user".into(),
+                    content: "a".into(),
+                },
+                ChatMessage {
+                    role: "assistant".into(),
+                    content: "b c".into(),
+                },
+            ],
+            teacher_extra_messages: vec![],
+            trajectory: vec![],
+        },
+        OpdPrompt {
+            messages: vec![
+                ChatMessage {
+                    role: "user".into(),
+                    content: "d e".into(),
+                },
+                ChatMessage {
+                    role: "assistant".into(),
+                    content: "f".into(),
+                },
+            ],
+            teacher_extra_messages: vec![],
+            trajectory: vec![],
+        },
+        OpdPrompt {
+            messages: vec![
+                ChatMessage {
+                    role: "user".into(),
+                    content: "g".into(),
+                },
+                ChatMessage {
+                    role: "assistant".into(),
+                    content: "h i j".into(),
+                },
+            ],
+            teacher_extra_messages: vec![],
+            trajectory: vec![],
+        },
+    ];
+
+    let config = OpdConfig {
+        training_mode: OpdTrainingMode::OffPolicy,
+        objective: OpdObjective::ReverseKl,
+        loss: OpdLossGranularity::TeacherTopK,
+        top_k: 16,
+        learning_rate: 5e-3,
+        lora_rank: 2,
+        lora_alpha: 4.0,
+        checkpoint_interval: Some(2),
+        seed: Some(7777),
+        epochs: 2,
+        ..Default::default()
+    };
+
+    let teacher: Arc<dyn LogitSource> =
+        Arc::new(DeterministicUniformLogitSource::new("test-teacher", 32, 16));
+    let progress = Arc::new(Mutex::new(Vec::new()));
+    let progress_cb = {
+        let progress = Arc::clone(&progress);
+        Box::new(move |p| progress.lock().unwrap().push(p))
+    };
+
+    let out = vk_native_opd_train(
+        &prompts,
+        &config,
+        &model_config,
+        &weights,
+        &tokenizer,
+        teacher,
+        &adapter_root,
+        "vk-opd-smoke",
+        Some(progress_cb),
+    )?;
+
+    let adapter_path = out.join("adapter_model.safetensors");
+    assert!(
+        adapter_path.exists(),
+        "vk-native OPD adapter not found at {}",
+        adapter_path.display()
+    );
+    let loaded = candle_core::safetensors::load(&adapter_path, &Device::Cpu)?;
+    for key in [
+        "self_attn.q_proj.lora_A.weight",
+        "self_attn.o_proj.lora_A.weight",
+        "mlp.gate_proj.lora_A.weight",
+        "mlp.down_proj.lora_A.weight",
+    ] {
+        assert!(
+            loaded.keys().any(|k| k.contains(key)),
+            "missing vk-native OPD adapter key containing {key}"
+        );
+    }
+    assert_vk_adapter_config_targets(&out)?;
+
+    // At least one mid-run checkpoint should have been written — with
+    // 3 prompts × 2 epochs = 6 steps and interval=2, expect checkpoints
+    // at steps 2 and 4 (step 6 is the final save and skipped by
+    // global_step < total_steps).
+    let ckpt2 = adapter_root
+        .join("vk-opd-smoke-checkpoint-2")
+        .join("adapter_model.safetensors");
+    assert!(
+        ckpt2.exists(),
+        "expected vk-native OPD checkpoint at step 2: {}",
+        ckpt2.display()
+    );
+    assert_vk_adapter_config_targets(ckpt2.parent().unwrap())?;
+
+    let updates = progress.lock().unwrap();
+    assert!(
+        updates.len() >= 6,
+        "expected at least one progress update per step (got {})",
+        updates.len()
+    );
+    assert!(
+        updates.last().is_some_and(|p| p.progress >= 0.999),
+        "final progress should reach completion"
+    );
+    for u in updates.iter() {
+        assert!(u.loss.is_finite(), "non-finite OPD loss in progress event");
+    }
+
+    let _ = std::fs::remove_dir_all(adapter_root);
+    Ok(())
+}
+
+/// Preflight rejection: vk_native_opd_train must refuse on-policy
+/// training because v1 only handles teacher-pre-masked off-policy
+/// prompts. Mirrors `vk_native_grpo_train`'s shape-preflight tests.
+#[test]
+fn vk_native_opd_train_rejects_on_policy_in_v1() -> Result<()> {
+    use kiln_core::tokenizer::ChatMessage;
+    use kiln_train::logit_source::{DeterministicUniformLogitSource, LogitSource};
+    use kiln_train::opd::{
+        OpdConfig, OpdLossGranularity, OpdObjective, OpdPrompt, OpdTrainingMode,
+    };
+    use std::sync::Arc;
+
+    let Some(_dev) = vk_dev() else { return Ok(()) };
+    let model_config = tiny_gpu_opd_model_config();
+    let weights = build_tiny_gpu_opd_weights()?;
+    let tokenizer = tiny_opd_tokenizer()?;
+    let prompts = vec![OpdPrompt {
+        messages: vec![
+            ChatMessage {
+                role: "user".into(),
+                content: "a".into(),
+            },
+            ChatMessage {
+                role: "assistant".into(),
+                content: "b".into(),
+            },
+        ],
+        teacher_extra_messages: vec![],
+        trajectory: vec![],
+    }];
+
+    // On-policy is rejected.
+    let mut config = OpdConfig {
+        training_mode: OpdTrainingMode::OnPolicy,
+        objective: OpdObjective::ReverseKl,
+        loss: OpdLossGranularity::TeacherTopK,
+        top_k: 16,
+        learning_rate: 1e-3,
+        lora_rank: 2,
+        lora_alpha: 4.0,
+        seed: Some(11),
+        epochs: 1,
+        ..Default::default()
+    };
+    let teacher: Arc<dyn LogitSource> =
+        Arc::new(DeterministicUniformLogitSource::new("test-teacher", 32, 16));
+    let adapter_root = std::env::temp_dir().join(format!(
+        "kiln-vk-opd-preflight-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&adapter_root);
+    std::fs::create_dir_all(&adapter_root)?;
+    let err = vk_native_opd_train(
+        &prompts,
+        &config,
+        &model_config,
+        &weights,
+        &tokenizer,
+        Arc::clone(&teacher),
+        &adapter_root,
+        "vk-opd-reject-onpolicy",
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("off_policy"),
+        "on-policy preflight message should mention off_policy: {err}"
+    );
+
+    // Cross-entropy is rejected.
+    config.training_mode = OpdTrainingMode::OffPolicy;
+    config.objective = OpdObjective::CrossEntropy;
+    let err = vk_native_opd_train(
+        &prompts,
+        &config,
+        &model_config,
+        &weights,
+        &tokenizer,
+        Arc::clone(&teacher),
+        &adapter_root,
+        "vk-opd-reject-ce",
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("reverse_kl"),
+        "cross-entropy preflight message should mention reverse_kl: {err}"
+    );
+
+    // top_k=8 (outside {16, 32}) is rejected.
+    config.objective = OpdObjective::ReverseKl;
+    config.top_k = 8;
+    let err = vk_native_opd_train(
+        &prompts,
+        &config,
+        &model_config,
+        &weights,
+        &tokenizer,
+        Arc::clone(&teacher),
+        &adapter_root,
+        "vk-opd-reject-topk",
+        None,
+    )
+    .unwrap_err();
+    assert!(
+        err.to_string().contains("top_k"),
+        "top_k preflight message should mention top_k: {err}"
+    );
+
     let _ = std::fs::remove_dir_all(adapter_root);
     Ok(())
 }

--- a/crates/kiln-train/tests/vk_train_smoke.rs
+++ b/crates/kiln-train/tests/vk_train_smoke.rs
@@ -2280,7 +2280,7 @@ fn vk_native_grpo_jsonl_smoke_streams_large_dataset() -> Result<()> {
 /// land in the right shape.
 #[test]
 fn vk_native_opd_train_smoke_saves_adapter() -> Result<()> {
-    use kiln_core::tokenizer::ChatMessage;
+    use kiln_train::ChatMessage;
     use kiln_train::logit_source::{DeterministicUniformLogitSource, LogitSource};
     use kiln_train::opd::{
         OpdConfig, OpdLossGranularity, OpdObjective, OpdPrompt, OpdTrainingMode,
@@ -2442,7 +2442,7 @@ fn vk_native_opd_train_smoke_saves_adapter() -> Result<()> {
 /// prompts. Mirrors `vk_native_grpo_train`'s shape-preflight tests.
 #[test]
 fn vk_native_opd_train_rejects_on_policy_in_v1() -> Result<()> {
-    use kiln_core::tokenizer::ChatMessage;
+    use kiln_train::ChatMessage;
     use kiln_train::logit_source::{DeterministicUniformLogitSource, LogitSource};
     use kiln_train::opd::{
         OpdConfig, OpdLossGranularity, OpdObjective, OpdPrompt, OpdTrainingMode,

--- a/docs/vk_native_training.md
+++ b/docs/vk_native_training.md
@@ -14,6 +14,19 @@ validation on a real model + adapter run.
 **Ready to use** (gated behind `KILN_VK_NATIVE_TRAINING=1`):
 - `vk_native_sft_train` (multi-epoch loop, LoRA init, AdamW, adapter
   save in PEFT format) — wired into `kiln-server`'s training queue.
+- `vk_native_grpo_train` / `vk_native_grpo_train_jsonl` (GRPO loss
+  with on-the-fly reference-logprob recompute via frozen-base forward,
+  PPO-style ratio clipping, checkpoint cadence). Independently
+  toggleable via `KILN_VK_NATIVE_GRPO`.
+- `vk_native_opd_train` (off-policy distillation, reverse-KL against
+  teacher top-K logprobs, `top_k ∈ {16, 32}` via the fused
+  `vk_opd_top_k_reverse_kl_loss` kernel). Independently toggleable via
+  `KILN_VK_NATIVE_OPD`. V1 envelope: `training_mode = off_policy`,
+  `objective = reverse_kl`, `loss = teacher_top_k`; on-policy student
+  rollouts, cross-entropy, full-vocab KL, ECHO env-CE, and continual
+  `base_adapter` resume all stay on the candle path. See issue #1075
+  for the implementation roadmap and #1076 for the planned
+  non-recompute hybrid GDN follow-up.
 - FullAttn layer with Qwen3.5 specifics: per-head Q/K-norm,
   `attn_output_gate` (q_proj fused with [Q, gate], sigmoid·attn),
   RoPE precomputed from `rotary_inv_freq` + applied between QK-norm


### PR DESCRIPTION
## What

Adds `vk_native_opd_train`, the off-policy distillation (OPD) analogue
of the existing `vk_native_sft_train` and `vk_native_grpo_train`. The
new entrypoint takes pre-masked `OpdPrompt`s + an `Arc<dyn LogitSource>`
teacher, fetches top-K logprobs at the action positions, and drives
the per-step VK kernel through the existing AdamW state book and
adapter-save pipeline.

Server routing: `run_opd` picks between the candle `opd_train` and the
new VK trainer via `KILN_VK_NATIVE_OPD`, which falls back to
`KILN_VK_NATIVE_TRAINING` when unset — mirroring how
`KILN_VK_NATIVE_GRPO` was wired up. The `vulkan` feature gates the
dispatch; non-vulkan builds emit an explicit warning and fall through
to the candle path so misconfiguration is visible.

Closes #1075.

## Why

#1075 called out the missing VK-native OPD entrypoint — the underlying
kernels (`vk_opd_train_step_with_state`,
`vk_recompute_opd_train_step_with_state`, `vk_opd_top_k_reverse_kl_loss`)
already shipped, but the public trainer (and server routing) didn't
exist. With this PR every kiln native training mode — SFT, GRPO, OPD —
shares the same shape:

| Mode | Public entrypoint                | Env switch                                |
|------|----------------------------------|-------------------------------------------|
| SFT  | `vk_native_sft_train`            | `KILN_VK_NATIVE_TRAINING`                 |
| GRPO | `vk_native_grpo_train{,_jsonl}`  | `KILN_VK_NATIVE_GRPO` (fallback above)    |
| OPD  | `vk_native_opd_train`            | `KILN_VK_NATIVE_OPD` (fallback above)     |

## V1 envelope (deliberately narrow)

Anything outside this returns an explicit "use the candle path" error,
not a silent wrong-gradient result:

- `training_mode = off_policy` (student rollouts stay on candle)
- `objective = reverse_kl` (cross-entropy stays on candle)
- `loss = teacher_top_k` (sampled-token / full-vocab stay on candle)
- `top_k ∈ {16, 32}` (the values the VK kernel is specialised for)
- no `base_adapter` (continual-learning resume stays on candle)
- no ECHO env-CE term (trajectory-mode OPD with ECHO stays on candle)

## Dispatch

- **FullAttn-only models**: `vk_opd_train_step_with_state` (single-pass
  forward + backward).
- **Hybrid GDN models (Qwen3.5-4B)**: `vk_recompute_opd_train_step_with_state`
  (layerwise reverse-recompute, same memory/perf trade as
  `vk_recompute_train_step_with_state`).

The non-recompute hybrid OPD fast path is tracked separately as
**#1076** — the kernel exists but the single-pass plumbing matches
the GRPO follow-up.

## Tests added

Both run on A6000 under `--features cuda,vulkan`:

1. `vk_native_opd_train_smoke_saves_adapter` — 3 prompts × 2 epochs,
   asserts:
   - `adapter_model.safetensors` lands on disk with the expected LoRA
     keys (`q_proj`, `o_proj`, `gate_proj`, `down_proj`).
   - `adapter_config.json` enumerates the expected LoRA targets.
   - Mid-run checkpoint at `step 2` exists.
   - Progress callback fires at every step and reaches `progress ≥ 0.999`.
   - All emitted losses are finite.

2. `vk_native_opd_train_rejects_on_policy_in_v1` — preflight rejects
   the three v1-envelope violations with explicit error messages:
   on-policy mode, cross-entropy objective, and `top_k ∉ {16, 32}`.

These complement the existing `vk_native_opd_training_loss_decreases`
and `vk_native_opd_recompute_training_loss_decreases` kernel-level
tests, which still pass as regression guards.

## Shared tokenization plumbing

`TokenizedOpdPrompt` and `tokenize_opd_prompt_for_training` in
`crates/kiln-train/src/opd.rs` are now `pub(crate)`, so
`vk_native_opd_train` reuses the *same* action_mask + env_mask
contract the candle path uses. No risk of "what does an OPD step's
active mask mean" drifting between the two paths.

## Test plan

- [x] Local `cargo check` of `kiln-train` + `kiln-server` with
      `--features cuda,vulkan,nvtx` (verified on A6000 — local CPU
      check would crash per the project's no-local-build rule).
- [x] `cargo nextest run` of the two new tests on A6000 with
      `--release --features cuda,vulkan`.
- [x] `cargo nextest run` of the existing
      `vk_native_opd_*training_loss_decreases` tests as a regression
      guard (no behaviour change to the underlying step kernels).
- [ ] Wire-up validation on a real Qwen3.5-4B OPD run is a Phase 7
      follow-up (tracked in #1076 alongside the non-recompute hybrid
      fast path).