### PR TITLE
forward: cfg-gate gdn multiblock byte-eq test to cuda feature

### DIFF
--- a/crates/kiln-model/src/forward.rs
+++ b/crates/kiln-model/src/forward.rs
@@ -22150,6 +22150,7 @@ mod tests {
     /// statement than "matches the candle reference within tolerance": each
     /// output cell is computed by a single thread on both paths with the same
     /// FMA chain and bf16 rounding, so equality is the contract.
+    #[cfg(feature = "cuda")]
     #[test]
     fn test_gdn_full_chunk_forward_multiblock_byte_eq_single_block() -> Result<()> {
         use half::bf16;


### PR DESCRIPTION
## What
Add `#[cfg(feature = "cuda")]` to `test_gdn_full_chunk_forward_multiblock_byte_eq_single_block` in `crates/kiln-model/src/forward.rs`. One-line fix.

## Why
This test uses `half::bf16` and calls `kiln_gdn_kernel::*` directly. Both are `optional = true` in `kiln-model/Cargo.toml`, only pulled in by `--features cuda`. Without the cfg gate, the default-feature CI job fails to compile the `kiln-model` test binary:

```
error[E0432]: unresolved import `half`
   --> crates/kiln-model/src/forward.rs:22155:13
error[E0433]: cannot find module or crate `kiln_gdn_kernel`
```

This has been red on `main` for every push since the `CI` workflow landed in #1077/#1080. Every adjacent kernel test in this file already has the cuda cfg gate — this one was missed when it landed in `4f6015c4` ("gdn-prefill: dv-tiled multi-block gdn_full_chunk_forward"), pre-CI.

## Verification
Compile check is what was actually failing. Runtime behavior is unchanged: the test already does `Device::new_cuda(0)` and bails at runtime when CUDA isn't present, so the cfg gate is purely a compile-time fix matching the existing pattern used by every other kernel test in the file.