### PR TITLE
release: bump workspace version to 0.2.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-conv1d-kernel"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "candle-core",
  "cc",
@@ -1774,7 +1774,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-core"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "chrono",
  "kiln-vulkan-kernel",
@@ -1791,7 +1791,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-eval"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1809,7 +1809,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flash-attn"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "candle-core",
  "cc",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-flce-kernel"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1827,7 +1827,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-gdn-kernel"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-marlin-gemm"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "candle-core",
  "cc",
@@ -1847,7 +1847,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-model"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1879,11 +1879,11 @@ dependencies = [
 
 [[package]]
 name = "kiln-nvtx"
-version = "0.2.18"
+version = "0.2.19"
 
 [[package]]
 name = "kiln-opd-loss-kernel"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1895,7 +1895,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-rmsnorm-kernel"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "candle-core",
  "cc",
@@ -1904,7 +1904,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-scheduler"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "kiln-core",
  "thiserror 2.0.18",
@@ -1913,7 +1913,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-server"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "axum",
@@ -1954,7 +1954,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-train"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -1985,7 +1985,7 @@ dependencies = [
 
 [[package]]
 name = "kiln-vulkan-kernel"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "anyhow",
  "ash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ default-members = [
 ]
 
 [workspace.package]
-version = "0.2.18"
+version = "0.2.19"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/ericflo/kiln"


### PR DESCRIPTION
## What
Bump root workspace version from 0.2.18 to 0.2.19. Cuts the kiln-v0.2.19 server release.

## Changes
- `Cargo.toml [workspace.package].version`: 0.2.18 → 0.2.19
- `Cargo.lock`: 15 kiln workspace crates bumped to match (verified all 15 are kiln crates, no incidental third-party packages affected)

## Rolls up
- CI fixes: #1081, #1083, #1084
- Perf/correctness work since v0.2.18:
  - prefix-cache tuning for streaming long-prompt strict prefixes
  - GDN multiblock dv-tiled forward + chunk_prep CUDA permute pre-pass
  - MLP-prefill packed silu*mul kernel
  - vk-native GRPO/OPD non-recompute path + workload-shape auto-tune
  - layerwise reverse-recompute for `cuda_native_sft_train`
  - RunPod kiln-smoke-check + per-SHA cache + recovery docs
  - completions prompt logprobs endpoint
  - perf-regression three-tier CI ladder

## Release process
1. Auto-merge this PR.
2. Tag `kiln-v0.2.19` on the merge commit.
3. Push the tag, which triggers `.github/workflows/server-release.yml` for the 4-platform matrix (macOS Metal + Linux CUDA + Linux Vulkan + Windows CUDA).
4. Each platform uploads its signed artifact to a draft GitHub release.
5. Publish the release from draft.