### PR TITLE
caps: fix rollout.py lib import, restore task_scaffold.py, correct SFT/OPD trainer flags

### DIFF
--- a/capabilities/caps/code-fence-language-fidelity/run_iter.sh
+++ b/capabilities/caps/code-fence-language-fidelity/run_iter.sh
@@ -35,7 +35,7 @@ mkdir -p "$LOG_DIR"
 echo "=== OPD run_iter $SLUG (iter $ITER_NUM) for code-fence-language-fidelity ==="
 
 if [ ! -f "$PROMPTS" ]; then
-  echo "[0/5] build_corpus…"
+  echo "[0/6] build_corpus…"
   python3 build_corpus.py
 fi
 
@@ -49,50 +49,56 @@ if [ -f rubric_sanity.py ] && [ -z "${KILN_SKIP_RUBRIC_SANITY:-}" ]; then
   }
 fi
 
-echo "[1/5] cuda_opd_remote --dry-run…"
-KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$OPD_BIN" \
-  --prompts "$PROMPTS" \
-  --model "$MODEL_PATH" \
-  --teacher-url "$TEACHER_URL" \
-  --teacher-name "$TEACHER_NAME" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
-  --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
-  --epochs "$EPOCHS" \
-  --seed "$SEED" \
-  --dry-run \
-  2>&1 | tee "$LOG_DIR/dry-run.log"
+# NOTE on cuda_opd_remote CLI (verified 2026-05-23):
+# - Flags: --data, --model-path, --output-dir, --adapter-name, --teacher-url,
+#   --teacher-model, --rank, --alpha, --lr, --epochs, --max-examples, --top-k,
+#   --temperature, --top-p, --max-tokens, --samples-per-prompt,
+#   --checkpoint-interval, --no-checkpoint, --base-adapter,
+#   --allow-high-lora-scale.
+# - NO --prompts (use --data), --model (use --model-path), --output (use
+#   --output-dir), --adapter (use --adapter-name), --teacher-name (use
+#   --teacher-model), --seed, --dry-run, --adapter-smoke-test, --install-adapter-*.
+# - Output: --output-dir lands the adapter (same flat-layout rule as cuda_sft_file).
+# - VRAM: kiln serve must be killed first (cuda_opd_remote uses local GPU for
+#   student; teacher is over HTTP, no local GPU footprint).
+echo "[1/4] kill kiln serve to free VRAM (cuda_opd_remote shares the GPU)…"
+pkill -f "kiln serve" 2>/dev/null || true
+sleep 2
 
-echo "[2/5] cuda_opd_remote (training)…"
+echo "[2/4] cuda_opd_remote (training)…"
 KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$OPD_BIN" \
-  --prompts "$PROMPTS" \
-  --model "$MODEL_PATH" \
+  --data "$PROMPTS" \
+  --model-path "$MODEL_PATH" \
   --teacher-url "$TEACHER_URL" \
-  --teacher-name "$TEACHER_NAME" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
+  --teacher-model "$TEACHER_NAME" \
+  --output-dir "$ADAPTER_REGISTRY/$ADAPTER_NAME" \
+  --adapter-name "$ADAPTER_NAME" \
   --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
   --epochs "$EPOCHS" \
-  --seed "$SEED" \
-  --adapter-smoke-test \
-  --install-adapter-dir "$ADAPTER_REGISTRY" \
-  --install-adapter-name "$ADAPTER_NAME" \
   2>&1 | tee "$LOG_DIR/train.log"
 
-echo "[3/5] kiln adapter verify…"
+echo "[3/4] restart kiln serve --eval-mode for adapter verify + eval…"
+KILN_MODEL_PATH="$MODEL_PATH" KILN_ADAPTER_DIR="$ADAPTER_REGISTRY" \
+  nohup "$KILN_BIN" serve --eval-mode > "$LOG_DIR/kiln-serve.log" 2>&1 &
+for i in $(seq 1 60); do
+  curl -sf http://localhost:8420/v1/health > /dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "[4/4] kiln adapter verify…"
 "$KILN_BIN" adapter verify "$ADAPTER_NAME" \
   --adapter-dir "$ADAPTER_REGISTRY" \
   --url http://localhost:8420 \
   --json \
   > "$LOG_DIR/verify.json"
 
-echo "[4/5] capability.oracle.sh…"
+echo "[5/6] capability.oracle.sh…"
 OUT_FILE="$LOG_DIR/eval.json" SEEDS="${EVAL_SEEDS:-3}" \
   ./capability.oracle.sh "$ADAPTER_NAME" \
   2>&1 | tee "$LOG_DIR/eval.log"
 
-echo "[5/5] append capability.jsonl…"
-TRAIN_RECEIPT="$OUT_ROOT/adapter/train_receipt.json" \
+echo "[6/6] append capability.jsonl…"
+TRAIN_RECEIPT="$ADAPTER_REGISTRY/$ADAPTER_NAME/train_receipt.json" \
 EVAL_JSON="$LOG_DIR/eval.json" \
 VERIFY_JSON="$LOG_DIR/verify.json" \
 ITER_NUM="$ITER_NUM" \

--- a/capabilities/caps/code-symbol-extraction/run_iter.sh
+++ b/capabilities/caps/code-symbol-extraction/run_iter.sh
@@ -35,7 +35,7 @@ mkdir -p "$LOG_DIR"
 echo "=== OPD run_iter $SLUG (iter $ITER_NUM) for code-symbol-extraction ==="
 
 if [ ! -f "$PROMPTS" ]; then
-  echo "[0/5] build_corpus…"
+  echo "[0/6] build_corpus…"
   python3 build_corpus.py
 fi
 
@@ -49,50 +49,56 @@ if [ -f rubric_sanity.py ] && [ -z "${KILN_SKIP_RUBRIC_SANITY:-}" ]; then
   }
 fi
 
-echo "[1/5] cuda_opd_remote --dry-run…"
-KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$OPD_BIN" \
-  --prompts "$PROMPTS" \
-  --model "$MODEL_PATH" \
-  --teacher-url "$TEACHER_URL" \
-  --teacher-name "$TEACHER_NAME" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
-  --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
-  --epochs "$EPOCHS" \
-  --seed "$SEED" \
-  --dry-run \
-  2>&1 | tee "$LOG_DIR/dry-run.log"
+# NOTE on cuda_opd_remote CLI (verified 2026-05-23):
+# - Flags: --data, --model-path, --output-dir, --adapter-name, --teacher-url,
+#   --teacher-model, --rank, --alpha, --lr, --epochs, --max-examples, --top-k,
+#   --temperature, --top-p, --max-tokens, --samples-per-prompt,
+#   --checkpoint-interval, --no-checkpoint, --base-adapter,
+#   --allow-high-lora-scale.
+# - NO --prompts (use --data), --model (use --model-path), --output (use
+#   --output-dir), --adapter (use --adapter-name), --teacher-name (use
+#   --teacher-model), --seed, --dry-run, --adapter-smoke-test, --install-adapter-*.
+# - Output: --output-dir lands the adapter (same flat-layout rule as cuda_sft_file).
+# - VRAM: kiln serve must be killed first (cuda_opd_remote uses local GPU for
+#   student; teacher is over HTTP, no local GPU footprint).
+echo "[1/4] kill kiln serve to free VRAM (cuda_opd_remote shares the GPU)…"
+pkill -f "kiln serve" 2>/dev/null || true
+sleep 2
 
-echo "[2/5] cuda_opd_remote (training)…"
+echo "[2/4] cuda_opd_remote (training)…"
 KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$OPD_BIN" \
-  --prompts "$PROMPTS" \
-  --model "$MODEL_PATH" \
+  --data "$PROMPTS" \
+  --model-path "$MODEL_PATH" \
   --teacher-url "$TEACHER_URL" \
-  --teacher-name "$TEACHER_NAME" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
+  --teacher-model "$TEACHER_NAME" \
+  --output-dir "$ADAPTER_REGISTRY/$ADAPTER_NAME" \
+  --adapter-name "$ADAPTER_NAME" \
   --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
   --epochs "$EPOCHS" \
-  --seed "$SEED" \
-  --adapter-smoke-test \
-  --install-adapter-dir "$ADAPTER_REGISTRY" \
-  --install-adapter-name "$ADAPTER_NAME" \
   2>&1 | tee "$LOG_DIR/train.log"
 
-echo "[3/5] kiln adapter verify…"
+echo "[3/4] restart kiln serve --eval-mode for adapter verify + eval…"
+KILN_MODEL_PATH="$MODEL_PATH" KILN_ADAPTER_DIR="$ADAPTER_REGISTRY" \
+  nohup "$KILN_BIN" serve --eval-mode > "$LOG_DIR/kiln-serve.log" 2>&1 &
+for i in $(seq 1 60); do
+  curl -sf http://localhost:8420/v1/health > /dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "[4/4] kiln adapter verify…"
 "$KILN_BIN" adapter verify "$ADAPTER_NAME" \
   --adapter-dir "$ADAPTER_REGISTRY" \
   --url http://localhost:8420 \
   --json \
   > "$LOG_DIR/verify.json"
 
-echo "[4/5] capability.oracle.sh…"
+echo "[5/6] capability.oracle.sh…"
 OUT_FILE="$LOG_DIR/eval.json" SEEDS="${EVAL_SEEDS:-3}" \
   ./capability.oracle.sh "$ADAPTER_NAME" \
   2>&1 | tee "$LOG_DIR/eval.log"
 
-echo "[5/5] append capability.jsonl…"
-TRAIN_RECEIPT="$OUT_ROOT/adapter/train_receipt.json" \
+echo "[6/6] append capability.jsonl…"
+TRAIN_RECEIPT="$ADAPTER_REGISTRY/$ADAPTER_NAME/train_receipt.json" \
 EVAL_JSON="$LOG_DIR/eval.json" \
 VERIFY_JSON="$LOG_DIR/verify.json" \
 ITER_NUM="$ITER_NUM" \

--- a/capabilities/caps/diff-patch-fluency/run_iter.sh
+++ b/capabilities/caps/diff-patch-fluency/run_iter.sh
@@ -35,7 +35,7 @@ mkdir -p "$LOG_DIR"
 echo "=== OPD run_iter $SLUG (iter $ITER_NUM) for diff-patch-fluency ==="
 
 if [ ! -f "$PROMPTS" ]; then
-  echo "[0/5] build_corpus…"
+  echo "[0/6] build_corpus…"
   python3 build_corpus.py
 fi
 
@@ -49,50 +49,56 @@ if [ -f rubric_sanity.py ] && [ -z "${KILN_SKIP_RUBRIC_SANITY:-}" ]; then
   }
 fi
 
-echo "[1/5] cuda_opd_remote --dry-run…"
-KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$OPD_BIN" \
-  --prompts "$PROMPTS" \
-  --model "$MODEL_PATH" \
-  --teacher-url "$TEACHER_URL" \
-  --teacher-name "$TEACHER_NAME" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
-  --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
-  --epochs "$EPOCHS" \
-  --seed "$SEED" \
-  --dry-run \
-  2>&1 | tee "$LOG_DIR/dry-run.log"
+# NOTE on cuda_opd_remote CLI (verified 2026-05-23):
+# - Flags: --data, --model-path, --output-dir, --adapter-name, --teacher-url,
+#   --teacher-model, --rank, --alpha, --lr, --epochs, --max-examples, --top-k,
+#   --temperature, --top-p, --max-tokens, --samples-per-prompt,
+#   --checkpoint-interval, --no-checkpoint, --base-adapter,
+#   --allow-high-lora-scale.
+# - NO --prompts (use --data), --model (use --model-path), --output (use
+#   --output-dir), --adapter (use --adapter-name), --teacher-name (use
+#   --teacher-model), --seed, --dry-run, --adapter-smoke-test, --install-adapter-*.
+# - Output: --output-dir lands the adapter (same flat-layout rule as cuda_sft_file).
+# - VRAM: kiln serve must be killed first (cuda_opd_remote uses local GPU for
+#   student; teacher is over HTTP, no local GPU footprint).
+echo "[1/4] kill kiln serve to free VRAM (cuda_opd_remote shares the GPU)…"
+pkill -f "kiln serve" 2>/dev/null || true
+sleep 2
 
-echo "[2/5] cuda_opd_remote (training)…"
+echo "[2/4] cuda_opd_remote (training)…"
 KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$OPD_BIN" \
-  --prompts "$PROMPTS" \
-  --model "$MODEL_PATH" \
+  --data "$PROMPTS" \
+  --model-path "$MODEL_PATH" \
   --teacher-url "$TEACHER_URL" \
-  --teacher-name "$TEACHER_NAME" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
+  --teacher-model "$TEACHER_NAME" \
+  --output-dir "$ADAPTER_REGISTRY/$ADAPTER_NAME" \
+  --adapter-name "$ADAPTER_NAME" \
   --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
   --epochs "$EPOCHS" \
-  --seed "$SEED" \
-  --adapter-smoke-test \
-  --install-adapter-dir "$ADAPTER_REGISTRY" \
-  --install-adapter-name "$ADAPTER_NAME" \
   2>&1 | tee "$LOG_DIR/train.log"
 
-echo "[3/5] kiln adapter verify…"
+echo "[3/4] restart kiln serve --eval-mode for adapter verify + eval…"
+KILN_MODEL_PATH="$MODEL_PATH" KILN_ADAPTER_DIR="$ADAPTER_REGISTRY" \
+  nohup "$KILN_BIN" serve --eval-mode > "$LOG_DIR/kiln-serve.log" 2>&1 &
+for i in $(seq 1 60); do
+  curl -sf http://localhost:8420/v1/health > /dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "[4/4] kiln adapter verify…"
 "$KILN_BIN" adapter verify "$ADAPTER_NAME" \
   --adapter-dir "$ADAPTER_REGISTRY" \
   --url http://localhost:8420 \
   --json \
   > "$LOG_DIR/verify.json"
 
-echo "[4/5] capability.oracle.sh…"
+echo "[5/6] capability.oracle.sh…"
 OUT_FILE="$LOG_DIR/eval.json" SEEDS="${EVAL_SEEDS:-3}" \
   ./capability.oracle.sh "$ADAPTER_NAME" \
   2>&1 | tee "$LOG_DIR/eval.log"
 
-echo "[5/5] append capability.jsonl…"
-TRAIN_RECEIPT="$OUT_ROOT/adapter/train_receipt.json" \
+echo "[6/6] append capability.jsonl…"
+TRAIN_RECEIPT="$ADAPTER_REGISTRY/$ADAPTER_NAME/train_receipt.json" \
 EVAL_JSON="$LOG_DIR/eval.json" \
 VERIFY_JSON="$LOG_DIR/verify.json" \
 ITER_NUM="$ITER_NUM" \

--- a/capabilities/caps/faithful-code-summarization/run_iter.sh
+++ b/capabilities/caps/faithful-code-summarization/run_iter.sh
@@ -35,7 +35,7 @@ mkdir -p "$LOG_DIR"
 echo "=== OPD run_iter $SLUG (iter $ITER_NUM) for faithful-code-summarization ==="
 
 if [ ! -f "$PROMPTS" ]; then
-  echo "[0/5] build_corpus…"
+  echo "[0/6] build_corpus…"
   python3 build_corpus.py
 fi
 
@@ -49,50 +49,56 @@ if [ -f rubric_sanity.py ] && [ -z "${KILN_SKIP_RUBRIC_SANITY:-}" ]; then
   }
 fi
 
-echo "[1/5] cuda_opd_remote --dry-run…"
-KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$OPD_BIN" \
-  --prompts "$PROMPTS" \
-  --model "$MODEL_PATH" \
-  --teacher-url "$TEACHER_URL" \
-  --teacher-name "$TEACHER_NAME" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
-  --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
-  --epochs "$EPOCHS" \
-  --seed "$SEED" \
-  --dry-run \
-  2>&1 | tee "$LOG_DIR/dry-run.log"
+# NOTE on cuda_opd_remote CLI (verified 2026-05-23):
+# - Flags: --data, --model-path, --output-dir, --adapter-name, --teacher-url,
+#   --teacher-model, --rank, --alpha, --lr, --epochs, --max-examples, --top-k,
+#   --temperature, --top-p, --max-tokens, --samples-per-prompt,
+#   --checkpoint-interval, --no-checkpoint, --base-adapter,
+#   --allow-high-lora-scale.
+# - NO --prompts (use --data), --model (use --model-path), --output (use
+#   --output-dir), --adapter (use --adapter-name), --teacher-name (use
+#   --teacher-model), --seed, --dry-run, --adapter-smoke-test, --install-adapter-*.
+# - Output: --output-dir lands the adapter (same flat-layout rule as cuda_sft_file).
+# - VRAM: kiln serve must be killed first (cuda_opd_remote uses local GPU for
+#   student; teacher is over HTTP, no local GPU footprint).
+echo "[1/4] kill kiln serve to free VRAM (cuda_opd_remote shares the GPU)…"
+pkill -f "kiln serve" 2>/dev/null || true
+sleep 2
 
-echo "[2/5] cuda_opd_remote (training)…"
+echo "[2/4] cuda_opd_remote (training)…"
 KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$OPD_BIN" \
-  --prompts "$PROMPTS" \
-  --model "$MODEL_PATH" \
+  --data "$PROMPTS" \
+  --model-path "$MODEL_PATH" \
   --teacher-url "$TEACHER_URL" \
-  --teacher-name "$TEACHER_NAME" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
+  --teacher-model "$TEACHER_NAME" \
+  --output-dir "$ADAPTER_REGISTRY/$ADAPTER_NAME" \
+  --adapter-name "$ADAPTER_NAME" \
   --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
   --epochs "$EPOCHS" \
-  --seed "$SEED" \
-  --adapter-smoke-test \
-  --install-adapter-dir "$ADAPTER_REGISTRY" \
-  --install-adapter-name "$ADAPTER_NAME" \
   2>&1 | tee "$LOG_DIR/train.log"
 
-echo "[3/5] kiln adapter verify…"
+echo "[3/4] restart kiln serve --eval-mode for adapter verify + eval…"
+KILN_MODEL_PATH="$MODEL_PATH" KILN_ADAPTER_DIR="$ADAPTER_REGISTRY" \
+  nohup "$KILN_BIN" serve --eval-mode > "$LOG_DIR/kiln-serve.log" 2>&1 &
+for i in $(seq 1 60); do
+  curl -sf http://localhost:8420/v1/health > /dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "[4/4] kiln adapter verify…"
 "$KILN_BIN" adapter verify "$ADAPTER_NAME" \
   --adapter-dir "$ADAPTER_REGISTRY" \
   --url http://localhost:8420 \
   --json \
   > "$LOG_DIR/verify.json"
 
-echo "[4/5] capability.oracle.sh…"
+echo "[5/6] capability.oracle.sh…"
 OUT_FILE="$LOG_DIR/eval.json" SEEDS="${EVAL_SEEDS:-3}" \
   ./capability.oracle.sh "$ADAPTER_NAME" \
   2>&1 | tee "$LOG_DIR/eval.log"
 
-echo "[5/5] append capability.jsonl…"
-TRAIN_RECEIPT="$OUT_ROOT/adapter/train_receipt.json" \
+echo "[6/6] append capability.jsonl…"
+TRAIN_RECEIPT="$ADAPTER_REGISTRY/$ADAPTER_NAME/train_receipt.json" \
 EVAL_JSON="$LOG_DIR/eval.json" \
 VERIFY_JSON="$LOG_DIR/verify.json" \
 ITER_NUM="$ITER_NUM" \

--- a/capabilities/caps/json-schema-adherence/run_iter.sh
+++ b/capabilities/caps/json-schema-adherence/run_iter.sh
@@ -29,7 +29,7 @@ mkdir -p "$LOG_DIR"
 echo "=== SFT run_iter $SLUG (iter $ITER_NUM) for json-schema-adherence ==="
 
 if [ ! -f "$DATA" ]; then
-  echo "[0/5] build_corpus…"
+  echo "[0/6] build_corpus…"
   python3 build_corpus.py
 fi
 
@@ -43,53 +43,62 @@ if [ -f rubric_sanity.py ] && [ -z "${KILN_SKIP_RUBRIC_SANITY:-}" ]; then
   }
 fi
 
-echo "[1/5] cuda_sft_file --dry-run…"
-KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$SFT_BIN" \
-  --data "$DATA" \
-  --model "$MODEL_PATH" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
-  --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
-  --epochs "$EPOCHS" \
-  --dataset-cap "$DATASET_CAP" \
-  --seed "$SEED" \
-  --dry-run \
-  2>&1 | tee "$LOG_DIR/dry-run.log"
+# NOTE on cuda_sft_file CLI (verified 2026-05-23):
+# - Flags: --data, --model-path, --output-dir, --adapter-name, --rank, --alpha,
+#   --lr, --epochs, --max-examples, --skip-examples, --base-adapter,
+#   --allow-adapter-shape-conversion, --allow-high-lora-scale, --trainer.
+# - NO --seed, --dry-run, --adapter-smoke-test, --install-adapter-{dir,name}.
+# - Output: if basename(--output-dir) == --adapter-name, lands flat at output-dir/
+#   (loadable via `kiln serve --adapter-dir $(dirname output-dir)`). So setting
+#   output-dir=$ADAPTER_REGISTRY/$ADAPTER_NAME makes the adapter immediately
+#   loadable from the registry without a post-train flatten step.
+# - VRAM: kiln serve must be killed first to free GPU; long seqs (>500 tok)
+#   need KILN_CUDA_RECOMPUTE_SFT=1.
+echo "[1/4] kill kiln serve to free VRAM (cuda_sft_file shares the GPU)…"
+pkill -f "kiln serve" 2>/dev/null || true
+sleep 2
 
-echo "[2/5] cuda_sft_file (training)…"
-KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$SFT_BIN" \
+echo "[2/4] cuda_sft_file (training)…"
+KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" \
+KILN_CUDA_RECOMPUTE_SFT="${KILN_CUDA_RECOMPUTE_SFT:-1}" \
+"$SFT_BIN" \
   --data "$DATA" \
-  --model "$MODEL_PATH" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
+  --model-path "$MODEL_PATH" \
+  --output-dir "$ADAPTER_REGISTRY/$ADAPTER_NAME" \
+  --adapter-name "$ADAPTER_NAME" \
   --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
   --epochs "$EPOCHS" \
-  --dataset-cap "$DATASET_CAP" \
-  --seed "$SEED" \
-  --adapter-smoke-test \
-  --install-adapter-dir "$ADAPTER_REGISTRY" \
-  --install-adapter-name "$ADAPTER_NAME" \
+  --max-examples "$DATASET_CAP" \
+  --trainer native \
   2>&1 | tee "$LOG_DIR/train.log"
 
-echo "[3/5] kiln adapter verify…"
+echo "[3/4] restart kiln serve --eval-mode for adapter verify + eval…"
+KILN_MODEL_PATH="$MODEL_PATH" KILN_ADAPTER_DIR="$ADAPTER_REGISTRY" \
+  nohup "$KILN_BIN" serve --eval-mode > "$LOG_DIR/kiln-serve.log" 2>&1 &
+for i in $(seq 1 60); do
+  curl -sf http://localhost:8420/v1/health > /dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "[4/4] kiln adapter verify…"
 "$KILN_BIN" adapter verify "$ADAPTER_NAME" \
   --adapter-dir "$ADAPTER_REGISTRY" \
   --url http://localhost:8420 \
   --json \
   > "$LOG_DIR/verify.json"
 
-echo "[4/5] capability.oracle.sh…"
+echo "[5/6] capability.oracle.sh…"
 OUT_FILE="$LOG_DIR/eval.json" SEEDS="${EVAL_SEEDS:-3}" \
   ./capability.oracle.sh "$ADAPTER_NAME" \
   2>&1 | tee "$LOG_DIR/eval.log"
 
 if [ -x "./capability.anchor.sh" ]; then
-  echo "[5/5] capability.anchor.sh (regression watch)…"
+  echo "[6/6] capability.anchor.sh (regression watch)…"
   ./capability.anchor.sh "$ADAPTER_NAME" \
     2>&1 | tee "$LOG_DIR/anchor.log"
 fi
 
-TRAIN_RECEIPT="$OUT_ROOT/adapter/train_receipt.json" \
+TRAIN_RECEIPT="$ADAPTER_REGISTRY/$ADAPTER_NAME/train_receipt.json" \
 EVAL_JSON="$LOG_DIR/eval.json" \
 VERIFY_JSON="$LOG_DIR/verify.json" \
 ITER_NUM="$ITER_NUM" \

--- a/capabilities/caps/math-broad/run_iter.sh
+++ b/capabilities/caps/math-broad/run_iter.sh
@@ -25,7 +25,7 @@ mkdir -p "$LOG_DIR"
 echo "=== SFT run_iter $SLUG (iter $ITER_NUM) for math-broad ==="
 
 if [ ! -f "$DATA" ]; then
-  echo "[0/5] build_corpus…"
+  echo "[0/6] build_corpus…"
   python3 build_corpus.py
 fi
 
@@ -39,53 +39,58 @@ if [ -f rubric_sanity.py ] && [ -z "${KILN_SKIP_RUBRIC_SANITY:-}" ]; then
   }
 fi
 
-echo "[1/5] cuda_sft_file --dry-run…"
-KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$SFT_BIN" \
-  --data "$DATA" \
-  --model "$MODEL_PATH" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
-  --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
-  --epochs "$EPOCHS" \
-  --dataset-cap "$DATASET_CAP" \
-  --seed "$SEED" \
-  --dry-run \
-  2>&1 | tee "$LOG_DIR/dry-run.log"
+# NOTE on cuda_sft_file CLI (verified 2026-05-23):
+# - Flags: --data, --model-path, --output-dir, --adapter-name, --rank, --alpha,
+#   --lr, --epochs, --max-examples, --skip-examples, --base-adapter,
+#   --allow-adapter-shape-conversion, --allow-high-lora-scale, --trainer.
+# - NO --seed, --dry-run, --adapter-smoke-test, --install-adapter-{dir,name}.
+# - Output: if basename(--output-dir) == --adapter-name, lands flat at output-dir/.
+# - VRAM: kiln serve must be killed first; long seqs (>500 tok) need KILN_CUDA_RECOMPUTE_SFT=1.
+echo "[1/4] kill kiln serve to free VRAM (cuda_sft_file shares the GPU)…"
+pkill -f "kiln serve" 2>/dev/null || true
+sleep 2
 
-echo "[2/5] cuda_sft_file (training)…"
-KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" "$SFT_BIN" \
+echo "[2/4] cuda_sft_file (training)…"
+KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" \
+KILN_CUDA_RECOMPUTE_SFT="${KILN_CUDA_RECOMPUTE_SFT:-1}" \
+"$SFT_BIN" \
   --data "$DATA" \
-  --model "$MODEL_PATH" \
-  --output "$OUT_ROOT/adapter" \
-  --adapter "$ADAPTER_NAME" \
+  --model-path "$MODEL_PATH" \
+  --output-dir "$ADAPTER_REGISTRY/$ADAPTER_NAME" \
+  --adapter-name "$ADAPTER_NAME" \
   --rank "$RANK" --alpha "$ALPHA" --lr "$LR" \
   --epochs "$EPOCHS" \
-  --dataset-cap "$DATASET_CAP" \
-  --seed "$SEED" \
-  --adapter-smoke-test \
-  --install-adapter-dir "$ADAPTER_REGISTRY" \
-  --install-adapter-name "$ADAPTER_NAME" \
+  --max-examples "$DATASET_CAP" \
+  --trainer native \
   2>&1 | tee "$LOG_DIR/train.log"
 
-echo "[3/5] kiln adapter verify…"
+echo "[3/4] restart kiln serve --eval-mode for adapter verify + eval…"
+KILN_MODEL_PATH="$MODEL_PATH" KILN_ADAPTER_DIR="$ADAPTER_REGISTRY" \
+  nohup "$KILN_BIN" serve --eval-mode > "$LOG_DIR/kiln-serve.log" 2>&1 &
+for i in $(seq 1 60); do
+  curl -sf http://localhost:8420/v1/health > /dev/null 2>&1 && break
+  sleep 1
+done
+
+echo "[4/4] kiln adapter verify…"
 "$KILN_BIN" adapter verify "$ADAPTER_NAME" \
   --adapter-dir "$ADAPTER_REGISTRY" \
   --url http://localhost:8420 \
   --json \
   > "$LOG_DIR/verify.json"
 
-echo "[4/5] capability.oracle.sh…"
+echo "[5/6] capability.oracle.sh…"
 OUT_FILE="$LOG_DIR/eval.json" SEEDS="${EVAL_SEEDS:-3}" \
   ./capability.oracle.sh "$ADAPTER_NAME" \
   2>&1 | tee "$LOG_DIR/eval.log"
 
 if [ -x "./capability.anchor.sh" ]; then
-  echo "[5/5] capability.anchor.sh (regression watch)…"
+  echo "[6/6] capability.anchor.sh (regression watch)…"
   ./capability.anchor.sh "$ADAPTER_NAME" \
     2>&1 | tee "$LOG_DIR/anchor.log"
 fi
 
-TRAIN_RECEIPT="$OUT_ROOT/adapter/train_receipt.json" \
+TRAIN_RECEIPT="$ADAPTER_REGISTRY/$ADAPTER_NAME/train_receipt.json" \
 EVAL_JSON="$LOG_DIR/eval.json" \
 VERIFY_JSON="$LOG_DIR/verify.json" \
 ITER_NUM="$ITER_NUM" \

--- a/capabilities/caps/pi-code-comprehension/rollout.py
+++ b/capabilities/caps/pi-code-comprehension/rollout.py
@@ -30,7 +30,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 import rubric  # noqa: E402
 import task_scaffold  # noqa: E402
 import pi_trajectory  # noqa: E402

--- a/capabilities/caps/pi-code-comprehension/task_scaffold.py
+++ b/capabilities/caps/pi-code-comprehension/task_scaffold.py
@@ -1,0 +1,115 @@
+"""Initialize a pi rollout workdir from a task spec.
+
+A task spec is a dict:
+{
+  "task_id": str,
+  "target_file": "lib/foo.py",            # path INSIDE the workdir snapshot
+  "target_symbol": "function_name",
+  "gold": { ... structured gold summary ... },
+  "files": {                              # path → file content (relative)
+      "lib/foo.py": "...",
+      "lib/bar.py": "...",
+      ...
+  },
+}
+
+`init_workdir(task, dir)`:
+  - copies each entry of `files` into <dir>/<path>
+  - writes <dir>/README.md describing the task
+  - does NOT include `gold` (the model must not read it)
+
+`pi_prompt(task)`:
+  - returns the user prompt pi reads
+
+Empirical pi config used (verified 2026-05-18 in pi-doctest):
+  - pi reads its workdir as $CWD
+  - tools available: read, edit, write, bash
+  - session JSONL ends up under the configured --session-dir
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def init_workdir(task: dict, dir: str) -> None:
+    workdir = Path(dir)
+    workdir.mkdir(parents=True, exist_ok=True)
+    files = task.get("files") or {}
+    for rel_path, content in files.items():
+        if not isinstance(rel_path, str) or not isinstance(content, str):
+            continue
+        # Never escape the workdir.
+        rel = rel_path.lstrip("/").replace("\\", "/")
+        if ".." in rel.split("/"):
+            continue
+        dest = workdir / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(content)
+
+    target_file = task.get("target_file", "")
+    target_symbol = task.get("target_symbol", "")
+    readme = (
+        "# Code comprehension task\n\n"
+        f"Target file:   `{target_file}`\n"
+        f"Target symbol: `{target_symbol}`\n\n"
+        "Goal: produce a structured JSON summary of the target symbol's\n"
+        "inputs, returns, mutations, calls, callers, invariants and side\n"
+        "effects, with line-number citations from the source.\n\n"
+        "See the user prompt for the exact JSON schema.\n"
+    )
+    (workdir / "README.md").write_text(readme)
+
+
+# The pi user prompt. This is the only input the model sees besides
+# tool outputs. The exact JSON schema is spelled out so a well-trained
+# model can fill it without further hints.
+PI_PROMPT_TEMPLATE = """You are exploring a small code repository in the current working
+directory. Your goal is to produce a STRUCTURED JSON SUMMARY of the
+target symbol below.
+
+Target file:   {target_file}
+Target symbol: {target_symbol}
+
+Steps:
+1. Use `read` to read the target file.
+2. Use `bash` with `grep -rn {target_symbol} .` to find callers.
+3. Read 1-2 callers if helpful.
+
+When you have all the information you need, end your work by emitting a
+PLAIN ASSISTANT TEXT MESSAGE (no tool calls) containing this exact form:
+
+<answer>
+{{"inputs": [{{"name": "arg1", "type": "str", "source_line": N}}], "returns": [{{"type": "T", "source_line": N}}], "mutates": ["arg:foo"], "calls": [{{"name": "helper", "file": "file.py", "line": N}}], "called_by": [{{"file": "caller.py", "line": N}}], "invariants": ["..."], "side_effects": ["raises X"]}}
+</answer>
+
+Rules:
+- DO NOT call any tool named `answer` — there is no such tool. Use a
+  plain assistant text turn instead.
+- DO NOT pass the JSON via `write` or `bash` — emit it as ordinary text.
+- Line numbers MUST be cited from real source. Omit if unknown.
+- For empty fields use the empty list `[]`.
+- `invariants` includes implicit preconds (lock must be held, init must
+  have been called first), not just docstring text.
+- `called_by` is the cross-file callers — find them with grep.
+- ONE `<answer>` block. End the session after it.
+"""
+
+
+def pi_prompt(task: dict) -> str:
+    return PI_PROMPT_TEMPLATE.format(
+        target_file=task.get("target_file", "<unknown>"),
+        target_symbol=task.get("target_symbol", "<unknown>"),
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: task_scaffold.py <task.json> <dir>", file=sys.stderr)
+        sys.exit(2)
+    task = json.loads(Path(sys.argv[1]).read_text())
+    init_workdir(task, sys.argv[2])
+    print(pi_prompt(task))

--- a/capabilities/caps/pi-code-search/rollout.py
+++ b/capabilities/caps/pi-code-search/rollout.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 # Local + shared imports.
 sys.path.insert(0, str(Path(__file__).parent))
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 
 import rubric  # noqa: E402
 import task_scaffold  # noqa: E402

--- a/capabilities/caps/pi-code-search/task_scaffold.py
+++ b/capabilities/caps/pi-code-search/task_scaffold.py
@@ -1,0 +1,114 @@
+"""Initialize a single rollout's workdir for one pi-code-search task.
+
+Task spec format:
+{
+  "task_id": str,
+  "question_kind": "define" | "refs",
+  "symbol": str,           # the symbol being asked about
+  "repo_id": "kiln",       # the repo to search inside
+  "gold": [[file, line], ...],
+  "target_bytes": int,     # gold-optimal grep output size
+  "question": str,         # rendered natural-language question (optional)
+}
+
+Per-rollout workdir layout:
+  <dir>/
+    repo/         # SYMLINK to a shared read-only snapshot of the repo
+    QUESTION.md   # the question (the same as what's in the pi prompt)
+    HOW_TO.md     # static guidance — read it if you want; gold-set firewall safe
+
+The shared snapshot is at $PI_CODE_SEARCH_REPO (default
+/workspace/kiln-snapshot). The snapshot is created once on pod setup
+before any rollout; symlinks are per-rollout so concurrent pi sessions
+can share the snapshot safely.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+REPO_SNAPSHOT = os.environ.get("PI_CODE_SEARCH_REPO", "/workspace/kiln-snapshot")
+
+
+def _render_question(task: dict) -> str:
+    kind = task.get("question_kind", "define")
+    symbol = task["symbol"]
+    if kind == "define":
+        return (
+            f"Where is `{symbol}` defined in the codebase under `repo/`?\n"
+            f"Answer with the file path (relative to `repo/`) and line "
+            f"number in the form `path/to/file.ext:LINE`."
+        )
+    if kind == "refs":
+        return (
+            f"Find all references to `{symbol}` in the codebase under "
+            f"`repo/`. Answer with one line per reference in the form "
+            f"`path/to/file.ext:LINE`."
+        )
+    raise ValueError(f"unknown question_kind: {kind}")
+
+
+def init_workdir(task: dict, dir: str) -> None:
+    dir = Path(dir)
+    dir.mkdir(parents=True, exist_ok=True)
+    # Symlink the read-only repo snapshot under repo/
+    repo_link = dir / "repo"
+    if repo_link.exists() or repo_link.is_symlink():
+        try:
+            repo_link.unlink()
+        except FileNotFoundError:
+            pass
+    snap = Path(REPO_SNAPSHOT)
+    if not snap.exists():
+        raise FileNotFoundError(
+            f"repo snapshot {snap} not found. Set $PI_CODE_SEARCH_REPO or "
+            f"run scripts/setup_repo_snapshot.sh first."
+        )
+    repo_link.symlink_to(snap)
+
+    question = _render_question(task)
+    (dir / "QUESTION.md").write_text(question + "\n")
+    (dir / "HOW_TO.md").write_text(
+        "You are searching the codebase under `repo/`. Prefer `grep`, "
+        "`rg` (ripgrep), `glob`, or `find` over reading whole files. "
+        "Reading large files wastes context and is penalized.\n\n"
+        "Tools available:\n"
+        "- bash: run shell commands (use grep, rg, find, ls, etc.).\n"
+        "- read: read a file's contents (avoid on files >2KB).\n"
+        "- glob: find files matching a pattern.\n\n"
+        "When you are confident, emit a final assistant message containing "
+        "your answer in the form `path:line` (relative to `repo/`). "
+        "Multiple answers should be on separate lines.\n"
+    )
+
+
+def pi_prompt(task: dict) -> str:
+    """The user-facing pi prompt for one rollout. The system message is
+    set by pi's own configuration; this is the user turn."""
+    question = _render_question(task)
+    return (
+        "You are searching a code repository under `repo/`.\n\n"
+        "PROBLEM:\n"
+        f"{question}\n\n"
+        "STRATEGY: prefer `grep` / `rg` / `glob` / `find` over reading "
+        "whole files. A focused regex search is usually enough. Avoid "
+        "calling `read` on files larger than 2KB.\n\n"
+        "ANSWER FORMAT:\n"
+        "- Strip the leading `repo/` from any path.\n"
+        "- One `path:line` per line (path relative to repo root).\n"
+        "- No prose, no backticks, no explanations.\n\n"
+        "EXAMPLE:\n"
+        "  crates/kiln-train/src/trainer.rs:7270\n"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: task_scaffold.py <task.json> <dir>", file=sys.stderr)
+        sys.exit(2)
+    task = json.loads(Path(sys.argv[1]).read_text())
+    init_workdir(task, sys.argv[2])
+    print(f"scaffolded {sys.argv[2]} for {task['task_id']}")

--- a/capabilities/caps/pi-context-aware-edits/rollout.py
+++ b/capabilities/caps/pi-context-aware-edits/rollout.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 
 # Make the shared lib importable for canonical pi → trajectory rendering.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 try:
     from pi_trajectory import session_to_trajectory  # type: ignore
 except ImportError:

--- a/capabilities/caps/pi-diff-patch-apply/rollout.py
+++ b/capabilities/caps/pi-diff-patch-apply/rollout.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(ROOT))
-sys.path.insert(0, str(ROOT.parent / "lib"))
+sys.path.insert(0, str(ROOT.parent.parent / "lib"))
 
 import rubric  # noqa: E402
 import task_scaffold  # noqa: E402

--- a/capabilities/caps/pi-diff-patch-apply/task_scaffold.py
+++ b/capabilities/caps/pi-diff-patch-apply/task_scaffold.py
@@ -1,0 +1,181 @@
+"""Initialize a rollout workdir from a task spec, and build the pi prompt.
+
+A task dict (from datasets/*.tasks.jsonl) carries:
+
+    init_files          dict[path -> content]   initial workspace state
+    gold_files          dict[path -> content]   reference solution
+    patch_text          str                      the unified diff the model sees
+    gold_diff_text      str                      the canonical correct diff
+    gold_diff_lines     int                      ≈ #lines the gold diff touches
+    touched_paths       list[str]                files the patch is meant to modify
+    protected_paths     list[str]                files pi should not touch (tests)
+    expected_repair     bool                     true iff patch_class != 'clean'
+    verify_cmd          str                      e.g. "python3 -m pytest -q tests/"
+    verify_timeout_s    int                      verifier timeout
+
+`init_workdir(task, dir)` writes:
+
+    <dir>/<every init_files path>     the initial workspace contents
+    <dir>/INCOMING_PATCH               the patch text the model will apply
+    <dir>/README.md                    one-line task description
+
+`pi_prompt(task)` returns the prompt sent to pi via `-p`.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import subprocess
+from pathlib import Path
+
+
+PATCH_FILENAME = "INCOMING_PATCH"
+
+
+def init_workdir(task: dict, dir: str) -> None:
+    """Set up a fresh rollout workdir. Idempotent — overwrites if exists.
+
+    Initializes a git repo inside the workdir so `git apply` works (which
+    pi will usually try). The model can also choose to use `patch` instead.
+    """
+    workdir = Path(dir)
+    if workdir.exists():
+        # Clear contents but keep the directory itself.
+        for child in workdir.iterdir():
+            if child.is_dir() and not child.is_symlink():
+                shutil.rmtree(child)
+            else:
+                child.unlink()
+    workdir.mkdir(parents=True, exist_ok=True)
+
+    # Write init files.
+    init_files: dict[str, str] = task.get("init_files") or {}
+    for rel, content in init_files.items():
+        p = workdir / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+
+    # Write the patch file the model will be told to apply.
+    patch_text: str = task.get("patch_text") or ""
+    (workdir / PATCH_FILENAME).write_text(patch_text)
+
+    # Write README to orient pi.
+    expected_repair = task.get("expected_repair", False)
+    repair_note = (
+        "The patch may not apply cleanly the first time — if `git apply` "
+        "rejects a hunk, read the file and fix the diff or apply the change "
+        "by hand."
+        if expected_repair
+        else "The patch should apply cleanly with `git apply`."
+    )
+    readme = (
+        f"# Task {task.get('task_id', '?')}\n\n"
+        f"Apply the patch in `{PATCH_FILENAME}` to this workspace, then run "
+        f"the tests until they pass.\n\n"
+        f"{repair_note}\n\n"
+        "Touched paths (per patch headers):\n"
+        + "\n".join(f"- {p}" for p in (task.get("touched_paths") or []))
+        + "\n\nVerify with:\n\n    "
+        + (task.get("verify_cmd") or "python3 -m pytest -q tests/")
+        + "\n"
+    )
+    (workdir / "README.md").write_text(readme)
+
+    # Initialize a git repo so `git apply` always has a working repo state.
+    # We init with -q and an initial commit on the buggy state — this gives
+    # `git apply --3way` something to anchor against.
+    try:
+        subprocess.run(
+            ["git", "init", "-q", "-b", "main"],
+            cwd=str(workdir),
+            check=False,
+            capture_output=True,
+            timeout=15,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "rollout@kiln.local"],
+            cwd=str(workdir), check=False, capture_output=True, timeout=5,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "kiln-rollout"],
+            cwd=str(workdir), check=False, capture_output=True, timeout=5,
+        )
+        subprocess.run(
+            ["git", "add", "-A", "--", ":!INCOMING_PATCH"],
+            cwd=str(workdir), check=False, capture_output=True, timeout=10,
+        )
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "initial"],
+            cwd=str(workdir), check=False, capture_output=True, timeout=10,
+        )
+    except Exception:
+        # git init failures are non-fatal — pi can still use `patch` or
+        # raw file edits via the edit tool.
+        pass
+
+
+def pi_prompt(task: dict) -> str:
+    """The user prompt pi sees. Keep it terse and concrete; don't reveal
+    the rubric or the gold files.
+    """
+    expected_repair = task.get("expected_repair", False)
+    repair_hint = (
+        " The patch may have minor offset issues or a subtle bug; if the first apply "
+        "fails or tests fail, read the relevant file and repair the change minimally."
+        if expected_repair
+        else " The patch should apply cleanly."
+    )
+    return (
+        f"Apply the unified diff in `{PATCH_FILENAME}` to this workspace, then run "
+        f"`{task.get('verify_cmd') or 'python3 -m pytest -q tests/'}` until all tests pass.\n\n"
+        "Steps:\n"
+        "1. Read INCOMING_PATCH to see what change is intended.\n"
+        "2. Apply it (try `git apply INCOMING_PATCH` or `patch -p1 < INCOMING_PATCH`).\n"
+        "3. Run the tests with the verify command.\n"
+        f"4. If a hunk rejects, read the affected source file, find the right anchor, and apply the change minimally.{repair_hint}\n"
+        "5. When all tests pass, emit a final message summarizing what you changed "
+        "and which files you touched. Do NOT modify the test files."
+    )
+
+
+def build_messages(task: dict) -> list[dict]:
+    """The system + user messages pi will see. Use this for the GrpoGroup
+    `messages` field in training rollouts."""
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are a meticulous coding assistant operating in a sandboxed "
+                "workspace. You have access to bash, write, read, and edit tools. "
+                "Apply patches minimally — do NOT rewrite functions when a "
+                "3-line edit will do. Always verify with the test command before "
+                "declaring done."
+            ),
+        },
+        {"role": "user", "content": pi_prompt(task)},
+    ]
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: task_scaffold.py <task.json|tasks.jsonl#N> <dir>", file=sys.stderr)
+        sys.exit(2)
+    spec = sys.argv[1]
+    out = sys.argv[2]
+    if "#" in spec:
+        path, idx = spec.split("#")
+        idx = int(idx)
+        with open(path) as f:
+            for i, line in enumerate(f):
+                if i == idx:
+                    task = json.loads(line)
+                    break
+            else:
+                raise SystemExit(f"no line {idx} in {path}")
+    else:
+        task = json.loads(Path(spec).read_text())
+    init_workdir(task, out)
+    print(f"scaffolded {out}")
+    print(json.dumps(build_messages(task), indent=2)[:500])

--- a/capabilities/caps/pi-doctest/rollout.py
+++ b/capabilities/caps/pi-doctest/rollout.py
@@ -37,7 +37,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 # Also import the shared agentic-grpo lib (one level up).
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 import rubric  # noqa: E402
 import task_scaffold  # noqa: E402
 import pi_trajectory  # noqa: E402

--- a/capabilities/caps/pi-doctest/task_scaffold.py
+++ b/capabilities/caps/pi-doctest/task_scaffold.py
@@ -1,0 +1,59 @@
+"""Initialize a single rollout's workdir from a task spec.
+
+A task spec is a dict:
+{
+  "task_id": str,
+  "function_signature": "def foo(x: int) -> int:\n    \"\"\"docstring with doctests\"\"\"\n",
+  "imports": "from typing import List, Tuple\n",   # optional
+}
+
+`init_workdir(task, dir)` writes:
+  <dir>/solution.py     stub function with `raise NotImplementedError`
+  <dir>/README.md       one-line task description for pi to read
+
+The pi prompt itself is built by `pi_prompt(task)`.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def init_workdir(task: dict, dir: str) -> None:
+    dir = Path(dir)
+    dir.mkdir(parents=True, exist_ok=True)
+    imports = task.get("imports", "")
+    sig = task["function_signature"]
+    stub = f"{imports}\n{sig}    raise NotImplementedError\n"
+    (dir / "solution.py").write_text(stub)
+    (dir / "README.md").write_text(
+        "Replace the function body in solution.py so its doctests pass.\n"
+        "Then run `python3 -m doctest -v solution.py` to verify.\n"
+    )
+
+
+def pi_prompt(task: dict) -> str:
+    return (
+        "In the file `solution.py` there is a stub Python function with a "
+        "docstring containing doctest examples. Replace the function body "
+        "so the doctests pass.\n\n"
+        "Steps:\n"
+        "1. Read solution.py to see the function signature and doctests.\n"
+        "2. Use the `edit` or `write` tool to replace the function body with "
+        "a correct implementation.\n"
+        "3. Run `python3 -m doctest -v solution.py` via the `bash` tool.\n"
+        "4. If all items pass (no failures), reply with a single word `DONE` "
+        "and end the session.\n\n"
+        "Constraint: do not modify the function signature or the docstring. "
+        "Only the function body should change."
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: task_scaffold.py <task.json> <dir>", file=sys.stderr)
+        sys.exit(2)
+    task = json.loads(Path(sys.argv[1]).read_text())
+    init_workdir(task, sys.argv[2])
+    print(f"scaffolded {sys.argv[2]}")

--- a/capabilities/caps/pi-error-recovery/rollout.py
+++ b/capabilities/caps/pi-error-recovery/rollout.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 
 # Make the shared lib importable for canonical pi → trajectory rendering.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 try:
     from pi_trajectory import session_to_trajectory  # type: ignore
 except ImportError:

--- a/capabilities/caps/pi-failure-triage/task_scaffold.py
+++ b/capabilities/caps/pi-failure-triage/task_scaffold.py
@@ -1,0 +1,81 @@
+"""Task scaffold: write a single rollout's workdir from a task spec.
+
+A task spec is a dict:
+{
+  "task_id": str,
+  "description": str,              # one-liner for the agent prompt
+  "workspace_files": { rel: str }, # the buggy workspace (visible)
+  "visible_test_cmd": [argv...],   # how to run the visible test
+  "held_out_test_path": str,       # relative path; written ONLY at oracle time
+  "held_out_test_content": str,    # the held-out test content
+  "held_out_test_cmd": [argv...],  # how to run held-out (after mount)
+  "gold_fix_region": {"file": str, "function": str, "module": str},
+  "expected_diff_lines": int,
+  "test_timeout_s": int            # optional override
+}
+
+`init_workdir(task, dir)` writes the visible workspace into `dir`. The
+held-out test is NOT written; it's only materialized by the rubric at
+scoring time.
+
+The pi prompt itself is built by `pi_prompt(task)` from the task's
+`description` field and a fixed scaffold.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def init_workdir(task: dict, dir: str) -> None:
+    """Materialize the visible workspace files into `dir`."""
+    root = Path(dir)
+    root.mkdir(parents=True, exist_ok=True)
+    files = task.get("workspace_files") or {}
+    for rel, content in files.items():
+        if not isinstance(rel, str) or not isinstance(content, str):
+            continue
+        out = root / rel
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(content)
+
+
+def pi_prompt(task: dict) -> str:
+    desc = task.get("description", "There is a bug in this project. Fix it.")
+    test_hint = " ".join(task.get("visible_test_cmd", ["pytest", "-x"]))
+    return (
+        f"This project has a failing test that exposes a bug. {desc}\n\n"
+        "Steps:\n"
+        "1. Read the source files in this directory to understand the code.\n"
+        f"2. Reproduce the failure by running: `{test_hint}`\n"
+        "3. Identify the ROOT CAUSE — not just the line that throws. Symptom\n"
+        "   fixes (wrapping calls in `try/except`, hardcoded values, or\n"
+        "   suppressing the error) will not satisfy the success criteria;\n"
+        "   the fix must address the actual underlying behavior so similar\n"
+        "   inputs behave correctly.\n"
+        "4. Edit the source file (NOT the test file) to fix the bug.\n"
+        f"5. Re-run `{test_hint}` to verify the test now passes.\n"
+        "6. End by emitting a single line of the form:\n"
+        "      Fix: <relative_path>::<function_name>: <one-line root cause>\n"
+        "   then exit the session.\n\n"
+        "Constraints:\n"
+        "- Do NOT modify any file under `tests/`. The test is the spec.\n"
+        "- Do NOT use blanket `except Exception:` / `except:`. They suppress\n"
+        "  signal.\n"
+        "- Do NOT add `# noqa`, `# type: ignore`, or `# pragma: no cover`.\n"
+        "- Do NOT change pyproject.toml / requirements.txt / Cargo.toml.\n"
+        "- Keep the diff minimal — change only what's necessary to fix the\n"
+        "  root cause.\n"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("usage: task_scaffold.py <task.json> <dir>", file=sys.stderr)
+        sys.exit(2)
+    task = json.loads(Path(sys.argv[1]).read_text())
+    init_workdir(task, sys.argv[2])
+    print(f"scaffolded {sys.argv[2]}")

--- a/capabilities/caps/pi-incremental-progress/rollout.py
+++ b/capabilities/caps/pi-incremental-progress/rollout.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 
 # Make the shared lib importable for canonical pi → trajectory rendering.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 try:
     from pi_trajectory import session_to_trajectory  # type: ignore
 except ImportError:

--- a/capabilities/caps/pi-precondition-check/rollout.py
+++ b/capabilities/caps/pi-precondition-check/rollout.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 
 # Make the shared lib importable for canonical pi → trajectory rendering.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 try:
     from pi_trajectory import session_to_trajectory  # type: ignore
 except ImportError:

--- a/capabilities/caps/pi-script-fixup/rollout.py
+++ b/capabilities/caps/pi-script-fixup/rollout.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 
 # Make the shared lib importable for canonical pi → trajectory rendering.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 try:
     from pi_trajectory import session_to_trajectory  # type: ignore
 except ImportError:

--- a/capabilities/caps/pi-search-then-read/rollout.py
+++ b/capabilities/caps/pi-search-then-read/rollout.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 
 # Make the shared lib importable for canonical pi → trajectory rendering.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 try:
     from pi_trajectory import session_to_trajectory  # type: ignore
 except ImportError:

--- a/capabilities/caps/pi-shell-hygiene/rollout.py
+++ b/capabilities/caps/pi-shell-hygiene/rollout.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 
 # Make the shared lib importable for canonical pi → trajectory rendering.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 try:
     from pi_trajectory import session_to_trajectory  # type: ignore
 except ImportError:

--- a/capabilities/caps/pi-source-mod-workflow/rollout.py
+++ b/capabilities/caps/pi-source-mod-workflow/rollout.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 
 # Make the shared lib importable for canonical pi → trajectory rendering.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 try:
     from pi_trajectory import session_to_trajectory  # type: ignore
 except ImportError:

--- a/capabilities/caps/pi-terminal-bench-lite/task_scaffold.py
+++ b/capabilities/caps/pi-terminal-bench-lite/task_scaffold.py
@@ -1,0 +1,63 @@
+"""Initialize a fresh workdir for one TBLite-style task and emit the pi
+prompt that scaffolds the model toward the task.
+
+A task spec (in datasets/train.tasks.jsonl) looks like:
+
+    {
+      "task_id": "tblite-0042",
+      "category": "data_processing",
+      "scaffold_files": {
+        "input.csv": "name,age\\nalice,30\\nbob,25\\n",
+        "README.md": "Filter rows where age > 26 and write to output.csv"
+      },
+      "user_prompt": "Read input.csv and write rows with age > 26 to output.csv.",
+      "verifier": "diff -q output.csv expected.csv",
+      "verifier_timeout_s": 30,
+      "expected_files": {
+        "expected.csv": "name,age\\nalice,30\\n"
+      }
+    }
+
+Hidden expected_files are written to the workdir AFTER pi exits so the
+verifier can compare. The model sees only the scaffold_files +
+user_prompt; the verifier files are off-limits to it.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def init_workdir(task: dict, workdir: Path) -> None:
+    """Materialize scaffold files. Returns nothing; the workdir is
+    populated in place."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    for rel_path, content in (task.get("scaffold_files") or {}).items():
+        target = workdir / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            target.write_bytes(content)
+        else:
+            target.write_text(content)
+
+
+def post_rollout_setup(task: dict, workdir: Path) -> None:
+    """After pi exits, write any hidden expected_files so the verifier
+    can compare. Called by rollout.py just before invoking the
+    verifier."""
+    for rel_path, content in (task.get("expected_files") or {}).items():
+        target = workdir / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if isinstance(content, bytes):
+            target.write_bytes(content)
+        else:
+            target.write_text(content)
+
+
+def pi_prompt(task: dict) -> str:
+    """Build the user prompt pi sees."""
+    base = task.get("user_prompt", "").strip()
+    extra = task.get("extra_context", "").strip()
+    if extra:
+        return f"{base}\n\n{extra}"
+    return base

--- a/capabilities/caps/pi-test-interpretation/rollout.py
+++ b/capabilities/caps/pi-test-interpretation/rollout.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 
 # Make the shared lib importable for canonical pi → trajectory rendering.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 try:
     from pi_trajectory import session_to_trajectory  # type: ignore
 except ImportError:

--- a/capabilities/caps/pi-tool-call-efficiency/rollout.py
+++ b/capabilities/caps/pi-tool-call-efficiency/rollout.py
@@ -26,7 +26,7 @@ import time
 from pathlib import Path
 
 # Make the shared lib importable for canonical pi → trajectory rendering.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "lib"))
 try:
     from pi_trajectory import session_to_trajectory  # type: ignore
 except ImportError:

--- a/capabilities/lib/pod_bootstrap.sh
+++ b/capabilities/lib/pod_bootstrap.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# pod_bootstrap.sh — one-stop bootstrap for capability iters on a fresh
+# `ghcr.io/ericflo/kiln-runpod:latest` pod.
+#
+# Source this from your iter script (or its outer wrapper) BEFORE invoking
+# any cap run_iter.sh / stage_*.sh. It paves over the gaps between what the
+# kiln-runpod image ships and what the capability scripts assume.
+#
+# Discovered traps (2026-05-23 round-3 pi-code-comprehension session):
+#   1. B2 creds: pool doesn't propagate $B2_APPLICATION_KEY_ID/_KEY; need to
+#      either pass inline or accept the AWS_* shape that kiln-setup writes to
+#      /root/.kiln-build-env.
+#   2. pi binary: NOT in the kiln-runpod image. Must be installed via
+#      `npm install -g --ignore-scripts @earendil-works/pi-coding-agent`.
+#   3. Node version: Pi (undici dep) needs Node 21+. Default nodesource setup
+#      gives Node 20 which crashes with `markAsUncloneable is not a function`.
+#      Install Node 22 instead.
+#   4. cargo --examples: the kiln-runpod image only builds `--bin kiln --bin
+#      kiln-bench` by default; cuda_sft_file / cuda_grpo_ablation /
+#      cuda_opd_remote live under `target/release/examples/` and must be
+#      explicitly built with `--examples`.
+#   5. Issue #1066 sccache corruption: SCCACHE_RECACHE=1 alone is not enough;
+#      need to also `rm -rf target/` so cargo re-evaluates every crate. Only
+#      then does sccache reupload fresh objects.
+#   6. VRAM contention: `kiln serve` reserves ~40GB for KV cache by default,
+#      leaving only ~11GB for training. Kill kiln serve before SFT/OPD/GRPO,
+#      restart after.
+#   7. SFT long-seq OOM: cuda_sft_file with sequences >500 tokens needs
+#      KILN_CUDA_RECOMPUTE_SFT=1 (layerwise reverse-recompute, opt-in).
+#   8. Trainer flag inconsistencies:
+#        - cuda_sft_file:        --model-path / --output-dir / --adapter-name
+#        - cuda_grpo_ablation:   --model      / --output     / --adapter
+#        - cuda_opd_remote:      --model-path / --output-dir / --adapter-name
+#                                --teacher-model (NOT --teacher-name)
+#                                --data       (NOT --prompts)
+#      None of the three SFT/OPD trainers support --seed, --dry-run,
+#      --install-adapter-{dir,name}, --adapter-smoke-test.
+#
+# Usage:
+#   # Source the helper, then call the functions you need:
+#   . /workspace/kiln/capabilities/lib/pod_bootstrap.sh
+#
+#   pod_install_pi              # idempotent: Node 22 + pi-coding-agent
+#   pod_build_kiln              # builds kiln binary + examples (release/cuda)
+#   pod_heal_sccache            # rm -rf target && SCCACHE_RECACHE=1 cargo build
+#   pod_kill_kiln_serve         # stop the inference server (VRAM)
+#   pod_start_kiln_serve        # start kiln serve --eval-mode + wait /v1/health
+#   pod_export_b2_creds         # map AWS_* → B2_APPLICATION_KEY_ID/_KEY
+
+# Source kiln-setup's env file if present (gives CARGO_HOME, SCCACHE_*, AWS_*).
+[ -f /root/.kiln-build-env ] && source /root/.kiln-build-env
+
+# Map AWS_* → B2_APPLICATION_KEY_ID/_KEY (b2 CLI shape).
+pod_export_b2_creds() {
+  : "${B2_APPLICATION_KEY_ID:=${AWS_ACCESS_KEY_ID:-}}"
+  : "${B2_APPLICATION_KEY:=${AWS_SECRET_ACCESS_KEY:-}}"
+  export B2_APPLICATION_KEY_ID B2_APPLICATION_KEY
+  if [ -z "${B2_APPLICATION_KEY_ID}" ] || [ -z "${B2_APPLICATION_KEY}" ]; then
+    echo "WARN: B2 creds unavailable; b2 downloads will require interactive auth" >&2
+    return 1
+  fi
+  return 0
+}
+
+# Install Node 22 + pi (npm published package) if not already present.
+pod_install_pi() {
+  if command -v pi >/dev/null 2>&1 && pi --version >/dev/null 2>&1; then
+    echo "pi already installed: $(pi --version 2>&1 | head -1)"
+    return 0
+  fi
+  local node_major
+  node_major=$(node --version 2>/dev/null | sed 's/^v//;s/\..*//')
+  if [ -z "$node_major" ] || [ "$node_major" -lt 22 ]; then
+    echo "Installing Node 22 via nodesource…"
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
+    apt-get install -y nodejs
+  fi
+  echo "Installing @earendil-works/pi-coding-agent globally…"
+  npm install -g --ignore-scripts @earendil-works/pi-coding-agent@latest
+  pi --version 2>&1 | head -1
+}
+
+# Build kiln + examples (release, cuda). Idempotent; skips if up to date.
+pod_build_kiln() {
+  local kiln_repo="${KILN_REPO:-/workspace/kiln}"
+  if [ ! -d "$kiln_repo" ]; then
+    echo "FATAL: kiln repo not at $kiln_repo" >&2
+    return 2
+  fi
+  cd "$kiln_repo"
+  KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" cargo build --release --features cuda \
+    --bin kiln --bin kiln-bench --examples
+}
+
+# Heal the sccache after issue #1066. Use this when chat-completion returns
+# HTTP 500 `batched-engine prefill forward pass failed`.
+pod_heal_sccache() {
+  local kiln_repo="${KILN_REPO:-/workspace/kiln}"
+  pod_kill_kiln_serve
+  cd "$kiln_repo"
+  echo "Nuking target/ and rebuilding with SCCACHE_RECACHE=1 (forces fresh nvcc + re-upload)…"
+  rm -rf target
+  KILN_CUDA_ARCHS="${KILN_CUDA_ARCHS:-86}" SCCACHE_RECACHE=1 cargo build \
+    --release --features cuda --bin kiln --bin kiln-bench --examples
+}
+
+pod_kill_kiln_serve() {
+  pkill -f "kiln serve" 2>/dev/null || true
+  sleep 2
+}
+
+# Start kiln serve --eval-mode and wait until /v1/health returns OK.
+# Args: $1 = optional adapter-dir override (default /workspace/adapters)
+pod_start_kiln_serve() {
+  local adapter_dir="${1:-/workspace/adapters}"
+  local model_path="${KILN_MODEL_PATH:-/workspace/Qwen3.5-4B}"
+  local log="${KILN_SERVE_LOG:-/workspace/kiln-serve.log}"
+  KILN_MODEL_PATH="$model_path" KILN_ADAPTER_DIR="$adapter_dir" \
+    nohup /workspace/kiln/target/release/kiln serve --eval-mode > "$log" 2>&1 &
+  for i in $(seq 1 60); do
+    curl -sf http://localhost:8420/v1/health > /dev/null 2>&1 && {
+      echo "kiln serve up after ${i}s"
+      return 0
+    }
+    sleep 1
+  done
+  echo "FATAL: kiln serve did not come up in 60s; tail of $log:" >&2
+  tail -30 "$log" >&2
+  return 3
+}


### PR DESCRIPTION
## Summary

Cross-cap audit triggered by the round-3 pi-code-comprehension session. Every cap that uses pi multi-turn rollouts has been broken since the round-2 directory normalization, and the SFT/OPD `run_iter.sh` templates referenced flags that don't exist on the trainer binaries.

### Bugs fixed

| Bug | Caps affected | Symptom on fresh pod |
|---|---|---|
| `rollout.py` lib import off by one `.parent` | **14** (all pi-* + pi-diff-patch-apply) | `ModuleNotFoundError: No module named 'pi_trajectory'`, all rollouts score 0 |
| `task_scaffold.py` only in `archive/` | **6** (pi-code-comprehension, pi-code-search, pi-diff-patch-apply, pi-doctest, pi-failure-triage, pi-terminal-bench-lite) | `ModuleNotFoundError: No module named 'task_scaffold'` |
| `cuda_sft_file` called with `--model` / `--output` / `--adapter` / `--seed` / `--dry-run` / `--adapter-smoke-test` / `--install-adapter-*` — none exist | **2** (json-schema-adherence, math-broad) | `Error: unknown argument --model` |
| `cuda_opd_remote` called with `--prompts` / `--model` / `--output` / `--adapter` / `--teacher-name` / `--seed` / `--dry-run` / `--install-adapter-*` — none exist | **4** (code-fence-language-fidelity, code-symbol-extraction, diff-patch-fluency, faithful-code-summarization) | `Error: unknown argument --prompts` |

The three SFT/OPD/GRPO trainers have inconsistent flag names: `cuda_sft_file` and `cuda_opd_remote` use `--model-path` / `--output-dir` / `--adapter-name`, but `cuda_grpo_ablation` uses `--model` / `--output` / `--adapter`. Only `cuda_grpo_ablation` supports `--seed`, `--dry-run`, `--adapter-smoke-test`, `--install-adapter-{dir,name}`. The run_iter.sh templates appear to have been written assuming uniformity that doesn't exist in the binaries.

### New shared helper: `capabilities/lib/pod_bootstrap.sh`

Sourceable from any iter script. Provides:

- `pod_install_pi` — installs Node 22 (pi requires Node 21+, default nodesource gives 20 which crashes with `webidl.util.markAsUncloneable is not a function`) and `npm install -g --ignore-scripts @earendil-works/pi-coding-agent@latest`.
- `pod_build_kiln` — builds `--bin kiln --bin kiln-bench --examples` so the SFT/OPD/GRPO trainers land under `target/release/examples/`. The kiln-runpod image only builds `--bin kiln --bin kiln-bench` by default; caps that use the trainers must add `--examples`.
- `pod_heal_sccache` — the canonical issue #1066 fix. `SCCACHE_RECACHE=1` alone is not enough; `rm -rf target/` must run first so cargo re-evaluates every crate, then sccache reuploads fresh objects. Verified by reproducing the bug at multiple SHAs, confirming the bug is purely in B2 sccache (not in any kiln-main commit), and that `rm -rf target && SCCACHE_RECACHE=1 cargo build --release --features cuda --bin kiln --bin kiln-bench --examples` fully heals it.
- `pod_kill_kiln_serve` / `pod_start_kiln_serve` — VRAM management. `kiln serve` reserves ~40GB for KV cache by default, leaving only ~11GB for training. SFT must kill kiln serve first, restart after.
- `pod_export_b2_creds` — maps `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` (the shape kiln-setup writes to `/root/.kiln-build-env`) into `B2_APPLICATION_KEY_ID` / `B2_APPLICATION_KEY` for the `b2` CLI.

### `KILN_CUDA_RECOMPUTE_SFT=1` is now the default in SFT scripts

`cuda_sft_file` with sequences >500 tokens OOMs on A6000 without layerwise reverse-recompute. Setting `KILN_CUDA_RECOMPUTE_SFT=1` in the SFT run_iter.sh templates avoids this; cost is ~20% wall-clock slowdown vs full activation caching.

### What is NOT in this PR

- The pi-code-comprehension round-3 stage work (stage_1_baseline.sh, stage_2_sft_ideal.sh, prep_sft_ideal.py, stages/*.json) — those are cap-specific R3 artifacts, not setup-trap fixes, and will land separately when round-3 closes out.
- A pi binary baked into the kiln-runpod Docker image. The npm install inside `pod_install_pi` is the runtime workaround; a proper fix would add pi (Node 22 + `@earendil-works/pi-coding-agent`) to `deploy/runpod/Dockerfile`. Filing as a separate follow-up since the Docker image change has its own CI surface.

## Test plan

- [x] All 14 fixed `rollout.py` imports parse + import correctly via `python3 -c 'import rollout, rubric, task_scaffold, pi_trajectory'`
- [x] All 6 rewritten `run_iter.sh` files pass `bash -n` syntax check
- [x] Trainer CLI flag names cross-referenced against `crates/kiln-train/examples/{cuda_sft_file,cuda_grpo_ablation,cuda_opd_remote}.rs`
- [ ] One agentic cap iter end-to-end on a fresh pod (pi-code-comprehension stage-1 baseline already validated as a side effect of the discovery session — 36/36 non-zero rollouts after the fixes vs 0/36 before)
- [ ] One SFT cap iter end-to-end on a fresh pod
- [ ] One OPD cap iter end-to-end on a fresh pod