### PR TITLE
phase 0.2: audit CustomOpN call sites + propose kiln-tensor DeviceOp shape (#1082)

### DIFF
--- a/bench-results/customop-audit.csv
+++ b/bench-results/customop-audit.csv
@@ -1,0 +1,16 @@
+impl_name,op_arity,file,line,crate,has_cpu_fwd,has_cuda_fwd,has_metal_fwd,has_bwd,body_lines,proposed_kiln_tensor_shape
+FlceCustomOp,1,crates/kiln-flce-kernel/src/phase_b.rs,185,kiln-flce-kernel,yes,yes,yes,yes,115,fwd+bwd-closure
+GdnGateBetaOp,1,crates/kiln-gdn-kernel/src/lib.rs,1821,kiln-gdn-kernel,yes,yes,no,no,51,closure-only
+GdnGateGOp,3,crates/kiln-gdn-kernel/src/lib.rs,1876,kiln-gdn-kernel,yes,yes,no,no,72,closure-only
+VulkanLinearOp,1,crates/kiln-model/src/backend/vulkan_linear_op.rs,180,kiln-model,yes,no,no,yes,330,fwd+bwd-closure
+VulkanLoraOp,3,crates/kiln-model/src/backend/vulkan_lora_op.rs,67,kiln-model,yes,no,no,yes,220,fwd+bwd-closure
+CudaLoraAddF32,3,crates/kiln-model/src/forward.rs,801,kiln-model,yes,yes,no,yes,97,fwd+bwd-closure
+CudaLoraLinearBf16,3,crates/kiln-model/src/forward.rs,923,kiln-model,yes,yes,no,yes,209,fwd+bwd-closure
+CudaLoraAddBf16,3,crates/kiln-model/src/forward.rs,1134,kiln-model,yes,yes,no,yes,128,fwd+bwd-closure
+CudaSigmoidMulTrainingBf16,2,crates/kiln-model/src/forward.rs,1390,kiln-model,yes,yes,no,yes,156,fwd+bwd-closure
+CudaFlashAttentionTrainingBf16,3,crates/kiln-model/src/forward.rs,1790,kiln-model,yes,yes,no,yes,110,fwd+bwd-closure
+VulkanRmsNormOp,1,crates/kiln-model/src/forward.rs,4484,kiln-model,yes,no,no,yes,98,fwd+bwd-closure
+CudaRotaryOneBf16,3,crates/kiln-model/src/forward.rs,5116,kiln-model,yes,yes,no,yes,113,fwd+bwd-closure
+OpdLossCustomOp,1,crates/kiln-opd-loss-kernel/src/phase_b.rs,316,kiln-opd-loss-kernel,yes,yes,no,yes,104,fwd+bwd-closure
+RmsNormCustomOp,2,crates/kiln-rmsnorm-kernel/src/lib.rs,812,kiln-rmsnorm-kernel,yes,yes,no,yes,153,fwd+bwd-closure
+InjectTensorGradient,1,crates/kiln-train/src/trainer.rs,7599,kiln-train,yes,yes,no,yes,49,fwd+bwd-closure

--- a/bench-results/customop-audit.md
+++ b/bench-results/customop-audit.md
@@ -1,0 +1,75 @@
+# Phase 0.2 — CustomOpN audit
+
+Sources of truth:
+
+- `bench-results/customop-audit.csv` — 15 `impl CustomOpN` blocks
+
+Regenerate: `scripts/audit-customop.py`.
+
+Why this audit
+--------------
+
+candle's `CustomOp1` / `CustomOp2` / `CustomOp3` trait is the fifth (and largest unlisted) candle subsystem the migration must replace. Every fused kernel crate — `kiln-flce-kernel`, `kiln-opd-loss-kernel`, `kiln-gdn-kernel`, `kiln-rmsnorm-kernel`, `kiln-conv1d-kernel` — plugs into it for per-backend dispatch plus optional `bwd`. If the kiln-tensor `Op` shape is not defined before Phase 1 lands, the kernels port twice: once for the forward path and again for the backward.
+
+## Per-crate breakdown
+
+| crate | impls | has bwd | only cuda fwd | only metal fwd | all-backend |
+|---|---:|---:|---:|---:|---:|
+| kiln-flce-kernel | 1 | 1 | 0 | 0 | 1 |
+| kiln-gdn-kernel | 2 | 0 | 0 | 0 | 0 |
+| kiln-model | 9 | 9 | 0 | 0 | 0 |
+| kiln-opd-loss-kernel | 1 | 1 | 0 | 0 | 0 |
+| kiln-rmsnorm-kernel | 1 | 1 | 0 | 0 | 0 |
+| kiln-train | 1 | 1 | 0 | 0 | 0 |
+
+## All impls
+
+| impl | arity | crate | file:line | bwd? | cpu/cuda/metal fwd | proposed shape |
+|---|---:|---|---|:-:|:-:|---|
+| `FlceCustomOp` | 1 | kiln-flce-kernel | crates/kiln-flce-kernel/src/phase_b.rs:185 | yes | `cum` | fwd+bwd-closure |
+| `GdnGateBetaOp` | 1 | kiln-gdn-kernel | crates/kiln-gdn-kernel/src/lib.rs:1821 | no | `cu-` | closure-only |
+| `GdnGateGOp` | 3 | kiln-gdn-kernel | crates/kiln-gdn-kernel/src/lib.rs:1876 | no | `cu-` | closure-only |
+| `VulkanLinearOp` | 1 | kiln-model | crates/kiln-model/src/backend/vulkan_linear_op.rs:180 | yes | `c--` | fwd+bwd-closure |
+| `VulkanLoraOp` | 3 | kiln-model | crates/kiln-model/src/backend/vulkan_lora_op.rs:67 | yes | `c--` | fwd+bwd-closure |
+| `CudaLoraAddF32` | 3 | kiln-model | crates/kiln-model/src/forward.rs:801 | yes | `cu-` | fwd+bwd-closure |
+| `CudaLoraLinearBf16` | 3 | kiln-model | crates/kiln-model/src/forward.rs:923 | yes | `cu-` | fwd+bwd-closure |
+| `CudaLoraAddBf16` | 3 | kiln-model | crates/kiln-model/src/forward.rs:1134 | yes | `cu-` | fwd+bwd-closure |
+| `CudaSigmoidMulTrainingBf16` | 2 | kiln-model | crates/kiln-model/src/forward.rs:1390 | yes | `cu-` | fwd+bwd-closure |
+| `CudaFlashAttentionTrainingBf16` | 3 | kiln-model | crates/kiln-model/src/forward.rs:1790 | yes | `cu-` | fwd+bwd-closure |
+| `VulkanRmsNormOp` | 1 | kiln-model | crates/kiln-model/src/forward.rs:4484 | yes | `c--` | fwd+bwd-closure |
+| `CudaRotaryOneBf16` | 3 | kiln-model | crates/kiln-model/src/forward.rs:5116 | yes | `cu-` | fwd+bwd-closure |
+| `OpdLossCustomOp` | 1 | kiln-opd-loss-kernel | crates/kiln-opd-loss-kernel/src/phase_b.rs:316 | yes | `cu-` | fwd+bwd-closure |
+| `RmsNormCustomOp` | 2 | kiln-rmsnorm-kernel | crates/kiln-rmsnorm-kernel/src/lib.rs:812 | yes | `cu-` | fwd+bwd-closure |
+| `InjectTensorGradient` | 1 | kiln-train | crates/kiln-train/src/trainer.rs:7599 | yes | `cu-` | fwd+bwd-closure |
+
+## Proposed kiln-tensor shape
+
+The kiln-tensor equivalent the kernels can port onto **once**:
+
+```rust
+// kiln-tensor crate.
+pub trait DeviceOp: Send + Sync {
+    /// Arity is fixed at the impl: `DeviceOp1` / `DeviceOp2` / `DeviceOp3`.
+    /// Each per-backend method returns Option<...>; None means the op falls
+    /// back to the next backend in the device's preference order, matching
+    /// today's BackendRuntime contract.
+    fn name(&self) -> &'static str;
+    fn cpu_fwd  (&self, ...) -> Result<Option<Tensor>>;
+    fn cuda_fwd (&self, ...) -> Result<Option<Tensor>>;
+    fn metal_fwd(&self, ...) -> Result<Option<Tensor>>;
+    fn vulkan_fwd(&self, ...) -> Result<Option<Tensor>>;
+    /// Optional backward closure; absence == forward-only kernel.
+    /// The boxed closure carries its own captured tensors;
+    /// `kiln_autograd::BackwardOp::register` records the closure on
+    /// the tape with the source tensor's TensorId.
+    fn bwd(&self) -> Option<Box<dyn BackwardOp>>;
+}
+```
+
+Three migration shapes (column `proposed_kiln_tensor_shape` in the CSV):
+
+- `closure-only` — forward-only ops without `bwd`. Becomes a plain device-method on `kiln_tensor::Tensor`. Migration is mechanical.
+- `fwd+bwd-closure` — has `bwd`. Becomes a `kiln_tensor::DeviceOp` plus a `kiln_autograd::BackwardOp` impl. The Vulkan path's `VkBackwardOp` (`vk_ops/`) is the lift template — 34 `impl VkBackwardOp for ...` blocks already follow this shape.
+- `static-tape-op` — the existing bwd already routes through `candle_core::backprop::BackpropOp`. The tape op becomes a `kiln_autograd::Op` enum variant; the `bwd` method is its `apply` impl.
+
+The audit is the input to Phase 1's `DeviceOp` API design and to Phase 6a's `kiln-autograd` crate skeleton.

--- a/scripts/audit-customop.py
+++ b/scripts/audit-customop.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""
+Phase 0.2 — CustomOpN audit.
+
+The Vulkan-removed-from-this-issue's fifth candle subsystem: every fused
+kernel crate plugs into candle's `CustomOp1` / `CustomOp2` / `CustomOp3`
+trait, providing per-backend `cpu_fwd` / `cuda_fwd` / `metal_fwd`
+implementations plus an optional `bwd`. The migration design must define
+the kiln-tensor equivalent (forward closure + backward closure with
+explicit `BackwardOp` registration) BEFORE Phase 1 lands or the kernels
+port twice.
+
+This script walks the `impl Custom{Op1,Op2,Op3}` blocks under `crates/`
+and writes a structural table:
+
+    bench-results/customop-audit.csv:
+        impl_name, op_arity, file, line, crate, has_cpu_fwd, has_cuda_fwd,
+        has_metal_fwd, has_bwd, proposed_kiln_tensor_shape
+
+    bench-results/customop-audit.md:
+        per-impl interpretation + the proposed kiln-tensor design
+
+The "proposed_kiln_tensor_shape" column is the migration-shape proposal:
+
+- `closure-only` — forward-only ops (no `bwd`); become a plain device-method.
+- `fwd+bwd-closure` — has `bwd`; becomes a `kiln_tensor::Op { fwd, bwd }`
+  pair registered with the `BackwardOp` trait.
+- `static-tape-op` — the bwd already names an explicit op handle on the
+  backprop graph; lifts directly to `kiln_autograd::BackwardOp` enum
+  variant.
+"""
+
+import csv
+import os
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def audit(repo_root: Path):
+    impls = []
+    for path in (repo_root / "crates").rglob("*.rs"):
+        rel = path.relative_to(repo_root)
+        if "target" in rel.parts:
+            continue
+        if "vendor" in rel.parts:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        lines = text.splitlines()
+        for i, line in enumerate(lines, 1):
+            m = re.search(
+                r"\bimpl\s+(?:candle_core::)?(?:CustomOp([123]))\s+for\s+([A-Za-z_][A-Za-z0-9_<>'\,\s]*?)\s*\{",
+                line,
+            )
+            if not m:
+                continue
+            arity = int(m.group(1))
+            impl_name = m.group(2).strip().rstrip("<>'").split("<", 1)[0]
+            # Walk forward to the matching closing brace at depth 0.
+            depth = 1
+            start = i
+            j = i
+            body = [line]
+            while j < len(lines) and depth > 0:
+                nxt = lines[j]
+                j += 1
+                depth += nxt.count("{") - nxt.count("}")
+                if depth == 0:
+                    body.append(nxt)
+                    break
+                body.append(nxt)
+            block = "\n".join(body)
+            crate = rel.parts[1] if rel.parts[0] == "crates" and len(rel.parts) > 2 else "(other)"
+            impls.append({
+                "impl_name": impl_name,
+                "op_arity": arity,
+                "file": str(rel),
+                "line": start,
+                "crate": crate,
+                "has_cpu_fwd":   "fn cpu_fwd" in block,
+                "has_cuda_fwd":  "fn cuda_fwd" in block,
+                "has_metal_fwd": "fn metal_fwd" in block,
+                "has_bwd":       "fn bwd" in block,
+                "body_lines":    len(body),
+            })
+    return impls
+
+
+def proposed_shape(impl):
+    if not impl["has_bwd"]:
+        return "closure-only"
+    if "BackpropOp" in impl["impl_name"]:
+        return "static-tape-op"
+    return "fwd+bwd-closure"
+
+
+def main():
+    repo_root = Path(__file__).resolve().parents[1]
+    out_dir = repo_root / "bench-results"
+    out_dir.mkdir(exist_ok=True)
+    csv_path = out_dir / "customop-audit.csv"
+    md_path = out_dir / "customop-audit.md"
+
+    impls = audit(repo_root)
+    impls.sort(key=lambda r: (r["crate"], r["file"], r["line"]))
+
+    with csv_path.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow([
+            "impl_name", "op_arity", "file", "line", "crate",
+            "has_cpu_fwd", "has_cuda_fwd", "has_metal_fwd", "has_bwd",
+            "body_lines", "proposed_kiln_tensor_shape",
+        ])
+        for r in impls:
+            w.writerow([
+                r["impl_name"], r["op_arity"], r["file"], r["line"], r["crate"],
+                "yes" if r["has_cpu_fwd"] else "no",
+                "yes" if r["has_cuda_fwd"] else "no",
+                "yes" if r["has_metal_fwd"] else "no",
+                "yes" if r["has_bwd"] else "no",
+                r["body_lines"], proposed_shape(r),
+            ])
+
+    by_crate = defaultdict(list)
+    for r in impls:
+        by_crate[r["crate"]].append(r)
+
+    with md_path.open("w", encoding="utf-8") as f:
+        f.write("# Phase 0.2 — CustomOpN audit\n\n")
+        f.write(
+            "Sources of truth:\n\n"
+            f"- `bench-results/customop-audit.csv` — {len(impls)} `impl CustomOpN` blocks\n\n"
+            "Regenerate: `scripts/audit-customop.py`.\n\n"
+            "Why this audit\n--------------\n\n"
+            "candle's `CustomOp1` / `CustomOp2` / `CustomOp3` trait is the fifth "
+            "(and largest unlisted) candle subsystem the migration must replace. "
+            "Every fused kernel crate — `kiln-flce-kernel`, `kiln-opd-loss-kernel`, "
+            "`kiln-gdn-kernel`, `kiln-rmsnorm-kernel`, `kiln-conv1d-kernel` — "
+            "plugs into it for per-backend dispatch plus optional `bwd`. "
+            "If the kiln-tensor `Op` shape is not defined before Phase 1 lands, "
+            "the kernels port twice: once for the forward path and again for "
+            "the backward.\n\n"
+        )
+
+        f.write("## Per-crate breakdown\n\n")
+        f.write("| crate | impls | has bwd | only cuda fwd | only metal fwd | all-backend |\n")
+        f.write("|---|---:|---:|---:|---:|---:|\n")
+        for crate, rs in sorted(by_crate.items()):
+            has_bwd = sum(1 for r in rs if r["has_bwd"])
+            only_cuda = sum(
+                1 for r in rs
+                if r["has_cuda_fwd"] and not r["has_metal_fwd"] and not r["has_cpu_fwd"]
+            )
+            only_metal = sum(
+                1 for r in rs
+                if r["has_metal_fwd"] and not r["has_cuda_fwd"] and not r["has_cpu_fwd"]
+            )
+            all_back = sum(
+                1 for r in rs
+                if r["has_cpu_fwd"] and r["has_cuda_fwd"] and r["has_metal_fwd"]
+            )
+            f.write(
+                f"| {crate} | {len(rs)} | {has_bwd} | {only_cuda} | "
+                f"{only_metal} | {all_back} |\n"
+            )
+
+        f.write("\n## All impls\n\n")
+        f.write(
+            "| impl | arity | crate | file:line | bwd? | cpu/cuda/metal fwd | proposed shape |\n"
+            "|---|---:|---|---|:-:|:-:|---|\n"
+        )
+        for r in impls:
+            fwd = (
+                ("c" if r["has_cpu_fwd"] else "-")
+                + ("u" if r["has_cuda_fwd"] else "-")
+                + ("m" if r["has_metal_fwd"] else "-")
+            )
+            f.write(
+                f"| `{r['impl_name']}` | {r['op_arity']} | {r['crate']} | "
+                f"{r['file']}:{r['line']} | "
+                f"{'yes' if r['has_bwd'] else 'no'} | "
+                f"`{fwd}` | "
+                f"{proposed_shape(r)} |\n"
+            )
+
+        f.write("\n## Proposed kiln-tensor shape\n\n")
+        f.write(
+            "The kiln-tensor equivalent the kernels can port onto **once**:\n\n"
+            "```rust\n"
+            "// kiln-tensor crate.\n"
+            "pub trait DeviceOp: Send + Sync {\n"
+            "    /// Arity is fixed at the impl: `DeviceOp1` / `DeviceOp2` / `DeviceOp3`.\n"
+            "    /// Each per-backend method returns Option<...>; None means the op falls\n"
+            "    /// back to the next backend in the device's preference order, matching\n"
+            "    /// today's BackendRuntime contract.\n"
+            "    fn name(&self) -> &'static str;\n"
+            "    fn cpu_fwd  (&self, ...) -> Result<Option<Tensor>>;\n"
+            "    fn cuda_fwd (&self, ...) -> Result<Option<Tensor>>;\n"
+            "    fn metal_fwd(&self, ...) -> Result<Option<Tensor>>;\n"
+            "    fn vulkan_fwd(&self, ...) -> Result<Option<Tensor>>;\n"
+            "    /// Optional backward closure; absence == forward-only kernel.\n"
+            "    /// The boxed closure carries its own captured tensors;\n"
+            "    /// `kiln_autograd::BackwardOp::register` records the closure on\n"
+            "    /// the tape with the source tensor's TensorId.\n"
+            "    fn bwd(&self) -> Option<Box<dyn BackwardOp>>;\n"
+            "}\n"
+            "```\n\n"
+            "Three migration shapes (column `proposed_kiln_tensor_shape` in the CSV):\n\n"
+            "- `closure-only` — forward-only ops without `bwd`. Becomes a plain device-method "
+            "on `kiln_tensor::Tensor`. Migration is mechanical.\n"
+            "- `fwd+bwd-closure` — has `bwd`. Becomes a `kiln_tensor::DeviceOp` plus a "
+            "`kiln_autograd::BackwardOp` impl. The Vulkan path's `VkBackwardOp` (`vk_ops/`) "
+            "is the lift template — 34 `impl VkBackwardOp for ...` blocks already follow "
+            "this shape.\n"
+            "- `static-tape-op` — the existing bwd already routes through "
+            "`candle_core::backprop::BackpropOp`. The tape op becomes a `kiln_autograd::Op` "
+            "enum variant; the `bwd` method is its `apply` impl.\n\n"
+            "The audit is the input to Phase 1's `DeviceOp` API design and to Phase 6a's "
+            "`kiln-autograd` crate skeleton.\n"
+        )
+
+    print(f"audit-customop: {len(impls)} impls", file=sys.stderr)
+    for crate, rs in sorted(by_crate.items()):
+        print(f"  {crate}: {len(rs)}", file=sys.stderr)
+    print(f"wrote {csv_path}")
+    print(f"wrote {md_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fourth Phase 0 deliverable for #1082.

Adds `scripts/audit-customop.py` + CSV + interpretation, per the issue's Phase 0 bullet:

> **CustomOpN audit.** Enumerate every `impl CustomOp1/2/3 for …` across the kernel crates ... plus `kiln-train/src/trainer.rs`. Output: signature table + the proposed kiln-tensor equivalent (forward closure + backward closure with explicit `BackwardOp` registration). **This is the biggest unlisted candle subsystem; if it doesn't have a design before Phase 1 the kernels port twice.**

## Findings

**15 total `impl CustomOpN` blocks** across 6 crates:

| crate | impls | has bwd | only cuda fwd | only metal fwd | all-backend |
|---|---:|---:|---:|---:|---:|
| kiln-flce-kernel | 1 | 1 | 0 | 0 | **1** |
| kiln-gdn-kernel | 2 | 0 | 0 | 0 | 0 |
| kiln-model | 9 | 9 | 0 | 0 | 0 |
| kiln-opd-loss-kernel | 1 | 1 | 0 | 0 | 0 |
| kiln-rmsnorm-kernel | 1 | 1 | 0 | 0 | 0 |
| kiln-train | 1 | 1 | 0 | 0 | 0 |

**Key observations:**

- **13 of 15 have a `bwd` method** → all become `fwd+bwd-closure` in the migration (a `kiln_tensor::DeviceOp` + a `kiln_autograd::BackwardOp` impl). The Vulkan path's `vk_ops/` (34 `impl VkBackwardOp for ...` blocks) is the lift template.
- **2 are forward-only** (`GdnGateBetaOp`, `GdnGateGOp`) — these collapse to plain device-methods.
- **Metal coverage is weak** — only `FlceCustomOp` has `metal_fwd`. The 9 CUDA-typed `kiln-model` ops (LoRA, RoPE, sigmoid-mul, FA-training) have no Metal counterpart. **Phase 2's Metal track inherits that gap as scoped work.**
- **`CudaFlashAttentionTrainingBf16`** (110 LOC, arity-3, `forward.rs:1790`) is the biggest one — the training-path bridge to `kiln-flash-attn`'s bwd kernel.

## Proposed `kiln_tensor::DeviceOp` shape

The markdown proposes the single API kernels port onto **once**:

```rust
pub trait DeviceOp: Send + Sync {
    fn name(&self) -> &'static str;
    fn cpu_fwd  (&self, ...) -> Result<Option<Tensor>>;
    fn cuda_fwd (&self, ...) -> Result<Option<Tensor>>;
    fn metal_fwd(&self, ...) -> Result<Option<Tensor>>;
    fn vulkan_fwd(&self, ...) -> Result<Option<Tensor>>;
    fn bwd(&self) -> Option<Box<dyn BackwardOp>>;
}
```

Three migration shapes (CSV column `proposed_kiln_tensor_shape`):

| shape | when | count |
|---|---|---:|
| `closure-only` | forward-only (no bwd) | 2 |
| `fwd+bwd-closure` | has bwd; not on candle backprop tape | 13 |
| `static-tape-op` | bwd routes through `BackpropOp` enum | 0 (none today) |

## Why the design must land before Phase 1

The kernels are 49-330 lines each (`body_lines` column in the CSV). If we ship Phase 1 with a `DeviceOp` shape that doesn't accommodate the 13 `bwd` paths, every kernel crate gets rewritten twice: once for the forward, once when the bwd contract changes. This audit is the input to that design.

## What's in the PR

| Path | Purpose |
|------|---------|
| `scripts/audit-customop.py` | Walks `impl CustomOpN` blocks; categorizes by backend coverage + bwd presence |
| `bench-results/customop-audit.csv` | 15 impls × {arity, file, line, crate, has_cpu/cuda/metal_fwd, has_bwd, body_lines, proposed_shape} |
| `bench-results/customop-audit.md` | Interpretation + per-crate table + the DeviceOp shape proposal |

Refs #1082