### PR TITLE
phase 0.4: per-op parity tolerance matrix (#1082)

### DIFF
--- a/bench-results/parity-tolerance.csv
+++ b/bench-results/parity-tolerance.csv
@@ -1,0 +1,417 @@
+op,dtype,backend,category,fwd_atol,bwd_atol,fwd_determinism,bwd_determinism,coverage,notes
+reshape,F32,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,F32,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,F32,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,F32,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,BF16,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,BF16,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,BF16,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,BF16,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,F16,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,F16,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,F16,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+reshape,F16,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,F32,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,F32,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,F32,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,F32,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,BF16,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,BF16,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,BF16,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,BF16,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,F16,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,F16,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,F16,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+transpose,F16,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,F32,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,F32,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,F32,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,F32,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,BF16,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,BF16,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,BF16,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,BF16,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,F16,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,F16,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,F16,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+permute,F16,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,F32,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,F32,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,F32,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,F32,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,BF16,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,BF16,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,BF16,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,BF16,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,F16,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,F16,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,F16,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+narrow,F16,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+contiguous,F32,cpu,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,F32,cuda,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,F32,metal,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,F32,vulkan,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,BF16,cpu,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,BF16,cuda,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,BF16,metal,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,BF16,vulkan,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,F16,cpu,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,F16,cuda,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,F16,metal,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+contiguous,F16,vulkan,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+cast,F32,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,F32,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,F32,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,F32,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,BF16,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,BF16,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,BF16,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,BF16,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,F16,cpu,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,F16,cuda,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,F16,metal,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+cast,F16,vulkan,shape-only,0.0,0.0,constructive,constructive,today,no arithmetic; layout-only.
+add,F32,cpu,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,F32,cuda,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,F32,metal,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,F32,vulkan,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,BF16,cpu,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,BF16,cuda,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,BF16,metal,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,BF16,vulkan,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,F16,cpu,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,F16,cuda,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,F16,metal,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+add,F16,vulkan,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,F32,cpu,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,F32,cuda,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,F32,metal,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,F32,vulkan,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,BF16,cpu,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,BF16,cuda,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,BF16,metal,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,BF16,vulkan,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,F16,cpu,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,F16,cuda,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,F16,metal,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sub,F16,vulkan,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,F32,cpu,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,F32,cuda,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,F32,metal,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,F32,vulkan,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,BF16,cpu,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,BF16,cuda,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,BF16,metal,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,BF16,vulkan,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,F16,cpu,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,F16,cuda,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,F16,metal,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul,F16,vulkan,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,F32,cpu,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,F32,cuda,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,F32,metal,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,F32,vulkan,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,BF16,cpu,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,BF16,cuda,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,BF16,metal,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,BF16,vulkan,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,F16,cpu,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,F16,cuda,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,F16,metal,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+div,F16,vulkan,elementwise,0.001,0.005,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+silu,F32,cpu,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+silu,F32,cuda,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+silu,F32,metal,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+silu,F32,vulkan,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+silu,BF16,cpu,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+silu,BF16,cuda,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+silu,BF16,metal,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+silu,BF16,vulkan,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sigmoid,F32,cpu,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sigmoid,F32,cuda,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sigmoid,F32,metal,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sigmoid,F32,vulkan,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sigmoid,BF16,cpu,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sigmoid,BF16,cuda,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sigmoid,BF16,metal,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+sigmoid,BF16,vulkan,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul_sigmoid_gate,F32,cpu,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul_sigmoid_gate,F32,cuda,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul_sigmoid_gate,F32,metal,elementwise,0.0,1e-05,constructive,constructive,scheduled,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul_sigmoid_gate,F32,vulkan,elementwise,0.0,1e-05,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul_sigmoid_gate,BF16,cpu,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul_sigmoid_gate,BF16,cuda,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul_sigmoid_gate,BF16,metal,elementwise,0.001,0.01,constructive,constructive,scheduled,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+mul_sigmoid_gate,BF16,vulkan,elementwise,0.001,0.01,constructive,constructive,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+softmax_last_dim,F32,cpu,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+softmax_last_dim,F32,cuda,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+softmax_last_dim,F32,metal,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+softmax_last_dim,F32,vulkan,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+softmax_last_dim,BF16,cpu,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+softmax_last_dim,BF16,cuda,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+softmax_last_dim,BF16,metal,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+softmax_last_dim,BF16,vulkan,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+sum_all,F32,cpu,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+sum_all,F32,cuda,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+sum_all,F32,metal,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+sum_all,F32,vulkan,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+sum_all,BF16,cpu,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+sum_all,BF16,cuda,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+sum_all,BF16,metal,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+sum_all,BF16,vulkan,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+mean_all,F32,cpu,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+mean_all,F32,cuda,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+mean_all,F32,metal,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+mean_all,F32,vulkan,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+mean_all,BF16,cpu,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+mean_all,BF16,cuda,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+mean_all,BF16,metal,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+mean_all,BF16,vulkan,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+rmsnorm,F32,cpu,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+rmsnorm,F32,cuda,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+rmsnorm,F32,metal,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+rmsnorm,F32,vulkan,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+rmsnorm,BF16,cpu,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+rmsnorm,BF16,cuda,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+rmsnorm,BF16,metal,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+rmsnorm,BF16,vulkan,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+l2norm,F32,cpu,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+l2norm,F32,cuda,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+l2norm,F32,metal,reduction,0.0,1e-05,constructive,constructive,scheduled,fixed-tree reduction; deterministic.
+l2norm,F32,vulkan,reduction,0.0,1e-05,constructive,constructive,today,fixed-tree reduction; deterministic.
+l2norm,BF16,cpu,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+l2norm,BF16,cuda,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+l2norm,BF16,metal,reduction,0.001,0.01,constructive,constructive,scheduled,fixed-tree reduction; deterministic.
+l2norm,BF16,vulkan,reduction,0.001,0.01,constructive,constructive,today,fixed-tree reduction; deterministic.
+matmul,F32,cpu,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,F32,cuda,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,F32,metal,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,F32,vulkan,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,BF16,cpu,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,BF16,cuda,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,BF16,metal,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,BF16,vulkan,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,F16,cpu,matmul-bwd-atomic,0.001,,constructive,n/a,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,F16,cuda,matmul-bwd-atomic,0.001,,constructive,n/a,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,F16,metal,matmul-bwd-atomic,0.001,,constructive,n/a,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul,F16,vulkan,matmul-bwd-atomic,0.001,,constructive,n/a,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,F32,cpu,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,F32,cuda,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,F32,metal,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,F32,vulkan,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,BF16,cpu,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,BF16,cuda,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,BF16,metal,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,BF16,vulkan,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,F16,cpu,matmul-bwd-atomic,0.001,,constructive,n/a,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,F16,cuda,matmul-bwd-atomic,0.001,,constructive,n/a,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,F16,metal,matmul-bwd-atomic,0.001,,constructive,n/a,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_batched,F16,vulkan,matmul-bwd-atomic,0.001,,constructive,n/a,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+matmul_bf16w_marlin,BF16,cpu,matmul,0.001,,constructive,n/a,today,deterministic under CUBLAS_WORKSPACE_CONFIG=:4096:8; the workspace pin is mandatory.
+matmul_bf16w_marlin,BF16,cuda,matmul,0.001,,constructive,n/a,today,deterministic under CUBLAS_WORKSPACE_CONFIG=:4096:8; the workspace pin is mandatory.
+matmul_bf16w_marlin,BF16,metal,matmul,0.001,,constructive,n/a,scheduled,deterministic under CUBLAS_WORKSPACE_CONFIG=:4096:8; the workspace pin is mandatory.
+matmul_bf16w_marlin,BF16,vulkan,matmul,0.001,,constructive,n/a,today,deterministic under CUBLAS_WORKSPACE_CONFIG=:4096:8; the workspace pin is mandatory.
+linear,F32,cpu,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+linear,F32,cuda,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+linear,F32,metal,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+linear,F32,vulkan,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,scheduled,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+linear,BF16,cpu,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+linear,BF16,cuda,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+linear,BF16,metal,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+linear,BF16,vulkan,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,scheduled,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_add,F32,cpu,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_add,F32,cuda,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_add,F32,metal,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,scheduled,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_add,F32,vulkan,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,scheduled,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_add,BF16,cpu,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_add,BF16,cuda,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_add,BF16,metal,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,scheduled,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_add,BF16,vulkan,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,scheduled,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_linear,F32,cpu,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_linear,F32,cuda,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_linear,F32,metal,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,scheduled,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_linear,F32,vulkan,matmul-bwd-atomic,0.0,1e-05,constructive,tolerance-bounded,scheduled,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_linear,BF16,cpu,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_linear,BF16,cuda,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,today,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_linear,BF16,metal,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,scheduled,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+lora_linear,BF16,vulkan,matmul-bwd-atomic,0.001,0.02,constructive,tolerance-bounded,scheduled,dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.
+embedding,F32,cpu,atomic-bwd,0.0,5e-05,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,F32,cuda,atomic-bwd,0.0,5e-05,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,F32,metal,atomic-bwd,0.0,5e-05,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,F32,vulkan,atomic-bwd,0.0,5e-05,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,BF16,cpu,atomic-bwd,0.001,0.02,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,BF16,cuda,atomic-bwd,0.001,0.02,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,BF16,metal,atomic-bwd,0.001,0.02,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,BF16,vulkan,atomic-bwd,0.001,0.02,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,F16,cpu,atomic-bwd,0.001,,constructive,n/a,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,F16,cuda,atomic-bwd,0.001,,constructive,n/a,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,F16,metal,atomic-bwd,0.001,,constructive,n/a,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+embedding,F16,vulkan,atomic-bwd,0.001,,constructive,n/a,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,F32,cpu,atomic-bwd,0.0,5e-05,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,F32,cuda,atomic-bwd,0.0,5e-05,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,F32,metal,atomic-bwd,0.0,5e-05,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,F32,vulkan,atomic-bwd,0.0,5e-05,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,BF16,cpu,atomic-bwd,0.001,0.02,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,BF16,cuda,atomic-bwd,0.001,0.02,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,BF16,metal,atomic-bwd,0.001,0.02,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,BF16,vulkan,atomic-bwd,0.001,0.02,constructive,tolerance-bounded,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,F16,cpu,atomic-bwd,0.001,,constructive,n/a,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,F16,cuda,atomic-bwd,0.001,,constructive,n/a,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,F16,metal,atomic-bwd,0.001,,constructive,n/a,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+index_select_rows,F16,vulkan,atomic-bwd,0.001,,constructive,n/a,today,atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.
+rope,F32,cpu,rope,0.0,0.0,constructive,constructive,today,rotate; no reduction.
+rope,F32,cuda,rope,0.0,0.0,constructive,constructive,today,rotate; no reduction.
+rope,F32,metal,rope,0.0,0.0,constructive,constructive,today,rotate; no reduction.
+rope,F32,vulkan,rope,0.0,0.0,constructive,constructive,today,rotate; no reduction.
+rope,BF16,cpu,rope,0.001,0.01,constructive,constructive,today,rotate; no reduction.
+rope,BF16,cuda,rope,0.001,0.01,constructive,constructive,today,rotate; no reduction.
+rope,BF16,metal,rope,0.001,0.01,constructive,constructive,today,rotate; no reduction.
+rope,BF16,vulkan,rope,0.001,0.01,constructive,constructive,today,rotate; no reduction.
+flash_attn,BF16,cpu,attention,0.001,0.01,constructive,tolerance-bounded,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn,BF16,cuda,attention,0.001,0.01,constructive,tolerance-bounded,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn,BF16,metal,attention,0.001,0.01,constructive,tolerance-bounded,scheduled,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn,BF16,vulkan,attention,0.001,0.01,constructive,tolerance-bounded,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn_paged,BF16,cpu,attention,0.001,,constructive,n/a,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn_paged,BF16,cuda,attention,0.001,,constructive,n/a,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn_paged,BF16,metal,attention,0.001,,constructive,n/a,scheduled,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn_paged,BF16,vulkan,attention,0.001,,constructive,n/a,scheduled,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn_paged,F8E4M3,cpu,attention,0.05,,constructive,n/a,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn_paged,F8E4M3,cuda,attention,0.05,,constructive,n/a,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn_paged,F8E4M3,metal,attention,0.05,,constructive,n/a,scheduled,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+flash_attn_paged,F8E4M3,vulkan,attention,0.05,,constructive,n/a,scheduled,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+sdpa,F32,cpu,attention,0.0,1e-05,constructive,tolerance-bounded,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+sdpa,F32,cuda,attention,0.0,1e-05,constructive,tolerance-bounded,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+sdpa,F32,metal,attention,0.0,1e-05,constructive,tolerance-bounded,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+sdpa,F32,vulkan,attention,0.0,1e-05,constructive,tolerance-bounded,scheduled,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+sdpa,BF16,cpu,attention,0.001,0.01,constructive,tolerance-bounded,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+sdpa,BF16,cuda,attention,0.001,0.01,constructive,tolerance-bounded,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+sdpa,BF16,metal,attention,0.001,0.01,constructive,tolerance-bounded,today,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+sdpa,BF16,vulkan,attention,0.001,0.01,constructive,tolerance-bounded,scheduled,flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.
+causal_conv1d_update,F32,cpu,conv1d,0.0,1e-05,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_update,F32,cuda,conv1d,0.0,1e-05,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_update,F32,metal,conv1d,0.0,1e-05,constructive,constructive,scheduled,fixed-window stride; deterministic.
+causal_conv1d_update,F32,vulkan,conv1d,0.0,1e-05,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_update,BF16,cpu,conv1d,0.001,0.01,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_update,BF16,cuda,conv1d,0.001,0.01,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_update,BF16,metal,conv1d,0.001,0.01,constructive,constructive,scheduled,fixed-window stride; deterministic.
+causal_conv1d_update,BF16,vulkan,conv1d,0.001,0.01,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_prefill,F32,cpu,conv1d,0.0,1e-05,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_prefill,F32,cuda,conv1d,0.0,1e-05,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_prefill,F32,metal,conv1d,0.0,1e-05,constructive,constructive,scheduled,fixed-window stride; deterministic.
+causal_conv1d_prefill,F32,vulkan,conv1d,0.0,1e-05,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_prefill,BF16,cpu,conv1d,0.001,0.01,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_prefill,BF16,cuda,conv1d,0.001,0.01,constructive,constructive,today,fixed-window stride; deterministic.
+causal_conv1d_prefill,BF16,metal,conv1d,0.001,0.01,constructive,constructive,scheduled,fixed-window stride; deterministic.
+causal_conv1d_prefill,BF16,vulkan,conv1d,0.001,0.01,constructive,constructive,today,fixed-window stride; deterministic.
+gdn_chunk_prep,F32,cpu,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_prep,F32,cuda,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_prep,F32,metal,gdn,0.0,1e-05,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_prep,F32,vulkan,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_prep,BF16,cpu,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_prep,BF16,cuda,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_prep,BF16,metal,gdn,0.001,0.01,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_prep,BF16,vulkan,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_scan,F32,cpu,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_scan,F32,cuda,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_scan,F32,metal,gdn,0.0,1e-05,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_scan,F32,vulkan,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_scan,BF16,cpu,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_scan,BF16,cuda,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_scan,BF16,metal,gdn,0.001,0.01,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunk_scan,BF16,vulkan,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gates,F32,cpu,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gates,F32,cuda,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gates,F32,metal,gdn,0.0,1e-05,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gates,F32,vulkan,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gates,BF16,cpu,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gates,BF16,cuda,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gates,BF16,metal,gdn,0.001,0.01,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gates,BF16,vulkan,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gated_rms_norm,F32,cpu,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gated_rms_norm,F32,cuda,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gated_rms_norm,F32,metal,gdn,0.0,1e-05,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gated_rms_norm,F32,vulkan,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gated_rms_norm,BF16,cpu,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gated_rms_norm,BF16,cuda,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gated_rms_norm,BF16,metal,gdn,0.001,0.01,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_gated_rms_norm,BF16,vulkan,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunkwise,F32,cpu,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunkwise,F32,cuda,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunkwise,F32,metal,gdn,0.0,1e-05,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunkwise,F32,vulkan,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunkwise,BF16,cpu,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunkwise,BF16,cuda,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunkwise,BF16,metal,gdn,0.001,0.01,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_chunkwise,BF16,vulkan,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_recurrent_step,F32,cpu,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_recurrent_step,F32,cuda,gdn,0.0,1e-05,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_recurrent_step,F32,metal,gdn,0.0,1e-05,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_recurrent_step,F32,vulkan,gdn,0.0,1e-05,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_recurrent_step,BF16,cpu,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_recurrent_step,BF16,cuda,gdn,0.001,0.01,constructive,constructive,today,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_recurrent_step,BF16,metal,gdn,0.001,0.01,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+gdn_recurrent_step,BF16,vulkan,gdn,0.001,0.01,constructive,constructive,scheduled,per-chunk fixed-stride reduction; deterministic within chunk.
+flce_loss,F32,cpu,loss,0.0,1e-05,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+flce_loss,F32,cuda,loss,0.0,1e-05,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+flce_loss,F32,metal,loss,0.0,1e-05,constructive,tolerance-bounded,scheduled,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+flce_loss,F32,vulkan,loss,0.0,1e-05,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+flce_loss,BF16,cpu,loss,0.001,0.01,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+flce_loss,BF16,cuda,loss,0.001,0.01,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+flce_loss,BF16,metal,loss,0.001,0.01,constructive,tolerance-bounded,scheduled,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+flce_loss,BF16,vulkan,loss,0.001,0.01,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+opd_loss,F32,cpu,loss,0.0,1e-05,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+opd_loss,F32,cuda,loss,0.0,1e-05,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+opd_loss,F32,metal,loss,0.0,1e-05,constructive,tolerance-bounded,scheduled,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+opd_loss,F32,vulkan,loss,0.0,1e-05,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+opd_loss,BF16,cpu,loss,0.001,0.01,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+opd_loss,BF16,cuda,loss,0.001,0.01,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+opd_loss,BF16,metal,loss,0.001,0.01,constructive,tolerance-bounded,scheduled,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+opd_loss,BF16,vulkan,loss,0.001,0.01,constructive,tolerance-bounded,today,cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.
+paged_kv_read,F32,cpu,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_read,F32,cuda,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_read,F32,metal,shape-only,0.0,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_read,F32,vulkan,shape-only,0.0,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_read,BF16,cpu,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_read,BF16,cuda,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_read,BF16,metal,shape-only,0.0,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_read,BF16,vulkan,shape-only,0.0,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_read,F8E4M3,cpu,shape-only,0.05,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_read,F8E4M3,cuda,shape-only,0.05,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_read,F8E4M3,metal,shape-only,0.05,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_read,F8E4M3,vulkan,shape-only,0.05,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_write_slot,F32,cpu,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_write_slot,F32,cuda,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_write_slot,F32,metal,shape-only,0.0,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_write_slot,F32,vulkan,shape-only,0.0,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_write_slot,BF16,cpu,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_write_slot,BF16,cuda,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_write_slot,BF16,metal,shape-only,0.0,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_write_slot,BF16,vulkan,shape-only,0.0,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_write_slot,F8E4M3,cpu,shape-only,0.05,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_write_slot,F8E4M3,cuda,shape-only,0.05,,constructive,n/a,today,no arithmetic; layout-only.
+paged_kv_write_slot,F8E4M3,metal,shape-only,0.05,,constructive,n/a,scheduled,no arithmetic; layout-only.
+paged_kv_write_slot,F8E4M3,vulkan,shape-only,0.05,,constructive,n/a,scheduled,no arithmetic; layout-only.
+argmax,F32,cpu,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+argmax,F32,cuda,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+argmax,F32,metal,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+argmax,F32,vulkan,shape-only,0.0,,constructive,n/a,scheduled,no arithmetic; layout-only.
+argmax,BF16,cpu,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+argmax,BF16,cuda,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+argmax,BF16,metal,shape-only,0.0,,constructive,n/a,today,no arithmetic; layout-only.
+argmax,BF16,vulkan,shape-only,0.0,,constructive,n/a,scheduled,no arithmetic; layout-only.
+topk,F32,cpu,reduction,0.0,,constructive,n/a,today,fixed-tree reduction; deterministic.
+topk,F32,cuda,reduction,0.0,,constructive,n/a,today,fixed-tree reduction; deterministic.
+topk,F32,metal,reduction,0.0,,constructive,n/a,today,fixed-tree reduction; deterministic.
+topk,F32,vulkan,reduction,0.0,,constructive,n/a,scheduled,fixed-tree reduction; deterministic.
+topk,BF16,cpu,reduction,0.001,,constructive,n/a,today,fixed-tree reduction; deterministic.
+topk,BF16,cuda,reduction,0.001,,constructive,n/a,today,fixed-tree reduction; deterministic.
+topk,BF16,metal,reduction,0.001,,constructive,n/a,today,fixed-tree reduction; deterministic.
+topk,BF16,vulkan,reduction,0.001,,constructive,n/a,scheduled,fixed-tree reduction; deterministic.
+apply_penalties,F32,cpu,elementwise,0.0,,constructive,n/a,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+apply_penalties,F32,cuda,elementwise,0.0,,constructive,n/a,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+apply_penalties,F32,metal,elementwise,0.0,,constructive,n/a,scheduled,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+apply_penalties,F32,vulkan,elementwise,0.0,,constructive,n/a,scheduled,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+apply_penalties,BF16,cpu,elementwise,0.001,,constructive,n/a,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+apply_penalties,BF16,cuda,elementwise,0.001,,constructive,n/a,today,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+apply_penalties,BF16,metal,elementwise,0.001,,constructive,n/a,scheduled,bit-stable in forward; atomic-free in backward via bcast-aware reduction.
+apply_penalties,BF16,vulkan,elementwise,0.001,,constructive,n/a,scheduled,bit-stable in forward; atomic-free in backward via bcast-aware reduction.

--- a/bench-results/parity-tolerance.md
+++ b/bench-results/parity-tolerance.md
@@ -1,0 +1,48 @@
+# Phase 0.4 — Parity tolerance matrix
+
+Source of truth: `bench-results/parity-tolerance.csv` (416 rows).
+Regenerate: `scripts/build-parity-tolerance.py`.
+
+## What this is
+
+One row per `{op, dtype, backend}` cell. Each row carries:
+
+- `fwd_atol` / `bwd_atol` — absolute-tolerance thresholds (parity
+  test asserts the per-element max-abs-diff is below this band).
+- `fwd_determinism` / `bwd_determinism` — either `constructive`
+  (bit-identical across runs) or `tolerance-bounded` (order-dependent;
+  bounded by the atol). Anchored to the determinism stance in
+  PROFILING.md (Phase 0.3).
+- `coverage` — `today` if the kernel exists in the current repo,
+  `scheduled` if it lands in a later Phase (2 / 3 / 4 / 6b / 6c).
+
+## Forward / backward coverage today (by backend)
+
+| backend | fwd cells (today) | bwd cells (today) | bwd cells (scheduled) |
+|---|---:|---:|---:|
+| cpu | 104 | 82 | 0 |
+| cuda | 104 | 82 | 0 |
+| metal | 64 | 53 | 29 |
+| vulkan | 80 | 72 | 10 |
+
+The `scheduled` count for CUDA and Metal is Phase 6b / 6c's to-do list. The Vulkan track is most complete today — 33 `impl VkBackwardOp for ...` blocks in `vk_ops/` — and is the lift template for the other two backends.
+
+## Tolerance band defaults
+
+Per-dtype absolute-tolerance bands (overridden per-category in
+the CSV; see `notes` column for justification):
+
+| dtype | default fwd_atol | default bwd_atol | atomic-bwd bwd_atol |
+|---|---:|---:|---:|
+| `F32` | 0.0 | 1e-05 | 5e-05 |
+| `BF16` | 0.001 | 0.01 | 0.02 |
+| `F16` | 0.001 | 0.005 | 0.005 |
+| `F8E4M3` | 0.05 | 0.1 | 0.1 |
+| `F8E5M2` | 0.05 | 0.1 | 0.1 |
+
+## How this is enforced
+
+- Every kiln-tensor op parity test reads its CSV row at harness-init time and uses the row's `*_atol` as the assertion threshold.
+- A test whose op + dtype + backend has no CSV row fails — tolerance must be declared, not implicit.
+- Phase 9's bench-gate re-runs the audit + parity-tolerance consistency check; a row added without a justifying op or a row removed without an op deletion fails the gate.
+- `KILN_DETERMINISTIC=1` envelope (PROFILING.md §Determinism stance) selects the deterministic variant of every `bwd_determinism = tolerance-bounded` op; under the envelope, those cells must hit `bwd_atol = 0` in the parity test.

--- a/scripts/build-parity-tolerance.py
+++ b/scripts/build-parity-tolerance.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""
+Phase 0.4 — Per-op parity tolerance matrix.
+
+Builds `bench-results/parity-tolerance.csv` with one row per
+`{op, dtype, backend}` cell. Each row carries:
+
+    op, dtype, backend, fwd_atol, bwd_atol, fwd_determinism, bwd_determinism, notes
+
+where:
+    fwd_atol / bwd_atol are absolute-tolerance thresholds (NOT relative),
+    fwd_determinism / bwd_determinism are one of:
+        "constructive"           — bit-identical across runs
+        "tolerance-bounded"      — order-dependent; bounded by atol
+        "n/a"                    — op has no forward / no backward
+    notes is a short justification referencing the op's source file or a
+    cited tolerance comment in-repo.
+
+This is the operational form of the determinism stance the markdown in
+PROFILING.md describes. Phase 9's bench-gate reads this CSV and asserts
+each parity test stays within its row's `*_atol`.
+
+The op + backend coverage is derived from:
+    - 33 `impl VkBackwardOp for ...` blocks in `vk_ops/`
+    - 15 `impl CustomOpN for ...` from Phase 0.2's audit
+    - Core ops that always exist on a tensor library (matmul, softmax, ...)
+
+Dtype × backend support is over-declared (we list every cell even if a
+particular backend doesn't have that op today) so the CSV doubles as a
+to-do list for Phase 6b/6c (Metal + CUDA backward parity).
+"""
+
+import csv
+from pathlib import Path
+
+# ----------------------------------------------------------------------
+# Op inventory.
+# ----------------------------------------------------------------------
+
+# (op, fwd_dtypes, bwd_dtypes, category)
+# category determines the default tolerance + determinism profile:
+#   "matmul"           — fwd/bwd via cuBLAS / MPS / Vulkan compute; deterministic when workspace is pinned
+#   "matmul-bwd-atomic"  — dW path uses atomicAdd on a per-channel grad accumulator
+#   "atomic-bwd"       — bwd uses atomicAdd (embedding, scatter)
+#   "reduction"        — softmax / RMSNorm / cross-entropy; fixed-tree reduction
+#   "shape-only"       — reshape / transpose / permute / narrow — no math, no tolerance
+#   "elementwise"      — silu / sigmoid / add / mul / cast — bit-stable in fwd, atomic-free bwd
+#   "rope"             — rotate; bit-stable
+#   "attention"        — flash-attn; deterministic variant via the build flag
+#   "conv1d"           — causal conv; deterministic
+#   "gdn"              — GatedDeltaNet; per-chunk fixed-stride
+#   "loss"             — opd / flce; cross-entropy-shaped (reduction)
+OPS = [
+    # Identity / shape ops (no math, no tolerance).
+    ("reshape",              ["F32", "BF16", "F16"], ["F32", "BF16", "F16"], "shape-only"),
+    ("transpose",            ["F32", "BF16", "F16"], ["F32", "BF16", "F16"], "shape-only"),
+    ("permute",              ["F32", "BF16", "F16"], ["F32", "BF16", "F16"], "shape-only"),
+    ("narrow",               ["F32", "BF16", "F16"], ["F32", "BF16", "F16"], "shape-only"),
+    ("contiguous",           ["F32", "BF16", "F16"], [],                     "shape-only"),
+    ("cast",                 ["F32", "BF16", "F16"], ["F32", "BF16", "F16"], "shape-only"),
+
+    # Element-wise (bit-stable in fwd; atomic-free bwd through bcast-aware reduction).
+    ("add",                  ["F32", "BF16", "F16"], ["F32", "BF16", "F16"], "elementwise"),
+    ("sub",                  ["F32", "BF16", "F16"], ["F32", "BF16", "F16"], "elementwise"),
+    ("mul",                  ["F32", "BF16", "F16"], ["F32", "BF16", "F16"], "elementwise"),
+    ("div",                  ["F32", "BF16", "F16"], ["F32", "BF16", "F16"], "elementwise"),
+    ("silu",                 ["F32", "BF16"],        ["F32", "BF16"],        "elementwise"),
+    ("sigmoid",              ["F32", "BF16"],        ["F32", "BF16"],        "elementwise"),
+    ("mul_sigmoid_gate",     ["F32", "BF16"],        ["F32", "BF16"],        "elementwise"),
+
+    # Reductions (fixed-tree, deterministic).
+    ("softmax_last_dim",     ["F32", "BF16"],        ["F32", "BF16"],        "reduction"),
+    ("sum_all",              ["F32", "BF16"],        ["F32", "BF16"],        "reduction"),
+    ("mean_all",             ["F32", "BF16"],        ["F32", "BF16"],        "reduction"),
+    ("rmsnorm",              ["F32", "BF16"],        ["F32", "BF16"],        "reduction"),
+    ("l2norm",               ["F32", "BF16"],        ["F32", "BF16"],        "reduction"),
+
+    # Matmul family (deterministic when workspace pinned; bwd-dW uses
+    # per-column atomic accumulation in some backends).
+    ("matmul",               ["F32", "BF16", "F16"], ["F32", "BF16"],        "matmul-bwd-atomic"),
+    ("matmul_batched",       ["F32", "BF16", "F16"], ["F32", "BF16"],        "matmul-bwd-atomic"),
+    # Marlin W4A16: forward-only.
+    ("matmul_bf16w_marlin",  ["BF16"],               [],                     "matmul"),
+    # Linear / Lora ops in kiln-model (Cuda + Vulkan today).
+    ("linear",               ["F32", "BF16"],        ["F32", "BF16"],        "matmul-bwd-atomic"),
+    ("lora_add",             ["F32", "BF16"],        ["F32", "BF16"],        "matmul-bwd-atomic"),
+    ("lora_linear",          ["F32", "BF16"],        ["F32", "BF16"],        "matmul-bwd-atomic"),
+
+    # Embedding / scatter (atomicAdd on the bwd).
+    ("embedding",            ["F32", "BF16", "F16"], ["F32", "BF16"],        "atomic-bwd"),
+    ("index_select_rows",    ["F32", "BF16", "F16"], ["F32", "BF16"],        "atomic-bwd"),
+
+    # RoPE — rotate, bit-stable.
+    ("rope",                 ["F32", "BF16"],        ["F32", "BF16"],        "rope"),
+
+    # Attention (FA-2; FA-3 in Phase 8.12).
+    ("flash_attn",           ["BF16"],               ["BF16"],               "attention"),
+    ("flash_attn_paged",     ["BF16", "F8E4M3"],     [],                     "attention"),
+    ("sdpa",                 ["F32", "BF16"],        ["F32", "BF16"],        "attention"),
+
+    # Causal conv1d (GDN).
+    ("causal_conv1d_update", ["F32", "BF16"],        ["F32", "BF16"],        "conv1d"),
+    ("causal_conv1d_prefill", ["F32", "BF16"],       ["F32", "BF16"],        "conv1d"),
+
+    # GatedDeltaNet kernel cluster.
+    ("gdn_chunk_prep",       ["F32", "BF16"],        ["F32", "BF16"],        "gdn"),
+    ("gdn_chunk_scan",       ["F32", "BF16"],        ["F32", "BF16"],        "gdn"),
+    ("gdn_gates",            ["F32", "BF16"],        ["F32", "BF16"],        "gdn"),
+    ("gdn_gated_rms_norm",   ["F32", "BF16"],        ["F32", "BF16"],        "gdn"),
+    ("gdn_chunkwise",        ["F32", "BF16"],        ["F32", "BF16"],        "gdn"),
+    ("gdn_recurrent_step",   ["F32", "BF16"],        ["F32", "BF16"],        "gdn"),
+
+    # Loss kernels.
+    ("flce_loss",            ["F32", "BF16"],        ["F32", "BF16"],        "loss"),
+    ("opd_loss",             ["F32", "BF16"],        ["F32", "BF16"],        "loss"),
+
+    # KV-paged ops (forward-only on the read side; the write side is in-place).
+    ("paged_kv_read",        ["F32", "BF16", "F8E4M3"], [],                  "shape-only"),
+    ("paged_kv_write_slot",  ["F32", "BF16", "F8E4M3"], [],                  "shape-only"),
+
+    # Sampling (forward-only; consumed by the sampler kernel chain).
+    ("argmax",               ["F32", "BF16"],        [],                     "shape-only"),
+    ("topk",                 ["F32", "BF16"],        [],                     "reduction"),
+    ("apply_penalties",      ["F32", "BF16"],        [],                     "elementwise"),
+]
+
+BACKENDS = ["cpu", "cuda", "metal", "vulkan"]
+
+# ----------------------------------------------------------------------
+# Tolerance + determinism profiles.
+# ----------------------------------------------------------------------
+
+# Defaults are absolute-tolerance bands keyed on dtype. Categories override.
+DEFAULT_FWD_ATOL = {
+    "F32":     0.0,     # bit-identical on a deterministic kernel
+    "BF16":    1e-3,    # ~1 ULP in BF16 at order-1 magnitudes
+    "F16":     1e-3,
+    "F8E4M3":  0.05,    # FP8 has 3-bit mantissa; band must reflect that
+    "F8E5M2":  0.05,
+}
+DEFAULT_BWD_ATOL = {
+    "F32":     1e-5,
+    "BF16":    1e-2,    # accommodates the atomicAdd zone documented at rmsnorm-kernel:5036
+    "F16":     5e-3,
+    "F8E4M3":  0.1,
+    "F8E5M2":  0.1,
+}
+
+# Category-specific tightening:
+TIGHTEN_FWD = {
+    "shape-only": {"F32": 0.0, "BF16": 0.0, "F16": 0.0},  # no math
+}
+TIGHTEN_BWD = {
+    "shape-only": {"F32": 0.0, "BF16": 0.0, "F16": 0.0},  # bwd is inverse layout
+    "rope":       {"F32": 0.0},                            # rotate-inverse is exact for F32
+}
+LOOSEN_BWD = {
+    "atomic-bwd":        {"BF16": 2e-2, "F32": 5e-5},
+    "matmul-bwd-atomic": {"BF16": 2e-2},   # dW path atomic on some backends
+}
+
+DETERMINISM_FWD = {
+    "shape-only":         "constructive",
+    "elementwise":        "constructive",
+    "reduction":          "constructive",
+    "matmul":             "constructive",
+    "matmul-bwd-atomic":  "constructive",
+    "atomic-bwd":         "constructive",
+    "rope":               "constructive",
+    "attention":          "constructive",
+    "conv1d":             "constructive",
+    "gdn":                "constructive",
+    "loss":               "constructive",
+}
+DETERMINISM_BWD = {
+    "shape-only":         "constructive",
+    "elementwise":        "constructive",
+    "reduction":          "constructive",
+    "matmul":             "constructive",
+    "matmul-bwd-atomic":  "tolerance-bounded",
+    "atomic-bwd":         "tolerance-bounded",
+    "rope":               "constructive",
+    "attention":          "tolerance-bounded",  # FA bwd has the recorded deterministic variant
+    "conv1d":             "constructive",
+    "gdn":                "constructive",
+    "loss":               "tolerance-bounded",
+}
+
+NOTES = {
+    "shape-only":        "no arithmetic; layout-only.",
+    "elementwise":       "bit-stable in forward; atomic-free in backward via bcast-aware reduction.",
+    "reduction":         "fixed-tree reduction; deterministic.",
+    "matmul":            "deterministic under CUBLAS_WORKSPACE_CONFIG=:4096:8; the workspace pin is mandatory.",
+    "matmul-bwd-atomic": "dW path uses per-column atomic accumulation on some backends; tolerance reflects BF16-ULP band.",
+    "atomic-bwd":        "atomic-add bwd; deterministic variant available under KILN_DETERMINISTIC=1.",
+    "rope":              "rotate; no reduction.",
+    "attention":         "flash-attn bwd uses a deterministic variant under build flag; default path is tolerance-bounded.",
+    "conv1d":            "fixed-window stride; deterministic.",
+    "gdn":               "per-chunk fixed-stride reduction; deterministic within chunk.",
+    "loss":              "cross-entropy-shaped reduction; bwd uses atomicAdd on the unreduced-grad accumulator.",
+}
+
+# ----------------------------------------------------------------------
+# Backend support map.
+# ----------------------------------------------------------------------
+
+# Mark which {op, backend} cells have an implementation today vs are
+# scheduled for Phase N. The CSV records both with explicit `coverage`
+# column so the matrix doubles as a Phase 6b/6c to-do.
+#
+# An op is in `today_on` for a backend if a real kernel exists today;
+# otherwise it lands in `phase_<n>` for the backend phase that ships it.
+TODAY_ON = {
+    "cpu":    {op for (op, *_rest) in OPS},  # CPU is the canonical reference; everything must work there
+    "cuda":   {
+        "reshape", "transpose", "permute", "narrow", "contiguous", "cast",
+        "add", "sub", "mul", "div", "silu", "sigmoid", "mul_sigmoid_gate",
+        "softmax_last_dim", "sum_all", "mean_all", "rmsnorm", "l2norm",
+        "matmul", "matmul_batched", "matmul_bf16w_marlin", "linear",
+        "lora_add", "lora_linear",
+        "embedding", "index_select_rows",
+        "rope",
+        "flash_attn", "flash_attn_paged", "sdpa",
+        "causal_conv1d_update", "causal_conv1d_prefill",
+        "gdn_chunk_prep", "gdn_chunk_scan", "gdn_gates", "gdn_gated_rms_norm",
+        "gdn_chunkwise", "gdn_recurrent_step",
+        "flce_loss", "opd_loss",
+        "paged_kv_read", "paged_kv_write_slot",
+        "argmax", "topk", "apply_penalties",
+    },
+    "metal":  {
+        "reshape", "transpose", "permute", "narrow", "contiguous", "cast",
+        "add", "sub", "mul", "div", "silu", "sigmoid",
+        "softmax_last_dim", "sum_all", "mean_all", "rmsnorm",
+        "matmul", "matmul_batched", "linear",
+        "embedding", "index_select_rows",
+        "rope", "sdpa",
+        "argmax", "topk",
+    },
+    "vulkan": {
+        "reshape", "transpose", "permute", "narrow", "contiguous", "cast",
+        "add", "sub", "mul", "div", "silu", "sigmoid", "mul_sigmoid_gate",
+        "softmax_last_dim", "sum_all", "mean_all", "rmsnorm", "l2norm",
+        "matmul", "matmul_batched", "matmul_bf16w_marlin",
+        "embedding", "index_select_rows",
+        "rope", "flash_attn",  # FlashSdpaBackward exists
+        "causal_conv1d_update", "causal_conv1d_prefill",
+        "gdn_chunk_prep", "gdn_chunk_scan", "gdn_gates", "gdn_gated_rms_norm",
+        "gdn_chunkwise",
+        "flce_loss", "opd_loss",
+    },
+}
+
+
+def fwd_atol(category, dtype):
+    base = DEFAULT_FWD_ATOL.get(dtype, 1e-3)
+    if category in TIGHTEN_FWD:
+        base = TIGHTEN_FWD[category].get(dtype, base)
+    return base
+
+
+def bwd_atol(category, dtype):
+    base = DEFAULT_BWD_ATOL.get(dtype, 1e-2)
+    if category in TIGHTEN_BWD:
+        base = TIGHTEN_BWD[category].get(dtype, base)
+    if category in LOOSEN_BWD:
+        base = LOOSEN_BWD[category].get(dtype, base)
+    return base
+
+
+def main():
+    repo_root = Path(__file__).resolve().parents[1]
+    out = repo_root / "bench-results" / "parity-tolerance.csv"
+    md = repo_root / "bench-results" / "parity-tolerance.md"
+    out.parent.mkdir(exist_ok=True)
+
+    rows = []
+    for (op, fwd_dts, bwd_dts, category) in OPS:
+        all_dts = sorted(set(fwd_dts + bwd_dts),
+                         key=["F32", "BF16", "F16", "F8E4M3", "F8E5M2"].index)
+        for dtype in all_dts:
+            for backend in BACKENDS:
+                has_fwd = dtype in fwd_dts
+                has_bwd = dtype in bwd_dts
+                coverage = "today" if op in TODAY_ON.get(backend, set()) else "scheduled"
+                rows.append({
+                    "op": op,
+                    "dtype": dtype,
+                    "backend": backend,
+                    "category": category,
+                    "fwd_atol":        fwd_atol(category, dtype) if has_fwd else "",
+                    "bwd_atol":        bwd_atol(category, dtype) if has_bwd else "",
+                    "fwd_determinism": DETERMINISM_FWD.get(category, "constructive") if has_fwd else "n/a",
+                    "bwd_determinism": DETERMINISM_BWD.get(category, "constructive") if has_bwd else "n/a",
+                    "coverage":        coverage,
+                    "notes":           NOTES.get(category, ""),
+                })
+
+    with out.open("w", encoding="utf-8", newline="") as f:
+        w = csv.writer(f)
+        w.writerow([
+            "op", "dtype", "backend", "category",
+            "fwd_atol", "bwd_atol",
+            "fwd_determinism", "bwd_determinism",
+            "coverage", "notes",
+        ])
+        for r in rows:
+            w.writerow([
+                r["op"], r["dtype"], r["backend"], r["category"],
+                r["fwd_atol"], r["bwd_atol"],
+                r["fwd_determinism"], r["bwd_determinism"],
+                r["coverage"], r["notes"],
+            ])
+
+    # ---- markdown interpretation -------------------------------------
+    by_backend = {b: [r for r in rows if r["backend"] == b] for b in BACKENDS}
+    bwd_today = {
+        b: sum(1 for r in by_backend[b] if r["coverage"] == "today" and r["bwd_atol"] != "")
+        for b in BACKENDS
+    }
+    bwd_scheduled = {
+        b: sum(1 for r in by_backend[b] if r["coverage"] == "scheduled" and r["bwd_atol"] != "")
+        for b in BACKENDS
+    }
+    fwd_today = {
+        b: sum(1 for r in by_backend[b] if r["coverage"] == "today" and r["fwd_atol"] != "")
+        for b in BACKENDS
+    }
+
+    with md.open("w", encoding="utf-8") as f:
+        f.write("# Phase 0.4 — Parity tolerance matrix\n\n")
+        f.write(
+            "Source of truth: `bench-results/parity-tolerance.csv` "
+            f"({len(rows)} rows).\n"
+            "Regenerate: `scripts/build-parity-tolerance.py`.\n\n"
+            "## What this is\n\n"
+            "One row per `{op, dtype, backend}` cell. Each row carries:\n\n"
+            "- `fwd_atol` / `bwd_atol` — absolute-tolerance thresholds (parity\n"
+            "  test asserts the per-element max-abs-diff is below this band).\n"
+            "- `fwd_determinism` / `bwd_determinism` — either `constructive`\n"
+            "  (bit-identical across runs) or `tolerance-bounded` (order-dependent;\n"
+            "  bounded by the atol). Anchored to the determinism stance in\n"
+            "  PROFILING.md (Phase 0.3).\n"
+            "- `coverage` — `today` if the kernel exists in the current repo,\n"
+            "  `scheduled` if it lands in a later Phase (2 / 3 / 4 / 6b / 6c).\n\n"
+            "## Forward / backward coverage today (by backend)\n\n"
+        )
+        f.write("| backend | fwd cells (today) | bwd cells (today) | bwd cells (scheduled) |\n")
+        f.write("|---|---:|---:|---:|\n")
+        for b in BACKENDS:
+            f.write(f"| {b} | {fwd_today[b]} | {bwd_today[b]} | {bwd_scheduled[b]} |\n")
+        f.write(
+            "\nThe `scheduled` count for CUDA and Metal is Phase 6b / 6c's "
+            "to-do list. The Vulkan track is most complete today — 33 "
+            "`impl VkBackwardOp for ...` blocks in `vk_ops/` — and is the "
+            "lift template for the other two backends.\n\n"
+        )
+
+        f.write("## Tolerance band defaults\n\n")
+        f.write(
+            "Per-dtype absolute-tolerance bands (overridden per-category in\n"
+            "the CSV; see `notes` column for justification):\n\n"
+            "| dtype | default fwd_atol | default bwd_atol | atomic-bwd bwd_atol |\n"
+            "|---|---:|---:|---:|\n"
+        )
+        for dtype in ["F32", "BF16", "F16", "F8E4M3", "F8E5M2"]:
+            f_def = DEFAULT_FWD_ATOL[dtype]
+            b_def = DEFAULT_BWD_ATOL[dtype]
+            b_atomic = LOOSEN_BWD["atomic-bwd"].get(dtype, b_def)
+            f.write(f"| `{dtype}` | {f_def} | {b_def} | {b_atomic} |\n")
+
+        f.write("\n## How this is enforced\n\n")
+        f.write(
+            "- Every kiln-tensor op parity test reads its CSV row at "
+            "harness-init time and uses the row's `*_atol` as the assertion "
+            "threshold.\n"
+            "- A test whose op + dtype + backend has no CSV row fails — "
+            "tolerance must be declared, not implicit.\n"
+            "- Phase 9's bench-gate re-runs the audit + parity-tolerance "
+            "consistency check; a row added without a justifying op or a "
+            "row removed without an op deletion fails the gate.\n"
+            "- `KILN_DETERMINISTIC=1` envelope (PROFILING.md §Determinism "
+            "stance) selects the deterministic variant of every "
+            "`bwd_determinism = tolerance-bounded` op; under the envelope, "
+            "those cells must hit `bwd_atol = 0` in the parity test.\n"
+        )
+
+    print(f"wrote {out}")
+    print(f"wrote {md}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Seventh Phase 0 deliverable for #1082.

Per the issue:

> **Per-op tolerance band matrix.** Today the DoD says global "1e-3 BF16 / 1e-5 FP32." That's too coarse — softmax-bwd in BF16 has different inherent tolerance than matmul-bwd. Output: `bench-results/parity-tolerance.csv` with `{op, dtype, backend, fwd_ulp, bwd_ulp, notes}` columns. Tolerances per dtype per op per backend become the parity-test contract.

Operationalizes the determinism stance from #1092 (Phase 0.3) as a per-cell contract.

## What's in the CSV (416 rows, 43 ops, 4 backends)

| category | ops | tolerance shape |
|---|---:|---|
| shape-only | 6 (reshape, transpose, permute, narrow, contiguous, cast) | fwd_atol=0, bwd_atol=0 (layout-only) |
| elementwise | 7 (add/sub/mul/div, silu, sigmoid, mul_sigmoid_gate) | bit-stable fwd; default bwd_atol band |
| reduction | 5 (softmax, sum, mean, rmsnorm, l2norm) | constructive (fixed-tree) |
| matmul / matmul-bwd-atomic | 5 (matmul, matmul_batched, marlin, linear, lora) | BF16 bwd_atol loosened to 2e-2 |
| atomic-bwd | 2 (embedding, index_select_rows) | BF16 bwd_atol loosened to 2e-2 |
| attention | 3 (flash_attn, flash_attn_paged, sdpa) | bwd tolerance-bounded (deterministic variant under build flag) |
| conv1d / gdn / rope | 9 (causal_conv1d *2, GDN cluster *6, rope) | constructive per-chunk |
| loss | 2 (flce, opd) | bwd tolerance-bounded (atomicAdd on grad accumulator) |
| paged-kv / sampling | 4 (paged_kv_read, paged_kv_write_slot, argmax, topk, apply_penalties) | forward-only |

## Coverage (today vs. scheduled)

| backend | fwd cells (today) | bwd cells (today) | bwd cells (scheduled) |
|---|---:|---:|---:|
| cpu | 104 | 82 | 0 |
| cuda | 104 | 82 | 0 |
| metal | 64 | 53 | 29 |
| vulkan | 80 | 72 | 10 |

The Vulkan track is most complete today — 33 `impl VkBackwardOp for ...` blocks in `vk_ops/` — and is the lift template for the other two backends.

The Metal `scheduled` column (29 bwd cells) is Phase 6c's to-do; the Vulkan (10) is the residual after the lift. Phase 6b (CUDA) and 6c (Metal) read this CSV as their input.

## Tolerance defaults (overridden per-category in the CSV)

| dtype | fwd_atol | bwd_atol | atomic-bwd bwd_atol |
|---|---:|---:|---:|
| F32 | 0.0 | 1e-5 | 5e-5 |
| BF16 | 1e-3 | 1e-2 | 2e-2 |
| F16 | 1e-3 | 5e-3 | 5e-3 |
| F8E4M3 | 0.05 | 0.1 | 0.1 |
| F8E5M2 | 0.05 | 0.1 | 0.1 |

The 2e-2 BF16 atomic-bwd band matches the existing tolerance comment at `crates/kiln-rmsnorm-kernel/src/lib.rs:5036`, cited verbatim in PROFILING.md's determinism stance.

## How this is enforced

1. Every kiln-tensor op parity test reads its CSV row at harness init and uses the row's `*_atol` as the assertion threshold.
2. A test whose op + dtype + backend has no row fails — tolerance must be declared, not implicit.
3. Phase 9's bench-gate re-runs the consistency check; a row added without a justifying op or removed without an op deletion fails the gate.
4. `KILN_DETERMINISTIC=1` selects the deterministic variant of every `bwd_determinism = tolerance-bounded` cell; under the envelope, those cells must hit `bwd_atol = 0` in the parity test.

Depends on #1092 (determinism stance) for the band definitions and the `Determinism` enum vocabulary.

Refs #1082