### PR TITLE
phase 0.8: kiln-blas crate skeleton + cublasLt MLP probe (#1082)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/kiln-blas",
     "crates/kiln-core",
     "crates/kiln-conv1d-kernel",
     "crates/kiln-eval",
@@ -17,10 +18,11 @@ members = [
     "crates/kiln-train",
     "crates/kiln-vulkan-kernel",
 ]
-# kiln-conv1d-kernel, kiln-flash-attn, kiln-gdn-kernel, kiln-marlin-gemm,
-# kiln-rmsnorm-kernel, and kiln-vulkan-kernel unconditionally depend on
-# platform-specific GPU runtimes (cudarc, vulkan-rs) which fail to link on
-# hosts without the matching GPU stack. They're only compiled when a downstream
+# kiln-blas, kiln-conv1d-kernel, kiln-flash-attn, kiln-gdn-kernel,
+# kiln-marlin-gemm, kiln-rmsnorm-kernel, and kiln-vulkan-kernel
+# unconditionally depend on platform-specific GPU runtimes
+# (cudarc, cublasLt, vulkan-rs) which fail to link on hosts without the
+# matching GPU stack. They're only compiled when a downstream
 # crate opts in via --features cuda or --features vulkan.
 # Excluding them from default-members lets `cargo check`, `cargo build`, and
 # `cargo test` work on any host; Linux+CUDA/Vulkan builds still pull them via

--- a/crates/kiln-blas/Cargo.toml
+++ b/crates/kiln-blas/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "kiln-blas"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "kiln-tensor's CUDA BLAS layer (cublasLt). Phase 0 ships only the probe; Phase 2 ships the production path."
+build = "build.rs"
+
+# The Phase 0 deliverable for this crate is the `cublaslt_mlp_probe`
+# example, which compares candle's gemm path against an explicit cublasLt
+# heuristic + workspace tuning for the Qwen3.5-4B MLP gate||up shape.
+#
+# The `lib.rs` is intentionally empty — Phase 2 fills it in. The crate is
+# excluded from `default-members` in the workspace manifest because it
+# unconditionally requires a CUDA toolchain.
+
+[features]
+default = []
+# Builds the cublasLt probe binary alongside candle's gemm baseline.
+# Enabled implicitly when running the example; explicit so a downstream
+# crate can opt out of the build.rs cublasLt link if it ever depends on
+# `kiln-blas` for something else.
+probe = []
+
+[dependencies]
+# Candle is used by the probe as the **baseline path** to compare against.
+# Phase 2's production `kiln-blas` removes this dep — for now we need it to
+# show the delta the cublasLt heuristic delivers.
+candle-core = { workspace = true, features = ["cuda"] }
+half = "2"
+
+# Timing + JSON output.
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[build-dependencies]
+cc = "1"

--- a/crates/kiln-blas/README.md
+++ b/crates/kiln-blas/README.md
@@ -1,0 +1,76 @@
+# kiln-blas
+
+CUDA BLAS layer for kiln-tensor. Phase 0 ships only the
+`cublaslt_mlp_probe` example; Phase 2 fills in the production matmul path
+(explicit algo cache, workspace pool, optional split-K, optional
+fused-bias-and-activation epilogue).
+
+## Running the Phase 0 probe
+
+The probe is GPU-only. Per the goal directive on #1082, do **not** run it
+locally — run it on a RunPod A6000 (or another supported tier-1 GPU).
+
+From inside a RunPod pod, after the standard kiln setup
+(`deploy/runpod/kiln-setup.sh` or equivalent):
+
+```bash
+cd /workspace/kiln
+
+# Build + run with the `probe` feature. The feature is what wires the
+# build.rs cublasLt link and the Rust FFI binding to the C++ probe.
+KILN_CUDA_ARCHS=86 cargo run --release \
+    -p kiln-blas \
+    --features probe \
+    --example cublaslt_mlp_probe -- \
+    --out bench-results/cublaslt_mlp_probe-a6000.json \
+    --iters 32
+
+# Then copy the JSON into the repo and commit it as the per-SKU baseline.
+git add bench-results/cublaslt_mlp_probe-*.json
+git commit -m "phase 0.8: cublasLt probe baseline (A6000)"
+git push
+```
+
+## What it measures
+
+Runs the Qwen3.5-4B MLP gate||up matmul shape
+`[B*T, 2560] @ [2560, 18432]` at `B*T ∈ {1024, 2048, 4096, 8192}` via:
+
+1. `cublasGemmEx` with `CUBLAS_GEMM_DEFAULT_TENSOR_OP` — the locked-in
+   candle path. Mirrors `vendor/candle-core/src/cuda_backend/mod.rs:2625`.
+2. `cublasLtMatmul` with `cublasLtMatmulAlgoGetHeuristic` algorithm
+   selection + an explicit workspace.
+
+Reports per-shape:
+
+- median (of `--iters`) ms for each path,
+- speedup ratio,
+- the algo ID `cublasLtMatmulAlgoGetHeuristic` picked,
+- the workspace size in bytes the heuristic asked for.
+
+The output (the JSON file under `bench-results/`) feeds into
+ARCHITECTURE.md's "which backend's explicit-control approach wins, by how
+much, on what hardware" decision per the issue's Phase 0 outcome bullet.
+
+## Why this is Phase 0, not Phase 2
+
+The probe is decision-shaping. Phase 0 outputs are recorded in
+ARCHITECTURE.md; they inform Phase 2's `kiln-blas` design knobs (how
+much workspace, which algos to cache, whether the heuristic's win
+justifies the API complexity). The probe binary is not on any production
+codepath.
+
+## File layout
+
+```
+crates/kiln-blas/
+├── Cargo.toml            # depends on candle-core (cuda) + half + cc
+├── build.rs              # compiles csrc/cublaslt_probe.cu via nvcc + cc
+├── csrc/
+│   └── cublaslt_probe.cu # C++ probe (cublasLt + cublasGemmEx)
+├── src/
+│   └── lib.rs            # FFI bindings to the C++ probe
+├── examples/
+│   └── cublaslt_mlp_probe.rs  # Rust main: timing harness + JSON output
+└── README.md             # this file
+```

--- a/crates/kiln-blas/build.rs
+++ b/crates/kiln-blas/build.rs
@@ -1,0 +1,118 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    let probe = env::var_os("CARGO_FEATURE_PROBE").is_some()
+        || env::var_os("CARGO_PRIMARY_PACKAGE").is_some();
+    if !probe {
+        // Phase 0 ships only the probe; lib.rs is otherwise empty. Skip
+        // the CUDA build if the feature isn't on.
+        return;
+    }
+
+    let cuda_root = match find_cuda_root() {
+        Some(p) => p,
+        None => {
+            println!(
+                "cargo:warning=CUDA not found; kiln-blas probe will not build. Set CUDA_ROOT / CUDA_HOME."
+            );
+            return;
+        }
+    };
+
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let csrc_dir = manifest_dir.join("csrc");
+
+    let cuda_archs = env::var("KILN_CUDA_ARCHS").unwrap_or_else(|_| "80;86;89;90".to_string());
+
+    let mut build = cc::Build::new();
+    build.cuda(true);
+    build.cpp(true);
+    configure_nvcc_from_cuda_root(&cuda_root);
+
+    build.include(&csrc_dir);
+    build.include(cuda_root.join("include"));
+
+    build.flag("-std=c++17");
+    build.flag("-O3");
+    build.flag("--use_fast_math");
+    build.flag("--expt-relaxed-constexpr");
+    build.flag("--expt-extended-lambda");
+    build.flag("-Xcompiler").flag("-fPIC");
+
+    for arch in cuda_archs.split(';') {
+        let arch = arch.trim();
+        if !arch.is_empty() {
+            build.flag(&format!("-gencode=arch=compute_{arch},code=sm_{arch}"));
+        }
+    }
+
+    build.file(csrc_dir.join("cublaslt_probe.cu"));
+
+    build.compile("kiln_blas_probe");
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        cuda_root.join("lib64").display()
+    );
+    // The probe links cublasLt + cublas + cudart (all part of CUDA toolkit).
+    println!("cargo:rustc-link-lib=cublasLt");
+    println!("cargo:rustc-link-lib=cublas");
+    println!("cargo:rustc-link-lib=cudart");
+
+    println!("cargo:rerun-if-changed=csrc/");
+    println!("cargo:rerun-if-env-changed=CUDA_ROOT");
+    println!("cargo:rerun-if-env-changed=CUDA_HOME");
+    println!("cargo:rerun-if-env-changed=NVCC");
+    println!("cargo:rerun-if-env-changed=KILN_CUDA_ARCHS");
+}
+
+fn configure_nvcc_from_cuda_root(cuda_root: &PathBuf) {
+    if env::var_os("NVCC").is_some() {
+        return;
+    }
+    let nvcc = cuda_root.join("bin").join("nvcc");
+    if nvcc.exists() {
+        unsafe {
+            env::set_var("NVCC", nvcc);
+        }
+    }
+}
+
+fn find_cuda_root() -> Option<PathBuf> {
+    for var in &["CUDA_ROOT", "CUDA_HOME", "CUDA_PATH"] {
+        if let Ok(val) = env::var(var) {
+            let p = PathBuf::from(val);
+            if p.join("include").join("cuda.h").exists() {
+                return Some(p);
+            }
+        }
+    }
+    for path in &[
+        "/usr/local/cuda",
+        "/usr/local/cuda-12",
+        "/usr/local/cuda-12.4",
+        "/usr/local/cuda-12.6",
+        "/usr/local/cuda-12.8",
+        "/opt/cuda",
+    ] {
+        let p = PathBuf::from(path);
+        if p.join("include").join("cuda.h").exists() {
+            return Some(p);
+        }
+    }
+    if let Ok(output) = std::process::Command::new("which").arg("nvcc").output() {
+        if output.status.success() {
+            let nvcc_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let p = PathBuf::from(nvcc_path);
+            if let Some(bin_dir) = p.parent() {
+                if let Some(cuda_dir) = bin_dir.parent() {
+                    if cuda_dir.join("include").join("cuda.h").exists() {
+                        return Some(cuda_dir.to_path_buf());
+                    }
+                }
+            }
+        }
+    }
+    None
+}

--- a/crates/kiln-blas/csrc/cublaslt_probe.cu
+++ b/crates/kiln-blas/csrc/cublaslt_probe.cu
@@ -1,0 +1,329 @@
+// Phase 0.8 — cublasLt vs cublas-default MLP gate||up probe.
+//
+// Compares the BF16-input BF16-output FP32-compute matmul at the Qwen3.5-4B
+// MLP gate||up shape `[B*T, 2560] @ [2560, 18432]` between:
+//
+//   (1) `cublasGemmEx` with `CUBLAS_GEMM_DEFAULT_TENSOR_OP`
+//       — the locked-in candle path (mirrors
+//         vendor/candle-core/src/cuda_backend/mod.rs:2625's call shape).
+//   (2) `cublasLtMatmul` with `cublasLtMatmulAlgoGetHeuristic` algorithm
+//       selection + an explicit workspace.
+//
+// The probe times each path with CUDA events, medians over `iters`
+// iterations, and reports per-shape ms + the chosen algo ID + the
+// workspace bytes selected by the heuristic.
+//
+// Builds via crates/kiln-blas/build.rs and links cublasLt + cublas + cudart.
+
+#include <cublasLt.h>
+#include <cublas_v2.h>
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+// Public result struct mirrored on the Rust side in `probe_ffi::ProbeResult`.
+extern "C" {
+
+struct ProbeResult {
+    int bt;
+    int k;
+    int n;
+    float ms_cublas_default;
+    float ms_cublaslt_heuristic;
+    int chosen_algo_id;
+    uint64_t chosen_workspace_bytes;
+    int iters;
+    int ok;
+    int err_code;
+};
+
+}  // extern "C"
+
+// Error-code conventions for `err_code` on the Rust side. Keep these
+// in sync with the probe markdown.
+constexpr int ERR_CUDA_ALLOC = 1;
+constexpr int ERR_CUBLAS_INIT = 2;
+constexpr int ERR_CUBLAS_GEMMEX = 3;
+constexpr int ERR_CUBLASLT_INIT = 4;
+constexpr int ERR_CUBLASLT_DESC = 5;
+constexpr int ERR_CUBLASLT_HEURISTIC = 6;
+constexpr int ERR_CUBLASLT_MATMUL = 7;
+
+namespace {
+
+// Helper: random BF16 fill on-device using a deterministic pattern.
+// We don't need real Gaussian inputs for timing — repeated bit-patterns
+// match the BLAS path's compute cost.
+__global__ void fill_bf16_pattern_kernel(__nv_bfloat16* x, int n, uint32_t seed) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    // Linear congruential then quantize to BF16 around [-0.1, 0.1].
+    uint32_t v = seed * (uint32_t)idx + 0x9E3779B9u;
+    v = (v ^ (v >> 16)) * 0x85EBCA6Bu;
+    float f = ((float)(v & 0xFFFF) - 32768.0f) / 327680.0f;
+    x[idx] = __float2bfloat16(f);
+}
+
+cudaError_t fill_bf16_pattern(__nv_bfloat16* x, int n, uint32_t seed,
+                              cudaStream_t stream) {
+    int block = 256;
+    int grid = (n + block - 1) / block;
+    fill_bf16_pattern_kernel<<<grid, block, 0, stream>>>(x, n, seed);
+    return cudaGetLastError();
+}
+
+// Median of an unsorted vector of floats.
+float median(std::vector<float>& v) {
+    std::sort(v.begin(), v.end());
+    return v[v.size() / 2];
+}
+
+}  // anonymous namespace
+
+extern "C" int kiln_blas_cublaslt_mlp_probe(int bt, int k, int n, int iters,
+                                            ProbeResult* out) {
+    *out = ProbeResult{};
+    out->bt = bt;
+    out->k = k;
+    out->n = n;
+    out->iters = iters;
+
+    cudaStream_t stream;
+    if (cudaStreamCreate(&stream) != cudaSuccess) {
+        out->err_code = ERR_CUDA_ALLOC;
+        return out->err_code;
+    }
+
+    // ------------------------------------------------------------------
+    // Allocate BF16 A [bt, k], B [k, n], C [bt, n] on the device.
+    // ------------------------------------------------------------------
+    __nv_bfloat16 *dA = nullptr, *dB = nullptr, *dC = nullptr;
+    size_t bytes_a = (size_t)bt * (size_t)k * sizeof(__nv_bfloat16);
+    size_t bytes_b = (size_t)k * (size_t)n * sizeof(__nv_bfloat16);
+    size_t bytes_c = (size_t)bt * (size_t)n * sizeof(__nv_bfloat16);
+    if (cudaMalloc(&dA, bytes_a) != cudaSuccess ||
+        cudaMalloc(&dB, bytes_b) != cudaSuccess ||
+        cudaMalloc(&dC, bytes_c) != cudaSuccess) {
+        out->err_code = ERR_CUDA_ALLOC;
+        goto cleanup;
+    }
+    fill_bf16_pattern(dA, bt * k, 1u, stream);
+    fill_bf16_pattern(dB, k * n, 2u, stream);
+    cudaStreamSynchronize(stream);
+
+    // ==================================================================
+    // (1) `cublasGemmEx` baseline (CUBLAS_GEMM_DEFAULT_TENSOR_OP).
+    // ==================================================================
+    {
+        cublasHandle_t blas;
+        if (cublasCreate(&blas) != CUBLAS_STATUS_SUCCESS) {
+            out->err_code = ERR_CUBLAS_INIT;
+            goto cleanup;
+        }
+        cublasSetStream(blas, stream);
+
+        const float alpha_f = 1.0f, beta_f = 0.0f;
+
+        // Warm-up.
+        cublasStatus_t st = cublasGemmEx(
+            blas, CUBLAS_OP_N, CUBLAS_OP_N,
+            n, bt, k,
+            &alpha_f,
+            dB, CUDA_R_16BF, n,
+            dA, CUDA_R_16BF, k,
+            &beta_f,
+            dC, CUDA_R_16BF, n,
+            CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+        if (st != CUBLAS_STATUS_SUCCESS) {
+            out->err_code = ERR_CUBLAS_GEMMEX;
+            cublasDestroy(blas);
+            goto cleanup;
+        }
+        cudaStreamSynchronize(stream);
+
+        std::vector<float> times(iters);
+        cudaEvent_t e0, e1;
+        cudaEventCreate(&e0);
+        cudaEventCreate(&e1);
+        for (int i = 0; i < iters; ++i) {
+            cudaEventRecord(e0, stream);
+            cublasGemmEx(
+                blas, CUBLAS_OP_N, CUBLAS_OP_N,
+                n, bt, k,
+                &alpha_f,
+                dB, CUDA_R_16BF, n,
+                dA, CUDA_R_16BF, k,
+                &beta_f,
+                dC, CUDA_R_16BF, n,
+                CUBLAS_COMPUTE_32F, CUBLAS_GEMM_DEFAULT_TENSOR_OP);
+            cudaEventRecord(e1, stream);
+            cudaEventSynchronize(e1);
+            float ms = 0.0f;
+            cudaEventElapsedTime(&ms, e0, e1);
+            times[i] = ms;
+        }
+        cudaEventDestroy(e0);
+        cudaEventDestroy(e1);
+        cublasDestroy(blas);
+        out->ms_cublas_default = median(times);
+    }
+
+    // ==================================================================
+    // (2) `cublasLtMatmul` with explicit heuristic + workspace.
+    // ==================================================================
+    {
+        cublasLtHandle_t lt;
+        if (cublasLtCreate(&lt) != CUBLAS_STATUS_SUCCESS) {
+            out->err_code = ERR_CUBLASLT_INIT;
+            goto cleanup;
+        }
+
+        // Build matmul descriptor: FP32 compute, BF16 scale type for
+        // the alpha/beta is unsupported on Ampere; use FP32 alpha/beta
+        // with FP32 compute. Operands are BF16.
+        cublasLtMatmulDesc_t matmulDesc = nullptr;
+        if (cublasLtMatmulDescCreate(&matmulDesc, CUBLAS_COMPUTE_32F, CUDA_R_32F)
+            != CUBLAS_STATUS_SUCCESS) {
+            out->err_code = ERR_CUBLASLT_DESC;
+            cublasLtDestroy(lt);
+            goto cleanup;
+        }
+
+        cublasOperation_t op_n = CUBLAS_OP_N;
+        cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSA,
+                                       &op_n, sizeof(op_n));
+        cublasLtMatmulDescSetAttribute(matmulDesc, CUBLASLT_MATMUL_DESC_TRANSB,
+                                       &op_n, sizeof(op_n));
+
+        // Layouts. cublasLt's convention is column-major; the equivalent
+        // of candle's row-major `[bt, k] @ [k, n] = [bt, n]` is the
+        // column-major `[n, k] @ [k, bt] = [n, bt]` with operands swapped.
+        cublasLtMatrixLayout_t aDesc = nullptr, bDesc = nullptr, cDesc = nullptr;
+        cublasLtMatrixLayoutCreate(&aDesc, CUDA_R_16BF, n, k, n);
+        cublasLtMatrixLayoutCreate(&bDesc, CUDA_R_16BF, k, bt, k);
+        cublasLtMatrixLayoutCreate(&cDesc, CUDA_R_16BF, n, bt, n);
+
+        // Preference: 32 MiB workspace cap (cublasLt will report what
+        // it actually wants; we record that).
+        cublasLtMatmulPreference_t pref = nullptr;
+        cublasLtMatmulPreferenceCreate(&pref);
+        uint64_t ws_limit = 32ull * 1024ull * 1024ull;
+        cublasLtMatmulPreferenceSetAttribute(
+            pref, CUBLASLT_MATMUL_PREF_MAX_WORKSPACE_BYTES,
+            &ws_limit, sizeof(ws_limit));
+
+        cublasLtMatmulHeuristicResult_t heuristic_result = {};
+        int returned_results = 0;
+        cublasStatus_t st = cublasLtMatmulAlgoGetHeuristic(
+            lt, matmulDesc, aDesc, bDesc, cDesc, cDesc,
+            pref, 1, &heuristic_result, &returned_results);
+        if (st != CUBLAS_STATUS_SUCCESS || returned_results == 0) {
+            out->err_code = ERR_CUBLASLT_HEURISTIC;
+            cublasLtMatmulPreferenceDestroy(pref);
+            cublasLtMatrixLayoutDestroy(aDesc);
+            cublasLtMatrixLayoutDestroy(bDesc);
+            cublasLtMatrixLayoutDestroy(cDesc);
+            cublasLtMatmulDescDestroy(matmulDesc);
+            cublasLtDestroy(lt);
+            goto cleanup;
+        }
+        // Extract algo ID (best-effort; the API exposes a int via the
+        // CUBLASLT_ALGO_CONFIG_ID attribute).
+        int algo_id = -1;
+        cublasLtMatmulAlgoConfigGetAttribute(
+            &heuristic_result.algo, CUBLASLT_ALGO_CONFIG_ID,
+            &algo_id, sizeof(algo_id), nullptr);
+
+        size_t ws_bytes = heuristic_result.workspaceSize;
+        out->chosen_algo_id = algo_id;
+        out->chosen_workspace_bytes = (uint64_t)ws_bytes;
+
+        void* d_ws = nullptr;
+        if (ws_bytes > 0 && cudaMalloc(&d_ws, ws_bytes) != cudaSuccess) {
+            out->err_code = ERR_CUDA_ALLOC;
+            cublasLtMatmulPreferenceDestroy(pref);
+            cublasLtMatrixLayoutDestroy(aDesc);
+            cublasLtMatrixLayoutDestroy(bDesc);
+            cublasLtMatrixLayoutDestroy(cDesc);
+            cublasLtMatmulDescDestroy(matmulDesc);
+            cublasLtDestroy(lt);
+            goto cleanup;
+        }
+
+        const float alpha_f = 1.0f, beta_f = 0.0f;
+
+        // Warm-up.
+        st = cublasLtMatmul(
+            lt, matmulDesc,
+            &alpha_f,
+            dB, aDesc,
+            dA, bDesc,
+            &beta_f,
+            dC, cDesc,
+            dC, cDesc,
+            &heuristic_result.algo,
+            d_ws, ws_bytes,
+            stream);
+        if (st != CUBLAS_STATUS_SUCCESS) {
+            out->err_code = ERR_CUBLASLT_MATMUL;
+            if (d_ws) cudaFree(d_ws);
+            cublasLtMatmulPreferenceDestroy(pref);
+            cublasLtMatrixLayoutDestroy(aDesc);
+            cublasLtMatrixLayoutDestroy(bDesc);
+            cublasLtMatrixLayoutDestroy(cDesc);
+            cublasLtMatmulDescDestroy(matmulDesc);
+            cublasLtDestroy(lt);
+            goto cleanup;
+        }
+        cudaStreamSynchronize(stream);
+
+        std::vector<float> times(iters);
+        cudaEvent_t e0, e1;
+        cudaEventCreate(&e0);
+        cudaEventCreate(&e1);
+        for (int i = 0; i < iters; ++i) {
+            cudaEventRecord(e0, stream);
+            cublasLtMatmul(
+                lt, matmulDesc,
+                &alpha_f,
+                dB, aDesc,
+                dA, bDesc,
+                &beta_f,
+                dC, cDesc,
+                dC, cDesc,
+                &heuristic_result.algo,
+                d_ws, ws_bytes,
+                stream);
+            cudaEventRecord(e1, stream);
+            cudaEventSynchronize(e1);
+            float ms = 0.0f;
+            cudaEventElapsedTime(&ms, e0, e1);
+            times[i] = ms;
+        }
+        cudaEventDestroy(e0);
+        cudaEventDestroy(e1);
+        if (d_ws) cudaFree(d_ws);
+        cublasLtMatmulPreferenceDestroy(pref);
+        cublasLtMatrixLayoutDestroy(aDesc);
+        cublasLtMatrixLayoutDestroy(bDesc);
+        cublasLtMatrixLayoutDestroy(cDesc);
+        cublasLtMatmulDescDestroy(matmulDesc);
+        cublasLtDestroy(lt);
+
+        out->ms_cublaslt_heuristic = median(times);
+    }
+
+    out->ok = 1;
+
+cleanup:
+    if (dA) cudaFree(dA);
+    if (dB) cudaFree(dB);
+    if (dC) cudaFree(dC);
+    cudaStreamDestroy(stream);
+    return out->err_code;
+}

--- a/crates/kiln-blas/examples/cublaslt_mlp_probe.rs
+++ b/crates/kiln-blas/examples/cublaslt_mlp_probe.rs
@@ -1,0 +1,162 @@
+//! Phase 0.8 — cublasLt vs cublas-default MLP gate||up probe.
+//!
+//! Runs the MLP gate||up matmul `[B*T, 2560] @ [2560, 18432]` via:
+//!   (1) `cublasGemmEx` with `CUBLAS_GEMM_DEFAULT_TENSOR_OP` (the locked-in
+//!       candle path)
+//!   (2) `cublasLtMatmul` with explicit `cublasLtMatmulAlgoGetHeuristic`
+//!       and a workspace
+//!
+//! at `B*T ∈ {1024, 2048, 4096, 8192}` and writes a JSON report to stdout
+//! (and optionally to a file if `--out <path>` is passed).
+//!
+//! See `crates/kiln-blas/csrc/cublaslt_probe.cu` for the C++ implementation.
+//!
+//! Run on RunPod (cublasLt is only available on a CUDA host):
+//!
+//! ```text
+//! cargo run --release \
+//!   -p kiln-blas --features probe \
+//!   --example cublaslt_mlp_probe -- \
+//!   --out bench-results/cublaslt_mlp_probe-<gpu-sku>.json
+//! ```
+
+use kiln_blas::probe_ffi::probe;
+use serde::Serialize;
+use std::path::PathBuf;
+
+#[derive(Serialize)]
+struct ShapeReport {
+    bt: i32,
+    k: i32,
+    n: i32,
+    iters: i32,
+    ms_cublas_default: f32,
+    ms_cublaslt_heuristic: f32,
+    speedup_x: f32,
+    chosen_algo_id: i32,
+    chosen_workspace_bytes: u64,
+}
+
+#[derive(Serialize)]
+struct Report {
+    gpu_query: String,
+    qwen3p5_4b_mlp_gate_up_shape: &'static str,
+    note: &'static str,
+    per_shape: Vec<ShapeReport>,
+}
+
+fn main() {
+    let mut out_path: Option<PathBuf> = None;
+    let mut iters: i32 = 32;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--out" => {
+                out_path = args.next().map(PathBuf::from);
+            }
+            "--iters" => {
+                if let Some(s) = args.next() {
+                    if let Ok(v) = s.parse::<i32>() {
+                        iters = v;
+                    }
+                }
+            }
+            "-h" | "--help" => {
+                eprintln!(
+                    "usage: cublaslt_mlp_probe [--out PATH] [--iters N]\n\
+                     \n\
+                     Benchmarks the Qwen3.5-4B MLP gate||up matmul shape\n\
+                     [B*T, 2560] @ [2560, 18432] at B*T in {{1024, 2048, 4096, 8192}}\n\
+                     via cublasGemmEx (DEFAULT_TENSOR_OP) vs cublasLtMatmul (heuristic).\n"
+                );
+                return;
+            }
+            other => eprintln!("ignoring unknown arg: {other}"),
+        }
+    }
+
+    let bts = [1024, 2048, 4096, 8192];
+    let k = 2560;
+    let n = 18432;
+
+    // Best-effort GPU name via `nvidia-smi --query-gpu=name --format=csv,noheader`.
+    let gpu_query = std::process::Command::new("nvidia-smi")
+        .args(["--query-gpu=name", "--format=csv,noheader"])
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("# Phase 0.8 cublasLt vs candle gemm probe");
+    println!("# GPU: {}", gpu_query);
+    println!(
+        "# shape: [B*T, k={}] @ [k, n={}]  →  [B*T, n]  (BF16 inputs, BF16 output, FP32 compute)",
+        k, n
+    );
+    println!("# iters per shape (median of): {}", iters);
+    println!(
+        "{:>5} | {:>16} | {:>20} | {:>9} | {:>10} | {:>15}",
+        "B*T", "cublas-default ms", "cublasLt-heuristic ms", "speedup", "algo_id", "workspace KB"
+    );
+
+    let mut per_shape = Vec::new();
+    for &bt in &bts {
+        match probe(bt, k, n, iters) {
+            Ok(r) => {
+                let speedup = if r.ms_cublaslt_heuristic > 0.0 {
+                    r.ms_cublas_default / r.ms_cublaslt_heuristic
+                } else {
+                    f32::NAN
+                };
+                println!(
+                    "{:>5} | {:>16.3} | {:>20.3} | {:>8.3}x | {:>10} | {:>15.1}",
+                    r.bt,
+                    r.ms_cublas_default,
+                    r.ms_cublaslt_heuristic,
+                    speedup,
+                    r.chosen_algo_id,
+                    (r.chosen_workspace_bytes as f64) / 1024.0,
+                );
+                per_shape.push(ShapeReport {
+                    bt: r.bt,
+                    k: r.k,
+                    n: r.n,
+                    iters: r.iters,
+                    ms_cublas_default: r.ms_cublas_default,
+                    ms_cublaslt_heuristic: r.ms_cublaslt_heuristic,
+                    speedup_x: speedup,
+                    chosen_algo_id: r.chosen_algo_id,
+                    chosen_workspace_bytes: r.chosen_workspace_bytes,
+                });
+            }
+            Err(rc) => {
+                eprintln!("probe failed at B*T={}: err_code={}", bt, rc);
+                std::process::exit(1);
+            }
+        }
+    }
+
+    let report = Report {
+        gpu_query,
+        qwen3p5_4b_mlp_gate_up_shape: "[B*T, 2560] @ [2560, 18432]",
+        note: "BF16 inputs, BF16 output, FP32 compute. (1) cublasGemmEx with \
+               CUBLAS_GEMM_DEFAULT_TENSOR_OP. (2) cublasLtMatmul with heuristic.",
+        per_shape,
+    };
+    let s = serde_json::to_string_pretty(&report).expect("serialize");
+    if let Some(p) = out_path {
+        std::fs::write(&p, &s).expect("write report");
+        eprintln!("wrote {}", p.display());
+    } else {
+        println!();
+        println!("# JSON report");
+        println!("{}", s);
+    }
+}

--- a/crates/kiln-blas/src/lib.rs
+++ b/crates/kiln-blas/src/lib.rs
@@ -1,0 +1,86 @@
+//! kiln-blas — CUDA BLAS layer (cublasLt) for kiln-tensor.
+//!
+//! Phase 0 ships the `cublaslt_mlp_probe` example only. Phase 2 fills in
+//! the production matmul path with explicit algo cache, workspace pool,
+//! optional split-K, and optional fused-bias-and-activation epilogue.
+//!
+//! See `examples/cublaslt_mlp_probe.rs` and the issue at
+//! <https://github.com/ericflo/kiln/issues/1082>.
+
+/// FFI declarations for the Phase 0 probe.
+///
+/// The probe binary is the only consumer today; Phase 2 will replace
+/// these with structured wrappers around the cublasLt API.
+#[cfg(feature = "probe")]
+pub mod probe_ffi {
+    use std::os::raw::{c_int, c_void};
+
+    /// Result struct returned by `kiln_blas_cublaslt_mlp_probe`.
+    ///
+    /// `chosen_algo_id` and `chosen_workspace_bytes` come from the
+    /// `cublasLtMatmulAlgoGetHeuristic` call inside the probe; they
+    /// document which algo the heuristic picked at the per-shape sweep.
+    #[repr(C)]
+    #[derive(Debug, Clone, Copy)]
+    pub struct ProbeResult {
+        pub bt: c_int,
+        pub k: c_int,
+        pub n: c_int,
+        pub ms_cublas_default: f32,
+        pub ms_cublaslt_heuristic: f32,
+        pub chosen_algo_id: c_int,
+        pub chosen_workspace_bytes: u64,
+        pub iters: c_int,
+        pub ok: c_int,
+        pub err_code: c_int,
+    }
+
+    unsafe extern "C" {
+        /// Run the cublasLt vs. cublas-default probe at the given shape.
+        ///
+        /// Inputs:
+        /// - `bt`, `k`, `n`: matmul shape `[bt, k] @ [k, n] = [bt, n]`.
+        /// - `iters`: number of timed iterations to median over.
+        /// - `out`: out-param pointer to a [`ProbeResult`].
+        ///
+        /// Returns 0 on success, nonzero on error.
+        pub fn kiln_blas_cublaslt_mlp_probe(
+            bt: c_int,
+            k: c_int,
+            n: c_int,
+            iters: c_int,
+            out: *mut ProbeResult,
+        ) -> c_int;
+    }
+
+    /// Safety: caller must ensure CUDA is initialized on a thread that
+    /// holds a CUDA context; the C function creates and tears down its
+    /// own cublasLt handle and workspace internally.
+    pub fn probe(bt: i32, k: i32, n: i32, iters: i32) -> Result<ProbeResult, i32> {
+        let mut out = ProbeResult {
+            bt: 0,
+            k: 0,
+            n: 0,
+            ms_cublas_default: 0.0,
+            ms_cublaslt_heuristic: 0.0,
+            chosen_algo_id: -1,
+            chosen_workspace_bytes: 0,
+            iters: 0,
+            ok: 0,
+            err_code: 0,
+        };
+        let rc = unsafe {
+            kiln_blas_cublaslt_mlp_probe(bt, k, n, iters, &mut out as *mut _)
+        };
+        if rc == 0 {
+            Ok(out)
+        } else {
+            Err(rc)
+        }
+    }
+}
+
+/// Empty placeholder for the Phase 2 production path. See lib doc.
+pub fn phase() -> &'static str {
+    "phase 0 — probe only"
+}


### PR DESCRIPTION
Eighth Phase 0 deliverable for #1082.

Adds the `kiln-blas` crate as a new workspace member (NOT in `default-members`, since it needs a CUDA toolchain) and ships the cublasLt-vs-cublas-default probe per the issue's Phase 0 bullet:

> `crates/kiln-blas/examples/cublaslt_mlp_probe.rs` — standalone binary. Run the MLP gate||up matmul (`[B*T, 2560] @ [2560, 18432]`) via candle's path and via cublasLt with `cublasLtMatmulAlgoGetHeuristic` + explicit workspace. Bench at `B*T ∈ {1024, 2048, 4096, 8192}` on every CUDA GPU reachable. Report per-shape ms + chosen algo IDs + workspace size.

## What's in the crate

| Path | Purpose |
|------|---------|
| `crates/kiln-blas/Cargo.toml` | Minimal manifest with a `probe` feature that wires build.rs cublasLt link + Rust FFI binding |
| `crates/kiln-blas/build.rs` | Compiles `csrc/cublaslt_probe.cu` via nvcc + cc; links cublasLt + cublas + cudart |
| `crates/kiln-blas/csrc/cublaslt_probe.cu` | C++ probe; two paths timed with cuda events |
| `crates/kiln-blas/src/lib.rs` | FFI struct + `probe()` Rust wrapper. Otherwise empty until Phase 2 fills in the production matmul path. |
| `crates/kiln-blas/examples/cublaslt_mlp_probe.rs` | Rust harness: runs probe at B*T ∈ {1024,2048,4096,8192}, queries `nvidia-smi`, writes JSON report |
| `crates/kiln-blas/README.md` | RunPod invocation + what the probe measures + Phase 2 hook |

## Architectural note: not built locally

Per the goal directive on #1082 (\"DO NOT BUILD OR TEST OR CHECK LOCALLY, always use runpod\"), this PR adds source only. The probe is run on RunPod A6000 per the README. The JSON result lands as a follow-up commit to `bench-results/cublaslt_mlp_probe-a6000.json`.

## Workspace impact

`kiln-blas` is added to `[workspace] members` but excluded from `default-members` — the same pattern as the other CUDA-needing crates (kiln-flash-attn, kiln-marlin-gemm, etc.). `cargo check` on the default no-GPU profile is unaffected.

## What this gates

- ARCHITECTURE.md gets a section recording \"which backend's explicit-control approach wins, by how much, on what hardware\" once results land.
- Phase 2 reads the JSON to decide algo cache + workspace pool API shape, and which algos to pre-ship-cache for the Qwen3.5-4B GEMM shapes.

## Follow-up PRs

- `phase 0.9: kiln-vulkan vk_mlp_probe` — same shape, Vulkan compute path.
- `phase 0.10: pre-migration baseline capture` — decode + prefill numbers on every reachable GPU.

Refs #1082