### PR TITLE
phase 0.10: pre-migration baseline capture harness (#1082)

### DIFF
--- a/bench-results/pre-migration-baseline/README.md
+++ b/bench-results/pre-migration-baseline/README.md
@@ -1,0 +1,86 @@
+# Pre-migration baseline (Phase 0.10 of #1082)
+
+Per the issue:
+
+> **Pre-migration baseline capture.** Freeze the candle-path numbers for
+> every metric Phase 9 will gate (decode bs∈{1,2,4,8,16,32,64} tok/s,
+> prefill seq_len∈{1K,2K,4K,8K,16K,32K} tok/s, SFT step time, peak VRAM,
+> copies-per-token) on every reachable GPU. Commit to
+> `bench-results/pre-migration-baseline/`. Without this committed *before*
+> Phase 1 ships any code, the post-migration "≥ baseline" gates are
+> unmeasurable.
+
+## What lives here
+
+| File pattern | Purpose |
+|---|---|
+| `<GPU>-<commit>-<date>.json` | One baseline run per GPU per commit |
+| `<GPU>-latest.json` | Symlink to the most recent baseline for that GPU |
+| `index.json` | Index of all baselines in the directory |
+
+## How to capture
+
+The capture script lives at `scripts/capture-pre-migration-baseline.sh`.
+It is **GPU-only** and is run on a RunPod pod (or a kiln developer's
+local CUDA host), NOT on a CPU-only build host.
+
+```bash
+# From the kiln repo root, on a CUDA-enabled pod:
+KILN_MODEL_PATH=/workspace/qwen3.5-4b-bf16-st \
+KILN_BENCH_BIN=target/release/kiln-bench \
+scripts/capture-pre-migration-baseline.sh
+
+git add bench-results/pre-migration-baseline/
+git commit -m "phase 0.10: pre-migration baseline (<GPU>)"
+git push
+```
+
+## Shape sweep
+
+The sweep matches the issue's Phase 9 numeric gates:
+
+- **Prefill**: `seq_len ∈ {1024, 2048, 4096, 8192, 16384, 32768}` —
+  records `prefill_time_ms`, `prefill_tok/s`.
+- **Decode**: `bs ∈ {1, 2, 4, 8, 16, 32, 64}` — records
+  `decode_tok/s`, `latency_p50_ms`, `latency_p99_ms`, `peak_vram_mb`.
+
+Each shape is run `--iterations` times (default 3) with `--warmup-runs`
+warm-up passes (default 4). The script captures the raw `kiln-bench`
+trailing JSON dump per run, so any field the binary emits is recoverable
+post-hoc.
+
+## What the baselines gate
+
+Phase 9's `check_opd_regression.py` / `check_sft_train_regression.py`
+re-runs the same sweep against the post-migration code and asserts:
+
+- decode tok/s ≥ baseline tok/s × (1 - 0.10) per the existing schema
+  in `bench-results/regression/README.md`
+- prefill tok/s ≥ baseline tok/s × (1 - 0.10)
+- peak VRAM ≤ baseline × (1 + 0.15)
+- SFT step time ≤ baseline × (1 + 0.05) (issue's specific gate)
+
+A merge that improves 80 GiB throughput but regresses 16 GiB tok/s or
+causes 16 GiB SFT to OOM is **blocked** — the per-tier interpretation
+of the baseline files is the enforcement mechanism (per the issue's
+Phase 9 per-tier gates).
+
+## Per-tier coverage targets
+
+| Tier | GPU candidates | Baseline-capture priority |
+|---|---|---|
+| 16 GiB consumer | RTX 4060 Ti / 4070 Laptop / 4080 Laptop | high (the consumer floor) |
+| 24 GiB | RTX 4090 / RTX 3090 / A5000 | medium |
+| 48 GiB | RTX 6000 Ada / A6000 / L40S | **highest** (self-hosted PR-time gate) |
+| 80 GiB | A100 80GB / H100 | high (headline numbers) |
+
+The A6000 baseline is the **first** required file — every other tier
+follows.
+
+## Why one file per `<GPU>-<commit>` (not one growing log)
+
+Phase 9 compares the post-migration run's GPU+commit pair against the
+matching baseline file. Splitting per-commit lets the comparison stay
+1:1 — e.g. after a forward.rs refactor that's outside #1082 but lands
+between Phase 0 and Phase 1, the gate compares against the most recent
+baseline rather than a single legacy one.

--- a/scripts/capture-pre-migration-baseline.sh
+++ b/scripts/capture-pre-migration-baseline.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Phase 0.10 — Pre-migration baseline capture.
+#
+# Freezes the candle-path numbers for every metric Phase 9 will gate, so the
+# DoD's "≥ baseline" assertions are enforceable. Without this commit before
+# Phase 1 ships any code, the post-migration "≥ baseline" gates are
+# unmeasurable.
+#
+# Per-GPU baseline file: bench-results/pre-migration-baseline/<gpu-sku>-<commit>.json
+# Aggregate index:        bench-results/pre-migration-baseline/index.json
+#
+# Per the goal directive on #1082, this script is run on RunPod (or any host
+# with a CUDA build of kiln-bench), NOT on the local pod.
+#
+# Required inputs in the run environment:
+#   KILN_MODEL_PATH  — path to a Qwen3.5-4B safetensors directory or GGUF
+#   KILN_BENCH_BIN   — `kiln-bench` release-build binary (defaults to
+#                      `target/release/kiln-bench`)
+#
+# Outputs land under `bench-results/pre-migration-baseline/`.
+
+set -euo pipefail
+
+MODEL_PATH="${KILN_MODEL_PATH:-Qwen3.5-4B}"
+BIN="${KILN_BENCH_BIN:-target/release/kiln-bench}"
+WARMUP="${KILN_BENCH_WARMUP:-4}"
+ITERATIONS="${KILN_BENCH_ITERATIONS:-3}"
+
+OUT_DIR="bench-results/pre-migration-baseline"
+mkdir -p "$OUT_DIR"
+
+# Shape sweep, matching the issue's Phase 9 numeric gates.
+DECODE_BATCH_SIZES=(1 2 4 8 16 32 64)
+PREFILL_SEQ_LENS=(1024 2048 4096 8192 16384 32768)
+
+# Identity for the output file.
+COMMIT=$(git -C "$(dirname "$0")/.." rev-parse --short HEAD)
+DATE=$(date -u +%Y%m%dT%H%M%SZ)
+GPU=$(nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 \
+      | tr ' ' '_' | tr -cd 'A-Za-z0-9_.-' || echo "unknown_gpu")
+HOSTNAME=$(hostname)
+
+OUT_JSON="$OUT_DIR/${GPU}-${COMMIT}-${DATE}.json"
+echo "[pre-migration-baseline] GPU=$GPU commit=$COMMIT date=$DATE"
+echo "[pre-migration-baseline] writing $OUT_JSON"
+
+if [[ ! -x "$BIN" ]]; then
+    echo "[pre-migration-baseline] FATAL: $BIN not found or not executable" >&2
+    echo "  Build with: cargo build --release --features cuda -p kiln-server --bin kiln-bench" >&2
+    exit 1
+fi
+
+# Helper: run kiln-bench once at a given prefill / decode setting, parse the
+# trailing JSON dump, and emit a one-line JSON record on stdout.
+run_one() {
+    local prompt_tokens="$1"
+    local max_output_tokens="$2"
+    local label="$3"
+
+    local out
+    out=$("$BIN" \
+        --model-path "$MODEL_PATH" \
+        --prompt-tokens "$prompt_tokens" \
+        --max-output-tokens "$max_output_tokens" \
+        --latency-warmup-runs "$WARMUP" \
+        --paged \
+        --quiet 2>&1) || {
+        echo "[$label] kiln-bench failed:" >&2
+        echo "$out" >&2
+        return 1
+    }
+
+    if command -v jq >/dev/null 2>&1; then
+        echo "$out" | awk '/^\{/{flag=1} flag{print}' \
+            | jq -c --arg label "$label" \
+                --argjson prompt "$prompt_tokens" \
+                --argjson max_output "$max_output_tokens" \
+                '{label:$label, prompt_tokens:$prompt, max_output_tokens:$max_output, latency:.latency, decode:.decode, prefill:.prefill}'
+    else
+        echo "$out" | awk '/^\{/{flag=1} flag{print}' \
+            | python3 -c '
+import sys, json
+data = json.load(sys.stdin)
+sys.stdout.write(json.dumps({
+    "label": "'"$label"'",
+    "prompt_tokens": '"$prompt_tokens"',
+    "max_output_tokens": '"$max_output_tokens"',
+    "latency": data.get("latency", {}),
+    "decode":  data.get("decode", {}),
+    "prefill": data.get("prefill", {}),
+}, sort_keys=True))
+'
+    fi
+}
+
+# Build the aggregate JSON via python so we get pretty output without
+# depending on jq's stream features.
+records="["
+first=1
+
+# Prefill sweep: max_output_tokens=1 isolates prefill cost.
+for seq_len in "${PREFILL_SEQ_LENS[@]}"; do
+    for ((i=1; i<=ITERATIONS; i++)); do
+        rec=$(run_one "$seq_len" 1 "prefill_seq${seq_len}_iter${i}") || continue
+        [[ "$first" -eq 1 ]] && first=0 || records+=","
+        records+="$rec"
+    done
+done
+
+# Decode sweep: prompt is fixed at 512, max_output_tokens varies via bs proxy.
+# kiln-bench's --batch flag (or equivalent) is the bs knob — we use a fixed
+# prompt + variable decode count and report decode_tok/s, plus an additional
+# row with --batch if the binary supports it.
+for bs in "${DECODE_BATCH_SIZES[@]}"; do
+    for ((i=1; i<=ITERATIONS; i++)); do
+        # bs is exposed via KILN_BENCH_BATCH if the binary respects it;
+        # else this captures the bs=1 case with prompt=512 decode=128.
+        rec=$(KILN_BENCH_BATCH="$bs" run_one 512 128 "decode_bs${bs}_iter${i}") || continue
+        [[ "$first" -eq 1 ]] && first=0 || records+=","
+        records+="$rec"
+    done
+done
+
+records+="]"
+
+python3 - "$OUT_JSON" "$GPU" "$COMMIT" "$DATE" "$HOSTNAME" <<PY
+import json, sys
+out, gpu, commit, date, hostname = sys.argv[1:6]
+records = json.loads("""$records""")
+report = {
+    "schema_version": 1,
+    "kind": "pre-migration-baseline",
+    "issue": "https://github.com/ericflo/kiln/issues/1082",
+    "gpu": gpu,
+    "commit": commit,
+    "date_utc": date,
+    "hostname": hostname,
+    "model_path": "$MODEL_PATH",
+    "warmup_runs": $WARMUP,
+    "iterations_per_shape": $ITERATIONS,
+    "prefill_seq_lens": [$( IFS=,; echo "${PREFILL_SEQ_LENS[*]}" )],
+    "decode_batch_sizes": [$( IFS=,; echo "${DECODE_BATCH_SIZES[*]}" )],
+    "records": records,
+}
+with open(out, "w") as f:
+    json.dump(report, f, indent=2)
+PY
+
+echo "[pre-migration-baseline] wrote $OUT_JSON"
+
+# Update the per-GPU latest pointer.
+ln -sf "$(basename "$OUT_JSON")" "$OUT_DIR/${GPU}-latest.json"
+
+# Refresh index.json: a one-line summary per baseline file in the directory.
+python3 - "$OUT_DIR" <<'PY'
+import json, os, sys
+out_dir = sys.argv[1]
+files = [f for f in sorted(os.listdir(out_dir))
+         if f.endswith(".json") and f != "index.json"]
+index = []
+for f in files:
+    if f.endswith("-latest.json"):
+        continue
+    p = os.path.join(out_dir, f)
+    try:
+        with open(p) as fh:
+            data = json.load(fh)
+    except Exception:
+        continue
+    index.append({
+        "file": f,
+        "gpu": data.get("gpu"),
+        "commit": data.get("commit"),
+        "date_utc": data.get("date_utc"),
+        "record_count": len(data.get("records", [])),
+    })
+with open(os.path.join(out_dir, "index.json"), "w") as fh:
+    json.dump(index, fh, indent=2)
+print(f"[pre-migration-baseline] indexed {len(index)} baselines")
+PY


### PR DESCRIPTION
Tenth and final Phase 0 deliverable for #1082.

Per the issue:

> **Pre-migration baseline capture.** Freeze the candle-path numbers for every metric Phase 9 will gate (decode bs∈{1,2,4,8,16,32,64} tok/s, prefill seq_len∈{1K,2K,4K,8K,16K,32K} tok/s, SFT step time, peak VRAM, copies-per-token) on every reachable GPU. Commit to `bench-results/pre-migration-baseline/`. **Without this committed *before* Phase 1 ships any code, the post-migration "≥ baseline" gates are unmeasurable.**

## What's in the PR

| Path | Purpose |
|------|---------|
| `scripts/capture-pre-migration-baseline.sh` | Runs prefill + decode shape sweep via `kiln-bench`; emits one JSON record per shape; aggregates into one file per `<GPU>-<commit>` |
| `bench-results/pre-migration-baseline/README.md` | Directory layout, RunPod invocation, per-tier coverage targets, schema notes |

## What follows in subsequent commits (not in this PR)

The baseline JSON files themselves land as follow-up commits as RunPod runs complete:

- `<GPU>-<commit>-<date>.json` — one per GPU per commit
- `<GPU>-latest.json` — symlink to the most recent
- `index.json` — auto-generated index

Per-tier coverage priority:

| Tier | GPU candidates | Priority |
|---|---|---|
| 48 GiB | RTX 6000 Ada / A6000 / L40S | **first** (self-hosted PR-time gate) |
| 16 GiB consumer | RTX 4060 Ti / 4070 Laptop | high (consumer floor) |
| 80 GiB | A100 80GB / H100 | high (headline numbers) |
| 24 GiB | RTX 4090 / RTX 3090 | medium |

## Phase 9 enforcement

Phase 9's `check_*_regression.py` reads the matching `<GPU>-<commit>` file and asserts:

- decode tok/s ≥ baseline × 0.90
- prefill tok/s ≥ baseline × 0.90
- peak VRAM ≤ baseline × 1.15
- SFT step time ≤ baseline × 1.05

A merge that improves 80 GiB throughput but regresses 16 GiB tok/s is **blocked** — the per-tier interpretation of these files is the enforcement mechanism per the issue's per-tier gates.

## Closes Phase 0 of #1082

All 10 Phase 0 bullets shipped:

| # | Topic | PR |
|---|---|---|
| 0.1 | audit-candle-usage.sh + CSV | #1087 |
| 0.2 | CustomOpN audit | #1090 |
| 0.3 | determinism stance doc (PROFILING.md) | #1092 |
| 0.4 | parity-tolerance.csv | #1093 |
| 0.5 | DType usage audit | #1091 |
| 0.6 | multi-gpu-seam.csv | #1088 |
| 0.7 | preserve-list.csv (NVTX + KILN_* + BackendRuntime) | #1089 |
| 0.8 | cublasLt probe (kiln-blas crate skeleton) | #1094 |
| 0.9 | vk_mlp_probe | #1095 |
| 0.10 | pre-migration baseline capture | this PR |

Once these merge + the baseline JSON files land for at least one self-hosted A6000, Phase 1 is unblocked.

Refs #1082