### PR TITLE
phase 1.1: kiln-tensor crate scaffold + Error/Result/bail!/ensure! (#1082)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/kiln-rmsnorm-kernel",
     "crates/kiln-scheduler",
     "crates/kiln-server",
+    "crates/kiln-tensor",
     "crates/kiln-train",
     "crates/kiln-vulkan-kernel",
 ]
@@ -34,6 +35,7 @@ default-members = [
     "crates/kiln-opd-loss-kernel",
     "crates/kiln-scheduler",
     "crates/kiln-server",
+    "crates/kiln-tensor",
     "crates/kiln-train",
 ]
 
@@ -122,6 +124,7 @@ kiln-eval = { path = "crates/kiln-eval" }
 kiln-model = { path = "crates/kiln-model" }
 kiln-scheduler = { path = "crates/kiln-scheduler" }
 kiln-server = { path = "crates/kiln-server" }
+kiln-tensor = { path = "crates/kiln-tensor" }
 kiln-train = { path = "crates/kiln-train" }
 
 [patch.crates-io]

--- a/crates/kiln-tensor/Cargo.toml
+++ b/crates/kiln-tensor/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "kiln-tensor"
+description = "In-house Tensor + Storage substrate for kiln. Phase 0/1 scaffold; backends fill in over Phases 1-7."
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# kiln-tensor is internal-only — no semver commitment.
+# Other kiln-* crates may break against minor version bumps until candle
+# is removed and the surface stabilizes (Phase 7 of #1082).
+# See `src/lib.rs` for the public-API stability statement.
+
+[dependencies]
+# Error machinery — Result wraps a thiserror enum, but a public callable
+# bail! macro mirrors candle's ergonomic shape so 491+ migration sites
+# can mechanically swap `candle_core::bail!(...)` -> `kiln_tensor::bail!(...)`.
+thiserror = { workspace = true }
+# anyhow is intentionally absent — kiln_tensor::Error owns its variants.
+
+[features]
+default = []
+# Reserved feature names for future PRs in Phase 1; declared early so
+# downstream `kiln-tensor = { features = ["cuda"] }` invocations don't
+# break when added.
+cuda = []
+metal = []
+vulkan = []

--- a/crates/kiln-tensor/src/error.rs
+++ b/crates/kiln-tensor/src/error.rs
@@ -1,0 +1,212 @@
+//! `kiln_tensor::Error` / `Result` and the public [`bail!`] / [`ensure!`] macros.
+//!
+//! These are the migration target for `candle_core::Error` (106 sites),
+//! `candle_core::Result` (43 sites), `candle_core::bail!` (491 sites), and
+//! `candle_core::ensure!` — together over 640 of the 1,799 candle call sites
+//! the Phase 0.1 audit captured.
+//!
+//! The shape mirrors candle's so the swap is mechanical in most call sites:
+//!
+//! ```ignore
+//! use kiln_tensor as kt;
+//!
+//! fn check(shape: &[usize]) -> kt::Result<()> {
+//!     kt::ensure!(!shape.is_empty(), "shape cannot be empty");
+//!     kt::ensure!(shape.iter().all(|&d| d > 0),
+//!                 "shape {shape:?} contains zero or negative dims");
+//!     Ok(())
+//! }
+//!
+//! fn lookup(name: &str) -> kt::Result<i32> {
+//!     match name {
+//!         "answer" => Ok(42),
+//!         other => kt::bail!("unknown name {other:?}"),
+//!     }
+//! }
+//! ```
+//!
+//! `Error::Msg` is the analogue of `candle_core::Error::Msg`; the typed
+//! variants are scaffolded for Phase 1.2 / 1.3 / 1.4 to populate.
+
+use std::fmt;
+
+/// kiln-tensor's error type.
+///
+/// Variants are split between:
+///
+/// - [`Error::Msg`] — free-form string. The migration's mechanical
+///   substitute for `candle_core::Error::Msg`.
+/// - Typed variants — added in subsequent Phase 1 PRs (mismatched
+///   dtype, bad shape, allocator OOM, etc.).
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Free-form error message. Use [`bail!`] / [`ensure!`] to construct.
+    #[error("{0}")]
+    Msg(String),
+}
+
+impl Error {
+    /// Construct a [`Error::Msg`] from any `Display` value.
+    #[inline]
+    pub fn msg<T: fmt::Display>(value: T) -> Self {
+        Error::Msg(value.to_string())
+    }
+
+    /// Wrap a borrowed [`str`] into a [`Error::Msg`]. Marginally cheaper
+    /// than [`Error::msg`] for static-string call sites.
+    #[inline]
+    pub fn from_str(s: &str) -> Self {
+        Error::Msg(s.to_owned())
+    }
+
+    /// Attach a static `&'static str` context phrase to an existing
+    /// error. Mirrors `anyhow::Context::context`; intended for the
+    /// per-call-site context-add idiom common in candle code.
+    #[inline]
+    pub fn with_context<C: fmt::Display>(self, context: C) -> Self {
+        Error::Msg(format!("{context}: {self}"))
+    }
+}
+
+/// kiln-tensor's [`std::result::Result`] alias.
+///
+/// Replaces `candle_core::Result<T>` at the 43+ call sites that name it
+/// explicitly, plus the implicit returns from `bail!` / `ensure!`.
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Return early with an [`Error::Msg`].
+///
+/// Mirrors `candle_core::bail!` ergonomically:
+///
+/// ```ignore
+/// kiln_tensor::bail!("got {} dims, expected at least {}", got, want);
+/// ```
+#[macro_export]
+macro_rules! bail {
+    ($msg:literal $(,)?) => {
+        return ::core::result::Result::Err($crate::Error::Msg(::std::format!($msg)))
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        return ::core::result::Result::Err($crate::Error::Msg(::std::format!($fmt, $($arg)*)))
+    };
+}
+
+/// Return early with an [`Error::Msg`] if a condition is false.
+///
+/// Mirrors `candle_core::ensure!`:
+///
+/// ```ignore
+/// kiln_tensor::ensure!(x.len() == y.len(), "lengths differ: {} vs {}", x.len(), y.len());
+/// ```
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $msg:literal $(,)?) => {
+        if !($cond) {
+            return ::core::result::Result::Err($crate::Error::Msg(::std::format!($msg)));
+        }
+    };
+    ($cond:expr, $fmt:expr, $($arg:tt)*) => {
+        if !($cond) {
+            return ::core::result::Result::Err($crate::Error::Msg(::std::format!($fmt, $($arg)*)));
+        }
+    };
+}
+
+// ----------------------------------------------------------------------
+// Conversions for ergonomic interop with anyhow / std error types.
+// ----------------------------------------------------------------------
+
+impl From<&str> for Error {
+    fn from(s: &str) -> Self {
+        Error::Msg(s.to_owned())
+    }
+}
+
+impl From<String> for Error {
+    fn from(s: String) -> Self {
+        Error::Msg(s)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Error::Msg(format!("io: {e}"))
+    }
+}
+
+impl From<std::num::ParseIntError> for Error {
+    fn from(e: std::num::ParseIntError) -> Self {
+        Error::Msg(format!("parse int: {e}"))
+    }
+}
+
+impl From<std::num::ParseFloatError> for Error {
+    fn from(e: std::num::ParseFloatError) -> Self {
+        Error::Msg(format!("parse float: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn returns_bail() -> Result<()> {
+        bail!("bail with format: {} + {}", 1, 2);
+    }
+
+    fn returns_ensure(cond: bool) -> Result<()> {
+        ensure!(cond, "ensure says no");
+        Ok(())
+    }
+
+    #[test]
+    fn bail_returns_msg() {
+        let e = returns_bail().unwrap_err();
+        match e {
+            Error::Msg(m) => assert_eq!(m, "bail with format: 1 + 2"),
+        }
+    }
+
+    #[test]
+    fn ensure_truthy_is_ok() {
+        assert!(returns_ensure(true).is_ok());
+    }
+
+    #[test]
+    fn ensure_falsy_returns_msg() {
+        let e = returns_ensure(false).unwrap_err();
+        match e {
+            Error::Msg(m) => assert_eq!(m, "ensure says no"),
+        }
+    }
+
+    #[test]
+    fn with_context_prefixes() {
+        let e = Error::from_str("inner cause").with_context("while reading model.safetensors");
+        assert_eq!(
+            e.to_string(),
+            "while reading model.safetensors: inner cause"
+        );
+    }
+
+    #[test]
+    fn from_str_and_string_construct_msg() {
+        let a: Error = "literal".into();
+        let b: Error = String::from("owned").into();
+        match (a, b) {
+            (Error::Msg(x), Error::Msg(y)) => {
+                assert_eq!(x, "literal");
+                assert_eq!(y, "owned");
+            }
+        }
+    }
+
+    #[test]
+    fn io_error_wraps_into_msg() {
+        let io_err = std::io::Error::new(std::io::ErrorKind::NotFound, "no such file");
+        let e: Error = io_err.into();
+        match e {
+            Error::Msg(m) => assert!(m.starts_with("io: ")),
+        }
+    }
+}

--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -1,0 +1,25 @@
+//! kiln-tensor — in-house Tensor + Storage substrate for kiln.
+//!
+//! # Status
+//!
+//! **Phase 1.1 scaffold** — see [GitHub issue #1082][epic] for the full
+//! migration plan. Today this crate ships only [`Error`], [`Result`],
+//! and the [`bail!`] macro. Subsequent Phase 1 PRs add `DType`,
+//! `TensorId`, `Layout`, `Storage`, and `Tensor`.
+//!
+//! # Public-API stability
+//!
+//! `kiln-tensor` is **internal-only — no semver commitment**. Other
+//! `kiln-*` crates may break against minor version bumps until candle is
+//! removed and the surface stabilizes (Phase 7 of #1082). Once Phase 7
+//! lands and the migration is complete, the public API of this crate
+//! freezes against the next major version bump.
+//!
+//! [epic]: https://github.com/ericflo/kiln/issues/1082
+
+#![deny(missing_debug_implementations)]
+#![warn(rust_2018_idioms)]
+
+mod error;
+
+pub use error::{Error, Result};


### PR DESCRIPTION
First Phase 1 deliverable for #1082, kicking off the kiln-tensor scaffold per the issue's "Crate skeleton" bullet. Scoped tightly to the smallest revertable slice: the error machinery.

## What this PR adds

| Path | Purpose |
|------|---------|
| `crates/kiln-tensor/Cargo.toml` | Minimal manifest. Only `thiserror` as a runtime dep. `{cuda, metal, vulkan}` features pre-declared (no-op today) so downstream `kiln-tensor = { features = ["cuda"] }` invocations don't break when Phase 1.4+ wires backend storage. |
| `crates/kiln-tensor/src/lib.rs` | Public re-exports + the **"internal-only, no semver"** stability statement per the issue's Phase 1 bullet. |
| `crates/kiln-tensor/src/error.rs` | `Error` (single `Msg(String)` variant for now), `Result<T>` alias, public `bail!` and `ensure!` macros mirroring candle's shape, plus `From<&str> / String / io::Error / ParseInt / ParseFloat` impls and a `with_context` builder. |

## Workspace impact

`kiln-tensor` is added to both `members` **and `default-members`** — the crate is CPU-only at this stage and must compile on any host, including the no-GPU `linux-default` CI lane at `.github/workflows/ci.yml:97`. Per the issue's DoD item:

> `cargo test` on the default (no-GPU) profile still passes — CPU is a tested backend, not just a numerical reference.

A `kiln-tensor = { path = "crates/kiln-tensor" }` workspace-dep entry is added so future crates can pull it in via `kiln-tensor = { workspace = true }`.

## Migration targets this PR unblocks

From Phase 0.1's audit (#1087), this scaffold is the migration target for ~640 of the 1,799 candle call sites:

| Candle symbol | Sites |
|---|---:|
| `candle_core::bail!` | 491 |
| `candle_core::Error::Msg` | 106 |
| `candle_core::Result` | 43 |

The substitution is mechanical: `use kiln_tensor as kt;` + search-and-replace.

## What this PR does NOT do

Each lands as a separate small PR per anti-pattern 5 ("PRs are small and individually revertable"):

- `DType` enum (Phase 1.2 — task queued)
- `TensorId` + `Layout` (Phase 1.3 — task queued)
- `Storage` trait + CPU storage impl (Phase 1.4)
- per-backend storage (CUDA, Metal, Vulkan) (Phases 1.5-1.7)
- `Tensor` struct (Phase 1.9)
- `Allocator` with Owned / Pool / Frozen modes (Phase 1.10)
- `StreamPlanner` (Phase 1.11)
- pinned-host staging pool (Phase 1.12)
- Activation registry, AmpPolicy, output-head registry (later)

## Tests

5 unit tests in `error.rs`:

- `bail!` returns `Msg` with format args
- `ensure!` truthy ⇒ `Ok`
- `ensure!` falsy ⇒ `Msg`
- `with_context` prefixes correctly
- `From<&str> / String / io::Error` round-trip

## Build / test note

Per the goal directive on #1082, this PR is NOT built locally. CPU-only, no platform-specific surface (only stdlib + thiserror) — verification is the standard CI lane.

Refs #1082