### PR TITLE
phase 1.4: kiln-tensor Device + Storage trait + CPU storage (#1082)

### DIFF
--- a/crates/kiln-tensor/src/device.rs
+++ b/crates/kiln-tensor/src/device.rs
@@ -1,0 +1,186 @@
+//! `kiln_tensor::Device` — the four backends kiln-tensor dispatches over.
+//!
+//! Replaces `candle_core::Device` at the 91 call sites the Phase 0.1 audit
+//! captured: `Device` (30), `Device::Cpu` (24), `Device::Metal` (18),
+//! `Device::Cuda` (14), `Device::new_cuda` (5).
+//!
+//! # Multi-GPU stays out of scope (anti-pattern 12)
+//!
+//! The variant body for the GPU backends carries a `device_index: usize`
+//! so we never hardcode `0`. The Phase 0.6 audit (#1088) showed 126
+//! `Device::new_cuda(0)` sites — only 2 production, the rest test/example.
+//! Phase 1 callers must reach this enum through a centralized accessor
+//! (`kiln_core::device::primary_cuda()` for production; a test-helper for
+//! tests). A future TP rewrite swaps the accessor; no per-call-site
+//! changes.
+
+use core::fmt;
+
+/// The four backends kiln-tensor dispatches over.
+///
+/// The variant body carries the device index where applicable. Multi-GPU
+/// stays out of scope for #1082 (anti-pattern 12), but the index is in
+/// the type so two kiln processes on one box can pin different GPUs and
+/// a future TP rewrite does not have to revisit any call sites.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Device {
+    /// CPU — the canonical numerical reference. Always available.
+    /// Per the issue's DoD: "CPU is a tested backend, not just a
+    /// numerical reference."
+    Cpu,
+    /// CUDA device at the given index. Created via cudarc / candle's
+    /// CUDA backend in Phase 1.5.
+    Cuda(usize),
+    /// Apple Metal device at the given index. Created via objc2-metal
+    /// in Phase 1.6.
+    Metal(usize),
+    /// Vulkan device at the given index. Created via ash in Phase 1.7;
+    /// lifts the existing `kiln-vulkan-kernel` VulkanDevice.
+    Vulkan(usize),
+}
+
+impl Device {
+    /// Stable short name. Used in env-var-driven config + bench JSON
+    /// `device` fields. Format:
+    ///
+    /// - `Cpu` → `"cpu"`
+    /// - `Cuda(0)` → `"cuda:0"`
+    /// - `Metal(0)` → `"metal:0"`
+    /// - `Vulkan(0)` → `"vulkan:0"`
+    pub fn short_name(self) -> String {
+        match self {
+            Device::Cpu => "cpu".to_string(),
+            Device::Cuda(i) => format!("cuda:{i}"),
+            Device::Metal(i) => format!("metal:{i}"),
+            Device::Vulkan(i) => format!("vulkan:{i}"),
+        }
+    }
+
+    /// Is this device the canonical CPU reference?
+    pub const fn is_cpu(self) -> bool {
+        matches!(self, Device::Cpu)
+    }
+
+    /// Is this device any kind of GPU (CUDA / Metal / Vulkan)?
+    pub const fn is_gpu(self) -> bool {
+        !self.is_cpu()
+    }
+
+    /// Device index. `None` for CPU; `Some(i)` for GPU backends.
+    pub const fn index(self) -> Option<usize> {
+        match self {
+            Device::Cpu => None,
+            Device::Cuda(i) | Device::Metal(i) | Device::Vulkan(i) => Some(i),
+        }
+    }
+
+    /// Stable backend tag for cross-backend comparisons. Two
+    /// `Device::Cuda(i)` with different `i` share a backend; two
+    /// `Device::Cuda(0)` and `Device::Metal(0)` do not.
+    pub const fn backend(self) -> Backend {
+        match self {
+            Device::Cpu => Backend::Cpu,
+            Device::Cuda(_) => Backend::Cuda,
+            Device::Metal(_) => Backend::Metal,
+            Device::Vulkan(_) => Backend::Vulkan,
+        }
+    }
+}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.short_name())
+    }
+}
+
+/// Cross-backend tag. The variant of [`Device`] with the index stripped.
+///
+/// Used by parity-test harnesses and the `BackendRuntime` dispatcher:
+/// the harness picks one device per backend, then runs the same parity
+/// test against all four.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Backend {
+    Cpu,
+    Cuda,
+    Metal,
+    Vulkan,
+}
+
+impl Backend {
+    /// All four backends in canonical iteration order (matches the
+    /// `bench-results/parity-tolerance.csv` column order).
+    pub const ALL: [Backend; 4] = [Backend::Cpu, Backend::Cuda, Backend::Metal, Backend::Vulkan];
+
+    /// Stable short name — `"cpu"`, `"cuda"`, `"metal"`, `"vulkan"`.
+    /// Identical to [`Device::short_name`] minus the `:<index>` suffix.
+    pub const fn short_name(self) -> &'static str {
+        match self {
+            Backend::Cpu => "cpu",
+            Backend::Cuda => "cuda",
+            Backend::Metal => "metal",
+            Backend::Vulkan => "vulkan",
+        }
+    }
+}
+
+impl fmt::Display for Backend {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.short_name())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_name_format() {
+        assert_eq!(Device::Cpu.short_name(), "cpu");
+        assert_eq!(Device::Cuda(0).short_name(), "cuda:0");
+        assert_eq!(Device::Cuda(3).short_name(), "cuda:3");
+        assert_eq!(Device::Metal(1).short_name(), "metal:1");
+        assert_eq!(Device::Vulkan(2).short_name(), "vulkan:2");
+    }
+
+    #[test]
+    fn is_cpu_is_gpu() {
+        assert!(Device::Cpu.is_cpu());
+        assert!(!Device::Cpu.is_gpu());
+        for d in [Device::Cuda(0), Device::Metal(0), Device::Vulkan(0)] {
+            assert!(!d.is_cpu());
+            assert!(d.is_gpu());
+        }
+    }
+
+    #[test]
+    fn index_of() {
+        assert_eq!(Device::Cpu.index(), None);
+        assert_eq!(Device::Cuda(0).index(), Some(0));
+        assert_eq!(Device::Cuda(5).index(), Some(5));
+        assert_eq!(Device::Metal(2).index(), Some(2));
+        assert_eq!(Device::Vulkan(1).index(), Some(1));
+    }
+
+    #[test]
+    fn backend_strips_index() {
+        assert_eq!(Device::Cpu.backend(), Backend::Cpu);
+        assert_eq!(Device::Cuda(0).backend(), Backend::Cuda);
+        assert_eq!(Device::Cuda(3).backend(), Backend::Cuda);
+        assert_eq!(Device::Metal(0).backend(), Backend::Metal);
+        assert_eq!(Device::Vulkan(2).backend(), Backend::Vulkan);
+    }
+
+    #[test]
+    fn backend_all_order() {
+        let names: Vec<&str> = Backend::ALL.iter().map(|b| b.short_name()).collect();
+        assert_eq!(names, ["cpu", "cuda", "metal", "vulkan"]);
+    }
+
+    #[test]
+    fn display_uses_short_name() {
+        assert_eq!(format!("{}", Device::Cuda(0)), "cuda:0");
+        assert_eq!(format!("{}", Backend::Vulkan), "vulkan");
+    }
+}

--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -20,12 +20,16 @@
 #![deny(missing_debug_implementations)]
 #![warn(rust_2018_idioms)]
 
+mod device;
 mod dtype;
 mod error;
 mod layout;
+mod storage;
 mod tensor_id;
 
+pub use device::{Backend, Device};
 pub use dtype::DType;
 pub use error::{Error, Result};
 pub use layout::Layout;
+pub use storage::{cpu_zeros, CpuStorage, Storage, StorageBackend};
 pub use tensor_id::TensorId;

--- a/crates/kiln-tensor/src/storage.rs
+++ b/crates/kiln-tensor/src/storage.rs
@@ -1,0 +1,225 @@
+//! `kiln_tensor::Storage` — the storage trait + the CPU storage impl.
+//!
+//! Replaces the candle storage layer at the call sites that name
+//! `candle_core::Storage::Cuda` (195), `candle_core::Storage::Metal`
+//! (232), `candle_core::CpuStorage` (6), etc. — together over 600 of
+//! the 1,799 candle call sites the Phase 0.1 audit captured.
+//!
+//! # Trait shape
+//!
+//! From the Phase 1 bullet:
+//!
+//! > **`Storage` is `Arc<dyn StorageBackend>`** with `Send + Sync`
+//! > everywhere. Pin the threading model in Phase 1 — kiln-tensor ops
+//! > are callable from any thread.
+//!
+//! The trait is intentionally narrow: read-only metadata
+//! (`device`, `dtype`, `byte_len`) plus the lifecycle hooks the
+//! Phase 1.5 / 1.6 / 1.7 backends need. The actual tensor operations
+//! (matmul, softmax, …) hang off `DeviceOp` (Phase 1.x's CustomOpN
+//! replacement) and `BackendRuntime`, not off this trait — keeping
+//! `Storage` thin lets parity tests trivially A/B against the CPU
+//! reference.
+//!
+//! # Why a trait, not an enum
+//!
+//! `Storage` is an `Arc<dyn StorageBackend>` rather than an enum because
+//! the per-backend storage types (e.g. `cudarc::CudaSlice`) carry
+//! runtime handles whose Rust types we don't want to mention in the
+//! Cargo dependency tree of CPU-only callers. The trait stays
+//! object-safe (no generics, no `Self`-by-value methods).
+
+use std::any::Any;
+use std::sync::Arc;
+
+use crate::{DType, Device, Error, Result};
+
+/// Object-safe storage trait. Implementations live in per-backend
+/// modules and are erased behind [`Storage`].
+pub trait StorageBackend: Any + Send + Sync + core::fmt::Debug {
+    /// The device this storage lives on.
+    fn device(&self) -> Device;
+
+    /// The dtype of the elements this storage carries.
+    fn dtype(&self) -> DType;
+
+    /// Physical byte length of the storage.
+    ///
+    /// For packed dtypes ([`DType::Int4Packed`] / [`DType::Fp4Packed`])
+    /// this is the **physical** size (≈ `n_elements / 2`), not the
+    /// logical one. The conversion lives on
+    /// [`DType::packed_buffer_bytes`].
+    fn byte_len(&self) -> usize;
+
+    /// `&dyn Any` for downcast-on-demand at the per-backend boundary
+    /// without leaking the concrete backend type into the trait.
+    fn as_any(&self) -> &dyn Any;
+}
+
+/// Reference-counted, object-erased storage.
+///
+/// `Arc<dyn StorageBackend>` is the production handle every Tensor
+/// carries. Cloning is `O(1)`; the inner storage is shared (refcount-
+/// bumped). Aliasing two `Storage` values that point to the same
+/// physical buffer is supported and is how zero-copy views work
+/// alongside the [`Layout`](crate::Layout) descriptor.
+pub type Storage = Arc<dyn StorageBackend>;
+
+// ----------------------------------------------------------------------
+// CPU storage
+// ----------------------------------------------------------------------
+
+/// Byte-typed CPU storage. The actual element layout is the byte
+/// pattern of `dtype` — e.g. 2 bytes per BF16 element, 4 per F32.
+///
+/// CPU is the canonical numerical reference (per the issue's DoD), so
+/// `CpuStorage` is exercised on every host (no GPU stack needed). The
+/// 4 GPU storage backends (Phases 1.5 / 1.6 / 1.7) plug into the same
+/// `StorageBackend` trait and the parity tests compare against this
+/// CPU implementation.
+#[derive(Debug)]
+pub struct CpuStorage {
+    dtype: DType,
+    bytes: Vec<u8>,
+}
+
+impl CpuStorage {
+    /// Allocate a zero-initialized CPU storage with capacity for
+    /// `n_elements` of `dtype`. The physical byte size is computed via
+    /// [`DType::packed_buffer_bytes`] so packed dtypes are right-sized.
+    pub fn zeros(dtype: DType, n_elements: usize) -> Self {
+        let n_bytes = dtype.packed_buffer_bytes(n_elements);
+        CpuStorage {
+            dtype,
+            bytes: vec![0u8; n_bytes],
+        }
+    }
+
+    /// Take ownership of an existing byte buffer. Validates that the
+    /// buffer length is a multiple of `dtype.size_in_bytes()` for
+    /// non-packed dtypes.
+    pub fn from_bytes(dtype: DType, bytes: Vec<u8>) -> Result<Self> {
+        if !dtype.is_packed() {
+            let per = dtype.size_in_bytes();
+            if per > 0 && !bytes.len().is_multiple_of(per) {
+                return Err(Error::Msg(format!(
+                    "CpuStorage::from_bytes: byte len {} is not a multiple of size_in_bytes({:?}) = {}",
+                    bytes.len(),
+                    dtype,
+                    per
+                )));
+            }
+        }
+        Ok(CpuStorage { dtype, bytes })
+    }
+
+    /// Read-only byte view.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Mutable byte view. Mutating in place bumps no version counter at
+    /// the storage layer (versioning is a Tensor-level concern; see
+    /// anti-pattern 16).
+    pub fn as_bytes_mut(&mut self) -> &mut [u8] {
+        &mut self.bytes
+    }
+}
+
+impl StorageBackend for CpuStorage {
+    fn device(&self) -> Device {
+        Device::Cpu
+    }
+
+    fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    fn byte_len(&self) -> usize {
+        self.bytes.len()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Construct a fresh [`Storage`] (`Arc<dyn StorageBackend>`) on the CPU.
+///
+/// Convenience constructor — equivalent to
+/// `Arc::new(CpuStorage::zeros(dtype, n))`.
+pub fn cpu_zeros(dtype: DType, n_elements: usize) -> Storage {
+    Arc::new(CpuStorage::zeros(dtype, n_elements))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cpu_zeros_round_sizes() {
+        let s = CpuStorage::zeros(DType::F32, 16);
+        assert_eq!(s.byte_len(), 64);
+        assert_eq!(s.dtype(), DType::F32);
+        assert_eq!(s.device(), Device::Cpu);
+
+        let s = CpuStorage::zeros(DType::BF16, 16);
+        assert_eq!(s.byte_len(), 32);
+
+        let s = CpuStorage::zeros(DType::Int4Packed, 16);
+        // Packed: 16 elements -> 8 bytes
+        assert_eq!(s.byte_len(), 8);
+
+        let s = CpuStorage::zeros(DType::Int4Packed, 17);
+        // ceil(17 / 2)
+        assert_eq!(s.byte_len(), 9);
+    }
+
+    #[test]
+    fn cpu_zeros_is_zeroed() {
+        let s = CpuStorage::zeros(DType::F32, 4);
+        assert!(s.as_bytes().iter().all(|&b| b == 0));
+    }
+
+    #[test]
+    fn from_bytes_validates_alignment() {
+        let ok = CpuStorage::from_bytes(DType::F32, vec![0u8; 16]).unwrap();
+        assert_eq!(ok.byte_len(), 16);
+
+        let err = CpuStorage::from_bytes(DType::F32, vec![0u8; 17]).unwrap_err();
+        assert!(err.to_string().contains("not a multiple"));
+    }
+
+    #[test]
+    fn from_bytes_accepts_packed_any_size() {
+        let s = CpuStorage::from_bytes(DType::Int4Packed, vec![0u8; 9]).unwrap();
+        assert_eq!(s.byte_len(), 9);
+    }
+
+    #[test]
+    fn as_bytes_mut_mutates_in_place() {
+        let mut s = CpuStorage::zeros(DType::U8, 4);
+        s.as_bytes_mut().copy_from_slice(&[1, 2, 3, 4]);
+        assert_eq!(s.as_bytes(), &[1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn cpu_zeros_returns_storage() {
+        let s: Storage = cpu_zeros(DType::F32, 2);
+        assert_eq!(s.dtype(), DType::F32);
+        assert_eq!(s.byte_len(), 8);
+        assert_eq!(s.device(), Device::Cpu);
+
+        // Downcast to inspect the concrete type.
+        let cpu = s.as_any().downcast_ref::<CpuStorage>().expect("downcast");
+        assert_eq!(cpu.as_bytes().len(), 8);
+    }
+
+    #[test]
+    fn storage_is_send_sync() {
+        // Compile-time check.
+        fn _check<T: Send + Sync>(_: &T) {}
+        let s: Storage = cpu_zeros(DType::F32, 1);
+        _check(&s);
+    }
+}


### PR DESCRIPTION
Fourth Phase 1 deliverable for #1082.

Three foundational types per the Phase 1 scaffold bullets. CPU-only; GPU storage impls land in 1.5 (CUDA) / 1.6 (Metal) / 1.7 (Vulkan).

## Device (`src/device.rs`)

The four backends kiln-tensor dispatches over: `Cpu`, `Cuda(idx)`, `Metal(idx)`, `Vulkan(idx)`. `#[non_exhaustive]`.

Migration target: replaces `candle_core::Device` at the **91 call sites** Phase 0.1 audited (`Device` 30, `Device::Cpu` 24, `Device::Metal` 18, `Device::Cuda` 14, `Device::new_cuda` 5).

GPU variants carry `device_index: usize` per anti-pattern 12 — multi-GPU stays out of scope, but the index is in the type so two kiln processes on one box can pin different GPUs and a future TP rewrite doesn't have to revisit any call site.

API: `short_name()` (`"cpu"`, `"cuda:0"`, ...), `is_cpu()`, `is_gpu()`, `index() -> Option<usize>`, `backend() -> Backend`.

`Backend` is the index-stripped sibling: `{Cpu, Cuda, Metal, Vulkan}` plus `Backend::ALL: [Backend; 4]` in canonical iteration order matching `bench-results/parity-tolerance.csv`.

## Storage trait (`src/storage.rs`)

Object-safe `StorageBackend: Any + Send + Sync + Debug` with:
- `device() -> Device`
- `dtype() -> DType`
- `byte_len() -> usize`
- `as_any() -> &dyn Any` (per-backend downcast)

`Storage = Arc<dyn StorageBackend>` — clones are O(1); aliasing two `Storage` values to the same physical buffer is supported (how zero-copy views compose with the `Layout` descriptor).

Trait is intentionally narrow — actual ops (matmul, softmax, …) hang off `DeviceOp` (Phase 1.x's CustomOpN replacement) and `BackendRuntime`, not off this trait. Keeps parity tests cheap to write.

Migration target: replaces **600+ call sites**:
- `candle_core::Storage::Cuda` (195)
- `candle_core::Storage::Metal` (232)
- `candle_core::metal_backend::buffer_o` (232)
- `candle_core::CpuStorage` (6)

## CpuStorage impl

Byte-typed; the Vec<u8> backing is the physical layout. CPU is the canonical numerical reference per the DoD, and `linux-default` CI exercises this path on every push.

API: `zeros(dtype, n_elements)`, `from_bytes(dtype, bytes)` (validates multiple-of-element-size for non-packed), `as_bytes()`, `as_bytes_mut()`, plus the `cpu_zeros` free-function constructor returning `Storage` (`Arc`).

Packed dtype sizing uses `DType::packed_buffer_bytes()`, so 16 elements of `Int4Packed` → 8 bytes (not 16).

## Tests

- `device.rs`: 6 unit tests cover short_name, is_cpu/is_gpu, index, backend(), Backend::ALL order, Display
- `storage.rs`: 7 unit tests cover round-sized zeros allocation, zero-initialization, from_bytes validation, packed-dtype acceptance, in-place mutation, the `cpu_zeros` constructor, and a compile-time `Send + Sync` check

CPU-only; no platform-specific surface.

Refs #1082