### PR TITLE
phase 1.6: kiln-tensor CUDA storage impl (cuda feature) (#1082)

### DIFF
--- a/crates/kiln-tensor/Cargo.toml
+++ b/crates/kiln-tensor/Cargo.toml
@@ -25,11 +25,22 @@ half = "2"
 # Safe byte-cast for typed CPU constructors (from_slice / to_vec).
 bytemuck = { version = "1", features = ["extern_crate_alloc"] }
 
+# Optional — pulled in under the `cuda` / `metal` features only. This is
+# the workspace's candle dep so the cudarc version stays coherent with
+# the rest of the crates. Phase 7 of #1082 (candle removal) replaces
+# this with a direct cudarc dependency.
+candle-core = { workspace = true, optional = true }
+
 [features]
 default = []
-# Reserved feature names for future PRs in Phase 1; declared early so
-# downstream `kiln-tensor = { features = ["cuda"] }` invocations don't
-# break when added.
-cuda = []
-metal = []
+# Phase 1.6 — CUDA storage. The `cuda` feature pulls candle-core (cuda)
+# as the cudarc vendor; we reach the driver types as
+# `candle_core::cuda_backend::cudarc::driver::*` matching the pattern in
+# kiln-conv1d-kernel / kiln-flash-attn / kiln-model::cuda_graph. This is
+# the SINGLE candle hook in kiln-tensor; Phase 7 replaces it.
+cuda = ["dep:candle-core", "candle-core?/cuda"]
+# Reserved for Phase 1.7. Same pattern as `cuda`.
+metal = ["dep:candle-core", "candle-core?/metal"]
+# Reserved for Phase 1.8. Vulkan does not go through candle — it lifts
+# from kiln-vulkan-kernel which has its own ash-based backend.
 vulkan = []

--- a/crates/kiln-tensor/src/cuda_storage.rs
+++ b/crates/kiln-tensor/src/cuda_storage.rs
@@ -1,0 +1,240 @@
+//! CUDA storage impl behind the `cuda` feature flag.
+//!
+//! Wraps `cudarc::driver::CudaSlice<u8>` (the actual buffer) + dtype +
+//! `Arc<candle_core::cuda_backend::CudaDevice>` for stream affinity.
+//!
+//! # Anti-pattern 1 compliance
+//!
+//! Per the issue:
+//!
+//! > `kiln-tensor` is not a candle wrapper. Storage is
+//! > `cudarc::CudaSlice` directly. No `candle_core::Tensor` field on
+//! > `kiln_tensor::Tensor`.
+//!
+//! `CudaStorage` does **not** hold a `candle_core::Tensor`. The buffer
+//! is a `CudaSlice<u8>` we own. The candle `CudaDevice` is held only
+//! for its `cuda_stream()` accessor + its `alloc_zeros::<T>` helper;
+//! that's the same pattern in use across `kiln-rmsnorm-kernel`,
+//! `kiln-gdn-kernel`, `kiln-marlin-gemm`, `kiln-flash-attn`, etc.
+//! Phase 7 of #1082 (candle removal) replaces `Arc<CudaDevice>` with a
+//! direct `Arc<cudarc::driver::CudaContext>` + `Arc<CudaStream>`.
+//!
+//! # Phase 1.6 scope (storage layer only)
+//!
+//! - `zeros(device, dtype, n_elements)` — async device alloc + memset.
+//! - `from_slice(device, dtype, slice)` — take ownership of an
+//!   existing `CudaSlice<u8>` allocated through candle's device. This
+//!   is the FFI seam that today's kernel crates plug into.
+//! - `StorageBackend` impl — `device() / dtype() / byte_len() / as_any()`.
+//! - `slice()` / `slice_mut()` accessors for the existing kernel-crate
+//!   FFI sites that want raw byte pointers.
+//!
+//! Math ops, H2D/D2H helpers, pinned-host staging — separate later PRs.
+
+use std::any::Any;
+use std::sync::Arc;
+
+use candle_core::cuda_backend::CudaDevice;
+use candle_core::cuda_backend::cudarc::driver::CudaSlice;
+
+use crate::{DType, Device, Error, Result, StorageBackend};
+
+/// CUDA-backed storage. Byte-typed; dtype carried alongside for dispatch.
+///
+/// The handed-down `CudaSlice<u8>` is allocated via candle's
+/// `CudaDevice` accessor today; Phase 7 swaps that for a direct cudarc
+/// `CudaContext::default_stream().alloc_zeros::<u8>` once the candle
+/// dep is gone.
+#[derive(Debug)]
+pub struct CudaStorage {
+    /// Device-index variant of [`Device`]. Stored explicitly so
+    /// `StorageBackend::device()` is O(1) (no context-query syscall).
+    device: Device,
+    /// Element dtype tag.
+    dtype: DType,
+    /// The actual byte buffer on the GPU.
+    slice: CudaSlice<u8>,
+    /// Candle CUDA device handle. Held for stream affinity (Phase 1.x
+    /// `StreamPlanner` reads it) and for the in-flight kernel-crate
+    /// FFI calls that take `&CudaDevice` as their first argument.
+    candle_device: Arc<CudaDevice>,
+}
+
+impl CudaStorage {
+    /// Allocate `n_elements` worth of bytes for `dtype` on
+    /// `candle_device`. Buffer is zero-initialized via candle's
+    /// `alloc_zeros::<u8>(n)`.
+    ///
+    /// `device_index` is the CUDA device index — must match the index
+    /// of the candle device's owning context. Stored as the
+    /// [`Device::Cuda`] variant.
+    pub fn zeros(
+        candle_device: Arc<CudaDevice>,
+        device_index: usize,
+        dtype: DType,
+        n_elements: usize,
+    ) -> Result<Self> {
+        let byte_len = dtype.packed_buffer_bytes(n_elements);
+        let slice = candle_device
+            .alloc_zeros::<u8>(byte_len)
+            .map_err(|e| {
+                Error::Msg(format!("CudaStorage::zeros: alloc_zeros<u8>({byte_len}) failed: {e:?}"))
+            })?;
+        Ok(CudaStorage {
+            device: Device::Cuda(device_index),
+            dtype,
+            slice,
+            candle_device,
+        })
+    }
+
+    /// Wrap an existing `CudaSlice<u8>` allocated by the caller.
+    ///
+    /// Validates the slice length against
+    /// `dtype.size_in_bytes()` for non-packed dtypes (must be a
+    /// multiple); packed dtypes have no per-element alignment.
+    pub fn from_slice(
+        candle_device: Arc<CudaDevice>,
+        device_index: usize,
+        dtype: DType,
+        slice: CudaSlice<u8>,
+    ) -> Result<Self> {
+        if !dtype.is_packed() {
+            let per = dtype.size_in_bytes();
+            if per > 0 && !slice.len().is_multiple_of(per) {
+                return Err(Error::Msg(format!(
+                    "CudaStorage::from_slice: slice len {} is not a multiple of \
+                     size_in_bytes({:?}) = {}",
+                    slice.len(),
+                    dtype,
+                    per
+                )));
+            }
+        }
+        Ok(CudaStorage {
+            device: Device::Cuda(device_index),
+            dtype,
+            slice,
+            candle_device,
+        })
+    }
+
+    /// Borrow the underlying byte slice. The existing kernel-crate
+    /// FFI sites that want the raw device pointer reach this then
+    /// call `.device_ptr(&stream)` per the cudarc 0.19 pattern.
+    pub fn slice(&self) -> &CudaSlice<u8> {
+        &self.slice
+    }
+
+    /// Mutable borrow for in-place ops. Bumps no version counter at
+    /// this layer (anti-pattern 16 versioning is a Tensor-level concern,
+    /// enforced once `kiln-autograd` lands).
+    pub fn slice_mut(&mut self) -> &mut CudaSlice<u8> {
+        &mut self.slice
+    }
+
+    /// The candle CUDA device handle this storage was allocated on.
+    /// Used by FFI sites + the Phase 1.x `StreamPlanner` to read
+    /// stream affinity.
+    pub fn candle_device(&self) -> &Arc<CudaDevice> {
+        &self.candle_device
+    }
+}
+
+impl StorageBackend for CudaStorage {
+    fn device(&self) -> Device {
+        self.device
+    }
+
+    fn dtype(&self) -> DType {
+        self.dtype
+    }
+
+    fn byte_len(&self) -> usize {
+        self.slice.len()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+/// Construct a fresh [`crate::Storage`] handle (`Arc<dyn StorageBackend>`)
+/// holding a [`CudaStorage`]. Convenience constructor matching the CPU
+/// `cpu_zeros` helper.
+pub fn cuda_zeros(
+    candle_device: Arc<CudaDevice>,
+    device_index: usize,
+    dtype: DType,
+    n_elements: usize,
+) -> Result<crate::Storage> {
+    let storage = CudaStorage::zeros(candle_device, device_index, dtype, n_elements)?;
+    Ok(Arc::new(storage))
+}
+
+// ----------------------------------------------------------------------
+// Tests are GPU-only — gated by KILN_TENSOR_CUDA_TEST=1 so a host with
+// cudarc + candle's cuda feature compiled in but no actual GPU doesn't
+// spuriously fail.
+// ----------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device as CandleDevice;
+
+    fn cuda_test_enabled() -> bool {
+        std::env::var("KILN_TENSOR_CUDA_TEST").ok().as_deref() == Some("1")
+    }
+
+    fn maybe_cuda_device() -> Option<Arc<CudaDevice>> {
+        if !cuda_test_enabled() {
+            return None;
+        }
+        match CandleDevice::new_cuda(0).ok()? {
+            CandleDevice::Cuda(d) => Some(Arc::new(d)),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn zeros_round_sizes() {
+        let Some(dev) = maybe_cuda_device() else {
+            eprintln!("skip: KILN_TENSOR_CUDA_TEST unset or no GPU");
+            return;
+        };
+        let storage = CudaStorage::zeros(dev.clone(), 0, DType::BF16, 64).unwrap();
+        assert_eq!(storage.device(), Device::Cuda(0));
+        assert_eq!(storage.dtype(), DType::BF16);
+        assert_eq!(storage.byte_len(), 128);
+
+        let storage = CudaStorage::zeros(dev, 0, DType::Int4Packed, 16).unwrap();
+        assert_eq!(storage.byte_len(), 8); // 16 elements packed -> 8 bytes
+    }
+
+    #[test]
+    fn from_slice_validates_alignment() {
+        let Some(dev) = maybe_cuda_device() else {
+            eprintln!("skip: KILN_TENSOR_CUDA_TEST unset or no GPU");
+            return;
+        };
+        let slice = dev.alloc_zeros::<u8>(17).unwrap();
+        let err = CudaStorage::from_slice(dev.clone(), 0, DType::F32, slice).unwrap_err();
+        assert!(err.to_string().contains("not a multiple"));
+    }
+
+    #[test]
+    fn cuda_zeros_returns_arc_storage() {
+        let Some(dev) = maybe_cuda_device() else {
+            eprintln!("skip: KILN_TENSOR_CUDA_TEST unset or no GPU");
+            return;
+        };
+        let s: crate::Storage = cuda_zeros(dev, 0, DType::F32, 4).unwrap();
+        assert_eq!(s.dtype(), DType::F32);
+        assert_eq!(s.byte_len(), 16);
+        assert_eq!(s.device(), Device::Cuda(0));
+        // Downcast to ensure the concrete type is CudaStorage.
+        let cuda = s.as_any().downcast_ref::<CudaStorage>().expect("downcast");
+        assert_eq!(cuda.slice().len(), 16);
+    }
+}

--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -29,6 +29,9 @@ mod storage;
 mod tensor;
 mod tensor_id;
 
+#[cfg(feature = "cuda")]
+mod cuda_storage;
+
 pub use device::{Backend, Device};
 pub use dtype::DType;
 pub use element::Element;
@@ -37,3 +40,6 @@ pub use layout::Layout;
 pub use storage::{cpu_zeros, CpuStorage, Storage, StorageBackend};
 pub use tensor::Tensor;
 pub use tensor_id::TensorId;
+
+#[cfg(feature = "cuda")]
+pub use cuda_storage::{cuda_zeros, CudaStorage};


### PR DESCRIPTION
Sixth Phase 1 deliverable for #1082.

Adds `CudaStorage` behind the new `cuda` feature flag. Default builds are unchanged.

## What's added

| File | Purpose |
|---|---|
| `crates/kiln-tensor/Cargo.toml` | `candle-core` optional dep + `cuda = [\"dep:candle-core\", \"candle-core?/cuda\"]` feature; `metal` feature reserved for Phase 1.7 |
| `crates/kiln-tensor/src/cuda_storage.rs` | `CudaStorage { device, dtype, slice: CudaSlice<u8>, candle_device }` + `StorageBackend` impl, gated `#[cfg(feature = \"cuda\")]` |

## API

| method | purpose |
|---|---|
| `zeros(candle_device, idx, dtype, n)` | `candle_device.alloc_zeros::<u8>()` matching the pattern in kiln-rmsnorm-kernel:899, kiln-gdn-kernel:1850, etc. |
| `from_slice(candle_device, idx, dtype, slice)` | take ownership of a caller-allocated `CudaSlice<u8>`; validates `slice.len() % dtype.size_in_bytes() == 0` for non-packed dtypes |
| `slice()` / `slice_mut()` | accessor for the existing kernel-crate FFI sites (e.g. marlin-gemm:234-238 pattern) |
| `candle_device()` | stream/affinity handle Phase 1.x StreamPlanner reads |
| `cuda_zeros(...)` | free-function returning `Arc<dyn StorageBackend>` (mirrors `cpu_zeros`) |

## Anti-pattern 1 compliance

`CudaStorage` holds a `CudaSlice<u8>` **directly** — no `candle_core::Tensor` field. The candle `CudaDevice` is held only for its `cuda_stream()` + `alloc_zeros::<T>` helpers, the same pattern in use across kiln-rmsnorm-kernel, kiln-gdn-kernel, kiln-marlin-gemm, kiln-flash-attn today.

The transitive candle dep is the **single** candle hook in `kiln-tensor`; Phase 7 of #1082 replaces it with a direct `Arc<cudarc::driver::CudaContext>` + `Arc<CudaStream>`. That's the explicit candle-removal scope.

## Tests

3 unit tests gated on `KILN_TENSOR_CUDA_TEST=1` env var + a real GPU context (silent skip otherwise):

- `zeros_round_sizes` — BF16 (64 elements → 128 bytes) + Int4Packed (16 elements → 8 bytes, packed)
- `from_slice_validates_alignment` — 17-byte slice with F32 dtype rejected
- `cuda_zeros_returns_arc_storage` — Arc Storage constructor + downcast from `&dyn StorageBackend`

## What's NOT here

Per the issue's \"small revertable PRs\" rule, the following land in subsequent PRs:

- H2D / D2H helpers (need a verifiable cudarc 0.19 API surface; comes in a follow-up after a RunPod compile-check)
- Stream affinity beyond `candle_device()` — Phase 1.11 StreamPlanner
- Pinned-host staging pool — Phase 1.12
- Math ops — Phase 2 BLAS + Phase 1.9 BackendRuntime dispatch

## Build / test note

This PR is NOT built locally per the goal directive on #1082. The `linux-default` CI lane is unaffected (no `--features cuda`). The CUDA path verifies on RunPod once merged.

Refs #1082