### PR TITLE
phase 1.10: copy-counter instrumentation (anti-pattern 2) (#1082)

### DIFF
--- a/crates/kiln-tensor/src/lib.rs
+++ b/crates/kiln-tensor/src/lib.rs
@@ -25,6 +25,7 @@ mod dtype;
 mod element;
 mod error;
 mod layout;
+pub mod profile;
 pub mod safetensors;
 mod storage;
 mod tensor;

--- a/crates/kiln-tensor/src/profile.rs
+++ b/crates/kiln-tensor/src/profile.rs
@@ -1,0 +1,147 @@
+//! Profile counters for the kiln-tensor migration (anti-pattern 2).
+//!
+//! Every explicit [`Tensor::contiguous`](crate::Tensor::contiguous) and
+//! every kernel that internally materializes a copy emits a
+//! [`kiln_profile_contiguous_copy`] event. The counter is aggregated
+//! by `bench-results/` regression scripts and surfaces as a
+//! "copies per token" metric — anti-pattern 2 mandates that
+//! regressions on the 712-call layout surface in `forward.rs` (the
+//! `.contiguous()` / `.narrow(` / `.reshape(` / `.transpose(` calls
+//! Phase 0.1 captured) are **visible without re-reading nsys traces**.
+//!
+//! # Counter shape
+//!
+//! Today: a process-global atomic `u64` counter per event kind. Phase
+//! 1.x adds per-call-site labels once the `kiln_nvtx` integration
+//! hooks here.
+//!
+//! # Threading model
+//!
+//! `Relaxed` ordering — we don't synchronize anything through the
+//! counter, only count events. The cost is one atomic add per
+//! materializing copy, sub-nanosecond on the hot path.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+/// Counter for explicit + implicit contiguous copies.
+///
+/// Bumped by [`emit_contiguous_copy`] and read by
+/// [`contiguous_copy_count`] / [`reset_contiguous_copy_count`].
+static CONTIGUOUS_COPY_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Bump the contiguous-copy counter by one.
+///
+/// Called from:
+/// - `Tensor::contiguous()` whenever it actually allocates a fresh
+///   buffer (the "fast path" early-return on already-contiguous
+///   tensors skips this).
+/// - Per-backend storage impls that internally materialize a copy
+///   inside an op (e.g. CPU `view.contiguous` walks the strided view).
+///
+/// **Anti-pattern 2 contract**: every site that copies bytes due to a
+/// stride/layout mismatch must call this. Adding a new copy in a
+/// kernel without calling this is a Phase 9 audit failure.
+#[inline]
+pub fn emit_contiguous_copy() {
+    CONTIGUOUS_COPY_COUNTER.fetch_add(1, Ordering::Relaxed);
+}
+
+/// Current counter value (process lifetime).
+pub fn contiguous_copy_count() -> u64 {
+    CONTIGUOUS_COPY_COUNTER.load(Ordering::Relaxed)
+}
+
+/// Reset the counter to zero and return the previous value.
+/// Used by bench harnesses around a single decode/prefill iteration
+/// to compute the "copies per token" metric.
+pub fn reset_contiguous_copy_count() -> u64 {
+    CONTIGUOUS_COPY_COUNTER.swap(0, Ordering::Relaxed)
+}
+
+/// RAII guard that captures the counter delta over a scope. Used by
+/// bench harnesses around a single iteration to compute the
+/// "copies per token" metric without manually pairing
+/// `contiguous_copy_count()` reads.
+///
+/// ```ignore
+/// use kiln_tensor::profile::CopyScope;
+///
+/// let scope = CopyScope::start();
+/// // ... run decode iteration ...
+/// let copies_this_iter = scope.finish();
+/// ```
+#[derive(Debug)]
+#[must_use = "CopyScope only measures; call `finish()` to read the delta"]
+pub struct CopyScope {
+    start: u64,
+}
+
+impl CopyScope {
+    /// Take a snapshot of the current counter.
+    pub fn start() -> Self {
+        CopyScope {
+            start: contiguous_copy_count(),
+        }
+    }
+
+    /// Compute and return the delta since [`start`](CopyScope::start).
+    pub fn finish(self) -> u64 {
+        contiguous_copy_count().saturating_sub(self.start)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Serialize tests that mutate the global counter so they don't
+    /// race. Rust's test harness runs tests in parallel by default.
+    fn serial_guard() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        LOCK.lock().unwrap()
+    }
+
+    #[test]
+    fn emit_and_read() {
+        let _g = serial_guard();
+        reset_contiguous_copy_count();
+        emit_contiguous_copy();
+        emit_contiguous_copy();
+        emit_contiguous_copy();
+        assert_eq!(contiguous_copy_count(), 3);
+    }
+
+    #[test]
+    fn reset_returns_previous() {
+        let _g = serial_guard();
+        reset_contiguous_copy_count();
+        emit_contiguous_copy();
+        emit_contiguous_copy();
+        let prev = reset_contiguous_copy_count();
+        assert_eq!(prev, 2);
+        assert_eq!(contiguous_copy_count(), 0);
+    }
+
+    #[test]
+    fn scope_measures_delta() {
+        let _g = serial_guard();
+        reset_contiguous_copy_count();
+        // Pre-existing counts shouldn't bleed into the scope.
+        emit_contiguous_copy();
+        let scope = CopyScope::start();
+        emit_contiguous_copy();
+        emit_contiguous_copy();
+        emit_contiguous_copy();
+        assert_eq!(scope.finish(), 3);
+    }
+
+    #[test]
+    fn scope_starts_at_current_count() {
+        let _g = serial_guard();
+        reset_contiguous_copy_count();
+        emit_contiguous_copy();
+        emit_contiguous_copy();
+        let scope = CopyScope::start();
+        assert_eq!(scope.finish(), 0);
+    }
+}

--- a/crates/kiln-tensor/src/tensor.rs
+++ b/crates/kiln-tensor/src/tensor.rs
@@ -34,8 +34,8 @@
 use std::sync::Arc;
 
 use crate::{
-    cpu_zeros, CpuStorage, DType, Device, Element, Error, Layout, Result, Storage, StorageBackend,
-    TensorId,
+    cpu_zeros, profile, CpuStorage, DType, Device, Element, Error, Layout, Result, Storage,
+    StorageBackend, TensorId,
 };
 
 /// kiln-tensor's production tensor handle.
@@ -216,19 +216,26 @@ impl Tensor {
         })
     }
 
-    /// Produce a contiguous copy of this tensor. **Always allocates** —
-    /// this is the "explicit `contiguous()` that logs" call site per
-    /// anti-pattern 2 (the copy-counter instrumentation lands in
-    /// Phase 1.x and reads this method's invocation count).
+    /// Produce a contiguous copy of this tensor. **Always allocates
+    /// when called on a non-contiguous tensor** (the fast path returns
+    /// the clone on already-contiguous inputs without a copy).
+    ///
+    /// This is the "explicit `contiguous()` that logs" call site per
+    /// anti-pattern 2 — the materializing branch bumps the
+    /// [`profile::contiguous_copy_count`](crate::profile::contiguous_copy_count)
+    /// counter so `bench-results/`'s "copies per token" metric stays
+    /// surfaced. Phase 9's bench-gate reads it.
     ///
     /// On CPU, materializes a fresh `CpuStorage` and walks the strided
     /// view. The CPU backend is the canonical reference; non-CPU
     /// backends override via `BackendRuntime::contiguous` once Phase
-    /// 1.5+ lands.
+    /// 1.x lands.
     pub fn contiguous(&self) -> Result<Self> {
         if self.is_contiguous() {
             return Ok(self.clone());
         }
+        // Anti-pattern 2: this is the materializing branch — count it.
+        profile::emit_contiguous_copy();
         if !self.device().is_cpu() {
             return Err(Error::Msg(format!(
                 "Tensor::contiguous: only CPU contiguous is implemented in Phase 1.5; \
@@ -391,6 +398,33 @@ mod tests {
         let c = t.contiguous().unwrap();
         // The clone optimization should preserve the storage Arc.
         assert!(Arc::ptr_eq(t.storage(), c.storage()));
+    }
+
+    #[test]
+    fn contiguous_emits_copy_counter_only_on_materializing_path() {
+        // anti-pattern 2 contract: the fast-path clone must NOT bump
+        // the counter; the materializing branch MUST.
+        //
+        // Serialize via a process-global mutex because the counter
+        // is shared across tests.
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = LOCK.lock().unwrap();
+
+        crate::profile::reset_contiguous_copy_count();
+
+        // Fast path: contiguous tensor -> no copy emitted.
+        let t = Tensor::zeros_cpu(vec![3, 4], DType::F32);
+        let _c = t.contiguous().unwrap();
+        assert_eq!(crate::profile::contiguous_copy_count(), 0);
+
+        // Materializing path: transpose then contiguous -> one copy.
+        let v = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let t = Tensor::from_slice(&v, vec![2, 3]).unwrap();
+        let tt = t.transpose(0, 1).unwrap();
+        let _c = tt.contiguous().unwrap();
+        assert_eq!(crate::profile::contiguous_copy_count(), 1);
+
+        crate::profile::reset_contiguous_copy_count();
     }
 
     #[test]


### PR DESCRIPTION
Tenth Phase 1 deliverable for #1082.

Adds the contiguous-copy counter per **anti-pattern 2**:

> Every `contiguous()` is explicit and logged. Emit `kiln_profile_contiguous_copy` from inside the op. This is how we caught the half-tensor copy regression in the MLP work; never lose that signal. Phase 1 ships a per-token "copies per forward" counter in `bench-results/` so regressions are visible without re-reading nsys traces.

## What's added

- `src/profile.rs` — new public module:
  - `emit_contiguous_copy()` — process-global AtomicU64, Relaxed ordering, sub-ns on the hot path
  - `contiguous_copy_count() -> u64` — current value
  - `reset_contiguous_copy_count() -> u64` — set to 0, return prior
  - `CopyScope` — RAII guard capturing the delta over a scope; bench harnesses use it to compute "copies per token"
- `Tensor::contiguous()` now bumps the counter on its materializing branch (the fast-path `Arc::clone` on already-contiguous tensors still skips it)

## Anti-pattern 2 contract going forward

- Every per-backend `BackendRuntime::contiguous` impl (CUDA / Metal / Vulkan, Phase 1.x) MUST call `emit_contiguous_copy` on its materializing branch
- Every kernel that internally materializes a copy (stride-fixup, format-conversion, packed-bf16-unpack, etc.) MUST call it
- Phase 9's bench-gate reads the counter via `CopyScope` and asserts the per-token copy count does not regress against the pre-migration baseline

## Tests

- `profile.rs`: 4 unit tests (emit + read, reset returning previous, `CopyScope::start/finish` delta math, scope-starts-at-current-count) — all serialized via a static `Mutex<()>` so parallel test execution doesn't race the global counter.
- `tensor.rs`: new `contiguous_emits_copy_counter_only_on_materializing_path` test asserts the fast path does NOT bump the counter and the materializing path (transpose + contiguous) DOES bump it exactly once. Serialized.

CPU-only; no platform-specific surface.

Refs #1082