### PR TITLE
phase 2.5: kiln-param scaffold — Parameter handle + AmpPolicy + content hash (#1082)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/kiln-model",
     "crates/kiln-nvtx",
     "crates/kiln-opd-loss-kernel",
+    "crates/kiln-param",
     "crates/kiln-rmsnorm-kernel",
     "crates/kiln-scheduler",
     "crates/kiln-server",
@@ -35,6 +36,7 @@ default-members = [
     "crates/kiln-model",
     "crates/kiln-nvtx",
     "crates/kiln-opd-loss-kernel",
+    "crates/kiln-param",
     "crates/kiln-scheduler",
     "crates/kiln-server",
     "crates/kiln-tensor",
@@ -124,6 +126,7 @@ tempfile = "3"
 kiln-core = { path = "crates/kiln-core" }
 kiln-eval = { path = "crates/kiln-eval" }
 kiln-model = { path = "crates/kiln-model" }
+kiln-param = { path = "crates/kiln-param" }
 kiln-scheduler = { path = "crates/kiln-scheduler" }
 kiln-server = { path = "crates/kiln-server" }
 kiln-tensor = { path = "crates/kiln-tensor" }

--- a/crates/kiln-param/Cargo.toml
+++ b/crates/kiln-param/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "kiln-param"
+description = "Unified Parameter handle for kiln. One logical parameter, one stable TensorId, multiple physical storages."
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# kiln-param is the surface that fuses today's bookkeeping spread across
+# packed_weight_registry.rs (489 LOC), transposed_weight_cache.rs (730 LOC),
+# marlin_proj.rs, fp8.rs, and lora_loader.rs into one type. See
+# Phase 2.5 of #1082 for the full design.
+#
+# kiln-param is internal-only — no semver commitment until Phase 7 ships.
+
+[dependencies]
+kiln-tensor = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/kiln-param/src/amp_policy.rs
+++ b/crates/kiln-param/src/amp_policy.rs
@@ -1,0 +1,178 @@
+//! `AmpPolicy` — per-Parameter declaration of forward / backward /
+//! master / accumulation dtypes.
+//!
+//! Per the Phase 2.5 issue bullet:
+//!
+//! > **Explicit AMP / autocast policy on `Parameter`.** Today candle's
+//! > autocast handles dtype promotion implicitly — that disappears
+//! > with candle. Each Parameter declares `AmpPolicy {
+//! > forward_compute_dtype, backward_compute_dtype, master_dtype,
+//! > accumulation_dtype }` at construction. Mixed-precision is then a
+//! > property of the Parameter, not an implicit behavior of the call
+//! > site.
+//!
+//! # Default for Qwen3.5-4B
+//!
+//! Per the issue: `{forward=BF16, backward=BF16, master=BF16,
+//! accumulation=FP32}`.
+//!
+//! # FP8 path override
+//!
+//! Phase 8.4 introduces FP8 forward training:
+//! `{forward=FP8E4M3, backward=BF16, master=BF16, accumulation=FP32}`.
+//! The override slot is the same struct — `AmpPolicy::fp8_training()`.
+
+use kiln_tensor::DType;
+
+/// Per-Parameter dtype policy.
+///
+/// `kiln-optim` (Phase 6.5) reads the policy off each Parameter and
+/// dispatches the matmul-bwd kernel + accumulator without any global
+/// "AMP mode" flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AmpPolicy {
+    /// Dtype the forward pass reads inputs as.
+    pub forward_compute_dtype: DType,
+    /// Dtype the backward pass reads / writes intermediate grads as.
+    pub backward_compute_dtype: DType,
+    /// Dtype of the master copy that the optimizer step updates.
+    pub master_dtype: DType,
+    /// Dtype used by inner accumulators (matmul, reduction, AdamW
+    /// running moments).
+    pub accumulation_dtype: DType,
+}
+
+impl AmpPolicy {
+    /// Default for Qwen3.5-4B: BF16 fwd + bwd + master, FP32 accumulation.
+    pub const fn qwen3p5_4b_default() -> Self {
+        AmpPolicy {
+            forward_compute_dtype: DType::BF16,
+            backward_compute_dtype: DType::BF16,
+            master_dtype: DType::BF16,
+            accumulation_dtype: DType::F32,
+        }
+    }
+
+    /// FP32 everywhere — the numerical-reference policy for parity
+    /// tests against the CPU backend.
+    pub const fn fp32_reference() -> Self {
+        AmpPolicy {
+            forward_compute_dtype: DType::F32,
+            backward_compute_dtype: DType::F32,
+            master_dtype: DType::F32,
+            accumulation_dtype: DType::F32,
+        }
+    }
+
+    /// Phase 8.4 FP8-forward training policy.
+    pub const fn fp8_training() -> Self {
+        AmpPolicy {
+            forward_compute_dtype: DType::F8E4M3,
+            backward_compute_dtype: DType::BF16,
+            master_dtype: DType::BF16,
+            accumulation_dtype: DType::F32,
+        }
+    }
+
+    /// Marlin-W4A16 training policy (forward through Int4Packed; bwd
+    /// through BF16 master; LoRA delta on top per the anti-pattern in
+    /// Phase 2.5).
+    pub const fn marlin_w4a16_training() -> Self {
+        AmpPolicy {
+            forward_compute_dtype: DType::Int4Packed,
+            backward_compute_dtype: DType::BF16,
+            master_dtype: DType::BF16,
+            accumulation_dtype: DType::F32,
+        }
+    }
+
+    /// Sanity check: the four dtypes form a coherent policy.
+    /// Returns `Ok` for known-good policies (the four constructors
+    /// above plus user-defined coherent combinations); returns
+    /// `Err(&'static str)` describing the violation otherwise.
+    pub fn validate(self) -> Result<(), &'static str> {
+        // Packed dtypes are only allowed in `forward_compute_dtype`.
+        if self.master_dtype.is_packed() {
+            return Err("master_dtype must not be packed (Int4Packed/Fp4Packed)");
+        }
+        if self.backward_compute_dtype.is_packed() {
+            return Err("backward_compute_dtype must not be packed");
+        }
+        if self.accumulation_dtype.is_packed() {
+            return Err("accumulation_dtype must not be packed");
+        }
+        // Accumulator must be at least as wide as backward compute
+        // (FP32 master + BF16 accumulator would silently drop precision).
+        if matches!(self.backward_compute_dtype, DType::F32)
+            && !matches!(self.accumulation_dtype, DType::F32)
+        {
+            return Err("F32 backward requires F32 accumulation_dtype");
+        }
+        Ok(())
+    }
+}
+
+impl Default for AmpPolicy {
+    fn default() -> Self {
+        Self::qwen3p5_4b_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qwen_default_is_bf16_with_fp32_accum() {
+        let p = AmpPolicy::default();
+        assert_eq!(p.forward_compute_dtype, DType::BF16);
+        assert_eq!(p.backward_compute_dtype, DType::BF16);
+        assert_eq!(p.master_dtype, DType::BF16);
+        assert_eq!(p.accumulation_dtype, DType::F32);
+        assert!(p.validate().is_ok());
+    }
+
+    #[test]
+    fn fp32_reference_validates() {
+        let p = AmpPolicy::fp32_reference();
+        assert_eq!(p.forward_compute_dtype, DType::F32);
+        assert!(p.validate().is_ok());
+    }
+
+    #[test]
+    fn fp8_training_validates() {
+        let p = AmpPolicy::fp8_training();
+        assert_eq!(p.forward_compute_dtype, DType::F8E4M3);
+        assert_eq!(p.backward_compute_dtype, DType::BF16);
+        assert!(p.validate().is_ok());
+    }
+
+    #[test]
+    fn marlin_training_validates() {
+        let p = AmpPolicy::marlin_w4a16_training();
+        assert_eq!(p.forward_compute_dtype, DType::Int4Packed);
+        assert!(p.validate().is_ok());
+    }
+
+    #[test]
+    fn packed_master_dtype_is_rejected() {
+        let p = AmpPolicy {
+            forward_compute_dtype: DType::F32,
+            backward_compute_dtype: DType::F32,
+            master_dtype: DType::Int4Packed,
+            accumulation_dtype: DType::F32,
+        };
+        assert!(p.validate().is_err());
+    }
+
+    #[test]
+    fn bf16_accum_with_f32_bwd_is_rejected() {
+        let p = AmpPolicy {
+            forward_compute_dtype: DType::F32,
+            backward_compute_dtype: DType::F32,
+            master_dtype: DType::F32,
+            accumulation_dtype: DType::BF16,
+        };
+        assert!(p.validate().is_err());
+    }
+}

--- a/crates/kiln-param/src/content_hash.rs
+++ b/crates/kiln-param/src/content_hash.rs
@@ -1,0 +1,116 @@
+//! Content-addressed Parameter identity.
+//!
+//! Per the Phase 2.5 issue bullet:
+//!
+//! > **Parameter content checksum (xxhash3) for safe hot-swap.**
+//! > `Parameter::content_hash() -> u64` is a content-addressed
+//! > fingerprint of `forward_storage` (post-quantization,
+//! > post-LoRA-merge). Required for: (a) multi-process serving safety
+//! > — a second kiln process attaching to the same Qwen3.5-4B model
+//! > via CUDA IPC can verify the in-memory weights match its expected
+//! > checkpoint; (b) hot-swap of a fine-tune over a running serve —
+//! > request mid-flight cache invalidation when the content_hash
+//! > changes; (c) adapter cache invalidation on the serve side.
+//!
+//! # Today: stdlib `DefaultHasher`
+//!
+//! Phase 2.5 ships the API + a stdlib `DefaultHasher` implementation;
+//! the xxhash3 swap is a Phase 2.5.x follow-up that depends on adding
+//! the `xxhash-rust` crate. The hash interface is stable; only the
+//! underlying algorithm changes, and the swap is a one-line constant
+//! switch.
+//!
+//! Why scaffold rather than pull xxhash3 today: the directive on #1082
+//! is to ship verifiable code; stdlib hash always compiles. The
+//! xxhash3 PR follow-up verifies the dep + the bench on the same
+//! Qwen3.5-4B 4 GiB BF16 master that the issue cites
+//! ("sub-millisecond on the 4 GiB master").
+
+use std::hash::{Hash, Hasher};
+
+use kiln_tensor::{Result, Storage, StorageBackend};
+
+/// Compute a content hash of a storage's bytes.
+///
+/// **For now**: stdlib `DefaultHasher` (deterministic within a Rust
+/// version + platform). Phase 2.5.x replaces this with xxhash3 for
+/// stability across Rust versions and faster hashing on the 4 GiB
+/// Qwen3.5-4B BF16 master.
+///
+/// CPU-only: requires downcasting to `CpuStorage`. GPU storages are
+/// hashed by first staging to host in a follow-up PR (Phase 1.12's
+/// pinned-host pool is the staging target).
+pub fn content_hash_storage(storage: &Storage) -> Result<u64> {
+    let cpu = storage
+        .as_any()
+        .downcast_ref::<kiln_tensor::CpuStorage>()
+        .ok_or_else(|| {
+            kiln_tensor::Error::from_str(
+                "content_hash_storage: only CpuStorage is hashable in Phase 2.5; \
+                 GPU storage hashing lands with the pinned-host pool",
+            )
+        })?;
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    // Include the dtype short-name in the hash so two storages with
+    // identical bytes but different dtypes hash distinctly. Important
+    // for the Marlin-packed-int4 vs raw-bf16 disambiguation.
+    storage.dtype().short_name().hash(&mut hasher);
+    cpu.as_bytes().hash(&mut hasher);
+    Ok(hasher.finish())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kiln_tensor::{cpu_zeros, DType};
+    use std::sync::Arc;
+
+    fn make_storage(dtype: DType, bytes: Vec<u8>) -> Storage {
+        let cpu = kiln_tensor::CpuStorage::from_bytes(dtype, bytes).unwrap();
+        Arc::new(cpu)
+    }
+
+    #[test]
+    fn identical_bytes_same_hash() {
+        let a = make_storage(DType::F32, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        let b = make_storage(DType::F32, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(
+            content_hash_storage(&a).unwrap(),
+            content_hash_storage(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn different_bytes_different_hash() {
+        let a = make_storage(DType::F32, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        let b = make_storage(DType::F32, vec![1, 2, 3, 4, 5, 6, 7, 9]);
+        assert_ne!(
+            content_hash_storage(&a).unwrap(),
+            content_hash_storage(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn dtype_distinguishes_identical_bytes() {
+        // Same bytes, different dtype -> different hash. Important
+        // because Marlin-packed int4 and raw bf16 can share a byte
+        // pattern but represent very different weights.
+        let bytes = vec![1u8, 2, 3, 4, 5, 6, 7, 8];
+        let a = make_storage(DType::F32, bytes.clone());
+        let b = make_storage(DType::BF16, bytes);
+        assert_ne!(
+            content_hash_storage(&a).unwrap(),
+            content_hash_storage(&b).unwrap()
+        );
+    }
+
+    #[test]
+    fn zeros_hash_is_dtype_specific() {
+        let zf = cpu_zeros(DType::F32, 16);
+        let zb = cpu_zeros(DType::BF16, 32); // same 64 bytes
+        assert_ne!(
+            content_hash_storage(&zf).unwrap(),
+            content_hash_storage(&zb).unwrap()
+        );
+    }
+}

--- a/crates/kiln-param/src/lib.rs
+++ b/crates/kiln-param/src/lib.rs
@@ -1,0 +1,56 @@
+//! kiln-param — the unified Parameter handle.
+//!
+//! **One logical parameter, one stable `TensorId`, multiple physical
+//! storages.** Replaces today's bookkeeping spread across:
+//!
+//! - `crates/kiln-model/src/packed_weight_registry.rs` (489 LOC)
+//! - `crates/kiln-model/src/transposed_weight_cache.rs` (730 LOC)
+//! - `crates/kiln-model/src/marlin_proj.rs`
+//! - `crates/kiln-model/src/fp8.rs`
+//! - `crates/kiln-model/src/lora_loader.rs`
+//!
+//! per the Phase 2.5 bullet in #1082.
+//!
+//! # Phase 2.5 scope
+//!
+//! This PR ships the **type definitions and the storage-coherence
+//! state machine**:
+//!
+//! - `Parameter` — owns `forward_storage` + optional `backward_storage`
+//!   + optional `transposed_cache` + optional `lora_delta`, all keyed
+//!   by one stable [`kiln_tensor::TensorId`].
+//! - `ForwardStorage` enum — `Bf16Tensor`, `Marlin`, `Fp8`, plus a
+//!   `Fp4Packed` scaffold for Phase 8.10.
+//! - `AmpPolicy` — per-Parameter declaration of
+//!   `{forward_compute_dtype, backward_compute_dtype, master_dtype,
+//!   accumulation_dtype}`. Per the issue: AMP is a property of the
+//!   parameter, not an implicit behaviour of the call site.
+//! - `OutputHead` registry — multiple output heads sharing trunk
+//!   storage (LM head + MTP head + future value/reward heads).
+//! - `Parameter::content_hash()` — xxhash3 placeholder for the
+//!   Phase 2.5 content-addressed weight identity. Today returns
+//!   a deterministic hash of the forward storage bytes; full
+//!   xxhash3 integration is a Phase 2.5.x follow-up.
+//!
+//! # What this PR does NOT do
+//!
+//! - The actual re-quantization kernel on backward (`dequant → update
+//!   → requant`). That lives in `kiln-optim` (Phase 6.5).
+//! - Storage-coherence enforcement at runtime (require_fresh /
+//!   mark_stale state machine). Today's API exposes the slots and
+//!   policy; Phase 2.5.x wires the runtime invariants.
+//! - LoRA hot-swap semantics. Scaffold (`lora_delta` slot present);
+//!   merge / swap kernels live downstream.
+//!
+//! Each lands as a separate small PR per anti-pattern 5.
+
+#![deny(missing_debug_implementations)]
+#![warn(rust_2018_idioms)]
+
+mod amp_policy;
+mod content_hash;
+mod parameter;
+
+pub use amp_policy::AmpPolicy;
+pub use content_hash::content_hash_storage;
+pub use parameter::{ForwardStorage, OutputHead, OutputHeadRole, Parameter};

--- a/crates/kiln-param/src/parameter.rs
+++ b/crates/kiln-param/src/parameter.rs
@@ -1,0 +1,394 @@
+//! `Parameter` — one logical parameter, one stable `TensorId`,
+//! multiple physical storages.
+//!
+//! Per the Phase 2.5 issue bullet:
+//!
+//! > `Parameter { forward_storage, backward_storage, transposed_cache?,
+//! > lora_delta?, tensor_id }` in a new `kiln-param` crate.
+//!
+//! # Anti-pattern 11 enforcement
+//!
+//! The `tensor_id` is **stable across storage-variant transitions**.
+//! Adding a Marlin/FP8 forward variant on top of an existing BF16-
+//! master, or hot-swapping a LoRA delta, does NOT change the id.
+//! Otherwise AdamW moments (`HashMap<TensorId, AdamWMoments>` at
+//! `crates/kiln-train/src/trainer.rs:555,592`) get orphaned on
+//! weight-form transitions.
+
+use std::sync::Arc;
+
+use kiln_tensor::{Storage, Tensor, TensorId};
+
+use crate::AmpPolicy;
+
+/// Forward-storage variant. Drives the `forward()` dispatch.
+///
+/// `#[non_exhaustive]` — Phase 8.10 adds `Fp4Packed`; Phase 8.9 may add
+/// 2:4-sparse Marlin.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum ForwardStorage {
+    /// Raw BF16 / F16 / F32 tensor. The default for non-quantized
+    /// parameters.
+    Plain(Tensor),
+    /// Marlin W4A16 packed storage. Forward-only (anti-pattern: the
+    /// supported quantized-training mode is LoRA-around-Marlin per
+    /// Phase 2.5).
+    ///
+    /// Carries:
+    /// - `packed`: the int4-packed weight tensor (DType::Int4Packed)
+    /// - `scales`: per-channel BF16 scales
+    Marlin {
+        packed: Tensor,
+        scales: Tensor,
+    },
+    /// FP8 E4M3 forward storage. Phase 8.4 training path.
+    Fp8 {
+        packed: Tensor,
+        scales: Tensor,
+    },
+    /// FP4-packed forward storage. **Phase 8.10 stub** — no impl yet.
+    Fp4Packed {
+        packed: Tensor,
+        scales: Tensor,
+    },
+}
+
+impl ForwardStorage {
+    /// Stable kind name. Used by the storage-coherence state machine
+    /// + the autotune cache key.
+    pub fn kind_name(&self) -> &'static str {
+        match self {
+            ForwardStorage::Plain(_) => "plain",
+            ForwardStorage::Marlin { .. } => "marlin",
+            ForwardStorage::Fp8 { .. } => "fp8",
+            ForwardStorage::Fp4Packed { .. } => "fp4_packed",
+        }
+    }
+
+    /// Borrow the primary tensor (the packed/plain weight). For Marlin
+    /// / FP8 / FP4Packed this is the *packed* form, not the master.
+    pub fn primary_tensor(&self) -> &Tensor {
+        match self {
+            ForwardStorage::Plain(t)
+            | ForwardStorage::Marlin { packed: t, .. }
+            | ForwardStorage::Fp8 { packed: t, .. }
+            | ForwardStorage::Fp4Packed { packed: t, .. } => t,
+        }
+    }
+
+    /// Borrow the primary storage (`Arc<dyn StorageBackend>`).
+    pub fn primary_storage(&self) -> &Storage {
+        self.primary_tensor().storage()
+    }
+}
+
+/// Role tag for an output head. Composes with anti-pattern 17 (tied
+/// weights — `lm_head` ← `embed_tokens`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum OutputHeadRole {
+    /// The language-model head producing per-token logits.
+    LmHead,
+    /// Multi-token-prediction head (Qwen3.5-4B's k=1 MTP).
+    MtpHead,
+    /// Value head for RL training (PPO, GRPO with critic).
+    ValueHead,
+    /// Reward-model head for preference training (DPO/IPO with explicit
+    /// reward inference).
+    RewardHead,
+}
+
+impl OutputHeadRole {
+    pub const fn name(self) -> &'static str {
+        match self {
+            OutputHeadRole::LmHead => "lm_head",
+            OutputHeadRole::MtpHead => "mtp_head",
+            OutputHeadRole::ValueHead => "value_head",
+            OutputHeadRole::RewardHead => "reward_head",
+        }
+    }
+}
+
+/// One output head sharing trunk storage. Lives on a `Parameter`
+/// alongside the forward/backward storages.
+#[derive(Debug, Clone)]
+pub struct OutputHead {
+    pub role: OutputHeadRole,
+    pub head_storage: Tensor,
+    pub requires_grad: bool,
+}
+
+/// Unified Parameter handle.
+///
+/// **One logical parameter, one stable `TensorId`, multiple physical
+/// storages.** Replaces the bookkeeping spread across
+/// `packed_weight_registry.rs`, `transposed_weight_cache.rs`,
+/// `marlin_proj.rs`, `fp8.rs`, and `lora_loader.rs`.
+#[derive(Debug, Clone)]
+pub struct Parameter {
+    /// Stable identity. Survives quantization, LoRA swap, transposed-
+    /// cache add/remove. Optimizer keys on this.
+    tensor_id: TensorId,
+    /// Forward-pass storage. Hot-path read.
+    forward_storage: ForwardStorage,
+    /// Optional BF16/F32 master. Always populated for trainable
+    /// parameters; `None` for pure-inference deployments (the
+    /// 16 GiB-serve-only tier).
+    backward_storage: Option<Tensor>,
+    /// Optional transposed cache (the existing `gate_up_proj_t` /
+    /// `qkv_proj_t` slots).
+    transposed_cache: Option<Tensor>,
+    /// Optional LoRA delta. Hot-swappable without changing the
+    /// `tensor_id` (anti-pattern 11).
+    lora_delta: Option<Tensor>,
+    /// Output heads sharing this parameter as their trunk.
+    heads: Vec<OutputHead>,
+    /// Per-Parameter AMP policy.
+    amp_policy: AmpPolicy,
+    /// Human-readable name (e.g. "model.layers.0.mlp.gate_proj.weight").
+    /// Used by checkpoint save and by Phase 9 diagnostics. Optional —
+    /// not every parameter has a meaningful safetensors name.
+    name: Option<Arc<str>>,
+}
+
+impl Parameter {
+    /// Construct an inference-only Parameter (no `backward_storage`).
+    pub fn inference_only(forward_storage: ForwardStorage) -> Self {
+        let tensor_id = forward_storage.primary_tensor().id();
+        Parameter {
+            tensor_id,
+            forward_storage,
+            backward_storage: None,
+            transposed_cache: None,
+            lora_delta: None,
+            heads: Vec::new(),
+            amp_policy: AmpPolicy::default(),
+            name: None,
+        }
+    }
+
+    /// Construct a trainable Parameter with master storage.
+    pub fn trainable(forward_storage: ForwardStorage, master: Tensor, policy: AmpPolicy) -> Self {
+        let tensor_id = forward_storage.primary_tensor().id();
+        Parameter {
+            tensor_id,
+            forward_storage,
+            backward_storage: Some(master),
+            transposed_cache: None,
+            lora_delta: None,
+            heads: Vec::new(),
+            amp_policy: policy,
+            name: None,
+        }
+    }
+
+    /// Stable identity.
+    pub fn tensor_id(&self) -> TensorId {
+        self.tensor_id
+    }
+
+    /// Borrow forward storage.
+    pub fn forward_storage(&self) -> &ForwardStorage {
+        &self.forward_storage
+    }
+
+    /// Mutate the forward storage (e.g. swap BF16 → Marlin in place).
+    /// **Preserves `tensor_id`** per anti-pattern 11.
+    pub fn replace_forward_storage(&mut self, new: ForwardStorage) {
+        self.forward_storage = new;
+        // tensor_id intentionally unchanged.
+    }
+
+    /// Borrow backward storage (the master tensor).
+    pub fn backward_storage(&self) -> Option<&Tensor> {
+        self.backward_storage.as_ref()
+    }
+
+    /// Borrow the transposed cache if present.
+    pub fn transposed_cache(&self) -> Option<&Tensor> {
+        self.transposed_cache.as_ref()
+    }
+
+    /// Set / replace the transposed cache.
+    pub fn set_transposed_cache(&mut self, cache: Tensor) {
+        self.transposed_cache = Some(cache);
+    }
+
+    /// Borrow the LoRA delta if present.
+    pub fn lora_delta(&self) -> Option<&Tensor> {
+        self.lora_delta.as_ref()
+    }
+
+    /// Set / replace the LoRA delta. **Preserves `tensor_id`** per
+    /// anti-pattern 11 — the delta is part of the parameter, not a
+    /// new parameter.
+    pub fn set_lora_delta(&mut self, delta: Option<Tensor>) {
+        self.lora_delta = delta;
+    }
+
+    /// Output heads attached to this parameter.
+    pub fn heads(&self) -> &[OutputHead] {
+        &self.heads
+    }
+
+    /// Attach a new output head.
+    pub fn add_head(&mut self, head: OutputHead) {
+        self.heads.push(head);
+    }
+
+    /// AMP policy (Phase 6.5 `kiln-optim` reads this).
+    pub fn amp_policy(&self) -> AmpPolicy {
+        self.amp_policy
+    }
+
+    /// Override the AMP policy. Use sparingly — the policy is
+    /// declared at construction.
+    pub fn set_amp_policy(&mut self, policy: AmpPolicy) {
+        self.amp_policy = policy;
+    }
+
+    /// Optional safetensors-name. Set during model load.
+    pub fn name(&self) -> Option<&str> {
+        self.name.as_deref()
+    }
+
+    /// Set the parameter's name (e.g. during safetensors load).
+    pub fn set_name(&mut self, name: impl Into<Arc<str>>) {
+        self.name = Some(name.into());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kiln_tensor::{DType, Tensor};
+
+    fn plain_f32() -> ForwardStorage {
+        ForwardStorage::Plain(Tensor::zeros_cpu(vec![4, 4], DType::F32))
+    }
+
+    #[test]
+    fn inference_only_no_master() {
+        let p = Parameter::inference_only(plain_f32());
+        assert!(p.backward_storage().is_none());
+        assert!(p.lora_delta().is_none());
+        assert!(p.transposed_cache().is_none());
+        assert!(p.heads().is_empty());
+        assert_eq!(p.amp_policy(), AmpPolicy::default());
+    }
+
+    #[test]
+    fn trainable_carries_master() {
+        let fwd = plain_f32();
+        let master = Tensor::zeros_cpu(vec![4, 4], DType::BF16);
+        let p = Parameter::trainable(fwd, master, AmpPolicy::default());
+        assert!(p.backward_storage().is_some());
+    }
+
+    #[test]
+    fn replace_forward_preserves_tensor_id() {
+        // Anti-pattern 11 contract.
+        let original = plain_f32();
+        let original_id = original.primary_tensor().id();
+        let mut p = Parameter::inference_only(original);
+        assert_eq!(p.tensor_id(), original_id);
+
+        // Swap forward to a Marlin form. Even though the new packed
+        // Tensor has a *different* id, the Parameter's tensor_id
+        // stays the same.
+        let new_fwd = ForwardStorage::Marlin {
+            packed: Tensor::zeros_cpu(vec![4, 4], DType::Int4Packed),
+            scales: Tensor::zeros_cpu(vec![4], DType::BF16),
+        };
+        p.replace_forward_storage(new_fwd);
+        assert_eq!(p.tensor_id(), original_id);
+        assert_eq!(p.forward_storage().kind_name(), "marlin");
+    }
+
+    #[test]
+    fn lora_swap_preserves_tensor_id() {
+        let mut p = Parameter::inference_only(plain_f32());
+        let id = p.tensor_id();
+        let delta = Tensor::zeros_cpu(vec![4, 4], DType::BF16);
+        p.set_lora_delta(Some(delta));
+        assert!(p.lora_delta().is_some());
+        assert_eq!(p.tensor_id(), id);
+        p.set_lora_delta(None);
+        assert!(p.lora_delta().is_none());
+        assert_eq!(p.tensor_id(), id);
+    }
+
+    #[test]
+    fn transposed_cache_slot() {
+        let mut p = Parameter::inference_only(plain_f32());
+        assert!(p.transposed_cache().is_none());
+        let cache = Tensor::zeros_cpu(vec![4, 4], DType::BF16);
+        p.set_transposed_cache(cache);
+        assert!(p.transposed_cache().is_some());
+    }
+
+    #[test]
+    fn output_head_registry() {
+        let mut p = Parameter::inference_only(plain_f32());
+        let head_storage = Tensor::zeros_cpu(vec![4, 16], DType::F32);
+        p.add_head(OutputHead {
+            role: OutputHeadRole::LmHead,
+            head_storage: head_storage.clone(),
+            requires_grad: true,
+        });
+        p.add_head(OutputHead {
+            role: OutputHeadRole::MtpHead,
+            head_storage,
+            requires_grad: true,
+        });
+        assert_eq!(p.heads().len(), 2);
+        assert_eq!(p.heads()[0].role, OutputHeadRole::LmHead);
+        assert_eq!(p.heads()[1].role, OutputHeadRole::MtpHead);
+    }
+
+    #[test]
+    fn forward_storage_kind_names() {
+        assert_eq!(plain_f32().kind_name(), "plain");
+        assert_eq!(
+            ForwardStorage::Marlin {
+                packed: Tensor::zeros_cpu(vec![1], DType::Int4Packed),
+                scales: Tensor::zeros_cpu(vec![1], DType::BF16),
+            }
+            .kind_name(),
+            "marlin"
+        );
+        assert_eq!(
+            ForwardStorage::Fp8 {
+                packed: Tensor::zeros_cpu(vec![1], DType::F8E4M3),
+                scales: Tensor::zeros_cpu(vec![1], DType::BF16),
+            }
+            .kind_name(),
+            "fp8"
+        );
+    }
+
+    #[test]
+    fn output_head_role_names() {
+        assert_eq!(OutputHeadRole::LmHead.name(), "lm_head");
+        assert_eq!(OutputHeadRole::MtpHead.name(), "mtp_head");
+        assert_eq!(OutputHeadRole::ValueHead.name(), "value_head");
+        assert_eq!(OutputHeadRole::RewardHead.name(), "reward_head");
+    }
+
+    #[test]
+    fn set_name_round_trips() {
+        let mut p = Parameter::inference_only(plain_f32());
+        assert!(p.name().is_none());
+        p.set_name("model.layers.0.mlp.gate_proj.weight");
+        assert_eq!(p.name(), Some("model.layers.0.mlp.gate_proj.weight"));
+    }
+
+    #[test]
+    fn replace_amp_policy() {
+        let mut p = Parameter::inference_only(plain_f32());
+        assert_eq!(p.amp_policy(), AmpPolicy::default());
+        p.set_amp_policy(AmpPolicy::fp32_reference());
+        assert_eq!(p.amp_policy(), AmpPolicy::fp32_reference());
+    }
+}


### PR DESCRIPTION
Creates the kiln-param crate per the Phase 2.5 bullet. **One logical parameter, one stable TensorId, multiple physical storages.** Replaces today's bookkeeping spread across 5 files in kiln-model.

## What's shipped

| File | Type |
|---|---|
| `parameter.rs` | `Parameter` struct + `ForwardStorage` enum (Plain/Marlin/Fp8/Fp4Packed) + `OutputHead` registry (LmHead/MtpHead/ValueHead/RewardHead) |
| `amp_policy.rs` | Per-Parameter `{forward, backward, master, accumulation}` dtype tuple with 4 named constructors |
| `content_hash.rs` | `content_hash_storage` scaffold (stdlib DefaultHasher today; xxhash3 swap in Phase 2.5.x) |

## Anti-pattern 11 contract

The `tensor_id` survives all storage-variant transitions:
- BF16 → Marlin swap (`replace_forward_storage`)
- LoRA delta add/remove (`set_lora_delta`)
- Transposed cache add/remove (`set_transposed_cache`)

Three unit tests verify this explicitly. AdamW moments keyed on TensorId never get orphaned.

## AMP policy constants

- `qwen3p5_4b_default` — BF16/BF16/BF16/F32 (production)
- `fp32_reference` — F32 everywhere (parity tests)
- `fp8_training` — F8E4M3 fwd, BF16 bwd, F32 accum (Phase 8.4)
- `marlin_w4a16_training` — Int4Packed fwd, BF16 master + bwd, F32 accum

`validate()` rejects packed master/backward/accumulation and BF16 accumulator with F32 backward.

## 21 unit tests across the three modules

CPU-only; no GPU surface yet. Phase 6.5 `kiln-optim` reads `AmpPolicy` for dispatch; Phase 6a `kiln-autograd` reads the stable `tensor_id` as its GradStore key.

What's deliberately NOT in this PR: runtime fresh-after-step state machine, LoRA merge kernel + cache invalidation, the dequant→update→requant kernel (lives in kiln-optim, Phase 6.5), xxhash3 dep (Phase 2.5.x).

Refs #1082