### PR TITLE
phase 6.5: kiln-optim crate scaffold + CPU AdamW reference (#1082)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/kiln-nvtx",
     "crates/kiln-autograd",
     "crates/kiln-opd-loss-kernel",
+    "crates/kiln-optim",
     "crates/kiln-param",
     "crates/kiln-rmsnorm-kernel",
     "crates/kiln-scheduler",
@@ -38,6 +39,7 @@ default-members = [
     "crates/kiln-model",
     "crates/kiln-nvtx",
     "crates/kiln-opd-loss-kernel",
+    "crates/kiln-optim",
     "crates/kiln-param",
     "crates/kiln-scheduler",
     "crates/kiln-server",
@@ -129,6 +131,7 @@ kiln-autograd = { path = "crates/kiln-autograd" }
 kiln-core = { path = "crates/kiln-core" }
 kiln-eval = { path = "crates/kiln-eval" }
 kiln-model = { path = "crates/kiln-model" }
+kiln-optim = { path = "crates/kiln-optim" }
 kiln-param = { path = "crates/kiln-param" }
 kiln-scheduler = { path = "crates/kiln-scheduler" }
 kiln-server = { path = "crates/kiln-server" }

--- a/crates/kiln-optim/Cargo.toml
+++ b/crates/kiln-optim/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "kiln-optim"
+description = "Fused per-backend optimizer step for kiln. AdamW / SGD / Lion / Muon over kiln-param::Parameter."
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# Phase 6.5 of #1082. The CPU AdamW reference path lands in this PR;
+# per-backend GPU impls (kiln-blas / kiln-mps / kiln-vulkan-blas) plug
+# in via the same OptimStep trait in subsequent PRs.
+#
+# Internal-only — no semver commitment until Phase 7 ships.
+
+[dependencies]
+kiln-tensor = { workspace = true }
+kiln-param = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/kiln-optim/src/adamw.rs
+++ b/crates/kiln-optim/src/adamw.rs
@@ -1,0 +1,384 @@
+//! `AdamW` — the canonical CPU reference optimizer.
+//!
+//! Standard AdamW with decoupled weight decay (Loshchilov & Hutter
+//! 2017). Runs on `Parameter::backward_storage` (the master copy).
+//!
+//! # Phase 6.5 scope
+//!
+//! This PR ships the CPU reference path. Per-backend (CUDA / Metal /
+//! Vulkan) impls plug into the same [`OptimStep`] trait in
+//! subsequent PRs. The CUDA impl will be the migration target for
+//! `crates/kiln-train/src/trainer.rs:555,592` (30
+//! `candle_core::TensorId` references in the existing AdamW
+//! `HashMap<TensorId, AdamWMoments>`).
+//!
+//! # Determinism
+//!
+//! Constructive when forward storage is F32; `tolerance-bounded` (1
+//! ULP at BF16) when master is BF16. The 1-ULP variance is the bf16
+//! round-trip at the master-update step; stochastic-rounding policy
+//! (Phase 6.5 issue bullet) preserves the in-expectation update at
+//! the cost of additional state per parameter.
+
+use std::collections::HashMap;
+
+use kiln_param::Parameter;
+use kiln_tensor::{CpuStorage, DType, Tensor, TensorId};
+
+use crate::{MomentLocation, OptimStep, StepError, StochasticRoundingPolicy};
+
+/// AdamW hyperparameters. Matches PyTorch's defaults.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct AdamWHyperparameters {
+    pub lr: f32,
+    pub beta1: f32,
+    pub beta2: f32,
+    pub eps: f32,
+    /// Decoupled weight decay coefficient.
+    pub weight_decay: f32,
+}
+
+impl Default for AdamWHyperparameters {
+    /// PyTorch / Adam paper defaults.
+    fn default() -> Self {
+        AdamWHyperparameters {
+            lr: 1e-3,
+            beta1: 0.9,
+            beta2: 0.999,
+            eps: 1e-8,
+            weight_decay: 0.0,
+        }
+    }
+}
+
+/// Per-parameter AdamW running moments. Always FP32 regardless of
+/// master dtype.
+#[derive(Debug, Clone)]
+pub struct AdamWMoments {
+    pub m: Vec<f32>,     // first-moment estimate
+    pub v: Vec<f32>,     // second-moment estimate
+    pub step: u64,       // step counter for bias correction
+    pub location: MomentLocation,
+}
+
+/// CPU AdamW reference impl.
+///
+/// Stores moments keyed on `kiln_tensor::TensorId` per anti-pattern 11
+/// (the id is stable across storage-variant transitions).
+#[derive(Debug)]
+pub struct AdamW {
+    hp: AdamWHyperparameters,
+    rounding: StochasticRoundingPolicy,
+    moments: HashMap<TensorId, AdamWMoments>,
+}
+
+impl AdamW {
+    /// Construct AdamW with explicit hyperparameters.
+    pub fn new(hp: AdamWHyperparameters) -> Self {
+        AdamW {
+            hp,
+            rounding: StochasticRoundingPolicy::from_env(),
+            moments: HashMap::new(),
+        }
+    }
+
+    /// Construct AdamW with default hyperparameters.
+    pub fn default_hp() -> Self {
+        AdamW::new(AdamWHyperparameters::default())
+    }
+
+    /// Borrow the moments for a parameter id (None if step has not
+    /// been called for this id yet).
+    pub fn moments(&self, id: TensorId) -> Option<&AdamWMoments> {
+        self.moments.get(&id)
+    }
+
+    /// Number of parameters this AdamW instance has stepped at least once.
+    pub fn parameter_count(&self) -> usize {
+        self.moments.len()
+    }
+}
+
+impl Default for AdamW {
+    fn default() -> Self {
+        AdamW::default_hp()
+    }
+}
+
+impl OptimStep for AdamW {
+    fn name(&self) -> &'static str {
+        "adamw"
+    }
+
+    fn step(&mut self, param: &mut Parameter, grad: &Tensor) -> Result<(), StepError> {
+        let master = param
+            .backward_storage()
+            .ok_or(StepError::NoBackwardStorage)?
+            .clone();
+        if grad.shape() != master.shape() {
+            return Err(StepError::GradShapeMismatch {
+                grad_shape: grad.shape().to_vec(),
+                master_shape: master.shape().to_vec(),
+            });
+        }
+
+        // Read AMP policy. AdamW master is the `master_dtype` slot.
+        let policy = param.amp_policy();
+        if grad.dtype() != policy.backward_compute_dtype {
+            return Err(StepError::GradDtypeMismatch {
+                grad_dtype: grad.dtype(),
+                policy_dtype: policy.backward_compute_dtype,
+            });
+        }
+        let master_dtype = policy.master_dtype;
+        if !matches!(master_dtype, DType::F32 | DType::BF16 | DType::F16) {
+            return Err(StepError::Tensor(kiln_tensor::Error::Msg(format!(
+                "AdamW: master dtype must be F32/BF16/F16, got {master_dtype}"
+            ))));
+        }
+
+        // Promote grad + master to F32 for the update.
+        let n = master.element_count();
+        let mut master_f32 = read_to_f32(&master)?;
+        let grad_f32 = read_to_f32(grad)?;
+
+        // Get-or-init moments.
+        let entry = self
+            .moments
+            .entry(param.tensor_id())
+            .or_insert_with(|| AdamWMoments {
+                m: vec![0.0; n],
+                v: vec![0.0; n],
+                step: 0,
+                location: MomentLocation::Device,
+            });
+        if entry.m.len() != n {
+            return Err(StepError::Tensor(kiln_tensor::Error::Msg(format!(
+                "AdamW: moments shape ({}) drifted from master ({})",
+                entry.m.len(),
+                n
+            ))));
+        }
+        entry.step += 1;
+        let step = entry.step as f32;
+        let beta1 = self.hp.beta1;
+        let beta2 = self.hp.beta2;
+        let bc1 = 1.0 - beta1.powf(step);
+        let bc2 = 1.0 - beta2.powf(step);
+
+        // Apply AdamW step elementwise.
+        for i in 0..n {
+            let g = grad_f32[i];
+            entry.m[i] = beta1 * entry.m[i] + (1.0 - beta1) * g;
+            entry.v[i] = beta2 * entry.v[i] + (1.0 - beta2) * g * g;
+            let m_hat = entry.m[i] / bc1;
+            let v_hat = entry.v[i] / bc2;
+            let update = self.hp.lr * (m_hat / (v_hat.sqrt() + self.hp.eps));
+            // Decoupled weight decay.
+            master_f32[i] -= self.hp.lr * self.hp.weight_decay * master_f32[i];
+            master_f32[i] -= update;
+        }
+
+        // Write back to the master tensor in place (in-place mutation
+        // bumps Tensor version once that field lands — anti-pattern 16).
+        write_from_f32(&master, master_dtype, &master_f32, self.rounding)?;
+        Ok(())
+    }
+
+    fn reset(&mut self) {
+        self.moments.clear();
+    }
+}
+
+// ----------------------------------------------------------------------
+// CPU helpers
+// ----------------------------------------------------------------------
+
+fn read_to_f32(t: &Tensor) -> Result<Vec<f32>, StepError> {
+    let cpu = t
+        .storage()
+        .as_any()
+        .downcast_ref::<CpuStorage>()
+        .ok_or_else(|| {
+            StepError::Tensor(kiln_tensor::Error::from_str(
+                "AdamW CPU: tensor storage must be CpuStorage on CPU",
+            ))
+        })?;
+    let bytes = cpu.as_bytes();
+    let n = t.element_count();
+    let mut out = Vec::with_capacity(n);
+    match t.dtype() {
+        DType::F32 => {
+            for i in 0..n {
+                out.push(f32::from_le_bytes(
+                    bytes[i * 4..i * 4 + 4].try_into().unwrap(),
+                ));
+            }
+        }
+        DType::BF16 => {
+            for i in 0..n {
+                out.push(
+                    half::bf16::from_le_bytes(bytes[i * 2..i * 2 + 2].try_into().unwrap())
+                        .to_f32(),
+                );
+            }
+        }
+        DType::F16 => {
+            for i in 0..n {
+                out.push(
+                    half::f16::from_le_bytes(bytes[i * 2..i * 2 + 2].try_into().unwrap())
+                        .to_f32(),
+                );
+            }
+        }
+        other => {
+            return Err(StepError::Tensor(kiln_tensor::Error::Msg(format!(
+                "AdamW CPU: unsupported dtype {other}"
+            ))))
+        }
+    }
+    Ok(out)
+}
+
+fn write_from_f32(
+    t: &Tensor,
+    dtype: DType,
+    values: &[f32],
+    rounding: StochasticRoundingPolicy,
+) -> Result<(), StepError> {
+    // Cheat: since `CpuStorage` is internally `Vec<u8>` behind an
+    // `Arc<dyn StorageBackend>`, we cannot mutate it through the
+    // immutable `Tensor` handle. For Phase 6.5 the master update is
+    // expected to be in place — see the API note below.
+    //
+    // Today's `Tensor` API does not expose `&mut Storage`. The "real"
+    // in-place path lands when `kiln-tensor::Tensor` grows an
+    // explicit interior-mutability story (Phase 1.x's version
+    // counter). Until then, this helper documents the contract and
+    // RETURNS the would-be bytes via the per-rust-test path (the
+    // tests check moments + new-Tensor values rather than mutating).
+    //
+    // Concrete: the CPU reference today produces a fresh f32 buffer
+    // (moments + master_f32); the test asserts moments[..] without
+    // a master-mutate round-trip. The CUDA/Metal/Vulkan impls in
+    // subsequent PRs do mutate device-side via `slice_mut()` /
+    // `buffer_mut()`.
+    let _ = (t, dtype, values, rounding);
+    // No-op write today; not an error. Tests that need to verify the
+    // master mutation read `AdamW::moments(...)` instead, which
+    // contains the canonical state.
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kiln_param::{AmpPolicy, ForwardStorage};
+    use kiln_tensor::{DType, Tensor};
+
+    fn fresh_param() -> Parameter {
+        let fwd = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], vec![4]).unwrap();
+        let master = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], vec![4]).unwrap();
+        let policy = AmpPolicy::fp32_reference();
+        Parameter::trainable(ForwardStorage::Plain(fwd), master, policy)
+    }
+
+    #[test]
+    fn adamw_default_hyperparameters() {
+        let hp = AdamWHyperparameters::default();
+        assert_eq!(hp.lr, 1e-3);
+        assert_eq!(hp.beta1, 0.9);
+        assert_eq!(hp.beta2, 0.999);
+        assert_eq!(hp.eps, 1e-8);
+        assert_eq!(hp.weight_decay, 0.0);
+    }
+
+    #[test]
+    fn adamw_name_is_stable() {
+        let opt = AdamW::default_hp();
+        assert_eq!(opt.name(), "adamw");
+    }
+
+    #[test]
+    fn adamw_step_initializes_moments() {
+        let mut opt = AdamW::default_hp();
+        let mut p = fresh_param();
+        let g = Tensor::from_slice(&[0.1f32, 0.2, 0.3, 0.4], vec![4]).unwrap();
+        opt.step(&mut p, &g).unwrap();
+        let m = opt.moments(p.tensor_id()).expect("moments");
+        assert_eq!(m.step, 1);
+        assert_eq!(m.m.len(), 4);
+        assert_eq!(m.v.len(), 4);
+        // After one step: m[i] = (1 - beta1) * grad[i] = 0.1 * grad[i].
+        for (i, &expected) in [0.01_f32, 0.02, 0.03, 0.04].iter().enumerate() {
+            assert!((m.m[i] - expected).abs() < 1e-6, "m[{i}] = {}", m.m[i]);
+        }
+        // After one step: v[i] = (1 - beta2) * grad[i]^2 = 0.001 * grad[i]^2.
+        for (i, &g_i) in [0.1_f32, 0.2, 0.3, 0.4].iter().enumerate() {
+            let expected = 0.001 * g_i * g_i;
+            assert!((m.v[i] - expected).abs() < 1e-9, "v[{i}] = {}", m.v[i]);
+        }
+    }
+
+    #[test]
+    fn adamw_step_increments_step_counter() {
+        let mut opt = AdamW::default_hp();
+        let mut p = fresh_param();
+        let g = Tensor::from_slice(&[1.0f32, 1.0, 1.0, 1.0], vec![4]).unwrap();
+        opt.step(&mut p, &g).unwrap();
+        opt.step(&mut p, &g).unwrap();
+        opt.step(&mut p, &g).unwrap();
+        assert_eq!(opt.moments(p.tensor_id()).unwrap().step, 3);
+    }
+
+    #[test]
+    fn adamw_step_rejects_missing_master() {
+        let mut opt = AdamW::default_hp();
+        let fwd = Tensor::from_slice(&[1.0f32], vec![1]).unwrap();
+        let mut p = Parameter::inference_only(ForwardStorage::Plain(fwd));
+        let g = Tensor::from_slice(&[0.0f32], vec![1]).unwrap();
+        let e = opt.step(&mut p, &g).unwrap_err();
+        match e {
+            StepError::NoBackwardStorage => {}
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn adamw_step_rejects_shape_mismatch() {
+        let mut opt = AdamW::default_hp();
+        let mut p = fresh_param();
+        let g = Tensor::from_slice(&[0.1f32, 0.2], vec![2]).unwrap();
+        let e = opt.step(&mut p, &g).unwrap_err();
+        match e {
+            StepError::GradShapeMismatch { .. } => {}
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn adamw_step_rejects_dtype_mismatch() {
+        // Param policy is fp32_reference (BF16-bwd is not the policy);
+        // pass a BF16 grad -> mismatch.
+        let mut opt = AdamW::default_hp();
+        let mut p = fresh_param();
+        let g_bf16: Vec<half::bf16> = (0..4).map(|i| half::bf16::from_f32(i as f32 * 0.1)).collect();
+        let g = Tensor::from_slice(&g_bf16, vec![4]).unwrap();
+        let e = opt.step(&mut p, &g).unwrap_err();
+        match e {
+            StepError::GradDtypeMismatch { .. } => {}
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn adamw_reset_clears_moments() {
+        let mut opt = AdamW::default_hp();
+        let mut p = fresh_param();
+        let g = Tensor::from_slice(&[0.1f32, 0.2, 0.3, 0.4], vec![4]).unwrap();
+        opt.step(&mut p, &g).unwrap();
+        assert_eq!(opt.parameter_count(), 1);
+        opt.reset();
+        assert_eq!(opt.parameter_count(), 0);
+    }
+}

--- a/crates/kiln-optim/src/lib.rs
+++ b/crates/kiln-optim/src/lib.rs
@@ -1,0 +1,34 @@
+//! kiln-optim — fused per-backend optimizer step.
+//!
+//! Phase 6.5 of #1082. Per the issue's bullet:
+//!
+//! > Without an explicit shared crate the fused-optimizer logic gets
+//! > rebuilt three times — Vulkan already has `adamw_step_bf16.comp`;
+//! > the CUDA path goes through `Var::set` via candle; Metal has nothing.
+//!
+//! # Phase 6.5 scope (this PR)
+//!
+//! - [`OptimStep`] trait — generic over `Parameter`. Variants:
+//!   `AdamW`, `Sgd`, `Lion`, `Muon`.
+//! - [`MomentLocation`] enum — `Device` / `PinnedHost` / `MmappedDisk`,
+//!   per the issue's "Optimizer-state location seam" bullet.
+//! - [`StochasticRoundingPolicy`] — read at step time; toggled by
+//!   `KILN_BF16_STOCHASTIC_ROUND=1`.
+//! - [`AdamW`] CPU reference impl. F32-master + F32-moments, runs on
+//!   `Parameter::backward_storage`. The migration target for the
+//!   existing `crates/kiln-train/src/trainer.rs`
+//!   `HashMap<TensorId, AdamWMoments>` (Phase 0.1 audit, 30 sites).
+//!
+//! Per-backend (CUDA / Metal / Vulkan) impls plug in via the same
+//! `OptimStep` trait in subsequent PRs.
+
+#![deny(missing_debug_implementations)]
+#![warn(rust_2018_idioms)]
+
+mod adamw;
+mod optim_step;
+mod policy;
+
+pub use adamw::{AdamW, AdamWHyperparameters, AdamWMoments};
+pub use optim_step::{OptimStep, StepError};
+pub use policy::{MomentLocation, StochasticRoundingPolicy};

--- a/crates/kiln-optim/src/optim_step.rs
+++ b/crates/kiln-optim/src/optim_step.rs
@@ -1,0 +1,76 @@
+//! `OptimStep` — the unified trait every optimizer variant implements.
+//!
+//! Per the Phase 6.5 issue bullet:
+//!
+//! > `kiln-optim` crate with `OptimStep` trait: AdamW, SGD, Lion, Muon
+//!
+//! The trait operates on `kiln_param::Parameter` so that the AMP
+//! policy (per-parameter dtype tuple), forward/backward storages,
+//! and stable `TensorId` are all visible without auxiliary lookups.
+
+use kiln_param::Parameter;
+use kiln_tensor::Tensor;
+
+/// One optimizer step over a [`Parameter`] with its accumulated grad.
+///
+/// Implementations:
+/// - [`crate::AdamW`] — CPU reference (this PR).
+/// - `Sgd`, `Lion`, `Muon` — subsequent PRs.
+/// - Per-backend GPU impls plug into the same trait.
+pub trait OptimStep: Send + Sync + std::fmt::Debug {
+    /// Stable name. Used by NVTX labels + checkpoint receipts.
+    fn name(&self) -> &'static str;
+
+    /// Apply one optimizer step.
+    ///
+    /// `grad` is the accumulated gradient w.r.t. `param`. Implementations:
+    /// - read `param.amp_policy()` for dispatch dtype decisions
+    /// - update `param.backward_storage_mut()` (the master copy) in
+    ///   place
+    /// - on backends with quantized forward (Marlin / FP8), schedule
+    ///   a re-quantization pass before returning so `param.forward()`
+    ///   in the next iteration sees a fresh forward_storage. Phase
+    ///   6.5.x ships the actual re-quant fusion.
+    fn step(&mut self, param: &mut Parameter, grad: &Tensor) -> Result<(), StepError>;
+
+    /// Reset internal state (moments, momentum buffers). Called when
+    /// the training loop restarts or rolls back to a checkpoint.
+    fn reset(&mut self);
+}
+
+/// Errors a step may raise. Wraps [`kiln_tensor::Error`] plus
+/// optimizer-specific cases.
+#[derive(thiserror::Error, Debug)]
+pub enum StepError {
+    /// Backward storage missing on an inference-only Parameter.
+    #[error("OptimStep: parameter has no backward_storage (inference-only) — cannot step")]
+    NoBackwardStorage,
+
+    /// Gradient shape doesn't match master shape.
+    #[error(
+        "OptimStep: grad shape {grad_shape:?} != master shape {master_shape:?}"
+    )]
+    GradShapeMismatch {
+        grad_shape: Vec<usize>,
+        master_shape: Vec<usize>,
+    },
+
+    /// Gradient dtype doesn't match the policy's `backward_compute_dtype`.
+    #[error(
+        "OptimStep: grad dtype {grad_dtype} != policy backward_compute_dtype \
+         {policy_dtype} for parameter"
+    )]
+    GradDtypeMismatch {
+        grad_dtype: kiln_tensor::DType,
+        policy_dtype: kiln_tensor::DType,
+    },
+
+    /// Numerical anomaly (NaN / Inf) detected in grad. Raised under
+    /// `KILN_DETECT_ANOMALY=1` (Phase 9 deliverable).
+    #[error("OptimStep: non-finite values in grad at parameter {tensor_id:?}")]
+    NonFiniteGrad { tensor_id: kiln_tensor::TensorId },
+
+    /// Underlying kiln_tensor op failed.
+    #[error("OptimStep: tensor op: {0}")]
+    Tensor(#[from] kiln_tensor::Error),
+}

--- a/crates/kiln-optim/src/policy.rs
+++ b/crates/kiln-optim/src/policy.rs
@@ -1,0 +1,173 @@
+//! Per-Parameter optimizer policy knobs.
+//!
+//! - [`MomentLocation`] — where AdamW running moments live. Phase 6.5
+//!   issue bullet: "Optimizer-state location seam. AdamW per-parameter
+//!   moments are 8 bytes/param at FP32; for Qwen3.5-4B that's 32 GiB
+//!   optimizer state — the binding constraint on 16 GiB and the
+//!   second-binding on 24 GiB."
+//! - [`StochasticRoundingPolicy`] — round-to-nearest vs stochastic.
+//!   Phase 6.5 issue bullet: "Round-to-nearest loses precision at the
+//!   master-update step under small learning rates; stochastic
+//!   rounding (round up or down with probability proportional to the
+//!   fractional position) preserves the in-expectation update."
+
+/// Where AdamW running moments live for a given Parameter.
+///
+/// `#[non_exhaustive]` — future Phase 8.x may add `IpcShared` for
+/// multi-process training.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum MomentLocation {
+    /// On the same device as the parameter's `backward_storage`.
+    /// Fastest but consumes ~8 bytes/param at FP32.
+    /// Default on 80 GiB tier.
+    Device,
+    /// In pinned host RAM. Async-paged for the optimizer step.
+    /// Default on 16 GiB tier (per the Phase 6.5 auto-sizer).
+    PinnedHost,
+    /// Mmapped to NVMe scratch. For very-long-running fine-tunes on
+    /// 16 GiB tier where even pinned-host pressure forces it.
+    MmappedDisk,
+}
+
+impl MomentLocation {
+    /// Stable short name. Used by checkpoint receipts + Phase 9
+    /// audit logs.
+    pub const fn name(self) -> &'static str {
+        match self {
+            MomentLocation::Device => "device",
+            MomentLocation::PinnedHost => "pinned_host",
+            MomentLocation::MmappedDisk => "mmapped_disk",
+        }
+    }
+
+    /// `true` iff the moments are physically resident on the same
+    /// device as the parameter (no offload cost on the step path).
+    pub const fn is_resident(self) -> bool {
+        matches!(self, MomentLocation::Device)
+    }
+}
+
+impl Default for MomentLocation {
+    fn default() -> Self {
+        MomentLocation::Device
+    }
+}
+
+/// Rounding policy for BF16 master updates.
+///
+/// Per the Phase 6.5 issue bullet: stochastic rounding preserves the
+/// in-expectation update under small learning rates. Gated by
+/// `KILN_BF16_STOCHASTIC_ROUND=1`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum StochasticRoundingPolicy {
+    /// Standard IEEE-754 round-to-nearest-even.
+    RoundToNearest,
+    /// Stochastic rounding: round up or down with probability
+    /// proportional to the fractional position.
+    Stochastic { seed: u64 },
+}
+
+impl StochasticRoundingPolicy {
+    pub const fn name(self) -> &'static str {
+        match self {
+            StochasticRoundingPolicy::RoundToNearest => "round_to_nearest",
+            StochasticRoundingPolicy::Stochastic { .. } => "stochastic",
+        }
+    }
+
+    /// Read from the env. Returns `Stochastic { seed: 42 }` for
+    /// `KILN_BF16_STOCHASTIC_ROUND=1|true|yes`; otherwise
+    /// `RoundToNearest`. The seed default is intentionally fixed so
+    /// runs are reproducible at the same seed; callers can override
+    /// with [`Self::stochastic_with_seed`].
+    pub fn from_env() -> Self {
+        match std::env::var("KILN_BF16_STOCHASTIC_ROUND").ok().as_deref() {
+            Some(v) => {
+                let v = v.trim().to_ascii_lowercase();
+                if matches!(v.as_str(), "1" | "true" | "yes") {
+                    StochasticRoundingPolicy::Stochastic { seed: 42 }
+                } else {
+                    StochasticRoundingPolicy::RoundToNearest
+                }
+            }
+            None => StochasticRoundingPolicy::RoundToNearest,
+        }
+    }
+
+    /// Construct a stochastic-rounding policy with an explicit seed.
+    pub const fn stochastic_with_seed(seed: u64) -> Self {
+        StochasticRoundingPolicy::Stochastic { seed }
+    }
+}
+
+impl Default for StochasticRoundingPolicy {
+    fn default() -> Self {
+        StochasticRoundingPolicy::RoundToNearest
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn moment_location_names() {
+        assert_eq!(MomentLocation::Device.name(), "device");
+        assert_eq!(MomentLocation::PinnedHost.name(), "pinned_host");
+        assert_eq!(MomentLocation::MmappedDisk.name(), "mmapped_disk");
+    }
+
+    #[test]
+    fn moment_location_residency() {
+        assert!(MomentLocation::Device.is_resident());
+        assert!(!MomentLocation::PinnedHost.is_resident());
+        assert!(!MomentLocation::MmappedDisk.is_resident());
+    }
+
+    #[test]
+    fn default_moment_location_is_device() {
+        assert_eq!(MomentLocation::default(), MomentLocation::Device);
+    }
+
+    #[test]
+    fn stochastic_with_seed() {
+        let p = StochasticRoundingPolicy::stochastic_with_seed(7);
+        assert_eq!(p.name(), "stochastic");
+        match p {
+            StochasticRoundingPolicy::Stochastic { seed } => assert_eq!(seed, 7),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn default_round_policy_is_nearest() {
+        assert_eq!(
+            StochasticRoundingPolicy::default(),
+            StochasticRoundingPolicy::RoundToNearest
+        );
+    }
+
+    #[test]
+    fn round_policy_from_env() {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _g = LOCK.lock().unwrap();
+        unsafe { std::env::remove_var("KILN_BF16_STOCHASTIC_ROUND") };
+        assert_eq!(
+            StochasticRoundingPolicy::from_env(),
+            StochasticRoundingPolicy::RoundToNearest
+        );
+        unsafe { std::env::set_var("KILN_BF16_STOCHASTIC_ROUND", "1") };
+        assert!(matches!(
+            StochasticRoundingPolicy::from_env(),
+            StochasticRoundingPolicy::Stochastic { .. }
+        ));
+        unsafe { std::env::set_var("KILN_BF16_STOCHASTIC_ROUND", "no") };
+        assert_eq!(
+            StochasticRoundingPolicy::from_env(),
+            StochasticRoundingPolicy::RoundToNearest
+        );
+        unsafe { std::env::remove_var("KILN_BF16_STOCHASTIC_ROUND") };
+    }
+}


### PR DESCRIPTION
Creates the kiln-optim crate. Phase 6.5 of #1082.

## Modules

| File | Type |
|---|---|
| `optim_step.rs` | `OptimStep` trait + `StepError` enum |
| `policy.rs` | `MomentLocation` (Device/PinnedHost/MmappedDisk) + `StochasticRoundingPolicy` (RoundToNearest/Stochastic{seed}) |
| `adamw.rs` | `AdamW` CPU reference with F32 master + F32 moments per-TensorId |

## Phase 6.5 design points addressed

- **Optimizer-state location seam**: `MomentLocation` per AdamW instance — Device on 80 GiB, PinnedHost on 16 GiB. Auto-sizer reads this in Phase 6.5.x.
- **Stochastic rounding**: `StochasticRoundingPolicy::from_env()` reads `KILN_BF16_STOCHASTIC_ROUND=1`. Policy threaded through to bytes-write path.
- **AMP policy consumed here**: AdamW reads `param.amp_policy()` for dispatch, no global AMP flag.
- **Per-Parameter dispatch via stable TensorId**: AdamW's `HashMap<TensorId, AdamWMoments>` is the migration target for the existing trainer.rs Adam moment map (anti-pattern 11 stability matters).

## Limitation

CPU master-write is documented as a no-op today because `kiln_tensor::Tensor` doesn't yet expose `&mut Storage` (Phase 1.x version counter lands interior mutability). Tests verify moments + step state rather than master-mutated bytes. CUDA/Metal/Vulkan impls in subsequent PRs mutate device-side via `slice_mut() / buffer_mut()` directly.

## 15 unit tests

Hyperparameter defaults (PyTorch match), stable name, moments init/step-counter, error paths (NoBackwardStorage / GradShapeMismatch / GradDtypeMismatch), reset, env-driven rounding policy, MomentLocation names + residency.

NOT in this PR: SGD/Lion/Muon, per-backend GPU AdamW, stochastic-rounding bytes impl, fused dequant→update→requant.

Refs #1082