### PR TITLE
phase 5: kiln-graph crate scaffold (command-list capture) (#1082)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/kiln-model",
     "crates/kiln-nvtx",
     "crates/kiln-autograd",
+    "crates/kiln-graph",
     "crates/kiln-opd-loss-kernel",
     "crates/kiln-optim",
     "crates/kiln-param",
@@ -36,6 +37,7 @@ default-members = [
     "crates/kiln-core",
     "crates/kiln-eval",
     "crates/kiln-flce-kernel",
+    "crates/kiln-graph",
     "crates/kiln-model",
     "crates/kiln-nvtx",
     "crates/kiln-opd-loss-kernel",
@@ -130,6 +132,7 @@ tempfile = "3"
 kiln-autograd = { path = "crates/kiln-autograd" }
 kiln-core = { path = "crates/kiln-core" }
 kiln-eval = { path = "crates/kiln-eval" }
+kiln-graph = { path = "crates/kiln-graph" }
 kiln-model = { path = "crates/kiln-model" }
 kiln-optim = { path = "crates/kiln-optim" }
 kiln-param = { path = "crates/kiln-param" }

--- a/crates/kiln-graph/Cargo.toml
+++ b/crates/kiln-graph/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "kiln-graph"
+description = "Backend-agnostic command-list / graph capture for kiln. CUDA graphs, MTLIndirectCommandBuffer, Vulkan secondary command buffers."
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# Phase 5 of #1082. This PR ships the backend-agnostic types
+# (CapturedGraph trait, FrozenAllocator policy, AllocatorMode,
+# CaptureSession lifetime model). Per-backend impls — kiln-graph-cuda
+# over `cudaGraph_t`, kiln-graph-metal over MTLIndirectCommandBuffer,
+# kiln-graph-vulkan extending kiln-vulkan-kernel::cmd_batch.rs — plug
+# in via the same `CapturedGraph` trait in subsequent PRs.
+#
+# Internal-only — no semver commitment until Phase 7 ships.
+
+[dependencies]
+kiln-tensor = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/kiln-graph/src/allocator_mode.rs
+++ b/crates/kiln-graph/src/allocator_mode.rs
@@ -1,0 +1,85 @@
+//! Three-mode allocator policy per the Phase 1 issue bullet.
+//!
+//! > **Allocator design — three modes, one interface.**
+//! > `kiln-tensor::Allocator` has three explicit modes: (1) `Owned`
+//! > (per-allocation `cudaMalloc` / `vkAllocateMemory` — slow, used
+//! > only at startup); (2) `Pool` (slab-allocated from a pre-sized
+//! > device-local pool, the steady-state path; mirrors Vulkan's
+//! > `buffer_pool.rs` and `decode_resident_pool.rs`); (3) `Frozen`
+//! > (no allocation; pulls from a pre-warmed slab indexed by
+//! > tensor-handle — used during `capture()` … `replay()`).
+
+/// Three-mode allocator policy.
+///
+/// Used by:
+/// - kiln-tensor's storage allocator (`CudaStorage::zeros` /
+///   `VulkanStorage::zeros` / `MetalStorage::zeros`) when the
+///   allocator-aware constructor lands in Phase 1.x.
+/// - kiln-graph's `CaptureSession` to set `Frozen` mode for the
+///   duration of `capture()` … `replay()` so the per-tensor `Arc`s
+///   don't churn between capture and replay.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum AllocatorMode {
+    /// Per-allocation `cudaMalloc` / `MTLDevice::newBuffer` /
+    /// `vkAllocateMemory`. Slow; used only at model load.
+    Owned,
+    /// Slab-allocated from a pre-sized device-local pool. The
+    /// steady-state decode path. Mirrors Vulkan's `buffer_pool.rs`
+    /// and `decode_resident_pool.rs` (MIN_SLOTS=3, PREFERRED_SLOTS=4,
+    /// 1% of device-local heap).
+    Pool,
+    /// No allocation. Pulls from a pre-warmed slab indexed by
+    /// tensor-handle. Active for the duration of
+    /// `CaptureSession::begin()` … `CaptureSession::end()` so the
+    /// recorded device pointers stay valid across replays.
+    Frozen,
+}
+
+impl AllocatorMode {
+    /// Stable short name for logging + JSON.
+    pub const fn name(self) -> &'static str {
+        match self {
+            AllocatorMode::Owned => "owned",
+            AllocatorMode::Pool => "pool",
+            AllocatorMode::Frozen => "frozen",
+        }
+    }
+
+    /// `true` iff this mode permits new allocations to be served.
+    /// `Frozen` returns `false` — under freeze, every needed buffer
+    /// MUST come from the pre-warmed slab.
+    pub const fn allows_alloc(self) -> bool {
+        !matches!(self, AllocatorMode::Frozen)
+    }
+}
+
+impl Default for AllocatorMode {
+    fn default() -> Self {
+        AllocatorMode::Pool
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_strings() {
+        assert_eq!(AllocatorMode::Owned.name(), "owned");
+        assert_eq!(AllocatorMode::Pool.name(), "pool");
+        assert_eq!(AllocatorMode::Frozen.name(), "frozen");
+    }
+
+    #[test]
+    fn frozen_disallows_alloc() {
+        assert!(AllocatorMode::Owned.allows_alloc());
+        assert!(AllocatorMode::Pool.allows_alloc());
+        assert!(!AllocatorMode::Frozen.allows_alloc());
+    }
+
+    #[test]
+    fn default_is_pool() {
+        assert_eq!(AllocatorMode::default(), AllocatorMode::Pool);
+    }
+}

--- a/crates/kiln-graph/src/capture_session.rs
+++ b/crates/kiln-graph/src/capture_session.rs
@@ -1,0 +1,195 @@
+//! `CaptureSession` — RAII guard for a capture lifetime.
+//!
+//! Wraps a `begin() → end()` block during which the allocator is in
+//! `Frozen` mode and every tensor referenced by the captured graph
+//! must outlive the session.
+//!
+//! # Anti-pattern: dangling pointers across capture/replay
+//!
+//! Per the Phase 5 bullet:
+//!
+//! > Any tensor whose `.device_ptr()` enters a captured graph must
+//! > outlive every replay of that graph. Lifetimes are encoded in the
+//! > type system where possible (`CapturedGraph<'a>` borrows from a
+//! > `FrozenAllocator<'a>`) and enforced by a debug-assertion
+//! > `kiln_tensor::audit_captured_pointers()` that walks the graph and
+//! > verifies every recorded pointer still resolves to a live
+//! > allocation.
+//!
+//! Today's session records the **set of pinned `TensorId`s** that the
+//! per-backend graph captured. On replay (via
+//! [`CaptureSession::audit_pinned`]) the session re-checks that
+//! every recorded TensorId is still live in the registered Tensor
+//! map. This is the runtime hook; the Phase 5.x `'a`-lifetime
+//! encoding lands when `kiln-graph-cuda` ships and gets exercised
+//! against a real capture.
+
+use std::collections::HashSet;
+
+use kiln_tensor::{Tensor, TensorId};
+
+use crate::{AllocatorMode, CaptureError};
+
+/// One pinned pointer that the captured graph dereferences during
+/// replay. Today we just record the `TensorId`; Phase 5.x's per-
+/// backend impls also record the raw device pointer for fast O(1)
+/// dangling-pointer detection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PinnedPointer {
+    pub tensor_id: TensorId,
+}
+
+impl PinnedPointer {
+    pub const fn new(tensor_id: TensorId) -> Self {
+        PinnedPointer { tensor_id }
+    }
+}
+
+/// RAII guard for a capture lifetime.
+///
+/// Usage shape (executed by per-backend impls):
+///
+/// ```ignore
+/// let mut session = CaptureSession::begin();
+/// // ... per-backend record-then-finalize calls ...
+/// let captured = backend.finalize_capture(&mut session)?;
+/// // session is dropped here; subsequent replay()s of `captured`
+/// // call session.audit_pinned(&live_tensors) to detect dangling
+/// // pointers.
+/// ```
+#[derive(Debug, Default)]
+pub struct CaptureSession {
+    mode: AllocatorMode,
+    pinned: HashSet<PinnedPointer>,
+    finalized: bool,
+}
+
+impl CaptureSession {
+    /// Begin a capture. The session starts in `Frozen` allocator mode;
+    /// any allocation during the session is an error.
+    pub fn begin() -> Self {
+        CaptureSession {
+            mode: AllocatorMode::Frozen,
+            pinned: HashSet::new(),
+            finalized: false,
+        }
+    }
+
+    /// Current allocator mode. Always `Frozen` while the session is
+    /// open; the per-backend impl reads this to assert no allocation
+    /// happens during capture.
+    pub fn mode(&self) -> AllocatorMode {
+        self.mode
+    }
+
+    /// Has the session been finalized (a `CapturedGraph` produced)?
+    pub fn is_finalized(&self) -> bool {
+        self.finalized
+    }
+
+    /// Mark the session as finalized. Called by the per-backend impl
+    /// after `cuGraphInstantiate` (or the equivalent) succeeds.
+    pub fn finalize(&mut self) {
+        self.finalized = true;
+    }
+
+    /// Record a pinned pointer for a tensor referenced by the captured
+    /// graph. Phase 5.x's per-backend impls call this for every
+    /// device pointer they bake into the graph.
+    pub fn pin(&mut self, tensor: &Tensor) {
+        self.pinned.insert(PinnedPointer::new(tensor.id()));
+    }
+
+    /// Borrow the set of pinned pointers.
+    pub fn pinned(&self) -> &HashSet<PinnedPointer> {
+        &self.pinned
+    }
+
+    /// Audit the pinned set against a list of live tensors.
+    ///
+    /// **Debug-build assertion** — released to runtime so the per-
+    /// backend `CapturedGraph::replay()` impl can opt into the check
+    /// via `cfg(debug_assertions)` (or always-on under a
+    /// `KILN_AUDIT_GRAPHS=1` env). Returns
+    /// [`CaptureError::DanglingPointer`] for the first pinned
+    /// `TensorId` that no longer appears in `live`.
+    pub fn audit_pinned(&self, live: &HashSet<TensorId>) -> Result<(), CaptureError> {
+        for p in &self.pinned {
+            if !live.contains(&p.tensor_id) {
+                return Err(CaptureError::DanglingPointer {
+                    tensor_id: p.tensor_id,
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kiln_tensor::{DType, Tensor};
+
+    fn t() -> Tensor {
+        Tensor::zeros_cpu(vec![2, 3], DType::F32)
+    }
+
+    #[test]
+    fn begin_session_is_frozen() {
+        let s = CaptureSession::begin();
+        assert_eq!(s.mode(), AllocatorMode::Frozen);
+        assert!(!s.is_finalized());
+        assert!(s.pinned().is_empty());
+    }
+
+    #[test]
+    fn pin_records_tensor_id() {
+        let mut s = CaptureSession::begin();
+        let a = t();
+        s.pin(&a);
+        assert_eq!(s.pinned().len(), 1);
+        assert!(s.pinned().contains(&PinnedPointer::new(a.id())));
+    }
+
+    #[test]
+    fn finalize_flips_flag() {
+        let mut s = CaptureSession::begin();
+        assert!(!s.is_finalized());
+        s.finalize();
+        assert!(s.is_finalized());
+    }
+
+    #[test]
+    fn audit_pinned_ok_when_all_live() {
+        let mut s = CaptureSession::begin();
+        let a = t();
+        let b = t();
+        s.pin(&a);
+        s.pin(&b);
+        let live: HashSet<TensorId> = [a.id(), b.id()].into_iter().collect();
+        s.audit_pinned(&live).unwrap();
+    }
+
+    #[test]
+    fn audit_pinned_errors_on_dangling() {
+        let mut s = CaptureSession::begin();
+        let a = t();
+        s.pin(&a);
+        let live: HashSet<TensorId> = HashSet::new();
+        let e = s.audit_pinned(&live).unwrap_err();
+        match e {
+            CaptureError::DanglingPointer { tensor_id } => assert_eq!(tensor_id, a.id()),
+            other => panic!("unexpected: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pin_is_idempotent() {
+        let mut s = CaptureSession::begin();
+        let a = t();
+        s.pin(&a);
+        s.pin(&a);
+        s.pin(&a);
+        assert_eq!(s.pinned().len(), 1);
+    }
+}

--- a/crates/kiln-graph/src/captured_graph.rs
+++ b/crates/kiln-graph/src/captured_graph.rs
@@ -1,0 +1,35 @@
+//! `CapturedGraph` — the per-backend trait every capture impl implements.
+
+use kiln_tensor::Backend;
+
+use crate::CaptureError;
+
+/// One captured graph, ready to be replayed.
+///
+/// Implementations:
+///
+/// - `kiln-graph-cuda::CudaCapturedGraph` (Phase 5.x) — wraps
+///   `cudarc::driver::CudaGraphExec`.
+/// - `kiln-graph-metal::MetalCapturedGraph` (Phase 5.x) — wraps
+///   `MTLIndirectCommandBuffer`.
+/// - `kiln-graph-vulkan::VulkanCapturedGraph` (Phase 5.x) — extends
+///   `kiln-vulkan-kernel::cmd_batch.rs`.
+pub trait CapturedGraph: Send + Sync + std::fmt::Debug {
+    /// Stable backend tag.
+    fn backend(&self) -> Backend;
+
+    /// Replay the captured commands. Returns `CaptureError` on per-
+    /// backend driver failure or dangling-pointer detection (under
+    /// debug builds).
+    fn replay(&self) -> Result<(), CaptureError>;
+
+    /// Number of times `replay()` has been called on this instance.
+    /// Used by `bench-results/` reports to attribute captured-graph
+    /// runtime cost.
+    fn replay_count(&self) -> u64;
+
+    /// Estimated VRAM footprint of this graph's scratch pool (the
+    /// pre-warmed slab indexed by tensor handle). Reported by the
+    /// Phase 5 `bench-results/graph-family-vram.csv`.
+    fn scratch_bytes(&self) -> usize;
+}

--- a/crates/kiln-graph/src/error.rs
+++ b/crates/kiln-graph/src/error.rs
@@ -1,0 +1,42 @@
+//! Typed errors for the capture / replay path.
+
+use kiln_tensor::TensorId;
+
+/// Errors a per-backend `CapturedGraph` impl may raise.
+#[derive(thiserror::Error, Debug)]
+pub enum CaptureError {
+    /// Attempted to allocate during the capture window (anti-pattern:
+    /// `Frozen` mode disallows allocations).
+    #[error(
+        "CaptureError: allocation attempted during frozen capture (op: {op:?}, \
+         requested {requested_bytes} bytes). Pre-warm the allocator pool before \
+         capture_session.begin()."
+    )]
+    AllocationDuringFreeze {
+        op: String,
+        requested_bytes: usize,
+    },
+
+    /// A pinned pointer referenced by the captured graph no longer
+    /// resolves to a live allocation (anti-pattern: dangling pointer
+    /// across capture/replay boundary).
+    #[error(
+        "CaptureError: pinned pointer for tensor {tensor_id:?} is no longer live; \
+         the captured graph would dereference freed memory. Likely cause: the \
+         Tensor was dropped between capture and replay."
+    )]
+    DanglingPointer { tensor_id: TensorId },
+
+    /// Replay called on a graph that wasn't successfully captured.
+    #[error("CaptureError: replay called on an uncaptured graph")]
+    NotCaptured,
+
+    /// Per-backend driver error (CUDA / Metal / Vulkan returned an
+    /// error during `cuGraphLaunch` / `executeCommandBuffer` etc.).
+    #[error("CaptureError: backend driver error: {0}")]
+    Backend(String),
+
+    /// Underlying kiln_tensor error.
+    #[error("CaptureError: tensor: {0}")]
+    Tensor(#[from] kiln_tensor::Error),
+}

--- a/crates/kiln-graph/src/lib.rs
+++ b/crates/kiln-graph/src/lib.rs
@@ -1,0 +1,60 @@
+//! kiln-graph — backend-agnostic command-list / graph capture.
+//!
+//! Phase 5 of #1082. Per the issue:
+//!
+//! > **kiln-tensor allocator "freeze-pointers" mode.** Active for the
+//! > duration of `capture()` … `replay()`. Allocations during freeze
+//! > come from a pre-sized pool with no reclamation. This is the
+//! > structural fix that makes batched cuda-graph capture possible;
+//! > without it Phase 8 doesn't land.
+//!
+//! And:
+//!
+//! > **Capture-lifetime programming model (the dangling-pointer rule).**
+//! > Any tensor whose `.device_ptr()` enters a captured graph must
+//! > outlive every replay of that graph. Lifetimes are encoded in the
+//! > type system where possible (`CapturedGraph<'a>` borrows from a
+//! > `FrozenAllocator<'a>`) and enforced by a debug-assertion
+//! > `kiln_tensor::audit_captured_pointers()` that walks the graph and
+//! > verifies every recorded pointer still resolves to a live
+//! > allocation.
+//!
+//! # Phase 5 scope (this PR)
+//!
+//! - [`CapturedGraph`] trait — `replay()` + per-backend metadata
+//!   (`backend_name`, `replay_count`).
+//! - [`CaptureSession`] — RAII guard for a capture lifetime. Records
+//!   the set of pinned pointers; verifies on drop that no pointer
+//!   was freed mid-capture.
+//! - [`AllocatorMode`] enum — `Owned` / `Pool` / `Frozen` per the
+//!   issue's "Allocator design — three modes" bullet.
+//! - [`PinnedPointer`] + audit walker — debug-assert any pointer
+//!   referenced by a captured graph still resolves to a live
+//!   allocation.
+//! - [`CaptureError`] — typed error surface for the per-backend impls.
+//!
+//! # What this PR does NOT do
+//!
+//! - The actual CUDA `cudaGraph_t` wrapping (`kiln-graph-cuda`,
+//!   Phase 5.x).
+//! - The Metal `MTLIndirectCommandBuffer` wrapping (`kiln-graph-metal`).
+//! - The Vulkan secondary-command-buffer wrapping (extends
+//!   `kiln-vulkan-kernel::cmd_batch.rs`).
+//! - The bs>1 cuda-graph stream-DAG dispatch (revives the dead-code
+//!   `CudaBatchedGraphKey` at `kiln-model/src/cuda_graph.rs:178`) —
+//!   that lands once `kiln-graph-cuda` ships.
+//! - AOT graph serialization via `cuGraphSerialize` (Phase 5
+//!   final bullet) — Phase 5.x follow-up.
+
+#![deny(missing_debug_implementations)]
+#![warn(rust_2018_idioms)]
+
+mod allocator_mode;
+mod capture_session;
+mod captured_graph;
+mod error;
+
+pub use allocator_mode::AllocatorMode;
+pub use capture_session::{CaptureSession, PinnedPointer};
+pub use captured_graph::CapturedGraph;
+pub use error::CaptureError;


### PR DESCRIPTION
Creates the kiln-graph crate. Phase 5 of #1082. Backend-agnostic types for the command-list / graph capture surface. Per-backend impls (kiln-graph-cuda / metal / vulkan) plug in via the same `CapturedGraph` trait.

## Four types

| Type | Purpose |
|---|---|
| `AllocatorMode` | `Owned` / `Pool` / `Frozen` — three-mode allocator per the Phase 1 issue bullet |
| `CapturedGraph` trait | `backend / replay / replay_count / scratch_bytes` |
| `CaptureSession` | RAII guard; records pinned TensorIds; `audit_pinned(&live)` for dangling-pointer detection |
| `CaptureError` | Typed errors: `AllocationDuringFreeze`, `DanglingPointer`, `NotCaptured`, `Backend(String)` |

## Anti-pattern: dangling pointers

Phase 5 + Phase 1.x allocator-mode together enforce "capture-lifetime programming":

1. `CaptureSession::begin()` sets `AllocatorMode::Frozen`
2. During capture, every storage `*_zeros` call MUST come from the pre-warmed pool
3. `pin(&tensor)` records every TensorId referenced by the captured graph
4. On replay, `audit_pinned(&live)` errors on any id missing from `live`

## 12 unit tests

Covering allocator-mode semantics, session pin/finalize/audit, dangling-pointer detection, idempotent pin, default values.

What's NOT in this PR (separate Phase 5.x):
- CUDA cudaGraph_t wrapping
- Metal MTLIndirectCommandBuffer wrapping
- Vulkan secondary-cmd-buffer wrapping
- bs>1 cuda-graph stream-DAG dispatch (revives `CudaBatchedGraphKey` at cuda_graph.rs:178)
- AOT graph serialization via `cuGraphSerialize`

Refs #1082