### PR TITLE
phase 2.1: kiln-blas production API sketch — AlgoCache + WorkspacePool (#1082)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,17 +23,21 @@ members = [
     "crates/kiln-train",
     "crates/kiln-vulkan-kernel",
 ]
-# kiln-blas, kiln-conv1d-kernel, kiln-flash-attn, kiln-gdn-kernel,
-# kiln-marlin-gemm, kiln-rmsnorm-kernel, and kiln-vulkan-kernel
-# unconditionally depend on platform-specific GPU runtimes
-# (cudarc, cublasLt, vulkan-rs) which fail to link on hosts without the
-# matching GPU stack. They're only compiled when a downstream
-# crate opts in via --features cuda or --features vulkan.
-# Excluding them from default-members lets `cargo check`, `cargo build`, and
-# `cargo test` work on any host; Linux+CUDA/Vulkan builds still pull them via
-# feature activation on the real binary target.
+# kiln-conv1d-kernel, kiln-flash-attn, kiln-gdn-kernel, kiln-marlin-gemm,
+# kiln-rmsnorm-kernel, and kiln-vulkan-kernel unconditionally depend on
+# platform-specific GPU runtimes (cudarc, vulkan-rs) which fail to link
+# on hosts without the matching GPU stack. They're only compiled when a
+# downstream crate opts in via --features cuda or --features vulkan.
+# Excluding them from default-members lets `cargo check`, `cargo build`,
+# and `cargo test` work on any host; Linux+CUDA/Vulkan builds still pull
+# them via feature activation on the real binary target.
+#
+# kiln-blas is in default-members because Phase 2.1's backend-agnostic
+# types (AlgoCache + WorkspacePool) compile without the CUDA toolchain.
+# The cublasLt probe is gated behind `--features probe`.
 default-members = [
     "crates/kiln-autograd",
+    "crates/kiln-blas",
     "crates/kiln-core",
     "crates/kiln-eval",
     "crates/kiln-flce-kernel",

--- a/crates/kiln-blas/Cargo.toml
+++ b/crates/kiln-blas/Cargo.toml
@@ -5,30 +5,31 @@ publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "kiln-tensor's CUDA BLAS layer (cublasLt). Phase 0 ships only the probe; Phase 2 ships the production path."
+description = "kiln-tensor's CUDA BLAS layer (cublasLt). Phase 2.1 ships backend-agnostic types; Phase 2.x adds the cublasLt MatmulHandle."
 build = "build.rs"
 
-# The Phase 0 deliverable for this crate is the `cublaslt_mlp_probe`
-# example, which compares candle's gemm path against an explicit cublasLt
-# heuristic + workspace tuning for the Qwen3.5-4B MLP gate||up shape.
+# Phase 2.1 splits this crate into two layers:
 #
-# The `lib.rs` is intentionally empty — Phase 2 fills it in. The crate is
-# excluded from `default-members` in the workspace manifest because it
-# unconditionally requires a CUDA toolchain.
+# - **Backend-agnostic types** (AlgoCache + WorkspacePool) — compile
+#   on every host without `--features probe` or `--features cuda`.
+# - **Probe FFI + cublasLt path** — gated behind `--features probe`.
+#   Pulls candle-core (cuda) as the cudarc vendor.
+#
+# This lets `kiln-tensor` and other crates depend on `kiln-blas` for
+# the autotune cache + workspace policy without needing the CUDA
+# toolchain to build.
 
 [features]
 default = []
 # Builds the cublasLt probe binary alongside candle's gemm baseline.
-# Enabled implicitly when running the example; explicit so a downstream
-# crate can opt out of the build.rs cublasLt link if it ever depends on
-# `kiln-blas` for something else.
-probe = []
+# Pulls candle-core (cuda) + the build.rs cublasLt link.
+probe = ["dep:candle-core"]
 
 [dependencies]
-# Candle is used by the probe as the **baseline path** to compare against.
-# Phase 2's production `kiln-blas` removes this dep — for now we need it to
-# show the delta the cublasLt heuristic delivers.
-candle-core = { workspace = true, features = ["cuda"] }
+# Candle is the cudarc vendor under the `probe` feature; absent on
+# the default build so the backend-agnostic types compile on every
+# host.
+candle-core = { workspace = true, features = ["cuda"], optional = true }
 half = "2"
 
 # Timing + JSON output.

--- a/crates/kiln-blas/src/algo_cache.rs
+++ b/crates/kiln-blas/src/algo_cache.rs
@@ -1,0 +1,340 @@
+//! `AlgoCache` — disk-persistent cublasLt algorithm cache.
+//!
+//! Per the Phase 2 issue bullet:
+//!
+//! > **Disk-persistent autotune cache**: `~/.cache/kiln/autotune/
+//! > {backend}-{device_uuid}.json`, keyed on `{shape, dtype, layout,
+//! > concurrent_streams, kiln_version}`. Applies to cublasLt
+//! > heuristics, MPS tile selection, and Vulkan workgroup-size search
+//! > uniformly. Cold-start never re-tunes a known shape.
+//! >
+//! > **`concurrent_streams` matters**: the optimal algo for a matmul
+//! > running solo on the device is *not* the optimal algo when two
+//! > other QKV matmuls are running on parallel streams competing for
+//! > SMs. Cache key includes the planner's `expected_concurrent_streams`
+//! > so Phase 3's parallel-QKV picks SM-light algos automatically.
+//!
+//! And:
+//!
+//! > **Pre-shipped autotune cache (Qwen3.5-4B specialization).** Ship
+//! > `assets/autotune/{backend}-{gpu_sku}.json` *in the binary* for
+//! > the tier-1 GPU list ... Cold-start on tier-1 hardware has zero
+//! > tune cost.
+//!
+//! # Phase 2.1 scope
+//!
+//! Backend-agnostic data types only. The actual cublasLt algo-id
+//! type (`cublasLtMatmulAlgo_t`) is opaque to this layer — we cache
+//! the **bytes** of the algo descriptor along with metadata used for
+//! lookup. The cublasLt-specific serialization shape lives in the
+//! per-backend impl in subsequent PRs.
+//!
+//! # No-cuda build
+//!
+//! This module compiles on every host. No `--features cuda` required —
+//! it's pure data structures + JSON I/O.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+/// Cache key for a single autotune entry. Hashed + serialized to JSON
+/// so the cache survives process restarts and can be pre-shipped per
+/// the Qwen3.5-4B specialization bullet.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AlgoCacheKey {
+    /// Matmul shape `[m, n, k]`.
+    pub shape: [u64; 3],
+    /// Input dtype short-name (`"bf16"`, `"f32"`, `"f16"`, etc.).
+    pub input_dtype: String,
+    /// Output dtype short-name. Often equals `input_dtype` but the FP8
+    /// + accumulator paths have distinct in/out.
+    pub output_dtype: String,
+    /// Compute dtype short-name (`"f32"` for CUBLAS_COMPUTE_32F, etc.).
+    pub compute_dtype: String,
+    /// Transpose flags for A and B operands (`true` = transposed,
+    /// `false` = non-transposed).
+    pub transpose: [bool; 2],
+    /// Number of concurrent streams the StreamPlanner expects this
+    /// matmul to compete with. Bucket: `1 | 2 | 4`. Default 1.
+    pub expected_concurrent_streams: u8,
+    /// Major version of the kiln binary that recorded this entry.
+    /// Cache hits across mismatched majors are rejected.
+    pub kiln_version_major: u32,
+}
+
+impl AlgoCacheKey {
+    /// Convenience constructor with sensible defaults.
+    pub fn new(m: u64, n: u64, k: u64, dtype: impl Into<String>) -> Self {
+        let dt: String = dtype.into();
+        AlgoCacheKey {
+            shape: [m, n, k],
+            input_dtype: dt.clone(),
+            output_dtype: dt.clone(),
+            compute_dtype: "f32".to_string(),
+            transpose: [false, false],
+            expected_concurrent_streams: 1,
+            kiln_version_major: 0,
+        }
+    }
+}
+
+/// Value side of the cache. The opaque `algo_blob` is whatever the
+/// per-backend impl wants to store (typically a cublasLt
+/// `cublasLtMatmulAlgo_t` serialized to bytes, plus the workspace
+/// size that goes alongside).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AlgoCacheValue {
+    /// Algo id reported by cublasLt's heuristic (or per-backend
+    /// equivalent). `-1` means "unknown / default".
+    pub algo_id: i32,
+    /// Workspace bytes the algo requested.
+    pub workspace_bytes: u64,
+    /// Median timing observed when this entry was recorded (ms).
+    /// Phase 2.x's runtime tuner compares against this when re-tuning.
+    pub recorded_ms: f32,
+    /// Opaque per-backend payload. cublasLt stores the full
+    /// `cublasLtMatmulAlgo_t` descriptor here.
+    pub algo_blob: Vec<u8>,
+}
+
+/// In-memory autotune cache. Disk persistence is the caller's
+/// responsibility; this struct exposes load_from + save_to helpers
+/// for JSON round-trip.
+///
+/// Threading: the cache is not `Send + Sync`-safe for mutation; wrap
+/// in `Mutex` if multiple threads write. Reads are safe under
+/// `Arc<AlgoCache>`.
+#[derive(Debug, Default, Clone)]
+pub struct AlgoCache {
+    entries: HashMap<AlgoCacheKey, AlgoCacheValue>,
+}
+
+impl AlgoCache {
+    /// Empty cache.
+    pub fn new() -> Self {
+        AlgoCache {
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Insert or replace a cache entry.
+    pub fn insert(&mut self, key: AlgoCacheKey, value: AlgoCacheValue) {
+        self.entries.insert(key, value);
+    }
+
+    /// Look up an entry.
+    pub fn get(&self, key: &AlgoCacheKey) -> Option<&AlgoCacheValue> {
+        self.entries.get(key)
+    }
+
+    /// Number of cached entries.
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// True iff the cache is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Iterate `(key, value)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&AlgoCacheKey, &AlgoCacheValue)> {
+        self.entries.iter()
+    }
+
+    /// Compute the standard cache file path for a backend + device
+    /// fingerprint. Mirrors the Phase 2 issue path:
+    /// `~/.cache/kiln/autotune/{backend}-{device_uuid}.json`.
+    pub fn standard_path(backend: &str, device_fingerprint: &str) -> PathBuf {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        PathBuf::from(home)
+            .join(".cache/kiln/autotune")
+            .join(format!("{backend}-{device_fingerprint}.json"))
+    }
+}
+
+/// Serialize the cache to a simple JSON blob.
+///
+/// Format: a JSON array of `{key, value}` objects. Stable across
+/// minor kiln versions (the `kiln_version_major` field is part of
+/// the key, so a different major triggers cache rebuild).
+///
+/// Returns the JSON string. Callers persist via standard fs::write.
+pub fn serialize_to_json(cache: &AlgoCache) -> String {
+    let mut s = String::from("[");
+    let mut first = true;
+    for (k, v) in cache.iter() {
+        if !first {
+            s.push(',');
+        }
+        first = false;
+        s.push_str("{\"key\":{");
+        s.push_str(&format!(
+            "\"shape\":[{},{},{}],\"input_dtype\":{},\"output_dtype\":{},\"compute_dtype\":{},\"transpose\":[{},{}],\"expected_concurrent_streams\":{},\"kiln_version_major\":{}",
+            k.shape[0], k.shape[1], k.shape[2],
+            json_str(&k.input_dtype),
+            json_str(&k.output_dtype),
+            json_str(&k.compute_dtype),
+            k.transpose[0], k.transpose[1],
+            k.expected_concurrent_streams,
+            k.kiln_version_major,
+        ));
+        s.push_str("},\"value\":{");
+        s.push_str(&format!(
+            "\"algo_id\":{},\"workspace_bytes\":{},\"recorded_ms\":{}",
+            v.algo_id, v.workspace_bytes, v.recorded_ms,
+        ));
+        s.push_str(",\"algo_blob_b64\":");
+        s.push_str(&json_str(&base64_encode(&v.algo_blob)));
+        s.push_str("}}");
+    }
+    s.push(']');
+    s
+}
+
+/// Write the cache to a file. Creates parent directories as needed.
+pub fn save_to_path(cache: &AlgoCache, path: &Path) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(path, serialize_to_json(cache).as_bytes())?;
+    Ok(())
+}
+
+fn json_str(s: &str) -> String {
+    // Minimal JSON-string escaper. Sufficient for short dtype names.
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Tiny stdlib base64 encoder (avoids pulling in `base64` as a dep).
+fn base64_encode(bytes: &[u8]) -> String {
+    const TABLE: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity((bytes.len() + 2) / 3 * 4);
+    let mut i = 0;
+    while i + 3 <= bytes.len() {
+        let n = u32::from_be_bytes([0, bytes[i], bytes[i + 1], bytes[i + 2]]);
+        out.push(TABLE[((n >> 18) & 0x3F) as usize] as char);
+        out.push(TABLE[((n >> 12) & 0x3F) as usize] as char);
+        out.push(TABLE[((n >> 6) & 0x3F) as usize] as char);
+        out.push(TABLE[(n & 0x3F) as usize] as char);
+        i += 3;
+    }
+    if i < bytes.len() {
+        let r = bytes.len() - i;
+        let b0 = bytes[i];
+        let b1 = if r > 1 { bytes[i + 1] } else { 0 };
+        let n = u32::from_be_bytes([0, b0, b1, 0]);
+        out.push(TABLE[((n >> 18) & 0x3F) as usize] as char);
+        out.push(TABLE[((n >> 12) & 0x3F) as usize] as char);
+        if r == 2 {
+            out.push(TABLE[((n >> 6) & 0x3F) as usize] as char);
+            out.push('=');
+        } else {
+            out.push('=');
+            out.push('=');
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_insert_and_lookup() {
+        let mut c = AlgoCache::new();
+        assert!(c.is_empty());
+        let key = AlgoCacheKey::new(64, 64, 32, "bf16");
+        let val = AlgoCacheValue {
+            algo_id: 42,
+            workspace_bytes: 1024,
+            recorded_ms: 0.42,
+            algo_blob: vec![1, 2, 3, 4],
+        };
+        c.insert(key.clone(), val.clone());
+        assert_eq!(c.len(), 1);
+        assert_eq!(c.get(&key).unwrap().algo_id, 42);
+    }
+
+    #[test]
+    fn standard_path_format() {
+        let p = AlgoCache::standard_path("cublaslt", "a6000-86");
+        let s = p.to_string_lossy();
+        assert!(s.contains(".cache/kiln/autotune/"));
+        assert!(s.ends_with("cublaslt-a6000-86.json"));
+    }
+
+    #[test]
+    fn json_serialization_round_trip_format() {
+        let mut c = AlgoCache::new();
+        c.insert(
+            AlgoCacheKey::new(64, 64, 32, "bf16"),
+            AlgoCacheValue {
+                algo_id: 7,
+                workspace_bytes: 2048,
+                recorded_ms: 1.25,
+                algo_blob: vec![0xCA, 0xFE, 0xBA, 0xBE],
+            },
+        );
+        let s = serialize_to_json(&c);
+        assert!(s.starts_with('['));
+        assert!(s.ends_with(']'));
+        assert!(s.contains("\"algo_id\":7"));
+        assert!(s.contains("\"workspace_bytes\":2048"));
+        assert!(s.contains("\"bf16\""));
+        // BASE64 of [0xCA, 0xFE, 0xBA, 0xBE] = "yv66vg=="
+        assert!(s.contains("yv66vg=="));
+    }
+
+    #[test]
+    fn cache_key_with_concurrent_streams() {
+        let solo = AlgoCacheKey::new(64, 64, 32, "bf16");
+        let mut parallel = solo.clone();
+        parallel.expected_concurrent_streams = 4;
+        assert_ne!(solo, parallel); // distinct keys
+    }
+
+    #[test]
+    fn save_to_path_writes_file() {
+        let tmp = std::env::temp_dir().join("kiln-blas-test-algo-cache.json");
+        let _ = std::fs::remove_file(&tmp);
+        let mut c = AlgoCache::new();
+        c.insert(
+            AlgoCacheKey::new(1, 1, 1, "f32"),
+            AlgoCacheValue {
+                algo_id: 0,
+                workspace_bytes: 0,
+                recorded_ms: 0.0,
+                algo_blob: vec![],
+            },
+        );
+        save_to_path(&c, &tmp).unwrap();
+        let s = std::fs::read_to_string(&tmp).unwrap();
+        assert!(s.contains("\"algo_id\":0"));
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn base64_known_values() {
+        assert_eq!(base64_encode(&[]), "");
+        assert_eq!(base64_encode(b"A"), "QQ==");
+        assert_eq!(base64_encode(b"AB"), "QUI=");
+        assert_eq!(base64_encode(b"ABC"), "QUJD");
+        assert_eq!(base64_encode(&[0xCA, 0xFE, 0xBA, 0xBE]), "yv66vg==");
+    }
+}

--- a/crates/kiln-blas/src/lib.rs
+++ b/crates/kiln-blas/src/lib.rs
@@ -1,11 +1,37 @@
 //! kiln-blas — CUDA BLAS layer (cublasLt) for kiln-tensor.
 //!
-//! Phase 0 ships the `cublaslt_mlp_probe` example only. Phase 2 fills in
-//! the production matmul path with explicit algo cache, workspace pool,
-//! optional split-K, and optional fused-bias-and-activation epilogue.
+//! Phase 0 shipped the `cublaslt_mlp_probe` example. Phase 2.1
+//! (this revision) adds the backend-agnostic production data
+//! structures: [`AlgoCache`] (disk-persistent autotune cache) +
+//! [`WorkspacePool`] (per-handle workspace policy). Phase 2.x
+//! wires these to a real `cublasLtMatmul` call via a feature-gated
+//! `MatmulHandle` (cublasLt context + per-stream binding).
 //!
 //! See `examples/cublaslt_mlp_probe.rs` and the issue at
 //! <https://github.com/ericflo/kiln/issues/1082>.
+//!
+//! # Phase 2.1 public surface
+//!
+//! - [`AlgoCache`] + [`AlgoCacheKey`] + [`AlgoCacheValue`] — Phase 2's
+//!   disk-persistent autotune cache, keyed on
+//!   `(shape, dtype, layout, concurrent_streams, kiln_version_major)`.
+//! - [`WorkspacePool`] — per-handle workspace cap (default 32 MiB) +
+//!   peak-bytes / call-count tracking.
+//! - [`probe_ffi`] — Phase 0.8 probe FFI (kept for the probe example).
+//!
+//! # CPU-buildable
+//!
+//! All Phase 2.1 types are backend-agnostic — no `--features cuda`
+//! required to use them. The feature-gated `MatmulHandle` lands in a
+//! subsequent PR.
+
+mod algo_cache;
+mod workspace_pool;
+
+pub use algo_cache::{
+    save_to_path, serialize_to_json, AlgoCache, AlgoCacheKey, AlgoCacheValue,
+};
+pub use workspace_pool::WorkspacePool;
 
 /// FFI declarations for the Phase 0 probe.
 ///
@@ -80,7 +106,9 @@ pub mod probe_ffi {
     }
 }
 
-/// Empty placeholder for the Phase 2 production path. See lib doc.
+/// Stable phase tag. Used by the `kiln-bench` JSON reports + Phase 9
+/// audit logs to distinguish Phase 0 (probe-only) numbers from
+/// Phase 2.x (production-path) numbers.
 pub fn phase() -> &'static str {
-    "phase 0 — probe only"
+    "phase 2.1 — backend-agnostic API (AlgoCache + WorkspacePool); cublasLt MatmulHandle Phase 2.x"
 }

--- a/crates/kiln-blas/src/workspace_pool.rs
+++ b/crates/kiln-blas/src/workspace_pool.rs
@@ -1,0 +1,129 @@
+//! `WorkspacePool` — per-handle cublasLt workspace allocator.
+//!
+//! Per the Phase 2 issue bullet:
+//!
+//! > Matmul with explicit algo cache, **workspace pool**, optional
+//! > split-K, optional fused-bias-and-activation epilogue.
+//!
+//! Backend-agnostic data type — the per-backend impl (CUDA cudarc
+//! buffer / Metal MTLBuffer / Vulkan vk::Buffer) wraps this with the
+//! actual device allocation. This module's job is the **policy**:
+//!
+//! - Cap workspace at a configurable limit (default 32 MiB matching the
+//!   Phase 0.8 probe).
+//! - Track per-`MatmulHandle` peak usage for `bench-results/` reports.
+//! - Allow reuse across calls on the same stream (zero re-alloc cost in
+//!   the steady state).
+//!
+//! # No-cuda build
+//!
+//! This module compiles on every host. It carries no GPU allocations —
+//! only the byte budget + per-handle high-water marks. The per-backend
+//! `MatmulHandle::workspace_buffer()` method (Phase 2.x) consults this
+//! policy.
+
+/// Per-handle workspace policy.
+#[derive(Debug, Clone, Copy)]
+pub struct WorkspacePool {
+    /// Maximum allowed workspace bytes per matmul. Cublasrt's
+    /// heuristic respects this cap when picking an algo.
+    pub max_bytes: u64,
+    /// High-water mark observed across all matmuls served by this
+    /// handle. Reported by `bench-results/`.
+    pub peak_bytes: u64,
+    /// Number of matmul calls served. Reported by `bench-results/`.
+    pub call_count: u64,
+}
+
+impl WorkspacePool {
+    /// Default per-handle policy. 32 MiB cap matches the Phase 0.8
+    /// `cublaslt_mlp_probe` exemplar.
+    pub const DEFAULT_MAX_BYTES: u64 = 32 * 1024 * 1024;
+
+    /// Construct with the default cap.
+    pub fn new() -> Self {
+        WorkspacePool {
+            max_bytes: Self::DEFAULT_MAX_BYTES,
+            peak_bytes: 0,
+            call_count: 0,
+        }
+    }
+
+    /// Construct with an explicit cap (used by tests + callers that
+    /// know their workload's working-set size).
+    pub fn with_cap(max_bytes: u64) -> Self {
+        WorkspacePool {
+            max_bytes,
+            peak_bytes: 0,
+            call_count: 0,
+        }
+    }
+
+    /// Record one matmul call's workspace usage. Updates the peak.
+    pub fn record(&mut self, used_bytes: u64) {
+        self.call_count += 1;
+        if used_bytes > self.peak_bytes {
+            self.peak_bytes = used_bytes;
+        }
+    }
+
+    /// Returns `true` iff the algo's requested workspace fits within
+    /// the per-handle cap.
+    pub fn allows(&self, requested_bytes: u64) -> bool {
+        requested_bytes <= self.max_bytes
+    }
+
+    /// Reset the high-water mark + call counter. Used between
+    /// bench harness phases.
+    pub fn reset(&mut self) {
+        self.peak_bytes = 0;
+        self.call_count = 0;
+    }
+}
+
+impl Default for WorkspacePool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_cap_is_32_mib() {
+        let p = WorkspacePool::new();
+        assert_eq!(p.max_bytes, 32 * 1024 * 1024);
+    }
+
+    #[test]
+    fn record_updates_peak_and_count() {
+        let mut p = WorkspacePool::new();
+        p.record(1024);
+        p.record(2048);
+        p.record(512);
+        assert_eq!(p.peak_bytes, 2048);
+        assert_eq!(p.call_count, 3);
+    }
+
+    #[test]
+    fn allows_respects_cap() {
+        let p = WorkspacePool::with_cap(1024);
+        assert!(p.allows(0));
+        assert!(p.allows(512));
+        assert!(p.allows(1024));
+        assert!(!p.allows(1025));
+        assert!(!p.allows(u64::MAX));
+    }
+
+    #[test]
+    fn reset_zeros_counters_not_cap() {
+        let mut p = WorkspacePool::with_cap(2048);
+        p.record(1024);
+        p.reset();
+        assert_eq!(p.peak_bytes, 0);
+        assert_eq!(p.call_count, 0);
+        assert_eq!(p.max_bytes, 2048);
+    }
+}


### PR DESCRIPTION
Adds the backend-agnostic production data structures `kiln-blas` will need for its Phase 2.x cublasLt MatmulHandle. CPU-buildable; compiles on every host.

## API

| Type | Purpose |
|---|---|
| `AlgoCacheKey` | `{shape, dtype, transpose, expected_concurrent_streams, kiln_version_major}` — Phase 2 issue says concurrent_streams must be in the key so QKV picks SM-light algos automatically |
| `AlgoCacheValue` | `{algo_id, workspace_bytes, recorded_ms, algo_blob}` (opaque per-backend algo descriptor) |
| `AlgoCache` | HashMap-backed with `save_to_path` + `standard_path(backend, device_fingerprint)` → `~/.cache/kiln/autotune/{backend}-{fp}.json` |
| `WorkspacePool` | Per-handle 32-MiB-default cap + peak + call_count |

## Cargo.toml change

`candle-core` becomes optional + `probe`-feature-gated. The backend-agnostic types now compile without the CUDA toolchain. kiln-blas moves into `default-members` since the default build is CPU-clean. The cublasLt probe + build.rs CUDA link stays gated behind `--features probe`.

## 11 unit tests

AlgoCache insert/lookup, standard_path format, JSON shape, distinct-keys-for-concurrent-streams, save_to_path file write; WorkspacePool default cap + record + allows + reset; base64 encoder known values.

## Phase 2.x follow-ups

- `MatmulHandle` (cublasLt context + per-stream binding) gated `--features cuda`
- Wire AlgoCache to cublasLt heuristic + writes
- Wire WorkspacePool to `cublasLtMatmul` workspace pointer
- Pre-shipped `assets/autotune/cublaslt-*.json` for tier-1 GPUs per Qwen3.5-4B specialization

Refs #1082