### PR TITLE
phase 2.2: kiln-mps crate scaffold (Metal BLAS) (#1082)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/kiln-nvtx",
     "crates/kiln-autograd",
     "crates/kiln-graph",
+    "crates/kiln-mps",
     "crates/kiln-opd-loss-kernel",
     "crates/kiln-optim",
     "crates/kiln-param",
@@ -43,6 +44,7 @@ default-members = [
     "crates/kiln-flce-kernel",
     "crates/kiln-graph",
     "crates/kiln-model",
+    "crates/kiln-mps",
     "crates/kiln-nvtx",
     "crates/kiln-opd-loss-kernel",
     "crates/kiln-optim",
@@ -134,6 +136,7 @@ tempfile = "3"
 
 # Internal crates
 kiln-autograd = { path = "crates/kiln-autograd" }
+kiln-blas = { path = "crates/kiln-blas" }
 kiln-core = { path = "crates/kiln-core" }
 kiln-eval = { path = "crates/kiln-eval" }
 kiln-graph = { path = "crates/kiln-graph" }

--- a/crates/kiln-mps/Cargo.toml
+++ b/crates/kiln-mps/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "kiln-mps"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "kiln-tensor's Metal BLAS layer (MPSMatrixMultiplication + custom MSL). Phase 2.2 backend-agnostic types + Apple-Silicon UMA helpers."
+build = "build.rs"
+
+# Sibling to kiln-blas (CUDA) and kiln-vulkan-blas (Vulkan).
+#
+# Phase 2.2 ships only the backend-agnostic types (extensions to
+# kiln-blas's AlgoCache + WorkspacePool with Metal-specific keys);
+# Phase 2.x adds the feature-gated MPSMatrixMultiplication wrapper
+# + the actual mps_mlp_probe example.
+
+[features]
+default = []
+# Builds the Metal probe binary. Pulls candle-core's metal feature
+# as the metal-rs vendor; build.rs links the Metal + MetalKit
+# frameworks. Same shape as kiln-blas's `probe` feature.
+probe = ["dep:candle-core"]
+
+[dependencies]
+# Backend-agnostic types come from kiln-blas; we re-export the
+# matching shapes here so Metal users have one consistent import path.
+kiln-blas = { workspace = true }
+kiln-tensor = { workspace = true }
+
+# Candle is the metal-rs vendor under the `probe` feature; absent on
+# the default build so the backend-agnostic types compile on every
+# host.
+candle-core = { workspace = true, features = ["metal"], optional = true }
+
+half = "2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[build-dependencies]
+cc = "1"

--- a/crates/kiln-mps/build.rs
+++ b/crates/kiln-mps/build.rs
@@ -1,0 +1,12 @@
+use std::env;
+
+fn main() {
+    // Only link Metal frameworks when the `probe` feature is on;
+    // backend-agnostic types compile without them.
+    if env::var_os("CARGO_FEATURE_PROBE").is_some() {
+        println!("cargo:rustc-link-lib=framework=Metal");
+        println!("cargo:rustc-link-lib=framework=MetalKit");
+        println!("cargo:rustc-link-lib=framework=Foundation");
+    }
+    println!("cargo:rerun-if-env-changed=CARGO_FEATURE_PROBE");
+}

--- a/crates/kiln-mps/src/lib.rs
+++ b/crates/kiln-mps/src/lib.rs
@@ -1,0 +1,53 @@
+//! kiln-mps — Metal BLAS layer (MPSMatrixMultiplication + custom MSL).
+//!
+//! Sibling to [`kiln-blas`](https://docs.rs/kiln-blas) (CUDA) and
+//! `kiln-vulkan-blas` (Vulkan). Phase 2.2 of #1082 ships the
+//! backend-agnostic Metal-specific extensions to the shared
+//! [`kiln_blas::AlgoCache`] / [`kiln_blas::WorkspacePool`] types;
+//! Phase 2.x adds the feature-gated `MPSMatmulHandle` (Metal
+//! command-queue + per-stream binding).
+//!
+//! # Why a separate crate
+//!
+//! Per the Phase 2 issue bullet:
+//!
+//! > BLAS crate: `kiln-blas` (cublasLt) / `kiln-mps`
+//! > (MPSMatrixMultiplication + transposed-coop GEMV port) /
+//! > `kiln-vulkan-blas` (extend `kiln-vulkan-kernel::vk_ops/matmul*`)
+//!
+//! Each per-backend crate carries its own opaque algo descriptor
+//! shape — cublasLt's `cublasLtMatmulAlgo_t` is a different blob from
+//! MPS's `MPSMatrixDescriptor` tile-config. The shared `AlgoCache`
+//! stores the bytes; per-backend crates serialize / deserialize.
+//!
+//! # Phase 2.2 public surface
+//!
+//! - [`MpsTilePolicy`] — Metal-side tile / transpose configuration.
+//!   Lives in the algo blob serialized into `kiln_blas::AlgoCacheValue::algo_blob`.
+//! - [`MpsUmaHint`] — UMA-aware allocation hint. On Apple Silicon the
+//!   storage mode picker reads this to decide Shared vs Private.
+//! - Re-exports of [`kiln_blas::AlgoCache`] + [`kiln_blas::WorkspacePool`]
+//!   so a Metal-only caller has one import path.
+//!
+//! # CPU-buildable
+//!
+//! All Phase 2.2 types compile on every host. The Metal-runtime
+//! `MPSMatmulHandle` lands in a subsequent PR gated behind the
+//! `probe` feature.
+
+#![deny(missing_debug_implementations)]
+#![warn(rust_2018_idioms)]
+
+mod tile_policy;
+mod uma;
+
+pub use tile_policy::MpsTilePolicy;
+pub use uma::MpsUmaHint;
+
+// Re-exports — Metal callers reach AlgoCache/WorkspacePool via kiln_mps.
+pub use kiln_blas::{AlgoCache, AlgoCacheKey, AlgoCacheValue, WorkspacePool};
+
+/// Stable phase tag (mirrors kiln_blas::phase()).
+pub fn phase() -> &'static str {
+    "phase 2.2 — backend-agnostic Metal types (MpsTilePolicy + MpsUmaHint); MPSMatmulHandle Phase 2.x"
+}

--- a/crates/kiln-mps/src/tile_policy.rs
+++ b/crates/kiln-mps/src/tile_policy.rs
@@ -1,0 +1,121 @@
+//! `MpsTilePolicy` — Metal-side tile + transpose configuration.
+//!
+//! `MPSMatrixMultiplication` doesn't expose an algo-id integer like
+//! cublasLt; instead the per-shape "algo" is encoded in:
+//! - tile dimensions (M, N, K splits)
+//! - transpose flags (transposeLeft / transposeRight)
+//! - alpha / beta scale type
+//! - storage mode (Shared on UMA, Private on discrete)
+//!
+//! `MpsTilePolicy` carries this configuration in a compact form that
+//! serializes cleanly to the algo_blob byte slot in
+//! [`kiln_blas::AlgoCacheValue`].
+
+use std::convert::TryInto;
+
+/// Metal tile + transpose configuration for one matmul shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct MpsTilePolicy {
+    /// Tile width along the M axis. 0 means "let MPS pick".
+    pub tile_m: u32,
+    /// Tile width along the N axis. 0 means "let MPS pick".
+    pub tile_n: u32,
+    /// Tile width along the K axis. 0 means "let MPS pick".
+    pub tile_k: u32,
+    /// Transpose left operand?
+    pub transpose_left: bool,
+    /// Transpose right operand?
+    pub transpose_right: bool,
+}
+
+impl MpsTilePolicy {
+    /// MPS-chooses-tiles default. Useful as the initial cache miss.
+    pub const AUTO: Self = MpsTilePolicy {
+        tile_m: 0,
+        tile_n: 0,
+        tile_k: 0,
+        transpose_left: false,
+        transpose_right: false,
+    };
+
+    /// Serialize to a 14-byte blob:
+    /// `[tile_m: u32 LE][tile_n: u32 LE][tile_k: u32 LE][transposes: 2 bytes]`.
+    /// Stable across kiln versions.
+    pub fn to_blob(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(14);
+        out.extend_from_slice(&self.tile_m.to_le_bytes());
+        out.extend_from_slice(&self.tile_n.to_le_bytes());
+        out.extend_from_slice(&self.tile_k.to_le_bytes());
+        out.push(self.transpose_left as u8);
+        out.push(self.transpose_right as u8);
+        out
+    }
+
+    /// Reverse of `to_blob`. Returns `None` on a malformed blob.
+    pub fn from_blob(blob: &[u8]) -> Option<Self> {
+        if blob.len() != 14 {
+            return None;
+        }
+        let tile_m = u32::from_le_bytes(blob[0..4].try_into().ok()?);
+        let tile_n = u32::from_le_bytes(blob[4..8].try_into().ok()?);
+        let tile_k = u32::from_le_bytes(blob[8..12].try_into().ok()?);
+        Some(MpsTilePolicy {
+            tile_m,
+            tile_n,
+            tile_k,
+            transpose_left: blob[12] != 0,
+            transpose_right: blob[13] != 0,
+        })
+    }
+}
+
+impl Default for MpsTilePolicy {
+    fn default() -> Self {
+        Self::AUTO
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auto_is_all_zero_no_transpose() {
+        let p = MpsTilePolicy::AUTO;
+        assert_eq!(p.tile_m, 0);
+        assert_eq!(p.tile_n, 0);
+        assert_eq!(p.tile_k, 0);
+        assert!(!p.transpose_left);
+        assert!(!p.transpose_right);
+    }
+
+    #[test]
+    fn blob_round_trip() {
+        let p = MpsTilePolicy {
+            tile_m: 64,
+            tile_n: 128,
+            tile_k: 32,
+            transpose_left: false,
+            transpose_right: true,
+        };
+        let blob = p.to_blob();
+        assert_eq!(blob.len(), 14);
+        let back = MpsTilePolicy::from_blob(&blob).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn blob_handles_auto() {
+        let p = MpsTilePolicy::AUTO;
+        let blob = p.to_blob();
+        let back = MpsTilePolicy::from_blob(&blob).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn blob_rejects_wrong_size() {
+        assert!(MpsTilePolicy::from_blob(&[]).is_none());
+        assert!(MpsTilePolicy::from_blob(&[0u8; 13]).is_none());
+        assert!(MpsTilePolicy::from_blob(&[0u8; 15]).is_none());
+    }
+}

--- a/crates/kiln-mps/src/uma.rs
+++ b/crates/kiln-mps/src/uma.rs
@@ -1,0 +1,80 @@
+//! `MpsUmaHint` — Apple-Silicon UMA storage-mode hint for matmul inputs.
+//!
+//! Per the Phase 1 issue bullet on Apple Silicon UMA:
+//!
+//! > On M-series, CPU and GPU share physical memory; `MTLStorageModeShared`
+//! > buffers are addressable from both. kiln-tensor exposes
+//! > `Tensor::is_unified_memory()` and `Tensor::as_host_slice()`
+//! > (zero-copy on UMA, errors elsewhere) so the safetensors loader
+//! > and the optimizer don't pay a copy round-trip on Mac.
+//!
+//! The MPS matmul path picks a storage mode for its inputs / output
+//! based on whether they will be touched from the CPU side. This hint
+//! crystallizes that policy in a typed enum that the per-shape algo
+//! cache can record.
+
+/// Apple-Silicon UMA storage hint.
+///
+/// `#[non_exhaustive]` — Phase 8.x may add `Managed` (mac-only,
+/// discrete-GPU optimization for the rare non-Apple-Silicon path).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum MpsUmaHint {
+    /// Touched only from the GPU. Use `MTLStorageModePrivate` for
+    /// fastest GPU access. Default for intermediate matmul outputs.
+    PrivateGpuOnly,
+    /// Touched from both CPU and GPU (host upload, host readback).
+    /// Use `MTLStorageModeShared` — zero-copy on UMA.
+    SharedUma,
+    /// Optimizer master / activation offload buffer; we'd ideally
+    /// keep this in pinned-host memory and let the GPU read across
+    /// the unified-memory boundary. Mac-specific Phase 6.5 hook.
+    HostMirror,
+}
+
+impl MpsUmaHint {
+    /// Stable short name (for parity-tolerance.csv keying + JSON).
+    pub const fn name(self) -> &'static str {
+        match self {
+            MpsUmaHint::PrivateGpuOnly => "private_gpu_only",
+            MpsUmaHint::SharedUma => "shared_uma",
+            MpsUmaHint::HostMirror => "host_mirror",
+        }
+    }
+
+    /// Returns `true` iff this hint requires a Shared / UMA-visible
+    /// buffer. The MPS storage-mode picker reads this.
+    pub const fn needs_uma_visible(self) -> bool {
+        matches!(self, MpsUmaHint::SharedUma | MpsUmaHint::HostMirror)
+    }
+}
+
+impl Default for MpsUmaHint {
+    fn default() -> Self {
+        MpsUmaHint::PrivateGpuOnly
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_strings() {
+        assert_eq!(MpsUmaHint::PrivateGpuOnly.name(), "private_gpu_only");
+        assert_eq!(MpsUmaHint::SharedUma.name(), "shared_uma");
+        assert_eq!(MpsUmaHint::HostMirror.name(), "host_mirror");
+    }
+
+    #[test]
+    fn uma_visible_classification() {
+        assert!(!MpsUmaHint::PrivateGpuOnly.needs_uma_visible());
+        assert!(MpsUmaHint::SharedUma.needs_uma_visible());
+        assert!(MpsUmaHint::HostMirror.needs_uma_visible());
+    }
+
+    #[test]
+    fn default_is_private() {
+        assert_eq!(MpsUmaHint::default(), MpsUmaHint::PrivateGpuOnly);
+    }
+}


### PR DESCRIPTION
Sibling to kiln-blas (CUDA) + kiln-vulkan-blas (Vulkan). Phase 2.2 ships only the backend-agnostic Metal-specific extensions; Phase 2.x adds the feature-gated `MPSMatmulHandle` + `mps_mlp_probe` example.

## Two types

| Type | Purpose |
|---|---|
| `MpsTilePolicy` | Metal tile + transpose configuration; serializes to a stable 14-byte blob for storage in `kiln_blas::AlgoCacheValue::algo_blob` |
| `MpsUmaHint` | `PrivateGpuOnly` / `SharedUma` / `HostMirror` — Apple-Silicon UMA storage-mode hint, threaded through the per-shape algo cache |

## Re-exports

`pub use kiln_blas::{AlgoCache, AlgoCacheKey, AlgoCacheValue, WorkspacePool}` so Metal callers have one import path.

## Cargo.toml

- `kiln-blas` workspace dep — re-exports the autotune-cache types
- `candle-core` optional, gated behind `--features probe` with `features = ["metal"]`
- build.rs links Metal + MetalKit + Foundation frameworks only under `probe`

## 7 unit tests

MpsTilePolicy blob round-trip + AUTO + size validation; MpsUmaHint name + UMA-visible classification + default.

## Phase 2.x follow-ups

- `MPSMatmulHandle` (Metal command-queue + per-stream binding)
- `examples/mps_mlp_probe.rs` — sibling to cublaslt probe
- Pre-shipped `assets/autotune/mps-{m1,m2,m3,m-ultra}.json`

Refs #1082