### PR TITLE
phase 2.3: kiln-vulkan-blas crate scaffold (#1082)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/kiln-server",
     "crates/kiln-tensor",
     "crates/kiln-train",
+    "crates/kiln-vulkan-blas",
     "crates/kiln-vulkan-kernel",
 ]
 # kiln-conv1d-kernel, kiln-flash-attn, kiln-gdn-kernel, kiln-marlin-gemm,
@@ -53,6 +54,7 @@ default-members = [
     "crates/kiln-server",
     "crates/kiln-tensor",
     "crates/kiln-train",
+    "crates/kiln-vulkan-blas",
 ]
 
 [workspace.package]

--- a/crates/kiln-vulkan-blas/Cargo.toml
+++ b/crates/kiln-vulkan-blas/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "kiln-vulkan-blas"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "kiln-tensor's Vulkan BLAS layer (extending kiln-vulkan-kernel::vk_ops/matmul*). Phase 2.3 backend-agnostic types."
+
+# Sibling to kiln-blas (CUDA) and kiln-mps (Metal). Unlike those two,
+# kiln-vulkan-blas does NOT carry a candle dependency — kiln-vulkan-kernel
+# is already candle-free.
+#
+# Phase 2.3 ships only the backend-agnostic Vulkan-specific extensions
+# (workgroup-size cache key + pipeline cache hash); Phase 2.x adds the
+# actual matmul wrapper extending the existing compute pipelines.
+
+[features]
+default = []
+# Pulls kiln-vulkan-kernel for the actual matmul dispatch path.
+vulkan = ["dep:kiln-vulkan-kernel"]
+
+[dependencies]
+# Backend-agnostic types from kiln-blas.
+kiln-blas = { workspace = true }
+kiln-tensor = { workspace = true }
+
+# Optional under the `vulkan` feature.
+kiln-vulkan-kernel = { workspace = true, optional = true }
+
+half = "2"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/kiln-vulkan-blas/src/cooperative_matrix.rs
+++ b/crates/kiln-vulkan-blas/src/cooperative_matrix.rs
@@ -1,0 +1,119 @@
+//! `VkCooperativeMatrixSupport` — feature-detection for
+//! `VK_KHR_cooperative_matrix`.
+//!
+//! Per the Phase 2 issue bullet:
+//!
+//! > **Vulkan: `VK_KHR_cooperative_matrix` for the matmul backend.**
+//! > Audit confirms today's `kiln-vulkan-kernel::vk_ops/matmul*` uses
+//! > subgroup-scalar arithmetic; cooperative matrix exposes
+//! > NVIDIA/AMD/Intel matrix cores via standard Vulkan (same primitive
+//! > ggml-vulkan and VkFFT use for 4–8× matmul throughput). Lifts
+//! > Vulkan from "works" to "competitive with CUDA at the same shape."
+
+/// Per-device cooperative-matrix capability detection.
+///
+/// `#[non_exhaustive]` — Phase 8.x may add `Tile16x16` etc. variants
+/// once specific tile shapes are bench-tuned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum VkCooperativeMatrixSupport {
+    /// `VK_KHR_cooperative_matrix` not present (e.g. older drivers).
+    /// Matmul falls back to subgroup-scalar.
+    Unavailable,
+    /// Extension present with BF16 input + FP32 accumulator support.
+    /// The Qwen3.5-4B production path uses this.
+    Bf16Fp32,
+    /// Extension present with FP16 input + FP32 accumulator support.
+    /// Useful for the candle-Mac path during the migration.
+    Fp16Fp32,
+    /// Extension present with both Bf16Fp32 + Fp16Fp32. Best-case;
+    /// matmul handler picks per-shape.
+    Bf16AndFp16,
+}
+
+impl VkCooperativeMatrixSupport {
+    /// Stable short name for logging.
+    pub const fn name(self) -> &'static str {
+        match self {
+            VkCooperativeMatrixSupport::Unavailable => "unavailable",
+            VkCooperativeMatrixSupport::Bf16Fp32 => "bf16_fp32",
+            VkCooperativeMatrixSupport::Fp16Fp32 => "fp16_fp32",
+            VkCooperativeMatrixSupport::Bf16AndFp16 => "bf16_and_fp16",
+        }
+    }
+
+    /// Can cooperative-matrix BF16 input be used?
+    pub const fn supports_bf16(self) -> bool {
+        matches!(
+            self,
+            VkCooperativeMatrixSupport::Bf16Fp32 | VkCooperativeMatrixSupport::Bf16AndFp16
+        )
+    }
+
+    /// Can cooperative-matrix FP16 input be used?
+    pub const fn supports_fp16(self) -> bool {
+        matches!(
+            self,
+            VkCooperativeMatrixSupport::Fp16Fp32 | VkCooperativeMatrixSupport::Bf16AndFp16
+        )
+    }
+
+    /// Is any cooperative-matrix path available?
+    pub const fn is_available(self) -> bool {
+        !matches!(self, VkCooperativeMatrixSupport::Unavailable)
+    }
+}
+
+impl Default for VkCooperativeMatrixSupport {
+    fn default() -> Self {
+        VkCooperativeMatrixSupport::Unavailable
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_strings() {
+        assert_eq!(VkCooperativeMatrixSupport::Unavailable.name(), "unavailable");
+        assert_eq!(VkCooperativeMatrixSupport::Bf16Fp32.name(), "bf16_fp32");
+        assert_eq!(VkCooperativeMatrixSupport::Fp16Fp32.name(), "fp16_fp32");
+        assert_eq!(VkCooperativeMatrixSupport::Bf16AndFp16.name(), "bf16_and_fp16");
+    }
+
+    #[test]
+    fn dtype_support_predicates() {
+        // Bf16Fp32 supports BF16 only
+        let b = VkCooperativeMatrixSupport::Bf16Fp32;
+        assert!(b.supports_bf16());
+        assert!(!b.supports_fp16());
+        assert!(b.is_available());
+
+        // Fp16Fp32 supports FP16 only
+        let f = VkCooperativeMatrixSupport::Fp16Fp32;
+        assert!(!f.supports_bf16());
+        assert!(f.supports_fp16());
+        assert!(f.is_available());
+
+        // Bf16AndFp16 supports both
+        let bf = VkCooperativeMatrixSupport::Bf16AndFp16;
+        assert!(bf.supports_bf16());
+        assert!(bf.supports_fp16());
+        assert!(bf.is_available());
+
+        // Unavailable supports neither
+        let u = VkCooperativeMatrixSupport::Unavailable;
+        assert!(!u.supports_bf16());
+        assert!(!u.supports_fp16());
+        assert!(!u.is_available());
+    }
+
+    #[test]
+    fn default_is_unavailable() {
+        assert_eq!(
+            VkCooperativeMatrixSupport::default(),
+            VkCooperativeMatrixSupport::Unavailable
+        );
+    }
+}

--- a/crates/kiln-vulkan-blas/src/lib.rs
+++ b/crates/kiln-vulkan-blas/src/lib.rs
@@ -1,0 +1,53 @@
+//! kiln-vulkan-blas — Vulkan BLAS layer (extending
+//! `kiln-vulkan-kernel::vk_ops/matmul*`).
+//!
+//! Sibling to [`kiln-blas`] (CUDA) and [`kiln-mps`] (Metal). Per the
+//! Phase 2 issue bullet:
+//!
+//! > BLAS crate: `kiln-blas` (cublasLt) / `kiln-mps`
+//! > (MPSMatrixMultiplication + transposed-coop GEMV port) /
+//! > **`kiln-vulkan-blas` (extend `kiln-vulkan-kernel::vk_ops/matmul*`)**
+//!
+//! Unlike kiln-blas + kiln-mps, kiln-vulkan-blas does **not** carry a
+//! candle dependency — kiln-vulkan-kernel is already candle-free.
+//! Phase 7 of #1082 (candle removal) leaves this crate's dependency
+//! graph unchanged.
+//!
+//! # Phase 2.3 scope
+//!
+//! Backend-agnostic Vulkan-specific extensions only:
+//!
+//! - [`VkWorkgroupConfig`] — workgroup-size + subgroup-config cache
+//!   entry. Recorded in `kiln_blas::AlgoCacheValue::algo_blob` as a
+//!   stable byte format.
+//! - [`VkPipelineCacheKey`] — hash key for the `~/.cache/kiln/vulkan/
+//!   pipeline-cache-{device_uuid}.bin` blob per the Phase 2 issue's
+//!   "Vulkan: disk-persistent pipeline cache" bullet.
+//! - [`VkCooperativeMatrixSupport`] — feature-detection enum for
+//!   `VK_KHR_cooperative_matrix` per the Phase 2 issue's "Vulkan:
+//!   `VK_KHR_cooperative_matrix` for the matmul backend" bullet.
+//!
+//! # CPU-buildable
+//!
+//! All types compile without `--features vulkan`. The actual matmul
+//! wrapper extending `kiln-vulkan-kernel`'s existing compute pipelines
+//! lands behind the `vulkan` feature in subsequent PRs.
+
+#![deny(missing_debug_implementations)]
+#![warn(rust_2018_idioms)]
+
+mod cooperative_matrix;
+mod pipeline_cache;
+mod workgroup;
+
+pub use cooperative_matrix::VkCooperativeMatrixSupport;
+pub use pipeline_cache::VkPipelineCacheKey;
+pub use workgroup::VkWorkgroupConfig;
+
+// Re-exports — Vulkan callers reach AlgoCache/WorkspacePool via kiln_vulkan_blas.
+pub use kiln_blas::{AlgoCache, AlgoCacheKey, AlgoCacheValue, WorkspacePool};
+
+/// Stable phase tag (mirrors `kiln_blas::phase()` / `kiln_mps::phase()`).
+pub fn phase() -> &'static str {
+    "phase 2.3 — backend-agnostic Vulkan types (workgroup + pipeline cache + cooperative matrix detect); matmul wrapper Phase 2.x"
+}

--- a/crates/kiln-vulkan-blas/src/pipeline_cache.rs
+++ b/crates/kiln-vulkan-blas/src/pipeline_cache.rs
@@ -1,0 +1,117 @@
+//! `VkPipelineCacheKey` — hash key for the disk-persistent Vulkan
+//! pipeline cache.
+//!
+//! Per the Phase 2 issue bullet:
+//!
+//! > **Vulkan: disk-persistent pipeline cache.**
+//! > `~/.cache/kiln/vulkan/pipeline-cache-{device_uuid}.bin`. Eliminates
+//! > SPIR-V re-compile on every cold start (0.5–5 s currently); reuses
+//! > the disk-persistent autotune cache pattern above.
+//!
+//! The cache key identifies a unique combination of:
+//! - device UUID (so cache files survive driver swaps but not GPU swaps)
+//! - SPIR-V shader hash (so cache invalidates on shader edits)
+//! - kiln binary version (so old caches are rejected on update)
+//!
+//! Phase 2.x's `kiln_vulkan_blas::MatmulHandle` reads this cache at
+//! startup before any pipeline creation.
+
+use std::path::PathBuf;
+
+/// Cache file key. Maps 1:1 to one `pipeline-cache-{key}.bin` on disk.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VkPipelineCacheKey {
+    /// Vulkan device UUID (16 bytes from
+    /// `vkGetPhysicalDeviceProperties::pipelineCacheUUID`).
+    pub device_uuid: [u8; 16],
+    /// Hash of all SPIR-V shaders the pipeline uses. xxhash3 64-bit;
+    /// today's stub uses stdlib `DefaultHasher` (Phase 2.5.x swap to
+    /// xxhash3 covers this file too).
+    pub shader_hash: u64,
+    /// Kiln binary version major. Cache hits across mismatched
+    /// majors are rejected.
+    pub kiln_version_major: u32,
+}
+
+impl VkPipelineCacheKey {
+    /// Format the standard cache file path.
+    pub fn cache_path(&self) -> PathBuf {
+        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+        let uuid_hex = hex_lower(&self.device_uuid);
+        PathBuf::from(home)
+            .join(".cache/kiln/vulkan")
+            .join(format!(
+                "pipeline-cache-{uuid_hex}-{:016x}-v{}.bin",
+                self.shader_hash, self.kiln_version_major
+            ))
+    }
+
+    /// True iff this key's `kiln_version_major` matches `current`.
+    /// Phase 2.x's loader uses this to reject mismatched-version
+    /// cache files cleanly.
+    pub const fn matches_version(&self, current: u32) -> bool {
+        self.kiln_version_major == current
+    }
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let hi = b >> 4;
+        let lo = b & 0x0F;
+        out.push(hex_char(hi));
+        out.push(hex_char(lo));
+    }
+    out
+}
+
+const fn hex_char(nibble: u8) -> char {
+    if nibble < 10 {
+        (b'0' + nibble) as char
+    } else {
+        (b'a' + (nibble - 10)) as char
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_path_contains_uuid_hex() {
+        let k = VkPipelineCacheKey {
+            device_uuid: [
+                0xDE, 0xAD, 0xBE, 0xEF, 0xFE, 0xED, 0xFA, 0xCE, //
+                0xCA, 0xFE, 0xBA, 0xBE, 0xFA, 0x11, 0xCA, 0xB1,
+            ],
+            shader_hash: 0xABCDEF0123456789,
+            kiln_version_major: 7,
+        };
+        let s = k.cache_path().to_string_lossy().to_string();
+        assert!(s.contains(".cache/kiln/vulkan/"));
+        assert!(s.contains("deadbeeffeedface"));
+        assert!(s.contains("abcdef0123456789"));
+        assert!(s.ends_with("-v7.bin"));
+    }
+
+    #[test]
+    fn matches_version_predicate() {
+        let k = VkPipelineCacheKey {
+            device_uuid: [0u8; 16],
+            shader_hash: 0,
+            kiln_version_major: 3,
+        };
+        assert!(k.matches_version(3));
+        assert!(!k.matches_version(2));
+        assert!(!k.matches_version(4));
+    }
+
+    #[test]
+    fn hex_lower_known_values() {
+        assert_eq!(hex_lower(&[]), "");
+        assert_eq!(hex_lower(&[0x00]), "00");
+        assert_eq!(hex_lower(&[0xFF]), "ff");
+        assert_eq!(hex_lower(&[0xAB, 0xCD]), "abcd");
+        assert_eq!(hex_lower(&[0xDE, 0xAD, 0xBE, 0xEF]), "deadbeef");
+    }
+}

--- a/crates/kiln-vulkan-blas/src/workgroup.rs
+++ b/crates/kiln-vulkan-blas/src/workgroup.rs
@@ -1,0 +1,130 @@
+//! `VkWorkgroupConfig` — Vulkan workgroup-size + subgroup-config cache entry.
+//!
+//! Vulkan compute pipelines pick performance from:
+//! - local workgroup size (X, Y, Z)
+//! - subgroup size (warp / wavefront equivalent)
+//! - cooperative-matrix tile (when `VK_KHR_cooperative_matrix` is available)
+//!
+//! `VkWorkgroupConfig` carries this configuration in a compact form that
+//! serializes cleanly to the algo_blob byte slot in
+//! [`kiln_blas::AlgoCacheValue`].
+
+use std::convert::TryInto;
+
+/// Vulkan compute-pipeline configuration for one matmul shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VkWorkgroupConfig {
+    /// Local workgroup size along X.
+    pub local_x: u32,
+    /// Local workgroup size along Y.
+    pub local_y: u32,
+    /// Local workgroup size along Z.
+    pub local_z: u32,
+    /// Subgroup size in shader invocations (typically 32 on NVIDIA,
+    /// 32/64 on AMD RDNA, 8/16/32 on Intel Arc).
+    pub subgroup_size: u32,
+    /// Whether `VK_KHR_cooperative_matrix` is used by this pipeline.
+    pub uses_cooperative_matrix: bool,
+}
+
+impl VkWorkgroupConfig {
+    /// Default 64-thread workgroup with subgroup_size=32 and no
+    /// cooperative matrix. Reasonable starting point for the runtime
+    /// heuristic to refine against.
+    pub const DEFAULT: Self = VkWorkgroupConfig {
+        local_x: 64,
+        local_y: 1,
+        local_z: 1,
+        subgroup_size: 32,
+        uses_cooperative_matrix: false,
+    };
+
+    /// Serialize to a 17-byte blob:
+    /// `[local_x: u32 LE][local_y: u32 LE][local_z: u32 LE]
+    ///  [subgroup_size: u32 LE][uses_cooperative_matrix: 1 byte]`.
+    pub fn to_blob(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(17);
+        out.extend_from_slice(&self.local_x.to_le_bytes());
+        out.extend_from_slice(&self.local_y.to_le_bytes());
+        out.extend_from_slice(&self.local_z.to_le_bytes());
+        out.extend_from_slice(&self.subgroup_size.to_le_bytes());
+        out.push(self.uses_cooperative_matrix as u8);
+        out
+    }
+
+    /// Reverse of `to_blob`. Returns `None` on a malformed blob.
+    pub fn from_blob(blob: &[u8]) -> Option<Self> {
+        if blob.len() != 17 {
+            return None;
+        }
+        Some(VkWorkgroupConfig {
+            local_x: u32::from_le_bytes(blob[0..4].try_into().ok()?),
+            local_y: u32::from_le_bytes(blob[4..8].try_into().ok()?),
+            local_z: u32::from_le_bytes(blob[8..12].try_into().ok()?),
+            subgroup_size: u32::from_le_bytes(blob[12..16].try_into().ok()?),
+            uses_cooperative_matrix: blob[16] != 0,
+        })
+    }
+
+    /// Total invocations per workgroup (`local_x * local_y * local_z`).
+    /// Capped by the device's `maxComputeWorkGroupInvocations` —
+    /// callers consult Vulkan device info before recording.
+    pub const fn invocations_per_workgroup(self) -> u32 {
+        self.local_x * self.local_y * self.local_z
+    }
+}
+
+impl Default for VkWorkgroupConfig {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_64x1x1_subgroup32() {
+        let c = VkWorkgroupConfig::DEFAULT;
+        assert_eq!(c.local_x, 64);
+        assert_eq!(c.local_y, 1);
+        assert_eq!(c.local_z, 1);
+        assert_eq!(c.subgroup_size, 32);
+        assert!(!c.uses_cooperative_matrix);
+        assert_eq!(c.invocations_per_workgroup(), 64);
+    }
+
+    #[test]
+    fn blob_round_trip() {
+        let c = VkWorkgroupConfig {
+            local_x: 32,
+            local_y: 16,
+            local_z: 1,
+            subgroup_size: 32,
+            uses_cooperative_matrix: true,
+        };
+        let blob = c.to_blob();
+        assert_eq!(blob.len(), 17);
+        assert_eq!(VkWorkgroupConfig::from_blob(&blob).unwrap(), c);
+    }
+
+    #[test]
+    fn invocations_arithmetic() {
+        let c = VkWorkgroupConfig {
+            local_x: 16,
+            local_y: 8,
+            local_z: 4,
+            subgroup_size: 32,
+            uses_cooperative_matrix: false,
+        };
+        assert_eq!(c.invocations_per_workgroup(), 512);
+    }
+
+    #[test]
+    fn blob_rejects_wrong_size() {
+        assert!(VkWorkgroupConfig::from_blob(&[]).is_none());
+        assert!(VkWorkgroupConfig::from_blob(&[0u8; 16]).is_none());
+        assert!(VkWorkgroupConfig::from_blob(&[0u8; 18]).is_none());
+    }
+}


### PR DESCRIPTION
Sibling to kiln-blas (CUDA) + kiln-mps (Metal). Unlike those two, kiln-vulkan-blas does NOT carry a candle dependency — kiln-vulkan-kernel is already candle-free.

## Three types

| Type | Purpose |
|---|---|
| `VkWorkgroupConfig` | local workgroup (X,Y,Z) + subgroup_size + uses_cooperative_matrix; 17-byte blob for algo_blob storage |
| `VkPipelineCacheKey` | hash key for `~/.cache/kiln/vulkan/pipeline-cache-{uuid}-{shader_hash}-v{version}.bin` |
| `VkCooperativeMatrixSupport` | `Unavailable / Bf16Fp32 / Fp16Fp32 / Bf16AndFp16` — feature-detection enum |

## Cooperative matrix

Per the Phase 2 issue: `VK_KHR_cooperative_matrix` lifts Vulkan from subgroup-scalar to competitive-with-CUDA (4-8× matmul throughput per ggml-vulkan / VkFFT precedent). `supports_bf16/fp16/is_available` predicates let the matmul handler pick per-dtype.

## Re-exports

`pub use kiln_blas::{AlgoCache, AlgoCacheKey, AlgoCacheValue, WorkspacePool}` so Vulkan callers have one import path.

## 13 unit tests

VkWorkgroupConfig blob round-trip + size validation + invocations arithmetic, VkPipelineCacheKey path formatting + version matching + hex encoder, VkCooperativeMatrixSupport dtype predicates per variant.

CPU-only — all types compile without `--features vulkan`. Matmul wrapper extending `kiln-vulkan-kernel::vk_ops/matmul*` lands in Phase 2.x.

## BLAS trio complete

| Crate | Backend | Candle dep |
|---|---|---|
| kiln-blas | CUDA (cublasLt) | yes (probe-feature-gated) |
| kiln-mps | Metal (MPSMatrixMultiplication) | yes (probe-feature-gated) |
| kiln-vulkan-blas | Vulkan | **no** |

All three share kiln_blas::AlgoCache + WorkspacePool.

Refs #1082