### PR TITLE
phase 1.32: Tensor version counter (anti-pattern 16 wiring) (#1082)

### DIFF
--- a/crates/kiln-autograd/src/tape.rs
+++ b/crates/kiln-autograd/src/tape.rs
@@ -10,17 +10,17 @@
 //! thread-local tape handle for parity with PyTorch's `torch.autograd`
 //! ergonomics if the explicit-pass turns out clumsy in practice.
 //!
-//! # Per-node version tracking (anti-pattern 16 hook)
+//! # Per-node version tracking (anti-pattern 16 hook) — wired in Phase 1.32
 //!
-//! Each [`TapeNode`] records the **version** of every input at record
-//! time. [`Tape::backward`] re-reads each input's current version and
-//! asserts equality before calling the op's `bwd`. Today's
-//! `kiln_tensor::Tensor` has no version field, so versions are
-//! always `0` and the assertion is a no-op. When in-place ops land
-//! (optimizer step, residual fuse), the version + this assertion
-//! together enforce the invariant.
+//! Each [`TapeNode`] records the version of every input at record time
+//! AND keeps an `Arc<AtomicU64>` handle to the live version. On backward,
+//! the live value is loaded and compared against the snapshot; if they
+//! differ, in-place mutation happened between forward and backward and
+//! the tape is stale (anti-pattern 16 violation).
 
 use std::collections::HashSet;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 use kiln_tensor::{Error, Result, Tensor, TensorId};
 
@@ -34,8 +34,12 @@ pub struct TapeNode {
     /// `TensorId`s of the op's inputs, in declaration order.
     pub input_ids: Vec<TensorId>,
     /// Input version counters at record time. See module doc.
-    /// Length matches `input_ids`. Today always `0`.
+    /// Length matches `input_ids`.
     pub input_versions: Vec<u64>,
+    /// Live handles to each input's version counter. The tape walker
+    /// loads from these on backward and compares against
+    /// `input_versions` to enforce anti-pattern 16.
+    pub input_version_handles: Vec<Arc<AtomicU64>>,
     /// Owning backward closure.
     pub op: BoxedBackwardOp,
 }
@@ -77,15 +81,18 @@ impl Tape {
 
     /// Record a forward op.
     ///
-    /// Captures `output_id`, `input_ids`, and the current `input_versions`
-    /// (always `0` until Tensor gets a version field in Phase 1.x).
+    /// Captures `output_id`, `input_ids`, the current `input_versions`,
+    /// and `Arc<AtomicU64>` handles to each input's live version.
     pub fn record(&mut self, output: &Tensor, inputs: &[&Tensor], op: BoxedBackwardOp) {
-        let input_ids = inputs.iter().map(|t| t.id()).collect::<Vec<_>>();
-        let input_versions = inputs.iter().map(|_| 0u64).collect::<Vec<_>>();
+        let input_ids: Vec<TensorId> = inputs.iter().map(|t| t.id()).collect();
+        let input_versions: Vec<u64> = inputs.iter().map(|t| t.current_version()).collect();
+        let input_version_handles: Vec<Arc<AtomicU64>> =
+            inputs.iter().map(|t| t.version_handle()).collect();
         self.nodes.push(TapeNode {
             output_id: output.id(),
             input_ids,
             input_versions,
+            input_version_handles,
             op,
         });
     }
@@ -132,12 +139,10 @@ impl Tape {
         // already topo-sorted producer-before-consumer because each
         // forward op records before its consumers.)
         for node in self.nodes.iter().rev() {
-            // 1. Anti-pattern 16: input version check. Today's
-            //    `current_version()` is a stub returning 0; once
-            //    Tensor has a real version counter, this asserts that
-            //    no in-place mutation happened since `record()`.
+            // 1. Anti-pattern 16: input version check via the live
+            //    Arc<AtomicU64> handles captured at record() time.
             for (i, recorded_version) in node.input_versions.iter().enumerate() {
-                let current = current_version_for_id(node.input_ids[i]);
+                let current = node.input_version_handles[i].load(Ordering::Relaxed);
                 if current != *recorded_version {
                     return Err(Error::Msg(format!(
                         "kiln_autograd: tape node {} input {} version drifted \
@@ -218,17 +223,10 @@ impl TapeNode {
     }
 }
 
-/// **Stub**: returns the current version counter for a `TensorId`.
-///
-/// Today there is no version field on `Tensor`, so this always returns 0
-/// and the anti-pattern 16 assertion in `Tape::backward` is a no-op.
-///
-/// Phase 1.x adds the version field; the stub gets replaced with a
-/// real lookup. The signature stays the same so this PR's tape walker
-/// is forward-compatible.
-fn current_version_for_id(_id: TensorId) -> u64 {
-    0
-}
+// The Phase 1.12 stub `current_version_for_id` was replaced in Phase
+// 1.32: `Tape::backward` now loads the live version directly from each
+// node's `input_version_handles` Arc<AtomicU64>. No process-wide
+// registry needed.
 
 #[cfg(test)]
 mod tests {
@@ -418,6 +416,61 @@ mod tests {
         assert!(r.contains(&a.id()));
         assert!(r.contains(&b.id()));
         assert!(r.contains(&c.id()));
+    }
+
+    #[test]
+    fn backward_detects_anti_pattern_16_version_drift() {
+        // Wire the Phase 1.32 version counter end-to-end:
+        // record an op, bump the input's version (simulating in-place
+        // mutation between forward and backward), then call backward.
+        // Expected: error message mentions anti-pattern 16 + the op name.
+        let mut tape = Tape::new();
+        let out = cpu_tensor();
+        let inp = cpu_tensor();
+        let calls = std::sync::Arc::new(AtomicUsize::new(0));
+        tape.record(
+            &out,
+            &[&inp],
+            Box::new(CountingOp {
+                name: "test/some_op",
+                input_count: 1,
+                calls,
+            }),
+        );
+        // Simulate in-place mutation of `inp` between forward and backward.
+        inp.bump_version();
+        let e = tape
+            .backward(out.id(), cpu_tensor(), passthrough_accumulator)
+            .unwrap_err();
+        let msg = e.to_string();
+        assert!(
+            msg.contains("Anti-pattern 16"),
+            "expected anti-pattern 16 error, got: {msg}"
+        );
+        assert!(msg.contains("test/some_op"));
+    }
+
+    #[test]
+    fn backward_ok_when_versions_unchanged() {
+        // No in-place mutation between forward and backward -> backward succeeds.
+        let mut tape = Tape::new();
+        let out = cpu_tensor();
+        let inp = cpu_tensor();
+        let calls = std::sync::Arc::new(AtomicUsize::new(0));
+        tape.record(
+            &out,
+            &[&inp],
+            Box::new(CountingOp {
+                name: "test/clean_op",
+                input_count: 1,
+                calls: calls.clone(),
+            }),
+        );
+        // No bump — versions stay at 0.
+        let _ = tape
+            .backward(out.id(), cpu_tensor(), passthrough_accumulator)
+            .unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
 
     #[test]

--- a/crates/kiln-tensor/src/tensor.rs
+++ b/crates/kiln-tensor/src/tensor.rs
@@ -31,6 +31,7 @@
 //! plus `BackendRuntime::dispatch`; this PR ships only the
 //! Tensor + view-op surface.
 
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use crate::{
@@ -40,12 +41,37 @@ use crate::{
 
 /// kiln-tensor's production tensor handle.
 ///
-/// See the module doc for the layout. Clones are O(1).
+/// See the module doc for the layout. Clones are O(1) — they share
+/// the underlying storage, layout (cheap copy), `TensorId`, and the
+/// version counter. Mutating one clone's storage via [`bump_version`]
+/// is observed by every other clone (the version is `Arc<AtomicU64>`).
+///
+/// # Version counter (anti-pattern 16 hook)
+///
+/// Per the issue's anti-pattern 16:
+///
+/// > In-place mutation invalidates the tape. Any in-place op
+/// > (optimizer step, residual accumulate-in-place, in-place norm)
+/// > bumps a per-tensor version counter; the backward path asserts
+/// > the version is unchanged from when the tape recorded the
+/// > forward. Failing the assertion is a programming error, not a
+/// > tolerated mode.
+///
+/// The version is stored as `Arc<AtomicU64>` so clones of a Tensor
+/// share it: if the optimizer step mutates `param`, the version
+/// stored on the autograd tape's input-list also observes the bump.
+/// `kiln_autograd::Tape::backward` compares the stored snapshot
+/// against the live load and errors on drift.
 #[derive(Debug, Clone)]
 pub struct Tensor {
     storage: Storage,
     layout: Layout,
     id: TensorId,
+    /// In-place mutation version counter. Bumped by callers that
+    /// mutate the underlying storage (optimizer step, residual fuse,
+    /// future in-place norm). Read by `kiln_autograd::Tape::backward`
+    /// to detect anti-pattern 16 violations.
+    version: Arc<AtomicU64>,
 }
 
 impl Tensor {
@@ -63,6 +89,7 @@ impl Tensor {
             storage,
             layout,
             id: TensorId::next(),
+            version: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -85,6 +112,7 @@ impl Tensor {
             storage,
             layout,
             id: TensorId::next(),
+            version: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -115,6 +143,7 @@ impl Tensor {
             storage,
             layout,
             id,
+            version: Arc::new(AtomicU64::new(0)),
         })
     }
 
@@ -177,11 +206,15 @@ impl Tensor {
     // ------------------------------------------------------------------
 
     /// Narrow along `axis` to `[offset .. offset+length]`. Zero-copy.
+    ///
+    /// View ops share the parent's version counter: if the parent's
+    /// storage is mutated in place, every view sees the bump.
     pub fn narrow(&self, axis: usize, offset: usize, length: usize) -> Result<Self> {
         Ok(Tensor {
             storage: Arc::clone(&self.storage),
             layout: self.layout.narrow_axis(axis, offset, length)?,
             id: TensorId::next(),
+            version: Arc::clone(&self.version),
         })
     }
 
@@ -191,6 +224,7 @@ impl Tensor {
             storage: Arc::clone(&self.storage),
             layout: self.layout.transpose(axis_a, axis_b)?,
             id: TensorId::next(),
+            version: Arc::clone(&self.version),
         })
     }
 
@@ -200,6 +234,7 @@ impl Tensor {
             storage: Arc::clone(&self.storage),
             layout: self.layout.permute(axes)?,
             id: TensorId::next(),
+            version: Arc::clone(&self.version),
         })
     }
 
@@ -213,6 +248,7 @@ impl Tensor {
             storage: Arc::clone(&self.storage),
             layout: self.layout.reshape(new_shape)?,
             id: TensorId::next(),
+            version: Arc::clone(&self.version),
         })
     }
 
@@ -307,7 +343,44 @@ impl Tensor {
             storage: Arc::new(new_cpu),
             layout: Layout::contiguous(shape.to_vec()),
             id: TensorId::next(),
+            // Materializing copy → fresh storage → fresh version.
+            // (View ops share the parent's version; this branch does
+            // not.)
+            version: Arc::new(AtomicU64::new(0)),
         })
+    }
+
+    // ------------------------------------------------------------------
+    // Version counter (anti-pattern 16)
+    // ------------------------------------------------------------------
+
+    /// Current version counter. `0` for a fresh tensor; bumps every
+    /// time the storage is mutated in place.
+    ///
+    /// `kiln_autograd::Tape::backward` compares this to the snapshot
+    /// stored on the tape node and errors if they differ.
+    pub fn current_version(&self) -> u64 {
+        self.version.load(Ordering::Relaxed)
+    }
+
+    /// Borrow the `Arc<AtomicU64>` version handle. Used by
+    /// `kiln_autograd::Tape::record` to store a live pointer so
+    /// backward-time checks see the up-to-date value.
+    pub fn version_handle(&self) -> Arc<AtomicU64> {
+        Arc::clone(&self.version)
+    }
+
+    /// Bump the version counter (returns the **new** version). Called
+    /// by in-place ops: optimizer step, residual fuse, future
+    /// in-place norm.
+    ///
+    /// This is the **anti-pattern 16 enforcement seam**: any code
+    /// path that mutates `self.storage()`'s bytes must call this. If
+    /// it doesn't, an autograd backward that reads the pre-mutation
+    /// tensor will silently use the post-mutation bytes — the
+    /// "silent corruption on step 2" the issue warns about.
+    pub fn bump_version(&self) -> u64 {
+        self.version.fetch_add(1, Ordering::Relaxed) + 1
     }
 }
 
@@ -450,5 +523,74 @@ mod tests {
         let layout = Layout::contiguous(vec![100]); // 100 elements != 4
         let e = Tensor::from_parts(storage, layout, TensorId::next()).unwrap_err();
         assert!(e.to_string().contains("requires"));
+    }
+
+    #[test]
+    fn fresh_tensor_version_is_zero() {
+        let t = Tensor::zeros_cpu(vec![2, 3], DType::F32);
+        assert_eq!(t.current_version(), 0);
+    }
+
+    #[test]
+    fn bump_version_returns_new_value() {
+        let t = Tensor::zeros_cpu(vec![2, 3], DType::F32);
+        assert_eq!(t.bump_version(), 1);
+        assert_eq!(t.bump_version(), 2);
+        assert_eq!(t.bump_version(), 3);
+        assert_eq!(t.current_version(), 3);
+    }
+
+    #[test]
+    fn clone_shares_version_counter() {
+        // Clone shares the Arc<AtomicU64>; a bump on one clone is
+        // observed by all clones.
+        let t = Tensor::zeros_cpu(vec![2, 3], DType::F32);
+        let c1 = t.clone();
+        let c2 = t.clone();
+        t.bump_version();
+        assert_eq!(t.current_version(), 1);
+        assert_eq!(c1.current_version(), 1);
+        assert_eq!(c2.current_version(), 1);
+    }
+
+    #[test]
+    fn view_op_shares_version_with_parent() {
+        // Views alias storage; they share the version counter.
+        let t = Tensor::zeros_cpu(vec![4, 5], DType::F32);
+        let v = t.narrow(0, 1, 2).unwrap();
+        t.bump_version();
+        assert_eq!(v.current_version(), 1);
+    }
+
+    #[test]
+    fn contiguous_materialized_has_fresh_version() {
+        // Materializing contiguous() copies bytes; the new tensor
+        // gets a fresh version counter independent of the source.
+        let v = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let t = Tensor::from_slice(&v, vec![2, 3]).unwrap();
+        let tt = t.transpose(0, 1).unwrap();
+        // tt shares t's version counter (view op).
+        t.bump_version();
+        assert_eq!(tt.current_version(), 1);
+        // contiguous() on a non-contig view materializes — fresh
+        // version starts at 0 independent of source.
+        let c = tt.contiguous().unwrap();
+        assert_eq!(c.current_version(), 0);
+        // Subsequent bumps on the source don't affect the materialized
+        // copy.
+        t.bump_version();
+        assert_eq!(t.current_version(), 2);
+        assert_eq!(c.current_version(), 0);
+    }
+
+    #[test]
+    fn version_handle_is_arc_to_same_atomic() {
+        let t = Tensor::zeros_cpu(vec![1], DType::F32);
+        let h = t.version_handle();
+        // The handle is to the same atomic as the tensor.
+        t.bump_version();
+        assert_eq!(h.load(Ordering::Relaxed), 1);
+        h.fetch_add(10, Ordering::Relaxed);
+        assert_eq!(t.current_version(), 11);
     }
 }


### PR DESCRIPTION
Closes the anti-pattern 16 in-place-mutation detection loop end-to-end.

## kiln-tensor: `Tensor` gains `Arc<AtomicU64>` version field

| Method | Purpose |
|---|---|
| `current_version() -> u64` | load with Relaxed |
| `version_handle() -> Arc<AtomicU64>` | clone the Arc for tape storage |
| `bump_version() -> u64` | in-place ops call this; returns new version |

**Cloning a Tensor shares the version counter** (Arc semantics). **View ops** (narrow / transpose / permute / reshape) share parent's version because they alias storage. **Materializing contiguous()** allocates fresh storage AND a fresh `AtomicU64::new(0)` — versions are storage-scoped.

## kiln-autograd: Tape uses live version handles

`TapeNode` now carries `input_version_handles: Vec<Arc<AtomicU64>>` alongside the snapshot `input_versions: Vec<u64>`. On record, both are captured; on backward, live value is loaded from the Arc and compared. The old `current_version_for_id` stub is deleted.

Drift triggers:
> Anti-pattern 16: in-place mutation invalidated the tape.

with op name + input index + recorded-vs-now values.

## 8 new tests

- 6 in kiln-tensor: fresh-is-zero, bump-returns-new, clone shares, view shares with parent, materialized has fresh version, version_handle Arc round-trip
- 2 in kiln-autograd: **`backward_detects_anti_pattern_16_version_drift`** end-to-end + happy path

## Wiring contract

Every code path that mutates a Tensor's storage bytes MUST call `tensor.bump_version()`. Phase 6.5's AdamW::step is the first real user (lands when interior-mutability arrives in Phase 1.x). Phase 9 audit can grep for in-place comments + assert matching bump_version() calls.

Refs #1082