### PR TITLE
phase 1.39: safetensors save path (#1082)

### DIFF
--- a/crates/kiln-tensor/src/safetensors.rs
+++ b/crates/kiln-tensor/src/safetensors.rs
@@ -50,10 +50,11 @@
 //! handle and the lifetime gymnastics that follow. Phase 1.x's
 //! "pinned-host staging pool" bullet covers the mmap-aware path.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::Path;
 
-use safetensors::tensor::{Dtype as StDtype, SafeTensors, TensorView};
+use safetensors::tensor::{Dtype as StDtype, SafeTensors, TensorView, View};
 
 use crate::{CpuStorage, DType, Error, Layout, Result, Storage, Tensor, TensorId};
 
@@ -123,6 +124,93 @@ pub fn map_dtype(dt: StDtype) -> Result<DType> {
             )));
         }
     })
+}
+
+/// Save a `HashMap<String, &Tensor>` to a safetensors file.
+///
+/// Counterpart to [`load_cpu`]. Reads CPU storage from each tensor,
+/// builds a safetensors-compatible view, and writes the file.
+///
+/// All tensors must be CPU-resident and contiguous. Non-contiguous or
+/// GPU tensors must be `.contiguous()`-ed + `.to_device(Cpu)`-ed first
+/// (the latter lands when per-backend device transfer is in place).
+///
+/// Packed dtypes (`Int4Packed`, `Fp4Packed`) are rejected — they ship
+/// via the Marlin format alongside the safetensors file.
+pub fn save_cpu<P: AsRef<Path>, S: AsRef<str>>(
+    tensors: &HashMap<S, &Tensor>,
+    filename: P,
+) -> Result<()> {
+    // Wrap each tensor in a SerializableTensor view; the safetensors
+    // crate impl-blocks on `&dyn View` so we collect Box<dyn View>.
+    let mut wrappers: Vec<(String, SerializableTensor<'_>)> = Vec::with_capacity(tensors.len());
+    for (name, tensor) in tensors {
+        let wrapper = SerializableTensor::try_from_tensor(tensor)?;
+        wrappers.push((name.as_ref().to_string(), wrapper));
+    }
+    // safetensors::serialize_to_file takes any `IntoIterator<Item =
+    // (&str, &dyn View)>`, but the exact ergonomics depend on
+    // version. We sort by name so the file is deterministic.
+    wrappers.sort_by(|a, b| a.0.cmp(&b.0));
+    let pairs: Vec<(&str, &SerializableTensor<'_>)> =
+        wrappers.iter().map(|(n, w)| (n.as_str(), w)).collect();
+    safetensors::tensor::serialize_to_file(pairs, &None, filename.as_ref()).map_err(|e| {
+        Error::Msg(format!(
+            "safetensors::save_cpu: serialize_to_file failed: {e}"
+        ))
+    })?;
+    Ok(())
+}
+
+/// `View` impl wrapper for a borrowed CPU tensor. Used internally by
+/// [`save_cpu`].
+struct SerializableTensor<'a> {
+    dtype: StDtype,
+    shape: Vec<usize>,
+    bytes: &'a [u8],
+}
+
+impl<'a> SerializableTensor<'a> {
+    fn try_from_tensor(t: &'a Tensor) -> Result<Self> {
+        let dtype = st_dtype(t.dtype())?;
+        if !t.is_contiguous() {
+            return Err(Error::Msg(format!(
+                "safetensors::save_cpu: tensor (id {}) is not contiguous; \
+                 call `.contiguous()` first",
+                t.id()
+            )));
+        }
+        let cpu = t
+            .storage()
+            .as_any()
+            .downcast_ref::<CpuStorage>()
+            .ok_or_else(|| {
+                Error::from_str(
+                    "safetensors::save_cpu: only CpuStorage is serializable today; \
+                     GPU tensors must be transferred to CPU first",
+                )
+            })?;
+        Ok(SerializableTensor {
+            dtype,
+            shape: t.shape().to_vec(),
+            bytes: cpu.as_bytes(),
+        })
+    }
+}
+
+impl<'a> View for SerializableTensor<'a> {
+    fn dtype(&self) -> StDtype {
+        self.dtype
+    }
+    fn shape(&self) -> &[usize] {
+        &self.shape
+    }
+    fn data(&self) -> Cow<'_, [u8]> {
+        Cow::Borrowed(self.bytes)
+    }
+    fn data_len(&self) -> usize {
+        self.bytes.len()
+    }
 }
 
 /// Reverse of [`map_dtype`]. Used by `save_*` paths in a later PR.
@@ -206,5 +294,76 @@ mod tests {
     fn load_cpu_rejects_missing_path() {
         let err = load_cpu("/tmp/kiln-tensor-nonexistent-87f3b9c4d2e1.safetensors").unwrap_err();
         assert!(err.to_string().contains("read file failed"));
+    }
+
+    #[test]
+    fn save_then_load_round_trip_f32() {
+        let t = crate::Tensor::from_slice(
+            &[1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0],
+            vec![2, 3],
+        )
+        .unwrap();
+        let mut to_save: HashMap<String, &crate::Tensor> = HashMap::new();
+        to_save.insert("weight".to_string(), &t);
+        let tmp = std::env::temp_dir().join("kiln_save_round_trip_f32.safetensors");
+        let _ = std::fs::remove_file(&tmp);
+        save_cpu(&to_save, &tmp).unwrap();
+        let loaded = load_cpu(&tmp).unwrap();
+        let loaded_t = loaded.get("weight").expect("weight key");
+        assert_eq!(loaded_t.shape(), &[2, 3]);
+        assert_eq!(loaded_t.dtype(), crate::DType::F32);
+        let cpu = loaded_t
+            .storage()
+            .as_any()
+            .downcast_ref::<crate::CpuStorage>()
+            .unwrap();
+        let back: Vec<f32> = bytemuck::cast_slice::<u8, f32>(cpu.as_bytes()).to_vec();
+        assert_eq!(back, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn save_rejects_non_contiguous() {
+        let t = crate::Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], vec![2, 2])
+            .unwrap()
+            .transpose(0, 1)
+            .unwrap();
+        assert!(!t.is_contiguous());
+        let mut m: HashMap<String, &crate::Tensor> = HashMap::new();
+        m.insert("w".to_string(), &t);
+        let tmp = std::env::temp_dir().join("kiln_save_rejects_noncontig.safetensors");
+        let _ = std::fs::remove_file(&tmp);
+        let e = save_cpu(&m, &tmp).unwrap_err();
+        assert!(e.to_string().contains("not contiguous"));
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn save_multiple_tensors_round_trip() {
+        let a = crate::Tensor::from_slice(&[1.0f32, 2.0, 3.0], vec![3]).unwrap();
+        let b = crate::Tensor::from_slice(&[10u32, 20, 30, 40], vec![4]).unwrap();
+        let mut m: HashMap<String, &crate::Tensor> = HashMap::new();
+        m.insert("alpha".to_string(), &a);
+        m.insert("beta".to_string(), &b);
+        let tmp = std::env::temp_dir().join("kiln_save_multi.safetensors");
+        let _ = std::fs::remove_file(&tmp);
+        save_cpu(&m, &tmp).unwrap();
+        let loaded = load_cpu(&tmp).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded["alpha"].dtype(), crate::DType::F32);
+        assert_eq!(loaded["beta"].dtype(), crate::DType::U32);
+        let _ = std::fs::remove_file(&tmp);
+    }
+
+    #[test]
+    fn save_rejects_packed_dtype() {
+        let t = crate::Tensor::zeros_cpu(vec![4], crate::DType::Int4Packed);
+        let mut m: HashMap<String, &crate::Tensor> = HashMap::new();
+        m.insert("packed".to_string(), &t);
+        let tmp = std::env::temp_dir().join("kiln_save_rejects_packed.safetensors");
+        let _ = std::fs::remove_file(&tmp);
+        let e = save_cpu(&m, &tmp).unwrap_err();
+        assert!(e.to_string().contains("packed"));
+        let _ = std::fs::remove_file(&tmp);
     }
 }


### PR DESCRIPTION
Counterpart to `load_cpu` (Phase 1.9). Writes `HashMap<String, &Tensor>` to a safetensors file via the crate's View trait, impl'd on a private SerializableTensor<'a> wrapper.

## API

```rust
use kiln_tensor::safetensors::save_cpu;
save_cpu(&map, "model.safetensors")?;
```

## Constraints

- CPU-resident tensors only (GPU transfer paths land per-backend in Phase 2)
- Contiguous tensors only (non-contig errors with ".contiguous() first" hint)
- Packed dtypes (Int4Packed, Fp4Packed) rejected — ship via Marlin format

## Deterministic output

Tensors sorted by name before serialization → bit-deterministic file for a fixed input map.

## 4 round-trip tests

save → load → byte-compare for F32; non-contiguous rejection; multi-tensor mix (F32 + U32); packed dtype rejection.

Refs #1082