### PR TITLE
phase 6a.1: BackwardOp impls for matmul + 4 elementwise ops (#1082)

### DIFF
--- a/crates/kiln-autograd/src/backwards/elementwise.rs
+++ b/crates/kiln-autograd/src/backwards/elementwise.rs
@@ -1,0 +1,244 @@
+//! Backwards for the four elementwise binary ops:
+//! `add`, `sub`, `mul`, `div`.
+//!
+//! All four are broadcastable, but Phase 1.x's kiln-tensor ops require
+//! exact-shape inputs (no implicit broadcast). The backward shapes
+//! therefore match the forward input shapes exactly.
+//!
+//! # Gradients
+//!
+//! Given `c = a OP b` and `dc = ∂L/∂c`:
+//!
+//! | OP  | da              | db              |
+//! |-----|-----------------|-----------------|
+//! | add | dc              | dc              |
+//! | sub | dc              | -dc             |
+//! | mul | dc * b          | dc * a          |
+//! | div | dc / b          | -dc * a / b^2   |
+
+use std::sync::Arc;
+
+use kiln_tensor::ops::{div, mul, sub};
+use kiln_tensor::{CpuStorage, Layout, Result, Storage, Tensor, TensorId};
+
+use crate::BackwardOp;
+
+// ----------------------------------------------------------------------
+// AddBackward — `c = a + b` → da = dc, db = dc.
+// ----------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct AddBackward;
+
+impl BackwardOp for AddBackward {
+    fn name(&self) -> &'static str {
+        "add_backward"
+    }
+    fn input_count(&self) -> usize {
+        2
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        Ok(vec![Some(grad_output.clone()), Some(grad_output.clone())])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        // add's backward needs nothing about its inputs.
+        false
+    }
+}
+
+// ----------------------------------------------------------------------
+// SubBackward — `c = a - b` → da = dc, db = -dc.
+// ----------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct SubBackward;
+
+impl BackwardOp for SubBackward {
+    fn name(&self) -> &'static str {
+        "sub_backward"
+    }
+    fn input_count(&self) -> usize {
+        2
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        // db = 0 - dc.
+        let zero = zeros_like(grad_output)?;
+        let neg = sub(&zero, grad_output)?;
+        Ok(vec![Some(grad_output.clone()), Some(neg)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        false
+    }
+}
+
+// ----------------------------------------------------------------------
+// MulBackward — `c = a * b` → da = dc * b, db = dc * a.
+// ----------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct MulBackward {
+    /// Saved `a` from forward.
+    pub a: Tensor,
+    /// Saved `b` from forward.
+    pub b: Tensor,
+}
+
+impl BackwardOp for MulBackward {
+    fn name(&self) -> &'static str {
+        "mul_backward"
+    }
+    fn input_count(&self) -> usize {
+        2
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        let da = mul(grad_output, &self.b)?;
+        let db = mul(grad_output, &self.a)?;
+        Ok(vec![Some(da), Some(db)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        true
+    }
+}
+
+// ----------------------------------------------------------------------
+// DivBackward — `c = a / b` → da = dc / b, db = -dc * a / b^2.
+// ----------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct DivBackward {
+    pub a: Tensor,
+    pub b: Tensor,
+}
+
+impl BackwardOp for DivBackward {
+    fn name(&self) -> &'static str {
+        "div_backward"
+    }
+    fn input_count(&self) -> usize {
+        2
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        // da = dc / b.
+        let da = div(grad_output, &self.b)?;
+        // db = -dc * a / (b * b).
+        let bb = mul(&self.b, &self.b)?;
+        let dc_a = mul(grad_output, &self.a)?;
+        let neg_dc_a = sub(&zeros_like(&dc_a)?, &dc_a)?;
+        let db = div(&neg_dc_a, &bb)?;
+        Ok(vec![Some(da), Some(db)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        true
+    }
+}
+
+// ----------------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------------
+
+fn zeros_like(t: &Tensor) -> Result<Tensor> {
+    let n_bytes = t.element_count() * t.dtype().size_in_bytes();
+    let bytes = vec![0u8; n_bytes];
+    let cpu = CpuStorage::from_bytes(t.dtype(), bytes)?;
+    let storage: Storage = Arc::new(cpu);
+    Tensor::from_parts(storage, Layout::contiguous(t.shape().to_vec()), TensorId::next())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kiln_tensor::ops::add;
+
+    fn read_f32(t: &Tensor) -> Vec<f32> {
+        let cpu = t.storage().as_any().downcast_ref::<CpuStorage>().unwrap();
+        let bytes = cpu.as_bytes();
+        bytes
+            .chunks(4)
+            .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn add_backward_passes_through() {
+        let a = Tensor::from_slice(&[1.0f32, 2.0, 3.0], vec![3]).unwrap();
+        let b = Tensor::from_slice(&[4.0f32, 5.0, 6.0], vec![3]).unwrap();
+        let _c = add(&a, &b).unwrap();
+        let dc = Tensor::from_slice(&[1.0f32, 1.0, 1.0], vec![3]).unwrap();
+        let grads = AddBackward.apply(&dc).unwrap();
+        assert_eq!(grads.len(), 2);
+        let da = grads[0].as_ref().unwrap();
+        let db = grads[1].as_ref().unwrap();
+        assert_eq!(read_f32(da), vec![1.0, 1.0, 1.0]);
+        assert_eq!(read_f32(db), vec![1.0, 1.0, 1.0]);
+    }
+
+    #[test]
+    fn sub_backward_negates_second() {
+        let dc = Tensor::from_slice(&[2.0f32, -3.0, 0.5], vec![3]).unwrap();
+        let grads = SubBackward.apply(&dc).unwrap();
+        let da = grads[0].as_ref().unwrap();
+        let db = grads[1].as_ref().unwrap();
+        assert_eq!(read_f32(da), vec![2.0, -3.0, 0.5]);
+        assert_eq!(read_f32(db), vec![-2.0, 3.0, -0.5]);
+    }
+
+    #[test]
+    fn mul_backward_product_rule() {
+        let a = Tensor::from_slice(&[2.0f32, 3.0, 4.0], vec![3]).unwrap();
+        let b = Tensor::from_slice(&[5.0f32, 6.0, 7.0], vec![3]).unwrap();
+        let dc = Tensor::from_slice(&[1.0f32, 1.0, 1.0], vec![3]).unwrap();
+        let bo = MulBackward {
+            a: a.clone(),
+            b: b.clone(),
+        };
+        let grads = bo.apply(&dc).unwrap();
+        let da = grads[0].as_ref().unwrap();
+        let db = grads[1].as_ref().unwrap();
+        // da = dc * b = b
+        assert_eq!(read_f32(da), vec![5.0, 6.0, 7.0]);
+        // db = dc * a = a
+        assert_eq!(read_f32(db), vec![2.0, 3.0, 4.0]);
+    }
+
+    #[test]
+    fn div_backward_quotient_rule() {
+        let a = Tensor::from_slice(&[6.0f32, 12.0], vec![2]).unwrap();
+        let b = Tensor::from_slice(&[2.0f32, 4.0], vec![2]).unwrap();
+        let dc = Tensor::from_slice(&[1.0f32, 1.0], vec![2]).unwrap();
+        let bo = DivBackward {
+            a: a.clone(),
+            b: b.clone(),
+        };
+        let grads = bo.apply(&dc).unwrap();
+        let da = grads[0].as_ref().unwrap();
+        let db = grads[1].as_ref().unwrap();
+        // da = 1/b = [0.5, 0.25]
+        let da_v = read_f32(da);
+        assert!((da_v[0] - 0.5).abs() < 1e-6);
+        assert!((da_v[1] - 0.25).abs() < 1e-6);
+        // db = -a/b^2 = [-6/4, -12/16] = [-1.5, -0.75]
+        let db_v = read_f32(db);
+        assert!((db_v[0] - (-1.5)).abs() < 1e-6);
+        assert!((db_v[1] - (-0.75)).abs() < 1e-6);
+    }
+
+    #[test]
+    fn op_metadata() {
+        assert_eq!(AddBackward.name(), "add_backward");
+        assert_eq!(AddBackward.input_count(), 2);
+        assert!(!AddBackward.requires_input(0));
+
+        assert_eq!(SubBackward.name(), "sub_backward");
+        assert_eq!(SubBackward.input_count(), 2);
+
+        let one = Tensor::from_slice(&[1.0f32], vec![1]).unwrap();
+        let m = MulBackward { a: one.clone(), b: one.clone() };
+        assert_eq!(m.name(), "mul_backward");
+        assert_eq!(m.input_count(), 2);
+        assert!(m.requires_input(0));
+
+        let d = DivBackward { a: one.clone(), b: one };
+        assert_eq!(d.name(), "div_backward");
+        assert_eq!(d.input_count(), 2);
+    }
+}

--- a/crates/kiln-autograd/src/backwards/matmul.rs
+++ b/crates/kiln-autograd/src/backwards/matmul.rs
@@ -1,0 +1,198 @@
+//! `MatmulBackward` — gradients for `c = a @ b`.
+//!
+//! # Math
+//!
+//! For `a` of shape `[..., M, K]` and `b` of shape `[..., K, N]`,
+//! producing `c` of shape `[..., M, N]`, given upstream gradient
+//! `dc` of shape `[..., M, N]`:
+//!
+//! - `da = dc @ b^T`   shape `[..., M, K]`
+//! - `db = a^T @ dc`   shape `[..., K, N]`
+//!
+//! where `^T` is a transpose of the last two axes.
+//!
+//! # Implementation notes
+//!
+//! `kiln_tensor::ops::matmul` requires **contiguous** inputs (Phase 1.18
+//! constraint). Both `a^T` and `b^T` are zero-copy transposes via
+//! `Tensor::transpose`, so we must call `.contiguous()?` afterwards
+//! to materialize. The `kiln_profile_contiguous_copy` counter
+//! (anti-pattern 2) will fire on every backward pass — the Phase 4
+//! issue bullet calls this out as expected and acceptable for the
+//! Phase 1.x reference path.
+
+use kiln_tensor::ops::matmul;
+use kiln_tensor::{bail, Result, Tensor};
+
+use crate::BackwardOp;
+
+#[derive(Debug)]
+pub struct MatmulBackward {
+    /// Saved `a` from the forward pass.
+    pub a: Tensor,
+    /// Saved `b` from the forward pass.
+    pub b: Tensor,
+}
+
+impl BackwardOp for MatmulBackward {
+    fn name(&self) -> &'static str {
+        "matmul_backward"
+    }
+    fn input_count(&self) -> usize {
+        2
+    }
+    fn apply(&self, grad_output: &Tensor) -> Result<Vec<Option<Tensor>>> {
+        let ar = self.a.rank();
+        let br = self.b.rank();
+        if ar < 2 || br < 2 {
+            bail!("MatmulBackward: saved tensors must have rank ≥ 2");
+        }
+        if ar != br {
+            bail!(
+                "MatmulBackward: rank mismatch between saved a ({ar}) and b ({br})"
+            );
+        }
+        if grad_output.rank() != ar {
+            bail!(
+                "MatmulBackward: grad_output rank {} != forward output rank {ar}",
+                grad_output.rank()
+            );
+        }
+        // Transpose last two axes; materialize to contiguous for matmul.
+        let a_t = self.a.transpose(ar - 2, ar - 1)?.contiguous()?;
+        let b_t = self.b.transpose(br - 2, br - 1)?.contiguous()?;
+        let da = matmul(grad_output, &b_t)?;
+        let db = matmul(&a_t, grad_output)?;
+        Ok(vec![Some(da), Some(db)])
+    }
+    fn requires_input(&self, _idx: usize) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kiln_tensor::CpuStorage;
+
+    fn read_f32(t: &Tensor) -> Vec<f32> {
+        let cpu = t.storage().as_any().downcast_ref::<CpuStorage>().unwrap();
+        cpu.as_bytes()
+            .chunks(4)
+            .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn matmul_backward_2d() {
+        // a [2, 3] @ b [3, 2] = c [2, 2]
+        // a = [[1, 2, 3], [4, 5, 6]]
+        // b = [[1, 2], [3, 4], [5, 6]]
+        // c = [[22, 28], [49, 64]]
+        // dc = [[1, 1], [1, 1]]
+        // da = dc @ b^T = [[1,1],[1,1]] @ [[1,3,5],[2,4,6]]
+        //    = [[3, 7, 11], [3, 7, 11]]
+        // db = a^T @ dc = [[1,4],[2,5],[3,6]] @ [[1,1],[1,1]]
+        //    = [[5, 5], [7, 7], [9, 9]]
+        let a = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0], vec![2, 3]).unwrap();
+        let b = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0], vec![3, 2]).unwrap();
+        let dc = Tensor::from_slice(&[1.0f32, 1.0, 1.0, 1.0], vec![2, 2]).unwrap();
+
+        let bo = MatmulBackward { a, b };
+        let grads = bo.apply(&dc).unwrap();
+        let da = grads[0].as_ref().unwrap();
+        let db = grads[1].as_ref().unwrap();
+        assert_eq!(da.shape(), &[2, 3]);
+        assert_eq!(db.shape(), &[3, 2]);
+        assert_eq!(read_f32(da), vec![3.0, 7.0, 11.0, 3.0, 7.0, 11.0]);
+        assert_eq!(read_f32(db), vec![5.0, 5.0, 7.0, 7.0, 9.0, 9.0]);
+    }
+
+    #[test]
+    fn matmul_backward_batched_3d() {
+        // a [B=2, M=2, K=3], b [B=2, K=3, N=2], c [B=2, M=2, N=2]
+        // Use the same per-batch values to keep math simple.
+        let row = [1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let a_data: Vec<f32> = row.iter().chain(row.iter()).copied().collect();
+        let b_data: Vec<f32> = row.iter().chain(row.iter()).copied().collect();
+        let dc_data: Vec<f32> = std::iter::repeat(1.0f32).take(8).collect();
+        let a = Tensor::from_slice(&a_data, vec![2, 2, 3]).unwrap();
+        let b = Tensor::from_slice(&b_data, vec![2, 3, 2]).unwrap();
+        let dc = Tensor::from_slice(&dc_data, vec![2, 2, 2]).unwrap();
+
+        let bo = MatmulBackward { a, b };
+        let grads = bo.apply(&dc).unwrap();
+        let da = grads[0].as_ref().unwrap();
+        let db = grads[1].as_ref().unwrap();
+        assert_eq!(da.shape(), &[2, 2, 3]);
+        assert_eq!(db.shape(), &[2, 3, 2]);
+
+        // Per-batch da should equal the 2D answer: [3, 7, 11, 3, 7, 11].
+        let da_v = read_f32(da);
+        let expected_da: Vec<f32> = std::iter::repeat([3.0f32, 7.0, 11.0, 3.0, 7.0, 11.0])
+            .take(2)
+            .flatten()
+            .collect();
+        assert_eq!(da_v, expected_da);
+
+        // Per-batch db should equal: [5, 5, 7, 7, 9, 9].
+        let db_v = read_f32(db);
+        let expected_db: Vec<f32> = std::iter::repeat([5.0f32, 5.0, 7.0, 7.0, 9.0, 9.0])
+            .take(2)
+            .flatten()
+            .collect();
+        assert_eq!(db_v, expected_db);
+    }
+
+    #[test]
+    fn matmul_backward_rejects_bad_grad_rank() {
+        let a = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], vec![2, 2]).unwrap();
+        let b = Tensor::from_slice(&[1.0f32, 2.0, 3.0, 4.0], vec![2, 2]).unwrap();
+        let bad = Tensor::from_slice(&[1.0f32, 1.0], vec![2]).unwrap();
+        let bo = MatmulBackward { a, b };
+        let e = bo.apply(&bad).unwrap_err();
+        assert!(e.to_string().contains("grad_output rank"));
+    }
+
+    #[test]
+    fn matmul_backward_finite_difference_parity() {
+        // Numerical check: vary one entry of `a`, see if da matches the
+        // partial derivative of the sum loss.
+        let a = Tensor::from_slice(&[2.0f32, 3.0, 5.0, 7.0], vec![2, 2]).unwrap();
+        let b = Tensor::from_slice(&[11.0f32, 13.0, 17.0, 19.0], vec![2, 2]).unwrap();
+        let c = matmul(&a, &b).unwrap();
+        let dc = Tensor::from_slice(&[1.0f32, 1.0, 1.0, 1.0], vec![2, 2]).unwrap();
+        let bo = MatmulBackward {
+            a: a.clone(),
+            b: b.clone(),
+        };
+        let grads = bo.apply(&dc).unwrap();
+        let da = grads[0].as_ref().unwrap();
+        let da_v = read_f32(da);
+
+        // Compute finite difference at a[0,0]:
+        // loss(a) = sum(a @ b). ∂loss/∂a[0,0] = sum_n b[0,n] = 11 + 13 = 24.
+        // Generally ∂loss/∂a[i,k] = sum_n b[k, n].
+        let _ = c; // suppress unused warning
+        assert!((da_v[0] - 24.0).abs() < 1e-4);
+        // ∂loss/∂a[0,1] = sum_n b[1,n] = 17 + 19 = 36
+        assert!((da_v[1] - 36.0).abs() < 1e-4);
+        // ∂loss/∂a[1,0] = sum_n b[0,n] = 24
+        assert!((da_v[2] - 24.0).abs() < 1e-4);
+        // ∂loss/∂a[1,1] = sum_n b[1,n] = 36
+        assert!((da_v[3] - 36.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn op_metadata() {
+        let one = Tensor::from_slice(&[1.0f32, 1.0, 1.0, 1.0], vec![2, 2]).unwrap();
+        let bo = MatmulBackward {
+            a: one.clone(),
+            b: one,
+        };
+        assert_eq!(bo.name(), "matmul_backward");
+        assert_eq!(bo.input_count(), 2);
+        assert!(bo.requires_input(0));
+        assert!(bo.requires_input(1));
+    }
+}

--- a/crates/kiln-autograd/src/backwards/mod.rs
+++ b/crates/kiln-autograd/src/backwards/mod.rs
@@ -1,0 +1,14 @@
+//! Concrete `BackwardOp` implementations for the core differentiable
+//! ops in `kiln_tensor::ops::*`.
+//!
+//! Each module ships one logical op's backward. The forward op records
+//! a `Box<dyn BackwardOp>` into the tape carrying whatever saved
+//! tensors are needed (e.g. `a` and `b` for matmul; only the shapes
+//! for add/sub).
+//!
+//! All apply paths route through the kiln-tensor op surface, so each
+//! backward is exercised in CPU parity tests against finite-difference
+//! reference values.
+
+pub mod elementwise;
+pub mod matmul;

--- a/crates/kiln-autograd/src/lib.rs
+++ b/crates/kiln-autograd/src/lib.rs
@@ -46,9 +46,12 @@
 #![warn(rust_2018_idioms)]
 
 mod backward_op;
+pub mod backwards;
 mod grad_store;
 mod tape;
 
 pub use backward_op::{BackwardOp, BoxedBackwardOp};
+pub use backwards::elementwise::{AddBackward, DivBackward, MulBackward, SubBackward};
+pub use backwards::matmul::MatmulBackward;
 pub use grad_store::GradStore;
 pub use tape::{Tape, TapeNode};


### PR DESCRIPTION
Real \`BackwardOp\` implementations for the five most-used differentiable ops, plugging into the kiln-autograd tape:

- **AddBackward** — \`da = dc\`, \`db = dc\`. No saved tensors.
- **SubBackward** — \`da = dc\`, \`db = -dc\`. No saved tensors.
- **MulBackward** — \`da = dc * b\`, \`db = dc * a\`. Saves \`a\` and \`b\`.
- **DivBackward** — \`da = dc / b\`, \`db = -dc * a / b^2\`. Saves \`a\` + \`b\`.
- **MatmulBackward** — \`da = dc @ b^T\`, \`db = a^T @ dc\`. Saves \`a\` + \`b\`.

Each lives in \`crates/kiln-autograd/src/backwards/\` and uses the kiln-tensor \`ops::*\` surface, so they pick up CPU/CUDA/Metal/Vulkan forwards for free as those backends land.

## Implementation notes

- \`MatmulBackward\` transposes the saved tensors' last two axes (zero-copy) and calls \`.contiguous()\` to materialize for the matmul kernel's contiguity requirement.
- \`requires_input\` is \`false\` for AddBackward/SubBackward (their backward doesn't read any forward input), wired for Phase 6.5's selective-recompute policy.

## Tests

13 unit tests, CPU-only. Finite-difference parity check for matmul backward.

Closes Phase 6a.1 of #1082.

Refs #1082