### PR TITLE
phase 5.1: kiln-graph-{cuda,metal,vulkan} scaffolds (#1082)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ members = [
     "crates/kiln-nvtx",
     "crates/kiln-autograd",
     "crates/kiln-graph",
+    "crates/kiln-graph-cuda",
+    "crates/kiln-graph-metal",
+    "crates/kiln-graph-vulkan",
     "crates/kiln-mps",
     "crates/kiln-opd-loss-kernel",
     "crates/kiln-optim",
@@ -44,6 +47,9 @@ default-members = [
     "crates/kiln-eval",
     "crates/kiln-flce-kernel",
     "crates/kiln-graph",
+    "crates/kiln-graph-cuda",
+    "crates/kiln-graph-metal",
+    "crates/kiln-graph-vulkan",
     "crates/kiln-model",
     "crates/kiln-mps",
     "crates/kiln-nvtx",
@@ -142,6 +148,9 @@ kiln-blas = { path = "crates/kiln-blas" }
 kiln-core = { path = "crates/kiln-core" }
 kiln-eval = { path = "crates/kiln-eval" }
 kiln-graph = { path = "crates/kiln-graph" }
+kiln-graph-cuda = { path = "crates/kiln-graph-cuda" }
+kiln-graph-metal = { path = "crates/kiln-graph-metal" }
+kiln-graph-vulkan = { path = "crates/kiln-graph-vulkan" }
 kiln-model = { path = "crates/kiln-model" }
 kiln-optim = { path = "crates/kiln-optim" }
 kiln-param = { path = "crates/kiln-param" }

--- a/crates/kiln-graph-cuda/Cargo.toml
+++ b/crates/kiln-graph-cuda/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "kiln-graph-cuda"
+description = "CUDA CapturedGraph impl — wraps cudarc CudaGraph + CudaGraphExec for the Phase 5 capture/replay surface."
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# Per Phase 5 of #1082, kiln-graph-cuda wraps `cudarc::driver::CudaGraph`
+# + `CudaGraphExec` and implements the `kiln_graph::CapturedGraph` trait.
+# Today the impl is a scaffold — backend tag + replay counter + scratch
+# bytes — that compiles on any host. The real cudarc-backed capture +
+# replay lifts the existing CUDA-graph wiring out of
+# `crates/kiln-model/src/forward.rs` (the `KILN_CUDA_GRAPHS=true` path).
+#
+# Internal-only — no semver commitment.
+
+[dependencies]
+kiln-graph = { workspace = true }
+kiln-tensor = { workspace = true }
+thiserror = { workspace = true }
+
+[features]
+# Compiles the real cudarc-backed capture pipeline. Without this
+# feature the crate exposes only the scaffold types so it can be
+# built / unit-tested on hosts without the CUDA toolchain.
+cuda = []

--- a/crates/kiln-graph-cuda/src/lib.rs
+++ b/crates/kiln-graph-cuda/src/lib.rs
@@ -1,0 +1,89 @@
+//! kiln-graph-cuda — CUDA `CapturedGraph` impl.
+//!
+//! Phase 5.1 of #1082: scaffold.
+//!
+//! Phase 5.x lifts the existing `KILN_CUDA_GRAPHS=true` path in
+//! `crates/kiln-model/src/forward.rs` (which wires
+//! `cudarc::driver::CudaGraph` + `CudaGraphExec` against the
+//! production decode loop) into this crate's
+//! [`CudaCapturedGraph`].
+//!
+//! # Today
+//!
+//! The scaffold wires:
+//!
+//! - `CudaCapturedGraph::new(scratch_bytes)` — constructor that takes
+//!   the pre-warmed scratch-pool footprint reported back to the Phase
+//!   5 `bench-results/graph-family-vram.csv`.
+//! - `CapturedGraph::backend()` — returns `Backend::Cuda`.
+//! - `CapturedGraph::replay()` — returns
+//!   `CaptureError::NotCaptured("kiln-graph-cuda: scaffold")` until
+//!   the real cudarc binding lands.
+//! - `CapturedGraph::replay_count()` / `scratch_bytes()` — bookkeeping.
+
+#![deny(missing_debug_implementations)]
+#![warn(rust_2018_idioms)]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use kiln_graph::{CaptureError, CapturedGraph};
+use kiln_tensor::Backend;
+
+/// CUDA-backed `CapturedGraph` scaffold.
+#[derive(Debug)]
+pub struct CudaCapturedGraph {
+    scratch_bytes: usize,
+    replay_count: AtomicU64,
+}
+
+impl CudaCapturedGraph {
+    /// Construct a scaffold instance reporting the given scratch-pool
+    /// byte footprint.
+    pub fn new(scratch_bytes: usize) -> Self {
+        CudaCapturedGraph {
+            scratch_bytes,
+            replay_count: AtomicU64::new(0),
+        }
+    }
+}
+
+impl CapturedGraph for CudaCapturedGraph {
+    fn backend(&self) -> Backend {
+        Backend::Cuda
+    }
+    fn replay(&self) -> Result<(), CaptureError> {
+        // Phase 5.x replaces this with the real cudarc CudaGraphExec
+        // launch. Until then, replay is a no-op (counted) — callers
+        // get the bookkeeping but no GPU work happens.
+        self.replay_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn replay_count(&self) -> u64 {
+        self.replay_count.load(Ordering::Relaxed)
+    }
+    fn scratch_bytes(&self) -> usize {
+        self.scratch_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaffold_reports_backend() {
+        let g = CudaCapturedGraph::new(1024);
+        assert_eq!(g.backend(), Backend::Cuda);
+        assert_eq!(g.scratch_bytes(), 1024);
+    }
+
+    #[test]
+    fn scaffold_replay_counts() {
+        let g = CudaCapturedGraph::new(0);
+        assert_eq!(g.replay_count(), 0);
+        g.replay().unwrap();
+        g.replay().unwrap();
+        g.replay().unwrap();
+        assert_eq!(g.replay_count(), 3);
+    }
+}

--- a/crates/kiln-graph-metal/Cargo.toml
+++ b/crates/kiln-graph-metal/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "kiln-graph-metal"
+description = "Metal CapturedGraph impl — wraps MTLIndirectCommandBuffer for the Phase 5 capture/replay surface."
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# Per Phase 5 of #1082, kiln-graph-metal wraps
+# `metal::IndirectCommandBuffer` for the production capture/replay
+# path on macOS. Scaffold today; the real ICB wiring lifts the existing
+# Metal-side decode loop in `crates/kiln-model/src/backend/metal.rs`.
+#
+# Internal-only — no semver commitment.
+
+[dependencies]
+kiln-graph = { workspace = true }
+kiln-tensor = { workspace = true }
+thiserror = { workspace = true }
+
+[features]
+# Compiles the real metal-rs-backed capture pipeline. Without this
+# feature the crate exposes only the scaffold types.
+metal = []

--- a/crates/kiln-graph-metal/src/lib.rs
+++ b/crates/kiln-graph-metal/src/lib.rs
@@ -1,0 +1,69 @@
+//! kiln-graph-metal — Metal `CapturedGraph` impl.
+//!
+//! Phase 5.1 of #1082: scaffold.
+//!
+//! Phase 5.x wraps `metal::IndirectCommandBuffer` (ICB) for the
+//! production replay path. ICBs are Metal's "graph" equivalent —
+//! pre-encoded compute pipeline state + buffer-binding records that
+//! can be replayed on a `MTLComputeCommandEncoder` with low CPU
+//! overhead.
+
+#![deny(missing_debug_implementations)]
+#![warn(rust_2018_idioms)]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use kiln_graph::{CaptureError, CapturedGraph};
+use kiln_tensor::Backend;
+
+#[derive(Debug)]
+pub struct MetalCapturedGraph {
+    scratch_bytes: usize,
+    replay_count: AtomicU64,
+}
+
+impl MetalCapturedGraph {
+    pub fn new(scratch_bytes: usize) -> Self {
+        MetalCapturedGraph {
+            scratch_bytes,
+            replay_count: AtomicU64::new(0),
+        }
+    }
+}
+
+impl CapturedGraph for MetalCapturedGraph {
+    fn backend(&self) -> Backend {
+        Backend::Metal
+    }
+    fn replay(&self) -> Result<(), CaptureError> {
+        self.replay_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn replay_count(&self) -> u64 {
+        self.replay_count.load(Ordering::Relaxed)
+    }
+    fn scratch_bytes(&self) -> usize {
+        self.scratch_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaffold_reports_backend() {
+        let g = MetalCapturedGraph::new(2048);
+        assert_eq!(g.backend(), Backend::Metal);
+        assert_eq!(g.scratch_bytes(), 2048);
+    }
+
+    #[test]
+    fn scaffold_replay_counts() {
+        let g = MetalCapturedGraph::new(0);
+        for _ in 0..5 {
+            g.replay().unwrap();
+        }
+        assert_eq!(g.replay_count(), 5);
+    }
+}

--- a/crates/kiln-graph-vulkan/Cargo.toml
+++ b/crates/kiln-graph-vulkan/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "kiln-graph-vulkan"
+description = "Vulkan CapturedGraph impl — extends kiln-vulkan-kernel cmd_batch.rs for the Phase 5 capture/replay surface."
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+# Per Phase 5 of #1082, kiln-graph-vulkan extends
+# `kiln_vulkan_kernel::cmd_batch` (the existing secondary command
+# buffer batcher) to implement the `kiln_graph::CapturedGraph` trait.
+# Vulkan's "graph" equivalent is a `VkSecondaryCommandBuffer` recorded
+# once and resubmitted; the Phase 5.x integration plugs into the same
+# `kiln-vulkan-kernel` device/queue plumbing.
+#
+# Internal-only — no semver commitment.
+
+[dependencies]
+kiln-graph = { workspace = true }
+kiln-tensor = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/kiln-graph-vulkan/src/lib.rs
+++ b/crates/kiln-graph-vulkan/src/lib.rs
@@ -1,0 +1,66 @@
+//! kiln-graph-vulkan — Vulkan `CapturedGraph` impl.
+//!
+//! Phase 5.1 of #1082: scaffold.
+//!
+//! Phase 5.x extends `kiln_vulkan_kernel::cmd_batch` (the existing
+//! secondary-command-buffer batcher) to record + resubmit on a
+//! capture/replay boundary aligned with the Phase 5 frozen-allocator
+//! lifetime.
+
+#![deny(missing_debug_implementations)]
+#![warn(rust_2018_idioms)]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use kiln_graph::{CaptureError, CapturedGraph};
+use kiln_tensor::Backend;
+
+#[derive(Debug)]
+pub struct VulkanCapturedGraph {
+    scratch_bytes: usize,
+    replay_count: AtomicU64,
+}
+
+impl VulkanCapturedGraph {
+    pub fn new(scratch_bytes: usize) -> Self {
+        VulkanCapturedGraph {
+            scratch_bytes,
+            replay_count: AtomicU64::new(0),
+        }
+    }
+}
+
+impl CapturedGraph for VulkanCapturedGraph {
+    fn backend(&self) -> Backend {
+        Backend::Vulkan
+    }
+    fn replay(&self) -> Result<(), CaptureError> {
+        self.replay_count.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn replay_count(&self) -> u64 {
+        self.replay_count.load(Ordering::Relaxed)
+    }
+    fn scratch_bytes(&self) -> usize {
+        self.scratch_bytes
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scaffold_reports_backend() {
+        let g = VulkanCapturedGraph::new(4096);
+        assert_eq!(g.backend(), Backend::Vulkan);
+        assert_eq!(g.scratch_bytes(), 4096);
+    }
+
+    #[test]
+    fn scaffold_replay_counts() {
+        let g = VulkanCapturedGraph::new(0);
+        g.replay().unwrap();
+        assert_eq!(g.replay_count(), 1);
+    }
+}


### PR DESCRIPTION
Three new workspace crates carrying the per-backend CapturedGraph impls. All three are scaffolds today; Phase 5.x plugs in real cudarc CudaGraphExec, Metal IndirectCommandBuffer, and Vulkan secondary command buffer.

## Scaffold contract

Each impl:
- Returns its proper \`Backend\` tag
- Reports \`scratch_bytes\` (pre-warmed scratch-pool footprint)
- Bumps an \`AtomicU64\` \`replay_count\` on every \`replay()\` call
- Currently returns \`Ok(())\` from replay (no GPU work); Phase 5.x replaces the body

## Workspace

Added to \`[workspace] members\`, \`default-members\`, and \`[workspace.dependencies]\`.

## Tests

Six unit tests (two per crate).

Closes Phase 5.1 of #1082.

Refs #1082